### PR TITLE
support for bf8 for prod op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -75,6 +75,24 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@pytest.mark.parametrize("width", [54])
+def test_prod_bf8(device, width):
+    torch.manual_seed(0)
+
+    input_shape = (1, 12, 16, width)
+    reduce_dim = -1
+
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.prod(torch_input_tensor, dim=reduce_dim, keepdim=True, dtype=torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.prod(input_tensor, dim=reduce_dim)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor)
+
+
 @pytest.mark.parametrize("batch_size", [32])
 @pytest.mark.parametrize("c", [32])
 @pytest.mark.parametrize("h", [37])


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14274)

### Problem description
prod op fails when datatype is bf8_b

### What's changed
Support ttnn::zeros (Fill op) to address bf8_b limitation

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
