### PR TITLE
Fix scaling issue with RT arguments in tilize/untilize with padding

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -166,7 +166,9 @@ def test_to_layout_6D(shape, input_layout, output_layout, device):
     assert_with_pcc(input_a, output_tensor)
 
 
-@pytest.mark.parametrize("shape", [[3, 50, 1, 1, 768], [3, 50, 1, 1, 1024], [3, 197, 1, 1, 768], [3, 197, 1, 1, 1024]])
+@pytest.mark.parametrize(
+    "shape", [[3, 1370, 1, 1, 1280], [3, 50, 1, 1, 768], [3, 50, 1, 1, 1024], [3, 197, 1, 1, 768], [3, 197, 1, 1, 1024]]
+)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 def test_to_layout_nd_hangs(shape, input_layout, output_layout, device):

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -182,6 +182,11 @@ struct FullRep {
     }
 };
 
+inline bool compare_assignments(const BlockRep& el0, const BlockRep& el1) {
+    return (
+        el0.n_data == el1.n_data && el0.n_mixed == el1.n_mixed && el0.n_pads == el1.n_pads && el0.times == el1.times);
+}
+
 inline std::vector<std::vector<BlockRep>> distribute_work(
     const ttnn::SimpleShape& logical_shape,
     const tt::tt_metal::Padding& padding,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -74,12 +74,24 @@ void kernel_main() {
 
     uint32_t stick_id = start_stick_id;
     uint32_t rt_arg_idx = 6;
-    for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
-        const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx++);   // number of full tile-rows
-        const uint32_t n_mixed = get_arg_val<uint32_t>(rt_arg_idx++);  // number of rows in a partially filled tile-row
-        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx++);   // number of padding tile-rows
-        const uint32_t times = get_arg_val<uint32_t>(rt_arg_idx++);  // number of times the pattern of tile-rows repeats
+    uint32_t count_repeat_idx = 10;
+    uint32_t count = 1;
 
+    for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
+        const uint32_t repeat_count = get_arg_val<uint32_t>(count_repeat_idx);
+        const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx);  // number of full tile-rows
+        const uint32_t n_mixed =
+            get_arg_val<uint32_t>(rt_arg_idx + 1);                      // number of rows in a partially filled tile-row
+        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + 2);  // number of padding tile-rows
+        const uint32_t times =
+            get_arg_val<uint32_t>(rt_arg_idx + 3);  // number of times the pattern of tile-rows repeats
+        if (count == repeat_count) {
+            rt_arg_idx = rt_arg_idx + 5;
+            count_repeat_idx = count_repeat_idx + 5;
+            count = 1;
+        } else {
+            count++;
+        }
         for (uint32_t t = 0; t < times; ++t) {
             for (uint32_t y_t = 0; y_t < n_data; y_t++) {
                 read_block(stick_id, tile_height);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -74,20 +74,24 @@ void kernel_main() {
 
     uint32_t stick_id = start_stick_id;
     uint32_t rt_arg_idx = 6;
-    uint32_t count_repeat_idx = 10;
     uint32_t count = 1;
+    constexpr int32_t n_mixed_idx = 1;
+    constexpr int32_t n_pad_idx = 2;
+    constexpr int32_t times_idx = 3;
+    constexpr uint32_t repeat_ct_idx = 4;
+    constexpr int32_t num_rt_idx = 5;
 
     for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
-        const uint32_t repeat_count = get_arg_val<uint32_t>(count_repeat_idx);
+        const uint32_t repeat_count =
+            get_arg_val<uint32_t>(rt_arg_idx + repeat_ct_idx);  // number of times the same block representation is used
         const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx);  // number of full tile-rows
         const uint32_t n_mixed =
-            get_arg_val<uint32_t>(rt_arg_idx + 1);                      // number of rows in a partially filled tile-row
-        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + 2);  // number of padding tile-rows
+            get_arg_val<uint32_t>(rt_arg_idx + n_mixed_idx);  // number of rows in a partially filled tile-row
+        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + n_pad_idx);  // number of padding tile-rows
         const uint32_t times =
