### PR TITLE
Add CI job for running models in comparison mode

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -85,3 +85,53 @@ jobs:
           path: |
             generated/test_reports/
           prefix: "test_reports_"
+
+  models-tests-slow-runtime-mode:
+    if: ${{ inputs.runner-label != 'E150' }} # Currently no tests for GS so skip it
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-20.04"]
+        test-group: [
+          {name: model},
+        ]
+    name: models slow dispatch
+    env:
+      LOGURU_LEVEL: INFO
+    runs-on:
+      - ${{ inputs.runner-label }}
+      - in-service
+      - cloud-virtual-machine
+    steps:
+      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
+      - uses: ./.github/actions/retry-command
+        with:
+          timeout-seconds: 100
+          max-retries: 10
+          backoff-seconds: 60
+          command: ./.github/scripts/cloud_utils/mount_weka.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: eager-dist-${{ matrix.os }}-any
+      - name: ${{ matrix.test-group.name }} slow runtime mode tests
+        timeout-minutes: ${{ inputs.timeout }}
+        uses: ./.github/actions/docker-run
+        with:
+          install_wheel: true
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e ARCH_NAME=${{ inputs.arch }}
+            -e SLOW_RUNTIME_MODE=true
+          run_args: |
+            source tests/scripts/run_python_model_tests.sh && run_python_model_tests_slow_runtime_mode_${{ inputs.arch }}
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U06CXU895AP # Michael Chiou
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -58,3 +58,14 @@ run_python_model_tests_wormhole_b0() {
         echo "LOG_METAL: Llama3 tests for $llama_dir completed"
     done
 }
+
+run_python_model_tests_slow_runtime_mode_wormhole_b0() {
+    # Unet Shallow
+    export TTNN_CONFIG_OVERRIDES='{
+        "enable_fast_runtime_mode": false,
+        "enable_comparison_mode": true,
+        "comparison_mode_should_raise_exception": true,
+        "comparison_mode_pcc": 0.998
+    }'
+    WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -svv models/experimental/functional_unet/tests/test_unet_model.py
+}


### PR DESCRIPTION
### Summary

This change adds a slow runtime job in post-commit for testing models in comparison mode. This will help catch regressions in all ops used by the models running in this job.

To start, I've added Shallow UNet forward pass to the N150/N300 job. The GS job is disabled since there are no comparison mode model tests for this target yet.

This new job takes around 3m 20s per target.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12838447147, https://github.com/tenstorrent/tt-metal/actions/runs/12849718303, https://github.com/tenstorrent/tt-metal/actions/runs/12868121632
