### PR TITLE
Disable Unstable Transpose 2D Test

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -662,7 +662,8 @@ def test_transpose_2D(dtype, shape, layout, device):
     torch.manual_seed(2005)
     if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull")
-
+    if layout == ttnn.ROW_MAJOR_LAYOUT and shape == [21843, 768] and dtype == ttnn.bfloat16:
+        pytest.skip("Unstable see #16779")
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(0, 1)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16779

### Problem description
Transpose 2D instable in main, disabling test.

### What's changed
Disabling test until further notice

### Checklist
- [ ] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12796968061)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
