### PR TITLE
Fix nightly stable diffusion tests

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -140,15 +140,17 @@ Tensor to_layout_impl(
                 output_memory_config =
                     tt::tt_metal::MemoryConfig{memory_config.memory_layout, memory_config.buffer_type};
             }
-            SmallVector<uint32_t> output_tensor_end;
+            SimpleShape output_tensor_end(SmallVector<uint32_t>(tensor.get_padded_shape().rank(), 0));
             int logical_rank = tensor.get_logical_shape().rank();
-            int padded_rank = tensor.get_padded_shape().rank();
-            for (auto index = 0; index < padded_rank; ++index) {
-                output_tensor_end.push_back(index < logical_rank ? tensor.get_logical_shape()[index] - 1 : 0);
+            for (int index = -1; index >= -logical_rank; --index) {
+                output_tensor_end[index] = tensor.get_logical_shape()[index] - 1;
             }
 
-            tensor =
-                ttnn::untilize_with_unpadding(tensor, output_tensor_end, output_memory_config, use_multicore_untilize);
+            tensor = ttnn::untilize_with_unpadding(
+                tensor,
+                tt::tt_metal::LegacyShape(output_tensor_end.view()),
+                output_memory_config,
+                use_multicore_untilize);
             return ttnn::reshape(tensor, ttnn::SimpleShape{output_shape});
 
         } else if (layout == ttnn::TILE_LAYOUT) {

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -141,8 +141,10 @@ Tensor to_layout_impl(
                     tt::tt_metal::MemoryConfig{memory_config.memory_layout, memory_config.buffer_type};
             }
             SmallVector<uint32_t> output_tensor_end;
-            for (auto index = 0; index < tensor.get_logical_shape().rank(); ++index) {
-                output_tensor_end.push_back(tensor.get_logical_shape()[index] - 1);
+            int logical_rank = tensor.get_logical_shape().rank();
+            int padded_rank = tensor.get_padded_shape().rank();
+            for (auto index = 0; index < padded_rank; ++index) {
+                output_tensor_end.push_back(index < logical_rank ? tensor.get_logical_shape()[index] - 1 : 0);
             }
 
             tensor =


### PR DESCRIPTION
### Ticket

### Problem description
Nightly stable diffusion tests are currently failing, after https://github.com/tenstorrent/tt-metal/pull/16484

### What's changed
Fixed calculation of `output_tensor_end` in one of the branches of layout conversion

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12718154798)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12718161215)
- [x] [Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/12718140006)
- [x] New/Existing tests provide coverage for changes
