### PR TITLE
[tt-train] Add nanogpt ddp mode

### DIFF
--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -188,10 +188,12 @@ int main(int argc, char **argv) {
     bool is_eval = false;
     bool add_time_to_name = true;
     bool enable_wandb = true;
+    bool ddp = false;
     app.add_option("-c,--config", config_name, "Yaml Config name")->default_val(config_name);
     app.add_option("-e,--eval", is_eval, "Is evaluation")->default_val(is_eval);
     app.add_option("-t,--add_time_to_name", add_time_to_name, "Add time to run name")->default_val(add_time_to_name);
     app.add_option("-w,--wandb", enable_wandb, "Enable wandb logging")->default_val(enable_wandb);
+    app.add_option("-d,--ddp", ddp, "Enable DDP")->default_val(ddp);
 
     CLI11_PARSE(app, argc, argv);
     if (enable_wandb) {
@@ -266,6 +268,11 @@ int main(int argc, char **argv) {
     fmt::print("Vocab size: {}\n", tokenizer->get_vocab_size());
     fmt::print("Tokenizer type: {}\n", config.tokenizer_type);
 
+    if (ddp) {
+        // currently supports only N300 device
+        ttml::autograd::ctx().set_mesh_shape({1, 2});
+    }
+
     auto *device = &ttml::autograd::ctx().get_device();
     device->enable_program_cache();
 
@@ -290,11 +297,21 @@ int main(int argc, char **argv) {
             }
         }
     }
-    cached_data.masks_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
-        mask, ttml::core::create_shape({config.batch_size, num_heads, sequence_length, sequence_length}), device));
+
+    if (ddp) {
+        ttml::core::XTensorToMeshVariant<float> float_composer =
+            ttml::core::ShardXTensorToMesh<float>(device->shape(), 0);
+        xt::xarray<float> mask_xtensor =
+            xt::adapt(mask, {config.batch_size, num_heads, sequence_length, sequence_length});
+        cached_data.masks_tensor =
+            ttml::autograd::create_tensor(ttml::core::from_xtensor(mask_xtensor, device, float_composer));
+    } else {
+        cached_data.masks_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+            mask, ttml::core::create_shape({config.batch_size, num_heads, sequence_length, sequence_length}), device));
+    }
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
-        [sequence_length, num_heads, device, &cached_data](std::vector<DatasetSample> &&samples) {
+        [sequence_length, num_heads, device, &cached_data, ddp](std::vector<DatasetSample> &&samples) {
             auto start_timer = std::chrono::high_resolution_clock::now();
             const uint32_t batch_size = samples.size();
             std::vector<uint32_t> &data = cached_data.data;
@@ -312,10 +329,31 @@ int main(int argc, char **argv) {
             auto end_timer = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();
             fmt::print("dataloader host only step time {} ms\n", (double)duration / 1000.);
-            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
-                data, ttml::core::create_shape({batch_size, 1, 1, sequence_length}), device, Layout::ROW_MAJOR));
-            auto targets_tensor = ttml::autograd::create_tensor(
-                ttml::core::from_vector<int32_t, DataType::INT32>(targets, {batch_size * sequence_length}, device));
+
+            auto create_data_and_targets = [&]() -> std::tuple<TensorPtr, TensorPtr> {
+                if (ddp) {
+                    auto data_xtensor = xt::adapt(data, {batch_size, 1U, 1U, sequence_length});
+                    auto data_composer = ttml::core::ShardXTensorToMesh<uint32_t>(device->shape(), 0);
+                    auto data_tensor =
+                        ttml::autograd::create_tensor(ttml::core::from_xtensor<uint32_t, DataType::UINT32>(
+                            data_xtensor, device, data_composer, Layout::ROW_MAJOR));
+
+                    auto targets_xtensor = xt::adapt(targets, {batch_size * sequence_length});
+                    auto targets_composer = ttml::core::ShardXTensorToMesh<int32_t>(device->shape(), 0);
+                    auto targets_tt_tensor =
+                        ttml::core::from_xtensor<int32_t, DataType::INT32>(targets_xtensor, device, targets_composer);
+                    auto targets_tensor = ttml::autograd::create_tensor(targets_tt_tensor);
+                    return {data_tensor, targets_tensor};
+                }
+
+                auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
+                    data, ttml::core::create_shape({batch_size, 1, 1, sequence_length}), device, Layout::ROW_MAJOR));
+                auto targets_tensor = ttml::autograd::create_tensor(
+                    ttml::core::from_vector<int32_t, DataType::INT32>(targets, {batch_size * sequence_length}, device));
+                return {data_tensor, targets_tensor};
+            };
+
+            auto [data_tensor, targets_tensor] = create_data_and_targets();
             end_timer = std::chrono::high_resolution_clock::now();
             duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();
             fmt::print("dataloader step time {} ms\n", (double)duration / 1000.);
