### PR TITLE
Build wheels in ttnn unit tests workflow because the tests need it and we forgot to put it in

### DIFF
--- a/.github/workflows/ttnn-post-commit-wrapper.yaml
+++ b/.github/workflows/ttnn-post-commit-wrapper.yaml
@@ -11,8 +11,22 @@ jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-  ttnn-unit-tests:
+  build-wheels:
     needs: build-artifact
+    strategy:
+      matrix:
+        # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
+        # The full 22.04 flow can be tested without precompiled
+        os: [ubuntu-20.04]
+        arch: [grayskull, wormhole_b0]
+    uses: ./.github/workflows/_build-wheels-impl.yaml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      from-precompiled: true
+    secrets: inherit
+  ttnn-unit-tests:
+    needs: build-wheels
     secrets: inherit
     strategy:
       fail-fast: false
@@ -24,5 +38,5 @@ jobs:
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
-      arch: ${{ matrix.test-group.arch}}
+      arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}


### PR DESCRIPTION
…

### Ticket

Quick change to fix ttnn unit tests.

### Problem description

We needed the wheel to run the tests because we run in Docker now.

### What's changed

We added the build-wheels job before the ttnn unit tests run.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
