### PR TITLE
#16379: make softmax call moreh_softmax if rank above 4

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/test_softmax.py
@@ -305,3 +305,26 @@ def test_specific_tensor_combination(device):
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
     assert_with_pcc(torch_output_tensor, output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [
+        ((1, 3, 56, 56, 3), -1),
+        ((3, 5, 63, 56, 33), -2),
+        ((7, 2, 56, 67, 31), -3),
+        ((4, 9, 6, 86, 13), -4),
+        ((32, 32, 32, 32, 32), -5),
+    ],
+)
+def test_5d_softmax(device, input_shape, dim):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.softmax(torch_input_tensor, dim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.softmax(input_tensor, dim)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.cpp
@@ -24,6 +24,17 @@ ttnn::Tensor ExecuteSoftmax::invoke(
     if (dim < 0) {
         dim = rank + dim;
     }
+    if (rank > 4) {
+        auto output_tensor = ttnn::prim::moreh_softmax(
+            input_tensor,
+            dim,
+            std::nullopt,
+            MorehSoftmaxOp::SOFTMAX,
+            MorehSoftmaxOpParallelizationStrategy::NONE,
+            memory_config.value_or(input_tensor.memory_config()),
+            compute_kernel_config);
+        return ttnn::reshape(output_tensor, input_shape);
+    }
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     if (dim == rank - 1) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #16379

### Problem description
softmax only supported tensors with rank up to 4

### What's changed
- softmax uses moreh_softmax, which supports nD tensors, except in one specific case.
- Therefore extend the use of moreh_softmax for all cases when rank is greater than 4 and use existing code otherwise. 

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12777242709
- [x] Blackhole Post commit (if applicable) passed except for tools test, which is unrelated to this change, due to no space left on device https://github.com/tenstorrent/tt-metal/actions/runs/12777245471/job/35625353262
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
