### PR TITLE
Build wheels in models unit tests workflow

### DIFF
--- a/.github/workflows/models-post-commit-wrapper.yaml
+++ b/.github/workflows/models-post-commit-wrapper.yaml
@@ -15,8 +15,22 @@ jobs:
     needs: build-docker-artifact
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-  models-unit-tests:
+  build-wheels:
     needs: build-artifact
+    strategy:
+      matrix:
+        # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
+        # The full 22.04 flow can be tested without precompiled
+        os: [ubuntu-20.04]
+        arch: [grayskull, wormhole_b0]
+    uses: ./.github/workflows/_build-wheels-impl.yaml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      from-precompiled: true
+    secrets: inherit
+  models-unit-tests:
+    needs: build-wheels
     secrets: inherit
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Ticket
...

### Problem description
Similar to https://github.com/tenstorrent/tt-metal/pull/16605 
Build wheels before running model unit tests because the tests run in Docker.

### What's changed
Added the build-wheels job before the models unit tests run.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes https://github.com/tenstorrent/tt-metal/actions/runs/12713035730 
