### PR TITLE
Remove redundant bank offset from destination address in `ttnn.reshard`

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
@@ -537,14 +537,13 @@ def test_dram_reshard(
     output_mem_config = ttnn.MemoryConfig(output_sharding_scheme, output_buffer_type, output_shard_spec)
 
     input = torch.randn(input_shape).bfloat16()
-
     input_tensor = ttnn.Tensor(input, ttnn.bfloat16).to(input_layout).to(device, input_mem_config)
 
     output_tensor = ttnn.reshard(input_tensor, output_mem_config)
 
     output = ttnn.to_torch(output_tensor)
-
-    passing, output_log = comp_equal(input, output)
+    passing, output_log = comp_pcc(input, output, 1.0)
+    assert passing, output_log
 
 
 @skip_for_blackhole("GH Issue #15234")

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp
@@ -36,5 +36,5 @@ void kernel_main() {
             noc_read_addr += remote_stride_bytes;
         }
     }
-    noc_async_write_barrier();
+    noc_async_read_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -588,14 +588,14 @@ compute_width_sharded_reshard_runtime_args(
             const uint32_t remaining_output = remote_shard_width - remote_shard_offset;
             const uint32_t transfer_size = std::min(remaining_input, remaining_output);
 
-            auto bank_id =
+            const auto bank_id =
                 device->bank_ids_from_logical_core(remote_buffer_type, remote_cores[current_remote_core_idx])[0];
-            auto bank_offset = device->bank_offset(remote_buffer_type, bank_id);
+            const auto bank_offset = device->bank_offset(remote_buffer_type, bank_id);
             core_args.emplace_back(
                 element_size * transfer_size,
                 element_size * local_shard_offset,
                 bank_id,
-                element_size * remote_shard_offset + bank_offset);
+                element_size * remote_shard_offset);
 
             local_shard_offset += transfer_size;
             remote_shard_offset += transfer_size;


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/16741

### What's changed
- Remove bank offset from stick destination address
- Fix Watcher assert in the kernel due to incorrect barrier which would trigger when doing a DRAM->L1 reshard
- Add missing assert in unit test

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12811334595
