### PR TITLE
#0: Migrate pytensor to use `from_vector` Tensor creation APIs

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -157,12 +157,18 @@ struct Tensor {
     static Tensor from_span(
         tt::stl::Span<const T> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt);
 
-    // Same as `from_span`, but takes a vector instead.
+    // Same as `from_span`, but operates on a vector instead.
     template <typename T>
     static Tensor from_vector(
         const std::vector<T>& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt) {
-        return from_span(tt::stl::Span<const T>(buffer.data(), buffer.size()), spec, device);
+        return from_span(tt::stl::Span<const T>(buffer), spec, device);
     }
+
+    // Same as `from_vector`, but takes in an rvalue. No copies will be made, if the target layout is row-major, and no
+    // type conversion is needed.
+    template <typename T>
+    static Tensor from_vector(
+        std::vector<T>&& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt);
 
     // Converts a `Tensor` to a `std::vector<T>`.
     // Elements in the vector will be stored in row-major order. The type of the requested vector has to match that of


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`pytensor.cpp` implements bespoke functionality to convert a flattened list / vector into a Tensor. This should be using the native `Tensor::from_vector<T>` / `Tensor::from_span<T>` APIs instead.

### What's changed
Add overload for `Tensor::from_vector<T>` that accepts `std::vector<T>&&`, and use it in `pytensor.cpp`.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12794575040)
- [X] New/Existing tests provide coverage for changes
