### PR TITLE
#0: Fix build of test_pgm_dispatch

### DIFF
--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -20,7 +20,7 @@ jobs:
             arch: wormhole_b0
             runs-on: ["cloud-virtual-machine", "N300", "in-service"]
             run-args: |
-              ./build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch --benchmark_out_format=json --benchmark_out=bench.json
+              ./build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_wormhole_b0 --benchmark_out_format=json --benchmark_out=bench.json
               ./tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py bench.json
             timeout: 10
     name: ${{ matrix.test-group.name }}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -71,6 +71,9 @@ foreach(arch ${ARCHITECTURES})
                 yaml-cpp::yaml-cpp
                 tt_fabric
         )
+        if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")
+            target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
+        endif()
         target_include_directories(
             ${TEST_TARGET}
             BEFORE
@@ -92,7 +95,5 @@ foreach(arch ${ARCHITECTURES})
         list(APPEND PERF_MICROBENCH_TEST_TARGETS ${TEST_TARGET})
     endforeach()
 endforeach()
-
-target_link_libraries(test_pgm_dispatch PRIVATE benchmark::benchmark)
 
 add_custom_target(metal_perf_microbenchmark_tests DEPENDS ${PERF_MICROBENCH_TEST_TARGETS})


### PR DESCRIPTION
### What's changed
In 2e6915b805e51445c53442863563953aa3010049 we started generating test executables per architecture, so we need to do target_link_libraries on the new executable name.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
