### PR TITLE
Port all data movements ops to compute_output_specs

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
@@ -27,7 +27,8 @@ struct EltwiseBinaryBroadcast {
 
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -36,20 +36,18 @@ void CloneOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-CloneOperation::shape_return_value_t CloneOperation::compute_output_shapes(
+CloneOperation::spec_return_value_t CloneOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tensor_args.input.get_logical_shape();
+    const auto& input = tensor_args.input;
+    return TensorSpec(
+        input.get_logical_shape(),
+        TensorLayout(operation_attributes.dtype, PageConfig(input.get_layout()), operation_attributes.memory_config));
 };
 
 CloneOperation::tensor_return_value_t CloneOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input = tensor_args.input;
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        operation_attributes.dtype,
-        input.get_layout(),
-        input.device(),
-        operation_attributes.memory_config);
+    auto spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(spec, tensor_args.input.device());
 }
 
 std::tuple<CloneOperation::operation_attributes_t, CloneOperation::tensor_args_t> CloneOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
@@ -20,7 +20,7 @@ struct CloneOperation {
         const Tensor& input;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -50,7 +50,7 @@ struct CloneOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -16,8 +16,7 @@ struct ConcatDeviceOperation {
     unsigned int groups;
     const tt::tt_metal::MemoryConfig output_mem_config;
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     ConcatOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
@@ -22,7 +22,8 @@ struct CopyDeviceOperation {
 
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
 
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/device/expand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/device/expand_device_operation.cpp
@@ -51,9 +51,17 @@ void ExpandOperation::validate_on_program_cache_hit(
     validate(operation_attributes, tensor_args);
 };
 
-ExpandOperation::shape_return_value_t ExpandOperation::compute_output_shapes(
+ExpandOperation::spec_return_value_t ExpandOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return SimpleShape{operation_attributes.output_shape};
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
+    return TensorSpec(
+        SimpleShape{operation_attributes.output_shape},
+        TensorLayout(
+            tensor_args.input.get_dtype(),
+            PageConfig(tensor_args.input.get_layout()),
+            operation_attributes.memory_config));
 };
 
 ExpandOperation::tensor_return_value_t ExpandOperation::create_output_tensors(
@@ -63,12 +71,7 @@ ExpandOperation::tensor_return_value_t ExpandOperation::create_output_tensors(
         return {tensor_args.output.value()};
     }
 
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        tensor_args.input.get_dtype(),
-        tensor_args.input.get_layout(),
-        tensor_args.input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<ExpandOperation::operation_attributes_t, ExpandOperation::tensor_args_t> ExpandOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/device/expand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/device/expand_device_operation.hpp
@@ -23,7 +23,7 @@ struct ExpandOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ExpandRowMajorFactory {
@@ -52,7 +52,7 @@ struct ExpandOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -100,14 +100,11 @@ void FillRM::validate(const std::vector<Tensor>& input_tensors) const {
         "FillRM does not currently support sharding");
 }
 
-std::vector<ttnn::SimpleShape> FillRM::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    return {ttnn::SimpleShape({this->N, this->C, this->H, this->W})};
-}
-
-std::vector<Tensor> FillRM::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+std::vector<ttnn::TensorSpec> FillRM::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    ttnn::SimpleShape shape({this->N, this->C, this->H, this->W});
     const auto& input_tensor = input_tensors.at(0);
-    return operation::generic_create_output_tensors(
-        *this, input_tensors, input_tensor.get_dtype(), Layout::ROW_MAJOR, this->output_mem_config);
+    return {
+        TensorSpec(shape, TensorLayout(input_tensor.get_dtype(), PageConfig(Layout::ROW_MAJOR), output_mem_config))};
 }
 
 operation::ProgramWithCallbacks FillRM::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.hpp
@@ -26,8 +26,7 @@ struct FillRM {
     const tt::tt_metal::MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -46,36 +46,34 @@ void Fold::validate_on_program_cache_hit(const operation_attributes_t& op_attr, 
     return validate_fold({tensors.input_tensor}, op_attr.is_sharded, op_attr.stride_h, op_attr.stride_w);
 }
 
-Fold::shape_return_value_t Fold::compute_output_shapes(
+Fold::spec_return_value_t Fold::compute_output_specs(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
     auto input_tensor = tensors.input_tensor;
     const ttnn::SimpleShape input_shape = input_tensor.get_logical_shape();
     // we concatenate (stride_h sticks in H-dim) * (stride_w in W-dim) into 1 stick along C-dim
-    return ttnn::SimpleShape(
+    ttnn::SimpleShape output_shape(
         {1,
          1,
          input_shape[0] * input_shape[1] * input_shape[2] / (op_attr.stride_h * op_attr.stride_w),
          input_shape[3] * op_attr.stride_h * op_attr.stride_w});
-}
-
-Fold::tensor_return_value_t Fold::create_output_tensors(
-    const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    const Tensor& input_tensor = tensors.input_tensor;
-    DataType output_dtype = input_tensor.get_dtype();
-
-    auto output_shape = compute_output_shapes(op_attr, tensors);
 
     if (op_attr.is_sharded) {
         MemoryConfig mem_config = input_tensor.memory_config();
         mem_config.shard_spec->shape[0] /= op_attr.stride_h * op_attr.stride_w;
         mem_config.shard_spec->shape[1] *= op_attr.stride_h * op_attr.stride_w;
 
-        return {create_device_tensor(
-            output_shape, output_dtype, input_tensor.get_layout(), input_tensor.device(), mem_config)};
-    } else {
-        return {create_device_tensor(
-            output_shape, output_dtype, Layout::ROW_MAJOR, input_tensor.device(), input_tensor.memory_config())};
+        return {TensorSpec(
+            output_shape, TensorLayout(input_tensor.get_dtype(), PageConfig(input_tensor.get_layout()), mem_config))};
     }
+
+    return {TensorSpec(
+        output_shape,
+        TensorLayout(input_tensor.get_dtype(), PageConfig(Layout::ROW_MAJOR), input_tensor.memory_config()))};
+}
+
+Fold::tensor_return_value_t Fold::create_output_tensors(
+    const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
+    return create_device_tensor(compute_output_specs(op_attr, tensors), tensors.input_tensor.device());
 }
 
 std::tuple<Fold::operation_attributes_t, Fold::tensor_args_t> Fold::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -24,7 +24,7 @@ struct Fold {
         const Tensor& input_tensor;
     };
 
-    using shape_return_value_t = ttnn::SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct SingleCore {
@@ -73,7 +73,7 @@ struct Fold {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
@@ -33,14 +33,11 @@ void IndexedFill::validate(const std::vector<Tensor>& input_tensors) const {
         "Index Fill does not currently support sharding");
 }
 
-std::vector<ttnn::SimpleShape> IndexedFill::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    return {input_tensors.at(1).get_logical_shape()};
-}
-
-std::vector<Tensor> IndexedFill::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+std::vector<ttnn::TensorSpec> IndexedFill::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(1);
-    return operation::generic_create_output_tensors(
-        *this, input_tensors, input_tensor.get_dtype(), input_tensor.get_layout(), this->output_mem_config);
+    return {TensorSpec(
+        input_tensor.get_logical_shape(),
+        TensorLayout(input_tensor.get_dtype(), PageConfig(input_tensor.get_layout()), output_mem_config))};
 }
 
 operation::ProgramWithCallbacks IndexedFill::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.hpp
@@ -13,8 +13,7 @@ struct IndexedFill {
     const tt::tt_metal::MemoryConfig output_mem_config;
     const int64_t dim;
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -15,9 +15,9 @@ void MoveDeviceOperation::validate(const std::vector<Tensor>& input_tensors) con
     const auto& input_tensor_a = input_tensors.at(0);
 }
 
-std::vector<ttnn::SimpleShape> MoveDeviceOperation::compute_output_shapes(
+std::vector<ttnn::TensorSpec> MoveDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
-    return {input_tensors.at(0).get_logical_shape()};
+    return {input_tensors.at(1).get_tensor_spec()};
 }
 
 std::vector<Tensor> MoveDeviceOperation::create_output_tensors(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -20,7 +20,7 @@ struct MoveDeviceOperation {
     const MoveOpParallelizationStrategy move_op_parallelization_strategy;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.cpp
@@ -24,14 +24,10 @@ void NonZeroIndices::validate(const std::vector<Tensor>& input_tensors) const {
         "Non-zero does not currently support sharding");
 }
 
-std::vector<ttnn::SimpleShape> NonZeroIndices::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+std::vector<ttnn::TensorSpec> NonZeroIndices::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     ttnn::SimpleShape num_non_zero_shape({1, 1, 1, 8});
-    return {std::move(num_non_zero_shape), input_tensors.at(0).get_logical_shape()};
-}
-
-std::vector<Tensor> NonZeroIndices::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    return operation::generic_create_output_tensors(
-        *this, input_tensors, DataType::UINT32, Layout::ROW_MAJOR, this->output_mem_config);
+    TensorLayout layout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR), output_mem_config);
+    return {TensorSpec(num_non_zero_shape, layout), TensorSpec(input_tensors.at(0).get_logical_shape(), layout)};
 }
 
 operation::ProgramWithCallbacks NonZeroIndices::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.hpp
@@ -19,8 +19,7 @@ namespace operations::data_movement {
 struct NonZeroIndices {
     const tt::tt_metal::MemoryConfig output_mem_config;
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -26,7 +26,7 @@ struct PermuteDeviceOperation {
         std::optional<Tensor> optional_output_tensor;
     };
 
-    using shape_return_value_t = ttnn::SimpleShape;  // waiting on TensorSpec here
+    using spec_return_value_t = ttnn::TensorSpec;
 
     using tensor_return_value_t = Tensor;
 
@@ -108,7 +108,7 @@ struct PermuteDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
     // Compute the output shapes based on the operation attributes and tensor args
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
@@ -32,18 +32,13 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
         "Output of repeat must be interleaved.");
 }
 
-std::vector<ttnn::SimpleShape> RepeatDeviceOperation::compute_output_shapes(
+std::vector<ttnn::TensorSpec> RepeatDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
-    ttnn::SimpleShape shape_out = input_tensors[0].get_logical_shape();
+    const auto& input_tensor = input_tensors.at(0);
+    ttnn::SimpleShape shape_out = input_tensor.get_logical_shape();
     shape_out[this->repeat_dim] *= this->num_repeats;
-    return {shape_out};
-}
-
-std::vector<Tensor> RepeatDeviceOperation::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    const Tensor& ref_in_tensor = input_tensors[0];
-
-    return operation::generic_create_output_tensors(
-        *this, input_tensors, ref_in_tensor.get_dtype(), ref_in_tensor.get_layout(), this->output_mem_config);
+    return {TensorSpec(
+        shape_out, TensorLayout(input_tensor.get_dtype(), PageConfig(input_tensor.get_layout()), output_mem_config))};
 }
 
 operation::ProgramWithCallbacks RepeatDeviceOperation::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.hpp
