### PR TITLE
#16366: Changed kernel config to HiFi4 for 32F matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -2112,13 +2112,12 @@ def test_optional_output_argument(device, n_size, c, m, k, n):
 
 def test_small_matmul_pcc(device):
     torch.manual_seed(0)
-    pcc = 0.99
-    torch_input_tensor_a = torch.rand([1, 2048])
-    torch_input_tensor_b = torch.rand([2048, 1000])
+    pcc = 0.999
+    torch_input_tensor_a = torch.rand([1, 2048], dtype=torch.float32)
+    torch_input_tensor_b = torch.rand([2048, 1000], dtype=torch.float32)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
-
-    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
     output1 = ttnn.matmul(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output1)
 

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -2112,7 +2112,7 @@ def test_optional_output_argument(device, n_size, c, m, k, n):
 
 def test_small_matmul_pcc(device):
     torch.manual_seed(0)
-    pcc = 0.999
+    pcc = 0.99
     torch_input_tensor_a = torch.rand([1, 2048], dtype=torch.float32)
     torch_input_tensor_b = torch.rand([2048, 1000], dtype=torch.float32)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1223,6 +1223,10 @@ Matmul create_matmul_struct(
          (input_tensor_b.get_dtype() == DataType::BFLOAT8_B || input_tensor_b.get_dtype() == DataType::BFLOAT4_B));
     const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
+    bool are_inputs_32F =
+        (input_tensor_a.get_dtype() == DataType::FLOAT32 && input_tensor_b.get_dtype() == DataType::FLOAT32);
+    math_fidelity = are_inputs_32F ? MathFidelity::HiFi4 : math_fidelity;
+
     bool broadcast_batch =
         parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
     TT_FATAL(!(has_user_grid && has_program_config), "Cannot use both user core grid/coordinates and a program config");


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/16366)

### Problem description
Lower than expected PCC for matmul with inputs for 32F

### What's changed
Changed matmul behavior to use HiFi4 when inputs are 32F

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