-            get_arg_val<uint32_t>(rt_arg_idx + 3);  // number of times the pattern of tile-rows repeats
+            get_arg_val<uint32_t>(rt_arg_idx + times_idx);  // number of times the pattern of tile-rows repeats
         if (count == repeat_count) {
-            rt_arg_idx = rt_arg_idx + 5;
-            count_repeat_idx = count_repeat_idx + 5;
+            rt_arg_idx = rt_arg_idx + num_rt_idx;
             count = 1;
         } else {
             count++;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -374,15 +374,28 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
         };
 
         uint32_t nblocks_per_core = 0;
-
+        BlockRep ref_el = assignment[0];
+        uint32_t count_repeated = 0;
         for (const auto& el : assignment) {
             nblocks_per_core += el.block_count();
             row_start_id += el.data_row_count();
-            reader_rt_args.push_back(el.n_data);
-            reader_rt_args.push_back(el.n_mixed);
-            reader_rt_args.push_back(el.n_pads);
-            reader_rt_args.push_back(el.times);
+            if (compare_assignments(ref_el, el)) {
+                count_repeated++;
+            } else {
+                reader_rt_args.push_back(ref_el.n_data);
+                reader_rt_args.push_back(ref_el.n_mixed);
+                reader_rt_args.push_back(ref_el.n_pads);
+                reader_rt_args.push_back(ref_el.times);
+                reader_rt_args.push_back(count_repeated);
+                count_repeated = 1;
+                ref_el = el;
+            }
         }
+        reader_rt_args.push_back(ref_el.n_data);
+        reader_rt_args.push_back(ref_el.n_mixed);
+        reader_rt_args.push_back(ref_el.n_pads);
+        reader_rt_args.push_back(ref_el.times);
+        reader_rt_args.push_back(count_repeated);
 
         uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -375,20 +375,22 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
 
         uint32_t nblocks_per_core = 0;
         BlockRep ref_el = assignment[0];
-        uint32_t count_repeated = 0;
+        uint32_t count_repeated = 0;  // will be incremented in first iteration of the loop
         for (const auto& el : assignment) {
             nblocks_per_core += el.block_count();
             row_start_id += el.data_row_count();
             if (compare_assignments(ref_el, el)) {
                 count_repeated++;
             } else {
+                // push back information for previous elements
                 reader_rt_args.push_back(ref_el.n_data);
                 reader_rt_args.push_back(ref_el.n_mixed);
                 reader_rt_args.push_back(ref_el.n_pads);
                 reader_rt_args.push_back(ref_el.times);
                 reader_rt_args.push_back(count_repeated);
-                count_repeated = 1;
+                // set up assignment for this element
                 ref_el = el;
+                count_repeated = 1;
             }
         }
         reader_rt_args.push_back(ref_el.n_data);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
@@ -59,20 +59,23 @@ void kernel_main() {
 
     uint32_t stick_id = start_stick_id;
     uint32_t rt_arg_idx = 5;
-    uint32_t count_repeat_idx = 9;
     uint32_t count = 1;
+    constexpr int32_t n_mixed_idx = 1;
+    constexpr int32_t n_pad_idx = 2;
+    constexpr int32_t times_idx = 3;
+    constexpr uint32_t repeat_ct_idx = 4;
+    constexpr int32_t num_rt_idx = 5;
 
     for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
-        const uint32_t repeat_count = get_arg_val<uint32_t>(count_repeat_idx);
+        const uint32_t repeat_count = get_arg_val<uint32_t>(rt_arg_idx + repeat_ct_idx);
         const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx);  // number of full tile-rows
         const uint32_t n_mixed =
-            get_arg_val<uint32_t>(rt_arg_idx + 1);                      // number of rows in a partially filled tile-row
-        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + 2);  // number of padding tile-rows
+            get_arg_val<uint32_t>(rt_arg_idx + n_mixed_idx);  // number of rows in a partially filled tile-row
+        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + n_pad_idx);  // number of padding tile-rows
         const uint32_t times =
