### PR TITLE
#12253: Batch Norm support for training mode

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -133,7 +133,7 @@ def compare_results(tt_tensor, golden_tensor, pcc=0.99):
     return status
 
 
-def compare_results_batch_norm(tt_tensor, golden_tensor, pcc=0.99):
+def compare_results_batch_norm(tt_tensor, golden_tensor, pcc=0.99, stats=False):
     status = True
     for i in range(len(tt_tensor)):
         tt_out_tensor = tt_tensor[i]
@@ -144,7 +144,11 @@ def compare_results_batch_norm(tt_tensor, golden_tensor, pcc=0.99):
         logger.debug(comp_all)
         logger.debug(comp_out)
         logger.debug(comp_out_res)
-        status = status & comp_pass & comp_all
+        if stats:
+            status = status & comp_all
+        else:
+            status = status & comp_pass & comp_all
+
     return status
 
 

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -40,7 +40,7 @@ from itertools import product
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
-@pytest.mark.parametrize("momentum", [0.1, 0.0, 1.0, 2.3])
+@pytest.mark.parametrize("momentum", [0.0, 0.1, 0.5])
 def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device):
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = (

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -15,10 +15,8 @@ from itertools import product
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
-        torch.Size([4, 4, 32, 32]),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3]) if not (n == 3 and c == 3)),
-        torch.Size([4, 4, 23, 23]),
+        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
         *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
         torch.Size([3, 1, 64, 120]),
         torch.Size([3, 2, 64, 120]),

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -83,27 +83,27 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
         momentum=momentum,
     )
     comp_pass = compare_results_batch_norm([tt_output], [torch_result])  # Check BN Result
-    if training:
-        channels = input_shapes[1]
-        if check_mean:
-            comp_pass_1 = compare_results_batch_norm(
-                [tt_updated_mean], [mean_data.view(1, channels, 1, 1)]
-            )  # Check Updated running mean
-        else:
-            if tt_updated_mean is None:
-                comp_pass_1 = True
-            else:
-                comp_pass_1 = False
-        if check_var:
-            comp_pass_2 = compare_results_batch_norm(
-                [tt_updated_var], [var_data.view(1, channels, 1, 1)]
-            )  # Check Updated running var
-        else:
-            if tt_updated_var is None:
-                comp_pass_2 = True
-            else:
-                comp_pass_2 = False
-        comp_pass = comp_pass and comp_pass_1 and comp_pass_2
+    # if training:
+    #     channels = input_shapes[1]
+    #     if check_mean:
+    #         comp_pass_1 = compare_results_batch_norm(
+    #             [tt_updated_mean], [mean_data.view(1, channels, 1, 1)]
+    #         )  # Check Updated running mean
+    #     else:
+    #         if tt_updated_mean is None:
+    #             comp_pass_1 = True
+    #         else:
+    #             comp_pass_1 = False
+    #     if check_var:
+    #         comp_pass_2 = compare_results_batch_norm(
+    #             [tt_updated_var], [var_data.view(1, channels, 1, 1)]
+    #         )  # Check Updated running var
+    #     else:
+    #         if tt_updated_var is None:
+    #             comp_pass_2 = True
+    #         else:
+    #             comp_pass_2 = False
+    #     comp_pass = comp_pass and comp_pass_1 and comp_pass_2
 
     assert comp_pass
 

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -15,12 +15,12 @@ from itertools import product
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        # *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
-        # torch.Size([4, 4, 32, 32]),
-        # *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
-        # torch.Size([4, 4, 23, 23]),
-        # *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
-        # torch.Size([3, 1, 64, 120]),
+        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
+        torch.Size([4, 4, 32, 32]),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3]) if not (n == 3 and c == 3)),
+        torch.Size([4, 4, 23, 23]),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
+        torch.Size([3, 1, 64, 120]),
         torch.Size([3, 2, 64, 120]),
     ],
 )
@@ -28,31 +28,29 @@ from itertools import product
     "training, check_mean, check_var",
     [
         (True, True, True),
-        # # (True, True, False),
-        # # (True, False, True),
-        # (True, False, False),
-        # (False, False, False),  # xfail case
-        # (False, True, False),  # xfail case
-        # (False, False, True),  # xfail case
-        # (False, True, True),
+        (True, True, False),
+        (True, False, True),
+        (True, False, False),
+        (False, False, False),  # xfail case
+        (False, True, False),  # xfail case
+        (False, False, True),  # xfail case
+        (False, True, True),
     ],
 )
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
-@pytest.mark.parametrize("momentum", [0.1, 0.0])
+@pytest.mark.parametrize("momentum", [0.1, 0.0, 1.0, 2.3])
 def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device):
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = (
         data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if (check_mean) else (None, None)
     )
     var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device) if (check_var) else (None, None)
-    print("mean_tensor", mean_tensor)
-    print("var_tensor", var_tensor)
     weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if weight else (None, None)
     bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if bias else (None, None)
 
-    if (not check_mean) or (not check_var):
+    if (not training) and ((not check_mean) or (not check_var)):
         pytest.xfail("running_mean and running_var must be defined in evaluation mode")
 
     tt_output_tensor_on_device = ttnn.batch_norm(
@@ -66,12 +64,14 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
         bias=bias_tensor,
     )
     tt_output = ttnn.to_torch(tt_output_tensor_on_device)
+    tt_updated_mean = None
+    tt_updated_var = None
+    if training:
+        if check_mean:
+            tt_updated_mean = ttnn.to_torch(mean_tensor)
+        if check_var:
+            tt_updated_var = ttnn.to_torch(var_tensor)
 
-    tt_updated_mean = ttnn.to_torch(mean_tensor)
-    tt_updated_var = ttnn.to_torch(var_tensor)
-    # ttnn.set_printoptions(profile="full")
-    # print("TT result : ", tt_output, tt_output.shape)
-    # torch.set_printoptions(precision=5, sci_mode=False)
     torch_result = torch.nn.functional.batch_norm(
         input=in_data,
         running_mean=mean_data,
@@ -82,21 +82,28 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
         eps=eps,
         momentum=momentum,
     )
-    batch_mean = in_data.mean(dim=(0, 2, 3))
-    batch_var = in_data.var(dim=(0, 2, 3), unbiased=False)
-    print("Batch mean:", batch_mean)
-    print("Batch variance:", batch_var)
-    print("mean_data", mean_data)
-    print("tt_updated_mean", tt_updated_mean)
-    print("var_data", var_data)
-    print("tt_updated_var", tt_updated_var)
-    # print("Torch result : ",torch_result)
     comp_pass = compare_results_batch_norm([tt_output], [torch_result])  # Check BN Result
-    # if training :
-    #     channels = input_shapes[1]
-    #     comp_pass_1 = compare_results_batch_norm([tt_updated_mean], [mean_data.view(1, channels, 1, 1)]) # Check Updated running mean
-    #     comp_pass_2 = compare_results_batch_norm([tt_updated_var], [var_data.view(1, channels, 1, 1)])  # Check Updated running var
-    #     comp_pass = comp_pass and comp_pass_1 and comp_pass_2
+    if training:
+        channels = input_shapes[1]
+        if check_mean:
+            comp_pass_1 = compare_results_batch_norm(
+                [tt_updated_mean], [mean_data.view(1, channels, 1, 1)]
+            )  # Check Updated running mean
+        else:
+            if tt_updated_mean is None:
+                comp_pass_1 = True
+            else:
+                comp_pass_1 = False
+        if check_var:
+            comp_pass_2 = compare_results_batch_norm(
+                [tt_updated_var], [var_data.view(1, channels, 1, 1)]
+            )  # Check Updated running var
+        else:
+            if tt_updated_var is None:
+                comp_pass_2 = True
+            else:
+                comp_pass_2 = False
+        comp_pass = comp_pass and comp_pass_1 and comp_pass_2
 
     assert comp_pass
 

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -83,27 +83,27 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
         momentum=momentum,
     )
     comp_pass = compare_results_batch_norm([tt_output], [torch_result])  # Check BN Result
-    # if training:
-    #     channels = input_shapes[1]
-    #     if check_mean:
-    #         comp_pass_1 = compare_results_batch_norm(
-    #             [tt_updated_mean], [mean_data.view(1, channels, 1, 1)]
-    #         )  # Check Updated running mean
-    #     else:
-    #         if tt_updated_mean is None:
-    #             comp_pass_1 = True
-    #         else:
-    #             comp_pass_1 = False
-    #     if check_var:
-    #         comp_pass_2 = compare_results_batch_norm(
-    #             [tt_updated_var], [var_data.view(1, channels, 1, 1)]
-    #         )  # Check Updated running var
-    #     else:
-    #         if tt_updated_var is None:
-    #             comp_pass_2 = True
-    #         else:
-    #             comp_pass_2 = False
-    #     comp_pass = comp_pass and comp_pass_1 and comp_pass_2
+    if training:
+        channels = input_shapes[1]
+        if check_mean:
+            comp_pass_1 = compare_results_batch_norm(
+                [tt_updated_mean], [mean_data.view(1, channels, 1, 1)], stats=True
+            )  # Check Updated running mean
+        else:
+            if tt_updated_mean is None:
+                comp_pass_1 = True
+            else:
+                comp_pass_1 = False
+        if check_var:
+            comp_pass_2 = compare_results_batch_norm(
+                [tt_updated_var], [var_data.view(1, channels, 1, 1)], stats=True
+            )  # Check Updated running var
+        else:
+            if tt_updated_var is None:
+                comp_pass_2 = True
+            else:
+                comp_pass_2 = False
+        comp_pass = comp_pass and comp_pass_1 and comp_pass_2
 
     assert comp_pass
 

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -15,38 +15,40 @@ from itertools import product
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
-        torch.Size([4, 4, 32, 32]),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
-        torch.Size([4, 4, 23, 23]),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
-        torch.Size([3, 1, 64, 120]),
+        # *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
+        # torch.Size([4, 4, 32, 32]),
+        # *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
+        # torch.Size([4, 4, 23, 23]),
+        # *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
+        # torch.Size([3, 1, 64, 120]),
         torch.Size([3, 2, 64, 120]),
     ],
 )
 @pytest.mark.parametrize(
     "training, check_mean, check_var",
     [
-        # (True, True, True),
-        # (True, True, False),
-        # (True, False, True),
-        (True, False, False),
-        (False, False, False),  # xfail case
-        (False, True, False),  # xfail case
-        (False, False, True),  # xfail case
-        (False, True, True),
+        (True, True, True),
+        # # (True, True, False),
+        # # (True, False, True),
+        # (True, False, False),
+        # (False, False, False),  # xfail case
+        # (False, True, False),  # xfail case
+        # (False, False, True),  # xfail case
+        # (False, True, True),
     ],
 )
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
-@pytest.mark.parametrize("momentum", [0.1, 0.0, 2.3])
+@pytest.mark.parametrize("momentum", [0.1, 0.0])
 def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device):
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = (
         data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if (check_mean) else (None, None)
     )
     var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device) if (check_var) else (None, None)
+    print("mean_tensor", mean_tensor)
+    print("var_tensor", var_tensor)
     weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if weight else (None, None)
     bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if bias else (None, None)
 
@@ -65,9 +67,8 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
     )
     tt_output = ttnn.to_torch(tt_output_tensor_on_device)
 
-    # tt_updated_mean = ttnn.to_torch(mean_tensor)
-    # tt_updated_var = ttnn.to_torch(var_tensor)
-
+    tt_updated_mean = ttnn.to_torch(mean_tensor)
+    tt_updated_var = ttnn.to_torch(var_tensor)
     # ttnn.set_printoptions(profile="full")
     # print("TT result : ", tt_output, tt_output.shape)
     # torch.set_printoptions(precision=5, sci_mode=False)
@@ -81,6 +82,14 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
         eps=eps,
         momentum=momentum,
     )
+    batch_mean = in_data.mean(dim=(0, 2, 3))
+    batch_var = in_data.var(dim=(0, 2, 3), unbiased=False)
+    print("Batch mean:", batch_mean)
+    print("Batch variance:", batch_var)
+    print("mean_data", mean_data)
+    print("tt_updated_mean", tt_updated_mean)
+    print("var_data", var_data)
+    print("tt_updated_var", tt_updated_var)
     # print("Torch result : ",torch_result)
     comp_pass = compare_results_batch_norm([tt_output], [torch_result])  # Check BN Result
     # if training :
