### PR TITLE
Fix L1 cache OOM for untilize with unpadding

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -244,3 +244,15 @@ def test_int_untilize(device, batch_size, sentence_size):
     output_torch = ttnn.to_torch(output_tt)
 
     assert_with_pcc(torch_input_tensor, output_torch)
+
+
+@pytest.mark.parametrize("shape", [[1, 1, 1, 50304], [1, 3, 5, 25152], [17, 32, 10944], [32, 64, 3, 8765]])
+@pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+def test_to_layout_large_tensors(shape, input_layout, output_layout, device):
+    torch.manual_seed(2005)
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
+    output_tensor = ttnn.to_layout(input_tensor, output_layout)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(input_a, output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_common.hpp"
+#include "ttnn/operations/functions.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -28,20 +29,12 @@ inline uint32_t get_estimated_size_of_cbs(
     return cb_src0_size + cb_output_size;
 }
 
-inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
-    auto device = input_tensor_a.device();
-    auto lowest_address = device->lowest_occupied_compute_l1_address();
-    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
-    max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
-    return max_l1_space;
-}
-
 inline bool enough_available_space(
     const Tensor& input_tensor_a,
     const uint32_t input_single_tile_size,
     const uint32_t output_single_tile_size,
     const uint32_t num_tiles_per_row) {
-    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    uint32_t max_l1_space = ttnn::get_max_l1_space(input_tensor_a);
     uint32_t estimated_size_of_cbs =
         get_estimated_size_of_cbs(input_tensor_a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     return max_l1_space > estimated_size_of_cbs;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -17,8 +17,8 @@
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement::detail {
-
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 inline uint32_t get_estimated_size_of_cbs(
     const Tensor& input_tensor_a,
     const uint32_t input_single_tile_size,
@@ -39,6 +39,10 @@ inline bool enough_available_space(
         get_estimated_size_of_cbs(input_tensor_a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     return max_l1_space > estimated_size_of_cbs;
 }
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::data_movement::detail {
 
 uint32_t get_packed_value(const Tensor tensor, const ttnn::PadValue pad_value) {
     return std::visit(
@@ -267,7 +271,8 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
     uint32_t num_blocks = output.volume() / output.get_padded_shape()[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = output.get_padded_shape()[-1] / TILE_WIDTH;
 
-    bool enough_space = enough_available_space(a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+    bool enough_space = CMAKE_UNIQUE_NAMESPACE::enough_available_space(
+        a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     if (!enough_space) {
         return tilize_with_val_padding_single_core(a, output, pad_value);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
+#include "ttnn/operations/functions.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -30,20 +31,12 @@ inline uint32_t get_estimated_size_of_cbs(
     return cb_src0_size + cb_output_size;
 }
 
-inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
-    auto device = input_tensor_a.device();
-    auto lowest_address = device->lowest_occupied_compute_l1_address();
-    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
-    max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
-    return max_l1_space;
-}
-
 inline bool enough_available_space(
     const Tensor& input_tensor_a,
     const uint32_t input_single_tile_size,
     const uint32_t output_single_tile_size,
     const uint32_t num_tiles_per_row) {
-    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    uint32_t max_l1_space = ttnn::get_max_l1_space(input_tensor_a);
     uint32_t estimated_size_of_cbs =
         get_estimated_size_of_cbs(input_tensor_a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     return max_l1_space > estimated_size_of_cbs;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -19,8 +19,8 @@
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement::detail {
-
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 inline uint32_t get_estimated_size_of_cbs(
     const Tensor& input_tensor_a,
     const uint32_t input_single_tile_size,
@@ -41,6 +41,9 @@ inline bool enough_available_space(
         get_estimated_size_of_cbs(input_tensor_a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     return max_l1_space > estimated_size_of_cbs;
 }
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+namespace ttnn::operations::data_movement::detail {
 
 operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
@@ -245,7 +248,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.volume() / input_shape[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = a.get_padded_shape()[-1] / TILE_WIDTH;
 
-    bool enough_space = enough_available_space(a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+    bool enough_space = CMAKE_UNIQUE_NAMESPACE::enough_available_space(
+        a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     if (!enough_space) {
         return untilize_with_unpadding_single_core(a, output, use_pack_untilize, fp32_dest_acc_en);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -20,6 +20,35 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement::detail {
 
+inline uint32_t get_estimated_size_of_cbs(
+    const Tensor& input_tensor_a,
+    const uint32_t input_single_tile_size,
+    const uint32_t output_single_tile_size,
+    const uint32_t num_tiles_per_row) {
+    uint32_t cb_src0_size = input_single_tile_size * num_tiles_per_row;
+    uint32_t cb_output_size = output_single_tile_size * num_tiles_per_row;
+    return cb_src0_size + cb_output_size;
+}
+
+inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
+    auto device = input_tensor_a.device();
+    auto lowest_address = device->lowest_occupied_compute_l1_address();
+    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+    max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
+    return max_l1_space;
+}
+
+inline bool enough_available_space(
+    const Tensor& input_tensor_a,
+    const uint32_t input_single_tile_size,
+    const uint32_t output_single_tile_size,
+    const uint32_t num_tiles_per_row) {
+    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    uint32_t estimated_size_of_cbs =
+        get_estimated_size_of_cbs(input_tensor_a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+    return max_l1_space > estimated_size_of_cbs;
+}
+
 operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
     const auto& input_shape = a.get_padded_shape();
@@ -222,6 +251,11 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
 
     uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.volume() / input_shape[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = a.get_padded_shape()[-1] / TILE_WIDTH;
+
+    bool enough_space = enough_available_space(a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+    if (!enough_space) {
+        return untilize_with_unpadding_single_core(a, output, use_pack_untilize, fp32_dest_acc_en);
+    }
 
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(grid_size, num_blocks);

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -636,4 +636,12 @@ static bool allclose(const Tensor& tensor_a, const Tensor& tensor_b, Args... arg
     return true;
 }
 
+inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
+    auto device = input_tensor_a.device();
+    auto lowest_address = device->lowest_occupied_compute_l1_address();
+    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+    max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
+    return max_l1_space;
+}
+
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/operations/functions.hpp"
 
 using namespace tt;
 using namespace tt::constants;
@@ -192,14 +193,6 @@ inline uint32_t get_estimated_size_of_cbs(
     return in0_size + in1_size + out_size + interm_size;
 }
 
-inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
-    auto device = input_tensor_a.device();
-    auto lowest_address = device->lowest_occupied_compute_l1_address();
-    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
-    max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
-    return max_l1_space;
-}
-
 inline bool can_cbs_fit_in_l1(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -208,7 +201,7 @@ inline bool can_cbs_fit_in_l1(
     uint32_t in0_block_w,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const tt::tt_metal::DataType output_dtype) {
-    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    uint32_t max_l1_space = ttnn::get_max_l1_space(input_tensor_a);
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well
@@ -230,7 +223,7 @@ inline uint32_t get_per_core_factor(
     uint32_t in0_block_w,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const tt::tt_metal::DataType output_dtype) {
-    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    uint32_t max_l1_space = ttnn::get_max_l1_space(input_tensor_a);
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well
@@ -259,7 +252,7 @@ inline std::vector<uint32_t> get_multi_dim_per_core_factor(
     uint32_t in0_block_w,
     uint32_t interm_cb_size,
     const bool adjust_in0_block_w) {
-    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    uint32_t max_l1_space = ttnn::get_max_l1_space(input_tensor_a);
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/16804

### Problem description
In the current implementation of multi-core untilize with unpadding, the parallelization is only over the columns. This causes L1 OOM when the tensor has a large width

### What's changed
Similar to tilize, we check the available space in L1, and run on a single core if the whole row doesn’t fit. Parallelization over different dimensions is to be added in the future

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12953909259
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
