### PR TITLE
Fix for P100 board type

### DIFF
--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -357,6 +357,7 @@ void metal_SocDescriptor::update_pcie_cores(const BoardType& board_type) {
         return;
     }
     switch (board_type) {
+        case P100:
         case UNKNOWN: {  // Workaround for BHs running FW that does not return board type in the cluster yaml
             this->pcie_cores = {CoreCoord(11, 0)};
         } break;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Recent umd submodule update broke assumption that P100s are listed as board type UNKNOWN

### What's changed


### Checklist
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12774058912)

