### PR TITLE
Add support for unpadded shapes in Matmul1D w/ gather_in0

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
@@ -161,6 +161,9 @@ def run_multi_core_matmul_1d(
 
     in0_block_h = M // ttnn.TILE_SIZE
     in0_block_w = K // num_cores // ttnn.TILE_SIZE
+    while (K / ttnn.TILE_SIZE) % in0_block_w != 0:
+        in0_block_w -= 1
+
     out_block_h = M // ttnn.TILE_SIZE
     out_block_w = N_padded // num_cores // ttnn.TILE_SIZE
 
@@ -346,9 +349,10 @@ def run_multi_core_matmul_1d(
     ],
 )
 @pytest.mark.parametrize(
-    "use_arbitrary_cores",
+    "use_arbitrary_cores, hop_grid",
     [
-        False,
+        (False, None),
+        (False, [(3, 6)]),
     ],
 )
 @pytest.mark.parametrize(
@@ -371,6 +375,7 @@ def test_multi_core_matmul_1d_pad_wh(
     N,
     activation,
     grid,
+    hop_grid,
     use_arbitrary_cores,
     num_iters,
     use_program_cache,
@@ -392,6 +397,7 @@ def test_multi_core_matmul_1d_pad_wh(
         grid,
         use_arbitrary_cores,
         num_iters,
+        hop_grid=hop_grid,
     )
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
@@ -161,7 +161,7 @@ def run_multi_core_matmul_1d(
 
     in0_block_h = M // ttnn.TILE_SIZE
     in0_block_w = K // num_cores // ttnn.TILE_SIZE
-    while (K / ttnn.TILE_SIZE) % in0_block_w != 0:
+    while (K / ttnn.TILE_SIZE) % in0_block_w != 0 or (K_per_shard / ttnn.TILE_SIZE) % in0_block_w != 0:
         in0_block_w -= 1
 
     out_block_h = M // ttnn.TILE_SIZE

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
@@ -161,7 +161,7 @@ def run_multi_core_matmul_1d(
 
     in0_block_h = M // ttnn.TILE_SIZE
     in0_block_w = K // num_cores // ttnn.TILE_SIZE
-    while (K / ttnn.TILE_SIZE) % in0_block_w != 0 or (K_per_shard / ttnn.TILE_SIZE) % in0_block_w != 0:
+    while (K / ttnn.TILE_SIZE) % in0_block_w != 0:
         in0_block_w -= 1
 
     out_block_h = M // ttnn.TILE_SIZE

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import ttnn
+import math
 from loguru import logger
 
 from ttnn import ReplicateTensorToMesh, ShardTensor2dMesh, ConcatMeshToTensor, ConcatMesh2dToTensor
@@ -20,6 +21,7 @@ from tests.tt_eager.python_api_testing.unit_testing.misc.test_matmul_1d_gather_i
     run_multi_core_matmul_1d,
     PREFETCHER_NOC1_GRID,
     num_cores_to_rectangle_grid,
+    round_up,
 )
 
 
@@ -210,6 +212,16 @@ def run_prefetcher_mm(
     dram_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core_coord, core_coord) for core_coord in dram_cores])
     sender_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core_coord, core_coord) for core_coord in sender_cores])
 
+    padded_shapes = []
+    for K, N in input_shapes:
+        num_cores = len(receiver_cores_list)
+        K_per_shard = round_up(math.ceil(K / num_cores), ttnn.TILE_SIZE)
+        K_padded = K_per_shard * num_cores
+        N_per_shard = round_up(math.ceil(N / num_cores), ttnn.TILE_SIZE)
+        N_padded = N_per_shard * num_cores
+
+        padded_shapes.append((K_padded, N_padded))
+
     cluster_shape = None
     mesh_mapper = None
     mesh_composer = None
