### PR TITLE
lower fabric erisc datamover eth context switching frequency when workload is running

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -116,13 +116,6 @@ struct KernelXY {
 
 enum Correctness { Correct, Incorrect };
 
-struct EthLinkBuilder {
-    ttnn::ccl::FabricEriscDatamoverBuilder sender_edm_builder;
-    ttnn::ccl::FabricEriscDatamoverBuilder receiver_edm_builder;
-    tt_xy_pair sender_core;
-    tt_xy_pair receiver_core;
-};
-
 template <typename CONTAINER_T>
 Correctness run_output_check(CONTAINER_T const& inputs, CONTAINER_T output_buffer) {
     constexpr bool debug_mode = true;
@@ -1066,6 +1059,7 @@ void setup_test_with_persistent_fabric(
 
     line_fabric = ttnn::ccl::EdmLineFabricOpInterface(
         devices, fabric_program_ptrs, enable_persistent_fabric, num_links.value_or(1));
+    line_fabric->set_firmware_context_switch_interval(0);
 
     if (enable_persistent_fabric) {
         TT_FATAL(fabric_programs.has_value(), "Fabric programs must be set if fabric is enabled");
@@ -1237,6 +1231,7 @@ int TestLoopbackEntrypoint(
         remote_chip_id,
         edm_config,
         enable_persistent_fabric);
+    chip_0_edm_builder.set_firmware_context_switch_interval(0);
     auto chip_1_edm_builder = ttnn::ccl::FabricEriscDatamoverBuilder::build(
         receiver_device,
         fabric_receiver_program,
@@ -1245,6 +1240,7 @@ int TestLoopbackEntrypoint(
         local_chip_id,
         edm_config,
         enable_persistent_fabric);
+    chip_1_edm_builder.set_firmware_context_switch_interval(0);
     // Create the loopback connection on the second device
     chip_1_edm_builder.connect_to_downstream_edm(chip_1_edm_builder);
     auto local_edm_kernel = ttnn::ccl::generate_edm_kernel(

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -210,6 +210,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
     log_trace(tt::LogTest, "Receiver num buffers: {}", this->receiver_num_buffers);
     log_trace(tt::LogTest, "Receiver channel address: {}", this->local_receiver_channel_buffer_address);
     return std::vector<uint32_t>{
+        this->firmware_context_switch_interval,
         is_handshake_master,
         this->handshake_address,
         this->channel_buffer_size,
@@ -711,6 +712,10 @@ void FabricEriscDatamoverBuilder::teardown_from_host(IDevice*d, tt::fabric::Term
         CoreType::ETH);}, true);
 }
 
+void FabricEriscDatamoverBuilder::set_firmware_context_switch_interval(size_t interval) {
+    this->firmware_context_switch_interval = interval;
+}
+
 void EdmLineFabricOpInterface::teardown_from_host(tt::fabric::TerminationSignal termination_signal) const {
     for (IDevice*d : this->device_sequence) {
         if (edm_builders_forward_direction.find(d->id()) != edm_builders_forward_direction.end()) {
@@ -722,6 +727,19 @@ void EdmLineFabricOpInterface::teardown_from_host(tt::fabric::TerminationSignal 
             for (auto& edm_builder : edm_builders_backward_direction.at(d->id())) {
                 edm_builder.teardown_from_host(d, termination_signal);
             }
+        }
+    }
+}
+
+void EdmLineFabricOpInterface::set_firmware_context_switch_interval(size_t interval) {
+    for (auto& edm_builder : edm_builders_forward_direction) {
+        for (auto& builder : edm_builder.second) {
+            builder.set_firmware_context_switch_interval(interval);
+        }
+    }
+    for (auto& edm_builder : edm_builders_backward_direction) {
+        for (auto& builder : edm_builder.second) {
+            builder.set_firmware_context_switch_interval(interval);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -258,7 +258,7 @@ enum PacketLocalForwardType : uint8_t {
     PACKET_FORWARD_LOCAL_AND_REMOTE = 0x3
 };
 
-static constexpr uint32_t SWITCH_INTERVAL = 0;
+static constexpr uint32_t SWITCH_INTERVAL = get_compile_time_arg_val(0);
 static constexpr size_t ETH_BYTES_TO_WORDS_SHIFT = 4;
 static constexpr size_t NUM_SENDER_CHANNELS = 2;
 static constexpr size_t num_workers_ctor = 1;
@@ -747,8 +747,8 @@ void kernel_main() {
     //
     // COMMON CT ARGS (not specific to sender or receiver)
     //
-    static constexpr bool is_handshake_sender = get_compile_time_arg_val(0) != 0;
-    static constexpr size_t handshake_addr = get_compile_time_arg_val(1);
+    static constexpr bool is_handshake_sender = get_compile_time_arg_val(1) != 0;
+    static constexpr size_t handshake_addr = get_compile_time_arg_val(2);
     *reinterpret_cast<volatile uint32_t*>(handshake_addr) = 0;
     auto eth_transaction_ack_word_addr = handshake_addr + sizeof(eth_channel_sync_t);
 
@@ -764,26 +764,26 @@ void kernel_main() {
     // the size of one of the buffers within a sender channel
     // For example if `channel_buffer_size` = 4k, with `SENDER_NUM_BUFFERS` = 2
     // then the total amount of buffering for that
-    static constexpr size_t channel_buffer_size = get_compile_time_arg_val(2);
+    static constexpr size_t channel_buffer_size = get_compile_time_arg_val(3);
 
-    static constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(3);
-    static constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(4);
-    static constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(5);
-    static constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(6);
-    static constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(7);
-    static constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(8);
-    static constexpr size_t local_receiver_channel_buffer_address = get_compile_time_arg_val(9);
-    static constexpr size_t remote_receiver_channel_buffer_address = get_compile_time_arg_val(10);
-    static constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(11);
-    static constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(12);
+    static constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(4);
+    static constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(5);
+    static constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(6);
+    static constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(7);
+    static constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(8);
+    static constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(9);
+    static constexpr size_t local_receiver_channel_buffer_address = get_compile_time_arg_val(10);
+    static constexpr size_t remote_receiver_channel_buffer_address = get_compile_time_arg_val(11);
+    static constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(12);
+    static constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(13);
 
     // TODO: CONVERT TO SEMAPHORE
     volatile auto termination_signal_ptr =
-        reinterpret_cast<volatile tt::fabric::TerminationSignal *>(get_compile_time_arg_val(13));
+        reinterpret_cast<volatile tt::fabric::TerminationSignal *>(get_compile_time_arg_val(14));
     // In persistent mode, we must rely on static addresses for our local semaphores that are locally
     // initialized, rather than metal device APIs. This way different subdevice programs can reliably
     // resolve the semaphore addresses on the EDM core
-    static constexpr bool persistent_mode = get_compile_time_arg_val(14) != 0;
+    static constexpr bool persistent_mode = get_compile_time_arg_val(15) != 0;
 
     static_assert(SENDER_NUM_BUFFERS > 0, "compile time argument [1]: SENDER_NUM_BUFFERS must be > 0");
     static_assert(RECEIVER_NUM_BUFFERS > 0, "compile time argument [2]: RECEIVER_NUM_BUFFERS must be > 0");


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16609)

### Problem description
EDM Currently context switches every loop iteration which incurs about a 1000x perf degradation.

### What's changed
Make context switching less frequent

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/12712931051
- [x] T3K unit, frequent, nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12712948426
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
