### PR TITLE
Sharding support for binary_ng

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -38,6 +38,7 @@ struct BinaryNgDeviceOperation {
         tt::tt_metal::MemoryConfig memory_config;
         DataType input_dtype;
         std::optional<DataType> dtype;
+        const CoreRangeSet worker_grid;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
         SubtileBroadcastType subtile_broadcast_type = SubtileBroadcastType::NONE;
 
@@ -56,7 +57,6 @@ struct BinaryNgDeviceOperation {
             tt::tt_metal::KernelHandle reader_kernel_id;
             tt::tt_metal::KernelHandle writer_kernel_id;
             tt::tt_metal::KernelHandle compute_kernel_id;
-            CoreCoord compute_with_storage_grid_size;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -14,15 +14,15 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 
 using namespace ttnn::operations::binary_ng;
 
-std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const Tensor& x) {
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
     const auto& shape = x.padded_shape();
     const auto& tile = x.tensor_spec().tile();
     return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};
 }
 
 std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
-    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t HtWt, uint32_t Wt) {
-    uint32_t start_t = start_tile_id % HtWt;
+    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t Ht, uint32_t Wt) {
+    uint32_t start_t = start_tile_id % (Ht * Wt);
     uint32_t start_tw = start_t % Wt;
 
     switch (broadcast_type) {
@@ -30,7 +30,7 @@ std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
         case SubtileBroadcastType::ROW_A:
         case SubtileBroadcastType::ROW_B: return {1, 0};
         case SubtileBroadcastType::SCALAR_A:
-        case SubtileBroadcastType::SCALAR_B: return {HtWt, start_t};
+        case SubtileBroadcastType::SCALAR_B: return {Ht * Wt, start_t};
         case SubtileBroadcastType::COL_A:
         case SubtileBroadcastType::ROW_B_COL_A:
         case SubtileBroadcastType::COL_B:
@@ -39,13 +39,42 @@ std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
     }
 }
 
+std::tuple<std::optional<ShardSpec>, TensorMemoryLayout> get_shard_spec(
+    const Tensor& a, const std::optional<Tensor>& b, const Tensor& c) {
+    if (a.memory_config().is_sharded()) {
+        return {a.shard_spec().value(), a.memory_config().memory_layout};
+    } else if (b.has_value() && b->memory_config().is_sharded()) {
+        return {b->shard_spec().value(), b->memory_config().memory_layout};
+    } else if (c.memory_config().is_sharded()) {
+        return {c.shard_spec().value(), c.memory_config().memory_layout};
+    }
+
+    return {std::nullopt, TensorMemoryLayout::INTERLEAVED};
+}
+
+uint32_t get_shards_per_width(
+    const CoreRangeSet& all_cores, TensorMemoryLayout memory_layout, ShardOrientation orientation) {
+    auto num_cores = all_cores.num_cores();
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+        return 1;
+    }
+
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        return num_cores;
+    }
+
+    const auto& bbox = all_cores.bounding_box();
+    const auto& start = bbox.start_coord;
+    const auto& end = bbox.end_coord;
+    return (orientation == ShardOrientation::ROW_MAJOR ? end.x - start.x : end.y - start.y) + 1;
+}
+
 template <typename F>
 void set_or_update_runtime_arguments(
     Program& program,
     KernelHandle reader_kernel_id,
     KernelHandle writer_kernel_id,
     KernelHandle compute_kernel_id,
-    CoreCoord compute_with_storage_grid_size,
     const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
     const BinaryNgDeviceOperation::tensor_args_t& tensor_args,
     BinaryNgDeviceOperation::tensor_return_value_t& c,
@@ -57,25 +86,94 @@ void set_or_update_runtime_arguments(
     const auto bshape = b.has_value() ? b->padded_shape() : SimpleShape{1, 1};
     const auto cshape = c.padded_shape();
 
-    const auto [aN, aC, aHt, aWt] = extract_shape_dims(a);
-    const auto [bN, bC, bHt, bWt] = b.has_value() ? extract_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u};
-    const auto [cN, cC, cHt, cWt] = extract_shape_dims(c);
+    const auto [aN, aC, aHt, aWt] = get_shape_dims(a);
+    const auto [bN, bC, bHt, bWt] = b.has_value() ? get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u};
+    const auto [cN, cC, cHt, cWt] = get_shape_dims(c);
+    const uint32_t cHt_unrolled = cN * cC * cHt;
 
