### PR TITLE
[TT-Train] Add bias=false in LinearLayer

### DIFF
--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -119,7 +119,7 @@ Transformer::Transformer(const TransformerConfig& config) {
             std::make_shared<ttml::modules::GPTBlock>(embedding_dim, num_heads, dropout_prob, use_composite_layernorm));
     }
     ln_fc = std::make_shared<ttml::modules::LayerNormLayer>(embedding_dim, use_composite_layernorm);
-    fc = std::make_shared<ttml::modules::LinearLayer>(embedding_dim, vocab_size, false);
+    fc = std::make_shared<ttml::modules::LinearLayer>(embedding_dim, vocab_size, /* bias */ false);
 
     create_name("transformer");
     register_module(tok_emb, "tok_emb");

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -119,7 +119,7 @@ Transformer::Transformer(const TransformerConfig& config) {
             std::make_shared<ttml::modules::GPTBlock>(embedding_dim, num_heads, dropout_prob, use_composite_layernorm));
     }
     ln_fc = std::make_shared<ttml::modules::LayerNormLayer>(embedding_dim, use_composite_layernorm);
-    fc = std::make_shared<ttml::modules::LinearLayer>(embedding_dim, vocab_size);
+    fc = std::make_shared<ttml::modules::LinearLayer>(embedding_dim, vocab_size, false);
 
     create_name("transformer");
     register_module(tok_emb, "tok_emb");

--- a/tt-train/sources/ttml/modules/linear_module.cpp
+++ b/tt-train/sources/ttml/modules/linear_module.cpp
@@ -12,26 +12,33 @@
 
 namespace ttml::modules {
 
-void LinearLayer::initialize_tensors(uint32_t in_features, uint32_t out_features) {
+void LinearLayer::initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias) {
     auto* device = &autograd::ctx().get_device();
     auto weight_shape = core::create_shape({1, 1, out_features, in_features});
     m_weight = ttml::autograd::create_tensor();
     const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
     init::uniform_init(m_weight, weight_shape, init::UniformRange{-init_k, init_k});
-    auto bias_shape = core::create_shape({1, 1, 1, out_features});
-    m_bias = ttml::autograd::create_tensor();
-    init::uniform_init(m_bias, bias_shape, init::UniformRange{-init_k, init_k});
+    if (has_bias) {
+        auto bias_shape = core::create_shape({1, 1, 1, out_features});
+        m_bias = ttml::autograd::create_tensor();
+        init::uniform_init(m_bias, bias_shape, init::UniformRange{-init_k, init_k});
+    }
 }
 
-LinearLayer::LinearLayer(uint32_t in_features, uint32_t out_features) {
+LinearLayer::LinearLayer(uint32_t in_features, uint32_t out_features, bool has_bias) {
     initialize_tensors(in_features, out_features);
 
     create_name("linear");
     register_tensor(m_weight, "weight");
-    register_tensor(m_bias, "bias");
+    if (has_bias) {
+        register_tensor(m_bias, "bias");
+    }
 }
 
 autograd::TensorPtr LinearLayer::operator()(const autograd::TensorPtr& tensor) {
+    if (m_bias == nullptr) {
+        return ops::linear_op_no_bias(tensor, m_weight);
+    }
     return ops::linear_op(tensor, m_weight, m_bias);
 }
 

--- a/tt-train/sources/ttml/modules/linear_module.cpp
+++ b/tt-train/sources/ttml/modules/linear_module.cpp
@@ -36,9 +36,6 @@ LinearLayer::LinearLayer(uint32_t in_features, uint32_t out_features, bool has_b
 }
 
 autograd::TensorPtr LinearLayer::operator()(const autograd::TensorPtr& tensor) {
-    if (m_bias == nullptr) {
-        return ops::linear_op_no_bias(tensor, m_weight);
-    }
     return ops::linear_op(tensor, m_weight, m_bias);
 }
 

--- a/tt-train/sources/ttml/modules/linear_module.hpp
+++ b/tt-train/sources/ttml/modules/linear_module.hpp
@@ -19,10 +19,10 @@ private:
     autograd::TensorPtr m_weight;
     autograd::TensorPtr m_bias;
 
-    void initialize_tensors(uint32_t in_features, uint32_t out_features);
+    void initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias = true);
 
 public:
-    LinearLayer(uint32_t in_features, uint32_t out_features);
+    LinearLayer(uint32_t in_features, uint32_t out_features, bool has_bias = true);
 
     [[nodiscard]] autograd::TensorPtr operator()(const autograd::TensorPtr& tensor);
 };

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -5,9 +5,6 @@
 #include "linear_op.hpp"
 
 #include <core/ttnn_all_includes.hpp>
-#include <cstddef>
-#include <optional>
-#include <ttnn/tensor/tensor.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -5,7 +5,9 @@
 #include "linear_op.hpp"
 
 #include <core/ttnn_all_includes.hpp>
+#include <cstddef>
 #include <optional>
