### PR TITLE
#16353: skip no volume tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -194,6 +194,12 @@ def test_sin(device, h, w):
     run_unary_test(device, h, w, ttnn.sin)
 
 
+@pytest.mark.parametrize("h", [0])
+@pytest.mark.parametrize("w", [1])
+def test_01_volume_sin(device, h, w):
+    run_unary_test(device, h, w, ttnn.sin)
+
+
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_asin(device, h, w):

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -340,6 +340,13 @@ operation::OpPerformanceModel BinaryDeviceOperation::create_op_performance_model
     return result;
 }
 
+bool BinaryDeviceOperation::skip_launch(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
 std::tuple<BinaryDeviceOperation::operation_attributes_t, BinaryDeviceOperation::tensor_args_t>
 BinaryDeviceOperation::invoke(
     const Tensor& input_tensor_a_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -243,6 +243,8 @@ struct BinaryDeviceOperation {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
 
+    static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -199,6 +199,13 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
         attributes, input_tensor_a.dtype(), std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
 }
 
+bool BinaryNgDeviceOperation::skip_launch(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
 std::tuple<BinaryNgDeviceOperation::operation_attributes_t, BinaryNgDeviceOperation::tensor_args_t>
 BinaryNgDeviceOperation::invoke(
     const Tensor& input_tensor_a_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -81,6 +81,7 @@ struct BinaryNgDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     // tensor-tensor invocation
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -201,6 +201,13 @@ tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     return hash;
 }
 
+bool UnaryDeviceOperation::skip_launch(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
 std::tuple<UnaryDeviceOperation::operation_attributes_t, UnaryDeviceOperation::tensor_args_t>
 UnaryDeviceOperation::invoke(
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -39,6 +39,8 @@ struct UnaryDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
+    static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,
         const std::vector<UnaryWithParam>& op_chain,


### PR DESCRIPTION
### Ticket
#16353

### Problem description
Watcher detects corrupted memory when eltwise binary kernel outputs zero volume tensor

### What's changed
Device operations may now optionally indicate when to skip launching program with `skip_launch` - this can be due to an output tensor with a logical volume of zero, or an output tensor that does not require initialization (`ttnn.empty`, for example).

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12715131819)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