-    uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
+    bool row_major = true;
+    const auto [shard_spec, memory_layout] = get_shard_spec(a, b, c);
+    const bool has_sharding = shard_spec.has_value();
 
-    constexpr bool row_major = true;
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
-    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
+    // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
+    // as well as having the sharded tensors (if any) start at (0, 0)
+    // This will run the original work/core distribution algorithms that are specifically for this setup, as these
+    // are faster than the generic work/core distribution algorithms that work on arbitrary CoreRangeSets
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid;
+    const auto& all_device_cores = operation_attributes.worker_grid;
+    if (all_device_cores.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (has_sharding) {
+                const auto& shard_start_coord = shard_spec->grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    zero_start_grid = true;
+                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                zero_start_grid = true;
+                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+    const uint32_t num_cores_total =
+        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
 
-    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores;
+    CoreCoord end_core;
+    std::vector<CoreCoord> cores;
+
+    const uint32_t tile_height = c.tensor_spec().tile().get_height();
+    const uint32_t tile_width = c.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = tile_height * tile_width;
+    const uint32_t num_output_tiles = c.volume() / tile_hw;
+
+    uint32_t shard_height = cHt_unrolled, shard_width = cWt;
+    uint32_t last_shard_height = shard_height, last_shard_width = shard_width;
+
+    if (has_sharding) {
+        core_group_1 = shard_spec->grid;
+        num_tiles_per_core_group_1 = shard_spec->numel() / tile_hw;
+        row_major = shard_spec->orientation == ShardOrientation::ROW_MAJOR;
+        shard_height = shard_spec->shape[0] / tile_height;
+        shard_width = shard_spec->shape[1] / tile_width;
+        end_core = (*shard_spec->grid.ranges().begin()).end_coord;
+        last_shard_height = shard_height - (tt::round_up(cHt_unrolled, shard_height) - cHt_unrolled);
+        last_shard_width = shard_width - (tt::round_up(cWt, shard_width) - cWt);
+
+        if (zero_start_grid) {
+            auto bbox = core_group_1.bounding_box();
+            cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                compute_with_storage_grid.x,
+                compute_with_storage_grid.y,
+                row_major);
+        } else {
+            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
+        }
+    } else if (zero_start_grid) {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid, num_output_tiles, row_major);
+        cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
+    } else {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(all_device_cores, num_output_tiles, row_major);
+        cores = corerange_to_cores(all_device_cores, {}, row_major);
+    }
+
+    auto num_shards_per_width =
+        has_sharding ? get_shards_per_width(shard_spec->grid, memory_layout, shard_spec->orientation) : 0u;
+
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
         const auto& core = cores[i];
 