+#include <ttnn/tensor/tensor.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
@@ -52,39 +54,17 @@ void ttnn_linear_backward(
 
     auto reshaped_grad =
         ttnn::reshape(out->get_grad(), ttnn::Shape({volume_without_features, out->get_grad().get_shape()[-1]}));
-    auto reshaped_bias_grad = ttnn_fixed::sum_over_dim(reshaped_grad, /* axis */ 0);
     auto reshaped_weight_grad =
         matmul(reshaped_grad, reshaped_tensor, /* transpose_a */ true, /* transpose_b */ false, config);
     auto reshaped_tensor_grad =
         matmul(reshaped_grad, weight->get_value(), /* transpose_a */ false, /* transpose_b */ false, config);
-
-    auto bias_grad = ttnn::reshape(reshaped_bias_grad, bias->get_value().get_shape());
+    if (bias) {
+        auto reshaped_bias_grad = ttnn_fixed::sum_over_dim(reshaped_grad, /* axis */ 0);
+        auto bias_grad = ttnn::reshape(reshaped_bias_grad, bias->get_value().get_shape());
+        bias->add_grad(bias_grad);
+    }
     auto weight_grad = ttnn::reshape(reshaped_weight_grad, weight->get_value().get_shape());
-    auto tensor_grad = ttnn::reshape(reshaped_tensor_grad, tensor_value.get_shape());
 
-    tensor->add_grad(tensor_grad);
-    weight->add_grad(weight_grad);
-    bias->add_grad(bias_grad);
-}
-
-void ttnn_linear_backward(
-    const autograd::TensorPtr& tensor,
-    const autograd::TensorPtr& weight,
-    const autograd::TensorPtr& out,
-    const ttnn::WormholeComputeKernelConfig& config) {
-    const auto& tensor_value = tensor->get_value();
-    auto volume_without_features = tensor_value.get_logical_volume() / tensor_value.get_shape()[-1];
-    auto reshaped_tensor =
-        ttnn::reshape(tensor_value, ttnn::Shape({volume_without_features, tensor_value.get_shape()[-1]}));
-
-    auto reshaped_grad =
-        ttnn::reshape(out->get_grad(), ttnn::Shape({volume_without_features, out->get_grad().get_shape()[-1]}));
-    auto reshaped_weight_grad =
-        matmul(reshaped_grad, reshaped_tensor, /* transpose_a */ true, /* transpose_b */ false, config);
-    auto reshaped_tensor_grad =
-        matmul(reshaped_grad, weight->get_value(), /* transpose_a */ false, /* transpose_b */ false, config);
-
-    auto weight_grad = ttnn::reshape(reshaped_weight_grad, weight->get_value().get_shape());
     auto tensor_grad = ttnn::reshape(reshaped_tensor_grad, tensor_value.get_shape());
 
     tensor->add_grad(tensor_grad);
@@ -97,7 +77,6 @@ void moreh_linear_backward(
     const autograd::TensorPtr& bias,
     const autograd::TensorPtr& out,
     const ttnn::WormholeComputeKernelConfig& config) {
-    auto bias_grad = ttnn::empty_like(bias->get_value());
     auto tensor_grad = ttnn::empty_like(tensor->get_value());
     auto weight_grad = ttnn::empty_like(weight->get_value());
 
@@ -105,11 +84,13 @@ void moreh_linear_backward(
         out->get_grad(),
         tensor->get_value(),
         weight->get_value(),
-        /* are required outputs */ std::vector<bool>{true, true, true},
-        bias->get_value(),
+        /* are required outputs */ std::vector<bool>{true, true, bias != nullptr},
+        bias != nullptr ? std::optional<tt::tt_metal::Tensor>(bias->get_value())
+                        : std::optional<tt::tt_metal::Tensor>(std::nullopt),
         tensor_grad,
         weight_grad,
-        bias_grad,
+        bias ? std::optional<tt::tt_metal::Tensor>(ttnn::empty_like(bias->get_value()))
+             : std::optional<tt::tt_metal::Tensor>(std::nullopt),
         /* input_grad_mem_config */ std::nullopt,
         /* weight_grad_mem_config */ std::nullopt,
         /* bias_grad_mem_config */ std::nullopt,
@@ -125,76 +106,9 @@ void moreh_linear_backward(
     }
     weight->add_grad(res[1].value());
 
-    if (!res[2].has_value()) {
-        throw std::runtime_error("Bias gradient is not available");
+    if (res[2].has_value()) {
+        bias->add_grad(res[2].value());
     }
-    bias->add_grad(res[2].value());
-}
-
-void moreh_linear_backward(
-    const autograd::TensorPtr& tensor,
-    const autograd::TensorPtr& weight,
-    const autograd::TensorPtr& out,
-    const ttnn::WormholeComputeKernelConfig& config) {
-    auto tensor_grad = ttnn::empty_like(tensor->get_value());
-    auto weight_grad = ttnn::empty_like(weight->get_value());
-
-    auto res = ttnn::moreh_linear_backward(
-        out->get_grad(),
-        tensor->get_value(),
-        weight->get_value(),
-        /* are required outputs */ std::vector<bool>{true, true, false},
-        std::nullopt,
-        tensor_grad,
-        weight_grad,
-        std::nullopt,
-        /* input_grad_mem_config */ std::nullopt,
-        /* weight_grad_mem_config */ std::nullopt,
-        /* bias_grad_mem_config */ std::nullopt,
-        /* compute_kernel_config */ config);
-
-    if (!res[0].has_value()) {
-        throw std::runtime_error("Tensor gradient is not available");
-    }
-    tensor->add_grad(res[0].value());
-
-    if (!res[1].has_value()) {
-        throw std::runtime_error("Weight gradient is not available");
-    }
-    weight->add_grad(res[1].value());
-}
-
-autograd::TensorPtr linear_op_no_bias(const autograd::TensorPtr& tensor, const autograd::TensorPtr& weight) {
-    auto out = autograd::create_tensor();
-
-    out->set_value(ttnn::linear(
-        tensor->get_value(),
-        weight->get_value(),
-        std::nullopt,
-        /* transpose_a */ false,
-        /* tranpose_b */ true,
-        /* memory_config */ std::nullopt,
-        /* dtype */ std::nullopt,
-        /* program_config */ std::nullopt,
-        /* activation */ std::nullopt,
-        /* compute_kernel_config */ core::ComputeKernelConfig::matmul(),
-        /* core_grid */ ttnn::CoreGrid{7, 8}));
-
-    autograd::GradFunction grad = [weight, tensor, out]() {
-        auto tensor_shape = tensor->get_value().get_shape();
-        auto grad_shape = out->get_grad().get_shape();
-        // for some reason, reshape produces wrong values when last dimensions not divisible by TILE
-        if (tensor_shape[-2] % TILE_HEIGHT != 0 ||
-            tensor_shape[-1] % TILE_WIDTH != 0 && grad_shape[-1] % TILE_WIDTH != 0) {
-            moreh_linear_backward(tensor, weight, out);
-        } else {
-            ttnn_linear_backward(tensor, weight, out);
-        }
-    };
-
-    auto links = autograd::get_links(weight, tensor);
-    out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
-    return out;
 }
 
 autograd::TensorPtr linear_op(

--- a/tt-train/sources/ttml/ops/linear_op.hpp
+++ b/tt-train/sources/ttml/ops/linear_op.hpp
@@ -12,8 +12,6 @@ namespace ttml::ops {
 autograd::TensorPtr linear_op(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& weight, const autograd::TensorPtr& bias);
 
-autograd::TensorPtr linear_op_no_bias(const autograd::TensorPtr& tensor, const autograd::TensorPtr& weight);
-
 void ttnn_linear_backward(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& weight,
@@ -25,18 +23,6 @@ void moreh_linear_backward(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& weight,
     const autograd::TensorPtr& bias,
-    const autograd::TensorPtr& out,
-    const ttnn::WormholeComputeKernelConfig& config = ttml::core::ComputeKernelConfig::matmul());
-
-void ttnn_linear_backward(
-    const autograd::TensorPtr& tensor,
-    const autograd::TensorPtr& weight,
-    const autograd::TensorPtr& out,
-    const ttnn::WormholeComputeKernelConfig& config = ttml::core::ComputeKernelConfig::matmul());
-
-void moreh_linear_backward(
-    const autograd::TensorPtr& tensor,
-    const autograd::TensorPtr& weight,
     const autograd::TensorPtr& out,
     const ttnn::WormholeComputeKernelConfig& config = ttml::core::ComputeKernelConfig::matmul());
 

--- a/tt-train/sources/ttml/ops/linear_op.hpp
+++ b/tt-train/sources/ttml/ops/linear_op.hpp
@@ -12,6 +12,8 @@ namespace ttml::ops {
 autograd::TensorPtr linear_op(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& weight, const autograd::TensorPtr& bias);
 
+autograd::TensorPtr linear_op_no_bias(const autograd::TensorPtr& tensor, const autograd::TensorPtr& weight);
+
 void ttnn_linear_backward(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& weight,
@@ -23,6 +25,18 @@ void moreh_linear_backward(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& weight,
     const autograd::TensorPtr& bias,
+    const autograd::TensorPtr& out,
+    const ttnn::WormholeComputeKernelConfig& config = ttml::core::ComputeKernelConfig::matmul());
+
+void ttnn_linear_backward(
+    const autograd::TensorPtr& tensor,
+    const autograd::TensorPtr& weight,
+    const autograd::TensorPtr& out,
+    const ttnn::WormholeComputeKernelConfig& config = ttml::core::ComputeKernelConfig::matmul());
+
+void moreh_linear_backward(
+    const autograd::TensorPtr& tensor,
+    const autograd::TensorPtr& weight,
     const autograd::TensorPtr& out,
     const ttnn::WormholeComputeKernelConfig& config = ttml::core::ComputeKernelConfig::matmul());
 


### PR DESCRIPTION
### Problem description
Our linear lyaer doesn't have bias=false support
### What's changed
Added has_bias parameter to the linear layer.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