@@ -15,8 +15,7 @@ struct RepeatDeviceOperation {
     const tt::tt_metal::MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -48,20 +48,17 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
     }
 }
 
-std::vector<ttnn::SimpleShape> ReshapeDeviceOperation::compute_output_shapes(
+std::vector<ttnn::TensorSpec> ReshapeDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
-    return {output_shape.logical_shape()};
-}
-
-std::vector<Tensor> ReshapeDeviceOperation::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    return {create_device_tensor(
-        output_shape,
-        input_tensor_a.get_dtype(),
-        input_tensor_a.get_layout(),
-        input_tensor_a.device(),
-        this->output_mem_config,
-        input_tensor_a.get_tensor_spec().tile())};
+    const auto& input_tensor = input_tensors.at(0);
+    return {TensorSpec(
+        output_shape.logical_shape(),
+        TensorLayout::fromPaddedShape(
+            input_tensor.get_dtype(),
+            input_tensor.get_tensor_spec().page_config(),
+            output_mem_config,
+            output_shape.logical_shape(),
+            output_shape.padded_shape()))};
 }
 
 operation::ProgramWithCallbacks ReshapeDeviceOperation::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
@@ -14,8 +14,7 @@ struct ReshapeDeviceOperation {
     const tt::tt_metal::MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.cpp
@@ -21,12 +21,7 @@ void RM_RESHAPE_STRUCT::validate(const std::vector<Tensor>& input_tensors) const
     TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Output tensor must have the same memory layout as input tensor");
 }
 