-            get_arg_val<uint32_t>(rt_arg_idx + 3);  // number of times the pattern of tile-rows repeats
+            get_arg_val<uint32_t>(rt_arg_idx + times_idx);  // number of times the pattern of tile-rows repeats
         if (count == repeat_count) {
-            rt_arg_idx = rt_arg_idx + 5;
-            count_repeat_idx = count_repeat_idx + 5;
+            rt_arg_idx = rt_arg_idx + num_rt_idx;
             count = 1;
         } else {
             count++;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
@@ -59,11 +59,24 @@ void kernel_main() {
 
     uint32_t stick_id = start_stick_id;
     uint32_t rt_arg_idx = 5;
+    uint32_t count_repeat_idx = 9;
+    uint32_t count = 1;
+
     for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
-        const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx++);   // number of full tile-rows
-        const uint32_t n_mixed = get_arg_val<uint32_t>(rt_arg_idx++);  // number of rows in a partially filled tile-row
-        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx++);   // number of padding tile-rows
-        const uint32_t times = get_arg_val<uint32_t>(rt_arg_idx++);  // number of times the pattern of tile-rows repeats
+        const uint32_t repeat_count = get_arg_val<uint32_t>(count_repeat_idx);
+        const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx);  // number of full tile-rows
+        const uint32_t n_mixed =
+            get_arg_val<uint32_t>(rt_arg_idx + 1);                      // number of rows in a partially filled tile-row
+        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + 2);  // number of padding tile-rows
+        const uint32_t times =
+            get_arg_val<uint32_t>(rt_arg_idx + 3);  // number of times the pattern of tile-rows repeats
+        if (count == repeat_count) {
+            rt_arg_idx = rt_arg_idx + 5;
+            count_repeat_idx = count_repeat_idx + 5;
+            count = 1;
+        } else {
+            count++;
+        }
 
         for (uint32_t t = 0; t < times; ++t) {
             for (uint32_t y_t = 0; y_t < n_data; y_t++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -337,20 +337,22 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
         uint32_t nblocks_per_core = 0;
 
         BlockRep ref_el = assignment[0];
-        uint32_t count_repeated = 0;
+        uint32_t count_repeated = 0;  // will be incremented in first iteration of the loop
         for (const auto& el : assignment) {
             nblocks_per_core += el.block_count();
             row_start_id += el.data_row_count();
             if (compare_assignments(ref_el, el)) {
                 count_repeated++;
             } else {
+                // push back information for previious elements
                 writer_rt_args.push_back(ref_el.n_data);
                 writer_rt_args.push_back(ref_el.n_mixed);
                 writer_rt_args.push_back(ref_el.n_pads);
                 writer_rt_args.push_back(ref_el.times);
                 writer_rt_args.push_back(count_repeated);
-                count_repeated = 1;
+                // Set up assignment for this element
                 ref_el = el;
+                count_repeated = 1;
             }
         }
         writer_rt_args.push_back(ref_el.n_data);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -336,14 +336,28 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
 
         uint32_t nblocks_per_core = 0;
 
+        BlockRep ref_el = assignment[0];
+        uint32_t count_repeated = 0;
         for (const auto& el : assignment) {
             nblocks_per_core += el.block_count();
             row_start_id += el.data_row_count();
-            writer_rt_args.push_back(el.n_data);
-            writer_rt_args.push_back(el.n_mixed);
-            writer_rt_args.push_back(el.n_pads);
-            writer_rt_args.push_back(el.times);
+            if (compare_assignments(ref_el, el)) {
+                count_repeated++;
+            } else {
+                writer_rt_args.push_back(ref_el.n_data);
+                writer_rt_args.push_back(ref_el.n_mixed);
+                writer_rt_args.push_back(ref_el.n_pads);
+                writer_rt_args.push_back(ref_el.times);
+                writer_rt_args.push_back(count_repeated);
+                count_repeated = 1;
+                ref_el = el;
+            }
         }
+        writer_rt_args.push_back(ref_el.n_data);
+        writer_rt_args.push_back(ref_el.n_mixed);
+        writer_rt_args.push_back(ref_el.n_pads);
+        writer_rt_args.push_back(ref_el.times);
+        writer_rt_args.push_back(count_repeated);
 
         uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
 


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/16689

### Problem description
The runtime arguments for the reader and the writer kernels of the tilize/untilize with padding operations scale with the size of the tensor. For large inputs, the number of RT args exceeds the limit and the test fails

### What's changed
Add a runtime argument that keeps track of the number of repeated RT args and pass them just once

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12717283206
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
