### PR TITLE
#0: Fix failing TG regression tests

### DIFF
--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -66,7 +66,7 @@ MeshShape get_system_mesh_shape(size_t system_num_devices) {
 
 std::pair<CoordinateTranslationMap, MeshShape> get_system_mesh_coordinate_translation_map() {
     static const auto* cached_translation_map = new std::pair<CoordinateTranslationMap, MeshShape>([] {
-        auto system_num_devices = tt::Cluster::instance().number_of_devices();
+        auto system_num_devices = tt::Cluster::instance().number_of_user_devices();
 
         std::string galaxy_mesh_descriptor = "TG.json";
         if (tt::Cluster::instance().number_of_pci_devices() == system_num_devices) {

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -95,9 +95,11 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
     // First check if total size fits
     TT_FATAL(
         requested_num_rows * requested_num_cols <= system_mesh_rows * system_mesh_cols,
-        "Requested submesh is too big: {}x{}",
+        "Requested submesh is too big: {}x{}, SystemMesh shape: {}x{}",
         requested_num_rows,
-        requested_num_cols);
+        requested_num_cols,
+        system_mesh_rows,
+        system_mesh_cols);
 
     bool is_single_row_or_column = requested_num_rows == 1 or requested_num_cols == 1;
     if (is_single_row_or_column) {


### PR DESCRIPTION
### Ticket
None

### Problem description
There are failing TG regression tests. T3000 tests are unaffected. The failures are because `tt::Cluster::instance().number_of_user_devices();`should be used instead (which filters out the gateway wormhole devices -- i.e. returns 32, instead of 36).

### What's changed
Predicate coordinate translation lookup based on: `tt::Cluster::instance().number_of_user_devices()` API instead.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12796267460
- [x] T3000 Tests: https://github.com/tenstorrent/tt-metal/actions/runs/12796287756
- [x] TG Tests: https://github.com/tenstorrent/tt-metal/actions/runs/12795978448