-std::vector<SimpleShape> RM_RESHAPE_STRUCT::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    return {output_shape.logical_shape()};
-}
-
-std::vector<Tensor> RM_RESHAPE_STRUCT::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    //Create the output tensor
+std::vector<TensorSpec> RM_RESHAPE_STRUCT::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto mem_config = this->output_mem_config;
     if (input_tensor_a.memory_config().is_sharded()) {
@@ -34,7 +29,14 @@ std::vector<Tensor> RM_RESHAPE_STRUCT::create_output_tensors(const std::vector<T
         shard_spec.shape[0] = output_shape[0];
         mem_config.shard_spec = shard_spec;
     }
-    return {create_device_tensor(output_shape, input_tensor_a.get_dtype(), input_tensor_a.get_layout(), input_tensor_a.device(), mem_config)};
+    return {TensorSpec(
+        output_shape.logical_shape(),
+        TensorLayout::fromPaddedShape(
+            input_tensor_a.get_dtype(),
+            PageConfig(input_tensor_a.get_layout()),
+            mem_config,
+            output_shape.logical_shape(),
+            output_shape.padded_shape()))};
 }
 
 operation::ProgramWithCallbacks RM_RESHAPE_STRUCT::create_program( const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.hpp
@@ -16,8 +16,7 @@ struct RM_RESHAPE_STRUCT {
     //Required functions to all tensor op functions
     void update_structure (const Tensor& input_tensor);
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -29,16 +29,14 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
 }
 
 
-std::vector<tt::tt_metal::LegacyShape> InterleavedToShardedDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+std::vector<ttnn::TensorSpec> InterleavedToShardedDeviceOperation::compute_output_specs(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
-}
-
-
-std::vector<Tensor> InterleavedToShardedDeviceOperation::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return operation::generic_create_output_tensors(
-        *this, input_tensors, this->output_dtype, input_tensor.get_layout(), this->output_mem_config);
+    return {TensorSpec(input_tensor.get_logical_shape(), TensorLayout::fromPaddedShape(
+        output_dtype,
+        PageConfig(input_tensor.get_layout()),
+        output_mem_config,
+        input_tensor.get_logical_shape(),
+        input_tensor.get_padded_shape()))};
 }
 
 operation::ProgramWithCallbacks InterleavedToShardedDeviceOperation::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -16,8 +16,7 @@ struct InterleavedToShardedDeviceOperation {
     const bool keep_l1_aligned = false;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
@@ -63,10 +63,21 @@ void ReshardDeviceOperation::validate_with_output_tensors(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> ReshardDeviceOperation::compute_output_shapes(
-    const std::vector<Tensor>& input_tensors) const {
+std::vector<ttnn::TensorSpec> ReshardDeviceOperation::compute_output_specs(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (output_tensors.size() == 1 && output_tensors[0].has_value()) {
+        return {output_tensors[0]->get_tensor_spec()};
+    }
+
     const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
+    return {TensorSpec(
+        input_tensor.get_logical_shape(),
+        TensorLayout::fromPaddedShape(
+            input_tensor.get_dtype(),
+            input_tensor.get_layout(),
+            output_mem_config,
+            input_tensor.get_logical_shape(),
+            input_tensor.get_padded_shape()))};
 }
 
 operation::ProgramWithCallbacks ReshardDeviceOperation::create_program(
@@ -79,19 +90,11 @@ operation::ProgramWithCallbacks ReshardDeviceOperation::create_program(
 
 std::vector<Tensor> ReshardDeviceOperation::create_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
     if (output_tensors.size() == 1 && output_tensors[0].has_value()) {
         return {output_tensors[0].value()};
-    } else {
-        auto mem_config = this->output_mem_config;
-
-        return {create_device_tensor(
-            this->compute_output_shapes(input_tensors).at(0),
-            input_tensor.get_dtype(),
-            input_tensor.get_layout(),
-            input_tensor.device(),
-            mem_config)};
     }
+
+    return {create_device_tensor(compute_output_specs(input_tensors, output_tensors)[0], input_tensors.at(0).device())};
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.hpp
@@ -15,7 +15,8 @@ struct ReshardDeviceOperation {
 
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.cpp
@@ -34,17 +34,17 @@ void ShardedToInterleavedDeviceOperation::validate(const std::vector<Tensor>& in
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> ShardedToInterleavedDeviceOperation::compute_output_shapes(
+std::vector<ttnn::TensorSpec> ShardedToInterleavedDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
-}
-
-std::vector<Tensor> ShardedToInterleavedDeviceOperation::create_output_tensors(
-    const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return operation::generic_create_output_tensors(
-        *this, input_tensors, this->output_dtype, input_tensor.get_layout(), this->output_mem_config);
+    return {TensorSpec(
+        input_tensor.get_logical_shape(),
+        TensorLayout::fromPaddedShape(
+            output_dtype,
+            PageConfig(input_tensor.get_layout()),
+            output_mem_config,
+            input_tensor.get_logical_shape(),
+            input_tensor.get_padded_shape()))};
 }
 
 operation::ProgramWithCallbacks ShardedToInterleavedDeviceOperation::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
@@ -16,8 +16,7 @@ struct ShardedToInterleavedDeviceOperation {
     const bool is_l1_aligned = false;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -20,8 +20,7 @@ struct InterleavedToShardedPartialDeviceOperation {
     const tt::tt_metal::DataType output_dtype;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
@@ -43,13 +43,7 @@ void ShardedToInterleavedPartialDeviceOperation::validate(const std::vector<Tens
     // Divisibility of num_cores and shard size with tensor shape is done in tensor creation, so no need to assert here
 }
 
-std::vector<tt::tt_metal::LegacyShape> ShardedToInterleavedPartialDeviceOperation::compute_output_shapes(
-    const std::vector<Tensor>& input_tensors) const {
-    const auto& output_tensor = input_tensors.at(1);
-    return {output_tensor.get_legacy_shape()};
-}
-
-std::vector<Tensor> ShardedToInterleavedPartialDeviceOperation::create_output_tensors(
+std::vector<ttnn::TensorSpec> ShardedToInterleavedPartialDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     // Don't create anything, we already passed in output tensor
     return {};

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.hpp
@@ -16,8 +16,7 @@ struct ShardedToInterleavedPartialDeviceOperation {
     const tt::tt_metal::DataType output_dtype;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.hpp
@@ -15,8 +15,7 @@ struct SplitDeviceOperation {
     const tt::tt_metal::MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -40,28 +40,29 @@ void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> Tilize::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    auto output_shape = input_tensor_a.get_legacy_shape();
-    return {output_shape};
-}
-
-std::vector<Tensor> Tilize::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+std::vector<ttnn::TensorSpec> Tilize::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     if (input_tensor.memory_config().is_sharded()) {
         auto mem_config = this->output_mem_config;
         mem_config.shard_spec = input_tensor.memory_config().shard_spec;
-        return {create_device_tensor(
-            this->compute_output_shapes(input_tensors).at(0),
-            this->output_dtype,
-            Layout::TILE,
-            input_tensor.device(),
-            mem_config)};
-    } else {
-        return operation::generic_create_output_tensors(
-            *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
+        return {TensorSpec(
+            input_tensor.get_logical_shape(),
+            TensorLayout::fromPaddedShape(
+                output_dtype,
+                PageConfig(Layout::TILE),
+                mem_config,
+                input_tensor.get_logical_shape(),
+                input_tensor.get_padded_shape()))};
     }
+
+    return {TensorSpec(
+        input_tensor.get_logical_shape(),
+        TensorLayout::fromPaddedShape(
+            output_dtype,
+            PageConfig(Layout::TILE),
+            output_mem_config,
+            input_tensor.get_logical_shape(),
+            input_tensor.get_padded_shape()))};
 }
 
 operation::ProgramWithCallbacks Tilize::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
@@ -17,9 +17,7 @@ struct Tilize {
     const bool use_multicore;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -60,14 +60,7 @@ void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> Untilize::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    return {input_tensor_a.get_legacy_shape()};
-}
-
-std::vector<Tensor> Untilize::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    using namespace tt::constants;
+std::vector<ttnn::TensorSpec> Untilize::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     DataType output_dtype =
         input_tensor.get_dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.get_dtype();
@@ -75,36 +68,46 @@ std::vector<Tensor> Untilize::create_output_tensors(
         if (input_tensor.memory_config().is_sharded()) {
             auto mem_config = this->output_mem_config;
             mem_config.shard_spec = input_tensor.memory_config().shard_spec;
-            return {create_device_tensor(
-                this->compute_output_shapes(input_tensors).at(0),
-                output_dtype,
-                Layout::ROW_MAJOR,
-                input_tensor.device(),
-                mem_config)};
-        } else {
-            uint32_t ntiles = input_tensor.volume() / TILE_HW;
-            uint32_t ntiles_per_block = input_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-            uint32_t nblocks = std::ceil((float)ntiles / ntiles_per_block);
-            auto num_cores =
-                untilize_helpers::get_num_cores(input_tensor.device()->compute_with_storage_grid_size(), nblocks);
-            auto shard_grid = tt::tt_metal::num_cores_to_corerangeset(
-                num_cores, input_tensor.device()->compute_with_storage_grid_size(), true);
-            uint32_t fused_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
-            std::array<uint32_t, 2> shard_shape = {fused_height / num_cores, input_tensor.get_legacy_shape()[-1]};
-            ShardSpec shard_spec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
-            auto mem_config = this->output_mem_config;
-            mem_config.shard_spec = shard_spec;
-            return {create_device_tensor(
-                this->compute_output_shapes(input_tensors).at(0),
-                output_dtype,
-                Layout::ROW_MAJOR,
-                input_tensor.device(),
-                mem_config)};
+            return {TensorSpec(
+                input_tensor.get_logical_shape(),
+                TensorLayout::fromPaddedShape(
+                    output_dtype,
+                    PageConfig(Layout::ROW_MAJOR),
+                    mem_config,
+                    input_tensor.get_logical_shape(),
+                    input_tensor.get_padded_shape()))};
         }
-    } else {
-        return operation::generic_create_output_tensors(
-            *this, input_tensors, output_dtype, Layout::ROW_MAJOR, this->output_mem_config);
+
+        uint32_t ntiles = input_tensor.volume() / TILE_HW;
+        uint32_t ntiles_per_block = input_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
+        uint32_t nblocks = std::ceil((float)ntiles / ntiles_per_block);
+        auto num_cores =
+            untilize_helpers::get_num_cores(input_tensor.device()->compute_with_storage_grid_size(), nblocks);
+        auto shard_grid = tt::tt_metal::num_cores_to_corerangeset(
+            num_cores, input_tensor.device()->compute_with_storage_grid_size(), true);
+        uint32_t fused_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
+        std::array<uint32_t, 2> shard_shape = {fused_height / num_cores, input_tensor.get_legacy_shape()[-1]};
+        ShardSpec shard_spec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
+        auto mem_config = this->output_mem_config;
+        mem_config.shard_spec = shard_spec;
+        return {TensorSpec(
+            input_tensor.get_logical_shape(),
+            TensorLayout::fromPaddedShape(
+                output_dtype,
+                PageConfig(Layout::ROW_MAJOR),
+                mem_config,
+                input_tensor.get_logical_shape(),
+                input_tensor.get_padded_shape()))};
     }
+
+    return {TensorSpec(
+        input_tensor.get_logical_shape(),
+        TensorLayout::fromPaddedShape(
+            output_dtype,
+            PageConfig(Layout::ROW_MAJOR),
+            output_mem_config,
+            input_tensor.get_logical_shape(),
+            input_tensor.get_padded_shape()))};
 }
 
 operation::ProgramWithCallbacks Untilize::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -25,9 +25,7 @@ struct Untilize {
     const std::optional<CoreRangeSet> sub_core_grids;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
@@ -31,10 +31,9 @@ void UntilizeWithHaloV2::validate(const std::vector<Tensor>& input_tensors) cons
     TT_FATAL(input_tensor.shard_spec().has_value(), "Error");
 }
 
-std::vector<tt::tt_metal::LegacyShape> UntilizeWithHaloV2::compute_output_shapes(
-    const std::vector<Tensor>& input_tensors) const {
-    const auto& input = input_tensors.at(0);
-    const auto& input_shape = input.get_legacy_shape();
+std::vector<ttnn::TensorSpec> UntilizeWithHaloV2::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto& input_shape = input_tensor.get_legacy_shape();
     auto output_shape = input_shape;
 
     uint32_t nbatch = input_shape[0];
@@ -51,16 +50,8 @@ std::vector<tt::tt_metal::LegacyShape> UntilizeWithHaloV2::compute_output_shapes
     log_debug(tt::LogOp, "max_out_nsticks_per_core: {}", max_out_nsticks_per_core_);
     log_debug(tt::LogOp, "ncores_nhw: {}", ncores_nhw_);
 
-    return {output_shape};
-}
-
-std::vector<Tensor> UntilizeWithHaloV2::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
     DataType output_dtype =
         input_tensor.get_dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.get_dtype();
-    auto output_shape = this->compute_output_shapes(input_tensors).at(0);
-
     TT_FATAL(
         input_tensor.memory_config().memory_layout == out_mem_config_.memory_layout,
         "{} {}",
@@ -78,7 +69,14 @@ std::vector<Tensor> UntilizeWithHaloV2::create_output_tensors(
     out_mem_config.shard_spec->shape[0] = tt::div_up(output_shape[0] * output_shape[2], ncores_nhw_);
     out_mem_config.shard_spec->shape[1] = input_tensor.memory_config().shard_spec->shape[1];
     out_mem_config.shard_spec->halo = true;
-    return {create_device_tensor(output_shape, output_dtype, Layout::ROW_MAJOR, input_tensor.device(), out_mem_config)};
+    return {TensorSpec(
+        output_shape.logical_shape(),
+        TensorLayout::fromPaddedShape(
+            output_dtype,
+            PageConfig(Layout::ROW_MAJOR),
+            out_mem_config,
+            output_shape.logical_shape(),
+            output_shape.padded_shape()))};
 }
 
 operation::ProgramWithCallbacks UntilizeWithHaloV2::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.hpp
@@ -21,9 +21,7 @@ struct UntilizeWithHaloV2 {
     const bool transpose_mcast_;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -35,7 +35,7 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
             }
             // What else?
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-            auto output_shape = this->compute_output_shapes(input_tensors).at(0);
+            auto output_shape = this->compute_output_specs(input_tensors).at(0).padded_shape();
             for (uint32_t i = 0; i < output_shape.rank() - 2; i++) {
                 TT_FATAL(input_tensor_a.get_legacy_shape()[i] == output_shape[i], "Error");
             }
@@ -68,26 +68,21 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> UntilizeWithUnpadding::compute_output_shapes(
+std::vector<ttnn::TensorSpec> UntilizeWithUnpadding::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     SmallVector<uint32_t> out_shape;
-    auto rank = input_tensors[0].get_legacy_shape().rank();
+    const auto& input_tensor_a = input_tensors.at(0);
+    auto rank = input_tensor_a.get_padded_shape().rank();
     out_shape.reserve(rank);
     for (uint32_t i = 0; i < rank; i++) {
         out_shape.push_back(this->output_tensor_end[i] + 1);
     }
-    tt::tt_metal::LegacyShape output_tensor_shape(out_shape);
-    return {output_tensor_shape};
-}
+    SimpleShape output_shape(std::move(out_shape));
 
-std::vector<Tensor> UntilizeWithUnpadding::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
     DataType output_dtype =
         input_tensor_a.get_dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor_a.get_dtype();
     if (input_tensor_a.memory_config().is_sharded() && this->output_mem_config.is_sharded()) {
-        auto output_shape = this->compute_output_shapes(input_tensors).at(0);
-        uint32_t fused_height = tt::tt_metal::compute_volume(output_shape) / output_shape[-1];
+        uint32_t fused_height = output_shape.volume() / output_shape[-1];
         uint32_t num_cores = input_tensor_a.shard_spec().value().num_cores();
         std::array<uint32_t, 2> shard_shape;
         ShardSpec shard_spec = input_tensor_a.shard_spec().value();
@@ -99,16 +94,10 @@ std::vector<Tensor> UntilizeWithUnpadding::create_output_tensors(
         shard_spec.shape = shard_shape;
         auto mem_config = this->output_mem_config;
         mem_config.shard_spec = shard_spec;
-        return {create_device_tensor(
-            this->compute_output_shapes(input_tensors).at(0),
-            output_dtype,
-            Layout::ROW_MAJOR,
-            input_tensor_a.device(),
-            mem_config)};
-    } else {
-        return operation::generic_create_output_tensors(
-            *this, input_tensors, output_dtype, Layout::ROW_MAJOR, this->output_mem_config);
+        return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), mem_config))};
     }
+
+    return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), output_mem_config))};
 }
 
 operation::ProgramWithCallbacks UntilizeWithUnpadding::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -19,9 +19,7 @@ struct UntilizeWithUnpadding {
     const bool fp32_dest_acc_en;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };


### PR DESCRIPTION
### Ticket

### Problem description
We're continuing to port all OPs from `compute_output_shapes` to `compute_output_specs`

### What's changed
Ported all data movement OPs to `compute_output_specs`

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12741209603)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12740497997)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12740494500)
- [x] [T3K frequent CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12739818104)
- [x] [T3K nightly CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12739820357)
- [x] New/Existing tests provide coverage for changes