-        uint32_t num_tiles_per_core;
+        uint32_t num_tiles_per_core = 0;
         if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
         } else if (core_group_2.contains(core)) {
@@ -87,12 +185,38 @@ void set_or_update_runtime_arguments(
             continue;
         }
 
-        uint32_t cHtWt = cHt * cWt;
+        uint32_t start_id = 0;
+        uint32_t current_shard_height = 0;
+        uint32_t current_shard_width = 0;
+        if (has_sharding) {
+            current_shard_height = shard_height;
+            current_shard_width = shard_width;
+            if (row_major) {
+                if (core.x == end_core.x) {
+                    current_shard_width = last_shard_width;
+                }
+                if (core.y == end_core.y) {
+                    current_shard_height = last_shard_height;
+                }
+            } else {
+                if (core.y == end_core.y) {
+                    current_shard_width = last_shard_width;
+                }
+                if (core.x == end_core.x) {
+                    current_shard_height = last_shard_height;
+                }
+            }
+            start_id = (i / num_shards_per_width) * (shard_height * cWt) + (i % num_shards_per_width) * shard_width;
+            num_tiles_per_core = current_shard_height * current_shard_width;
+        } else {
+            start_id = start_tile_id;
+        }
+
         std::array reader_runtime_args = {
             a.buffer()->address(),
-            start_tile_id,
+            start_id,
             num_tiles_per_core,
-            cHtWt,
+            current_shard_width,
             aHt * aWt * aC * (aN > 1),
             aHt * aWt * (aC > 1),
             cN,
@@ -105,9 +229,9 @@ void set_or_update_runtime_arguments(
             std::array writer_runtime_args = {
                 b->buffer()->address(),
                 c.buffer()->address(),
-                start_tile_id,
+                start_id,
                 num_tiles_per_core,
-                cHtWt,
+                current_shard_width,
                 bHt * bWt * bC * (bN > 1),
                 bHt * bWt * (bC > 1),
                 cN,
@@ -117,7 +241,7 @@ void set_or_update_runtime_arguments(
             handle_args(program, writer_kernel_id, core, writer_runtime_args);
 
             auto [freq, counter] =
-                calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, start_tile_id, cHtWt, cWt);
+                calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, start_id, cHt, cWt);
             std::array compute_runtime_args = {num_tiles_per_core, freq, counter};
             handle_args(program, compute_kernel_id, core, compute_runtime_args);
         } else {
@@ -126,9 +250,9 @@ void set_or_update_runtime_arguments(
             std::array writer_runtime_args = {
                 packed_scalar,
                 c.buffer()->address(),
-                start_tile_id,
+                start_id,
                 num_tiles_per_core,
-                cHtWt,
+                current_shard_width,
                 cN,
                 cC,
                 cHt,
@@ -160,8 +284,11 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     const auto& b = tensor_args.input_tensor_b;
 
     auto program = CreateProgram();
-
     auto* device = a.device();
+
+    auto [shard_spec, memory_layout] = CMAKE_UNIQUE_NAMESPACE::get_shard_spec(a, b, c);
+    const bool has_sharding = shard_spec.has_value();
+    uint32_t num_tiles_per_shard = has_sharding ? shard_spec->numel() / a.tensor_spec().tile().get_tile_hw() : 0;
 
     auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
     auto b_data_format = b.has_value() ? datatype_to_dataformat_converter(b->get_dtype()) : DataFormat::Float16_b;
@@ -175,13 +302,10 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     // we parallelize the computation across the output tiles
     constexpr bool row_major = true;
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const auto& all_device_cores = operation_attributes.worker_grid;
 
     Buffer* a_buffer = a.buffer();
-    Buffer* b_buffer = nullptr;
+    Buffer* b_buffer = b.has_value() ? b->buffer() : nullptr;
     Buffer* c_buffer = c.buffer();
 
     auto op_type = operation_attributes.binary_op_type;
@@ -221,10 +345,19 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     bool op_has_exp =
         op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
 
+    bool a_sharded = a.memory_config().is_sharded();
+    bool b_sharded = b.has_value() && b->memory_config().is_sharded();
+    bool c_sharded = c.memory_config().is_sharded();
+
     // How many tiles to store per input CB (double buffer)
-    constexpr uint32_t num_tiles_per_cb = 2;
-    auto [a_cb, a_cb_handle] =
-        create_cb(tt::CBIndex::c_0, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
+    auto [a_cb, a_cb_handle] = create_cb(
+        tt::CBIndex::c_0,
+        program,
+        all_device_cores,
+        a_single_tile_size,
+        a_sharded ? num_tiles_per_shard : 2,
+        a_data_format,
+        a_sharded ? a_buffer : nullptr);
 
     if (not compute_kernel_defines["PROCESS_LHS_ACTIVATIONS(i)"].empty()) {
         auto a_intermediate_format = op_has_exp ? tt::DataFormat::Float16_b : a_data_format;
@@ -233,13 +366,15 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             tt::CBIndex::c_3, program, all_device_cores, a_intermediate_single_tile_size, 1, a_intermediate_format);
     }
 
-    auto [c_cb, c_cb_handle] =
-        create_cb(tt::CBIndex::c_2, program, all_device_cores, c_single_tile_size, num_tiles_per_cb, c_data_format);
-
     // If b is a scalar, we only need one tile in the CB
-    uint32_t b_num_tiles_per_cb = b_buffer != nullptr ? num_tiles_per_cb : 1;
-    auto [b_cb, b_cb_handle] =
-        create_cb(tt::CBIndex::c_1, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+    auto [b_cb, b_cb_handle] = create_cb(
+        tt::CBIndex::c_1,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_buffer == nullptr ? 1 : (b_sharded ? num_tiles_per_shard : 2),
+        b_data_format,
+        b_sharded ? b_buffer : nullptr);
 
     if (not compute_kernel_defines["PROCESS_RHS_ACTIVATIONS(i)"].empty()) {
         auto b_intermediate_format = op_has_exp ? tt::DataFormat::Float16_b : b_data_format;
@@ -248,9 +383,18 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
             tt::CBIndex::c_4, program, all_device_cores, b_intermediate_single_tile_size, 1, b_intermediate_format);
     }
 
-    auto a_is_dram = static_cast<uint32_t>(a_buffer->buffer_type() == tt_metal::BufferType::DRAM);
-    bool b_is_dram = false;
-    auto c_is_dram = static_cast<uint32_t>(c_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    auto [c_cb, c_cb_handle] = create_cb(
+        tt::CBIndex::c_2,
+        program,
+        all_device_cores,
+        c_single_tile_size,
+        c_sharded ? num_tiles_per_shard : 2,
+        c_data_format,
+        c_sharded ? c_buffer : nullptr);
+
+    uint32_t a_is_dram = a_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    uint32_t b_is_dram = false;
+    uint32_t c_is_dram = c_buffer->buffer_type() == tt_metal::BufferType::DRAM;
 
     auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
 
@@ -259,14 +403,13 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         program,
         get_kernel_file_path(kernel_config.reader_kernel),
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig({a_is_dram}));
+        tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding}, {{"SRC_SHARDED", a_sharded ? "1" : "0"}}));
 
     // WRITER KERNEL
     auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
     auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
     if (b.has_value()) {
-        b_buffer = b->buffer();
-        b_is_dram = static_cast<uint32_t>(b_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+        b_is_dram = b_buffer->buffer_type() == tt_metal::BufferType::DRAM;
         writer_kernel = kernel_config.writer_kernel;
         compute_kernel = kernel_config.compute_kernel;
     }
@@ -275,15 +418,14 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         program,
         get_kernel_file_path(writer_kernel),
         all_device_cores,
-        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram}));
+        tt_metal::WriterDataMovementConfig(
+            {b_is_dram, c_is_dram, has_sharding},
+            {{"SRC_SHARDED", b_sharded ? "1" : "0"}, {"DST_SHARDED", c_sharded ? "1" : "0"}}));
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
                             c_data_format == tt::DataFormat::Float32;
 
