### PR TITLE
update build flag on programming examples docs

### DIFF
--- a/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
@@ -1,9 +1,18 @@
 # Tutorial - Add Two Integers in a Compute Kernel 🚧
 
-1. To build and execute use the following commands
-```export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh  --build-tests
+1. To build and execute:
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
+```bash
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/add_2_integers_in_compute
 ```
 

--- a/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -7,10 +7,18 @@ This program can be found in
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/add_2_integers_in_compute
 ```
 ## Set up device and program/collaboration mechanisms

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/Tutorial_Add_Two_Integers_in_a_Baby_RISC-V.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/Tutorial_Add_Two_Integers_in_a_Baby_RISC-V.md
@@ -1,9 +1,17 @@
 # Tutorial - Add Two Integers in a Baby RISC-V 🚧
-1. To build and execute use the following commands:
+1. To build and execute:
+Run the appropriate command for the Tenstorrent card you have installed:
 
-```export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh  --build-tests
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
+```bash
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/add_2_integers_in_riscv
 ```
 2. Setup the host program:

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
@@ -8,10 +8,18 @@ so you can follow along.
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh  --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/add_2_integers_in_riscv
 ```
 ## Set up device and program/collaboration mechanisms

--- a/tech_reports/prog_examples/dram_loopback/dram_loopback.md
+++ b/tech_reports/prog_examples/dram_loopback/dram_loopback.md
@@ -8,11 +8,20 @@ We\'ll go through this code section by section. Note that we have this exact, fu
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
-    ./build/programming_examples/loopback
+Run the appropriate command for the Tenstorrent card you have installed:
 
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
+```bash
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
+    ./build/programming_examples/loopback
+```
 ## Device setup
 
 ``` cpp

--- a/tech_reports/prog_examples/eltwise_binary/eltwise_binary.md
+++ b/tech_reports/prog_examples/eltwise_binary/eltwise_binary.md
@@ -7,10 +7,18 @@ We'll go through any new code section by section. This builds on top of previous
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/eltwise_binary
 ```
 ## New buffers

--- a/tech_reports/prog_examples/eltwise_sfpu/eltwise_sfpu.md
+++ b/tech_reports/prog_examples/eltwise_sfpu/eltwise_sfpu.md
@@ -6,10 +6,18 @@ We'll go through any new code section by section. This builds on top of previous
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/eltwise_sfpu
 ```
 ## Circular buffers for data movement to/from compute engine

--- a/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
+++ b/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
@@ -6,10 +6,18 @@ We'll go through this code section by section. The full example program is at [h
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/hello_world_compute_kernel
 ```
 ## Device setup

--- a/tech_reports/prog_examples/hello_world_data_movement/hello_world_data_movement.md
+++ b/tech_reports/prog_examples/hello_world_data_movement/hello_world_data_movement.md
@@ -8,10 +8,18 @@ so you can follow along.
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/hello_world_datamovement_kernel
 ```
 

--- a/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
+++ b/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
@@ -13,10 +13,18 @@ The full example program is in [matmul_multi_core.cpp](../../../tt_metal/program
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/matmul_multi_core
 ```
 ## Accessing all the cores

--- a/tech_reports/prog_examples/matmul_multi_core_optimized/matmul_multi_core_optimized.md
+++ b/tech_reports/prog_examples/matmul_multi_core_optimized/matmul_multi_core_optimized.md
@@ -2,10 +2,18 @@
 
 The Tensix core architecture's secret weapon is its full user control over memory workload spread, core communication style, novel block matmul kernels, and compute patterns. In this section, we will harness real power through 3 shiny optimizations, each building off one another: data reuse, data multicast, and multidimensional systolic arrays (coming soon).
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/matmul_multi_core_reuse
     ./build/programming_examples/matmul_multi_core_reuse_mcast
 ```

--- a/tech_reports/prog_examples/matmul_single_core/matmul_single_core.md
+++ b/tech_reports/prog_examples/matmul_single_core/matmul_single_core.md
@@ -7,10 +7,18 @@ The full example program is in
 
 To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
 
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/matmul_single_core
 ```
 

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -14,10 +14,18 @@ In this example, we will implement a basic TT-Metalium program for padding an in
 The code for this program can be found in [pad_multi_core.cpp](../../../tt_metal/programming_examples/pad/pad_multi_core.cpp).
 
 The following commands will build and execute the code for this example. Environment variables may be modified based on the latest specifications.
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/pad_multi_core
 ```
 ## Device setup

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -6,10 +6,18 @@ In this example, we will implement a simple TT-Metalium program to demonstrate h
 The following commands will build and execute the code for this example.
 Environment variables may be modified based on the latest
 specifications.
+Run the appropriate command for the Tenstorrent card you have installed:
+
+| Card             | Command                              |
+|------------------|--------------------------------------|
+| Grayskull        | ```export ARCH_NAME=grayskull```     |
+| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
+| Blackhole        | ```export ARCH_NAME=blackhole```     |
+
+Then run the following:
 ```bash
-    export ARCH_NAME=<arch name>
-    export TT_METAL_HOME=<this repo dir>
-    ./build_metal.sh --build-tests
+    export TT_METAL_HOME=$(pwd)
+    ./build_metal.sh --build-programming-examples
     ./build/programming_examples/shard_data_rm
 ```
 # Device setup


### PR DESCRIPTION
### Ticket
[Update programming examples' instructions #16628
](https://github.com/tenstorrent/tt-metal/issues/16628)

### Problem description
Flag for building the programming examples was not the appropriate one.

### What's changed
- Added chart with environment variables per TT card
- Updated build flag to: --build-programming-examples