@@ -367,6 +405,18 @@ int main(int argc, char **argv) {
         return global_step * config.batch_size * config.gradient_accumulation_steps;
     };
 
+    auto get_loss_value = [device](const TensorPtr &loss) {
+        ttml::core::MeshToXTensorVariant<float> composer = ttml::core::VectorMeshToXTensor<float>(device->shape());
+        auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), composer);
+        // sum of loss xtensors
+        float loss_float =
+            std::accumulate(loss_xtensors.begin(), loss_xtensors.end(), 0.0F, [](float acc, auto &xtensor) {
+                return acc + xtensor(0);
+            });
+
+        return loss_float / static_cast<float>(loss_xtensors.size());
+    };
+
     const uint32_t num_epochs = config.num_epochs;
     auto gradient_accumulator_helper = GradientAccumulator(config.gradient_accumulation_steps);
     for (uint32_t epoch = 0; epoch < num_epochs; ++epoch) {
@@ -378,7 +428,7 @@ int main(int argc, char **argv) {
             auto output = (*model)(features, masks);
             auto loss = ttml::ops::nll_loss(output, target);
             loss = gradient_accumulator_helper.scale(loss);
-            auto loss_float = ttml::core::to_vector(loss->get_value())[0];
+            float loss_float = get_loss_value(loss);
 
             loss->backward();
             ttml::autograd::ctx().reset_graph();

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -194,8 +194,10 @@ int main(int argc, char **argv) {
     app.add_option("-t,--add_time_to_name", add_time_to_name, "Add time to run name")->default_val(add_time_to_name);
     app.add_option("-w,--wandb", enable_wandb, "Enable wandb logging")->default_val(enable_wandb);
     app.add_option("-d,--ddp", ddp, "Enable DDP")->default_val(ddp);
-
     CLI11_PARSE(app, argc, argv);
+
+    initialize_device(ddp);
+
     if (enable_wandb) {
         auto result = signal(SIGINT, signal_handler);
         if (result == SIG_ERR) {
@@ -267,11 +269,6 @@ int main(int argc, char **argv) {
     fmt::print("Dataset size: {}\n", dataset.get_size());
     fmt::print("Vocab size: {}\n", tokenizer->get_vocab_size());
     fmt::print("Tokenizer type: {}\n", config.tokenizer_type);
-
-    if (ddp) {
-        // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
-    }
 
     auto *device = &ttml::autograd::ctx().get_device();
     device->enable_program_cache();

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -4,6 +4,7 @@
 
 #include "utils.hpp"
 
+#include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "ops/binary_ops.hpp"
 
@@ -91,4 +92,11 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
         std::make_unique<ttml::schedulers::LinearScheduler>(optimizer, 1.0F, 0.01F, linear_decay_steps));
     std::vector<size_t> steps = {warmup_steps, linear_decay_steps};
     return std::make_unique<ttml::schedulers::SequentialScheduler>(optimizer, std::move(schedulers), std::move(steps));
+}
+
+void initialize_device(bool ddp) {
+    if (ddp) {
+        // currently supports only N300 device
+        ttml::autograd::ctx().set_mesh_shape({1, 2});
+    }
 }

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -133,3 +133,5 @@ std::string generate_run_name(const TrainingConfig &config, bool add_time_to_run
 
     return ss.str();
 }
+
+void initialize_device(bool ddp);

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -303,4 +303,47 @@ void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& n
     }
 }
 
+template <class T, DataType TensorType>
+tt::tt_metal::Tensor from_xtensor(
+    const xt::xarray<T>& tensor,
+    ttnn::distributed::MeshDevice* device,
+    const XTensorToMeshVariant<T>& composer,
+    Layout layout) {
+    auto sharded_tensors = std::visit([&tensor](auto&& arg) { return arg.map(tensor); }, composer);
+    auto config = std::visit([](auto&& arg) { return arg.config(); }, composer);
+    auto output = from_xtensors_to_host<T, TensorType>(sharded_tensors, config);
+    MemoryConfig output_mem_config{};
+
+    if constexpr (std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>) {
+        if (layout != Layout::ROW_MAJOR) {
+            output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config, device);
+        }
+        output = ttnn::to_device(output, device, output_mem_config);
+    } else {
+        output = ttnn::to_device(output, device, output_mem_config);
+        if (layout == Layout::TILE) {
+            output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
+        }
+    }
+    return output;
+}
+
+template tt::tt_metal::Tensor from_xtensor<float, DataType::BFLOAT16>(
+    const xt::xarray<float>& tensor,
+    ttnn::distributed::MeshDevice* device,
+    const XTensorToMeshVariant<float>& composer,
+    Layout layout);
+
+template tt::tt_metal::Tensor from_xtensor<int32_t, DataType::INT32>(
+    const xt::xarray<int32_t>& tensor,
+    ttnn::distributed::MeshDevice* device,
+    const XTensorToMeshVariant<int32_t>& composer,
+    Layout layout);
+
+template tt::tt_metal::Tensor from_xtensor<uint32_t, DataType::UINT32>(
+    const xt::xarray<uint32_t>& tensor,
+    ttnn::distributed::MeshDevice* device,
+    const XTensorToMeshVariant<uint32_t>& composer,
+    Layout layout);
+
 }  // namespace ttml::core

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -81,24 +81,6 @@ tt::tt_metal::Tensor from_xtensor(
     const xt::xarray<T>& tensor,
     ttnn::distributed::MeshDevice* device,
     const XTensorToMeshVariant<T>& composer,
-    Layout layout = Layout::TILE) {
-    auto sharded_tensors = std::visit([&tensor](auto&& arg) { return arg.map(tensor); }, composer);
-    auto config = std::visit([](auto&& arg) { return arg.config(); }, composer);
-    auto output = from_xtensors_to_host<T, TensorType>(sharded_tensors, config);
-    MemoryConfig output_mem_config{};
-
-    if constexpr (std::is_same_v<T, int32_t>) {
-        if (layout != Layout::ROW_MAJOR) {
-            output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config, device);
-        }
-        output = ttnn::to_device(output, device, output_mem_config);
-    } else {
-        output = ttnn::to_device(output, device, output_mem_config);
-        if (layout == Layout::TILE) {
-            output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ false);
-        }
-    }
-    return output;
-}
+    Layout layout = Layout::TILE);
 
 }  // namespace ttml::core

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -30,6 +30,36 @@ protected:
     }
 };
 