-    // Compute kernel needs to know which op it's going to perform
-    // This has to be passed as a compile-time argument
-    // For now we're just going to do addition
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
@@ -300,14 +442,12 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         reader_kernel_id,
         writer_kernel_id,
         compute_kernel_id,
-        compute_with_storage_grid_size,
         operation_attributes,
         tensor_args,
         c,
         set_runtime_args);
 
-    return {
-        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id}};
 }
 
 void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
@@ -326,7 +466,6 @@ void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
         cached_program.shared_variables.reader_kernel_id,
         cached_program.shared_variables.writer_kernel_id,
         cached_program.shared_variables.compute_kernel_id,
-        cached_program.shared_variables.compute_with_storage_grid_size,
         operation_attributes,
         tensor_args,
         c,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
@@ -8,16 +8,17 @@
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    uint32_t HtWt = get_arg_val<uint32_t>(3);
-    uint32_t n_stride = get_arg_val<uint32_t>(4);
-    uint32_t c_stride = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t C = get_arg_val<uint32_t>(7);
-    uint32_t Ht = get_arg_val<uint32_t>(8);
-    uint32_t Wt = get_arg_val<uint32_t>(9);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t shard_width = get_arg_val<uint32_t>(3);
+    const uint32_t n_stride = get_arg_val<uint32_t>(4);
+    const uint32_t c_stride = get_arg_val<uint32_t>(5);
+    const uint32_t N = get_arg_val<uint32_t>(6);
+    const uint32_t C = get_arg_val<uint32_t>(7);
+    const uint32_t Ht = get_arg_val<uint32_t>(8);
+    const uint32_t Wt = get_arg_val<uint32_t>(9);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -7,49 +7,65 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    uint32_t HtWt = get_arg_val<uint32_t>(3);
-    uint32_t n_stride = get_arg_val<uint32_t>(4);
-    uint32_t c_stride = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t C = get_arg_val<uint32_t>(7);
-
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t shard_width = get_arg_val<uint32_t>(3);
+    const uint32_t n_stride = get_arg_val<uint32_t>(4);
+    const uint32_t c_stride = get_arg_val<uint32_t>(5);
+    const uint32_t N = get_arg_val<uint32_t>(6);
+    const uint32_t C = get_arg_val<uint32_t>(7);
+    const uint32_t Ht = get_arg_val<uint32_t>(8);
+    const uint32_t Wt = get_arg_val<uint32_t>(9);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
-    constexpr uint32_t onetile = 1;
 
