### PR TITLE
#6983: Renable skipped TT-NN unit test

### DIFF
--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -55,11 +55,10 @@ def test_multi_device_open_close_full_mesh_device_fixture(mesh_device):
 
 def test_multi_device_open_close_using_context_manager(silicon_arch_name, silicon_arch_wormhole_b0):
     """Using context manager to open and close multi-device"""
-    pytest.skip("Issue #6983")
-    mesh_shape, device_ids = ttnn.MeshShape(2, 2), ttnn.get_device_ids()
-    if len(device_ids) <= 1:
+    if ttnn.get_num_devices() < 4:
         pytest.skip()
-    with ttnn.create_mesh_device(mesh_shape, device_ids) as mesh_device:
+    mesh_shape = ttnn.MeshShape(2, 2)
+    with ttnn.create_mesh_device(mesh_shape) as mesh_device:
         # Do something with multi_device
         pass
 

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -182,27 +182,13 @@ def close_mesh_device(mesh_device):
 
 
 @contextlib.contextmanager
-def create_mesh_device(
-    mesh_shape: ttnn.MeshShape,
-    device_ids: List[int],
-    l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
-    trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
-    num_command_queues: int = 1,
-    dispatch_core_config: ttnn._ttnn.device.DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig(),
-):
+def create_mesh_device(*args, **kwargs):
     """
-    create_mesh_device(mesh_shape: ttnn.MeshShape, device_ids: List[int]) -> ttnn.MeshDevice
+    create_mesh_device(*args, **kwargs) -> ttnn.MeshDevice
 
     Context manager for opening and closing a device.
     """
-    mesh_device = open_mesh_device(
-        mesh_shape=mesh_shape,
-        device_ids=device_ids,
-        l1_small_size=l1_small_size,
-        trace_region_size=trace_region_size,
-        num_command_queues=num_command_queues,
-        dispatch_core_type=dispatch_core_config,
-    )
+    mesh_device = open_mesh_device(*args, **kwargs)
     try:
         yield mesh_device
     finally:


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/6983)

### Problem description
Refactor interface for `create_mesh_device` to match open_mesh_device and reenable `test_multi_device_open_close_using_context_manager`


### What's changed
Reenable skipped TT-NN unit test.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12762574153
- [x] T3000 Test Coverage: https://github.com/tenstorrent/tt-metal/actions/runs/12762601868
