### PR TITLE
Fix Pre-allgather Layernorm bad PCC when use 1D reduction

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -233,7 +233,7 @@ def test_pre_allgather_layernorm(
 @pytest.mark.parametrize("core_grid", ((4, 1),))
 @pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
 @pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.987, 0.04)])
-def test_pre_allgather_layernorm_single_core(
+def test_pre_allgather_layernorm_1d_reduce(
     device,
     use_program_cache,
     input_width,

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -226,7 +226,7 @@ def test_pre_allgather_layernorm(
 @skip_for_grayskull()
 @pytest.mark.parametrize("is_rmsnorm", [True, False])
 @pytest.mark.parametrize("seed", [0, 1234])
-@pytest.mark.parametrize("input_width", [256])
+@pytest.mark.parametrize("input_width", [1024])
 @pytest.mark.parametrize("num_devices", [4, 8])
 @pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -124,17 +124,7 @@ def compute_reference_output(torch_input_tensor, torch_weight, is_rmsnorm, eps):
         )
 
 
-@skip_for_grayskull()
-@pytest.mark.parametrize("is_rmsnorm", [True, False])
-@pytest.mark.parametrize("seed", [0, 1234])
-@pytest.mark.parametrize("input_width", [2048])
-@pytest.mark.parametrize("num_devices", [4, 8])
-@pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
-@pytest.mark.parametrize(("mean", "std"), ([0, 1],))
-@pytest.mark.parametrize("core_grid", ((4, 8),))
-@pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
-@pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.987, 0.04)])
-def test_pre_allgather_layernorm(
+def run_pre_allgather_layernorm(
     device,
     use_program_cache,
     input_width,
@@ -187,6 +177,94 @@ def test_pre_allgather_layernorm(
             ), f"E(x^2) mismatch for device {d} (atol: {atol_delta_ex2})"
 
     logger.info("Pre-allgather layernorm test passed for all devices")
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("is_rmsnorm", [True, False])
+@pytest.mark.parametrize("seed", [0, 1234])
+@pytest.mark.parametrize("input_width", [2048])
+@pytest.mark.parametrize("num_devices", [4, 8])
+@pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize(("mean", "std"), ([0, 1],))
+@pytest.mark.parametrize("core_grid", ((4, 8),))
+@pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
+@pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.987, 0.04)])
+def test_pre_allgather_layernorm(
+    device,
+    use_program_cache,
+    input_width,
+    num_devices,
+    is_rmsnorm,
+    input_df,
+    seed,
+    mean,
+    std,
+    core_grid,
+    min_pcc_ex,
+    max_atol_ex,
+    min_pcc_ex2,
+    max_atol_ex2,
+):
+    run_pre_allgather_layernorm(
+        device,
+        use_program_cache,
+        input_width,
+        num_devices,
+        is_rmsnorm,
+        input_df,
+        seed,
+        mean,
+        std,
+        core_grid,
+        min_pcc_ex,
+        max_atol_ex,
+        min_pcc_ex2,
+        max_atol_ex2,
+    )
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("is_rmsnorm", [True, False])
+@pytest.mark.parametrize("seed", [0, 1234])
+@pytest.mark.parametrize("input_width", [256])
+@pytest.mark.parametrize("num_devices", [4, 8])
+@pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize(("mean", "std"), ([0, 1],))
+@pytest.mark.parametrize("core_grid", ((4, 1),))
+@pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
+@pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.987, 0.04)])
+def test_pre_allgather_layernorm_single_core(
+    device,
+    use_program_cache,
+    input_width,
+    num_devices,
+    is_rmsnorm,
+    input_df,
+    seed,
+    mean,
+    std,
+    core_grid,
+    min_pcc_ex,
+    max_atol_ex,
+    min_pcc_ex2,
+    max_atol_ex2,
+):
+    run_pre_allgather_layernorm(
+        device,
+        use_program_cache,
+        input_width,
+        num_devices,
+        is_rmsnorm,
+        input_df,
+        seed,
+        mean,
+        std,
+        core_grid,
+        min_pcc_ex,
+        max_atol_ex,
+        min_pcc_ex2,
+        max_atol_ex2,
+    )
 
 
 @skip_for_grayskull()

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -166,7 +166,6 @@ void MAIN {
             for (uint32_t w = 0; w < num_tiles_per_partial_result * num_blocks_reduce;
                  w++) {  // Need to read this interleaved now, we have SUM(X) and SUM(X^2) interleaved
                 cb_wait_front(cb_ex_external2, 1);
-                // DPRINT_UNPACK({ DPRINT  << TSLICE(cb_ex_external2, 0, SliceRange::h0_32_w0()) << ENDL(); });
                 reduce_tile(
                     cb_ex_external2,
                     cb_scaler_global,
@@ -186,8 +185,6 @@ void MAIN {
         }
         reduce_revert_delta();
         cb_push_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
-        cb_wait_front(cb_reduction_out, 1);
-        // DPRINT_UNPACK({ DPRINT  << TSLICE(cb_reduction_out, 0, SliceRange::h0_32_w0()) << ENDL(); });
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -59,7 +59,7 @@ void MAIN {
 
     constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;   // E[x^2] partial reduce
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;  // E[x^2] partials recieved from other cores
-    const uint32_t cb_reduction_out = is_second_stage_reader ? cb_out : cb_ex2;
+    const uint32_t cb_reduction_out = (!use_two_stage_reduce or is_second_stage_reader) ? cb_out : cb_ex2;
 
     binary_op_init_common(cb_in0, cb_in0, cb_x2);
 
@@ -76,8 +76,8 @@ void MAIN {
     num_tiles_per_partial_result = 1;
 #endif
 
-    cb_wait_front(cb_scaler, 1);
 #ifndef RMSNORM
+    cb_wait_front(cb_scaler, 1);
     reconfig_data_format_srcb(cb_in0, cb_scaler);
     // E[x],
     index_h_offset = 0;
@@ -129,6 +129,9 @@ void MAIN {
     reconfig_data_format_srcb(cb_in0, cb_scaler);
 
     cb_wait_front(cb_x2, num_tiles_per_block);
+#ifdef RMSNORM
+    cb_wait_front(cb_scaler, 1);
+#endif  // RMSNORM
 
     cb_reserve_back(cb_ex_partial2, block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
@@ -163,6 +166,7 @@ void MAIN {
             for (uint32_t w = 0; w < num_tiles_per_partial_result * num_blocks_reduce;
                  w++) {  // Need to read this interleaved now, we have SUM(X) and SUM(X^2) interleaved
                 cb_wait_front(cb_ex_external2, 1);
+                // DPRINT_UNPACK({ DPRINT  << TSLICE(cb_ex_external2, 0, SliceRange::h0_32_w0()) << ENDL(); });
                 reduce_tile(
                     cb_ex_external2,
                     cb_scaler_global,
@@ -182,6 +186,8 @@ void MAIN {
         }
         reduce_revert_delta();
         cb_push_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
+        cb_wait_front(cb_reduction_out, 1);
+        // DPRINT_UNPACK({ DPRINT  << TSLICE(cb_reduction_out, 0, SliceRange::h0_32_w0()) << ENDL(); });
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -572,7 +572,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     bool use_two_stage_reduce = false;
     if (mcast_1d) {
         // only do this for row/col dim are full length
-        if (row_wise && grid_size.x <= device->compute_with_storage_grid_size().x &&
+        if (row_wise && grid_size.x > 1 && grid_size.x <= device->compute_with_storage_grid_size().x &&
             grid_size.y > 1) {  // row major and multiple rows
             use_two_stage_reduce = true;
         } else if (


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16606)

### Problem description
Currently due to the usage of 2D reduction, the 1d reduction is not tested for Pre-allgather Layernorm, after disable the 2d, it has pcc error.

### What's changed
problem is output cb is wrong, changed to correct output cb.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12716575239
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
