### PR TITLE
#16758: Optimize usage and implementation of encode/decode tensor data

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
@@ -107,19 +107,19 @@ TEST_P(ShardWithAlignmentTests, LogicalToPhysical) {
     auto physical_shape = tensor_spec.physical_shape();
     ASSERT_EQ(physical_shape, params.expected.physical_shape);
 
-    const auto& logical_data = params.inputs.logical_data;
+    auto logical_data = params.inputs.logical_data;
     const auto& expected_physical_data = params.expected.physical_data;
 
     // Convert output physical data to row major (if necessary) for testing
-    auto physical_data = tensor_impl::encode_tensor_data(logical_data, tensor_spec);
+    auto physical_data = tensor_impl::encode_tensor_data(std::move(logical_data), tensor_spec);
     if (tensor_spec.layout() == Layout::TILE) {
         // TODO: Fix convert_layout_tile_to_row_major to take in vector instead of buffer?
         physical_data = tensor_impl::convert_layout_tile_to_row_major(
             physical_shape, tensor_spec.tile(), owned_buffer::create(std::move(physical_data)));
     }
 
-    // auto shape_2D = tt::tt_metal::get_2d_shape(tensor_spec.logical_shape());
-    // pretty_print_data_as_shards(logical_data, shape_2D, logical_shard_shape);
+    // auto shape_2d = tensor_spec.logical_2d_shape();
+    // pretty_print_data_as_shards(params.inputs.logical_data, shape_2d, logical_shard_shape);
     // pretty_print_data_as_shards(physical_data, physical_shape, physical_shard_shape);
 
     ASSERT_EQ(physical_data.size(), expected_physical_data.size());
@@ -165,11 +165,11 @@ TEST_P(ShardWithAlignmentTests, PhysicalToLogical) {
         physical_data = tensor_impl::convert_layout_row_major_to_tile(
             physical_shape, tensor_spec.tile(), owned_buffer::create(std::move(physical_data)));
     }
-    auto logical_data = tensor_impl::decode_tensor_data(physical_data, tensor_spec);
+    auto logical_data = tensor_impl::decode_tensor_data(std::move(physical_data), tensor_spec);
 
-    // auto shape_2D = tt::tt_metal::get_2d_shape(tensor_spec.logical_shape());
-    // pretty_print_data_as_shards(physical_data, physical_shape, physical_shard_shape);
-    // pretty_print_data_as_shards(logical_data, shape_2D, logical_shard_shape);
+    // auto shape_2d = tensor_spec.logical_2d_shape();
+    // pretty_print_data_as_shards(params.expected.physical_data, physical_shape, physical_shard_shape);
+    // pretty_print_data_as_shards(logical_data, shape_2d, logical_shard_shape);
 
     ASSERT_EQ(logical_data.size(), expected_data.size());
     for (size_t i = 0; i < logical_data.size(); i++) {

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -78,7 +78,7 @@ Tensor create_owned_tensor(T* data_ptr, const ttnn::TensorSpec& tensor_spec) {
     auto logical_data = std::vector<T>(data_ptr, data_ptr + num_elements);
 
     // See implementation for documentation
-    auto physical_data = tensor_impl::encode_tensor_data(logical_data, tensor_spec);
+    auto physical_data = tensor_impl::encode_tensor_data(std::move(logical_data), tensor_spec);
 
     auto buffer = owned_buffer::create(std::move(physical_data));
     auto storage = OwnedStorage{std::move(buffer)};
@@ -94,8 +94,7 @@ Tensor create_tt_tensor_from_py_data(
     const std::function<void()>& on_destruction_callback) {
     auto layout = tensor_spec.layout();
 
-    const bool requires_padding = tensor_spec.logical_shape().volume() !=
-                                  tensor_spec.physical_shape().height() * tensor_spec.physical_shape().width();
+    const bool requires_padding = tensor_spec.logical_2d_shape() != tensor_spec.physical_shape();
     const bool requires_tilization = layout != Layout::ROW_MAJOR;
     const bool enable_borrow = !requires_padding and !requires_tilization and !force_disable_borrow;
 
@@ -418,7 +417,7 @@ Tensor convert_python_tensors_to_tt_tensors(
 
 template <typename T>
 owned_buffer::Buffer<T> create_row_major_owned_buffer(
-    owned_buffer::Buffer<T> owned_buffer, const ttnn::TensorSpec& tensor_spec, const bool legacy_output) {
+    owned_buffer::Buffer<T>&& owned_buffer, const ttnn::TensorSpec& tensor_spec, const bool legacy_output) {
     TT_FATAL(
         !tensor_spec.memory_config().is_sharded() or tensor_spec.memory_config().shard_spec.has_value(),
         "Sharded tensors must have a shard spec when converting to tt tensors!");
@@ -435,7 +434,7 @@ owned_buffer::Buffer<T> create_row_major_owned_buffer(
     auto physical_data = owned_buffer.get();
 
     // See implementation for documentation
-    auto logical_data = tensor_impl::decode_tensor_data(physical_data, tensor_spec);
+    auto logical_data = tensor_impl::decode_tensor_data(std::move(physical_data), tensor_spec);
 
     return owned_buffer::create(std::move(logical_data));
 }
@@ -453,27 +452,27 @@ std::variant<OwnedBuffer, BorrowedBuffer> get_host_buffer_from_tensor(
                 switch (tt_dtype) {
                     case DataType::UINT8: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<uint8_t>(storage.buffer), tensor_spec, legacy_output);
+                            std::move(owned_buffer::get_as<uint8_t>(storage.buffer)), tensor_spec, legacy_output);
                     }
                     case DataType::UINT16: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<uint16_t>(storage.buffer), tensor_spec, legacy_output);
+                            std::move(owned_buffer::get_as<uint16_t>(storage.buffer)), tensor_spec, legacy_output);
                     }
                     case DataType::INT32: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<int32_t>(storage.buffer), tensor_spec, legacy_output);
+                            std::move(owned_buffer::get_as<int32_t>(storage.buffer)), tensor_spec, legacy_output);
                     }
                     case DataType::UINT32: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<uint32_t>(storage.buffer), tensor_spec, legacy_output);