+#if SRC_SHARDED
+    cb_reserve_back(cb_id_src, num_tiles);
+    cb_push_back(cb_id_src, num_tiles);
+#else
+    constexpr uint32_t onetile = 1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const DataFormat src_data_format = get_dataformat(cb_id_src);
     const InterleavedAddrGenFast<src_is_dram> src = {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_tile_id / tiles_per_batch;
-    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    const uint32_t HtWt = Ht * Wt;
+    const uint32_t tiles_per_batch = HtWt * C;
+    const uint32_t start_n = start_tile_id / tiles_per_batch;
+    const uint32_t start_remaining = start_tile_id % tiles_per_batch;
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
+    uint32_t start_th = start_t / Wt;
+    uint32_t start_tw = start_t % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
-
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_th * Wt;
     uint32_t next_channel_shift = c_stride - HtWt;
     uint32_t next_batch_shift = n_stride - c_stride * C;
 
     uint32_t num_tiles_read = 0;
     for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
-        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
-            for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_src, onetile);
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_th = 0) {
+            for (uint32_t th = start_th; th < Ht && num_tiles_read < num_tiles; ++th, tile_offset += Wt) {
+                for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < num_tiles; ++tw, ++num_tiles_read) {
+                    cb_reserve_back(cb_id_src, onetile);
+                    uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_src, onetile);
+                }
+                if constexpr (!has_sharding) {
+                    // next row of tiles should start at the first column
+                    start_tw = 0;
+                }
             }
             tile_offset += next_channel_shift;
         }
         tile_offset += next_batch_shift;
     }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
