### PR TITLE
#16621: Add barriers at end of cq_dispatch_slave.cpp on IERISC

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1762,9 +1762,13 @@ void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
     do {
         invalidate_l1_cache();
     } while (!ncrisc_noc_reads_flushed(noc_idx));
+    WAYPOINT("NFCW");
     while (!ncrisc_noc_nonposted_writes_sent(noc_idx));
+    WAYPOINT("NFDW");
     while (!ncrisc_noc_nonposted_writes_flushed(noc_idx));
+    WAYPOINT("NFEW");
     while (!ncrisc_noc_nonposted_atomics_flushed(noc_idx));
+    WAYPOINT("NFFW");
     while (!ncrisc_noc_posted_writes_sent(noc_idx));
     WAYPOINT("NFBD");
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -294,5 +294,14 @@ void kernel_main() {
     }
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_dispatch_cb_sem_id>(total_pages_acquired);
+#ifdef COMPILE_FOR_IDLE_ERISC
+    // Wait for all transactions to complete, to avoid hitting the asserts in
+    // idle_erisck.cc if there are outstanding transactions. These barriers
+    // don't work on worker cores, because there cq_dispatch is on the same core
+    // and shares use of this noc, but doesn't update this risc's transaction
+    // counts. However, we don't have the barrier checks in brisck.cc, so we can
+    // skip this for now.
+    noc_async_full_barrier();
+#endif
     DPRINT << "dispatch_s : done" << ENDL();
 }


### PR DESCRIPTION

### Ticket
#16621 

### Problem description
Like other kernels that can run on erisc, cq_dispatch_slave needs a barrier at the end to ensure all transactions have finished. Otherwise, an assert will be hit if the watcher is running.

### What's changed
Add a barrier only on ierisc. These barriers don't work on worker cores, because there cq_dispatch is on the
same core and shares use of this noc, but doesn't update this risc's transaction counts. However, we don't have the barrier checks in brisck.cc, so we can skip this for now.


### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
