### PR TITLE
Add tiled interleaved permute for when width dimension doesn't move (row-major tiled invariant)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .idea
 runtime
 *.log
-*.csv
+# *.csv
 *.xlsx
 *.code-workspace
 /tt-perf*
@@ -58,9 +58,9 @@ docs/doxygen_build
 **.swo
 **.swn
 
-*profile_log*.csv
-**/profiler/output/*
-generated
+# *profile_log*.csv
+# **/profiler/output/*
+# generated
 
 env/
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .idea
 runtime
 *.log
-# *.csv
+*.csv
 *.xlsx
 *.code-workspace
 /tt-perf*
@@ -58,9 +58,9 @@ docs/doxygen_build
 **.swo
 **.swn
 
-# *profile_log*.csv
-# **/profiler/output/*
-# generated
+*profile_log*.csv
+**/profiler/output/*
+generated
 
 env/
 tags

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1094,22 +1094,7 @@ def test_transpose_hw_rm(shape, device):
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
-@pytest.mark.parametrize("shape", [(5, 3, 1, 1, 12, 8)])
-def test_transpose_13(shape, device):
-    torch_input = torch.randn(shape, dtype=torch.bfloat16)
-    torch_output = torch_input.transpose(1, 3)
-    tt_input = ttnn.from_torch(
-        torch_input,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-    )
-    tt_output = ttnn.transpose(tt_input, 1, 3)
-    tt_output = ttnn.to_torch(tt_output)
-    assert_with_pcc(torch_output, tt_output, 0.9999)
-
-
+@skip_for_grayskull("Grayskull does not support float32")
 def test_transpose_16411(device):
     torch.manual_seed(2005)
     input_shape = (5, 3, 1, 1, 12, 8)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1092,3 +1092,19 @@ def test_transpose_hw_rm(shape, device):
     tt_output = ttnn.transpose(tt_input, 2, 3)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+@pytest.mark.parametrize("shape", [(5, 3, 1, 1, 12, 8)])
+def test_transpose_13(shape, device):
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = torch_input.transpose(1, 3)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    tt_output = ttnn.transpose(tt_input, 1, 3)
+    tt_output = ttnn.to_torch(tt_output)
+    assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1108,3 +1108,30 @@ def test_transpose_13(shape, device):
     tt_output = ttnn.transpose(tt_input, 1, 3)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+def test_transpose_16411(device):
+    torch.manual_seed(2005)
+    input_shape = (5, 3, 1, 1, 12, 8)
+    a = torch.rand(input_shape, dtype=torch.bfloat16)
+    p_b2 = torch.transpose(a, 1, 3)
+    p_b3 = torch.transpose(a, 1, 5)
+    p_c = torch.transpose(a, 0, 4)
+    p_c2 = torch.transpose(a, 1, 4)
+    p_c3 = torch.transpose(a, 2, 4)
+    p_c4 = torch.transpose(a, 3, 4)
+
+    b = ttnn.from_torch(a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    b2 = ttnn.transpose(b, 1, 3)
+    b3 = ttnn.transpose(b, 1, 5)
+    c = ttnn.transpose(b, 0, 4)
+    c2 = ttnn.transpose(b, 1, 4)
+    c3 = ttnn.transpose(b, 2, 4)
+    c4 = ttnn.transpose(b, 3, 4)
+
+    assert_with_pcc(p_b2, ttnn.to_torch(b2), 0.9999)
+    assert_with_pcc(p_b3, ttnn.to_torch(b3), 0.9999)
+    assert_with_pcc(p_c, ttnn.to_torch(c), 0.9999)
+    assert_with_pcc(p_c2, ttnn.to_torch(c2), 0.9999)
+    assert_with_pcc(p_c3, ttnn.to_torch(c3), 0.9999)
+    assert_with_pcc(p_c4, ttnn.to_torch(c4), 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -372,16 +372,16 @@ def test_permute_5d_tiled_row_invariant(shape, perm, device):
     assert_with_pcc(torch_output, output_tensor, 0.9999)
 
 
-@pytest.mark.parametrize("shape", [[1, 1, 36, 33, 35]])
+@pytest.mark.parametrize("shape", [[2, 2, 36, 33, 35]])
 @pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4)])
 def test_permute_5d_xc_pad(shape, perm, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2, 4), pad_value=1.0)
+    output_tensor = ttnn.permute(input_tensor, perm)
     print(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    torch_output = torch.permute(torch_tensor, (0, 1, 3, 2, 4))
+    torch_output = torch.permute(torch_tensor, perm)
     # print(torch_tensor)
     # print(torch_output)
     # print(output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -365,9 +365,6 @@ def test_permute_5d_tiled_row_invariant(shape, perm, device):
     output_tensor = ttnn.permute(input_tensor, perm)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, perm)
-    # print(torch_tensor)
-    # print(torch_output)
-    # print(output_tensor)
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
 
@@ -379,11 +376,7 @@ def test_permute_5d_xc_pad(shape, perm, device):
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, perm)
-    print(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, perm)
-    # print(torch_tensor)
-    # print(torch_output)
-    # print(output_tensor)
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -358,11 +358,28 @@ def test_permute_identity(shape, device):
     "shape", [[1, 1, 32, 32, 32], [1, 1, 1, 2, 33], [1, 1, 2, 1, 33], [1, 2, 1, 33, 1], [33, 33, 33, 33, 33]]
 )
 @pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4), (3, 2, 1, 0, 4), (0, 3, 2, 1, 4), (1, 3, 2, 0, 4), (0, 3, 1, 2, 4)])
-def test_permute_5d_xc(shape, perm, device):
+def test_permute_5d_tiled_row_invariant(shape, perm, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2, 4))
+    output_tensor = ttnn.permute(input_tensor, perm)
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, perm)
+    # print(torch_tensor)
+    # print(torch_output)
+    # print(output_tensor)
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("shape", [[1, 1, 36, 33, 35]])
+@pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4)])
+def test_permute_5d_xc_pad(shape, perm, device):
+    torch.manual_seed(2005)
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2, 4), pad_value=1.0)
+    print(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, (0, 1, 3, 2, 4))
     # print(torch_tensor)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -352,3 +352,21 @@ def test_permute_identity(shape, device):
     torch_output = torch.permute(torch_tensor, (0, 1, 2, 3))
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape", [[1, 1, 32, 32, 32], [1, 1, 1, 2, 33], [1, 1, 2, 1, 33], [1, 2, 1, 33, 1], [33, 33, 33, 33, 33]]
+)
+@pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4), (3, 2, 1, 0, 4), (0, 3, 2, 1, 4), (1, 3, 2, 0, 4), (0, 3, 1, 2, 4)])
+def test_permute_5d_xc(shape, perm, device):
+    torch.manual_seed(2005)
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2, 4))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (0, 1, 3, 2, 4))
+    # print(torch_tensor)
+    # print(torch_output)
+    # print(output_tensor)
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -399,3 +399,17 @@ def test_permutations_5d_fixed_w(shape, perm, device):
     torch_output = torch.permute(torch_tensor, perm)
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.skip("#16575 to_layout from tiled to RM fails on reshape")
+@pytest.mark.parametrize("shape", [[1, 9, 91, 7, 9]])
+@pytest.mark.parametrize("perm", [[0, 3, 4, 1, 2]])
+def test_permute_adversarial(shape, perm, device):
+    torch.manual_seed(2005)
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, perm)
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, perm)
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -388,7 +388,7 @@ def generate_fixed_w_permutations(N):
         yield perm + (N - 1,)
 
 
-@pytest.mark.parametrize("shape", [[7, 7, 7, 7, 7]])
+@pytest.mark.parametrize("shape", [[7, 7, 7, 33, 33]])
 @pytest.mark.parametrize("perm", generate_fixed_w_permutations(5))
 def test_permutations_5d_fixed_w(shape, perm, device):
     torch.manual_seed(2005)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -371,7 +371,26 @@ def test_permute_5d_tiled_row_invariant(shape, perm, device):
 
 @pytest.mark.parametrize("shape", [[2, 2, 36, 33, 35]])
 @pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4)])
-def test_permute_5d_xc_pad(shape, perm, device):
+def test_permute_5d_xh_pad(shape, perm, device):
+    torch.manual_seed(2005)
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, perm)
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, perm)
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+def generate_fixed_w_permutations(N):
+    perms_Nd = generate_permutations(N - 1)
+    for perm in perms_Nd:
+        yield perm + (N - 1,)
+
+
+@pytest.mark.parametrize("shape", [[7, 7, 7, 7, 7]])
+@pytest.mark.parametrize("perm", generate_fixed_w_permutations(5))
+def test_permutations_5d_fixed_w(shape, perm, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -369,6 +369,8 @@ def test_permute_identity(shape, device):
 @pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4)])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
 def test_permute_5d_xh_pad(shape, perm, dtype, device):
+    if is_grayskull() and dtype == ttnn.float32:
+        pytest.skip("Grayskull doesn't support float32")
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
@@ -389,6 +391,8 @@ def generate_fixed_w_permutations(N):
 @pytest.mark.parametrize("perm", generate_fixed_w_permutations(5))
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
 def test_permutations_5d_fixed_w(shape, perm, dtype, device):
+    if is_grayskull() and dtype == ttnn.float32:
+        pytest.skip("Grayskull doesn't support float32")
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
@@ -405,7 +409,7 @@ def test_permutations_5d_fixed_w(shape, perm, dtype, device):
 def test_permute_adversarial(shape, perm, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
     output_tensor = ttnn.permute(input_tensor, perm)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, perm)
@@ -420,7 +424,7 @@ def test_permute_adversarial(shape, perm, device):
 def test_permute_4d_fixed_w(shape, perm, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
     output_tensor = ttnn.permute(input_tensor, perm)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, perm)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -230,6 +230,7 @@ def test_permute_5d_blocked(shape, perm, memory_config, dtype, device):
 @skip_for_blackhole("tilize_block gives bad pcc after second iteration")
 @skip_for_grayskull("tilize_block gives bad pcc after second iteration")
 def test_permute_nd(device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand((1, 3, 16, 16, 16, 16), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (0, 2, 4, 3, 5, 1))
@@ -239,6 +240,7 @@ def test_permute_nd(device):
 
 
 def test_permute_squeeze(device):
+    torch.manual_seed(2005)
     ones = ttnn.ones((1, 1, 3))
     tensor = ttnn.to_device(ones, device)
     out = ttnn.permute(tensor, (0, 1, 2))
@@ -253,6 +255,7 @@ def test_permute_squeeze(device):
 def test_permute_3D(shape, perm, layout, memory_config, dtype, device):
     if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Grayskull doesn't support float32")
+    torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=layout, device=device, dtype=dtype, memory_config=memory_config)
     output_tensor = ttnn.permute(input_tensor, perm)
@@ -263,6 +266,7 @@ def test_permute_3D(shape, perm, layout, memory_config, dtype, device):
 
 
 def test_nil_volume_permute(device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand([1, 0, 30, 32], dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2))
@@ -273,6 +277,7 @@ def test_nil_volume_permute(device):
 
 
 def test_permute_5d_tiled_basic(device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand([10, 10, 10, 100, 100], dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (2, 1, 0, 3, 4))
@@ -283,6 +288,7 @@ def test_permute_5d_tiled_basic(device):
 
 
 def test_permute_5d_tiled_swap(device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand([10, 10, 10, 100, 100], dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (2, 1, 0, 4, 3))
@@ -296,6 +302,7 @@ def test_permute_5d_tiled_swap(device):
     "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [32, 32, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 64, 64]]
 )
 def test_permute_4d_cn(shape, device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (1, 0, 2, 3))
@@ -309,6 +316,7 @@ def test_permute_4d_cn(shape, device):
     "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [32, 32, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 64, 64]]
 )
 def test_permute_4d_wh(shape, device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2))
@@ -322,6 +330,7 @@ def test_permute_4d_wh(shape, device):
     "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [32, 32, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 64, 64]]
 )
 def test_permute_4d_cnwh(shape, device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (1, 0, 3, 2))
@@ -334,6 +343,7 @@ def test_permute_4d_cnwh(shape, device):
 @pytest.mark.parametrize("shape", [[2, 2, 2, 2, 2, 2, 32, 32]])
 @pytest.mark.parametrize("dims", [(5, 4, 3, 2, 1, 0, 7, 6), (5, 4, 3, 2, 1, 0, 6, 7)])
 def test_permute_8d_swapped(shape, dims, device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, dims)
@@ -345,6 +355,7 @@ def test_permute_8d_swapped(shape, dims, device):
 
 @pytest.mark.parametrize("shape", [[1, 1, 32, 32]])
 def test_permute_identity(shape, device):
+    torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.permute(input_tensor, (0, 1, 2, 3))
@@ -354,27 +365,13 @@ def test_permute_identity(shape, device):
     assert_with_pcc(torch_output, output_tensor, 0.9999)
 
 
-@pytest.mark.parametrize(
-    "shape", [[1, 1, 32, 32, 32], [1, 1, 1, 2, 33], [1, 1, 2, 1, 33], [1, 2, 1, 33, 1], [33, 33, 33, 33, 33]]
-)
-@pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4), (3, 2, 1, 0, 4), (0, 3, 2, 1, 4), (1, 3, 2, 0, 4), (0, 3, 1, 2, 4)])
-def test_permute_5d_tiled_row_invariant(shape, perm, device):
-    torch.manual_seed(2005)
-    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.permute(input_tensor, perm)
-    output_tensor = ttnn.to_torch(output_tensor)
-    torch_output = torch.permute(torch_tensor, perm)
-    assert torch_output.shape == output_tensor.shape
-    assert_with_pcc(torch_output, output_tensor, 0.9999)
-
-
-@pytest.mark.parametrize("shape", [[2, 2, 36, 33, 35]])
+@pytest.mark.parametrize("shape", [[2, 2, 67, 67, 65]])
 @pytest.mark.parametrize("perm", [(0, 1, 3, 2, 4)])
-def test_permute_5d_xh_pad(shape, perm, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_permute_5d_xh_pad(shape, perm, dtype, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
     output_tensor = ttnn.permute(input_tensor, perm)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, perm)
@@ -390,10 +387,11 @@ def generate_fixed_w_permutations(N):
 
 @pytest.mark.parametrize("shape", [[7, 7, 7, 33, 33]])
 @pytest.mark.parametrize("perm", generate_fixed_w_permutations(5))
-def test_permutations_5d_fixed_w(shape, perm, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_permutations_5d_fixed_w(shape, perm, dtype, device):
     torch.manual_seed(2005)
     torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
-    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
     output_tensor = ttnn.permute(input_tensor, perm)
     output_tensor = ttnn.to_torch(output_tensor)
     torch_output = torch.permute(torch_tensor, perm)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -413,3 +413,18 @@ def test_permute_adversarial(shape, perm, device):
     torch_output = torch.permute(torch_tensor, perm)
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 32, 32], [32, 32, 64, 64]]
+)
+@pytest.mark.parametrize("perm", generate_fixed_w_permutations(4))
+def test_permute_4d_fixed_w(shape, perm, device):
+    torch.manual_seed(2005)
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, perm)
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, perm)
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -1,0 +1,400 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "debug/dprint.h"
+
+template <size_t N, typename T>
+void dprint_array(T arr[N], const char* name) {
+    DPRINT << name << ": ";
+    for (size_t i = 0; i < N; i++) {
+        DPRINT << arr[i] << " ";
+    }
+    DPRINT << ENDL();
+}
+
+// ------------------------------------------------------------------
+// 1) unflatten_index<N>:
+//    Unflatten 'flat_idx' in row-major order for a shape[] of length N.
+//    shape[d] is also uint32_t. We store the result into out_multi_idx[].
+template <uint32_t N>
+inline void unflatten_index(uint32_t flat_idx, const uint32_t (&shape)[N], uint32_t (&out_multi_idx)[N]) {
+    // Process from last dimension to first, in row-major unflattening.
+    for (int d = N - 1; d >= 0; d--) {
+        uint32_t dim_size = shape[d];
+        out_multi_idx[d] = flat_idx % dim_size;
+        flat_idx = flat_idx / dim_size;
+    }
+}
+
+// ------------------------------------------------------------------
+// 2) flatten_index_ignore_last_dim<N>:
+//    Flatten the first (N-1) coords in row-major order, ignoring dimension N-1.
+//    shape[] has length (N-1). The result is a uint32_t "row" offset.
+template <uint32_t N>
+inline uint32_t flatten_index_ignore_last_dim(const uint32_t (&multi_idx)[N - 1], const uint32_t (&shape)[N - 1]) {
+    uint32_t offset = 0;
+    for (uint32_t d = 0; d < N - 1; d++) {
+        offset = offset * shape[d] + multi_idx[d];
+    }
+    return offset;
+}
+
+// ------------------------------------------------------------------
+// 3) get_unpadded_linear_row_index_for_tile<N, TILE_HEIGHT, TILE_WIDTH>:
+//    - 'tile' is a 0-based tile index in the "tiled_shape" (flattened row-major).
+//    - 'input_tiled_shape':  length N, [ ..., X_t, W_t ]
+//    - 'input_shape':        length N, [ ..., X,   W   ] (the unpadded shape).
+//    - TILE_HEIGHT, TILE_WIDTH are compile-time constants.
+//
+//  Returns the linear row index (flattened in row-major ignoring the last dim)
+//  in the UNPADDED shape where that tile starts.
+//
+//  Steps, conceptually:
+//    a) unflatten 'tile' -> tile_multi_idx[N] in input_tiled_shape
+//    b) x_t = tile_multi_idx[N-2]
+//    c) x = x_t * TILE_HEIGHT
+//    d) row_multi_idx[d < N-2] = tile_multi_idx[d], row_multi_idx[N-2] = x
+//    e) flatten row_multi_idx[] vs input_shape[0..N-2]
+//
+template <uint32_t N, uint32_t TILE_HEIGHT, uint32_t TILE_WIDTH>
+inline uint32_t get_unpadded_linear_row_index_for_tile(
+    uint32_t tile,
+    const uint32_t (&input_tiled_shape)[N],  // [ ..., X_t, W_t ]
+    const uint32_t (&input_shape)[N]         // [ ..., X,   W   ]
+) {
+    // a) unflatten tile into tile_multi_idx
+    uint32_t tile_multi_idx[N];
+    unflatten_index<N>(tile, input_tiled_shape, tile_multi_idx);
+
+    // b) x_t = tile_multi_idx[N-2]
+    uint32_t x_t = tile_multi_idx[N - 2];
+
+    // c) x = x_t * TILE_HEIGHT
+    uint32_t x = x_t * TILE_HEIGHT;
+
+    // d) Build row_multi_idx of length N-1, ignoring last dimension
+    //    row_multi_idx[d] = tile_multi_idx[d] for d < N-2
+    //    row_multi_idx[N-2] = x
+    uint32_t row_multi_idx[N - 1];
+    uint32_t row_shape[N - 1];
+    for (uint32_t d = 0; d < N - 2; d++) {
+        row_multi_idx[d] = tile_multi_idx[d];
+        row_shape[d] = input_shape[d];
+    }
+    row_multi_idx[N - 2] = x;               // the actual row
+    row_shape[N - 2] = input_shape[N - 2];  // dimension X
+
+    // e) Flatten row_multi_idx in row_shape => linear row index
+    return flatten_index_ignore_last_dim<N>(row_multi_idx, row_shape);
+}
+
+void kernel_main() {
+    // Compile-time constants
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t element_size = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(2);
+    constexpr uint32_t X = get_compile_time_arg_val(3);
+    constexpr uint32_t H = get_compile_time_arg_val(4);
+    constexpr uint32_t W = get_compile_time_arg_val(5);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(6);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
+    constexpr bool needs_padding = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t N = get_compile_time_arg_val(11);
+
+    DPRINT << "Starting writer_permute_interleaved_tiled_row_invariant" << ENDL();
+    DPRINT << "dst_is_dram: " << (uint32_t)dst_is_dram << ENDL();
+    DPRINT << "element_size: " << element_size << ENDL();
+    DPRINT << "cb_id_out0: " << cb_id_out0 << ENDL();
+    DPRINT << "X: " << X << ENDL();
+    DPRINT << "H: " << H << ENDL();
+    DPRINT << "W: " << W << ENDL();
+    DPRINT << "TILE_HEIGHT: " << TILE_HEIGHT << ENDL();
+    DPRINT << "TILE_WIDTH: " << TILE_WIDTH << ENDL();
+    DPRINT << "FACE_HEIGHT: " << FACE_HEIGHT << ENDL();
+    DPRINT << "FACE_WIDTH: " << FACE_WIDTH << ENDL();
+    DPRINT << "needs_padding: " << (uint32_t)needs_padding << ENDL();
+    DPRINT << "N: " << N << ENDL();
+
+    // Retrieve arguments
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_tile = get_arg_val<uint32_t>(1);
+    uint32_t end_tile = get_arg_val<uint32_t>(2);
+    uint32_t start_padding_tile_idx = get_arg_val<uint32_t>(3);
+    uint32_t end_padding_tile_idx = get_arg_val<uint32_t>(4);
+
+    DPRINT << "dst_addr: " << dst_addr << ENDL();
+    DPRINT << "start_tile: " << start_tile << ENDL();
+    DPRINT << "end_tile: " << end_tile << ENDL();
+    DPRINT << "start_padding_tile_idx: " << start_padding_tile_idx << ENDL();
+    DPRINT << "end_padding_tile_idx: " << end_padding_tile_idx << ENDL();
+
+    // Input shape, permutation, and destination strides
+    uint32_t array_start_offset = 5;  // input shape starts at arg 5
+    uint32_t input_shape[N], perm[N], output_shape[N];
+    for (uint32_t i = 0; i < N; i++) {
+        input_shape[i] = get_arg_val<uint32_t>(i + array_start_offset);
+        perm[i] = get_arg_val<uint32_t>(i + array_start_offset + N);
+    }
+    for (uint32_t i = 0; i < N; i++) {
+        output_shape[i] = input_shape[perm[i]];
+    }
+    dprint_array<N, uint32_t>(input_shape, "input_shape");
+    dprint_array<N, uint32_t>(perm, "perm");
+
+    // Derived compile-time constants
+    constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
+    constexpr uint8_t NUM_FACES_H = TILE_HEIGHT / FACE_HEIGHT;
+    constexpr uint8_t NUM_FACES_W = TILE_WIDTH / FACE_WIDTH;
+
+    constexpr uint32_t X_p = tt::data_movement::common::round_up<X, TILE_HEIGHT>();
+    constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
+    constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
+
+    constexpr uint32_t W_t = W_p / TILE_WIDTH;
+    constexpr uint32_t H_t = H_p / TILE_HEIGHT;
+    constexpr uint32_t X_t = X_p / TILE_HEIGHT;
+
+    constexpr uint32_t SUBTILE_LINE_BYTES = FACE_WIDTH * element_size;
+
+    DPRINT << "TILE_HW: " << TILE_HW << ENDL();
+    DPRINT << "NUM_FACES_H: " << (uint32_t)NUM_FACES_H << ENDL();
+    DPRINT << "NUM_FACES_W: " << (uint32_t)NUM_FACES_W << ENDL();
+    DPRINT << "X_p: " << X_p << ENDL();
+    DPRINT << "H_p: " << H_p << ENDL();
+    DPRINT << "W_p: " << W_p << ENDL();
+    DPRINT << "W_t: " << W_t << ENDL();
+    DPRINT << "H_t: " << H_t << ENDL();
+    DPRINT << "X_t: " << X_t << ENDL();
+
+    // Initialize address generator
+    const uint32_t tile_bytes = get_tile_size(cb_id_out0);
+    const auto input_data_format = get_dataformat(cb_id_out0);
+
+    const InterleavedAddrGenFast<dst_is_dram, TILE_HW> s = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = input_data_format};
+
+    // Calculate actual data height in the last tile
+    constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
+
+    // Calculate real_faces_h
+    uint8_t remainder_faces_h = tt::data_movement::common::div_up<H_last_tile, FACE_HEIGHT>();
+
+    uint32_t remainder = H_last_tile % FACE_HEIGHT;
+    uint8_t sub_tile_lines_real = (remainder == 0) ? FACE_HEIGHT : static_cast<uint8_t>(remainder);
+
+    // Precompute constants used in inner loops
+    const uint32_t face_height_width = FACE_HEIGHT * FACE_WIDTH;
+    const uint32_t num_faces_wh = NUM_FACES_W * FACE_WIDTH;
+
+    // Main single loop over all tiles
+    uint32_t src_multi_idx[N];
+    uint32_t dest_multi_idx[N];
+
+    uint32_t input_padded_shape[N];
+    for (uint32_t i = 0; i < N - 2; i++) {
+        input_padded_shape[i] = input_shape[i];
+    }
+    input_padded_shape[N - 2] = H_p;
+    input_padded_shape[N - 1] = W_p;
+    dprint_array<N, uint32_t>(input_padded_shape, "input_padded_shape");
+
+    uint32_t input_tiled_shape[N];
+    for (uint32_t i = 0; i < N - 2; i++) {
+        input_tiled_shape[i] = input_padded_shape[i];
+    }
+    input_tiled_shape[N - 2] = H_t;
+    input_tiled_shape[N - 1] = W_t;
+    dprint_array<N, uint32_t>(input_tiled_shape, "input_tiled_shape");
+
+    uint32_t output_padded_shape[N];
+    for (uint32_t i = 0; i < N - 2; i++) {
+        output_padded_shape[i] = output_shape[i];
+    }
+    output_padded_shape[N - 2] = X_p;
+    output_padded_shape[N - 1] = W_p;
+    dprint_array<N, uint32_t>(output_padded_shape, "output_padded_shape");
+
+    uint32_t output_tiled_shape[N];
+    for (uint32_t i = 0; i < N - 2; i++) {
+        output_tiled_shape[i] = output_padded_shape[i];
+    }
+    output_tiled_shape[N - 2] = X_t;
+    output_tiled_shape[N - 1] = W_t;
+    DPRINT << ENDL();
+
+    for (uint32_t tile = start_tile; tile < end_tile; ++tile) {
+        uint32_t tile_start =
+            get_unpadded_linear_row_index_for_tile<N, TILE_HEIGHT, TILE_WIDTH>(tile, input_tiled_shape, input_shape);
+        uint32_t w_t = tile % W_t;
+        uint32_t temp = tile / W_t;
+        uint32_t h_t = temp % H_t;
+
+        // Determine the number of faces in the height dimension
+        uint8_t num_faces_h = (h_t == H_t - 1) ? remainder_faces_h : NUM_FACES_H;
+        cb_wait_front(cb_id_out0, 1);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+
+        // DPRINT << "tile_start: " << tile_start << ENDL();
+        // Iterate over faces in the height dimension
+        for (uint8_t face_h = 0; face_h < num_faces_h; ++face_h) {
+            // Determine the number of sub-tile lines to process
+            bool is_last_sub_tile_line = (h_t == H_t - 1) && (face_h == num_faces_h - 1);
+            uint8_t sub_tile_lines = is_last_sub_tile_line ? sub_tile_lines_real : FACE_HEIGHT;
+
+            // Iterate over faces in the width dimension
+            for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                // Iterate over sub-tile lines
+                for (uint8_t sub_tile_line = 0; sub_tile_line < sub_tile_lines; ++sub_tile_line) {
+                    // Compute multi-dimensional index for the row that we're on
+                    uint32_t row = tile_start + (uint32_t)(face_h * FACE_HEIGHT + sub_tile_line);
+                    uint32_t original_row = row;
+                    for (uint32_t i = 0; i < N - 1; ++i) {
+                        size_t dim = N - 2 - i;  // Start from the second last dimension
+                        src_multi_idx[dim] = row % input_shape[dim];
+                        row /= input_shape[dim];
+                    }
+                    src_multi_idx[N - 1] = 0;  // Logical row dimension index for output tensor
+
+                    // Apply permutation to get destination multi-dimensional index
+                    for (uint32_t i = 0; i < N; ++i) {
+                        dest_multi_idx[i] = src_multi_idx[perm[i]];  // Logical row dimension index for output tensor
+                    }
+                    // Convert destination multi-dimensional index to linear index
+                    // Account for tiled, faced/subtiled shape of the destination tensor
+                    // tensor is permuted from input: [..., X, ... H, ...W] to output: [..., H, ...X, W]
+                    // tensors are tiled as input: [..., X, ... H/TILE_HEIGHT, W/TILE_WIDTH] and output: [..., H,
+                    // ...X/TILE_HEIGHT, W/TILE_WIDTH] each tensor tile is faced as input: [..., X, ... H/TILE_HEIGHT,
+                    // W/TILE_WIDTH, NUM_FACES_H, NUM_FACES_W, FACE_HEIGHT, FACE_WIDTH] and output: [..., H,
+                    // ...X/TILE_HEIGHT, W/TILE_WIDTH, NUM_FACES_H, NUM_FACES_W, FACE_HEIGHT, FACE_WIDTH] where
+                    // NUM_FACES_H = TILE_HEIGHT / FACE_HEIGHT and NUM_FACES_W = TILE_WIDTH / FACE_WIDTH
+
+                    // First find the tile that this belongs to
+                    // 1) Flatten all outer dimensions into outer_flat
+                    // logical output shape: [..., X, W]
+                    // padded output shape: [..., X_p, W_p]
+                    // tiled output shape: [..., X_t, W_t] = [..., X_p/TILE_HEIGHT, W_p/TILE_WIDTH]
+                    uint32_t output_row_offset = 0;
+                    for (uint32_t i = 0; i < N - 1; i++) {
+                        output_row_offset = output_row_offset * output_padded_shape[i] + dest_multi_idx[i];
+                    }
+
+                    uint32_t output_tile_idx = (output_row_offset / TILE_HEIGHT) * W_t + w_t;
+
+                    // 1) The row coordinate in the X dimension:
+                    uint32_t output_row = dest_multi_idx[N - 2];
+
+                    // 2) Position of this output_row within the tile:
+                    uint32_t output_row_in_tile = output_row % TILE_HEIGHT;
+
+                    // 3) Face index along the tile's height dimension:
+                    uint32_t output_face_h = output_row_in_tile / FACE_HEIGHT;  // in [0..NUM_FACES_H-1]
+
+                    // 4) Row within that face:
+                    uint32_t output_sub_tile_line = output_row_in_tile % FACE_HEIGHT;  // in [0..FACE_HEIGHT-1]
+
+                    // Precompute offset for the current face_h
+                    uint32_t face_h_offset = output_face_h * NUM_FACES_W * face_height_width;
+
+                    // Combine face_w for the overall tile column
+                    uint32_t face_w_offset = face_w * face_height_width;
+
+                    // Since we are writing in SUBTILE_LINE_BYTES chunks, we don't need an offset within the sub-tile
+                    // line
+
+                    // Sub-tile/face line offset where our data starts in the tile
+                    uint32_t offset =
+                        (face_h_offset + face_w_offset + output_sub_tile_line * FACE_WIDTH) * element_size;
+
+                    uint64_t write_noc_base_addr = get_noc_addr(output_tile_idx, s, offset);
+                    {
+                        // DPRINT << "input tile: " << tile << ENDL();
+                        // DPRINT << "starting linear index of tile: " << tile_start << ENDL();
+                        // DPRINT << "linear input row: " << original_row << ENDL();
+                        // dprint_array<N, uint32_t>(src_multi_idx, "source index");
+                        // dprint_array<N, uint32_t>(dest_multi_idx, "dest index");
+                        // DPRINT << "sub_tile_line: " << (uint32_t) sub_tile_line << ENDL();
+
+                        // DPRINT << "output_row_offset: " << output_row_offset << ENDL();
+                        // DPRINT << "output_tile_idx: " << output_tile_idx << ENDL();
+                        // DPRINT << "output_row in tile: " << output_row_in_tile << ENDL();
+                        // DPRINT << "output_face_h: " << output_face_h << ENDL();
+                        // DPRINT << "output_face_w: " << (uint32_t) face_w << ENDL();
+                        // DPRINT << "output_sub_tile_line: " << output_sub_tile_line << ENDL();
+                        // DPRINT << "face_h_offset: " << face_h_offset << ENDL();
+                        // DPRINT << "face_w_offset: " << face_w_offset << ENDL();
+                        // DPRINT << "offset: " << offset << ENDL();
+                        // // DPRINT << "write_noc_base_addr: " << write_noc_base_addr << ENDL();
+                        // tt_l1_ptr uint16_t* l1_ptr = reinterpret_cast<tt_l1_ptr uint16_t*>(l1_read_addr);
+                        // DPRINT << "l1_ptr[0]: " << BF16(l1_ptr[0]) << ENDL();
+                        DPRINT << ENDL();
+                    }
+                    // Perform asynchronous write
+                    noc_async_write(l1_read_addr, write_noc_base_addr, SUBTILE_LINE_BYTES);
+
+                    // Increment the read address
+                    l1_read_addr += SUBTILE_LINE_BYTES;
+                }
+
+                // Skip padding if not all lines are real
+                if (is_last_sub_tile_line) {
+                    l1_read_addr += (FACE_HEIGHT - sub_tile_lines) * SUBTILE_LINE_BYTES;
+                }
+            }
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out0, 1);
+    }
+
+    // add padding
+    if constexpr (needs_padding) {
+        cb_wait_front(tt::CBIndex::c_1, 1);
+
+        uint32_t l1_read_ptr = get_read_ptr(tt::CBIndex::c_1);
+
+        constexpr uint32_t x_t = X_t - 1;
+        constexpr uint8_t X_in_tile = X % TILE_HEIGHT;
+        constexpr uint8_t face_c_start = X_in_tile / FACE_HEIGHT;
+
+        for (uint32_t tile_idx = start_padding_tile_idx; tile_idx < end_padding_tile_idx; ++tile_idx) {
+            // Map tile_idx to (n, h, w_t)
+            uint32_t n = tile_idx / (H * W_t);
+            uint32_t remainder1 = tile_idx % (H * W_t);
+            uint32_t h = remainder1 / W_t;
+            uint32_t w_t = remainder1 % W_t;
+
+            // Calculate linear_idx of padded tile inside output tensor buffer
+            uint32_t linear_idx = n * H * X_t * W_t + h * X_t * W_t + x_t * W_t + w_t;
+
+            for (uint8_t face_c = face_c_start; face_c < NUM_FACES_H; ++face_c) {
+                // Offset to the start of the current face along the channel dimension/height of the tile
+                uint32_t face_c_offset = face_c * NUM_FACES_W * face_height_width;
+
+                // Sub-tile/face line where our padded data starts
+                uint8_t sub_tile_line_start = face_c == face_c_start ? X_in_tile % FACE_HEIGHT : 0;
+
+                for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                    // Offset to the start of the current face along the width of the tile
+                    uint32_t face_w_offset = face_w * face_height_width;
+                    for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
+                        // offset to the start of the current sub-tile line
+                        uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line * FACE_WIDTH) * element_size;
+
+                        // Compute the write address
+                        uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+
+                        // Perform asynchronous write
+                        noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);
+                    }
+                }
+            }
+        }
+        noc_async_write_barrier();
+        cb_pop_front(tt::CBIndex::c_1, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -138,39 +138,42 @@ void kernel_main() {
     constexpr uint32_t face_h_stride_bytes = face_h_stride * element_size;
 
     // ------------------------------------------------------------------------
-    // 4) Build padded shapes
+    // 4) Build padded and tiled shapes
     // ------------------------------------------------------------------------
     uint32_t input_padded_shape[N];
-    for (uint32_t i = 0; i < N - 2; i++) {
-        input_padded_shape[i] = input_shape[i];
-    }
-    input_padded_shape[N - 2] = H_p;
-    input_padded_shape[N - 1] = W_p;
-
     uint32_t input_tiled_shape[N];
-    for (uint32_t i = 0; i < N - 2; i++) {
-        input_tiled_shape[i] = input_padded_shape[i];
+    for (uint32_t i = 0; i < N; i++) {
+        if (i < N - 2) {
+            input_padded_shape[i] = input_shape[i];
+            input_tiled_shape[i] = input_shape[i];
+        } else if (i == N - 2) {
+            input_padded_shape[i] = H_p;
+            input_tiled_shape[i] = H_t;
+        } else {
+            // i == N - 1
+            input_padded_shape[i] = W_p;
+            input_tiled_shape[i] = W_t;
+        }
     }
-    input_tiled_shape[N - 2] = H_t;
-    input_tiled_shape[N - 1] = W_t;
 
     uint32_t output_padded_shape[N];
-    for (uint32_t i = 0; i < N - 2; i++) {
-        output_padded_shape[i] = output_shape[i];
-    }
-    output_padded_shape[N - 2] = X_p;
-    output_padded_shape[N - 1] = W_p;
-
     uint32_t output_tiled_shape[N];
-    for (uint32_t i = 0; i < N - 2; i++) {
-        output_tiled_shape[i] = output_padded_shape[i];
+    for (uint32_t i = 0; i < N; i++) {
+        if (i < N - 2) {
+            output_padded_shape[i] = output_shape[i];
+            output_tiled_shape[i] = output_shape[i];
+        } else if (i == N - 2) {
+            output_padded_shape[i] = X_p;
+            output_tiled_shape[i] = X_t;
+        } else {
+            // i == N - 1
+            output_padded_shape[i] = W_p;
+            output_tiled_shape[i] = W_t;
+        }
     }
-    output_tiled_shape[N - 2] = X_t;
-    output_tiled_shape[N - 1] = W_t;
 
     // ------------------------------------------------------------------------
-    // 5) Build strides for the destination padded shape
-    //    ( ignoring last dimension? )
+    // 5) Build row strides for the destination padded shape
     // ------------------------------------------------------------------------
     uint32_t dest_padded_strides[N];
     dest_padded_strides[N - 1] = 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_row_invariant.cpp
@@ -5,15 +5,6 @@
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
-template <size_t N, typename T>
-void dprint_array(const T arr[N], const char* name) {
-    DPRINT << name << ": ";
-    for (size_t i = 0; i < N; i++) {
-        DPRINT << arr[i] << " ";
-    }
-    DPRINT << ENDL();
-}
-
 // ------------------------------------------------------------------
 // 1) unflatten_index<N>:
 //    Unflatten 'flat_idx' in row-major order for a shape[] of length N.

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -26,6 +26,8 @@ PermuteDeviceOperation::program_factory_t PermuteDeviceOperation::select_program
         if ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2) ||
             (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
             return MultiCoreTileInvariant{};
+        } else if (dims[rank - 1] == rank - 1) {
+            return MultiCoreTileRowInvariant{};
         }
     }
     return MultiCoreBlockedGeneric{};
@@ -42,8 +44,7 @@ void PermuteDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         tensor_args.input_tensor.get_layout() == Layout::ROW_MAJOR ||
             (tensor_args.input_tensor.get_layout() == Layout::TILE &&
-             ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2) ||
-              (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1))),
+             ((dims[rank - 1] == rank - 1) || (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1))),
         "Permute operation only supports row-major layout");
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -84,9 +84,13 @@ PermuteDeviceOperation::invoke(
     const Tensor& input_tensor,
     const SmallVector<uint32_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
-    std::optional<Tensor> optional_output_tensor) {
+    std::optional<Tensor> optional_output_tensor,
+    const std::optional<float>& pad_value) {
     return {
-        operation_attributes_t{.dims = dims, .output_mem_config = memory_config.value_or(input_tensor.memory_config())},
+        operation_attributes_t{
+            .dims = dims,
+            .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+            .pad_value = pad_value},
         tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = std::move(optional_output_tensor)}};
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -94,7 +94,29 @@ struct PermuteDeviceOperation {
             tensor_return_value_t& tensor_return_value);
     };
 
-    using program_factory_t = std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric, MultiCoreTileInvariant>;
+    struct MultiCoreTileRowInvariant {
+        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
+        struct shared_variables_t {
+            tt::tt_metal::KernelHandle unary_reader_kernel_id;
+            tt::tt_metal::KernelHandle unary_writer_kernel_id;
+            CoreRangeSet core_range;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t =
+        std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric, MultiCoreTileInvariant, MultiCoreTileRowInvariant>;
 
     // Mandatory methods
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -20,6 +20,7 @@ struct PermuteDeviceOperation {
     struct operation_attributes_t {
         const SmallVector<uint32_t> dims;
         const MemoryConfig output_mem_config;
+        const std::optional<float>& pad_value;
     };
     struct tensor_args_t {
         const Tensor& input_tensor;
@@ -145,7 +146,8 @@ struct PermuteDeviceOperation {
         const Tensor& input_tensor,
         const SmallVector<uint32_t>& dims,
         const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor);
+        std::optional<Tensor> optional_output_tensor,
+        const std::optional<float>& pad_value = std::nullopt);
 };
 }  // namespace ttnn::operations::data_movement
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -73,6 +73,9 @@ struct PermuteDeviceOperation {
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
     };
+
+    // Implementation for when the tile is not broken apart (either dims = {..., rank - 2, rank - 1} or {..., rank - 1,
+    // rank - 2})
     struct MultiCoreTileInvariant {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
         struct shared_variables_t {
@@ -95,6 +98,8 @@ struct PermuteDeviceOperation {
             tensor_return_value_t& tensor_return_value);
     };
 
+    // Implemention for when the height dimension (rank - 2) is swapped with another dimension (dims = {..., rank - 2,
+    // ..., i, rank - 1})
     struct MultiCoreTileRowInvariant {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
         struct shared_variables_t {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -20,7 +20,7 @@ struct PermuteDeviceOperation {
     struct operation_attributes_t {
         const SmallVector<uint32_t> dims;
         const MemoryConfig output_mem_config;
-        const std::optional<float>& pad_value;
+        const std::optional<float> pad_value;
     };
     struct tensor_args_t {
         const Tensor& input_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -332,6 +332,14 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
         }
     }
 
+    uint32_t h_in_dest = 0;
+    for (uint32_t i = 0; i < N; i++) {
+        if (dims[i] == N - 2) {
+            h_in_dest = i;
+            break;
+        }
+    }
+
     std::vector<uint32_t> reader_compile_time_args = {
         (uint32_t)src_is_dram, num_writes, padding_val_packed, (uint32_t)needs_padding};
 
@@ -354,7 +362,8 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
         face_shape[0],
         face_shape[1],
         (uint32_t)needs_padding,
-        N};
+        N,
+        h_in_dest};
 
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -264,7 +264,7 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
     uint32_t num_tiles = detail::num_tiles(input_tensor);
     uint32_t num_output_tiles = detail::num_tiles(tensor_return_value);
 
-    tt::tt_metal::Device* device = input_tensor.device();
+    tt::tt_metal::IDevice* device = input_tensor.device();
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t padding_cb_index = tt::CBIndex::c_1;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -279,8 +279,8 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
     uint32_t padded_num_tensor_tiles = num_output_tiles / (output_tensor.get_padded_shape()[N - 2] /
                                                            tile_shape[0]);  // only last row of Xt should have padding
 
-    // auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-    CoreCoord compute_with_storage_grid_size = {1u, 1u};
+    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    // CoreCoord compute_with_storage_grid_size = {1u, 1u};
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
     auto

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -41,7 +41,7 @@ ttnn::Tensor permute_impl(
     };
 
     if (rank > 4) {
-        if (a.get_layout() == Layout::TILE && ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2)) ||
+        if (a.get_layout() == Layout::TILE && (dims[rank - 1] == rank - 1) ||
             (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
             return prim_permute(a);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -39,8 +39,8 @@ ttnn::Tensor permute_impl(
     };
 
     if (rank > 4) {
-        if (a.get_layout() == Layout::TILE && (dims[rank - 1] == rank - 1) ||
-            (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
+        if (a.get_layout() == Layout::TILE &&
+            ((dims[rank - 1] == rank - 1) || (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1))) {
             return prim_permute(a);
         }
         auto input = a.get_layout() == Layout::TILE

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -96,7 +96,7 @@ ttnn::Tensor permute_impl(
     } else if (N == 1 && C == 0 && H == 3 && W == 2) {
         output = prim_permute(formatted_input_tensor);
     } else if (N == 1 && C == 2 && H == 0 && W == 3) {
-        output = transpose_hc(transpose_cn(formatted_input_tensor));
+        output = prim_permute(formatted_input_tensor);
     } else if (N == 1 && C == 2 && H == 3 && W == 0) {
         output = transpose_wh(transpose_hc(transpose_cn(formatted_input_tensor)));
     } else if (N == 1 && C == 3 && H == 0 && W == 2) {
@@ -104,11 +104,11 @@ ttnn::Tensor permute_impl(
     } else if (N == 1 && C == 3 && H == 2 && W == 0) {
         output = transpose_wh(transpose_hc(transpose_wh(transpose_cn(formatted_input_tensor))));
     } else if (N == 2 && C == 0 && H == 1 && W == 3) {
-        output = transpose_cn(transpose_hc(formatted_input_tensor));
+        output = prim_permute(formatted_input_tensor);
     } else if (N == 2 && C == 0 && H == 3 && W == 1) {
         output = transpose_wh(transpose_cn(transpose_hc(formatted_input_tensor)));
     } else if (N == 2 && C == 1 && H == 0 && W == 3) {
-        output = transpose_cn(transpose_hc(transpose_cn(formatted_input_tensor)));
+        output = prim_permute(formatted_input_tensor);
     } else if (N == 2 && C == 1 && H == 3 && W == 0) {
         output = transpose_wh(transpose_cn(transpose_hc(transpose_cn(formatted_input_tensor))));
     } else if (N == 2 && C == 3 && H == 0 && W == 1) {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -30,14 +30,12 @@ ttnn::Tensor permute_impl(
     const ttnn::SmallVector<uint32_t>& dims,
     const MemoryConfig& output_mem_config,
     const std::optional<float>& pad_value) {
-    using ttnn::operations::experimental::auto_format::AutoFormat;
-
     // Get the device
     IDevice* device = a.device();
     uint32_t rank = a.get_shape().rank();
 
     auto prim_permute = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
-        return ttnn::prim::permute(input, dims, output_mem_config, std::nullopt);
+        return ttnn::prim::permute(input, dims, output_mem_config, std::nullopt, pad_value);
     };
 
     if (rank > 4) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -566,7 +566,6 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
                     static_cast<uint32_t>(pad_value.value()) | (static_cast<uint32_t>(pad_value.value()) << 16);
             } else {
                 padding_val_packed = std::bit_cast<uint32_t>(pad_value.value());
-                ;
             }
         }
     }


### PR DESCRIPTION
### Ticket
#16464
#16465

### Problem description
Currently tiled permute only works when the tiles are not changed at all, and we attempt to convert it to row major before permuting otherwise. 

### What's changed
Add native support for tiled permute when the height dimension in the tile is swapped elsewhere.

PyTorch2 transpose sweeps coverage increases to 100% with the following caveats:
- for 3 large 2D tensors, the PCC drops from 0.999 to 0.998, which needs to be investigated (this is in another kernel)
- for 1 large 2D tensor, the PCC check takes so long that it causes a sweep timeout occasionally
Permute PyTorch2 transpose sweeps coverage increases from 94.5 to 95.4% with this change. The PR for #16466 will increase this to 100%.
As part of this change, we also remove some more recursive transpose chains in permute, increasing performance. For example:

| Input size     | Perm       | Percent speed-up |
|----------------|------------|------------------|
| 96,96,96,96    | 1,2,0,3    | 3.298783825      |
| 96,96,96,96    | 2,0,1,3    | 11.49442464      |
| 96,96,96,96    | 2,1,0,3    | 24.72870581      |


### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12793824665
- [ ] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12750563591
- [ ] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12750576671
- [ ] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12718706607
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