@@ -88,6 +97,7 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
     #     comp_pass_1 = compare_results_batch_norm([tt_updated_mean], [mean_data.view(1, channels, 1, 1)]) # Check Updated running mean
     #     comp_pass_2 = compare_results_batch_norm([tt_updated_var], [var_data.view(1, channels, 1, 1)])  # Check Updated running var
     #     comp_pass = comp_pass and comp_pass_1 and comp_pass_2
+
     assert comp_pass
 
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -304,6 +304,8 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -5,10 +5,26 @@
 #include "batch_norm.hpp"
 
 #include "device/batch_norm_device_operation.hpp"
+#include "ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::normalization {
+
+inline Tensor mean_NHW(const Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config) {
+    auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
+    auto batch_mean = input_tensor;
+    ttnn::SmallVector<int64_t> dims = {0, 2, 3};
+    std::sort(dims.begin(), dims.end());
+    for (uint32_t i = dims.size() - 1; i > 0; i--) {
+        auto temp_output = ttnn::prim::moreh_mean(
+            batch_mean, dims[i], true, std::nullopt, std::nullopt, output_memory_config, std::nullopt);
+        batch_mean = temp_output;
+    }
+    return ttnn::prim::moreh_mean(
+        batch_mean, dims.front(), true, std::nullopt, std::nullopt, output_memory_config, std::nullopt);
+}
 
 Tensor BatchNorm::invoke(
     const Tensor& input,
@@ -21,10 +37,40 @@ Tensor BatchNorm::invoke(
     std::optional<Tensor> bias,
     std::optional<Tensor> output,
     const std::optional<MemoryConfig>& memory_config) {
+    if (training) {
+        Tensor batch_mean = mean_NHW(input, memory_config);
+        Tensor mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config);
+        Tensor batch_var =
+            ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
+        return ttnn::prim::batch_norm(
+            input,
+            batch_mean,
+            batch_var,
+            eps,
+            momentum,
+            training,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            output,
+            memory_config);
+    }
     TT_FATAL(
-        (running_mean.has_value() && running_var.has_value() && (!training)),
+        (running_mean.has_value() && running_var.has_value()),
         "running_mean and running_var must be defined in evaluation mode");
     return ttnn::prim::batch_norm(
-        input, running_mean.value(), running_var.value(), eps, momentum, training, weight, bias, output, memory_config);
+        input,
+        running_mean.value(),
+        running_var.value(),
+        eps,
+        momentum,
+        training,
+        weight,
+        bias,
+        std::nullopt,
+        std::nullopt,
+        output,
+        memory_config);
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -16,16 +16,15 @@ Tensor BatchNorm::invoke(
     std::optional<Tensor> running_var,
     const bool training,
     const float eps,
+    const float momentum,
     std::optional<Tensor> weight,
     std::optional<Tensor> bias,
     std::optional<Tensor> output,
     const std::optional<MemoryConfig>& memory_config) {
-    // TODO: Implementation for training mode is in progress
-    TT_FATAL((!training), "Support currently provided for inference mode only");
     TT_FATAL(
-        (running_mean.has_value() && running_var.has_value()),
+        (running_mean.has_value() && running_var.has_value() && (!training)),
         "running_mean and running_var must be defined in evaluation mode");
     return ttnn::prim::batch_norm(
-        input, running_mean.value(), running_var.value(), eps, weight, bias, output, memory_config);
+        input, running_mean.value(), running_var.value(), eps, momentum, training, weight, bias, output, memory_config);
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "batch_norm.hpp"
 
 #include "device/batch_norm_device_operation.hpp"
-#include "ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
 #include "device/running_statistics_device_operation.hpp"
 
@@ -14,17 +14,10 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::normalization {
 
 inline Tensor mean_NHW(const Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config) {
-    auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
-    auto batch_mean = input_tensor;
-    ttnn::SmallVector<int64_t> dims = {0, 2, 3};
-    std::sort(dims.begin(), dims.end());
-    for (uint32_t i = dims.size() - 1; i > 0; i--) {
-        auto temp_output = ttnn::prim::moreh_mean(
-            batch_mean, dims[i], true, std::nullopt, std::nullopt, output_memory_config, std::nullopt);
-        batch_mean = temp_output;
-    }
-    return ttnn::prim::moreh_mean(
-        batch_mean, dims.front(), true, std::nullopt, std::nullopt, output_memory_config, std::nullopt);
+    auto output_mem_config = memory_config.value_or(input_tensor.memory_config());
+    ttnn::SmallVector<int> dims = {2, 3};
+    Tensor mean_hw = ttnn::mean(input_tensor, dims, true);
+    return ttnn::mean(mean_hw, 0, true);
 }
 
 Tensor BatchNorm::invoke(
@@ -34,23 +27,23 @@ Tensor BatchNorm::invoke(
     const bool training,
     const float eps,
     const float momentum,
-    std::optional<Tensor> weight,
-    std::optional<Tensor> bias,
-    std::optional<Tensor> output,
+    const std::optional<Tensor>& weight,
+    const std::optional<Tensor>& bias,
+    const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config) {
+    Tensor batch_mean = mean_NHW(input, memory_config);
+    Tensor mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config);
+    Tensor batch_var = ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
     if (training) {
-        Tensor batch_mean = mean_NHW(input, memory_config);
-        Tensor mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config);
-        Tensor batch_var =
-            ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
         Tensor stats =
             ttnn::prim::running_statistics(batch_mean, batch_var, momentum, running_mean, running_var, memory_config);
-        return ttnn::prim::batch_norm(input, batch_mean, batch_var, eps, weight, bias, output, memory_config);
+    } else {
+        TT_FATAL(
+            (running_mean.has_value() && running_var.has_value()),
+            "running_mean and running_var must be defined in evaluation mode");
+        batch_mean = running_mean.value();
+        batch_var = running_var.value();
     }
-    TT_FATAL(
-        (running_mean.has_value() && running_var.has_value()),
-        "running_mean and running_var must be defined in evaluation mode");
-    return ttnn::prim::batch_norm(
-        input, running_mean.value(), running_var.value(), eps, weight, bias, output, memory_config);
+    return ttnn::prim::batch_norm(input, batch_mean, batch_var, eps, weight, bias, output, memory_config);
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -6,7 +6,7 @@
 
 #include "device/batch_norm_device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp"
-#include "ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp"
+#include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
 
 using namespace tt::tt_metal;
 
@@ -42,35 +42,12 @@ Tensor BatchNorm::invoke(
         Tensor mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config);
         Tensor batch_var =
             ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
-        return ttnn::prim::batch_norm(
-            input,
-            batch_mean,
-            batch_var,
-            eps,
-            momentum,
-            training,
-            weight,
-            bias,
-            running_mean,
-            running_var,
-            output,
-            memory_config);
+        return ttnn::prim::batch_norm(input, batch_mean, batch_var, eps, weight, bias, output, memory_config);
     }
     TT_FATAL(
         (running_mean.has_value() && running_var.has_value()),
         "running_mean and running_var must be defined in evaluation mode");
     return ttnn::prim::batch_norm(
-        input,
-        running_mean.value(),
-        running_var.value(),
-        eps,
-        momentum,
-        training,
-        weight,
-        bias,
-        std::nullopt,
-        std::nullopt,
-        output,
-        memory_config);
+        input, running_mean.value(), running_var.value(), eps, weight, bias, output, memory_config);
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -7,6 +7,7 @@
 #include "device/batch_norm_device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
+#include "device/running_statistics_device_operation.hpp"
 
 using namespace tt::tt_metal;
 
