### PR TITLE
Enable to/from torch tests for 0D/1D tensors

### DIFF
--- a/tests/ttnn/unit_tests/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/test_to_and_from_torch.py
@@ -92,6 +92,7 @@ def test_from_torch_large(device):
         (),
         (1),
         (2),
+        (127),
         (0),
     ],
 )
@@ -100,6 +101,26 @@ def test_from_torch_large(device):
 def test_to_for_01_rank(shape, layout, dtype):
     torch_input_tensor = torch.rand(shape, dtype=dtype)
     tensor = ttnn.from_torch(torch_input_tensor, layout=layout)
-    # Conversion in the opposite direction is not yet supported
-    # torch_output_tensor = ttnn.to_torch(tensor)
-    # assert torch.allclose(torch_input_tensor, torch_output_tensor)
+    torch_output_tensor = ttnn.to_torch(tensor)
+    assert torch_input_tensor.shape == torch_output_tensor.shape
+    assert torch.allclose(torch_input_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (),
+        (1),
+        (2),
+        (127),
+        (0),
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_to_for_01_rank_on_device(device, shape, layout, dtype):
+    torch_input_tensor = torch.rand(shape, dtype=dtype)
+    tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+    torch_output_tensor = ttnn.to_torch(tensor)
+    assert torch_input_tensor.shape == torch_output_tensor.shape
+    assert torch.allclose(torch_input_tensor, torch_output_tensor)


### PR DESCRIPTION
### Ticket

### Problem description
We're adding proper support for 0D/1D tensors in TTNN, and we need to enable conversion tests. They were previously failing, but are passing now.

### What's changed
Enabled to_torch/from_torch tests for 0D/1D tests both on CPU and on device

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12740721485)
- [x] New/Existing tests provide coverage for changes
