### PR TITLE
Remove ARCH_NAME from host library code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ project(
         CXX
 )
 message(STATUS "Metalium version: ${PROJECT_VERSION}")
+message(STATUS "Building Unified Library for all architectures, thanks to blozano-tt")
 
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
     message(
@@ -204,9 +205,6 @@ target_link_libraries(
         numa
 )
 
-if(NOT DEFINED ENV{ARCH_NAME})
-    message(FATAL_ERROR "Please set ARCH_NAME to grayskull, wormhole_b0, or blackhole")
-endif(NOT DEFINED ENV{ARCH_NAME})
 add_compile_options(
     -Werror
     -Wno-deprecated-declarations

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,15 @@
+if(NOT DEFINED ENV{ARCH_NAME})
+    message(FATAL_ERROR "Please set ARCH_NAME to grayskull, wormhole_b0, or blackhole")
+endif(NOT DEFINED ENV{ARCH_NAME})
+
+set(currentArch "$ENV{ARCH_NAME}")
+string(REPLACE "wormhole_b0" "wormhole" currentArch "${currentArch}")
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${currentArch}
+    $<$<STREQUAL:${currentArch},wormhole>:${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines>/inc/wormhole/wormhole_b0_defines>
+)
+
 enable_testing()
 include(GoogleTest)
 add_library(test_common_libs INTERFACE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,6 @@ string(REPLACE "wormhole_b0" "wormhole" currentArch "${currentArch}")
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${currentArch}
-    $<$<STREQUAL:${currentArch},wormhole>:${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines>/inc/wormhole/wormhole_b0_defines>
 )
 
 enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,9 +5,7 @@ endif(NOT DEFINED ENV{ARCH_NAME})
 set(currentArch "$ENV{ARCH_NAME}")
 string(REPLACE "wormhole_b0" "wormhole" currentArch "${currentArch}")
 
-include_directories(
-    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${currentArch}
-)
+include_directories(${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${currentArch})
 
 enable_testing()
 include(GoogleTest)

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -201,14 +201,6 @@ add_custom_target(
 add_library(hw INTERFACE)
 add_library(Metalium::Metal::Hardware ALIAS hw)
 
-set(currentArch "$ENV{ARCH_NAME}")
-string(REPLACE "wormhole_b0" "wormhole" currentArch "${currentArch}")
-target_include_directories(
-    hw
-    INTERFACE
-        inc
-        inc/${currentArch}
-        $<$<STREQUAL:${currentArch},wormhole>:${CMAKE_CURRENT_SOURCE_DIR}/inc/wormhole/wormhole_b0_defines>
-)
+target_include_directories(hw INTERFACE inc)
 
 target_link_libraries(hw INTERFACE TT::Metalium::HostDevCommon)

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -30,10 +30,7 @@
 #include <fmt/base.h>
 #include <fmt/ranges.h>
 
-// FIXME: ARCH_NAME specific
-#include "dev_msgs.h" // RUN_MSG_DONE
-#include "dev_mem_map.h" // MEM_IERISC_FIRMWARE_BASE
-
+#include "dev_msgs.h"
 
 namespace tt {
 


### PR DESCRIPTION
### Ticket
#596 

### Problem description
The include path `tt_metal/hw/inc/ARCH_NAME` forces build variants per architecture.

### What's changed
Remove the include path from the core libraries.
It is moved to the tests/ directory, as tests still depend on it.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12714702205)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