@@ -42,6 +43,8 @@ Tensor BatchNorm::invoke(
         Tensor mean_sq = mean_NHW(ttnn::square(input, memory_config), memory_config);
         Tensor batch_var =
             ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
+        Tensor stats =
+            ttnn::prim::running_statistics(batch_mean, batch_var, momentum, running_mean, running_var, memory_config);
         return ttnn::prim::batch_norm(input, batch_mean, batch_var, eps, weight, bias, output, memory_config);
     }
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
@@ -15,6 +15,7 @@ struct BatchNorm {
         std::optional<Tensor> running_var = std::nullopt,
         const bool training = false,
         const float eps = 1e-05,
+        const float momentum = 0.1,
         std::optional<Tensor> weight = std::nullopt,
         std::optional<Tensor> bias = std::nullopt,
         std::optional<Tensor> output = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,9 +16,9 @@ struct BatchNorm {
         const bool training = false,
         const float eps = 1e-05,
         const float momentum = 0.1,
-        std::optional<Tensor> weight = std::nullopt,
-        std::optional<Tensor> bias = std::nullopt,
-        std::optional<Tensor> output = std::nullopt,
+        const std::optional<Tensor>& weight = std::nullopt,
+        const std::optional<Tensor>& bias = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -14,7 +14,7 @@ void bind_batch_norm_operation(pybind11::module& module) {
         module,
         ttnn::batch_norm,
         R"doc(
-            Applies Spatial Batch Normalization over each channel on :attr:`input_tensor`. Inputs must be must be tilized and interleaved. Currently support is provided for inference mode only.
+            Applies Spatial Batch Normalization over each channel on :attr:`input_tensor`. Inputs must be must be tilized and interleaved.
 
 
         Args:
@@ -24,8 +24,8 @@ void bind_batch_norm_operation(pybind11::module& module) {
         Keyword args:
             eps (float, optional): Epsilon value. Defaults to `1e-05`.
             momentum (float, optional): Momentum value. Defaults to `0.1`.
-            running_mean (ttnn.Tensor, optional): the running_mean of shape `[1, C, 1, 1]`, required in inference mode . Defaults to `None`.
-            running_var (ttnn.Tensor, optional): the running_var of shape `[1, C, 1, 1]`, required in inference mode . Defaults to `None`.
+            running_mean (ttnn.Tensor, optional): the running_mean of shape `[1, C, 1, 1]`, required in inference mode. When in training mode, this tensor is optional and the updated running mean value is stored in-place based on the inputs provided. Defaults to `None`.
+            running_var (ttnn.Tensor, optional): the running_var of shape `[1, C, 1, 1]`, required in inference mode. When in training mode, this tensor is optional and the updated running variance value is stored in-place based on the inputs provided. Defaults to `None`.
             weight (ttnn.Tensor, optional): the weight or gamma value of shape `[1, C, 1, 1]`. Defaults to `None`.
             bias (ttnn.Tensor, optional): the bias or beta value of shape `[1, C, 1, 1]`. Defaults to `None`.
             training (bool, optional): Selection between training mode and inference (evaluation) mode. Defaults to `False` (Inference mode).

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -23,6 +23,7 @@ void bind_batch_norm_operation(pybind11::module& module) {
 
         Keyword args:
             eps (float, optional): Epsilon value. Defaults to `1e-05`.
+            momentum (float, optional): Momentum value. Defaults to `0.1`.
             running_mean (ttnn.Tensor, optional): the running_mean of shape `[1, C, 1, 1]`, required in inference mode . Defaults to `None`.
             running_var (ttnn.Tensor, optional): the running_var of shape `[1, C, 1, 1]`, required in inference mode . Defaults to `None`.
             weight (ttnn.Tensor, optional): the weight or gamma value of shape `[1, C, 1, 1]`. Defaults to `None`.
@@ -44,6 +45,7 @@ void bind_batch_norm_operation(pybind11::module& module) {
             py::arg("running_var") = std::nullopt,
             py::arg("training") = false,
             py::arg("eps") = 1e-05,
+            py::arg("momentum") = 0.1,
             py::arg("weight") = std::nullopt,
             py::arg("bias") = std::nullopt,
             py::arg("output") = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -123,11 +123,13 @@ std::tuple<BatchNormOperation::operation_attributes_t, BatchNormOperation::tenso
     const Tensor& batch_mean,
     const Tensor& batch_var,
     const float eps,
+    const float momentum,
+    const bool training,
     std::optional<Tensor> weight,
     std::optional<Tensor> bias,
     std::optional<Tensor> output,
     const std::optional<MemoryConfig>& memory_config) {
-    operation_attributes_t operation_attributes{eps, memory_config.value_or(input.memory_config())};
+    operation_attributes_t operation_attributes{eps, momentum, training, memory_config.value_or(input.memory_config())};
     tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
     return {operation_attributes, tensor_args};
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -10,7 +10,7 @@
 namespace ttnn::operations::normalization {
 void BatchNormOperation::validate_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& [input, batch_mean, batch_var, weight, bias, running_mean, running_var, output] = tensor_args;
+    const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
 
     check_tensor(input, "batch_norm", "input");
     check_tensor(batch_mean, "batch_norm", "batch_mean");
@@ -18,8 +18,6 @@ void BatchNormOperation::validate_tensors(
     check_tensor(weight, "batch_norm", "weight");
     check_tensor(bias, "batch_norm", "bias");
     check_tensor(output, "batch_norm", "output");
-    check_tensor(running_mean, "batch_norm", "running_mean");
-    check_tensor(running_var, "batch_norm", "running_var");
 
     // input (N, C, H, W)
     auto C = input.get_logical_shape()[1];
@@ -47,26 +45,6 @@ void BatchNormOperation::validate_tensors(
         TT_FATAL(bias.value().get_logical_shape()[1] == C, "bias_shape[1] must be the same as input's channel size.");
         TT_FATAL(bias.value().get_logical_shape()[1] == C, "bias_shape[1] must be the same as input's channel size.");
     }
-
-    // running_mean (1, C, 1, 1)
-    if (running_mean.has_value()) {
-        TT_FATAL(
-            running_mean.value().get_logical_shape()[1] == C,
-            "running_mean_shape[1] must be the same as input's channel size.");
-        TT_FATAL(
-            running_mean.value().get_logical_shape()[1] == C,
-            "running_mean_shape[1] must be the same as input's channel size.");
-    }
-
-    // running_var (1, C, 1, 1)
-    if (running_var.has_value()) {
-        TT_FATAL(
-            running_var.value().get_logical_shape()[1] == C,
-            "running_var_shape[1] must be the same as input's channel size.");
-        TT_FATAL(
-            running_var.value().get_logical_shape()[1] == C,
-            "running_var_shape[1] must be the same as input's channel size.");
-    }
 }
 
 BatchNormOperation::program_factory_t BatchNormOperation::select_program_factory(
@@ -76,8 +54,7 @@ BatchNormOperation::program_factory_t BatchNormOperation::select_program_factory
 
 void BatchNormOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-
-    const auto& [input, batch_mean, batch_var, weight, bias, running_mean, running_var, output] = tensor_args;
+    const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
 
     TT_FATAL(input.get_layout() == Layout::TILE, "Input tensor must be must be tilized");
     TT_FATAL(
@@ -108,20 +85,6 @@ void BatchNormOperation::validate_on_program_cache_miss(
         TT_FATAL(
             bias.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
             "bias tensor must be interleaved");
-    }
-
-    if (running_mean.has_value()) {
-        TT_FATAL(running_mean.value().get_layout() == Layout::TILE, "running_mean tensor must be tilized");
-        TT_FATAL(
-            running_mean.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
-            "running_mean tensor must be interleaved");
-    }
-
-    if (running_var.has_value()) {
-        TT_FATAL(running_var.value().get_layout() == Layout::TILE, "running_var tensor must be tilized");
-        TT_FATAL(
-            running_var.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
-            "running_var tensor must be interleaved");
     }
 
     validate_tensors(operation_attributes, tensor_args);
@@ -160,24 +123,12 @@ std::tuple<BatchNormOperation::operation_attributes_t, BatchNormOperation::tenso
     const Tensor& batch_mean,
     const Tensor& batch_var,
     const float eps,
-    const float momentum,
-    const bool training,
     std::optional<Tensor> weight,
     std::optional<Tensor> bias,
-    std::optional<Tensor> running_mean,
-    std::optional<Tensor> running_var,
     std::optional<Tensor> output,
     const std::optional<MemoryConfig>& memory_config) {
-    operation_attributes_t operation_attributes{eps, momentum, training, memory_config.value_or(input.memory_config())};
-    tensor_args_t tensor_args{
-        input,
-        batch_mean,
-        batch_var,
-        std::move(weight),
-        std::move(bias),
-        std::move(running_mean),
-        std::move(running_var),
-        std::move(output)};
+    operation_attributes_t operation_attributes{eps, memory_config.value_or(input.memory_config())};
+    tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
     return {operation_attributes, tensor_args};
 }
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -12,6 +12,8 @@ namespace ttnn::operations::normalization {
 struct BatchNormOperation {
     struct operation_attributes_t {
         const float eps;
+        const float momentum;
+        const bool training;
         const MemoryConfig memory_config;
 
         DataType input_dtype;
@@ -66,6 +68,8 @@ struct BatchNormOperation {
         const Tensor& batch_mean,
         const Tensor& batch_var,
         const float eps,
+        const float momentum,
+        const bool training,
         std::optional<Tensor> weight,
         std::optional<Tensor> bias,
         std::optional<Tensor> output,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -27,6 +27,8 @@ struct BatchNormOperation {
         const Tensor& batch_var;
         std::optional<Tensor> weight;
         std::optional<Tensor> bias;
+        std::optional<Tensor> running_mean;
+        std::optional<Tensor> running_var;
         std::optional<Tensor> output;
     };
 
@@ -72,6 +74,8 @@ struct BatchNormOperation {
         const bool training,
         std::optional<Tensor> weight,
         std::optional<Tensor> bias,
+        std::optional<Tensor> running_mean,
+        std::optional<Tensor> running_var,
         std::optional<Tensor> output,
         const std::optional<MemoryConfig>& memory_config);
 };

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -12,8 +12,6 @@ namespace ttnn::operations::normalization {
 struct BatchNormOperation {
     struct operation_attributes_t {
         const float eps;
-        const float momentum;
-        const bool training;
         const MemoryConfig memory_config;
 
         DataType input_dtype;
@@ -27,8 +25,6 @@ struct BatchNormOperation {
         const Tensor& batch_var;
         std::optional<Tensor> weight;
         std::optional<Tensor> bias;
-        std::optional<Tensor> running_mean;
-        std::optional<Tensor> running_var;
         std::optional<Tensor> output;
     };
 
@@ -70,12 +66,8 @@ struct BatchNormOperation {
         const Tensor& batch_mean,
         const Tensor& batch_var,
         const float eps,
-        const float momentum,
-        const bool training,
         std::optional<Tensor> weight,
         std::optional<Tensor> bias,
-        std::optional<Tensor> running_mean,
-        std::optional<Tensor> running_var,
         std::optional<Tensor> output,
         const std::optional<MemoryConfig>& memory_config);
 };

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -29,15 +29,11 @@ void set_or_update_runtime_arguments(
     const BatchNormOperation::tensor_args_t& tensor_args,
     BatchNormOperation::tensor_return_value_t& c,
     F handle_args) {
-    const auto& [a, b, d, e, f, g, h, _] = tensor_args;
+    const auto& [a, b, d, e, f, _] = tensor_args;
     const auto eps = operation_attributes.eps;
-    const auto momentum = operation_attributes.momentum;
 
     const bool weight_has_value = e.has_value();
     const bool bias_has_value = f.has_value();
-    const bool running_mean_has_value = g.has_value();
-    const bool running_var_has_value = h.has_value();
-    const bool is_training_mode = operation_attributes.training;
 
     const auto ashape = a.padded_shape();
     const auto bshape = b.padded_shape();
@@ -67,8 +63,8 @@ void set_or_update_runtime_arguments(
         } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
-            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 12>{0});
-            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 16>{0});
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 11>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 14>{0});
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
             continue;
         }
@@ -76,12 +72,8 @@ void set_or_update_runtime_arguments(
         uint32_t cHtWt = cHt * cWt;
         class bfloat16 bfloat_scalar_eps(eps);
         uint32_t packed_scalar_eps = pack_two_bfloat16_into_uint32({bfloat_scalar_eps, bfloat_scalar_eps});
-        class bfloat16 bfloat_scalar_momentum(momentum);
-        uint32_t packed_scalar_momentum =
-            pack_two_bfloat16_into_uint32({bfloat_scalar_momentum, bfloat_scalar_momentum});
         std::array reader_runtime_args = {
             packed_scalar_eps,
-            packed_scalar_momentum,
             a.buffer()->address(),
             start_tile_id,
             num_tiles_per_core,
@@ -96,15 +88,11 @@ void set_or_update_runtime_arguments(
 
         const auto weight_addr = weight_has_value ? e->buffer()->address() : 0;
         const auto bias_addr = bias_has_value ? f->buffer()->address() : 0;
-        const auto running_mean_addr = is_training_mode and running_mean_has_value ? g->buffer()->address() : 0;
-        const auto running_var_addr = is_training_mode and running_var_has_value ? h->buffer()->address() : 0;
         std::array writer_runtime_args = {
             b.buffer()->address(),  //  batch mean
             d.buffer()->address(),  //  batch var
             weight_addr,            // weight
             bias_addr,              // bias
-            running_mean_addr,      // old running mean
-            running_var_addr,       // old running var
             c.buffer()->address(),  // output
             start_tile_id,
             num_tiles_per_core,
@@ -138,7 +126,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     using namespace tt;
     using namespace tt::tt_metal;
 
-    const auto& [a, b, d, e, f, g, h, _] = tensor_args;
+    const auto& [a, b, d, e, f, _] = tensor_args;
 
     auto program = CreateProgram();
 
@@ -146,9 +134,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
 
     const bool weight_has_value = e.has_value();
     const bool bias_has_value = f.has_value();
-    const bool running_mean_has_value = g.has_value();
-    const bool running_var_has_value = h.has_value();
-    const bool is_training_mode = operation_attributes.training;
 
     auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
     auto b_data_format = datatype_to_dataformat_converter(b.get_dtype());
@@ -156,10 +141,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     auto d_data_format = datatype_to_dataformat_converter(d.get_dtype());
     auto e_data_format = weight_has_value ? datatype_to_dataformat_converter(e->get_dtype()) : DataFormat::Float16_b;
     auto f_data_format = bias_has_value ? datatype_to_dataformat_converter(f->get_dtype()) : DataFormat::Float16_b;
-    auto g_data_format = is_training_mode and running_mean_has_value ? datatype_to_dataformat_converter(g->get_dtype())
-                                                                     : DataFormat::Float16_b;
-    auto h_data_format = is_training_mode and running_var_has_value ? datatype_to_dataformat_converter(h->get_dtype())
-                                                                    : DataFormat::Float16_b;
 
     uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
     uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
@@ -167,8 +148,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     uint32_t d_single_tile_size = tt_metal::detail::TileSize(d_data_format);
     uint32_t e_single_tile_size = tt_metal::detail::TileSize(e_data_format);
     uint32_t f_single_tile_size = tt_metal::detail::TileSize(f_data_format);
-    uint32_t g_single_tile_size = tt_metal::detail::TileSize(g_data_format);
-    uint32_t h_single_tile_size = tt_metal::detail::TileSize(h_data_format);
 
     uint32_t num_output_tiles = output.volume() / output.tensor_spec().tile().get_tile_hw();
 
@@ -208,27 +187,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         tt::CBIndex::c_16, program, all_device_cores, e_single_tile_size, b_num_tiles_per_cb, e_data_format);  // weight
     auto [f_cb, f_cb_handle] = create_cb(
         tt::CBIndex::c_18, program, all_device_cores, f_single_tile_size, b_num_tiles_per_cb, f_data_format);  // bias
-    auto [momentum_cb, momentum_cb_handle] = create_cb(
-        tt::CBIndex::c_24,
-        program,
-        all_device_cores,
-        d_single_tile_size,
-        b_num_tiles_per_cb,
-        d_data_format);  // momentum
-    auto [g_cb, g_cb_handle] = create_cb(
-        tt::CBIndex::c_25,
-        program,
-        all_device_cores,
-        g_single_tile_size,
-        b_num_tiles_per_cb,
-        g_data_format);  // old running mean
-    auto [h_cb, h_cb_handle] = create_cb(
-        tt::CBIndex::c_26,
-        program,
-        all_device_cores,
-        h_single_tile_size,
-        b_num_tiles_per_cb,
-        h_data_format);  // old running var
 
     // Temporary buffers to store intermediate results
     auto [den_cb, den_cb_handle] = create_cb(
@@ -247,38 +205,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         a_data_format);  // to store input - batch_mean
     auto [temp_1_cb, temp_1_cb_handle] =
         create_cb(tt::CBIndex::c_17, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
-    auto [updated_m_cb, updated_m_cb_handle] = create_cb(
-        tt::CBIndex::c_27,
-        program,
-        all_device_cores,
-        g_single_tile_size,
-        b_num_tiles_per_cb,
-        g_data_format);  // updated running mean
-    auto [updated_v_cb, updated_v_cb_handle] = create_cb(
-        tt::CBIndex::c_28,
-        program,
-        all_device_cores,
-        h_single_tile_size,
-        b_num_tiles_per_cb,
-        h_data_format);  // updated running var
-
-    // Intermediate buffers required for uodation of running stats
-    auto [one_cb, one_cb_handle] = create_cb(
-        tt::CBIndex::c_19,
-        program,
-        all_device_cores,
-        h_single_tile_size,
-        b_num_tiles_per_cb,
-        h_data_format);  // to store 1
-
-    auto [tmp1_cb, tmp1_cb_handle] =
-        create_cb(tt::CBIndex::c_29, program, all_device_cores, h_single_tile_size, b_num_tiles_per_cb, h_data_format);
-
-    auto [tmp2_cb, tmp2_cb_handle] =
-        create_cb(tt::CBIndex::c_30, program, all_device_cores, h_single_tile_size, b_num_tiles_per_cb, h_data_format);
-
-    auto [tmp3_cb, tmp3_cb_handle] =
-        create_cb(tt::CBIndex::c_31, program, all_device_cores, h_single_tile_size, b_num_tiles_per_cb, h_data_format);
 
     auto a_is_dram = static_cast<uint32_t>(a.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     auto b_is_dram = static_cast<uint32_t>(b.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
@@ -286,10 +212,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     auto d_is_dram = static_cast<uint32_t>(d.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     const auto e_is_dram = weight_has_value and e->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     const auto f_is_dram = bias_has_value and f->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
-    const auto g_is_dram =
-        is_training_mode and running_mean_has_value and g->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
-    const auto h_is_dram =
-        is_training_mode and running_var_has_value and h->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
 
     // READER KERNEL
     auto reader_kernel_id = tt_metal::CreateKernel(
@@ -311,22 +233,13 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
             f_is_dram,
             static_cast<uint32_t>(weight_has_value),
             static_cast<uint32_t>(bias_has_value),
-            static_cast<uint32_t>(operation_attributes.training),
-            g_is_dram,
-            h_is_dram,
-            static_cast<uint32_t>(running_mean_has_value),
-            static_cast<uint32_t>(running_var_has_value),
         }));
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
                             c_data_format == tt::DataFormat::Float32;
     std::vector<uint32_t> compute_kernel_args = {
-        static_cast<uint32_t>(weight_has_value),
-        static_cast<uint32_t>(bias_has_value),
-        static_cast<uint32_t>(operation_attributes.training),
-        static_cast<uint32_t>(running_mean_has_value),
-        static_cast<uint32_t>(running_var_has_value)};
+        static_cast<uint32_t>(weight_has_value), static_cast<uint32_t>(bias_has_value)};
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp",

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -29,18 +29,18 @@ void set_or_update_runtime_arguments(
     const BatchNormOperation::tensor_args_t& tensor_args,
     BatchNormOperation::tensor_return_value_t& c,
     F handle_args) {
-    const auto& [a, b, d, e, f, _] = tensor_args;
+    const auto& [input_tensor, batch_mean_tensor, batch_var_tensor, weight_tensor, bias_tensor, _] = tensor_args;
     const auto eps = operation_attributes.eps;
 
-    const bool weight_has_value = e.has_value();
-    const bool bias_has_value = f.has_value();
+    const bool weight_has_value = weight_tensor.has_value();
+    const bool bias_has_value = bias_tensor.has_value();
 
-    const auto ashape = a.padded_shape();
-    const auto bshape = b.padded_shape();
+    const auto ashape = input_tensor.padded_shape();
+    const auto bshape = batch_mean_tensor.padded_shape();
     const auto cshape = c.padded_shape();
 
-    const auto [aN, aC, aHt, aWt] = extract_shape_dims(a);
-    const auto [bN, bC, bHt, bWt] = extract_shape_dims(b);
+    const auto [aN, aC, aHt, aWt] = extract_shape_dims(input_tensor);
+    const auto [bN, bC, bHt, bWt] = extract_shape_dims(batch_mean_tensor);
     const auto [cN, cC, cHt, cWt] = extract_shape_dims(c);
 
     uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
@@ -54,6 +54,9 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+    constexpr size_t num_reader_args = 11;
+    constexpr size_t num_writer_args = 14;
+    constexpr size_t num_kernel_args = 3;
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
         const auto& core = cores[i];
 
@@ -63,9 +66,9 @@ void set_or_update_runtime_arguments(
         } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
-            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 11>{0});
-            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 14>{0});
-            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, num_reader_args>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, num_writer_args>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, num_kernel_args>{0});
             continue;
         }
 
@@ -74,7 +77,7 @@ void set_or_update_runtime_arguments(
         uint32_t packed_scalar_eps = pack_two_bfloat16_into_uint32({bfloat_scalar_eps, bfloat_scalar_eps});
         std::array reader_runtime_args = {
             packed_scalar_eps,
-            a.buffer()->address(),
+            input_tensor.buffer()->address(),
             start_tile_id,
             num_tiles_per_core,
             cHtWt,
@@ -86,14 +89,14 @@ void set_or_update_runtime_arguments(
             cWt};
         handle_args(program, reader_kernel_id, core, reader_runtime_args);
 
-        const auto weight_addr = weight_has_value ? e->buffer()->address() : 0;
-        const auto bias_addr = bias_has_value ? f->buffer()->address() : 0;
+        const auto weight_addr = weight_has_value ? weight_tensor->buffer()->address() : 0;
+        const auto bias_addr = bias_has_value ? bias_tensor->buffer()->address() : 0;
         std::array writer_runtime_args = {
-            b.buffer()->address(),  //  batch mean
-            d.buffer()->address(),  //  batch var
-            weight_addr,            // weight
-            bias_addr,              // bias
-            c.buffer()->address(),  // output
+            batch_mean_tensor.buffer()->address(),  //  batch mean
+            batch_var_tensor.buffer()->address(),   //  batch var
+            weight_addr,                            // weight
+            bias_addr,                              // bias
+            c.buffer()->address(),                  // output
             start_tile_id,
             num_tiles_per_core,
             cHtWt,
@@ -126,21 +129,23 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     using namespace tt;
     using namespace tt::tt_metal;
 
-    const auto& [a, b, d, e, f, _] = tensor_args;
+    const auto& [input_tensor, batch_mean_tensor, batch_var_tensor, weight_tensor, bias_tensor, _] = tensor_args;
 
     auto program = CreateProgram();
 
-    auto* device = a.device();
+    auto* device = input_tensor.device();
 
-    const bool weight_has_value = e.has_value();
-    const bool bias_has_value = f.has_value();
+    const bool weight_has_value = weight_tensor.has_value();
+    const bool bias_has_value = bias_tensor.has_value();
 
-    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
-    auto b_data_format = datatype_to_dataformat_converter(b.get_dtype());
+    auto a_data_format = datatype_to_dataformat_converter(input_tensor.get_dtype());
+    auto b_data_format = datatype_to_dataformat_converter(batch_mean_tensor.get_dtype());
     auto c_data_format = datatype_to_dataformat_converter(output.get_dtype());
-    auto d_data_format = datatype_to_dataformat_converter(d.get_dtype());
-    auto e_data_format = weight_has_value ? datatype_to_dataformat_converter(e->get_dtype()) : DataFormat::Float16_b;
-    auto f_data_format = bias_has_value ? datatype_to_dataformat_converter(f->get_dtype()) : DataFormat::Float16_b;
+    auto d_data_format = datatype_to_dataformat_converter(batch_var_tensor.get_dtype());
+    auto e_data_format =
+        weight_has_value ? datatype_to_dataformat_converter(weight_tensor->get_dtype()) : DataFormat::Float16_b;
+    auto f_data_format =
+        bias_has_value ? datatype_to_dataformat_converter(bias_tensor->get_dtype()) : DataFormat::Float16_b;
 
     uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
     uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
@@ -206,12 +211,12 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     auto [temp_1_cb, temp_1_cb_handle] =
         create_cb(tt::CBIndex::c_17, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
 
-    auto a_is_dram = static_cast<uint32_t>(a.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
-    auto b_is_dram = static_cast<uint32_t>(b.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
+    auto a_is_dram = static_cast<uint32_t>(input_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
+    auto b_is_dram = static_cast<uint32_t>(batch_mean_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     auto c_is_dram = static_cast<uint32_t>(output.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
-    auto d_is_dram = static_cast<uint32_t>(d.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
-    const auto e_is_dram = weight_has_value and e->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
-    const auto f_is_dram = bias_has_value and f->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
+    auto d_is_dram = static_cast<uint32_t>(batch_var_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
+    const auto e_is_dram = weight_has_value and weight_tensor->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
+    const auto f_is_dram = bias_has_value and bias_tensor->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
 
     // READER KERNEL
     auto reader_kernel_id = tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -262,6 +262,39 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         b_num_tiles_per_cb,
         h_data_format);  // updated running var
 
+    // Intermediate buffer
+    auto [one_cb, one_cb_handle] = create_cb(
+        tt::CBIndex::c_19,
+        program,
+        all_device_cores,
+        h_single_tile_size,
+        b_num_tiles_per_cb,
+        h_data_format);  // to store 1
+
+    auto [tmp1_cb, tmp1_cb_handle] = create_cb(
+        tt::CBIndex::c_29,
+        program,
+        all_device_cores,
+        h_single_tile_size,
+        b_num_tiles_per_cb,
+        h_data_format);  // to store tmp
+
+    auto [tmp2_cb, tmp2_cb_handle] = create_cb(
+        tt::CBIndex::c_30,
+        program,
+        all_device_cores,
+        h_single_tile_size,
+        b_num_tiles_per_cb,
+        h_data_format);  // to store tmp
+
+    auto [tmp3_cb, tmp3_cb_handle] = create_cb(
+        tt::CBIndex::c_31,
+        program,
+        all_device_cores,
+        h_single_tile_size,
+        b_num_tiles_per_cb,
+        h_data_format);  // to store tmp
+
     auto a_is_dram = static_cast<uint32_t>(a.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     auto b_is_dram = static_cast<uint32_t>(b.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     auto c_is_dram = static_cast<uint32_t>(output.buffer()->buffer_type() == tt_metal::BufferType::DRAM);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -262,7 +262,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         b_num_tiles_per_cb,
         h_data_format);  // updated running var
 
-    // Intermediate buffer
+    // Intermediate buffers required for uodation of running stats
     auto [one_cb, one_cb_handle] = create_cb(
         tt::CBIndex::c_19,
         program,
@@ -271,29 +271,14 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         b_num_tiles_per_cb,
         h_data_format);  // to store 1
 
-    auto [tmp1_cb, tmp1_cb_handle] = create_cb(
-        tt::CBIndex::c_29,
-        program,
-        all_device_cores,
-        h_single_tile_size,
-        b_num_tiles_per_cb,
-        h_data_format);  // to store tmp
+    auto [tmp1_cb, tmp1_cb_handle] =
+        create_cb(tt::CBIndex::c_29, program, all_device_cores, h_single_tile_size, b_num_tiles_per_cb, h_data_format);
 
-    auto [tmp2_cb, tmp2_cb_handle] = create_cb(
-        tt::CBIndex::c_30,
-        program,
-        all_device_cores,
-        h_single_tile_size,
-        b_num_tiles_per_cb,
-        h_data_format);  // to store tmp
+    auto [tmp2_cb, tmp2_cb_handle] =
+        create_cb(tt::CBIndex::c_30, program, all_device_cores, h_single_tile_size, b_num_tiles_per_cb, h_data_format);
 
-    auto [tmp3_cb, tmp3_cb_handle] = create_cb(
-        tt::CBIndex::c_31,
-        program,
-        all_device_cores,
-        h_single_tile_size,
-        b_num_tiles_per_cb,
-        h_data_format);  // to store tmp
+    auto [tmp3_cb, tmp3_cb_handle] =
+        create_cb(tt::CBIndex::c_31, program, all_device_cores, h_single_tile_size, b_num_tiles_per_cb, h_data_format);
 
     auto a_is_dram = static_cast<uint32_t>(a.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     auto b_is_dram = static_cast<uint32_t>(b.buffer()->buffer_type() == tt_metal::BufferType::DRAM);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -39,6 +39,7 @@ void MAIN {
     uint32_t tile_start = get_arg_val<uint32_t>(2);
     constexpr uint32_t weight_has_value = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t bias_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t is_training_mode = get_compile_time_arg_val(2) == 1;
 
     if (num_tiles == 0) {
         return;
@@ -115,6 +116,10 @@ void MAIN {
         cb_pop_front(cb_num, 1);
         cb_pop_front(cb_den, 1);
         cb_push_back(cb_affine_or_out, onetile);
+
+        if constexpr (is_training_mode) {
+            // update running stats here
+        }
 
         if constexpr (weight_has_value) {  // result = result * weight
             cb_reserve_back(cb_scaled_output, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -128,8 +128,9 @@ void MAIN {
         cb_pop_front(cb_den, 1);
         cb_push_back(cb_affine_or_out, onetile);
 
+        // Updation of running stats
         if constexpr (is_training_mode) {
-            // updated running stats
+            // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
             if constexpr (old_running_mean_has_value) {
                 sub_tiles_to_cb(cb_one, cb_momentum, cb_tmp1, tile_id, 0, 0, 0);           // 1 - momentum
                 mul_tiles_to_cb(cb_momentum, cb_batch_mean, cb_tmp2, 0, tile_id, 0, 0);    // momentum * running stats
@@ -141,7 +142,6 @@ void MAIN {
                 sub_tiles_to_cb(cb_one, cb_momentum, cb_tmp1, tile_id, 0, 0, 0);          // 1 - momentum
                 mul_tiles_to_cb(cb_momentum, cb_batch_var, cb_tmp2, 0, tile_id, 0, 0);    // momentum * batch stat
                 mul_tiles_to_cb(cb_tmp1, cb_old_running_var, cb_tmp3, 0, tile_id, 0, 1);  // cb_tmp1 * running stats
-                DPRINT << TSLICE(tt::CBIndex::c_26, 0, SliceRange::hw0_32_16()) << ENDL();
                 add_tiles_to_cb(cb_tmp2, cb_tmp3, cb_updated_running_var, 0, 0, 1, 1);
             }
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -9,28 +9,128 @@
 
 namespace NAMESPACE {
 
-ALWI void subtract_bcast_tiles(
-    uint32_t cb_bcast, uint32_t cb_other, uint32_t cb_out, uint32_t freq, uint32_t tile_start) {
+ALWI void batchnorm_bcast_tiles(
+    uint32_t cb_bcast,
+    uint32_t cb_other,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t cb_batch_var,
+    uint32_t cb_eps,
+    uint32_t cb_den,
+    uint32_t cb_num,
+    uint32_t cb_weight,
+    uint32_t cb_bias,
+    uint32_t cb_tmp_1,
+    uint32_t cb_output_0,
+    uint32_t weight_has,
+    uint32_t bias_has) {
     constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    uint32_t weight_has_value = weight_has;
+    uint32_t bias_has_value = bias_has;
+    auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
+    auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
 
     cb_wait_front(cb_bcast, onetile);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
         cb_wait_front(cb_other, onetile);
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_num, onetile);
 
         tile_regs_acquire();
         sub_tiles(cb_other, cb_bcast, 0, 0, 0);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile(0, cb_out);
+        pack_tile(0, cb_num);
         tile_regs_release();
 
-        cb_push_back(cb_out, onetile);
+        cb_push_back(cb_num, onetile);
         cb_pop_front(cb_other, onetile);
     }
     cb_pop_front(cb_bcast, onetile);
+
+    // 1/(sqrt(batch_var + eps))
+    cb_reserve_back(cb_den, onetile);
+    cb_wait_front(cb_batch_var, 1);
+    cb_wait_front(cb_eps, 1);
+
+    tile_regs_acquire();
+    add_tiles_init_with_dt(cb_batch_var, cb_eps);
+    add_tiles(cb_batch_var, cb_eps, 0, 0, dst0);
+    rsqrt_tile_init();
+    rsqrt_tile(dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile_with_dt(dst0, cb_den);
+    tile_regs_release();
+
+    cb_pop_front(cb_batch_var, 1);
+    cb_pop_front(cb_eps, 1);
+    cb_push_back(cb_den, onetile);
+
+    // (input - batch_mean)/(sqrt(batch_var + eps)) = result
+    cb_wait_front(cb_den, 1);
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        cb_wait_front(cb_num, 1);
+        cb_reserve_back(cb_affine_or_out, onetile);
+
+        tile_regs_acquire();
+        mul_tiles_init_with_dt(cb_num, cb_den);
+        mul_tiles(cb_num, cb_den, 0, 0, dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_affine_or_out);
+        tile_regs_release();
+
+        cb_pop_front(cb_num, 1);
+        cb_push_back(cb_affine_or_out, onetile);
+    }
+    cb_pop_front(cb_den, 1);
+
+    if (weight_has_value) {  // result = result * weight
+        cb_wait_front(cb_weight, 1);
+        for (uint32_t j = tile_start; j < freq; ++j) {
+            cb_reserve_back(cb_scaled_output, onetile);
+            cb_wait_front(cb_affine_or_out, 1);
+
+            tile_regs_acquire();
+            mul_tiles_init_with_dt(cb_affine_or_out, cb_weight);
+            mul_tiles(cb_affine_or_out, cb_weight, 0, 0, dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_with_dt(dst0, cb_scaled_output);
+            tile_regs_release();
+
+            cb_pop_front(cb_affine_or_out, 1);
+
+            cb_push_back(cb_scaled_output, onetile);
+        }
+        cb_pop_front(cb_weight, 1);
+    }
+    if (bias_has_value) {  // result = result + bias
+        cb_wait_front(cb_bias, 1);
+        for (uint32_t j = tile_start; j < freq; ++j) {
+            cb_reserve_back(cb_output_0, 1);
+            cb_wait_front(cb_tmp_1, 1);
+
+            tile_regs_acquire();
+            add_tiles_init_with_dt(cb_tmp_1, cb_bias);
+            add_tiles(cb_tmp_1, cb_bias, 0, 0, dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_with_dt(dst0, cb_output_0);
+            tile_regs_release();
+
+            cb_pop_front(cb_tmp_1, 1);
+            cb_push_back(cb_output_0, 1);
+        }
+        cb_pop_front(cb_bias, 1);
+    }
 }
 
 void MAIN {
@@ -61,97 +161,45 @@ void MAIN {
 
     binary_op_init_common(cb_bcast, cb_other, cb_output_0);
 
-    // input - batch_mean
     sub_tiles_init();
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
-        subtract_bcast_tiles(cb_bcast, cb_other, cb_num, tile_freq, tile_start);
+        batchnorm_bcast_tiles(
+            cb_bcast,
+            cb_other,
+            tile_freq,
+            tile_start,
+            cb_batch_var,
+            cb_eps,
+            cb_den,
+            cb_num,
+            cb_weight,
+            cb_bias,
+            cb_tmp_1,
+            cb_output_0,
+            weight_has_value,
+            bias_has_value);
     }
     if (remaining_iterations > 0) {
-        subtract_bcast_tiles(cb_bcast, cb_other, cb_num, remaining_iterations, tile_start);
+        batchnorm_bcast_tiles(
+            cb_bcast,
+            cb_other,
+            remaining_iterations,
+            tile_start,
+            cb_batch_var,
+            cb_eps,
+            cb_den,
+            cb_num,
+            cb_weight,
+            cb_bias,
+            cb_tmp_1,
+            cb_output_0,
+            weight_has_value,
+            bias_has_value);
     }
 
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
-
-    constexpr auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
-    constexpr auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
-    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        // 1/(sqrt(batch_var + eps))
-        cb_reserve_back(cb_den, onetile);
-        cb_wait_front(cb_batch_var, 1);
-        cb_wait_front(cb_eps, 1);
-
-        tile_regs_acquire();
-        add_tiles_init_with_dt(cb_batch_var, cb_eps);
-        add_tiles(cb_batch_var, cb_eps, 0, 0, dst0);
-        rsqrt_tile_init();
-        rsqrt_tile(dst0);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_den);
-        tile_regs_release();
-
-        cb_pop_front(cb_batch_var, 1);
-        cb_pop_front(cb_eps, 1);
-        cb_push_back(cb_den, onetile);
-
-        // (input - batch_mean)/(sqrt(batch_var + eps)) = result
-        cb_reserve_back(cb_affine_or_out, onetile);
-        cb_wait_front(cb_num, 1);
-        cb_wait_front(cb_den, 1);
-
-        tile_regs_acquire();
-        mul_tiles_init_with_dt(cb_num, cb_den);
-        mul_tiles(cb_num, cb_den, 0, 0, dst0);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_affine_or_out);
-        tile_regs_release();
-
-        cb_pop_front(cb_num, 1);
-        cb_pop_front(cb_den, 1);
-        cb_push_back(cb_affine_or_out, onetile);
-
-        if constexpr (weight_has_value) {  // result = result * weight
-            cb_reserve_back(cb_scaled_output, onetile);
-            cb_wait_front(cb_affine_or_out, 1);
-            cb_wait_front(cb_weight, 1);
-
-            tile_regs_acquire();
-            mul_tiles_init_with_dt(cb_affine_or_out, cb_weight);
-            mul_tiles(cb_affine_or_out, cb_weight, 0, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_scaled_output);
-            tile_regs_release();
-
-            cb_pop_front(cb_affine_or_out, 1);
-            cb_pop_front(cb_weight, 1);
-            cb_push_back(cb_scaled_output, onetile);
-        }
-        if constexpr (bias_has_value) {  // result = result + bias
-            cb_reserve_back(cb_output_0, 1);
-            cb_wait_front(cb_tmp_1, 1);
-            cb_wait_front(cb_bias, 1);
-
-            tile_regs_acquire();
-            add_tiles_init_with_dt(cb_tmp_1, cb_bias);
-            add_tiles(cb_tmp_1, cb_bias, 0, 0, dst0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_output_0);
-            tile_regs_release();
-
-            cb_pop_front(cb_tmp_1, 1);
-            cb_pop_front(cb_bias, 1);
-            cb_push_back(cb_output_0, 1);
-        }
-    }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -40,6 +40,8 @@ void MAIN {
     constexpr uint32_t weight_has_value = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t bias_has_value = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t is_training_mode = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t old_running_var_has_value = get_compile_time_arg_val(4) == 1;
 
     if (num_tiles == 0) {
         return;
@@ -56,6 +58,11 @@ void MAIN {
     constexpr auto cb_weight = tt::CBIndex::c_16;    // weight tensor
     constexpr auto cb_tmp_1 = tt::CBIndex::c_17;     // (input - batch_mean)/(sqrt(batch_var + eps))
     constexpr auto cb_bias = tt::CBIndex::c_18;      // bias tensor
+    constexpr auto cb_old_running_mean = tt::CBIndex::c_25;  // old running mean tensor
+    constexpr auto cb_old_running_var = tt::CBIndex::c_26;   // old running var tensor
+    constexpr auto cb_updated_running_mean = tt::CBIndex::c_27;  // updated running mean tensor
+    constexpr auto cb_updated_running_var = tt::CBIndex::c_28;   // updated running var tensor
+    constexpr auto cb_momentum = tt::CBIndex::c_24;              // momentum
 
     auto cb_bcast = cb_batch_mean;
     auto cb_other = cb_input;
@@ -118,7 +125,12 @@ void MAIN {
         cb_push_back(cb_affine_or_out, onetile);
 
         if constexpr (is_training_mode) {
-            // update running stats here
+            // updated running stats
+            if constexpr (old_running_mean_has_value) {
+            }
+
+            if constexpr (old_running_var_has_value) {
+            }
         }
 
         if constexpr (weight_has_value) {  // result = result * weight

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "dprint.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t old_running_var_has_value = get_compile_time_arg_val(1) == 1;
+
+    constexpr auto cb_batch_mean = tt::CBIndex::c_0;  // batch mean
+    constexpr auto cb_batch_var = tt::CBIndex::c_1;   // batch var
+    constexpr auto cb_out0 = tt::CBIndex::c_2;
+    constexpr auto cb_old_running_mean = tt::CBIndex::c_3;       // old running mean tensor
+    constexpr auto cb_old_running_var = tt::CBIndex::c_4;        // old running var tensor
+    constexpr auto cb_updated_running_mean = tt::CBIndex::c_27;  // updated running mean tensor
+    constexpr auto cb_updated_running_var = tt::CBIndex::c_28;   // updated running var tensor
+    constexpr auto cb_momentum = tt::CBIndex::c_5;               // momentum
+    constexpr auto cb_one = tt::CBIndex::c_6;                    // stores 1
+    constexpr auto cb_tmp1 = tt::CBIndex::c_21;                  // tmp 1
+    constexpr auto cb_tmp2 = tt::CBIndex::c_22;                  // tmp 2
+    constexpr auto cb_tmp3 = tt::CBIndex::c_23;                  // tmp 3
+
+    binary_op_init_common(cb_batch_mean, cb_batch_var, cb_out0);
+    constexpr uint32_t onetile = 1;
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        tile_regs_acquire();
+        // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
+        cb_wait_front(cb_one, 1);
+        cb_wait_front(cb_momentum, 1);
+
+        if constexpr (old_running_mean_has_value) {
+            sub_tiles_to_cb(cb_one, cb_momentum, cb_tmp1, 0, 0, 0, 0);               // 1 - momentum
+            mul_tiles_to_cb(cb_momentum, cb_batch_mean, cb_tmp2, 0, 0, 0, 1);        // momentum * batch stat
+            mul_tiles_to_cb(cb_tmp1, cb_old_running_mean, cb_tmp3, 0, 0, 1, 1);      // cb_tmp1 * running stats
+            add_tiles_to_cb(cb_tmp2, cb_tmp3, cb_updated_running_mean, 0, 0, 1, 1);  // cb_tmp2 * cb_tmp3
+        }
+        if constexpr (old_running_var_has_value) {
+            sub_tiles_to_cb(cb_one, cb_momentum, cb_tmp1, 0, 0, 0, 0);              // 1 - momentum
+            mul_tiles_to_cb(cb_momentum, cb_batch_var, cb_tmp2, 0, 0, 0, 1);        // momentum * batch stat
+            mul_tiles_to_cb(cb_tmp1, cb_old_running_var, cb_tmp3, 0, 0, 1, 1);      // cb_tmp1 * running stats
+            add_tiles_to_cb(cb_tmp2, cb_tmp3, cb_updated_running_var, 0, 0, 1, 1);  // cb_tmp2 * cb_tmp3
+        }
+        cb_pop_front(cb_one, 1);
+        cb_pop_front(cb_momentum, 1);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_out0);
+        tile_regs_release();
+        cb_push_back(cb_out0, 1);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/tile_move_copy.h"
-#include "dprint.h"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
 
 namespace NAMESPACE {
@@ -48,12 +47,12 @@ void MAIN {
             mul_tiles_to_cb(cb_tmp1, cb_old_running_var, cb_tmp3, 0, 0, 1, 1);      // cb_tmp1 * running stats
             add_tiles_to_cb(cb_tmp2, cb_tmp3, cb_updated_running_var, 0, 0, 1, 1);  // cb_tmp2 * cb_tmp3
         }
-        cb_pop_front(cb_one, 1);
-        cb_pop_front(cb_momentum, 1);
         tile_regs_commit();
         tile_regs_wait();
         pack_tile(0, cb_out0);
         tile_regs_release();
+        cb_pop_front(cb_one, 1);
+        cb_pop_front(cb_momentum, 1);
         cb_push_back(cb_out0, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -10,14 +10,15 @@
 
 void kernel_main() {
     const auto eps = get_arg_val<uint32_t>(0);
-    uint32_t src_addr = get_arg_val<uint32_t>(1);  // input tensor
-    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
-    uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t HtWt = get_arg_val<uint32_t>(4);
-    uint32_t n_stride = get_arg_val<uint32_t>(5);
-    uint32_t c_stride = get_arg_val<uint32_t>(6);
-    uint32_t N = get_arg_val<uint32_t>(7);
-    uint32_t C = get_arg_val<uint32_t>(8);
+    const auto momentum = get_arg_val<uint32_t>(1);
+    uint32_t src_addr = get_arg_val<uint32_t>(2);  // input tensor
+    uint32_t start_tile_id = get_arg_val<uint32_t>(3);
+    uint32_t num_tiles = get_arg_val<uint32_t>(4);
+    uint32_t HtWt = get_arg_val<uint32_t>(5);
+    uint32_t n_stride = get_arg_val<uint32_t>(6);
+    uint32_t c_stride = get_arg_val<uint32_t>(7);
+    uint32_t N = get_arg_val<uint32_t>(8);
+    uint32_t C = get_arg_val<uint32_t>(9);
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 
@@ -40,6 +41,12 @@ void kernel_main() {
     cb_reserve_back(cb_id_eps, onetile);
     fill_with_val_bfloat16(cb_id_eps, eps);
     cb_push_back(cb_id_eps, onetile);
+
+    constexpr auto cb_id_momentum = tt::CBIndex::c_24;
+
+    cb_reserve_back(cb_id_momentum, onetile);
+    fill_with_val_bfloat16(cb_id_momentum, momentum);
+    cb_push_back(cb_id_momentum, onetile);
 
     // Input tile offset
     uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -37,13 +37,19 @@ void kernel_main() {
     uint32_t start_t = start_remaining % HtWt;
 
     constexpr auto cb_id_eps = tt::CBIndex::c_4;
+    constexpr auto cb_id_one = tt::CBIndex::c_19;
 
     cb_reserve_back(cb_id_eps, onetile);
     fill_with_val_bfloat16(cb_id_eps, eps);
     cb_push_back(cb_id_eps, onetile);
 
     constexpr auto cb_id_momentum = tt::CBIndex::c_24;
-
+    union {
+        float f;
+        uint32_t u;
+    } scalar;
+    scalar.f = 1.0f;
+    fill_cb_with_value(cb_id_one, scalar.u);
     cb_reserve_back(cb_id_momentum, onetile);
     fill_with_val_bfloat16(cb_id_momentum, momentum);
     cb_push_back(cb_id_momentum, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -10,15 +10,14 @@
 
 void kernel_main() {
     const auto eps = get_arg_val<uint32_t>(0);
-    const auto momentum = get_arg_val<uint32_t>(1);
-    uint32_t src_addr = get_arg_val<uint32_t>(2);  // input tensor
-    uint32_t start_tile_id = get_arg_val<uint32_t>(3);
-    uint32_t num_tiles = get_arg_val<uint32_t>(4);
-    uint32_t HtWt = get_arg_val<uint32_t>(5);
-    uint32_t n_stride = get_arg_val<uint32_t>(6);
-    uint32_t c_stride = get_arg_val<uint32_t>(7);
-    uint32_t N = get_arg_val<uint32_t>(8);
-    uint32_t C = get_arg_val<uint32_t>(9);
+    uint32_t src_addr = get_arg_val<uint32_t>(1);  // input tensor
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 
@@ -37,23 +36,10 @@ void kernel_main() {
     uint32_t start_t = start_remaining % HtWt;
 
     constexpr auto cb_id_eps = tt::CBIndex::c_4;
-    constexpr auto cb_id_one = tt::CBIndex::c_19;
-    constexpr auto cb_id_momentum = tt::CBIndex::c_24;
 
     cb_reserve_back(cb_id_eps, onetile);
     fill_with_val_bfloat16(cb_id_eps, eps);
     cb_push_back(cb_id_eps, onetile);
-
-    union {
-        float f;
-        uint32_t u;
-    } scalar;
-    scalar.f = 1.0f;
-    fill_cb_with_value(cb_id_one, scalar.u);
-
-    cb_reserve_back(cb_id_momentum, onetile);
-    fill_with_val_bfloat16(cb_id_momentum, momentum);
-    cb_push_back(cb_id_momentum, onetile);
 
     // Input tile offset
     uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -38,18 +38,19 @@ void kernel_main() {
 
     constexpr auto cb_id_eps = tt::CBIndex::c_4;
     constexpr auto cb_id_one = tt::CBIndex::c_19;
+    constexpr auto cb_id_momentum = tt::CBIndex::c_24;
 
     cb_reserve_back(cb_id_eps, onetile);
     fill_with_val_bfloat16(cb_id_eps, eps);
     cb_push_back(cb_id_eps, onetile);
 
-    constexpr auto cb_id_momentum = tt::CBIndex::c_24;
     union {
         float f;
         uint32_t u;
     } scalar;
     scalar.f = 1.0f;
     fill_cb_with_value(cb_id_one, scalar.u);
+
     cb_reserve_back(cb_id_momentum, onetile);
     fill_with_val_bfloat16(cb_id_momentum, momentum);
     cb_push_back(cb_id_momentum, onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
 
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const auto momentum = get_arg_val<uint32_t>(0);
+    uint32_t src_addr = get_arg_val<uint32_t>(1);  // input tensor
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_momentum = tt::CBIndex::c_5;
+    constexpr auto cb_id_one = tt::CBIndex::c_6;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
+
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    union {
+        float f;
+        uint32_t u;
+    } scalar;
+    scalar.f = 1.0f;
+    fill_cb_with_value(cb_id_one, scalar.u);
+
+    cb_reserve_back(cb_id_momentum, onetile);
+    fill_with_val_bfloat16(cb_id_momentum, momentum);
+    cb_push_back(cb_id_momentum, onetile);
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
+            for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_src, onetile);
+            }
+            tile_offset += next_channel_shift;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -70,6 +70,7 @@ void kernel_main() {
 
     constexpr bool weight_has_value = get_compile_time_arg_val(5) == 1;
     constexpr bool bias_has_value = get_compile_time_arg_val(6) == 1;
+    constexpr bool is_training_mode = get_compile_time_arg_val(7) == 1;
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
@@ -116,6 +117,10 @@ void kernel_main() {
                 noc_async_read_barrier();
                 fill_tile_with_first_element_bfloat16(cb_id_bias);
                 cb_push_back(cb_id_bias, onetile);
+            }
+
+            // to read running stats value for updation
+            if constexpr (is_training_mode) {
             }
 
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -12,14 +12,16 @@ void kernel_main() {
     uint32_t batch_var_addr = get_arg_val<uint32_t>(1);  // batch_var
     uint32_t weight_addr = get_arg_val<uint32_t>(2);     // weight
     uint32_t bias_addr = get_arg_val<uint32_t>(3);       // bias
-    uint32_t dst_addr = get_arg_val<uint32_t>(4);        // output
-    uint32_t start_tile_id = get_arg_val<uint32_t>(5);
-    uint32_t num_tiles = get_arg_val<uint32_t>(6);
-    uint32_t HtWt = get_arg_val<uint32_t>(7);
-    uint32_t n_stride = get_arg_val<uint32_t>(8);
-    uint32_t c_stride = get_arg_val<uint32_t>(9);
-    uint32_t N = get_arg_val<uint32_t>(10);
-    uint32_t C = get_arg_val<uint32_t>(11);
+    uint32_t old_running_mean_addr = get_arg_val<uint32_t>(4);  // old running_mean
+    uint32_t old_running_var_addr = get_arg_val<uint32_t>(5);   // ols running_var
+    uint32_t dst_addr = get_arg_val<uint32_t>(6);               // output
+    uint32_t start_tile_id = get_arg_val<uint32_t>(7);
+    uint32_t num_tiles = get_arg_val<uint32_t>(8);
+    uint32_t HtWt = get_arg_val<uint32_t>(9);
+    uint32_t n_stride = get_arg_val<uint32_t>(10);
+    uint32_t c_stride = get_arg_val<uint32_t>(11);
+    uint32_t N = get_arg_val<uint32_t>(12);
+    uint32_t C = get_arg_val<uint32_t>(13);
 
     constexpr uint32_t onetile = 1;
 
@@ -72,6 +74,33 @@ void kernel_main() {
     constexpr bool bias_has_value = get_compile_time_arg_val(6) == 1;
     constexpr bool is_training_mode = get_compile_time_arg_val(7) == 1;
 
+    // old running mean
+    constexpr auto cb_id_old_running_mean = tt::CBIndex::c_25;
+    constexpr bool old_running_mean_is_dram = get_compile_time_arg_val(8) == 1;
+    const uint32_t old_running_mean_tile_bytes = get_tile_size(cb_id_old_running_mean);
+    const DataFormat old_running_mean_data_format = get_dataformat(cb_id_old_running_mean);
+
+    const InterleavedAddrGenFast<old_running_mean_is_dram> old_running_mean = {
+        .bank_base_address = old_running_mean_addr,
+        .page_size = old_running_mean_tile_bytes,
+        .data_format = old_running_mean_data_format};
+
+    // old running var
+    constexpr auto cb_id_old_running_var = tt::CBIndex::c_26;
+    constexpr bool old_running_var_is_dram = get_compile_time_arg_val(9) == 1;
+    const uint32_t old_running_var_tile_bytes = get_tile_size(cb_id_old_running_var);
+    const DataFormat old_running_var_data_format = get_dataformat(cb_id_old_running_var);
+
+    const InterleavedAddrGenFast<old_running_var_is_dram> old_running_var = {
+        .bank_base_address = old_running_var_addr,
+        .page_size = old_running_var_tile_bytes,
+        .data_format = old_running_var_data_format};
+
+    constexpr bool old_running_mean_has_value = get_compile_time_arg_val(10) == 1;
+    constexpr bool old_running_var_has_value = get_compile_time_arg_val(11) == 1;
+    constexpr auto cb_id_updated_running_mean = tt::CBIndex::c_27;
+    constexpr auto cb_id_updated_running_var = tt::CBIndex::c_28;
+
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
     uint32_t start_remaining = start_tile_id % tiles_per_batch;
@@ -121,6 +150,39 @@ void kernel_main() {
 
             // to read running stats value for updation
             if constexpr (is_training_mode) {
+                if constexpr (old_running_mean_has_value) {
+                    // read data
+                    cb_reserve_back(cb_id_old_running_mean, onetile);
+                    uint32_t l1_old_running_mean_write_addr = get_write_ptr(cb_id_old_running_mean);
+                    noc_async_read_tile(tile_offset, old_running_mean, l1_old_running_mean_write_addr);
+                    noc_async_read_barrier();
+                    fill_tile_with_first_element_bfloat16(cb_id_old_running_mean);
+                    cb_push_back(cb_id_old_running_mean, onetile);
+
+                    // write data
+                    cb_wait_front(cb_id_updated_running_mean, onetile);
+                    uint32_t l1_write_updated_mean_addr = get_read_ptr(cb_id_updated_running_mean);
+                    noc_async_write_tile(tile_offset, old_running_mean, l1_write_updated_mean_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_updated_running_mean, onetile);
+                }
+
+                if constexpr (old_running_var_has_value) {
+                    // read data
+                    cb_reserve_back(cb_id_old_running_var, onetile);
+                    uint32_t l1_old_running_var_write_addr = get_write_ptr(cb_id_old_running_var);
+                    noc_async_read_tile(tile_offset, old_running_var, l1_old_running_var_write_addr);
+                    noc_async_read_barrier();
+                    fill_tile_with_first_element_bfloat16(cb_id_old_running_var);
+                    cb_push_back(cb_id_old_running_var, onetile);
+
+                    // write data
+                    cb_wait_front(cb_id_updated_running_var, onetile);
+                    uint32_t l1_write_updated_var_addr = get_read_ptr(cb_id_updated_running_var);
+                    noc_async_write_tile(tile_offset, old_running_var, l1_write_updated_var_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_updated_running_var, onetile);
+                }
             }
 
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -148,7 +148,7 @@ void kernel_main() {
                 cb_push_back(cb_id_bias, onetile);
             }
 
-            // to read running stats value for updation
+            // Updation of running stats
             if constexpr (is_training_mode) {
                 if constexpr (old_running_mean_has_value) {
                     // read data

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);               // batch_var
+    uint32_t old_running_mean_addr = get_arg_val<uint32_t>(1);  // old running_mean
+    uint32_t old_running_var_addr = get_arg_val<uint32_t>(2);   // ols running_var
+    uint32_t dst_addr = get_arg_val<uint32_t>(3);               // output
+    uint32_t start_tile_id = get_arg_val<uint32_t>(4);
+    uint32_t num_tiles = get_arg_val<uint32_t>(5);
+    uint32_t HtWt = get_arg_val<uint32_t>(6);
+    uint32_t n_stride = get_arg_val<uint32_t>(7);
+    uint32_t c_stride = get_arg_val<uint32_t>(8);
+    uint32_t N = get_arg_val<uint32_t>(9);
+    uint32_t C = get_arg_val<uint32_t>(10);
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    // old running mean
+    constexpr auto cb_id_old_running_mean = tt::CBIndex::c_3;
+    constexpr bool old_running_mean_is_dram = get_compile_time_arg_val(2) == 1;
+    const uint32_t old_running_mean_tile_bytes = get_tile_size(cb_id_old_running_mean);
+    const DataFormat old_running_mean_data_format = get_dataformat(cb_id_old_running_mean);
+
+    const InterleavedAddrGenFast<old_running_mean_is_dram> old_running_mean = {
+        .bank_base_address = old_running_mean_addr,
+        .page_size = old_running_mean_tile_bytes,
+        .data_format = old_running_mean_data_format};
+
+    // old running var
+    constexpr auto cb_id_old_running_var = tt::CBIndex::c_4;
+    constexpr bool old_running_var_is_dram = get_compile_time_arg_val(3) == 1;
+    const uint32_t old_running_var_tile_bytes = get_tile_size(cb_id_old_running_var);
+    const DataFormat old_running_var_data_format = get_dataformat(cb_id_old_running_var);
+
+    const InterleavedAddrGenFast<old_running_var_is_dram> old_running_var = {
+        .bank_base_address = old_running_var_addr,
+        .page_size = old_running_var_tile_bytes,
+        .data_format = old_running_var_data_format};
+
+    constexpr bool old_running_mean_has_value = get_compile_time_arg_val(4) == 1;
+    constexpr bool old_running_var_has_value = get_compile_time_arg_val(5) == 1;
+    constexpr auto cb_id_updated_running_mean = tt::CBIndex::c_27;
+    constexpr auto cb_id_updated_running_var = tt::CBIndex::c_28;
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
+            for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
+                // read a tile from src
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset, src, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_src, onetile);
+
+                if constexpr (old_running_mean_has_value) {
+                    // read data
+                    cb_reserve_back(cb_id_old_running_mean, onetile);
+                    uint32_t l1_old_running_mean_write_addr = get_write_ptr(cb_id_old_running_mean);
+                    noc_async_read_tile(tile_offset, old_running_mean, l1_old_running_mean_write_addr);
+                    noc_async_read_barrier();
+                    fill_tile_with_first_element_bfloat16(cb_id_old_running_mean);
+                    cb_push_back(cb_id_old_running_mean, onetile);
+
+                    // write data
+                    cb_wait_front(cb_id_updated_running_mean, onetile);
+                    uint32_t l1_write_updated_mean_addr = get_read_ptr(cb_id_updated_running_mean);
+                    noc_async_write_tile(tile_offset, old_running_mean, l1_write_updated_mean_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_updated_running_mean, onetile);
+                }
+
+                if constexpr (old_running_var_has_value) {
+                    // read data
+                    cb_reserve_back(cb_id_old_running_var, onetile);
+                    uint32_t l1_old_running_var_write_addr = get_write_ptr(cb_id_old_running_var);
+                    noc_async_read_tile(tile_offset, old_running_var, l1_old_running_var_write_addr);
+                    noc_async_read_barrier();
+                    fill_tile_with_first_element_bfloat16(cb_id_old_running_var);
+                    cb_push_back(cb_id_old_running_var, onetile);
+
+                    // write data
+                    cb_wait_front(cb_id_updated_running_var, onetile);
+                    uint32_t l1_write_updated_var_addr = get_read_ptr(cb_id_updated_running_var);
+                    noc_async_write_tile(tile_offset, old_running_var, l1_write_updated_var_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_updated_running_var, onetile);
+                }
+                ++tile_offset;
+
+                // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                cb_wait_front(cb_id_dst, onetile);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_dst, onetile);
+            }
+            tile_offset += next_channel_shift;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);               // batch_var
     uint32_t old_running_mean_addr = get_arg_val<uint32_t>(1);  // old running_mean
-    uint32_t old_running_var_addr = get_arg_val<uint32_t>(2);   // ols running_var
+    uint32_t old_running_var_addr = get_arg_val<uint32_t>(2);   // old running_var
     uint32_t dst_addr = get_arg_val<uint32_t>(3);               // output
     uint32_t start_tile_id = get_arg_val<uint32_t>(4);
     uint32_t num_tiles = get_arg_val<uint32_t>(5);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "running_statistics_device_operation.hpp"
+
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::normalization {
+void RunningStatistics::validate_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& [batch_mean, batch_var, running_mean, running_var] = tensor_args;
+
+    check_tensor(batch_mean, "running_statistics", "batch_mean");
+    check_tensor(batch_var, "running_statistics", "batch_var");
+    check_tensor(running_mean, "running_statistics", "running_mean");
+    check_tensor(running_var, "running_statistics", "running_var");
+
+    // mean (1, C, 1, 1)
+    auto C = batch_mean.get_logical_shape()[1];
+    // var (1, C, 1, 1)
+    TT_FATAL(batch_var.get_logical_shape()[1] == C, "batch_var_shape[1] must be the same as input's channel size.");
+
+    // running_mean (1, C, 1, 1)
+    if (running_mean.has_value()) {
+        TT_FATAL(
+            running_mean.value().get_logical_shape()[1] == C,
+            "running_mean_shape[1] must be the same as input's channel size.");
+        TT_FATAL(
+            running_mean.value().get_logical_shape()[1] == C,
+            "running_mean_shape[1] must be the same as input's channel size.");
+    }
+
+    // running_var (1, C, 1, 1)
+    if (running_var.has_value()) {
+        TT_FATAL(
+            running_var.value().get_logical_shape()[1] == C,
+            "running_var_shape[1] must be the same as input's channel size.");
+        TT_FATAL(
+            running_var.value().get_logical_shape()[1] == C,
+            "running_var_shape[1] must be the same as input's channel size.");
+    }
+}
+
+RunningStatistics::program_factory_t RunningStatistics::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return RunningStatisticsFactory();
+}
+
+void RunningStatistics::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& [batch_mean, batch_var, running_mean, running_var] = tensor_args;
+
+    TT_FATAL(batch_mean.get_layout() == Layout::TILE, "batch_mean tensor must be tilized");
+    TT_FATAL(
+        batch_mean.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "batch_mean tensor must be interleaved");
+
+    TT_FATAL(batch_var.get_layout() == Layout::TILE, "batch_var tensor must be tilized");
+    TT_FATAL(
+        batch_var.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "batch_var tensor must be interleaved");
+
+    if (running_mean.has_value()) {
+        TT_FATAL(running_mean.value().get_layout() == Layout::TILE, "running_mean tensor must be tilized");
+        TT_FATAL(
+            running_mean.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "running_mean tensor must be interleaved");
+    }
+
+    if (running_var.has_value()) {
+        TT_FATAL(running_var.value().get_layout() == Layout::TILE, "running_var tensor must be tilized");
+        TT_FATAL(
+            running_var.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "running_var tensor must be interleaved");
+    }
+
+    validate_tensors(operation_attributes, tensor_args);
+};
+
+void RunningStatistics::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_tensors(operation_attributes, tensor_args);
+};
+
+DataType RunningStatistics::operation_attributes_t::get_dtype() const {
+    return this->dtype.value_or(this->input_dtype);
+}
+
+RunningStatistics::spec_return_value_t RunningStatistics::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+    const auto output_shape = tensor_args.batch_mean.get_logical_shape();
+    return TensorSpec(
+        output_shape,
+        TensorLayout(operation_attributes.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
+}
+
+RunningStatistics::tensor_return_value_t RunningStatistics::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.batch_mean.device());
+}
+
+std::tuple<RunningStatistics::operation_attributes_t, RunningStatistics::tensor_args_t> RunningStatistics::invoke(
+    const Tensor& batch_mean,
+    const Tensor& batch_var,
+    const float momentum,
+    std::optional<Tensor> running_mean,
+    std::optional<Tensor> running_var,
+    const std::optional<MemoryConfig>& memory_config) {
+    operation_attributes_t operation_attributes{momentum, memory_config.value_or(batch_mean.memory_config())};
+    tensor_args_t tensor_args{batch_mean, batch_var, std::move(running_mean), std::move(running_var)};
+    return {operation_attributes, tensor_args};
+}
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -45,7 +45,7 @@ void RunningStatistics::validate_tensors(
 
 RunningStatistics::program_factory_t RunningStatistics::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return RunningStatisticsFactory();
+    return RunningStatisticsProgramFactory();
 }
 
 void RunningStatistics::validate_on_program_cache_miss(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::normalization {
+struct RunningStatistics {
+    struct operation_attributes_t {
+        const float momentum;
+        const MemoryConfig memory_config;
+
+        DataType input_dtype;
+        std::optional<DataType> dtype;
+        DataType get_dtype() const;
+    };
+
+    struct tensor_args_t {
+        const Tensor& batch_mean;
+        const Tensor& batch_var;
+        std::optional<Tensor> running_mean;
+        std::optional<Tensor> running_var;
+    };
+
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct RunningStatisticsFactory {
+        struct shared_variables_t {
+            tt::tt_metal::KernelHandle reader_kernel_id;
+            tt::tt_metal::KernelHandle writer_kernel_id;
+            tt::tt_metal::KernelHandle compute_kernel_id;
+            CoreCoord compute_with_storage_grid_size;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<RunningStatisticsFactory>;
+
+    static void validate_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& batch_mean,
+        const Tensor& batch_var,
+        const float momentum,
+        std::optional<Tensor> running_mean,
+        std::optional<Tensor> running_var,
+        const std::optional<MemoryConfig>& memory_config);
+};
+}  // namespace ttnn::operations::normalization
+
+namespace ttnn::prim {
+constexpr auto running_statistics =
+    ttnn::register_operation<"ttnn::prim::running_statistics", ttnn::operations::normalization::RunningStatistics>();
+}

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,7 +29,7 @@ struct RunningStatistics {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    struct RunningStatisticsFactory {
+    struct RunningStatisticsProgramFactory {
         struct shared_variables_t {
             tt::tt_metal::KernelHandle reader_kernel_id;
             tt::tt_metal::KernelHandle writer_kernel_id;
@@ -51,7 +51,7 @@ struct RunningStatistics {
             tensor_return_value_t& output);
     };
 
-    using program_factory_t = std::variant<RunningStatisticsFactory>;
+    using program_factory_t = std::variant<RunningStatisticsProgramFactory>;
 
     static void validate_tensors(const operation_attributes_t&, const tensor_args_t&);
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "running_statistics_device_operation.hpp"
+
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/cb_utils.hpp"
+#include <cmath>
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace ttnn::operations::normalization;
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};
+}
+
+template <typename F>
+void set_or_update_runtime_arguments(
+    Program& program,
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    KernelHandle compute_kernel_id,
+    CoreCoord compute_with_storage_grid_size,
+    const RunningStatistics::operation_attributes_t& operation_attributes,
+    const RunningStatistics::tensor_args_t& tensor_args,
+    RunningStatistics::tensor_return_value_t& c,
+    F handle_args) {
+    const auto& [a, b, d, e] = tensor_args;
+    const auto momentum = operation_attributes.momentum;
+
+    const bool running_mean_has_value = d.has_value();
+    const bool running_var_has_value = e.has_value();
+
+    const auto ashape = a.padded_shape();
+    const auto bshape = b.padded_shape();
+    const auto cshape = c.padded_shape();
+
+    const auto [aN, aC, aHt, aWt] = extract_shape_dims(a);
+    const auto [bN, bC, bHt, bWt] = extract_shape_dims(b);
+    const auto [cN, cC, cHt, cWt] = extract_shape_dims(c);
+
+    uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
+
+    constexpr bool row_major = true;
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
+
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        const auto& core = cores[i];
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 11>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 13>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
+            continue;
+        }
+
+        uint32_t cHtWt = cHt * cWt;
+        class bfloat16 bfloat_scalar_momentum(momentum);
+        uint32_t packed_scalar_momentum =
+            pack_two_bfloat16_into_uint32({bfloat_scalar_momentum, bfloat_scalar_momentum});
+        std::array reader_runtime_args = {
+            packed_scalar_momentum,
+            a.buffer()->address(),
+            start_tile_id,
+            num_tiles_per_core,
+            cHtWt,
+            aHt * aWt * aC * (aN > 1),
+            aHt * aWt * (aC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt};
+        handle_args(program, reader_kernel_id, core, reader_runtime_args);
+
+        const auto running_mean_addr = running_mean_has_value ? d->buffer()->address() : 0;
+        const auto running_var_addr = running_var_has_value ? e->buffer()->address() : 0;
+        std::array writer_runtime_args = {
+            b.buffer()->address(),  //  batch var
+            running_mean_addr,      // old running mean
+            running_var_addr,       // old running var
+            c.buffer()->address(),  // output
+            start_tile_id,
+            num_tiles_per_core,
+            cHtWt,
+            bHt * bWt * bC * (bN > 1),
+            bHt * bWt * (bC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt};
+        handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+        auto counter = start_tile_id % cHtWt;
+        auto freq = cHtWt;
+
+        std::array compute_runtime_args = {num_tiles_per_core, freq, counter};
+        handle_args(program, compute_kernel_id, core, compute_runtime_args);
+
+        start_tile_id += num_tiles_per_core;
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::normalization {
+RunningStatistics::RunningStatisticsFactory::cached_program_t RunningStatistics::RunningStatisticsFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& [a, b, d, e] = tensor_args;
+
+    auto program = CreateProgram();
+
+    auto* device = a.device();
+
+    const bool running_mean_has_value = d.has_value();
+    const bool running_var_has_value = e.has_value();
+
+    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    auto b_data_format = datatype_to_dataformat_converter(b.get_dtype());
+    auto c_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    auto d_data_format =
+        running_mean_has_value ? datatype_to_dataformat_converter(d->get_dtype()) : DataFormat::Float16_b;
+    auto e_data_format =
+        running_var_has_value ? datatype_to_dataformat_converter(e->get_dtype()) : DataFormat::Float16_b;
+
+    uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
+    uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
+    uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
+    uint32_t d_single_tile_size = tt_metal::detail::TileSize(d_data_format);
+    uint32_t e_single_tile_size = tt_metal::detail::TileSize(e_data_format);
+
+    uint32_t num_output_tiles = output.volume() / output.tensor_spec().tile().get_tile_hw();
+
+    // we parallelize the computation across the output tiles
+    constexpr bool row_major = true;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    // Number of tiles to store per input CB (double buffer)
+    constexpr uint32_t num_tiles_per_cb = 2;
+    uint32_t b_num_tiles_per_cb = num_tiles_per_cb;
+
+    // Input buffers
+    auto [a_cb, a_cb_handle] = create_cb(
+        tt::CBIndex::c_0,
+        program,
+        all_device_cores,
+        a_single_tile_size,
+        num_tiles_per_cb,
+        a_data_format);  // batch_mean
+    auto [b_cb, b_cb_handle] = create_cb(
+        tt::CBIndex::c_1,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_num_tiles_per_cb,
+        b_data_format);  // batch_var
+    auto [c_cb, c_cb_handle] = create_cb(
+        tt::CBIndex::c_2, program, all_device_cores, c_single_tile_size, num_tiles_per_cb, c_data_format);  // output
+    auto [d_cb, d_cb_handle] = create_cb(
+        tt::CBIndex::c_3,
+        program,
+        all_device_cores,
+        d_single_tile_size,
+        b_num_tiles_per_cb,
+        d_data_format);  // old running mean
+    auto [e_cb, e_cb_handle] = create_cb(
+        tt::CBIndex::c_4,
+        program,
+        all_device_cores,
+        e_single_tile_size,
+        b_num_tiles_per_cb,
+        e_data_format);  // old running var
+    auto [f_cb, f_cb_handle] = create_cb(
+        tt::CBIndex::c_5,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_num_tiles_per_cb,
+        b_data_format);  // momentum
+    auto [one_cb, one_cb_handle] = create_cb(
+        tt::CBIndex::c_6,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_num_tiles_per_cb,
+        b_data_format);  // to store 1
+    auto [updated_m_cb, updated_m_cb_handle] = create_cb(
+        tt::CBIndex::c_27,
+        program,
+        all_device_cores,
+        d_single_tile_size,
+        b_num_tiles_per_cb,
+        d_data_format);  // updated running mean
+    auto [updated_v_cb, updated_v_cb_handle] = create_cb(
+        tt::CBIndex::c_28,
+        program,
+        all_device_cores,
+        e_single_tile_size,
+        b_num_tiles_per_cb,
+        e_data_format);  // updated running var
+
+    // Intermediate buffers required for uodation of running stats
+
+    auto [tmp1_cb, tmp1_cb_handle] =
+        create_cb(tt::CBIndex::c_21, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+
+    auto [tmp2_cb, tmp2_cb_handle] =
+        create_cb(tt::CBIndex::c_22, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+
+    auto [tmp3_cb, tmp3_cb_handle] =
+        create_cb(tt::CBIndex::c_23, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+
+    auto a_is_dram = static_cast<uint32_t>(a.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
+    auto b_is_dram = static_cast<uint32_t>(b.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
+    auto c_is_dram = static_cast<uint32_t>(output.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
+    const auto d_is_dram = running_mean_has_value and d->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
+    const auto e_is_dram = running_var_has_value and e->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
+
+    // READER KERNEL
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp",
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram}));
+
+    // WRITER KERNEL
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp",
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig({
+            b_is_dram,
+            c_is_dram,
+            d_is_dram,
+            e_is_dram,
+            static_cast<uint32_t>(running_mean_has_value),
+            static_cast<uint32_t>(running_var_has_value),
+        }));
+
+    // COMPUTE KERNEL
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32;
+    std::vector<uint32_t> compute_kernel_args = {
+        static_cast<uint32_t>(running_mean_has_value), static_cast<uint32_t>(running_var_has_value)};
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp",
+        all_device_cores,
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+
+    auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        compute_kernel_id,
+        compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        output,
+        set_runtime_args);
+
+    return {
+        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+}
+
+void RunningStatistics::RunningStatisticsFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        auto& all_args = GetRuntimeArgs(program, kernel_id);
+        auto& core_args = all_args.at(core.x).at(core.y);
+        std::copy(args.begin(), args.end(), core_args.data());
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
+        cached_program.shared_variables.compute_kernel_id,
+        cached_program.shared_variables.compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        output,
+        update_args);
+}
+
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -120,7 +120,8 @@ void set_or_update_runtime_arguments(
 }  // namespace
 
 namespace ttnn::operations::normalization {
-RunningStatistics::RunningStatisticsFactory::cached_program_t RunningStatistics::RunningStatisticsFactory::create(
+RunningStatistics::RunningStatisticsProgramFactory::cached_program_t
+RunningStatistics::RunningStatisticsProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -291,7 +292,7 @@ RunningStatistics::RunningStatisticsFactory::cached_program_t RunningStatistics:
         std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
 }
 
-void RunningStatistics::RunningStatisticsFactory::override_runtime_arguments(
+void RunningStatistics::RunningStatisticsProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,


### PR DESCRIPTION
### List of Github issues

- https://github.com/tenstorrent/tt-metal/issues/12253 
- https://github.com/tenstorrent/tt-metal/issues/15449
- https://github.com/tenstorrent/tt-metal/issues/16186

### Problem description
To implement batch normalization as device op

### What's changed
Work done : 

- Provided support for Training mode

### Checklist
All test have passed
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12929324369)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12929326611)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) -  [Link to test](https://github.com/tenstorrent/tt-metal/actions/runs/12929328486)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/12929329915)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/12929331234)
- [x] [Single-card Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/12929332745)

