### PR TITLE
Update code-analysis.yaml

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -190,6 +190,9 @@ jobs:
             # Symlink tomfoolery here so that Ninja believes the build command has not changed from the previous run
             ln -sf $(which clang-tidy-17) ./clang-tidy-shim
 
+            # For Debug, check md5sum of a library
+            md5sum tt_metal/third_party/umd/device/libs/x86_64/libcreate_ethernet_map.a
+
             cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
             nice -n 19 cmake --build --preset clang-tidy
             mkdir -p out

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -137,6 +137,9 @@ jobs:
             # Suppress clang-tidy to first get an up-to-date build tree
             ln -sf /usr/bin/true ./clang-tidy-shim
 
+            # For Debug, check md5sum of a library
+            md5sum tt_metal/third_party/umd/device/libs/x86_64/libcreate_ethernet_map.a
+
             cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY=$(pwd)/clang-tidy-shim -DCMAKE_C_CLANG_TIDY=$(pwd)/clang-tidy-shim
             nice -n 19 cmake --build --preset clang-tidy
 


### PR DESCRIPTION
### Problem description
```
/usr/bin/ld:../../tt_metal/third_party/umd/device/libs/x86_64/libcreate_ethernet_map.a: file format not recognized; treating as linker script
/usr/bin/ld:../../tt_metal/third_party/umd/device/libs/x86_64/libcreate_ethernet_map.a:1: syntax error
clang++-17: error: linker command failed with exit code 1 (use -v to see invocation)
```

### What's changed
Add a debug step to check the md5sum of that file

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12778085604)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
