### PR TITLE
fuse residual add with layernorm

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -68,7 +68,7 @@ def create_tt_tensors(
     return tt_tensor
 
 
-def compute_pre_allgather_stats(tt_input_tensor, core_grid, input_width, is_rmsnorm):
+def compute_pre_allgather_stats(tt_input_tensor, core_grid, input_width, is_rmsnorm, residual_input_tensor=None):
     SHARDED_NORM_PRGM_CFG = ttnn.LayerNormShardedMultiCoreProgramConfig(
         compute_with_storage_grid_size=[core_grid[1], core_grid[0]],
         subblock_w=(input_width // (core_grid[0] * core_grid[1])) // 32,
@@ -78,9 +78,13 @@ def compute_pre_allgather_stats(tt_input_tensor, core_grid, input_width, is_rmsn
     )
 
     if is_rmsnorm:
-        return ttnn.rms_norm_pre_all_gather(tt_input_tensor, program_config=SHARDED_NORM_PRGM_CFG)
+        return ttnn.rms_norm_pre_all_gather(
+            tt_input_tensor, residual_input_tensor=residual_input_tensor, program_config=SHARDED_NORM_PRGM_CFG
+        )
     else:
-        return ttnn.layer_norm_pre_all_gather(tt_input_tensor, program_config=SHARDED_NORM_PRGM_CFG)
+        return ttnn.layer_norm_pre_all_gather(
+            tt_input_tensor, residual_input_tensor=residual_input_tensor, program_config=SHARDED_NORM_PRGM_CFG
+        )
 
 
 def compute_post_allgather_output(
@@ -139,14 +143,30 @@ def run_pre_allgather_layernorm(
     max_atol_ex,
     min_pcc_ex2,
     max_atol_ex2,
+    fuse_residual=False,
 ):
     torch_input_tensor, _, torch_input_chunks, _ = create_input_and_weight_tensors(
         input_width, num_devices, seed, mean, std
     )
 
+    if fuse_residual:
+        torch_residual_input_tensor, _, torch_residual_input_chunks, _ = create_input_and_weight_tensors(
+            input_width, num_devices, seed + 100, mean, std
+        )
+
     for d in range(num_devices):
         tt_input_tensor = create_tt_tensors(torch_input_chunks[d], device, input_df, core_grid, input_width)
-        tt_pre_allgather_output = compute_pre_allgather_stats(tt_input_tensor, core_grid, input_width, is_rmsnorm)
+        if fuse_residual:
+            tt_residual_input_tensor = create_tt_tensors(
+                torch_residual_input_chunks[d], device, input_df, core_grid, input_width
+            )
+            torch_input_chunks = list(torch_input_chunks)
+            torch_input_chunks[d] = torch_input_chunks[d] + torch_residual_input_chunks[d]
+        else:
+            tt_residual_input_tensor = None
+        tt_pre_allgather_output = compute_pre_allgather_stats(
+            tt_input_tensor, core_grid, input_width, is_rmsnorm, tt_residual_input_tensor
+        )
         tt_pre_allgather_torch = ttnn.to_torch(tt_pre_allgather_output).to(torch.bfloat16)
 
         if is_rmsnorm:
@@ -188,7 +208,13 @@ def run_pre_allgather_layernorm(
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))
 @pytest.mark.parametrize("core_grid", ((4, 8),))
 @pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
-@pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.987, 0.04)])
+@pytest.mark.parametrize(
+    "min_pcc_ex2",
+    [
+        0.983,
+    ],
+)
+@pytest.mark.parametrize(("fuse_residual", "max_atol_ex2"), [(False, 0.04), (True, 0.09)])
 def test_pre_allgather_layernorm(
     device,
     use_program_cache,
@@ -204,6 +230,7 @@ def test_pre_allgather_layernorm(
     max_atol_ex,
     min_pcc_ex2,
     max_atol_ex2,
+    fuse_residual,
 ):
     run_pre_allgather_layernorm(
         device,
@@ -220,6 +247,7 @@ def test_pre_allgather_layernorm(
         max_atol_ex,
         min_pcc_ex2,
         max_atol_ex2,
+        fuse_residual,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -48,6 +48,10 @@ void MAIN {
     constexpr uint32_t scaler0 = 0;
 
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
+#ifdef FUSE_PRE_ADD
+    constexpr uint32_t cb_in = tt::CBIndex::c_14;
+#endif
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
     constexpr uint32_t cb_scaler_global = tt::CBIndex::c_4;
     constexpr uint32_t cb_x = tt::CBIndex::c_24;  // x minus mean
@@ -60,8 +64,6 @@ void MAIN {
     constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;   // E[x^2] partial reduce
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;  // E[x^2] partials recieved from other cores
     const uint32_t cb_reduction_out = (!use_two_stage_reduce or is_second_stage_reader) ? cb_out : cb_ex2;
-
-    binary_op_init_common(cb_in0, cb_in0, cb_x2);
 
     // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow
     const uint32_t block_h = (block_w == 1) ? block_h_volatile : block_h_const;
@@ -76,9 +78,44 @@ void MAIN {
     num_tiles_per_partial_result = 1;
 #endif
 
+// pre-add x + y
+#ifdef FUSE_PRE_ADD
+    binary_op_init_common(cb_in0, cb_in1, cb_in);
+    add_tiles_init();
+    cb_reserve_back(cb_in, num_tiles_per_block);
+    for (uint32_t i = 0; i < block_h; i++) {
+        index_subblock_w_offset = 0;
+        for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < subblock_w; w++) {
+                index = w + index_subblock_w_offset + index_h_offset;
+                add_tiles(cb_in0, cb_in1, index, index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < subblock_w; i++) {
+                pack_tile(i, cb_in);
+            }
+            tile_regs_release();
+            index_subblock_w_offset += subblock_w;
+        }
+        index_h_offset += block_w;
+    }
+    cb_push_back(cb_in, num_tiles_per_block);
+    cb_wait_front(cb_in, num_tiles_per_block);
+    pack_reconfig_data_format(cb_in, cb_x2);
+#else
+    constexpr uint32_t cb_in = cb_in0;
+    binary_op_init_common(cb_in, cb_in, cb_x2);
+#endif
+
 #ifndef RMSNORM
     cb_wait_front(cb_scaler, 1);
-    reconfig_data_format_srcb(cb_in0, cb_scaler);
+#ifdef FUSE_PRE_ADD
+    reconfig_data_format(cb_in0, cb_in, cb_in1, cb_scaler);
+#else
+    reconfig_data_format_srcb(cb_in, cb_scaler);
+#endif
     // E[x],
     index_h_offset = 0;
     reduce_init_delta<false>(cb_ex_partial2, cb_in0, cb_scaler);
@@ -87,7 +124,7 @@ void MAIN {
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
-            reduce_tile(cb_in0, cb_scaler, w + index_h_offset, scaler0, dst0);
+            reduce_tile(cb_in, cb_scaler, w + index_h_offset, scaler0, dst0);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -97,7 +134,11 @@ void MAIN {
     }
     reduce_revert_delta(cb_ex_partial2);
     cb_push_back(cb_ex_partial2, block_h);
-    reconfig_data_format_srcb(cb_scaler, cb_in0);
+    reconfig_data_format_srcb(cb_scaler, cb_in);
+#else
+#ifdef FUSE_PRE_ADD
+    reconfig_data_format(cb_in0, cb_in, cb_in1, cb_in);
+#endif
 #endif  // not RMSNORM
 
     // X^2
@@ -110,7 +151,7 @@ void MAIN {
             tile_regs_acquire();
             for (uint32_t w = 0; w < subblock_w; w++) {
                 index = w + index_subblock_w_offset + index_h_offset;
-                mul_tiles(cb_in0, cb_in0, index, index, w);
+                mul_tiles(cb_in, cb_in, index, index, w);
             }
             tile_regs_commit();
             tile_regs_wait();
@@ -125,8 +166,8 @@ void MAIN {
     cb_push_back(cb_x2, num_tiles_per_block);
 
     // E(x^2)
-    reconfig_data_format_srca(cb_in0, cb_x2);
-    reconfig_data_format_srcb(cb_in0, cb_scaler);
+    reconfig_data_format_srca(cb_in, cb_x2);
+    reconfig_data_format_srcb(cb_in, cb_scaler);
 
     cb_wait_front(cb_x2, num_tiles_per_block);
 #ifdef RMSNORM

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -51,6 +51,8 @@ void MAIN {
     constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
 #ifdef FUSE_PRE_ADD
     constexpr uint32_t cb_in = tt::CBIndex::c_14;
+#else
+    constexpr uint32_t cb_in = cb_in0;
 #endif
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
     constexpr uint32_t cb_scaler_global = tt::CBIndex::c_4;
@@ -105,7 +107,6 @@ void MAIN {
     cb_wait_front(cb_in, num_tiles_per_block);
     pack_reconfig_data_format(cb_in, cb_x2);
 #else
-    constexpr uint32_t cb_in = cb_in0;
     binary_op_init_common(cb_in, cb_in, cb_x2);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -106,6 +106,11 @@ void LayerNorm::validate(
     if (this->distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER ||
         this->distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {
         TT_FATAL(a.get_legacy_shape()[-2] == TILE_HEIGHT, "Only activations with batch size = 32 are supported");
+        if (b.has_value()) {
+            TT_FATAL(
+                b.value().get_legacy_shape()[-2] == TILE_HEIGHT,
+                "Only residual tensors with batch size = 32 are supported");
+        }
     }
     if (this->distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {
         TT_FATAL(stats.has_value(), "Post all gather layernorm requires stats");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -102,6 +102,11 @@ void LayerNorm::validate(
             this->output_mem_config.is_sharded() &&
                 this->output_mem_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED,
             "Error");
+        if (b.has_value()) {
+            TT_FATAL(b.value().is_sharded(), "residual tensor b should be sharded if input a is sharded");
+            TT_FATAL(b.value().shard_spec() == a.shard_spec(), "Both a and b should have the same shard spec");
+            TT_FATAL(b.value().memory_config() == a.memory_config(), "Both a and b should have the same memory config");
+        }
     }
     if (this->distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER ||
         this->distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -1189,12 +1189,21 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     // in1 sharded
     uint32_t in1_cb_index = tt::CBIndex::c_1;
     CBHandle cb_in1 = 0;
+    CBHandle cb_add_out = 0;
     if (b) {
         tt::tt_metal::CircularBufferConfig in1_cb_config =
             tt::tt_metal::CircularBufferConfig(in1_CB_size, {{in1_cb_index, in_data_format}})
                 .set_page_size(in1_cb_index, in_single_tile_size)
                 .set_globally_allocated_address(*b.value().buffer());
         cb_in1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, in1_cb_config);
+        if (is_pre_all_gather) {
+            uint32_t add_out_cb_index = tt::CBIndex::c_14;
+            tt::tt_metal::CircularBufferConfig add_out_cb_config =
+                tt::tt_metal::CircularBufferConfig(in1_CB_size, {{add_out_cb_index, in_data_format}})
+                    .set_page_size(add_out_cb_index, in_single_tile_size)
+                    .set_globally_allocated_address(*a.buffer());
+            cb_add_out = tt::tt_metal::CreateCircularBuffer(program, all_cores, add_out_cb_config);
+        }
     }
     // in2 scaler
     uint32_t in2_cb_index = tt::CBIndex::c_2;
@@ -1597,9 +1606,11 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
          writer_mcast_sender_kernels_id,
          writer_mcast_receiver_kernels_id,
          num_none_all_to_all_workers,
+         is_pre_all_gather,
          cb_in0,
          cb_in1,
          cb_stats,
+         cb_add_out,
          cb_output,
          cores](
             const void* operation,
@@ -1618,6 +1629,9 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
 
             if (b_tensor.has_value()) {
                 UpdateDynamicCircularBufferAddress(program, cb_in1, *b_tensor.value().buffer());
+                if (is_pre_all_gather) {
+                    UpdateDynamicCircularBufferAddress(program, cb_add_out, *src_buffer_a);
+                }
             }
             if (stats_tensor.has_value()) {
                 UpdateDynamicCircularBufferAddress(program, cb_stats, *stats_tensor.value().buffer());

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
@@ -22,6 +22,7 @@ void bind_normalization_layernorm_pre_all_gather_operation(py::module& module) {
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("residual_input_tensor") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("program_config") = std::nullopt,
             py::arg("memory_config") = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -12,6 +12,7 @@ namespace ttnn::operations::normalization {
 ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const DataType dtype,
+    const std::optional<const ttnn::Tensor>& residual_input_tensor,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const LayerNormProgramConfig>& program_config,
     const std::optional<MemoryConfig>& memory_config) {
@@ -30,7 +31,7 @@ ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
                        .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                        .compute_kernel_config = kernel_config_val},
                    {input_tensor},
-                   {std::nullopt, std::nullopt, std::nullopt, std::nullopt})
+                   {residual_input_tensor, std::nullopt, std::nullopt, std::nullopt})
             .at(0);
     } else {
         return operation::run(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
@@ -16,6 +16,7 @@ struct ExecuteLayerNormPreAllGather {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const DataType dtype = DataType::BFLOAT16,
+        const std::optional<const ttnn::Tensor>& residual_input_tensor = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -27,6 +27,7 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("residual_input_tensor") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
             py::arg("program_config") = std::nullopt,
             py::arg("memory_config") = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -12,6 +12,7 @@ namespace ttnn::operations::normalization {
 ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const DataType dtype,
+    const std::optional<const ttnn::Tensor>& residual_input_tensor,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const LayerNormProgramConfig>& program_config,
     const std::optional<MemoryConfig>& memory_config) {
@@ -30,7 +31,7 @@ ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
                        .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                        .compute_kernel_config = kernel_config_val},
                    {input_tensor},
-                   {std::nullopt, std::nullopt, std::nullopt, std::nullopt})
+                   {residual_input_tensor, std::nullopt, std::nullopt, std::nullopt})
             .at(0);
     } else {
         return operation::run(

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
@@ -16,6 +16,7 @@ struct ExecuteRMSNormPreAllGather {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const DataType dtype = DataType::BFLOAT16,
+        const std::optional<const ttnn::Tensor>& residual_input_tensor = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);


### PR DESCRIPTION
### Ticket
Link to Github Issue #11664

### Problem description
Fuse residual stream with distributed layernorm. See Issue for the proposal.

### What's changed
1. Passing new tensor argument to pre_all_gather_layernorm Op: `residual_input_tensor`.
2. Doing in_place addition of residual_input_tensor with input_tensor and storing result in input_tensor buffer
3. The input_tensor now can be used as residual stream for next layer
4. Updated pre_all_gather unit test to check pcc with fusion.


### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12803797970
- [x] New/Existing tests provide coverage for changes