@@ -225,7 +237,7 @@ def run_prefetcher_mm(
 
     tt_tensors_all = []
     for tid in range(num_tensors * num_layers):
-        K, N = input_shapes[tid % num_tensors]
+        K, N = padded_shapes[tid % num_tensors]
         input_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.DRAM,
@@ -281,20 +293,29 @@ def run_prefetcher_mm(
     storage_grid = num_cores_to_rectangle_grid(num_cores, device)
     M = 32
 
-    in0_shapes = []
+    in0_shapes, in0_padded_shapes = [], []
     out_shapes = []
     block_dims = []
     for tid in range(num_tensors):
         K, N = input_shapes[tid]
+        K_padded, N_padded = padded_shapes[tid]
+
         in0_shape = [1, 1, M, K]
         in0_shapes.append(in0_shape)
-        out_shape = [1, 1, M, N]
+
+        in0_padded_shape = [1, 1, M, K_padded]
+        in0_padded_shapes.append(in0_padded_shape)
+
+        out_shape = [1, 1, M, N_padded]
         out_shapes.append(out_shape)
 
         in0_block_h = M // ttnn.TILE_SIZE
         in0_block_w = K // num_cores // ttnn.TILE_SIZE
+        while (K / ttnn.TILE_SIZE) % in0_block_w != 0:
+            in0_block_w -= 1
+
         out_block_h = M // ttnn.TILE_SIZE
-        out_block_w = N // num_cores // ttnn.TILE_SIZE
+        out_block_w = N_padded // num_cores // ttnn.TILE_SIZE
 
         out_subblock_h = 1
         out_subblock_w = max_dst_tiles
@@ -362,11 +383,11 @@ def run_prefetcher_mm(
 
     in0_tensors = []
     in0_t_tensors = []
-    for shape in in0_shapes:
+    for shape, padded_shape in zip(in0_shapes, in0_padded_shapes):
         in0 = torch.randn(shape)
         in0_tensors.append(in0)
 
-        _, _, M, K = shape
+        _, _, M, K = padded_shape
 
         in0_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -310,7 +310,7 @@ def run_prefetcher_mm(
 
         in0_block_h = M // ttnn.TILE_SIZE
         in0_block_w = K // num_cores // ttnn.TILE_SIZE
-        while (K / ttnn.TILE_SIZE) % in0_block_w != 0 or (K_per_shard / ttnn.TILE_SIZE) % in0_block_w != 0:
+        while (K / ttnn.TILE_SIZE) % in0_block_w != 0:
             in0_block_w -= 1
 
         out_block_h = M // ttnn.TILE_SIZE

--- a/tests/ttnn/unit_tests/operations/test_prefetcher.py
+++ b/tests/ttnn/unit_tests/operations/test_prefetcher.py
@@ -22,6 +22,14 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import run_prefetcher_mm
         (2, 3, [(256, 1024), (256, 2048), (512, 256)], [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b], 5),
         (2, 2, [(256, 1024), (128, 128)], [ttnn.bfloat4_b, ttnn.bfloat8_b], 5),
         (2, 3, [(256, 1024), (128, 128), (1024, 256)], [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b], 5),
+        # Padding check
+        (
+            2,
+            3,
+            [(256 + 32, 512 + 224), (128, 128 + 64), (512 + 256, 224)],
+            [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b],
+            5,
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
@@ -37,13 +37,20 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import run_prefetcher_mm
         (12, 5, [(3840, 2304)] * 5, [ttnn.bfloat8_b] * 5, 5),  # FF2
         (12, 6, [(2304, 1536)] * 6, [ttnn.bfloat8_b] * 6, 5),  # QKV
         (12, 5, [(2304, 2304)] * 5, [ttnn.bfloat8_b] * 5, 5),  # DO
+        (
+            12,
+            5,
+            [(2304, 1536), (1536, 2304), (2304, 3840), (2304, 3840), (3840, 2304)],
+            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
+            5,
+        ),  # qkv + do + ff1 + ff3 + ff2
         # Takes really long to set up
         (
             12,
             5,
-            [(2304, 1536), (2304, 2304), (2304, 3840), (2304, 3840), (3840, 2304)],
+            [(2048, 1280), (1280, 2048), (2048, 3584), (2048, 3584), (3584, 2048)],
             [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
-            80,  # DRAM OOM issue?
+            80,
         ),  # qkv + do + ff1 + ff3 + ff2
     ],
 )

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -130,10 +130,7 @@ FORCE_INLINE void update_rd_ptr_to_ring_index(
 }
 
 void MAIN {
-    // Runtime args
-    uint32_t rt_args_idx = 0;
-    uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
-
+    // Compile time args
     constexpr uint32_t in0_block_w = get_compile_time_arg_val(0);        // inner block size in tiles
     constexpr uint32_t in0_num_subblocks = get_compile_time_arg_val(1);  // outer row block size (in inner row blocks)
     constexpr uint32_t in0_block_num_tiles =
@@ -153,6 +150,13 @@ void MAIN {
     constexpr uint32_t batch = get_compile_time_arg_val(13);                   // batch dim
     constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);     // number of tiles in out_block
     constexpr bool untilize_out = get_compile_time_arg_val(15);                // untilize output
+    constexpr uint32_t ring_size = num_blocks;
+
+    // Runtime args
+    uint32_t rt_args_idx = 0;
+    uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t* unpadded_in0_shard_widths_in_tiles = (uint32_t*)get_arg_addr(rt_args_idx);
+    rt_args_idx += ring_size;
 
     constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
 
@@ -216,6 +220,9 @@ void MAIN {
         cb_pop_front(sync_cb2, 1);
 
         for (uint32_t block = 0; block < num_blocks; block++) {
+            const uint32_t curr_ring_idx = (ring_idx + block) % ring_size;
+            uint32_t unpadded_in0_block_w = unpadded_in0_shard_widths_in_tiles[curr_ring_idx];
+
             const uint32_t input0_cb_id = block == 0 ? in0_cb_id : in2_cb_id;
             bool last_out = block == (num_blocks - 1);
 // Configure packer once for pack out without Bias
@@ -251,7 +258,7 @@ void MAIN {
 #ifdef ENABLE_GLOBAL_CB
                 int in1_index_subblock_offset = 0;
 #else
-                int in1_index_subblock_offset = in1_block_num_tiles * ((ring_idx + block) % num_blocks);
+                int in1_index_subblock_offset = in1_block_num_tiles * (curr_ring_idx);
 #endif
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
                     tile_regs_acquire();
@@ -273,7 +280,7 @@ void MAIN {
                     uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
                     uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
                     // inner dim that we accumualte is the inner dim of in0/in1, which is in0_block_w
-                    for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
+                    for (uint32_t inner_dim_idx = 0; inner_dim_idx < unpadded_in0_block_w; ++inner_dim_idx) {
                         // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
                         // accumulation is done by iterating matmul_block across inner dim
                         // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride in0

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -227,10 +227,10 @@ void MAIN {
 #endif
 
             // Wait to receive in0 block
-            if (block == 0) {
-                cb_reserve_back(input0_cb_id, in0_block_num_tiles);
-                cb_push_back(input0_cb_id, in0_block_num_tiles);
-            }
+            // if (block == 0) {
+            //     cb_reserve_back(input0_cb_id, in0_block_num_tiles);
+            //     cb_push_back(input0_cb_id, in0_block_num_tiles);
+            // }
             cb_wait_front(input0_cb_id, in0_block_num_tiles);
 
 #ifdef ENABLE_GLOBAL_CB

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -234,10 +234,10 @@ void MAIN {
 #endif
 
             // Wait to receive in0 block
-            // if (block == 0) {
-            //     cb_reserve_back(input0_cb_id, in0_block_num_tiles);
-            //     cb_push_back(input0_cb_id, in0_block_num_tiles);
-            // }
+            if (block == 0) {
+                cb_reserve_back(input0_cb_id, in0_block_num_tiles);
+                cb_push_back(input0_cb_id, in0_block_num_tiles);
+            }
             cb_wait_front(input0_cb_id, in0_block_num_tiles);
 
 #ifdef ENABLE_GLOBAL_CB

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -43,9 +43,7 @@ void kernel_main() {
 
     bool use_padding = unpadded_in0_shard_widths_in_tiles[ring_idx] != shard_width_in_tiles;
 
-    // Reserving/pushing the local shard
-    cb_reserve_back(cb_id_in0, batch * shard_size_in_tiles);
-    cb_push_back(cb_id_in0, batch * shard_size_in_tiles);
+    // Reserving/pushing the local shard is done in compute
     cb_reserve_back(cb_id_in2, batch * (ring_size - 1) * shard_size_in_tiles);
 
     uint32_t local_shard_read_addr = get_read_ptr(cb_id_in0);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -7,7 +7,6 @@
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "debug/dprint.h"
-#include "debug/dprint_tile.h"
 
 void kernel_main() {
     // Compile time args
@@ -41,8 +40,6 @@ void kernel_main() {
     constexpr uint32_t shard_size_in_tiles = shard_width_in_tiles * shard_height_in_tiles;
     constexpr uint32_t shard_size_bytes = shard_size_in_tiles * in0_single_tile_size_bytes;
 
-    bool use_padding = unpadded_in0_shard_widths_in_tiles[ring_idx] != shard_width_in_tiles;
-
     // Reserving/pushing the local shard is done in compute
     cb_reserve_back(cb_id_in2, batch * (ring_size - 1) * shard_size_in_tiles);
 
@@ -54,7 +51,7 @@ void kernel_main() {
     for (uint32_t b = 0; b < batch; ++b) {
         for (uint32_t shard_cnt = hop_core_offset; shard_cnt < ring_size; shard_cnt++) {
             uint32_t curr_ring_idx = (ring_idx + shard_cnt) % ring_size;
-            bool skip_send = unpadded_in0_shard_widths_in_tiles[curr_ring_idx] == 0;
+            bool skip_send = unpadded_in0_shard_widths_in_tiles[curr_ring_idx] == 0 && !is_hop_core;
 
             uint32_t curr_shard_write_addr = l1_write_addr_in0 + shard_size_bytes * (shard_cnt - hop_core_offset);
             uint64_t remote_curr_shard_write_addr =

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1538,7 +1538,9 @@ void Matmul::validate(
                         TT_FATAL(M == per_core_M, "Error");
                         TT_FATAL(per_core_M == (shard_shape[0] / in0_tile_shape[0]), "Error");
                         TT_FATAL(K % program_config.in0_block_w == 0, "Error");
-                        TT_FATAL((shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0, "Error");
+                        if (!program_config.gather_in0) {  // Padding allowed for gather_in0
+                            TT_FATAL((shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0, "Error");
+                        }
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1538,9 +1538,7 @@ void Matmul::validate(
                         TT_FATAL(M == per_core_M, "Error");
                         TT_FATAL(per_core_M == (shard_shape[0] / in0_tile_shape[0]), "Error");
                         TT_FATAL(K % program_config.in0_block_w == 0, "Error");
-                        if (!program_config.gather_in0) {  // Padding allowed for gather_in0
-                            TT_FATAL((shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0, "Error");
-                        }
+                        TT_FATAL((shard_shape[1] / in0_tile_shape[1]) % program_config.in0_block_w == 0, "Error");
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2059,6 +2059,10 @@ operation::ProgramWithCallbacks create_program_gather_in0(
         std::vector<uint32_t> mm_kernel_compute_args = {
             i,  // ring_idx
         };
+        mm_kernel_compute_args.insert(
+            mm_kernel_compute_args.end(),
+            unpadded_in0_shard_widths_in_tiles.begin(),
+            unpadded_in0_shard_widths_in_tiles.end());
 
         tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_kernel_compute_args);
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -8,7 +8,6 @@
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/math.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -1698,18 +1697,6 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
-template <typename T>
-void printVector(const std::vector<T>& vec) {
-    std::cout << "[";
-    for (size_t i = 0; i < vec.size(); ++i) {
-        std::cout << vec[i];
-        if (i != vec.size() - 1) {
-            std::cout << ", ";
-        }
-    }
-    std::cout << "]" << std::endl;
-}
-
 operation::ProgramWithCallbacks create_program_gather_in0(
     tt_metal::Program& program,
     const Tensor& a,
@@ -1759,7 +1746,7 @@ operation::ProgramWithCallbacks create_program_gather_in0(
     bool use_hop_cores = num_hop_cores > 0;
 
     /* Inner dim padding */
-    const uint32_t Kt_pad = round_up(K, num_cores);
+    const uint32_t Kt_pad = in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1] * num_cores;
     in0_block_w = Kt_pad / num_cores;  // FIXME: in0_block_w does not need to equal shard width.
 
     uint32_t num_blocks = Kt_pad / in0_block_w;
@@ -1804,17 +1791,10 @@ operation::ProgramWithCallbacks create_program_gather_in0(
 
     uint32_t K_ = K;
     std::vector<uint32_t> unpadded_in0_shard_widths_in_tiles(num_cores, 0);
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        if (K_ > in0_shard_width_in_tiles) {
-            unpadded_in0_shard_widths_in_tiles[i] = in0_shard_width_in_tiles;
-            K_ -= in0_shard_width_in_tiles;
-        } else {
-            unpadded_in0_shard_widths_in_tiles[i] = K_;
-            break;
-        }
+    for (uint32_t i = 0; i < num_cores && K_ > 0; ++i) {
+        unpadded_in0_shard_widths_in_tiles[i] = std::min(K_, in0_shard_width_in_tiles);
+        K_ -= unpadded_in0_shard_widths_in_tiles[i];
     }
-
-    printVector(unpadded_in0_shard_widths_in_tiles);
 
     /* semaphores */
     auto in0_signal_semaphore_id = tt_metal::CreateSemaphore(program, ring_cores, INVALID);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1749,11 +1749,6 @@ operation::ProgramWithCallbacks create_program_gather_in0(
     /* Inner dim padding */
     const uint32_t Kt_pad = in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1] * num_cores;
     in0_block_w = Kt_pad / num_cores;
-    TT_FATAL(
-        in0_block_w == in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1],
-        "Padded in0_block_w {} must match in0 shard width {}",
-        in0_block_w,
-        in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1]);
 
     uint32_t num_blocks = Kt_pad / in0_block_w;
     // Only enable packer l1 accumulation when there are spills, otherwise

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2219,14 +2219,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     // TODO: Max used grid can actually exceed mcast receiver grid if in0 is sharded
     // TODO: Move these validates to op validate and properly check for this
     TT_FATAL(
-        num_blocks_total <= num_cores_x * num_cores_y,
+        num_blocks_total <= num_cores,
         "Number of blocks exceeds number of cores: {} blocks > {} cores",
         num_blocks_total,
         num_cores);
 
     if (gather_in0) {
         TT_FATAL(
-            num_blocks_total == num_cores_x * num_cores_y,
+            num_blocks_total == num_cores,
             "Number of blocks must equal number of cores for gather_in0 mode: {} blocks != {} cores",
             num_blocks_total,
             num_cores);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2204,12 +2204,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t num_cores = gather_in0 ? a.shard_spec().value().grid.num_cores() : num_cores_x * num_cores_y;
-
-    if (gather_in0) {
-        // Outer dim padding
-        Nt = round_up(Nt, num_cores);
-    }
+    uint32_t num_cores = num_cores_x * num_cores_y;
 
     // Calculate number of blocks along x and y; tensor dims are padded up to 512
     uint32_t num_blocks_y = (Mt - 1) / per_core_M + 1;
@@ -2224,15 +2219,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
         num_blocks_total,
         num_cores);
 
-    if (gather_in0) {
-        TT_FATAL(
-            num_blocks_total == num_cores,
-            "Number of blocks must equal number of cores for gather_in0 mode: {} blocks != {} cores",
-            num_blocks_total,
-            num_cores);
-
-        TT_FATAL(!untilize_out, "Untilize out is not suported wit gather_in0 mode");
-    } else {
+    if (!gather_in0) {
         TT_FATAL(hop_cores.empty(), "Hop cores are not supported for any mode besides gather_in0.");
     }
 

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
@@ -23,6 +23,7 @@ void DramPrefetcher::validate(const std::vector<Tensor>& input_tensors) const {
 
     auto global_cb = get_global_circular_buffer(*this->global_cb, input_tensors[0].device()->id());
     uint32_t num_receiver_cores = global_cb.receiver_cores().num_cores();
+    uint32_t num_sender_cores = global_cb.sender_cores().num_cores();
 
     // Check that global_cb sender_receiver_core_mapping has same number of receivers for each sender core
     const auto& sender_receiver_core_mapping = global_cb.sender_receiver_core_mapping();
@@ -31,6 +32,7 @@ void DramPrefetcher::validate(const std::vector<Tensor>& input_tensors) const {
             receiver_core_range.size() == sender_receiver_core_mapping.begin()->second.size(),
             "Global circular buffer must have same number of receivers for each sender core");
     }
+    const uint32_t num_receivers_per_sender = num_receiver_cores / num_sender_cores;
 
     for (size_t i = 0; i < input_tensors.size() - 1; ++i) {
         const auto& tensor = input_tensors[i];
@@ -41,6 +43,14 @@ void DramPrefetcher::validate(const std::vector<Tensor>& input_tensors) const {
             tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
             "Input tensors must be width sharded");
         TT_FATAL(tensor.memory_config().buffer_type == BufferType::DRAM, "Input tensors must be in DRAM");
+
+        // Check that all tensors' N (per shard) is divisible by number of cores in global CB receiver
+        TT_FATAL(
+            tensor.buffer()->shard_spec().shape()[1] % num_receivers_per_sender == 0,
+            "All tensors' padded shard size (in last dim) {} must be divisible by the number of receiver cores per "
+            "sender {}.",
+            tensor.buffer()->shard_spec().shape()[1],
+            num_receivers_per_sender);
 
         tt::DataFormat tensor_data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
@@ -42,12 +42,6 @@ void DramPrefetcher::validate(const std::vector<Tensor>& input_tensors) const {
             "Input tensors must be width sharded");
         TT_FATAL(tensor.memory_config().buffer_type == BufferType::DRAM, "Input tensors must be in DRAM");
 
-        // Check that all tensors' k is divisible by number of cores in global CB receiver
-        TT_FATAL(
-            tensor.get_padded_shape()[1] % num_receiver_cores == 0,
-            "All tensors' k must be divisible by the number of receiver cores = {}.",
-            num_receiver_cores);
-
         tt::DataFormat tensor_data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
         TT_FATAL(
             tensor_data_format == tt::DataFormat::Bfp4_b || tensor_data_format == tt::DataFormat::Bfp8_b ||


### PR DESCRIPTION
### Ticket
- #16626

### Problem description
In the current use case of Matmul1D with gather_in0 in the Llama models, the activations and weights need to be padded. This results in significant overhead.

### What's changed
- Added support to skip part of in0_block_w that is padding information
- Pad the Kt and Nt in the host code for gather_in0

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12893880800)
- [x] New/Existing tests provide coverage for changes (https://github.com/tenstorrent/tt-metal/actions/runs/12893883783)
