### PR TITLE
#16460: Add more helpful error message when tt-topology needs to be run

### DIFF
--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -61,7 +61,13 @@ void SystemMesh::Impl::initialize() {
 
     std::tie(logical_to_physical_coordinates_, logical_mesh_shape_) = get_system_mesh_coordinate_translation_map();
     for (const auto& [logical_coordinate, physical_coordinate] : logical_to_physical_coordinates_) {
-        logical_to_device_id_.emplace(logical_coordinate, physical_coordinate_to_device_id_.at(physical_coordinate));
+        auto physical_device_id_iter = physical_coordinate_to_device_id_.find(physical_coordinate);
+        TT_FATAL(
+            physical_device_id_iter != physical_coordinate_to_device_id_.end(),
+            "Physical (Ethernet) coordinate: {} not found. Have you used `tt-topology` to flash the ethernet "
+            "coordinates with the correct topology?",
+            physical_coordinate);
+        logical_to_device_id_.try_emplace(logical_coordinate, physical_device_id_iter->second);
     }
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/16460)

### Problem description
When user hasn't flashed the ethernet coordinates with `tt-topology`, it doesn't provide a helpful message back to the user.

### What's changed
Added a more helpful user error message.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12819627932

