### PR TITLE
Fixes for conversion to row major for 0D and 0-volume tensors

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -190,10 +190,10 @@ def test_to_layout_for_2D(shape, input_layout, output_layout, device):
     assert_with_pcc(input_a, output_tensor)
 
 
-@pytest.mark.parametrize("w", [1, 5, 14, 97])
-def test_to_from_1d(device, w):
+@pytest.mark.parametrize("shape", [1, 5, 14, 97, 0, ()])
+def test_to_from_01d(device, shape):
     torch.manual_seed(2005)
-    torch_input = torch.rand(w)
+    torch_input = torch.rand(shape)
 
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.float32)
     ttnn_input = ttnn.to_layout(ttnn_input, ttnn.TILE_LAYOUT)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -336,6 +336,8 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     //The following case should only be called for the device storage case, the rest is a bandaid
     //for issue 15317
 
+    const uint32_t shape_last_dim = shape.rank() >= 1 ? shape[-1] : 1;
+    const uint32_t tensor_shape_last_dim = tensor_shape.rank() >= 1 ? tensor_shape[-1] : 1;
     const uint32_t shape_second_last_dim = shape.rank() >= 2 ? shape[-2]:1;
     const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2]:1;
 
@@ -351,7 +353,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     TT_FATAL(shape.logical_shape().volume() != 0, "Tensor volume is not 0, but shape volume is 0");
 
     bool this_is_view =
-        (tensor_shape[-1] == shape[-1]) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&
+        (tensor_shape_last_dim == shape_last_dim) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&
         (mem_config.is_l1() == tensor.memory_config().is_l1()) &&
         ((tensor.get_layout() == ttnn::ROW_MAJOR_LAYOUT) ||          // Its row major
          (tensor_shape_second_last_dim == shape_second_last_dim) ||  // Second last dimension is the same

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -1218,10 +1218,10 @@ Tensor unpad(
     ttnn::SmallVector<uint32_t> output_shape;
     for (auto i = 0; i < input_shape.rank(); i++) {
         // Check if tensor start and end indices are within input tensor shape
-        TT_ASSERT(output_tensor_start[i] < input_shape[i]);
+        TT_ASSERT(output_tensor_start[i] <= input_shape[i]);
         TT_ASSERT(output_tensor_end[i] <= input_shape[i]);
         // Check if start shape is < end shape
-        TT_ASSERT(output_tensor_start[i] < output_tensor_end[i]);
+        TT_ASSERT(output_tensor_start[i] <= output_tensor_end[i]);
         // Figure out output tensor shape
         output_shape.push_back(output_tensor_end[i] - output_tensor_start[i]);
     }

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -313,8 +313,8 @@ Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const ttnn::SimpleShap
             input_tensor.get_padded_shape()[-1] % constants::TILE_WIDTH == 0,
         "Last 2 dims of input shape must be multiples of 32");
     TT_ASSERT(
-        input_tensor.get_padded_shape()[-2] - constants::TILE_HEIGHT < output_tensor_shape[-2] &&
-            input_tensor.get_padded_shape()[-1] - constants::TILE_WIDTH < output_tensor_shape[-1],
+        input_tensor.get_padded_shape()[-2] < output_tensor_shape[-2] + constants::TILE_HEIGHT &&
+            input_tensor.get_padded_shape()[-1] < output_tensor_shape[-1] + constants::TILE_WIDTH,
         "Last 2 dims of output must be within range to have been padded to input");
     SimpleShape output_tensor_start(ttnn::SmallVector<uint32_t>(input_tensor.padded_shape().rank(), 0));
     SimpleShape output_tensor_end(ttnn::SmallVector<uint32_t>(input_tensor.padded_shape().rank(), 1));

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -193,6 +193,9 @@ ttnn::SimpleShape LegacyShape::padded_shape() const {
 const uint32_t LegacyShape::get_normalized_index(std::int64_t index) const {
     std::int64_t rank = static_cast<std::int64_t>(this->rank_);
     std::uint64_t normalized_index = index >= 0 ? index : rank + index;
+    if (normalized_index < 0 || normalized_index >= rank) {
+        TT_THROW("qq");
+    }
     TT_FATAL(
         normalized_index >= 0 and normalized_index < rank,
         "Index is out of bounds for the rank, should be between 0 and {} however is {}",

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -193,9 +193,6 @@ ttnn::SimpleShape LegacyShape::padded_shape() const {
 const uint32_t LegacyShape::get_normalized_index(std::int64_t index) const {
     std::int64_t rank = static_cast<std::int64_t>(this->rank_);
     std::uint64_t normalized_index = index >= 0 ? index : rank + index;
-    if (normalized_index < 0 || normalized_index >= rank) {
-        TT_THROW("qq");
-    }
     TT_FATAL(
         normalized_index >= 0 and normalized_index < rank,
         "Index is out of bounds for the rank, should be between 0 and {} however is {}",


### PR DESCRIPTION
### Ticket

### Problem description
Conversion to row major layout was broken for 0D and 0-volume tensors

### What's changed
Minor fixes to make the conversion work
Added tests for it

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12778106437)
- [x] New/Existing tests provide coverage for changes
