### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Tile Move Copy

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/move_copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/move_copy_tile.rst
@@ -4,4 +4,4 @@ move_copy_tile
 
 .. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
 .. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid = 0, uint32_t transpose = 0)
-.. doxygenfunction:: copy_tile_init()
+.. doxygenfunction:: copy_tile_init(uint32_t cbid)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -360,7 +360,7 @@ void MAIN {
 #endif
 #endif  // FUSE_BIAS
             pack_untilize_dst_init_short<out_subblock_w, out_block_w>(out_cb_id);
-            copy_tile_to_dst_init_short();
+            copy_tile_to_dst_init_short(mm_partials_cb_id);
             for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                 reblock_and_untilize<out_subblock_w, out_block_w>(
                     in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, mm_partials_cb_id, out_cb_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm.cpp
@@ -41,7 +41,7 @@ void MAIN {
                     acquire_dst();
 
                     if (enable_reload) {
-                        copy_tile_to_dst_init_short();
+                        copy_tile_to_dst_init_short(tt::CBIndex::c_24);
                         cb_wait_front(tt::CBIndex::c_24, out_subblock_num_tiles);
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             copy_tile(tt::CBIndex::c_24, i, i);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -59,7 +59,7 @@ inline void reblock_and_untilize(
         int block_offset = 0;
 
         // Reblock
-        copy_tile_to_dst_init_short();
+        copy_tile_to_dst_init_short(interm_cb_id);
         cb_reserve_back(reblock_cb_id, out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             for (uint32_t w = 0; w < out_subblock_w; w++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
@@ -45,7 +45,7 @@ inline void reblock_and_untilize(
         int block_offset = 0;
 
         // Reblock
-        copy_tile_to_dst_init_short();
+        copy_tile_to_dst_init_short(interm_cb_id);
         cb_reserve_back(reblock_cb_id, out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             for (uint32_t w = 0; w < out_subblock_w; w++) {
@@ -154,7 +154,7 @@ void MAIN {
                 acquire_dst();
 
                 if (enable_reload) {
-                    copy_tile_to_dst_init_short();
+                    copy_tile_to_dst_init_short(matmul_partials_cb);
                     cb_wait_front(matmul_partials_cb, out_subblock_num_tiles);
                     for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                         copy_tile(matmul_partials_cb, i, i);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
@@ -42,7 +42,7 @@ inline void reblock_and_untilize(
         int block_offset = 0;
 
         // Reblock
-        copy_tile_to_dst_init_short();
+        copy_tile_to_dst_init_short(interm_cb_id);
         cb_reserve_back(reblock_cb_id, out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             for (uint32_t w = 0; w < out_subblock_w; w++) {
@@ -158,7 +158,7 @@ void MAIN {
                         acquire_dst();
 
                         if (enable_reload) {
-                            copy_tile_to_dst_init_short();
+                            copy_tile_to_dst_init_short(matmul_partials_cb);
                             cb_wait_front(matmul_partials_cb, out_subblock_num_tiles);
                             for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                                 copy_tile(matmul_partials_cb, i, i);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
@@ -39,7 +39,7 @@ void MAIN {
                 acquire_dst();
 
                 if (enable_reload) {
-                    copy_tile_to_dst_init_short();
+                    copy_tile_to_dst_init_short(tt::CBIndex::c_24);
                     cb_wait_front(tt::CBIndex::c_24, out_subblock_num_tiles);
                     for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                         copy_tile(tt::CBIndex::c_24, i, i);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -36,7 +36,7 @@ void MAIN {
         // Tests both inits, 1st one inits UNPACK for Bfp8_b
         // data inside CB_0, 2nd one inits it to Bfp16_b
         // which is inside CB_2
-        copy_tile_init();
+        copy_tile_init(cb_in0);
         // This call will test copy_tile_to_dst_init_short as well
         copy_tile_to_dst_init_short_with_dt(cb_in0, cb_in2);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -106,7 +106,7 @@ void MAIN {
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             ACQ();
             cb_wait_front(cb_in0, ndst);
-            copy_tile_init();  // need to copy from CB to DST to be able to run sfpu math
+            copy_tile_init(cb_in0);  // need to copy from CB to DST to be able to run sfpu math
             for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
                 copy_tile(cb_in0, wt8, wt8);  // copy from c_in[0] to DST[0]
             }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -29,7 +29,7 @@ void MAIN {
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
         acquire_dst();
         if (block_id > 0) {
-            copy_tile_to_dst_init_short();
+            copy_tile_to_dst_init_short(partials_cb);
             cb_wait_front(partials_cb, out_block_num_tiles);
             for (uint32_t i = 0; i < out_block_num_tiles; i++) {
                 copy_tile(partials_cb, i, i);

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -25,7 +25,7 @@ namespace ckernel {
  * Flag to perform transpose on SrcA                 | uint32_t |  Any positive value will indicate tranpose is set   |
  * False    |
  */
-ALWI void copy_tile_to_dst_init_short(uint32_t cbid = 0, uint32_t transpose = 0) {
+ALWI void copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0) {
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, false /*transpose within 16x16 face*/, cbid)));
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(
@@ -35,7 +35,7 @@ ALWI void copy_tile_to_dst_init_short(uint32_t cbid = 0, uint32_t transpose = 0)
  * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset
  * registers.
  */
-ALWI void copy_tile_init() { copy_tile_to_dst_init_short(); }
+ALWI void copy_tile_init(uint32_t cbid) { copy_tile_to_dst_init_short(cbid); }
 
 /**
  * Return value: None

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -45,7 +45,7 @@ void MAIN {
 
 #if defined(DST_ACCUM_MODE) || defined(ELTWISE_DEST_REUSE_TYPE)
         cb_wait_front(cb_in2, per_core_block_size);
-        copy_tile_to_dst_init_short();
+        copy_tile_to_dst_init_short(cb_in2);
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
             copy_tile(cb_in2, i, i);  // copy from c_in[0] to DST[0]
         }

--- a/tt_metal/programming_examples/matmul_common/kernels/compute/bmm_large_block_zm.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/compute/bmm_large_block_zm.cpp
@@ -41,7 +41,7 @@ void MAIN {
                     acquire_dst();
 
                     if (enable_reload) {
-                        copy_tile_to_dst_init_short();
+                        copy_tile_to_dst_init_short(tt::CBIndex::c_24);
                         cb_wait_front(tt::CBIndex::c_24, out_subblock_num_tiles);
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             copy_tile(tt::CBIndex::c_24, i, i);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -65,7 +65,7 @@ inline void reblock_and_untilize(
         int block_offset = 0;
 
         // Reblock
-        copy_tile_to_dst_init_short();
+        copy_tile_to_dst_init_short(interm_cb_id);
         cb_reserve_back(reblock_cb_id, out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             for (uint32_t w = 0; w < out_subblock_w; w++) {
@@ -170,7 +170,7 @@ void MAIN {
                         tile_regs_acquire();
                         if (enable_reload) {
                             // Reconfigure input
-                            copy_tile_to_dst_init_short();
+                            copy_tile_to_dst_init_short(matmul_partials_cb);
                             UNPACK((llk_unpack_reconfig_data_format(1, matmul_partials_cb, 0, 0)));
                             MATH((llk_math_reconfig_data_format(1, matmul_partials_cb, 0, 0)));
                             cb_wait_front(matmul_partials_cb, out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -61,7 +61,7 @@ inline void eltwise_mul_and_add_block_v2(
         cb_pop_front(in0_cb_id, 1);
         cb_pop_front(in1_cb_id, 1);
         if (idx == 0) {
-            copy_tile_to_dst_init_short();
+            copy_tile_to_dst_init_short(eltwise_mul_partials_cb_cb_id);
             ACQ();
             cb_wait_front(eltwise_mul_partials_cb_cb_id, 1);
             cb_reserve_back(out_cb_id, 1);
@@ -82,7 +82,7 @@ inline void eltwise_mul_and_add_block_v2(
             cb_pop_front(eltwise_mul_partials_cb_cb_id, 1);
             cb_pop_front(out_cb_id, 1);
 
-            copy_tile_to_dst_init_short();
+            copy_tile_to_dst_init_short(temp_sum_cb);
             ACQ();
             cb_wait_front(temp_sum_cb, 1);
             cb_reserve_back(out_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -438,7 +438,7 @@ void MAIN {
                 reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);
 #endif
                 pack_untilize_dst_init_short<out_subblock_w, out_block_w>(out_cb_id);
-                copy_tile_to_dst_init_short();
+                copy_tile_to_dst_init_short(matmul_partials_cb);
                 uint32_t curr_tile_output_rows_h = 0;
                 uint32_t TILE_SIZE = is_non_tile_height ? 32 : out_block_w;
                 TILE_SIZE = TILE_SIZE * out_subblock_h;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -43,7 +43,7 @@ void MAIN {
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
 #if PRE_SCALE
-        copy_tile_to_dst_init_short();  // need to copy from CB to DST to be able to run sfpu math
+        copy_tile_to_dst_init_short(cb_in0);  // need to copy from CB to DST to be able to run sfpu math
 #endif
 
 #ifdef SFPU_OP_INIT_PRE_IN0_0

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -47,7 +47,7 @@ void MAIN {
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
 
 #if PRE_SCALE
-    copy_tile_to_dst_init_short();  // need to copy from CB to DST to be able to run sfpu math
+        copy_tile_to_dst_init_short(cb_in0);  // need to copy from CB to DST to be able to run sfpu math
 #endif
 
 #ifdef SFPU_OP_INIT_PRE_IN0_0

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp
@@ -196,7 +196,7 @@
                                                                        \
         tile_regs_acquire();                                           \
         for (uint32_t i = 0; i < per_core_block_size; ++i) {           \
-            copy_tile_to_dst_init_short();                             \
+            copy_tile_to_dst_init_short(cb_pre);                       \
             copy_tile(cb_pre, i, i);                                   \
             PROCESS_ACTIVATIONS(op, i);                                \
         }                                                              \

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -111,7 +111,7 @@ FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out, uint32_t num_input_units
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
-    copy_tile_to_dst_init_short();
+    copy_tile_to_dst_init_short(cb_in);
 
     cb_wait_front(cb_in, num_input_units);
     cb_reserve_back(cb_out, 1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -385,7 +385,7 @@ void MAIN {
 #endif
 #endif  // FUSE_BIAS
                     pack_untilize_dst_init_short<out_subblock_w, out_block_w>(out_cb_id);
-                    copy_tile_to_dst_init_short();
+                    copy_tile_to_dst_init_short(mm_partials_cb_id);
                     for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                         reblock_and_untilize<out_subblock_w, out_block_w>(
                             in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, mm_partials_cb_id, out_cb_id);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -62,11 +62,11 @@ void MAIN {
         cb_wait_front(cb_x, onetile);  // comes from the reader
         cb_reserve_back(cb_xabs, onetile);
 
-        copy_tile_init();
+        copy_tile_init(cb_x);
         copy_tile(cb_x, 0, dst0);
 
         if (do_mask_h && need_to_do_mask_h(tile_idx, ht, wt)) {
-            copy_tile_init();
+            copy_tile_init(cb_mask_h_w);
             copy_tile(cb_mask_h_w, 0, dst1);
 
             mask_tile_init();
@@ -74,7 +74,7 @@ void MAIN {
         }
 
         if (do_mask_w && ((tile_idx + 1) % wt) == 0) {
-            copy_tile_init();
+            copy_tile_init(cb_mask_h_w);
             copy_tile(cb_mask_h_w, 1, dst1);
 
             mask_tile_init();
@@ -99,7 +99,7 @@ void MAIN {
             cb_wait_front(cb_correct_xpow, onetile);
             cb_reserve_back(cb_xpowadd, onetile);
 
-            copy_tile_init();
+            copy_tile_init(cb_correct_xpow);
             copy_tile(cb_correct_xpow, 0, dst0);
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
@@ -44,7 +44,7 @@ void MAIN {
             cb_wait_front(cb_input, onetile);  // comes from the reader
             cb_reserve_back(cb_x, onetile);
 
-            copy_tile_init();
+            copy_tile_init(cb_input);
             copy_tile(cb_input, 0, dst0);
             cb_pop_front(cb_input, onetile);
             tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/kernels/moreh_cumsum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/kernels/moreh_cumsum_nc.cpp
@@ -50,7 +50,7 @@ void MAIN {
             // copy tile from intermed0 to out0
             ACQ();
             cb_wait_front(cb_intermed0, onetile);
-            copy_tile_to_dst_init_short();
+            copy_tile_to_dst_init_short(tt::CBIndex::c_24);
             copy_tile(tt::CBIndex::c_24, first_tile, dst0);
             cb_reserve_back(cb_out0, onetile);
             pack_tile(dst0, cb_out0);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -41,7 +41,7 @@ void MAIN {
         ACQ();
         if (enable_reload) {
             cb_wait_front(tt::CBIndex::c_25, onetile);
-            copy_tile_to_dst_init_short();
+            copy_tile_to_dst_init_short(tt::CBIndex::c_25);
             copy_tile(tt::CBIndex::c_25, 0, 0);
             cb_pop_front(tt::CBIndex::c_25, onetile);
         }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -413,7 +413,7 @@ void MAIN {
                 uint32_t index_h1_offset = 0;
 
                 if (copy_or_add == true) {
-                    copy_tile_init();
+                    copy_tile_init(cb_xmm);
                 } else {
                     add_tiles_init();
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -189,7 +189,7 @@ void MAIN {
 #else
         reconfig_data_format(cb_in0, cb_in0);
         pack_reconfig_data_format(cb_exps);
-        copy_tile_to_dst_init_short();  // need to copy from CB to DST to be able to run sfpu math
+        copy_tile_to_dst_init_short(cb_in0);  // need to copy from CB to DST to be able to run sfpu math
 #ifndef NUMERIC_STABLE
         exp_tile_init<EXP_APPROX>();
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -179,7 +179,7 @@ void MAIN {
         pack_reconfig_data_format(cb_exps);
         // exp(x)
         index_subblock_w_offset = 0;
-        copy_tile_to_dst_init_short();
+        copy_tile_to_dst_init_short(cb_in0);
         exp_tile_init<EXP_APPROX>();
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             ACQ();

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
@@ -28,7 +28,7 @@ void MAIN {
             if (once) {
                 cb_reserve_back(tt::CBIndex::c_24, 1);
                 tile_regs_acquire();
-                copy_tile_to_dst_init_short();
+                copy_tile_to_dst_init_short(tt::CBIndex::c_0);
                 copy_tile(tt::CBIndex::c_0, 0, 0);  // copy from c_in[0] to DST[0]
                 tile_regs_commit();
                 tile_regs_wait();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK compute API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the tile_move_copy kernel APIs:
- ./tt_metal/include/compute_kernel_api/tile_move_copy.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12756238945)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12811501902) (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