@@ -8,16 +8,17 @@
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    uint32_t HtWt = get_arg_val<uint32_t>(3);
-    uint32_t n_stride = get_arg_val<uint32_t>(4);
-    uint32_t c_stride = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t C = get_arg_val<uint32_t>(7);
-    uint32_t Ht = get_arg_val<uint32_t>(8);
-    uint32_t Wt = get_arg_val<uint32_t>(9);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t shard_width = get_arg_val<uint32_t>(3);
+    const uint32_t n_stride = get_arg_val<uint32_t>(4);
+    const uint32_t c_stride = get_arg_val<uint32_t>(5);
+    const uint32_t N = get_arg_val<uint32_t>(6);
+    const uint32_t C = get_arg_val<uint32_t>(7);
+    const uint32_t Ht = get_arg_val<uint32_t>(8);
+    const uint32_t Wt = get_arg_val<uint32_t>(9);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -7,16 +7,18 @@
 #include "dataflow_api.h"
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
-
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    uint32_t HtWt = get_arg_val<uint32_t>(3);
-    uint32_t n_stride = get_arg_val<uint32_t>(4);
-    uint32_t c_stride = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t C = get_arg_val<uint32_t>(7);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t shard_width = get_arg_val<uint32_t>(3);
+    const uint32_t n_stride = get_arg_val<uint32_t>(4);
+    const uint32_t c_stride = get_arg_val<uint32_t>(5);
+    const uint32_t N = get_arg_val<uint32_t>(6);
+    const uint32_t C = get_arg_val<uint32_t>(7);
+    const uint32_t Ht = get_arg_val<uint32_t>(8);
+    const uint32_t Wt = get_arg_val<uint32_t>(9);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
@@ -8,17 +8,18 @@
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
-    uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t HtWt = get_arg_val<uint32_t>(4);
-    uint32_t n_stride = get_arg_val<uint32_t>(5);
-    uint32_t c_stride = get_arg_val<uint32_t>(6);
-    uint32_t N = get_arg_val<uint32_t>(7);
-    uint32_t C = get_arg_val<uint32_t>(8);
-    uint32_t Ht = get_arg_val<uint32_t>(9);
-    uint32_t Wt = get_arg_val<uint32_t>(10);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t n_stride = get_arg_val<uint32_t>(5);
+    const uint32_t c_stride = get_arg_val<uint32_t>(6);
+    const uint32_t N = get_arg_val<uint32_t>(7);
+    const uint32_t C = get_arg_val<uint32_t>(8);
+    const uint32_t Ht = get_arg_val<uint32_t>(9);
+    const uint32_t Wt = get_arg_val<uint32_t>(10);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr uint32_t onetile = 1;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
@@ -8,66 +8,95 @@
 
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
     uint32_t start_tile_id = get_arg_val<uint32_t>(2);
-    uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t HtWt = get_arg_val<uint32_t>(4);
-    uint32_t n_stride = get_arg_val<uint32_t>(5);
-    uint32_t c_stride = get_arg_val<uint32_t>(6);
-    uint32_t N = get_arg_val<uint32_t>(7);
-    uint32_t C = get_arg_val<uint32_t>(8);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t n_stride = get_arg_val<uint32_t>(5);
+    const uint32_t c_stride = get_arg_val<uint32_t>(6);
+    const uint32_t N = get_arg_val<uint32_t>(7);
+    const uint32_t C = get_arg_val<uint32_t>(8);
+    const uint32_t Ht = get_arg_val<uint32_t>(9);
+    const uint32_t Wt = get_arg_val<uint32_t>(10);
 
     constexpr uint32_t onetile = 1;
 
     constexpr auto cb_id_src = tt::CBIndex::c_1;
+#if SRC_SHARDED
+    cb_reserve_back(cb_id_src, num_tiles);
+    cb_push_back(cb_id_src, num_tiles);
+#else
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const DataFormat src_data_format = get_dataformat(cb_id_src);
 
     const InterleavedAddrGenFast<src_is_dram> src = {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+#endif
 
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
+#if !DST_SHARDED
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const DataFormat dst_data_format = get_dataformat(cb_id_dst);
 
     const InterleavedAddrGenFast<dst_is_dram> dst = {
         .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+#endif
 
-    uint32_t tiles_per_batch = HtWt * C;
-    uint32_t start_n = start_tile_id / tiles_per_batch;
-    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+#if !SRC_SHARDED || !DST_SHARDED
+    constexpr bool has_sharding = get_compile_time_arg_val(2) == 1;
+    const uint32_t HtWt = Ht * Wt;
+    const uint32_t tiles_per_batch = HtWt * C;
+    const uint32_t start_n = start_tile_id / tiles_per_batch;
+    const uint32_t start_remaining = start_tile_id % tiles_per_batch;
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
+    uint32_t start_th = start_t / Wt;
+    uint32_t start_tw = start_t % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + shard_width : Wt;
 
     // this is the INPUT tile offset
-    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_th * Wt;
     uint32_t next_channel_shift = c_stride - HtWt;
     uint32_t next_batch_shift = n_stride - c_stride * C;
 
     uint32_t num_tiles_written = 0;
     for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
-        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
-            for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
-                // read a tile from src
-                cb_reserve_back(cb_id_src, onetile);
-                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset, src, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_src, onetile);
-                ++tile_offset;
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_th = 0) {
+            for (uint32_t th = start_th; th < Ht && num_tiles_written < num_tiles; ++th) {
+                for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < num_tiles; ++tw, ++num_tiles_written) {
+#if !SRC_SHARDED
+                    // read a tile from src
+                    cb_reserve_back(cb_id_src, onetile);
+                    uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_src, onetile);
+#endif
 
-                // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                cb_wait_front(cb_id_dst, onetile);
-                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_dst, onetile);
+#if !DST_SHARDED
+                    // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                    cb_wait_front(cb_id_dst, onetile);
+                    uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_dst, onetile);
+#endif
+                }
+                tile_offset += Wt;
+                if constexpr (has_sharding) {
+                    // adjust the output tile offset since we had to skip parts of the row
+                    start_tile_id += (Wt - shard_width);
+                } else {
+                    // otherwise, next row of tiles should start at the first column
+                    start_tw = 0;
+                }
             }
             tile_offset += next_channel_shift;
         }
         tile_offset += next_batch_shift;
     }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
