### PR TITLE
fix reduce scatter multi-link support bug

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -385,6 +385,10 @@ def test_line_reduce_scatter_async_post_commit(
     [
         (2, 2, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
         (2, 2, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (2, 2, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -383,8 +383,8 @@ def test_line_reduce_scatter_async_post_commit(
 @pytest.mark.parametrize(
     "num_devices, num_links, per_chip_input_shape, dim, layout",
     [
-        (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (2, 2, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
+        (2, 2, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem description
Two issues:
- reduce scatter was aliasing fabric endpoint connections between workers on the same device, leading to undefined behaviour
- a general fabric edm connection teardown race condition exists which may lead to a hang

### What's changed
- Fixed worker <-> EDM connection setup bug in reduce-scatter-async program factory that connected multiple workers to the same endpoint
- Added a change to worker <-> EDM connection teardown to lower the probability of teardown hang

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/12719584219
- [x] T3K frequent, nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12718133092
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
