### PR TITLE
#0: Disable BH tools test at workflow level

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -84,6 +84,8 @@ jobs:
         with:
           arch: ${{ inputs.arch }}
       - name: ${{ matrix.test-group.name }} tests
+        #GH Issue 16167
+        if: ${{ !(inputs.runner-label == 'BH' && matrix.test-group.name == 'tools') }}
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16167
Disables the tools job in the C++ workflow so that  whichever poor BH machine picks up job won't max out storage space 

### Problem description
BH machines hang when dumping command queues. This maxes out storage space on the runner.

### What's changed
Disable the tools portion of the test only for Blackhole machines

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12781145178/job/35628657745
- [ ] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12779865742
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
