### PR TITLE
#0: Skip build-docker-image during post-commit code-analysis since the docker image is already built in a previous job

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -165,7 +165,7 @@ jobs:
     secrets: inherit
     with:
       os: ubuntu-22.04-amd64
-      skip-build-docker-image: true
+      build-docker: false
   tt-train-cpp-unit-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -165,6 +165,7 @@ jobs:
     secrets: inherit
     with:
       os: ubuntu-22.04-amd64
+      skip-build-docker-image: true
   tt-train-cpp-unit-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -43,6 +43,7 @@ jobs:
 
   clang-tidy:
     needs: build-docker-image
+    if: always()
     env:
       ARCH_NAME: wormhole_b0
     runs-on:

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -11,6 +11,10 @@ on:
         required: false
         type: boolean
         default: false
+      skip-build-docker-image:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       os:
@@ -21,9 +25,14 @@ on:
         required: false
         type: boolean
         default: false
+      skip-build-docker-image:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-docker-image:
+    if: ${{ inputs.skip-build-docker-image != 'true' }}
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -11,10 +11,11 @@ on:
         required: false
         type: boolean
         default: false
-      skip-build-docker-image:
+      build-docker:
         required: false
         type: boolean
-        default: false
+        default: true
+        description: "Build docker image"
   workflow_dispatch:
     inputs:
       os:
@@ -25,14 +26,15 @@ on:
         required: false
         type: boolean
         default: false
-      skip-build-docker-image:
+      build-docker:
         required: false
         type: boolean
-        default: false
+        default: true
+        description: "Build docker image"
 
 jobs:
   build-docker-image:
-    if: ${{ inputs.skip-build-docker-image != 'true' }}
+    if: ${{ inputs.build-docker == true }}
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
### Ticket
...

### Problem description
code-analysis step in APC already has `needs:build-docker-image-2204`, so `build-docker-image` before `clang-tidy`  can be skipped 

### What's changed
Added `build-docker` input to code-analysis with `default:true` ; set to `false` during APC.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12757498518 https://github.com/tenstorrent/tt-metal/actions/runs/12757500785
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
