### PR TITLE
#16657: Fix to_layout conversion into row major for 1D tensors

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -188,3 +188,18 @@ def test_to_layout_for_2D(shape, input_layout, output_layout, device):
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)
+
+
+@pytest.mark.parametrize("w", [1, 5, 14, 97])
+def test_to_from_1d(device, w):
+    torch.manual_seed(2005)
+    torch_input = torch.rand(w)
+
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.float32)
+    ttnn_input = ttnn.to_layout(ttnn_input, ttnn.TILE_LAYOUT)
+    ttnn_input = ttnn.to_device(ttnn_input, device)
+    ttnn_input = ttnn.from_device(ttnn_input)
+    ttnn_input = ttnn.to_layout(ttnn_input, ttnn.ROW_MAJOR_LAYOUT)
+    ttnn_input = ttnn.to_torch(ttnn_input)
+
+    assert_with_pcc(ttnn_input, torch_input)

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -316,14 +316,12 @@ Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const ttnn::SimpleShap
         input_tensor.get_padded_shape()[-2] - constants::TILE_HEIGHT < output_tensor_shape[-2] &&
             input_tensor.get_padded_shape()[-1] - constants::TILE_WIDTH < output_tensor_shape[-1],
         "Last 2 dims of output must be within range to have been padded to input");
-    ttnn::SmallVector<uint32_t> output_tensor_start{};
-    ttnn::SmallVector<uint32_t> output_tensor_end{};
-    for (auto index = 0; index < input_tensor.get_padded_shape().rank(); index++) {
-        output_tensor_start.push_back(0);
-        output_tensor_end.push_back(index < output_tensor_shape.rank() ? output_tensor_shape[index] : 1);
+    SimpleShape output_tensor_start(ttnn::SmallVector<uint32_t>(input_tensor.padded_shape().rank(), 0));
+    SimpleShape output_tensor_end(ttnn::SmallVector<uint32_t>(input_tensor.padded_shape().rank(), 1));
+    for (int index = -1; index >= -static_cast<int>(output_tensor_shape.rank()); index--) {
+        output_tensor_end[index] = output_tensor_shape[index];
     }
-    auto output = input_tensor.unpad(
-        ttnn::SimpleShape(std::move(output_tensor_start)), ttnn::SimpleShape(std::move(output_tensor_end)));
+    auto output = input_tensor.unpad(output_tensor_start, output_tensor_end);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16657

### Problem description
Converting 1D tensor to row major layout resulted in incorrect data

### What's changed
Updated some shape calculations in `tensor_unpad_from_tile`
Added a test to cover this case

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12755468344)
- [x] New/Existing tests provide coverage for changes
