### PR TITLE
Sever TT-Train's dependency on TT-Metalium's tests

### DIFF
--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -51,9 +51,7 @@ int main() {
     size_t num_devices_ = 0;
 
     std::srand(0);
-    arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
     num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-    std::cout << "Arch:" << tt::test_utils::get_env_arch_name() << std::endl;
     std::cout << "num_devices:" << num_devices_ << std::endl;
     device = tt::tt_metal::CreateDevice(0);
     std::cout << "Device created" << std::endl;

--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -12,7 +12,6 @@
 #include <common/bfloat16.hpp>                                                                     // NOLINT
 #include <distributed/mesh_device_view.hpp>                                                        // NOLINT
 #include <hostdevcommon/common_values.hpp>                                                         // NOLINT
-#include <tests/tt_metal/test_utils/env_vars.hpp>                                                  // NOLINT
 #include <tt_metal/common/base_types.hpp>                                                          // NOLINT
 #include <tt_metal/common/math.hpp>                                                                // NOLINT
 #include <tt_metal/host_api.hpp>                                                                   // NOLINT


### PR DESCRIPTION
### Ticket
#16678

### Problem description
TT-Train is depending on a bit from TT-Metalium's tests.  This was exposed when cleaning up include directories.

### What's changed
Turns out that header was used to:
1) Populate an unused variable
2) Print a log message.

If that log message in the sample code is important, we can find another way to get the info.  This diff assumes that log message isn't crucial.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
