### PR TITLE
Remove `sharded_to_interleaved` workaround in UNet Shallow

### DIFF
--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-UNET_FULL_MODEL_PCC = 0.9999
+UNET_FULL_MODEL_PCC = 0.99999
 
 
 def is_n300_with_eth_dispatch_cores(mesh_device) -> bool:
@@ -26,10 +26,10 @@ def is_t3k_with_eth_dispatch_cores(mesh_device) -> bool:
 
 def verify_with_pcc(torch_tensor, ttnn_tensor, pcc):
     _, computed_pcc = assert_with_pcc(torch_tensor, ttnn_tensor, pcc)
-    logger.info(f"PCC check was successful ({computed_pcc:.5f} > {pcc:.5f})")
+    logger.info(f"PCC check was successful ({computed_pcc:.6f} > {pcc:.6f})")
     if (computed_pcc - pcc) / pcc > 0.0025:
         logger.warning(
-            f"Computed PCC ({computed_pcc:.5f}) was higher than the expected PCC ({pcc:.5f}) - consider updating the expected PCC value"
+            f"Computed PCC ({computed_pcc:.6f}) was higher than the expected PCC ({pcc:.6f}) - consider updating the expected PCC value"
         )
 
 

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -32,7 +32,7 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 2, 1017.0),),
+    ((1, 2, 1065.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -27,8 +27,8 @@ from models.experimental.functional_unet.tests.common import (
     [
         ("upblock1", 64, 66, 10, 32),
         ("upblock2", 32, 132, 20, 32),
-        # ("upblock3", 32, 264, 40, 16),
-        # ("upblock4", 16, 528, 80, 16),
+        ("upblock3", 32, 264, 40, 16),
+        ("upblock4", 16, 528, 80, 16),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
@@ -70,7 +70,7 @@ def test_unet_upblock(
     ttnn_input, ttnn_residual = ttnn.to_device(ttnn_input, device), ttnn.to_device(ttnn_residual, device)
     ttnn_output = getattr(ttnn_model, block_name)(ttnn_input, ttnn_residual)
 
-    check_pcc_conv(torch_output, ttnn_output, pcc=0.998)
+    check_pcc_conv(torch_output, ttnn_output, pcc=0.999)
 
 
 @pytest.mark.parametrize("batch, groups", [(1, 2)])
@@ -79,8 +79,8 @@ def test_unet_upblock(
     [
         ("upblock1", 64, 66, 10, 32),
         ("upblock2", 32, 132, 20, 32),
-        # ("upblock3", 32, 264, 40, 16),
-        # ("upblock4", 16, 528, 80, 16),
+        ("upblock3", 32, 264, 40, 16),
+        ("upblock4", 16, 528, 80, 16),
     ],
 )
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
@@ -143,4 +143,4 @@ def test_unet_upblock_multi_device(
     ttnn_output = getattr(ttnn_model, block_name)(ttnn_input, ttnn_residual)
 
     assert len(ttnn_output.devices()) == 2, "Expected output tensor to be sharded across 2 devices"
-    check_pcc_conv(torch_output, ttnn_output, pcc=0.998, mesh_composer=output_mesh_composer)
+    check_pcc_conv(torch_output, ttnn_output, pcc=0.999, mesh_composer=output_mesh_composer)


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/16601

### Checklist
- [x] Post commit CI passes. - https://github.com/tenstorrent/tt-metal/actions/runs/12849255896
- [x] Model regression CI testing passes - https://github.com/tenstorrent/tt-metal/actions/runs/12839984852
- [x] Device performance regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12849261609