@@ -8,17 +8,18 @@
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
-    uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t HtWt = get_arg_val<uint32_t>(4);
-    uint32_t n_stride = get_arg_val<uint32_t>(5);
-    uint32_t c_stride = get_arg_val<uint32_t>(6);
-    uint32_t N = get_arg_val<uint32_t>(7);
-    uint32_t C = get_arg_val<uint32_t>(8);
-    uint32_t Ht = get_arg_val<uint32_t>(9);
-    uint32_t Wt = get_arg_val<uint32_t>(10);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t n_stride = get_arg_val<uint32_t>(5);
+    const uint32_t c_stride = get_arg_val<uint32_t>(6);
+    const uint32_t N = get_arg_val<uint32_t>(7);
+    const uint32_t C = get_arg_val<uint32_t>(8);
+    const uint32_t Ht = get_arg_val<uint32_t>(9);
+    const uint32_t Wt = get_arg_val<uint32_t>(10);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr uint32_t onetile = 1;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -9,15 +9,16 @@
 
 
 void kernel_main() {
-    uint32_t packed_scalar = get_arg_val<uint32_t>(0);
-    uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
-    uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t HtWt = get_arg_val<uint32_t>(4);
-    uint32_t N = get_arg_val<uint32_t>(5);
-    uint32_t C = get_arg_val<uint32_t>(6);
-    uint32_t H = get_arg_val<uint32_t>(7);
-    uint32_t W = get_arg_val<uint32_t>(8);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t N = get_arg_val<uint32_t>(5);
+    const uint32_t C = get_arg_val<uint32_t>(6);
+    const uint32_t Ht = get_arg_val<uint32_t>(7);
+    const uint32_t Wt = get_arg_val<uint32_t>(8);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
@@ -8,15 +8,18 @@
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
-    uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t HtWt = get_arg_val<uint32_t>(4);
-    uint32_t n_stride = get_arg_val<uint32_t>(5);
-    uint32_t c_stride = get_arg_val<uint32_t>(6);
-    uint32_t N = get_arg_val<uint32_t>(7);
-    uint32_t C = get_arg_val<uint32_t>(8);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t n_stride = get_arg_val<uint32_t>(5);
+    const uint32_t c_stride = get_arg_val<uint32_t>(6);
+    const uint32_t N = get_arg_val<uint32_t>(7);
+    const uint32_t C = get_arg_val<uint32_t>(8);
+    const uint32_t Ht = get_arg_val<uint32_t>(9);
+    const uint32_t Wt = get_arg_val<uint32_t>(10);
+    const uint32_t HtWt = Ht * Wt;
 
     constexpr uint32_t onetile = 1;
 


### PR DESCRIPTION
### Ticket
#16138 

### Problem description
The new broadcasting `binary_ng` family of ops does not accept sharded tensors as inputs and/or outputs

### What's changed
This commit adds sharding support for `binary_ng`, but without broadcasting. It serves as the groundwork for the next PRs that add broadcasting. Any combination of sharded/interleaved tensors is supported, as well as all sharding types.

### Checklist
- [x] Post commit CI passes
- [x] New/Existing tests provide coverage for changes
