### PR TITLE
Enable test_rotary_embedding_llama for blackhole

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -52,7 +52,6 @@ class TtLlamaRotary(torch.nn.Module):
     def apply_rotary(self, x, cos, sin):
         # n_head = 8 for Q
         # n_head = 1 for K
-
         rotary_output = ttnn.experimental.rotary_embedding_llama(
             x,
             cos,
@@ -284,7 +283,6 @@ def run_test_rotary_embedding_llama(
         assert does_pass, f"PCC value is lower than {pcc}"
 
 
-@skip_for_blackhole("Requires eth connected devices to run, only single chip BH available. See #12349")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "batch, seq_len",
@@ -303,7 +301,7 @@ def run_test_rotary_embedding_llama(
         (32, 1),
         (15, 1),
         (8, 1),
-        (1, 1),
+        (1, 1),  # Llama 8B and 70B #16013
     ),
     ids=(
         "prefill_32",
@@ -329,6 +327,7 @@ def run_test_rotary_embedding_llama(
         (8, 1, 64),
         (8, 1, 128),
         (11, 3, 128),
+        (32, 32, 128),  # Llama 8B and 70B #16013
         (71, 32, 64),
         (8, 1, 96),
         (8, 1, 256),
@@ -374,7 +373,6 @@ def test_rotary_embedding_llama(
     )
 
 
-@skip_for_blackhole("Requires eth connected devices to run, only single chip BH available. See #12349")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "batch, seq_len",


### PR DESCRIPTION
### Ticket
#14062 
#16013 

### Problem description
test_rotary_embedding_llama was intentionally skipped on blackhole but this skip was no longer necessary.

### What's changed
Re-enabled the test and test and ran on Blackhole on IRD. Also, added one test case relevant to Llama (#16013 )

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