+TEST_F(N300UtilsTest, TestXTensorReplicateInt32) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    auto mesh_shape = device->shape();
+    xt::xarray<int32_t> test_data = {30, 20, 2};
+    xt::xarray<int32_t> xtensor = test_data.reshape({1, 1, 1, 3});
+    ttml::core::XTensorToMeshVariant<int32_t> replicate_composer =
+        ttml::core::ReplicateXTensorToMesh<int32_t>(mesh_shape);
+    auto tensor = ttml::core::from_xtensor<int32_t, DataType::INT32>(xtensor, device, replicate_composer);
+    ttml::core::MeshToXTensorVariant<int32_t> identity_composer = ttml::core::VectorMeshToXTensor<int32_t>(mesh_shape);
+    auto xtensors_back = ttml::core::to_xtensor<int32_t>(tensor, identity_composer);
+
+    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[0]));
+    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[1]));
+}
+
+TEST_F(N300UtilsTest, TestXTensorReplicateUInt32) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    auto mesh_shape = device->shape();
+    xt::xarray<uint32_t> test_data = {30U, 20U, 2U};
+    xt::xarray<uint32_t> xtensor = test_data.reshape({1, 1, 1, 3});
+    ttml::core::XTensorToMeshVariant<uint32_t> replicate_composer =
+        ttml::core::ReplicateXTensorToMesh<uint32_t>(mesh_shape);
+    auto tensor = ttml::core::from_xtensor<uint32_t, DataType::UINT32>(xtensor, device, replicate_composer);
+    ttml::core::MeshToXTensorVariant<uint32_t> identity_composer =
+        ttml::core::VectorMeshToXTensor<uint32_t>(mesh_shape);
+    auto xtensors_back = ttml::core::to_xtensor<uint32_t>(tensor, identity_composer);
+    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[0]));
+    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[1]));
+}
+
 TEST_F(N300UtilsTest, TestXTensorReplicate) {
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();


### PR DESCRIPTION
### Problem description
Multi device training is not currently supported for NanoGPT example.

### What's changed
Add support for DDP in NanoGPT example (currently supports only N300).
Extended support `from_xtensor` for other types than float. 

Improved speed of training
280ms vs 190ms (~16 minutes) 

Speed of ddp with relu and `fast` config - 165-168 ms
Speed of ddp with relu and `fast` config (+packer_l1_acc) - 165-168 ms

Training looks similar, but a little bit worse
![image](https://github.com/user-attachments/assets/5817b758-4113-42b3-890d-2c238408f943)


### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12715859141
- [x] New/Existing tests provide coverage for changes
