### PR TITLE
#16625: Refactor tracking of sub-device managers from Device to a new class

### DIFF
--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager_tracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -24,6 +24,7 @@
 #include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
 #include "llrt/hal.hpp"
 #include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tt_metal/impl/sub_device/sub_device_manager_tracker.hpp"
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
 #include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/tt_stl/span.hpp"
@@ -72,11 +73,11 @@ bool Device::is_mmio_capable() const {
 }
 
 CoreRangeSet Device::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->sub_device(sub_device_id).cores(core_type);
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device(sub_device_id).cores(core_type);
 }
 
 uint32_t Device::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->sub_device(sub_device_id).num_cores(core_type);
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device(sub_device_id).num_cores(core_type);
 }
 
 /* Get all dispatch cores associated with this device. On return, my_dispatch_cores contains dispatch cores used by
@@ -225,14 +226,8 @@ void Device::initialize_cluster() {
 
 void Device::initialize_default_sub_device_state(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     // Create the default sub-device manager representing the entire chip
-    this->next_sub_device_manager_id_ = {0};
-    auto [sub_device_manager, _] = this->sub_device_managers_.insert_or_assign(this->get_next_sub_device_manager_id(), std::make_unique<detail::SubDeviceManager>(this, this->initialize_allocator(l1_small_size, trace_region_size, l1_bank_remap)));
-    this->default_sub_device_manager_id_ = sub_device_manager->first;
-    this->default_sub_device_manager_ = sub_device_manager->second.get();
-    this->active_sub_device_manager_id_ = this->default_sub_device_manager_id_;
-    this->active_sub_device_manager_ = this->default_sub_device_manager_;
-    this->allocator_ = this->get_initialized_allocator().get();
-
+    sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
+        this, this->initialize_allocator(l1_small_size, trace_region_size, l1_bank_remap));
 }
 
 std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap) {
@@ -971,8 +966,10 @@ void Device::init_command_queue_device() {
     }
 
     for (auto& hw_cq : this->hw_command_queues_) {
-        hw_cq->set_num_worker_sems_on_dispatch(this->active_sub_device_manager_->num_sub_devices());
-        hw_cq->set_go_signal_noc_data_on_dispatch(this->active_sub_device_manager_->noc_mcast_unicast_data());
+        hw_cq->set_num_worker_sems_on_dispatch(
+            sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices());
+        hw_cq->set_go_signal_noc_data_on_dispatch(
+            sub_device_manager_tracker_->get_active_sub_device_manager()->noc_mcast_unicast_data());
     }
 }
 
@@ -1051,11 +1048,7 @@ bool Device::close() {
     this->work_executor_.reset();
     tt_metal::detail::DumpDeviceProfileResults(this, true);
 
-    this->active_sub_device_manager_ = nullptr;
-    for (auto sub_device_manager = this->sub_device_managers_.begin(); sub_device_manager != this->sub_device_managers_.end();) {
-        this->remove_sub_device_manager((sub_device_manager++)->first);
-    }
-    this->default_sub_device_manager_ = nullptr;
+    sub_device_manager_tracker_.reset(nullptr);
 
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> not_done_dispatch_cores;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> cores_to_skip;
@@ -1275,34 +1268,15 @@ uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& 
 }
 
 const std::unique_ptr<Allocator> &Device::get_initialized_allocator() const {
-    return this->default_sub_device_manager_->get_initialized_allocator(SubDeviceId{0});
+    return sub_device_manager_tracker_->get_default_sub_device_manager()->get_initialized_allocator(SubDeviceId{0});
 }
 
 const std::unique_ptr<Allocator> &Device::get_initialized_allocator(SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->get_initialized_allocator(sub_device_id);
-}
-
-void Device::reset_sub_devices_state(const std::unique_ptr<detail::SubDeviceManager> &sub_device_manager) {
-    auto num_sub_devices = sub_device_manager->num_sub_devices();
-
-    // TODO: This could be further optimized by combining all of these into a single prefetch entry
-    // Currently each one will be pushed into its own prefetch entry
-    for (auto& hw_cq : this->hw_command_queues_) {
-        // Only need to reset launch messages once, so reset on cq 0
-        TT_FATAL(!hw_cq->sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
-        hw_cq->reset_worker_state(hw_cq->get_id() == 0);
-        hw_cq->set_num_worker_sems_on_dispatch(num_sub_devices);
-        hw_cq->set_go_signal_noc_data_on_dispatch(sub_device_manager->noc_mcast_unicast_data());
-        hw_cq->reset_config_buffer_mgr(num_sub_devices);
-    }
-    // Reset the launch_message ring buffer state seen on host
-    sub_device_manager->reset_worker_launch_message_buffer_state();
-
-    sub_device_manager->reset_sub_device_stall_group();
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_initialized_allocator(sub_device_id);
 }
 
 uint32_t Device::num_sub_devices() const {
-    return this->active_sub_device_manager_->num_sub_devices();
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices();
 }
 
 uint32_t Device::num_banks(const BufferType &buffer_type) const {
@@ -1471,7 +1445,8 @@ std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(tt::stl::Sp
     uint32_t sub_device_bank_id = 0;
     DeviceAddr lowest_addr = std::numeric_limits<DeviceAddr>::max();
     for (const auto& sub_device_id : sub_device_ids) {
-        const auto& allocator = this->active_sub_device_manager_->sub_device_allocator(sub_device_id);
+        const auto& allocator =
+            sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device_allocator(sub_device_id);
         if (allocator) {
             auto found_addr = allocator::lowest_occupied_l1_address(*allocator, sub_device_bank_id);
             if (found_addr.has_value()) {
@@ -1619,8 +1594,14 @@ void Device::begin_trace(const uint8_t cq_id, const uint32_t tid) {
     TT_FATAL(!this->hw_command_queues_[cq_id]->get_tid().has_value(), "CQ {} is already being used for tracing tid {}", (uint32_t)cq_id, tid);
     this->mark_allocations_safe();
     // Create an empty trace buffer here. This will get initialized in end_trace
-    TT_FATAL(this->active_sub_device_manager_->get_trace(tid) == nullptr, "Trace already exists for tid {} on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
-    auto &trace_buffer = this->active_sub_device_manager_->create_trace(tid);
+    auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
+    TT_FATAL(
+        active_sub_device_manager->get_trace(tid) == nullptr,
+        "Trace already exists for tid {} on device {}'s active sub-device manager {}",
+        tid,
+        this->id_,
+        active_sub_device_manager->id());
+    auto& trace_buffer = active_sub_device_manager->create_trace(tid);
     this->hw_command_queues_[cq_id]->record_begin(tid, trace_buffer->desc);
 }
 
@@ -1628,8 +1609,14 @@ void Device::end_trace(const uint8_t cq_id, const uint32_t tid) {
     ZoneScoped;
     TracyTTMetalEndTrace(this->id(), tid);
     TT_FATAL(this->hw_command_queues_[cq_id]->get_tid() == tid, "CQ {} is not being used for tracing tid {}", (uint32_t)cq_id, tid);
-    auto trace_buffer = this->active_sub_device_manager_->get_trace(tid);
-    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
+    auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
+    auto trace_buffer = active_sub_device_manager->get_trace(tid);
+    TT_FATAL(
+        trace_buffer != nullptr,
+        "Trace instance {} must exist on device {}'s active sub-device manager {}",
+        tid,
+        this->id_,
+        active_sub_device_manager->id());
     this->hw_command_queues_[cq_id]->record_end();
     Trace::initialize_buffer(this->command_queue(cq_id), trace_buffer);
     this->mark_allocations_unsafe();
@@ -1639,8 +1626,14 @@ void Device::replay_trace(const uint8_t cq_id, const uint32_t tid, const bool bl
     ZoneScoped;
     TracyTTMetalReplayTrace(this->id(), tid);
     constexpr bool check = false;
-    const auto &trace_buffer = this->active_sub_device_manager_->get_trace(tid);
-    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
+    auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
+    const auto& trace_buffer = active_sub_device_manager->get_trace(tid);
+    TT_FATAL(
+        trace_buffer != nullptr,
+        "Trace instance {} must exist on device {}'s active sub-device manager {}",
+        tid,
+        this->id_,
+        active_sub_device_manager->id());
     if constexpr (check) {
         Trace::validate_instance(*trace_buffer);
     }
@@ -1651,7 +1644,7 @@ void Device::release_trace(const uint32_t tid) {
     ZoneScoped;
     TracyTTMetalReleaseTrace(this->id(), tid);
 
-    this->active_sub_device_manager_->release_trace(tid);
+    sub_device_manager_tracker_->get_active_sub_device_manager()->release_trace(tid);
 
     // Only enable allocations once all captured traces are released
     if (this->trace_buffers_size_ == 0) {
@@ -1660,7 +1653,7 @@ void Device::release_trace(const uint32_t tid) {
 }
 
 std::shared_ptr<TraceBuffer> Device::get_trace(uint32_t tid) {
-    return this->active_sub_device_manager_->get_trace(tid);
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_trace(tid);
 }
 
 void Device::enable_program_cache() {
@@ -1741,25 +1734,27 @@ size_t Device::get_device_kernel_defines_hash() {
 }
 
 uint8_t Device::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->num_noc_mcast_txns(sub_device_id);
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_mcast_txns(sub_device_id);
 }
 
 uint8_t Device::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->num_noc_unicast_txns(sub_device_id);
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_unicast_txns(sub_device_id);
 }
 
 uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data, bool unicast_data) const {
     if (mcast_data) {
-        return this->active_sub_device_manager_->noc_mcast_data_start_index(sub_device_id);
+        return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_mcast_data_start_index(sub_device_id);
     } else if (unicast_data) {
-        return this->active_sub_device_manager_->noc_unicast_data_start_index(sub_device_id);
+        return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_unicast_data_start_index(
+            sub_device_id);
     } else {
         return 0;
     }
 }
 
 LaunchMessageRingBufferState& Device::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
-    return this->active_sub_device_manager_->get_worker_launch_message_buffer_state(sub_device_id);
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_worker_launch_message_buffer_state(
+        sub_device_id);
 }
 
 CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
@@ -1771,85 +1766,50 @@ NOC Device::dispatch_go_signal_noc() const {
     return this->dispatch_s_enabled() ? NOC::NOC_1 : NOC::NOC_0;
 }
 
-SubDeviceManagerId Device::get_next_sub_device_manager_id() {
-    return this->next_sub_device_manager_id_++;
-}
-
 SubDeviceManagerId Device::get_active_sub_device_manager_id() const {
-    return this->active_sub_device_manager_id_;
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->id();
 }
 
 SubDeviceManagerId Device::get_default_sub_device_manager_id() const {
-    return this->default_sub_device_manager_id_;
+    return sub_device_manager_tracker_->get_default_sub_device_manager()->id();
 }
 
 SubDeviceManagerId Device::create_sub_device_manager(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    auto [sub_device_manager, _] = this->sub_device_managers_.insert_or_assign(this->get_next_sub_device_manager_id(), std::make_unique<detail::SubDeviceManager>(sub_devices, local_l1_size, this));
-    return sub_device_manager->first;
+    return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
 
 std::tuple<SubDeviceManagerId, SubDeviceId> Device::create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    auto fabric_sub_device = SubDevice(std::array{CoreRangeSet(), this->default_sub_device_manager_->sub_device(SubDeviceId{0}).cores(HalProgrammableCoreType::ACTIVE_ETH)});
-    auto new_sub_devices = std::vector<SubDevice>(sub_devices.begin(), sub_devices.end());
-    new_sub_devices.push_back(fabric_sub_device);
-    auto fabric_sub_device_id = SubDeviceId{static_cast<uint32_t>(new_sub_devices.size() - 1)};
-    auto sub_device_manager_id = this->create_sub_device_manager(new_sub_devices, local_l1_size);
-    this->sub_device_managers_[sub_device_manager_id]->set_fabric_sub_device_id(fabric_sub_device_id);
-    return {sub_device_manager_id, fabric_sub_device_id};
+    return sub_device_manager_tracker_->create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
 }
 
 std::optional<SubDeviceId> Device::get_fabric_sub_device_id() const {
-    return this->active_sub_device_manager_->fabric_sub_device_id();
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->fabric_sub_device_id();
 }
 
 void Device::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
-    TT_FATAL(!this->using_slow_dispatch(), "Using sub device managers is unsupported with slow dispatch");
-    if (this->active_sub_device_manager_id_ == sub_device_manager_id) {
-        return;
-    }
-    if (this->active_sub_device_manager_id_ != this->default_sub_device_manager_id_) {
-        TT_FATAL(!this->active_sub_device_manager_->has_allocations(), "Cannot switch sub device managers while sub devices still have local allocations");
-    }
-    auto sub_device_manager = this->sub_device_managers_.find(sub_device_manager_id);
-    TT_FATAL(sub_device_manager != this->sub_device_managers_.end(), "Sub device manager does not exist");
-    this->reset_sub_devices_state(sub_device_manager->second);
-    const auto& global_allocator = this->get_initialized_allocator();
-    allocator::reset_allocator_size(*global_allocator, BufferType::L1);
-    // Shrink the global allocator size to make room for sub-device allocators
-    auto local_l1_size = sub_device_manager->second->local_l1_size();
-    allocator::shrink_allocator_size(*global_allocator, BufferType::L1, local_l1_size, true);
-    this->active_sub_device_manager_id_ = sub_device_manager_id;
-    this->active_sub_device_manager_ = sub_device_manager->second.get();
+    sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }
 
-void Device::clear_loaded_sub_device_manager() {
-    this->load_sub_device_manager(this->default_sub_device_manager_id_);
-}
+void Device::clear_loaded_sub_device_manager() { sub_device_manager_tracker_->clear_loaded_sub_device_manager(); }
 
 void Device::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
-    if (this->active_sub_device_manager_ != nullptr) {
-        TT_FATAL(sub_device_manager_id != this->active_sub_device_manager_id_, "Cannot remove active sub device manager {}", sub_device_manager_id);
-        TT_FATAL(sub_device_manager_id != this->default_sub_device_manager_id_, "Cannot remove default sub device manager {}", sub_device_manager_id);
-    }
-    auto sub_device_manager = this->sub_device_managers_.find(sub_device_manager_id);
-    TT_FATAL(sub_device_manager != this->sub_device_managers_.end(), "Sub device manager does not exist");
-    this->sub_device_managers_.erase(sub_device_manager);
+    sub_device_manager_tracker_->remove_sub_device_manager(sub_device_manager_id);
 }
 
 const std::vector<SubDeviceId> &Device::get_sub_device_ids() const {
-    return this->active_sub_device_manager_->get_sub_device_ids();
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_ids();
 }
 
 const std::vector<SubDeviceId> &Device::get_sub_device_stall_group() const {
-    return this->active_sub_device_manager_->get_sub_device_stall_group();
+    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_stall_group();
 }
 
 void Device::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    this->active_sub_device_manager_->set_sub_device_stall_group(sub_device_ids);
+    sub_device_manager_tracker_->get_active_sub_device_manager()->set_sub_device_stall_group(sub_device_ids);
 }
 
 void Device::reset_sub_device_stall_group() {
-    this->active_sub_device_manager_->reset_sub_device_stall_group();
+    sub_device_manager_tracker_->get_active_sub_device_manager()->reset_sub_device_stall_group();
 }
 
 DeviceAddr Device::get_base_allocator_addr(const HalMemType &mem_type) const {

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -11,7 +11,6 @@
 
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/memcpy.hpp"
-#include "tt_metal/impl/kernels/data_types.hpp"
 #include "tt_metal/impl/sub_device/sub_device.hpp"
 #include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/tt_stl/span.hpp"
@@ -25,7 +24,6 @@ inline namespace v0 {
 class IDevice;
 }  // namespace v0
 
-namespace detail {
 class SubDeviceManager {
 public:
     static constexpr uint32_t MAX_NUM_SUB_DEVICES = 16;
@@ -44,6 +42,8 @@ public:
     SubDeviceManager& operator=(SubDeviceManager&& other) noexcept = default;
 
     ~SubDeviceManager();
+
+    SubDeviceManagerId id() const;
 
     const std::vector<SubDeviceId>& get_sub_device_ids() const;
     const SubDevice& sub_device(SubDeviceId sub_device_id) const;
@@ -85,6 +85,10 @@ private:
     void populate_noc_data();
     void populate_worker_launch_message_buffer_state();
 
+    static std::atomic<uint64_t> next_sub_device_manager_id_;
+
+    SubDeviceManagerId id_;
+
     // TODO: We have a max number of sub-devices, so we can use a fixed size array
     std::vector<SubDevice> sub_devices_;
     std::vector<SubDeviceId> sub_device_ids_;
@@ -110,7 +114,5 @@ private:
     // TODO #15944: Temporary until migration to actual fabric is complete
     std::optional<SubDeviceId> fabric_sub_device_id_ = std::nullopt;
 };
-
-}  // namespace detail
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "tt_metal/impl/sub_device/sub_device_manager_tracker.hpp"
+
+#include "tt_metal/device.hpp"
+#include "tt_metal/impl/allocator/allocator.hpp"
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "tt_metal/impl/kernels/data_types.hpp"
+#include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tt_metal/impl/sub_device/sub_device_manager.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+namespace tt::tt_metal {
+
+SubDeviceManagerTracker::SubDeviceManagerTracker(IDevice* device, std::unique_ptr<Allocator>&& global_allocator) :
+    device_(device) {
+    auto sub_device_manager = std::make_unique<SubDeviceManager>(device, std::move(global_allocator));
+    default_sub_device_manager_ = sub_device_manager.get();
+    active_sub_device_manager_ = default_sub_device_manager_;
+    sub_device_managers_.insert_or_assign(sub_device_manager->id(), std::move(sub_device_manager));
+}
+
+SubDeviceManagerTracker::~SubDeviceManagerTracker() {
+    active_sub_device_manager_ = nullptr;
+    for (auto sub_device_manager = sub_device_managers_.begin(); sub_device_manager != sub_device_managers_.end();) {
+        this->remove_sub_device_manager((sub_device_manager++)->first);
+    }
+    default_sub_device_manager_ = nullptr;
+}
+
+SubDeviceManagerId SubDeviceManagerTracker::create_sub_device_manager(
+    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
+    auto sub_device_manager = std::make_unique<SubDeviceManager>(sub_devices, local_l1_size, device_);
+    auto sub_device_manager_id = sub_device_manager->id();
+    sub_device_managers_.insert_or_assign(sub_device_manager_id, std::move(sub_device_manager));
+    return sub_device_manager_id;
+}
+
+std::tuple<SubDeviceManagerId, SubDeviceId> SubDeviceManagerTracker::create_sub_device_manager_with_fabric(
+    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
+    auto fabric_sub_device = SubDevice(std::array{
+        CoreRangeSet(),
+        default_sub_device_manager_->sub_device(SubDeviceId{0}).cores(HalProgrammableCoreType::ACTIVE_ETH)});
+    auto new_sub_devices = std::vector<SubDevice>(sub_devices.begin(), sub_devices.end());
+    new_sub_devices.push_back(fabric_sub_device);
+    auto fabric_sub_device_id = SubDeviceId{static_cast<uint32_t>(new_sub_devices.size() - 1)};
+    auto sub_device_manager_id = this->create_sub_device_manager(new_sub_devices, local_l1_size);
+    sub_device_managers_[sub_device_manager_id]->set_fabric_sub_device_id(fabric_sub_device_id);
+    return {sub_device_manager_id, fabric_sub_device_id};
+}
+
+void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDeviceManager>& sub_device_manager) {
+    auto num_sub_devices = sub_device_manager->num_sub_devices();
+    // TODO: This could be further optimized by combining all of these into a single prefetch entry
+    // Currently each one will be pushed into its own prefetch entry
+    for (uint8_t cq_id = 0; cq_id < device_->num_hw_cqs(); ++cq_id) {
+        auto& hw_cq = device_->hw_command_queue(cq_id);
+        // Only need to reset launch messages once, so reset on cq 0
+        TT_FATAL(!hw_cq.sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
+        hw_cq.reset_worker_state(cq_id == 0);
+        hw_cq.set_num_worker_sems_on_dispatch(num_sub_devices);
+        hw_cq.set_go_signal_noc_data_on_dispatch(sub_device_manager->noc_mcast_unicast_data());
+        hw_cq.reset_config_buffer_mgr(num_sub_devices);
+    }
+    // Reset the launch_message ring buffer state seen on host
+    sub_device_manager->reset_worker_launch_message_buffer_state();
+
+    sub_device_manager->reset_sub_device_stall_group();
+}
+
+void SubDeviceManagerTracker::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    TT_FATAL(!device_->using_slow_dispatch(), "Using sub device managers is unsupported with slow dispatch");
+    if (active_sub_device_manager_->id() == sub_device_manager_id) {
+        return;
+    }
+    if (active_sub_device_manager_->id() != default_sub_device_manager_->id()) {
+        TT_FATAL(
+            !active_sub_device_manager_->has_allocations(),
+            "Cannot switch sub device managers while sub devices still have local allocations");
+    }
+    auto sub_device_manager = sub_device_managers_.find(sub_device_manager_id);
+    TT_FATAL(sub_device_manager != sub_device_managers_.end(), "Sub device manager does not exist");
+    this->reset_sub_device_state(sub_device_manager->second);
+    const auto& default_allocator = default_sub_device_manager_->get_initialized_allocator(SubDeviceId{0});
+    allocator::reset_allocator_size(*default_allocator, BufferType::L1);
+    // Shrink the global allocator size to make room for sub-device allocators
+    auto local_l1_size = sub_device_manager->second->local_l1_size();
+    allocator::shrink_allocator_size(*default_allocator, BufferType::L1, local_l1_size, /*bottom_up=*/true);
+    active_sub_device_manager_ = sub_device_manager->second.get();
+}
+
+void SubDeviceManagerTracker::clear_loaded_sub_device_manager() {
+    this->load_sub_device_manager(default_sub_device_manager_->id());
+}
+
+void SubDeviceManagerTracker::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    if (active_sub_device_manager_ != nullptr) {
+        TT_FATAL(
+            sub_device_manager_id != active_sub_device_manager_->id(),
+            "Cannot remove active sub device manager {}",
+            sub_device_manager_id);
+        TT_FATAL(
+            sub_device_manager_id != default_sub_device_manager_->id(),
+            "Cannot remove default sub device manager {}",
+            sub_device_manager_id);
+    }
+    auto sub_device_manager = sub_device_managers_.find(sub_device_manager_id);
+    TT_FATAL(sub_device_manager != sub_device_managers_.end(), "Sub device manager does not exist");
+    sub_device_managers_.erase(sub_device_manager);
+}
+
+SubDeviceManager* SubDeviceManagerTracker::get_active_sub_device_manager() const { return active_sub_device_manager_; }
+
+SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() const {
+    return default_sub_device_manager_;
+}
+
+SubDeviceManagerId SubDeviceManagerTracker::get_active_sub_device_manager_id() const {
+    return active_sub_device_manager_->id();
+}
+
+SubDeviceManagerId SubDeviceManagerTracker::get_default_sub_device_manager_id() const {
+    return default_sub_device_manager_->id();
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+
+#include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+namespace tt::tt_metal {
+
+inline namespace v0 {
+class IDevice;
+}  // namespace v0
+
+class Allocator;
+class SubDeviceManager;
+
+// This class is used by Device-like objects for tracking the SubDeviceManagers set up by the user
+class SubDeviceManagerTracker {
+public:
+    // TODO: Potentially move the global allocator creation into here instead of from the device
+    // This creates the SubDeviceManagerTracker with a default SubDeviceManager that has the entire grid as a sub-device
+    SubDeviceManagerTracker(IDevice* device, std::unique_ptr<Allocator>&& global_allocator);
+
+    SubDeviceManagerTracker(const SubDeviceManagerTracker& other) = delete;
+    SubDeviceManagerTracker& operator=(const SubDeviceManagerTracker& other) = delete;
+
+    SubDeviceManagerTracker(SubDeviceManagerTracker&& other) noexcept = default;
+    SubDeviceManagerTracker& operator=(SubDeviceManagerTracker&& other) noexcept = default;
+
+    ~SubDeviceManagerTracker();
+
+    SubDeviceManagerId create_sub_device_manager(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
+
+    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
+        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
+
+    void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
+
+    void clear_loaded_sub_device_manager();
+
+    void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
+
+    SubDeviceManager* get_active_sub_device_manager() const;
+
+    SubDeviceManager* get_default_sub_device_manager() const;
+
+    // Used for caching program state by manager and buffers to check that the required manager is still active
+    SubDeviceManagerId get_active_sub_device_manager_id() const;
+
+    // Currently only used by program's determine_sub_device_ids algorithm to avoid running the search algorithm in the
+    // default case to not affect performance
+    SubDeviceManagerId get_default_sub_device_manager_id() const;
+
+private:
+    void reset_sub_device_state(const std::unique_ptr<SubDeviceManager>& sub_device_manager);
+
+    IDevice* device_ = nullptr;
+
+    std::unordered_map<SubDeviceManagerId, std::unique_ptr<SubDeviceManager>> sub_device_managers_;
+    SubDeviceManager* active_sub_device_manager_ = nullptr;
+    SubDeviceManager* default_sub_device_manager_ = nullptr;
+};
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
to enable easy porting for MeshDevice

### Ticket
https://github.com/tenstorrent/tt-metal/issues/16625

### Problem description
Device was originally managing the tracking of managers and the active/default internally.
This meant that porting sub device to MeshDevice level required copying a number of attributes/logic.

### What's changed
Move these attributes/logic into a new class, SubDeviceCoordinator, so that Device/MeshDevice just need to instantiate and query this class instead of managing things themselves.

Naming of SubDeviceManager/SubDeviceManagerTracker could use improvement. Open to any ideas.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12774878624
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12774874012