### PR TITLE
Finish porting OPs to compute_output_specs

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -34,7 +34,7 @@ New Device Operation
 
     struct <NewOperation> {
         void validate(const std::vector<Tensor> &input_tensors) const;
-        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
         std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
         operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     };
@@ -48,7 +48,7 @@ New Device Operation with a member
         int some_member
 
         void validate(const std::vector<Tensor> &input_tensors) const;
-        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
         std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
         operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     };
@@ -61,7 +61,7 @@ New Device Operation with Optional Input Tensors
     struct <NewOperation> {
         void validate(const std::vector<Tensor> &input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
         std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
         operation::ProgramWithCallbacks create_program(
             const std::vector<Tensor>& input_tensors,
@@ -80,7 +80,7 @@ and create_output_tensors with the additional parameter for the output_tensors.
 
     struct <NewOperation> {
         void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::TensorSpec> compute_output_spec(const std::vector<Tensor> &input_tensors) const;
         std::vector<std::optional<Tensor>> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
         operation::ProgramWithOptionalOutputTensors create_program(const std::vector<Tensor>& input_tensors, std::vector<std::optional<Tensor>> &output_tensors) const;
 

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -31,14 +31,8 @@ std::vector<Tensor> run_operation(
     static_assert(
         operation::detail::is_device_operation<OpConfig>(), "ttnn::run_operation can only dispatch Device Operations!");
     // Create output tensor vector by examining the number of output shapes created by the device operation
-    auto output_shapes = operation::DeviceOperation<operation::Tensors>(devop).compute_output_shapes(input_tensors, {});
-    size_t output_shapes_size = 0;
-    if (std::holds_alternative<std::vector<ttnn::SimpleShape>>(output_shapes)) {
-        output_shapes_size = std::get<std::vector<ttnn::SimpleShape>>(output_shapes).size();
-    } else {
-        output_shapes_size = std::get<std::vector<tt::tt_metal::LegacyShape>>(output_shapes).size();
-    }
-    std::vector<Tensor> outputs(output_shapes_size);
+    auto output_specs = operation::DeviceOperation<operation::Tensors>(devop).compute_output_specs(input_tensors, {});
+    std::vector<Tensor> outputs(output_specs.size());
     // Populate the workers of the output tensors, based on the input tensors. This is needed for the async engine.
     for (int i = 0; i < outputs.size(); i++) {
         outputs[i] = Tensor(operation::get_workers_for_op_output(input_tensors, optional_input_tensors));

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -33,13 +33,6 @@ concept ProgramFactoryConcept = requires {
 };
 
 template <typename device_operation_t>
-concept HasComputeOutputShapes = requires(device_operation_t op,
-    const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args) {
-    {op.compute_output_shapes(operation_attributes, tensor_args)} -> std::same_as<typename device_operation_t::shape_return_value_t>;
-};
-
-template <typename device_operation_t>
 concept HasComputeOutputSpecs = requires(device_operation_t op,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
@@ -66,7 +59,7 @@ concept DeviceOperationConcept = requires {
             },
             program_factory);
     };
-} && (HasComputeOutputSpecs<device_operation_t> || HasComputeOutputShapes<device_operation_t>);
+} && HasComputeOutputSpecs<device_operation_t>;
 
 template <typename device_operation_t>
 concept DeviceOperationWithCustomProgramCacheConcept =

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -288,14 +288,6 @@ constexpr bool implements_validate_with_output_tensors_and_optional_input_tensor
 }
 
 template <class T, class... Args>
-using has_compute_output_shapes_t = decltype(std::declval<T>().compute_output_shapes(std::declval<Args>()...));
-
-template <class T>
-constexpr bool implements_compute_output_shapes() {
-    return std::experimental::is_detected_v<has_compute_output_shapes_t, T, const Tensors&>;
-}
-
-template <class T, class... Args>
 using has_compute_output_specs_t = decltype(std::declval<T>().compute_output_specs(std::declval<Args>()...));
 
 template <class T>
@@ -433,8 +425,7 @@ template <class OutputTensorsT = Tensors>
 struct DeviceOperation final {
     using storage_t = std::array<std::byte, 1152>;
     using OutputTensors = OutputTensorsT;
-    using ComputedShapes = std::
-        variant<std::vector<tt::tt_metal::LegacyShape>, std::vector<ttnn::SimpleShape>, std::vector<ttnn::TensorSpec>>;
+    using ComputedSpecs = std::vector<ttnn::TensorSpec>;
 
     inline const std::string get_type_name() const { return this->get_type_name_impl_(this->type_erased_storage); }
 
@@ -446,10 +437,9 @@ struct DeviceOperation final {
             this->type_erased_storage, input_tensors, optional_input_tensors, optional_output_tensors);
     }
 
-    // TODO: Rename into compute_output_specs in later PR
-    inline const ComputedShapes compute_output_shapes(
+    inline const ComputedSpecs compute_output_specs(
         const Tensors& input_tensors, const OptionalTensors& output_tensors) const {
-        return this->compute_output_shapes_impl_(this->type_erased_storage, input_tensors, output_tensors);
+        return this->compute_output_specs_impl_(this->type_erased_storage, input_tensors, output_tensors);
     }
 
     inline const OutputTensors create_output_tensors(
@@ -588,26 +578,18 @@ struct DeviceOperation final {
                         "Operation must implement either validate or validate_with_output_tensors");
                 }
             }},
-        compute_output_shapes_impl_{
+        compute_output_specs_impl_{
             [](const storage_t& storage,
                const Tensors& input_tensors,
-               const OptionalTensors& output_tensors) -> const ComputedShapes {
+               const OptionalTensors& output_tensors) -> const ComputedSpecs {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
-                if constexpr (
-                    detail::implements_compute_output_shapes<T>() and detail::implements_compute_output_specs<T>()) {
-                    static_assert(
-                        tt::stl::concepts::always_false_v<T>,
-                        "Operation cannot implement both compute_output_shapes and compute_output_specs");
-                } else if constexpr (detail::implements_compute_output_shapes<T>()) {
-                    return operation.compute_output_shapes(input_tensors);
-                } else if constexpr (detail::implements_compute_output_specs_with_optional_output_tensors<T>()) {
+                if constexpr (detail::implements_compute_output_specs_with_optional_output_tensors<T>()) {
                     return operation.compute_output_specs(input_tensors, output_tensors);
                 } else if constexpr (detail::implements_compute_output_specs<T>()) {
                     return operation.compute_output_specs(input_tensors);
                 } else {
                     static_assert(
-                        tt::stl::concepts::always_false_v<T>,
-                        "Operation must implement either compute_output_shapes or compute_output_specs");
+                        tt::stl::concepts::always_false_v<T>, "Operation must implement compute_output_specs");
                 }
             }},
         create_output_tensors_impl_{
@@ -617,15 +599,13 @@ struct DeviceOperation final {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 if constexpr (detail::implements_create_output_tensors_with_optional_output_tensors<T>()) {
                     static_assert(
-                        detail::implements_compute_output_shapes<T>() || detail::implements_compute_output_specs<T>(),
-                        "Operation must implement compute_output_shapes or compute_output_specs if it implements "
-                        "create_output_tensors");
+                        detail::implements_compute_output_specs<T>(),
+                        "Operation must implement compute_output_specs if it implements create_output_tensors");
                     return operation.create_output_tensors(input_tensors, output_tensors);
                 } else if constexpr (detail::implements_create_output_tensors<T>()) {
                     static_assert(
-                        detail::implements_compute_output_shapes<T>() || detail::implements_compute_output_specs<T>(),
-                        "Operation must implement compute_output_shapes or compute_output_specs if it implements "
-                        "create_output_tensors");
+                        detail::implements_compute_output_specs<T>(),
+                        "Operation must implement compute_output_specs if it implements create_output_tensors");
                     return operation.create_output_tensors(input_tensors);
                 } else if constexpr (detail::implements_compute_output_specs<T>()) {
                     return default_create_output_tensors(operation, input_tensors, output_tensors);
@@ -732,7 +712,7 @@ struct DeviceOperation final {
         move_storage{other.move_storage},
         get_type_name_impl_{other.get_type_name_impl_},
         validate_impl_{other.validate_impl_},
-        compute_output_shapes_impl_{other.compute_output_shapes_impl_},
+        compute_output_specs_impl_{other.compute_output_specs_impl_},
         create_output_tensors_impl_{other.create_output_tensors_impl_},
         create_program_impl_{other.create_program_impl_},
         create_op_performance_model_impl_{other.create_op_performance_model_impl_},
@@ -754,7 +734,7 @@ struct DeviceOperation final {
             this->move_storage = other.move_storage;
             this->get_type_name_impl_ = other.get_type_name_impl_;
             this->validate_impl_ = other.validate_impl_;
-            this->compute_output_shapes_impl_ = other.compute_output_shapes_impl_;
+            this->compute_output_specs_impl_ = other.compute_output_specs_impl_;
             this->create_output_tensors_impl_ = other.create_output_tensors_impl_;
             this->create_program_impl_ = other.create_program_impl_;
             this->create_op_performance_model_impl_ = other.create_op_performance_model_impl_;
@@ -774,7 +754,7 @@ struct DeviceOperation final {
         move_storage{other.move_storage},
         get_type_name_impl_{other.get_type_name_impl_},
         validate_impl_{other.validate_impl_},
-        compute_output_shapes_impl_{other.compute_output_shapes_impl_},
+        compute_output_specs_impl_{other.compute_output_specs_impl_},
         create_output_tensors_impl_{other.create_output_tensors_impl_},
         create_program_impl_{other.create_program_impl_},
         create_op_performance_model_impl_{other.create_op_performance_model_impl_},
@@ -796,7 +776,7 @@ struct DeviceOperation final {
             this->move_storage = other.move_storage;
             this->get_type_name_impl_ = other.get_type_name_impl_;
             this->validate_impl_ = other.validate_impl_;
-            this->compute_output_shapes_impl_ = other.compute_output_shapes_impl_;
+            this->compute_output_specs_impl_ = other.compute_output_specs_impl_;
             this->create_output_tensors_impl_ = other.create_output_tensors_impl_;
             this->create_program_impl_ = other.create_program_impl_;
             this->create_op_performance_model_impl_ = other.create_op_performance_model_impl_;
@@ -825,7 +805,7 @@ private:
         const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
         const OptionalTensors&);
-    const ComputedShapes (*compute_output_shapes_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
+    const ComputedSpecs (*compute_output_specs_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
     const OutputTensors (*create_output_tensors_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
 
     CacheableProgram<OutputTensors> (*create_program_impl_)(

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
@@ -14,10 +14,14 @@ void Barrier::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(this->topology == ccl::Topology::Ring, "We currently only support Ring topologies on the barrier op");
 }
 
-std::vector<SimpleShape> Barrier::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+std::vector<TensorSpec> Barrier::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     // For a Barrier the output shape should match the input
-    SimpleShape shape = input_tensors[0].get_logical_shape();
-    return std::vector<SimpleShape>(input_tensors.size(), shape);
+    std::vector<TensorSpec> result;
+    result.reserve(input_tensors.size());
+    for (const auto& input_tensor : input_tensors) {
+        result.push_back(input_tensor.get_tensor_spec());
+    }
+    return result;
 }
 
 std::vector<Tensor> Barrier::create_output_tensors(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
@@ -23,7 +23,7 @@ struct Barrier {
     // Required functions to all tensor op functions
     void update_structure(const Tensor& input_tensor);
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -25,8 +25,7 @@ struct ReduceScatter {
     const std::optional<size_t> user_defined_num_buffers_per_channel;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -21,16 +21,18 @@ void ExampleDeviceOperation::validate_on_program_cache_miss(
 void ExampleDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
 
-ExampleDeviceOperation::shape_return_value_t ExampleDeviceOperation::compute_output_shapes(
+ExampleDeviceOperation::spec_return_value_t ExampleDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
-    return tensor_args.input_tensor.shape();
+    const auto& input_tensor = tensor_args.input_tensor;
+    return TensorSpec(
+        input_tensor.get_logical_shape(),
+        TensorLayout(input_tensor.get_dtype(), PageConfig(input_tensor.get_layout()), MemoryConfig{}));
 }
 
 ExampleDeviceOperation::tensor_return_value_t ExampleDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
-    const auto& input_tensor = tensor_args.input_tensor;
-    return create_device_tensor(output_shape, input_tensor.dtype(), input_tensor.layout(), input_tensor.device());
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
 std::tuple<ExampleDeviceOperation::operation_attributes_t, ExampleDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -50,17 +50,18 @@ struct ExampleDeviceOperation {
         // std::tuple<std::vector<std::optional<Tensor>>, std::optional<Tensor>> some_crazy_tuple_of_tensors;
     };
 
-    // Define the return types for the shape(s) of the operation
-    // Can be a single ttnn::Shape, std::optional<ttnn::Shape>, std::vector<ttnn::Shape>, std::tuple<ttnn::Shape> etc.
-    using shape_return_value_t = ttnn::Shape;
+    // Define the return types for the spec(s) of the operation
+    // Can be a single ttnn::TensorSpec, std::optional<ttnn::TensorSpec>, std::vector<ttnn::TensorSpec>,
+    // std::tuple<ttnn::TensorSpec> etc.
+    using spec_return_value_t = ttnn::TensorSpec;
 
     // Define the return types for the tensor(s) of the operation
     // Can be a single Tensor, std::optional<Tensor, ...>, std::vector<Tensor>, std::tuple<Tensor, ...> etc.
     using tensor_return_value_t = Tensor;
 
-    // Note shape_return_value_t and tensor_return_value_t should follow the same pattern
-    // i.e. if shape_return_value_t is a std::vector<std::optional<ttnn::Shape>> then tensor_return_value_t should be
-    // std::vector<std::optional<Tensor>>
+    // Note spec_return_value_t and tensor_return_value_t should follow the same pattern
+    // i.e. if spec_return_value_t is a std::vector<std::optional<ttnn::TensorSpec>> then tensor_return_value_t should
+    // be std::vector<std::optional<Tensor>>
 
     struct SingleCore {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
@@ -117,8 +118,8 @@ struct ExampleDeviceOperation {
     // Validate the operation when it reuses a program. Usually will have less checks
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    // Compute the output shapes based on the operation attributes and tensor args
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    // Compute the output specs based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
@@ -25,35 +25,33 @@ void ExampleMultipleReturnDeviceOperation::validate_on_program_cache_hit(
         attributes.return_output2);
 }
 
-ExampleMultipleReturnDeviceOperation::shape_return_value_t ExampleMultipleReturnDeviceOperation::compute_output_shapes(
-    const operation_attributes_t&, const tensor_args_t& tensor_args) {
-    return {tensor_args.input_tensor.shape(), tensor_args.input_tensor.shape()};
+ExampleMultipleReturnDeviceOperation::spec_return_value_t ExampleMultipleReturnDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    TensorSpec spec(
+        input_tensor.get_logical_shape(),
+        TensorLayout(input_tensor.get_dtype(), PageConfig(input_tensor.get_layout()), MemoryConfig{}));
+    spec_return_value_t result = {std::nullopt, std::nullopt};
+    if (operation_attributes.return_output1) {
+        std::get<0>(result) = spec;
+    }
+    if (operation_attributes.return_output2) {
+        std::get<1>(result) = spec;
+    }
+    return result;
 }
 
 ExampleMultipleReturnDeviceOperation::tensor_return_value_t ExampleMultipleReturnDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto [output1_shape_opt, output2_shape_opt] = compute_output_shapes(operation_attributes, tensor_args);
-
-    auto output1_shape = output1_shape_opt.value();
-    auto output2_shape = output2_shape_opt.value();
-
-    auto return_output1 = operation_attributes.return_output1;
-    auto return_output2 = operation_attributes.return_output2;
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto output1 =
-        create_device_tensor(output1_shape, input_tensor.dtype(), input_tensor.layout(), input_tensor.device());
-
-    auto output2 =
-        create_device_tensor(output2_shape, input_tensor.dtype(), input_tensor.layout(), input_tensor.device());
+    auto [output1_spec_opt, output2_spec_opt] = compute_output_specs(operation_attributes, tensor_args);
 
     std::vector<std::optional<Tensor>> ret(2);
-
-    if (return_output1) {
-        ret[0] = output1;
+    if (output1_spec_opt) {
+        ret[0] = create_device_tensor(*output1_spec_opt, tensor_args.input_tensor.device());
     }
-    if (return_output2) {
-        ret[1] = output2;
+    if (output2_spec_opt) {
+        ret[1] = create_device_tensor(*output2_spec_opt, tensor_args.input_tensor.device());
+        ;
     }
 
     return ret;

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
@@ -51,7 +51,6 @@ ExampleMultipleReturnDeviceOperation::tensor_return_value_t ExampleMultipleRetur
     }
     if (output2_spec_opt) {
         ret[1] = create_device_tensor(*output2_spec_opt, tensor_args.input_tensor.device());
-        ;
     }
 
     return ret;

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
@@ -52,17 +52,18 @@ struct ExampleMultipleReturnDeviceOperation {
         // std::tuple<std::vector<std::optional<Tensor>>, std::optional<Tensor>> some_crazy_tuple_of_tensors;
     };
 
-    // Define the return types for the shape(s) of the operation
-    // Can be a single ttnn::Shape, std::optional<ttnn::Shape>, std::vector<ttnn::Shape>, std::tuple<ttnn::Shape> etc.
-    using shape_return_value_t = std::tuple<std::optional<ttnn::Shape>, std::optional<ttnn::Shape>>;
+    // Define the return types for the spec(s) of the operation
+    // Can be a single ttnn::TensorSpec, std::optional<ttnn::TensorSpec>, std::vector<ttnn::TensorSpec>,
+    // std::tuple<ttnn::TensorSpec> etc.
+    using spec_return_value_t = std::tuple<std::optional<ttnn::TensorSpec>, std::optional<ttnn::TensorSpec>>;
 
     // Define the return types for the tensor(s) of the operation
     // Can be a single Tensor, std::optional<Tensor, ...>, std::vector<Tensor>, std::tuple<Tensor, ...> etc.
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
-    // Note shape_return_value_t and tensor_return_value_t should follow the same pattern
-    // i.e. if shape_return_value_t is a std::vector<std::optional<ttnn::Shape>> then tensor_return_value_t should be
-    // std::vector<std::optional<Tensor>>
+    // Note spec_return_value_t and tensor_return_value_t should follow the same pattern
+    // i.e. if spec_return_value_t is a std::vector<std::optional<ttnn::TensorSpec>> then tensor_return_value_t should
+    // be std::vector<std::optional<Tensor>>
 
     struct SingleCore {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
@@ -97,8 +98,8 @@ struct ExampleMultipleReturnDeviceOperation {
     // Validate the operation when it reuses a program. Usually will have less checks
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    // Compute the output shapes based on the operation attributes and tensor args
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    // Compute the output specs based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
@@ -65,18 +65,10 @@ void DramPrefetcher::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(tensor_addrs_data_format == tt::DataFormat::UInt32, "Tensor containing addresses must be of type UInt32");
 }
 // TODO: Remove output tensor entirely (if possible)
-std::vector<ttnn::SimpleShape> DramPrefetcher::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    return {ttnn::SimpleShape{32, 32}};
-}
-std::vector<Tensor> DramPrefetcher::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    auto output_tensor = create_device_tensor(
+std::vector<ttnn::TensorSpec> DramPrefetcher::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    return {TensorSpec(
         ttnn::SimpleShape{32, 32},
-        input_tensors[0].dtype(),
-        input_tensors[0].layout(),
-        input_tensors[0].device(),
-        MemoryConfig{});
-    std::vector<Tensor> output_tensors = {output_tensor};
-    return output_tensors;
+        TensorLayout(input_tensors[0].get_dtype(), PageConfig(input_tensors[0].get_layout()), MemoryConfig{}))};
 }
 operation::ProgramWithCallbacks DramPrefetcher::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.hpp
@@ -27,8 +27,7 @@ struct DramPrefetcher {
     const uint32_t num_layers;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -94,7 +94,7 @@ struct OldInfraDeviceOperation {
         const operation::OptionalTensors optional_output_tensors;
     };
 
-    using shape_return_value_t = std::vector<tt::tt_metal::LegacyShape>;
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
 
     using tensor_return_value_t = OutputTensors;
 
@@ -173,10 +173,10 @@ struct OldInfraDeviceOperation {
         validate_on_program_cache_miss(attributes, tensor_args);
     }
 
-    // Compute the output shapes based on the operation attributes and tensor args
-    static shape_return_value_t compute_output_shapes(
+    // Compute the output specs based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(
         const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        return attributes.compute_output_shapes(tensor_args.input_tensors);
+        return attributes.compute_output_specs(tensor_args.input_tensors);
     }
 
     // Create the output tensors based on the operation attributes and tensor args
@@ -380,7 +380,7 @@ Tensors run_with_autoformat(
         }
     }
 
-    auto output_specs = operation.compute_output_shapes(input_tensors, optional_output_tensors);
+    auto output_specs = operation.compute_output_specs(input_tensors, optional_output_tensors);
     auto output_tensors = run<Tensors>(
         std::move(operation),
         formatted_input_tensors,
@@ -453,7 +453,7 @@ Tensors run_with_autoformat(
         }
     }
 
-    auto output_specs = operation.compute_output_shapes(input_tensors, optional_output_tensors);
+    auto output_specs = operation.compute_output_specs(input_tensors, optional_output_tensors);
     auto output_tensors = run<Tensors>(
         std::move(operation),
         formatted_input_tensors,

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -18,36 +18,6 @@ namespace operation {
 
 using ttnn::operations::experimental::auto_format::FormatParams;
 
-// TODO: create_output_tensors should become a fully manual path with no dependency on infra
-// - Pass output shapes directly
-// - Move default values for output_dtype and output_mem_config inside ops
-// - This function becomes just a regular helper function
-template <typename ConcreteOperation>
-auto generic_create_output_tensors(
-    const ConcreteOperation& operation,
-    const Tensors& input_tensors,
-    const std::optional<DataType> output_dtype,
-    const Layout output_layout,
-    const std::optional<MemoryConfig>& output_mem_config,
-    const std::optional<Tile>& tile = std::nullopt) -> ProgramOutputTensors<ConcreteOperation> {
-    const auto& input_tensor = input_tensors.at(0);
-    const auto& output_shapes = operation.compute_output_shapes(input_tensors);
-
-    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
-    OutputTensors output_tensors;
-    output_tensors.reserve(output_shapes.size());
-    for (const auto& output_shape : output_shapes) {
-        output_tensors.emplace_back(create_device_tensor(
-            output_shape,
-            output_dtype.value_or(input_tensors.at(0).get_dtype()),
-            output_layout,
-            input_tensor.device(),
-            output_mem_config.value_or(input_tensors.at(0).memory_config()),
-            tile));
-    }
-    return output_tensors;
-}
-
 template <class OutputTensors = Tensors>
 OutputTensors run(
     DeviceOperation<OutputTensors>&& operation,


### PR DESCRIPTION
### Ticket

### Problem description
Finish porting OPs from `compute_output_shapes` to `compute_output_specs`

### What's changed
Port the rest of the OPs from `compute_output_shapes` to `compute_output_specs`
Update the examples
Remove infra for `compute_output_shapes`

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12756657959)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12756669702)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12756661295)
- [x] New/Existing tests provide coverage for changes