+                            std::move(owned_buffer::get_as<uint32_t>(storage.buffer)), tensor_spec, legacy_output);
                     }
                     case DataType::FLOAT32: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<float>(storage.buffer), tensor_spec, legacy_output);
+                            std::move(owned_buffer::get_as<float>(storage.buffer)), tensor_spec, legacy_output);
                     }
                     case DataType::BFLOAT16: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<::bfloat16>(storage.buffer), tensor_spec, legacy_output);
+                            std::move(owned_buffer::get_as<::bfloat16>(storage.buffer)), tensor_spec, legacy_output);
                     }
                     case DataType::BFLOAT8_B:
                     case DataType::BFLOAT4_B: {
@@ -486,7 +485,7 @@ std::variant<OwnedBuffer, BorrowedBuffer> get_host_buffer_from_tensor(
                                 : unpack_bfp4_tiles_into_float_vec(
                                       uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
                         auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
-                        return create_row_major_owned_buffer(input_float_buffer, tensor_spec, legacy_output);
+                        return create_row_major_owned_buffer(std::move(input_float_buffer), tensor_spec, legacy_output);
                     }
                     default: {
                         TT_THROW("Unsupported DataType: {}", tt_dtype);

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
@@ -260,6 +260,18 @@ Shape2D TensorLayout::get_physical_shard_shape() const {
     }
 }
 
+Shape2D TensorLayout::compute_logical_2d_shape(const ttnn::SimpleShape& shape) const {
+    if (shape.rank() < 2) {
+        return Shape2D{1, shape[-1]};
+    }
+    size_t width = shape[-1];
+    size_t height = shape[-2];
+    for (int i = -3; i >= -shape.rank(); --i) {
+        height *= shape[i];
+    }
+    return Shape2D{height, width};
+}
+
 Shape2D TensorLayout::compute_physical_shape(const ttnn::SimpleShape& shape) const {
     const int rank = static_cast<int>(shape.rank());
     const int alignment_rank = static_cast<int>(alignment_.size());

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
@@ -57,6 +57,11 @@ public:
     [[deprecated("Use of LegacyPaddedShape is deprecated. Please use get_physical_size() or get_strides() instead.")]]
     ttnn::SimpleShape compute_padded_shape(const ttnn::SimpleShape& shape) const;
 
+    // Flattens input shape into height and width
+    // - Height is accumulated over all dims except last
+    // - Width is equal to the last dim
+    Shape2D compute_logical_2d_shape(const ttnn::SimpleShape& shape) const;
+
     // Returns number of elements laid out in physically memory across H:W dimensions
     //  W is row width aligned to page width and shard width, depends on data type
     //  H is all dimensions except W multiplied and aligned to tile and shard height

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -718,7 +718,7 @@ std::vector<float> Tensor::to_vector<float>() const {
                     : unpack_bfp4_tiles_into_float_vec(
                           packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
 
-            return tensor_impl::decode_tensor_data(unpacked_data, cpu_tensor.tensor_spec());
+            return tensor_impl::decode_tensor_data(std::move(unpacked_data), cpu_tensor.tensor_spec());
         }
         default: {
             TT_THROW("Cannot convert tensor to vector for data type: {}", cpu_tensor.get_dtype());

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -96,7 +96,7 @@ static ttnn::SmallVector<uint32_t> to_4D_shape(const tt::tt_metal::LegacyShape& 
 
 }  // namespace detail
 
-template <typename T, template <typename> typename BufferType>
+template <typename T, template <typename...> typename BufferType>
 inline std::vector<T> convert_layout_row_major_to_tile(
     const Shape2D& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     if (shape.width() * shape.height() == 0) {
@@ -126,7 +126,7 @@ inline std::vector<T> convert_layout_row_major_to_tile(
         transpose_of_faces);
 }
 
-template <typename T, template <typename> typename BufferType>
+template <typename T, template <typename...> typename BufferType>
 inline std::vector<T> convert_layout_tile_to_row_major(
     const Shape2D& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     auto tile_shape = tile.get_tile_shape();
@@ -158,7 +158,7 @@ inline std::vector<T> convert_layout_tile_to_row_major(
 //     ** For the last shard, we only align to nearest page instead of full shard size for partial shards
 //   * After conversion, size of physical data will match 2D physical size indicated by tensor_spec.physical_shape()
 template <typename T>
-std::vector<T> encode_tensor_data(const std::vector<T>& logical_data, const TensorSpec& tensor_spec);
+std::vector<T> encode_tensor_data(std::vector<T>&& logical_data, const TensorSpec& tensor_spec);
 
 // Converts physical data into logical data based on tensor spec (see encode_tensor_data for details)
 // - Physical data: Flat container of physical data corresponding to tensor spec
@@ -168,7 +168,7 @@ std::vector<T> encode_tensor_data(const std::vector<T>& logical_data, const Tens
 //   * To get logical data, perform the exact inverse process of encode_tensor_data
 //   * Resulting data is safe to be converted to python tensors or general consumption with just a ND logical shape
 template <typename T>
-std::vector<T> decode_tensor_data(const std::vector<T>& physical_data, const TensorSpec& tensor_spec);
+std::vector<T> decode_tensor_data(std::vector<T>&& physical_data, const TensorSpec& tensor_spec);
 
 // ======================================================================================
 //                                      Validators

--- a/ttnn/cpp/ttnn/tensor/tensor_spec.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_spec.hpp
@@ -15,6 +15,7 @@ public:
         logical_shape_(std::move(logical_shape)),
         tensor_layout_(std::move(tensor_layout)),
         cached_padded_shape_(tensor_layout_.compute_padded_shape(logical_shape_)),
+        cached_logical_2d_shape_(tensor_layout_.compute_logical_2d_shape(logical_shape_)),
         cached_physical_shape_(tensor_layout_.compute_physical_shape(logical_shape_)) {}
     TensorSpec(TensorSpec&&) noexcept = default;
     TensorSpec& operator=(TensorSpec&&) = default;
@@ -30,6 +31,7 @@ public:
     PageConfig page_config() const { return tensor_layout_.get_page_config(); }
     const MemoryConfig& memory_config() const { return tensor_layout_.get_memory_config(); }
     const ttnn::SimpleShape& padded_shape() const { return cached_padded_shape_; }
+    const Shape2D& logical_2d_shape() const { return cached_logical_2d_shape_; }
     const Shape2D& physical_shape() const { return cached_physical_shape_; }
     ttnn::Shape shape() const { return ttnn::Shape(logical_shape_.view(), cached_padded_shape_.view()); }
 
@@ -52,6 +54,7 @@ private:
     TensorLayout tensor_layout_;
 
     ttnn::SimpleShape cached_padded_shape_;
+    Shape2D cached_logical_2d_shape_;
     Shape2D cached_physical_shape_;
 };
 

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -200,12 +200,6 @@ Tensor copy_borrowed_tensor_in_async_mode(IDevice* worker, const Tensor& tensor)
     return tensor;
 }
 
-Shape2D get_2d_shape(const ttnn::SimpleShape& shape) {
-    size_t width = shape[-1];
-    size_t height = shape.volume() / width;
-    return Shape2D{height, width};
-}
-
 ShardDivisionSpec compute_shard_division_spec(const Shape2D& shape, const Shape2D& shard_shape) {
     const auto num_shards_height = tt::div_up(shape.height(), shard_shape.height());
     const auto last_shard_height =

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -127,11 +127,6 @@ inline uint32_t get_batch_size(const T& shape) {
     return result;
 }
 
-// Flattens input shape into height and width
-// - Height is accumulated over all dims except last
-// - Width is equal to the last dim
-Shape2D get_2d_shape(const ttnn::SimpleShape& shape);
-
 // Useful information about how a shard_shape cuts a 2D shape
 // - num_shards_height: Number of shards along the height (including partial last shard, if any)
 // - last_shard_height: Height of last partial shard (if None, it will be same as full shard shape height)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16758)

### Problem description
Encode/decode tensor data is inefficient for cases where we are just returning the same vector. It's leading to slowdown in e2e tests that include host->device transfer for perf.

### What's changed
- Switch to rval inputs for encode/decode and move vectors when possible
   * Switch to rval for passing buffer in create_row_major_owned_buffer
- Skip unnecessary conversion steps in encode/decode tensor data when possible
   * If no conversions are neeeded, only minor overhead for moving vectors (no copies)
- Add support for vectors in convert_layout_row_major_to_tile and convert_layout_tile_to_row_major
   * Switch to variadic args in template for BufferType
   * Switch to directly use vectors instead of creating an owned buffer when calling
- Cache logical_2d_shape calculation in tensor spec
   * Move get_2d_shape to tensor layout
- Add unnamed namespace around CMAKE_UNIQUE_NAMESPACE in tensor_impl

For this perf test:
```
WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b_common/tests/test_perf_falcon.py::TestParametrized::test_perf_t3000_bare_metal -k "prefill_seq2048_async"
```
On my system, I recover most of the perf lost:
- Before logical sharding commit ([212be31](https://github.com/tenstorrent/tt-metal/commit/212be311f5f14e9a73cf2e25562e2908c18eb8cb)): ~0.87s
- After logical sharding commit: ~1.01s
- After this PR and fix: 0.88s


### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12821433903
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable): 
- T3000 model perf tests: https://github.com/tenstorrent/tt-metal/actions/runs/12815991243
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
