### PR TITLE
[tt-train] Update serialization of tensor for DDP

### DIFF
--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -59,11 +59,22 @@ void write_ttnn_tensor(MsgPackFile& file, std::string_view name, const tt::tt_me
     file.put(std::string(name) + "/layout", static_cast<int>(layout));
     file.put(std::string(name) + "/storage_type", static_cast<int>(storage_type));
 
+    // we currently assume that there are two types of runs: single device and DDP
+    // once we decide to use other parallelization techniques (tensor parallel, FSDP) we need to update this code
     if (data_type == tt::tt_metal::DataType::BFLOAT16) {
-        auto data = ttml::core::to_vector<float>(tensor);
+        auto* device = &ttml::autograd::ctx().get_device();
+        ttml::core::MeshToXTensorVariant<float> composer = ttml::core::VectorMeshToXTensor<float>(device->shape());
+        auto data_all_devices = ttml::core::to_xtensor<float>(tensor, composer);
+        // pick weights from first device
+        auto data = data_all_devices.front();
         file.put(std::string(name) + "/data", std::span<const float>(data.data(), data.size()));
     } else if (data_type == tt::tt_metal::DataType::UINT32) {
-        auto data = ttml::core::to_vector<uint32_t>(tensor);
+        auto* device = &ttml::autograd::ctx().get_device();
+        ttml::core::MeshToXTensorVariant<uint32_t> composer =
+            ttml::core::VectorMeshToXTensor<uint32_t>(device->shape());
+        auto data_all_devices = ttml::core::to_xtensor<uint32_t>(tensor, composer);
+        // pick weights from first device
+        auto data = data_all_devices.front();
         file.put(std::string(name) + "/data", std::span<const uint32_t>(data.data(), data.size()));
     } else {
         throw std::runtime_error(fmt::format("Unsupported data type: {}", magic_enum::enum_name(data_type)));


### PR DESCRIPTION
### Problem description
Checkpoint saving doesn't work when multi device training is enabled.

### What's changed
Update serialization of ttnn::Tensor.

### Checklist
- [x] New/Existing tests provide coverage for changes
