### PR TITLE
#16621: Add barriers at end of cq_dispatch_slave.cpp

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -294,5 +294,6 @@ void kernel_main() {
     }
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_dispatch_cb_sem_id>(total_pages_acquired);
+    noc_async_full_barrier();
     DPRINT << "dispatch_s : done" << ENDL();
 }


### PR DESCRIPTION

### Ticket
#16621 

### Problem description
I recently added an assert at the end of erisck.cc that all transactions were completed.

### What's changed
Like other kernels that can run on erisc, cq_dispatch_slave needs a barrier at the end to ensure all transactions have finished. Otherwise, an assert will be hit if the watcher is running.


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
