### PR TITLE
Page size assertion error

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -268,3 +268,18 @@ def test_tilize_with_padding_for_1D(shape, dtype, device):
     output_tensor = ttnn.tilize_with_zero_padding(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[1, 9, 91, 7, 9]])
+def test_to_layout_page_error(shape, device):
+    torch.manual_seed(2005)
+
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_layout(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    torch_output = torch_tensor
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -123,11 +123,6 @@ Tensor to_layout_impl(
             } else if (layout == ttnn::TILE_LAYOUT) {
                 if (tensor.is_sharded()) {
                     const auto shard_shape = get_memory_config(tensor).value().shard_spec.value().shape;
-                    // if (shard_shape[0] % ttnn::TILE_SIZE != 0 or shard_shape[1] % ttnn::TILE_SIZE != 0) {
-                    //     TT_THROW(
-                    //         "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
-                    //         "TILE_SIZE!");
-                    // }
                 }
                 return ttnn::tilize(tensor, output_memory_config, dtype, use_multicore_tilize);
             } else {
@@ -149,12 +144,8 @@ Tensor to_layout_impl(
                 output_tensor_end[index] = tensor.get_logical_shape()[index] - 1;
             }
 
-            tensor = ttnn::untilize_with_unpadding(
-                tensor,
-                // tt::tt_metal::LegacyShape(output_tensor_end.view()),
-                output_tensor_end,
-                output_memory_config,
-                use_multicore_untilize);
+            tensor =
+                ttnn::untilize_with_unpadding(tensor, output_tensor_end, output_memory_config, use_multicore_untilize);
             return ttnn::reshape(tensor, ttnn::SimpleShape{output_shape});
 
         } else if (layout == ttnn::TILE_LAYOUT) {

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -151,7 +151,8 @@ Tensor to_layout_impl(
 
             tensor = ttnn::untilize_with_unpadding(
                 tensor,
-                tt::tt_metal::LegacyShape(output_tensor_end.view()),
+                // tt::tt_metal::LegacyShape(output_tensor_end.view()),
+                output_tensor_end,
                 output_memory_config,
                 use_multicore_untilize);
             return ttnn::reshape(tensor, ttnn::SimpleShape{output_shape});

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -122,7 +122,15 @@ Tensor to_layout_impl(
                 return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize);
             } else if (layout == ttnn::TILE_LAYOUT) {
                 if (tensor.is_sharded()) {
+                    const auto tensor_tile = tensor.get_tensor_spec().tile();
+                    uint32_t tile_height = tensor_tile.get_height();
+                    uint32_t tile_width = tensor_tile.get_width();
                     const auto shard_shape = get_memory_config(tensor).value().shard_spec.value().shape;
+                    if (shard_shape[0] % tile_height != 0 or shard_shape[1] % tile_width != 0) {
+                        TT_THROW(
+                            "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
+                            "TILE_SIZE!");
+                    }
                 }
                 return ttnn::tilize(tensor, output_memory_config, dtype, use_multicore_tilize);
             } else {

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -123,11 +123,11 @@ Tensor to_layout_impl(
             } else if (layout == ttnn::TILE_LAYOUT) {
                 if (tensor.is_sharded()) {
                     const auto shard_shape = get_memory_config(tensor).value().shard_spec.value().shape;
-                    if (shard_shape[0] % ttnn::TILE_SIZE != 0 or shard_shape[1] % ttnn::TILE_SIZE != 0) {
-                        TT_THROW(
-                            "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
-                            "TILE_SIZE!");
-                    }
+                    // if (shard_shape[0] % ttnn::TILE_SIZE != 0 or shard_shape[1] % ttnn::TILE_SIZE != 0) {
+                    //     TT_THROW(
+                    //         "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
+                    //         "TILE_SIZE!");
+                    // }
                 }
                 return ttnn::tilize(tensor, output_memory_config, dtype, use_multicore_tilize);
             } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -25,24 +25,15 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
 
     TT_FATAL(input_shape.rank() >= 1, "Input tensor must be of rank >= 1, but its shape is {}", input_shape);
 
-    if (input_shape.rank() == 1) {
+    for (auto i = 0; i < input_shape.rank(); i++) {
         TT_FATAL(
-            input_shape[0] <= this->output_padded_shape[1],
-            "Output tensor shape {} must be greater than or equal to input shape {} , but is smaller "
-            "in dimension 0",
+            input_shape[i] <= this->output_padded_shape[i],
+            "Output tensor shape {} must be greater than or equal to input shape {} in each dimension, but is "
+            "smaller "
+            "in dimension {}",
             this->output_padded_shape,
-            input_shape);
-    } else {
-        for (auto i = 0; i < input_shape.rank(); i++) {
-            TT_FATAL(
-                input_shape[i] <= this->output_padded_shape[i],
-                "Output tensor shape {} must be greater than or equal to input shape {} in each dimension, but is "
-                "smaller "
-                "in dimension {}",
-                this->output_padded_shape,
-                input_shape,
-                i);
-        }
+            input_shape,
+            i);
     }
 
     uint32_t num_rows = this->output_padded_shape[-1];

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -25,14 +25,24 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
 
     TT_FATAL(input_shape.rank() >= 1, "Input tensor must be of rank >= 1, but its shape is {}", input_shape);
 
-    for (auto i = 0; i < input_shape.rank(); i++) {
+    if (input_shape.rank() == 1) {
         TT_FATAL(
-            input_shape[i] <= this->output_padded_shape[i],
-            "Output tensor shape {} must be greater than or equal to input shape {} in each dimension, but is smaller "
-            "in dimension {}",
+            input_shape[0] <= this->output_padded_shape[1],
+            "Output tensor shape {} must be greater than or equal to input shape {} , but is smaller "
+            "in dimension 0",
             this->output_padded_shape,
-            input_shape,
-            i);
+            input_shape);
+    } else {
+        for (auto i = 0; i < input_shape.rank(); i++) {
+            TT_FATAL(
+                input_shape[i] <= this->output_padded_shape[i],
+                "Output tensor shape {} must be greater than or equal to input shape {} in each dimension, but is "
+                "smaller "
+                "in dimension {}",
+                this->output_padded_shape,
+                input_shape,
+                i);
+        }
     }
 
     uint32_t num_rows = this->output_padded_shape[-1];

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -22,14 +22,14 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
         input_tensor_a.get_dtype() == DataType::BFLOAT16 or input_tensor_a.get_dtype() == DataType::UINT32 or
             input_tensor_a.get_dtype() == DataType::FLOAT32,
         "Can only tilize bfloat16/float32 or uint32 tensors");
+    TT_FATAL(input_shape.rank() >= 2, "Input tensor must be of rank >2, but its shape is {}", input_shape);
 
     TT_FATAL(input_shape.rank() >= 1, "Input tensor must be of rank >= 1, but its shape is {}", input_shape);
 
     for (auto i = 0; i < input_shape.rank(); i++) {
         TT_FATAL(
             input_shape[i] <= this->output_padded_shape[i],
-            "Output tensor shape {} must be greater than or equal to input shape {} in each dimension, but is "
-            "smaller "
+            "Output tensor shape {} must be greater than or equal to input shape {} in each dimension, but is smaller "
             "in dimension {}",
             this->output_padded_shape,
             input_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -22,7 +22,6 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
         input_tensor_a.get_dtype() == DataType::BFLOAT16 or input_tensor_a.get_dtype() == DataType::UINT32 or
             input_tensor_a.get_dtype() == DataType::FLOAT32,
         "Can only tilize bfloat16/float32 or uint32 tensors");
-    TT_FATAL(input_shape.rank() >= 2, "Input tensor must be of rank >2, but its shape is {}", input_shape);
 
     TT_FATAL(input_shape.rank() >= 1, "Input tensor must be of rank >= 1, but its shape is {}", input_shape);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -93,6 +93,35 @@ ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
         DefaultQueueId, input_tensor, output_padded_shape, pad_value, memory_config, output_dtype, use_multicore);
 }
 
+ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
+    uint8_t queue_id,
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<uint32_t>& output_padded_shape,
+    const PadValue pad_value,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DataType> output_dtype,
+    bool use_multicore) {
+    return invoke(
+        queue_id,
+        input_tensor,
+        ttnn::SimpleShape{output_padded_shape},
+        pad_value,
+        memory_config,
+        output_dtype,
+        use_multicore);
+}
+
+ttnn::Tensor ExecuteTilizeWithValPadding::invoke(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::SmallVector<uint32_t>& output_padded_shape,
+    const PadValue pad_value,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<DataType> output_dtype,
+    bool use_multicore) {
+    return invoke(
+        DefaultQueueId, input_tensor, output_padded_shape, pad_value, memory_config, output_dtype, use_multicore);
+}
+
 ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
     uint8_t queue_id,
     const ttnn::Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -18,6 +18,23 @@ struct ExecuteTilizeWithValPadding {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
+        const ttnn::SmallVector<uint32_t>& output_padded_shape,
+        const PadValue pad_value,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<DataType> output_dtype = std::nullopt,
+        bool use_multicore = true);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::SmallVector<uint32_t>& output_padded_shape,
+        const PadValue pad_value,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<DataType> output_dtype = std::nullopt,
+        bool use_multicore = true);
+
+    static ttnn::Tensor invoke(
+        uint8_t queue_id,
+        const ttnn::Tensor& input_tensor,
         const ttnn::SimpleShape& output_padded_shape,
         const PadValue pad_value,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.hpp
@@ -46,20 +46,15 @@ void bind_tilize_with_val_padding(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const tt::tt_metal::LegacyShape& output_tensor_shape,
+               // const tt::tt_metal::LegacyShape& output_tensor_shape,
+               const ttnn::SmallVector<uint32_t>& output_tensor_shape,
                const PadValue value,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<DataType> output_dtype,
                bool use_multicore,
                uint8_t queue_id) {
                 return self(
-                    queue_id,
-                    input_tensor,
-                    output_tensor_shape.padded_shape(),
-                    value,
-                    memory_config,
-                    output_dtype,
-                    use_multicore);
+                    queue_id, input_tensor, output_tensor_shape, value, memory_config, output_dtype, use_multicore);
             },
             py::arg("input_tensor"),
             py::arg("output_tensor_shape"),

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.hpp
@@ -46,7 +46,6 @@ void bind_tilize_with_val_padding(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               // const tt::tt_metal::LegacyShape& output_tensor_shape,
                const ttnn::SmallVector<uint32_t>& output_tensor_shape,
                const PadValue value,
                const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -12,7 +12,8 @@
 namespace ttnn::operations::data_movement {
 
 struct UntilizeWithUnpadding {
-    const tt::tt_metal::LegacyShape output_tensor_end;
+    // const tt::tt_metal::LegacyShape output_tensor_end;
+    const ttnn::SimpleShape output_tensor_end;
     const MemoryConfig output_mem_config;
     const bool use_multicore;
     const bool use_pack_untilize;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -12,7 +12,6 @@
 namespace ttnn::operations::data_movement {
 
 struct UntilizeWithUnpadding {
-    // const tt::tt_metal::LegacyShape output_tensor_end;
     const ttnn::SimpleShape output_tensor_end;
     const MemoryConfig output_mem_config;
     const bool use_multicore;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -13,7 +13,6 @@
 
 using namespace tt::tt_metal;
 
-// LegacyShape squeeze_vector_shape(tt::tt_metal::LegacyShape output_shape) {
 std::vector<uint32_t> squeeze_vector_shape(std::vector<uint32_t> output_shape) {
     if (output_shape.size() > 4) {
         std::vector<uint32_t> output_shape_4d(output_shape.size());
@@ -61,7 +60,6 @@ MassagedUntilizeVal build_ndiml_untilize_val(BaseUntilizeValType base_untilize) 
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     uint8_t queue_id,
     const ttnn::Tensor& input_tensor,
-    // const tt::tt_metal::LegacyShape& output_tensor_end,
     const ttnn::SimpleShape& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
@@ -70,7 +68,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32;
 
     std::vector<uint32_t> output_end_vector;
-    // tt::tt_metal::LegacyShape output_end = tt::tt_metal::LegacyShape{};
     std::vector<uint32_t> output_end;
     if (input_tensor.get_logical_shape().rank() > 4) {
         for (auto index = 0; index < input_tensor.get_logical_shape().rank(); ++index) {
@@ -78,7 +75,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
         }
         output_end = squeeze_vector_shape(output_end_vector);
     } else {
-        // output_end = output_tensor_end;
         for (auto index = 0; index < input_tensor.get_logical_shape().rank(); ++index) {
             output_end_vector.push_back(output_tensor_end[index]);
         }
@@ -104,7 +100,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
 
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     const ttnn::Tensor& input_tensor,
-    // const tt::tt_metal::LegacyShape& output_tensor_end,
     const ttnn::SimpleShape& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
@@ -115,7 +110,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     uint8_t queue_id,
     const ttnn::Tensor& input_tensor,
-    // const tt::tt_metal::LegacyShape& output_tensor_end,
     const ttnn::SmallVector<uint32_t>& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
@@ -124,7 +118,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32;
 
     std::vector<uint32_t> output_end_vector;
-    // tt::tt_metal::LegacyShape output_end = tt::tt_metal::LegacyShape{};
     std::vector<uint32_t> output_end;
     if (input_tensor.get_logical_shape().rank() > 4) {
         for (auto index = 0; index < input_tensor.get_logical_shape().rank(); ++index) {
@@ -132,7 +125,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
         }
         output_end = squeeze_vector_shape(output_end_vector);
     } else {
-        // output_end = output_tensor_end;
         for (auto index = 0; index < input_tensor.get_logical_shape().rank(); ++index) {
             output_end_vector.push_back(output_tensor_end[index]);
         }
@@ -158,7 +150,6 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
 
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     const ttnn::Tensor& input_tensor,
-    // const tt::tt_metal::LegacyShape& output_tensor_end,
     const ttnn::SmallVector<uint32_t>& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -13,7 +13,6 @@ struct ExecuteUntilizeWithUnpadding {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
-        // const tt::tt_metal::LegacyShape& output_tensor_end,
         const ttnn::SimpleShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,
@@ -21,7 +20,6 @@ struct ExecuteUntilizeWithUnpadding {
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        // const tt::tt_metal::LegacyShape& output_tensor_end,
         const ttnn::SimpleShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,
@@ -30,7 +28,6 @@ struct ExecuteUntilizeWithUnpadding {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
-        // const tt::tt_metal::LegacyShape& output_tensor_end,
         const ttnn::SmallVector<uint32_t>& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,
@@ -38,7 +35,6 @@ struct ExecuteUntilizeWithUnpadding {
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        // const tt::tt_metal::LegacyShape& output_tensor_end,
         const ttnn::SmallVector<uint32_t>& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -13,14 +13,33 @@ struct ExecuteUntilizeWithUnpadding {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
-        const tt::tt_metal::LegacyShape& output_tensor_end,
+        // const tt::tt_metal::LegacyShape& output_tensor_end,
+        const ttnn::SimpleShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,
         bool use_pack_untilize = true);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        const tt::tt_metal::LegacyShape& output_tensor_end,
+        // const tt::tt_metal::LegacyShape& output_tensor_end,
+        const ttnn::SimpleShape& output_tensor_end,
+        const std::optional<MemoryConfig>& memory_config,
+        bool use_multicore = true,
+        bool use_pack_untilize = true);
+
+    static ttnn::Tensor invoke(
+        uint8_t queue_id,
+        const ttnn::Tensor& input_tensor,
+        // const tt::tt_metal::LegacyShape& output_tensor_end,
+        const ttnn::SmallVector<uint32_t>& output_tensor_end,
+        const std::optional<MemoryConfig>& memory_config,
+        bool use_multicore = true,
+        bool use_pack_untilize = true);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        // const tt::tt_metal::LegacyShape& output_tensor_end,
+        const ttnn::SmallVector<uint32_t>& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = true,
         bool use_pack_untilize = true);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
@@ -44,7 +44,8 @@ void bind_untilize_with_unpadding(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const tt::tt_metal::LegacyShape& output_tensor_end,
+               // const tt::tt_metal::LegacyShape& output_tensor_end,
+               const ttnn::SmallVector<uint32_t>& output_tensor_end,
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
                bool use_pack_untilize,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
@@ -44,7 +44,6 @@ void bind_untilize_with_unpadding(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               // const tt::tt_metal::LegacyShape& output_tensor_end,
                const ttnn::SmallVector<uint32_t>& output_tensor_end,
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/16575

### Problem description
Untilize with unpadding fails for some input shapes because of a page size assertion 

### What's changed
- Fix page size assertion issue that is due to the shape format used
- Replace legacy shape used in tilize/untilize with padding
- Remove to_layout shard check 

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12933116999
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
