### PR TITLE
#5424: Clean up Sfpu Sign kernel api

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -36,6 +36,7 @@ const map<string, std::map<string, string>> sfpu_op_to_op_name = {
     {"sigmoid", {{"SFPU_OP_CHAIN_0", "sigmoid_tile_init(); sigmoid_tile(0);"}}},
     {"log", {{"SFPU_OP_CHAIN_0", "log_tile_init(); log_tile(0);"}}},
     {"tanh", {{"SFPU_OP_CHAIN_0", "tanh_tile_init(); tanh_tile(0);"}}},
+    {"sign", {{"SFPU_OP_CHAIN_0", "sign_tile_init(); sign_tile(0);"}}},
 };
 
 bfloat16 sfpu_function(const string& op_name, const bfloat16& input) {
@@ -61,6 +62,8 @@ bfloat16 sfpu_function(const string& op_name, const bfloat16& input) {
         return bfloat16(logf(input.to_float()));
     } else if (op_name == "tanh") {
         return bfloat16(std::tanh(input.to_float()));
+    } else if (op_name == "sign") {
+        return bfloat16((0.0f < input.to_float()) ? 1.0f : ((input.to_float() < 0.0f) ? -1.0f : 0.0f));
     } else {
         TT_THROW("Unsupported op_name in test");
         return bfloat16(0.0f);
@@ -253,6 +256,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "sigmoid"),
         std::make_tuple(1, "log"),
         std::make_tuple(1, "tanh"),
+        std::make_tuple(1, "sign"),
         std::make_tuple(4, "relu"),
         std::make_tuple(4, "exponential"),
         std::make_tuple(4, "reciprocal"),
@@ -260,7 +264,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(4, "sqrt"),
         std::make_tuple(4, "sigmoid"),
         std::make_tuple(4, "log"),
-        std::make_tuple(4, "tanh")));
+        std::make_tuple(4, "tanh"),
+        std::make_tuple(4, "sign")));
 class SingleCoreSingleDeviceSfpuParameterizedApproxFixture
     : public DeviceFixture,
       public testing::WithParamInterface<std::tuple<size_t, string>> {};
@@ -302,6 +307,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "sigmoid"),
         std::make_tuple(1, "log"),
         std::make_tuple(1, "tanh"),
+        std::make_tuple(1, "sign"),
         std::make_tuple(4, "relu"),
         std::make_tuple(4, "exponential"),
         std::make_tuple(4, "reciprocal"),
@@ -309,7 +315,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(4, "sqrt"),
         std::make_tuple(4, "sigmoid"),
         std::make_tuple(4, "log"),
-        std::make_tuple(4, "tanh")));
+        std::make_tuple(4, "tanh"),
+        std::make_tuple(4, "sign")));
 
 TEST_F(DeviceFixture, DISABLED_TensixMultiContinguousCoreSingleTileSfpuApproxCompute) {
     CoreRange core_range({0, 0}, {1, 0});

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -13,19 +13,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign() {
-    // All params are in FP16 format
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        vFloat result = vConst1;
-        v_if(v < 0.0f) { result = vConstNeg1; }
-        v_elseif(v > 0.0f) { result = vConst1; }
-        v_else { result = vConst0; }
-        v_endif;
-
-        dst_reg[0] = result;
-        dst_reg++;
-    }
+inline void calculate_sign(const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -18,8 +18,10 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_sign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode);
+inline void llk_math_eltwise_unary_sfpu_sign(
+    uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -14,19 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign() {
-    // All params are in FP16 format
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        vFloat result = vConst1;
-        v_if(v < 0.0f) { result = vConstNeg1; }
-        v_elseif(v > 0.0f) { result = vConst1; }
-        v_else { result = vConst0; }
-        v_endif;
-
-        dst_reg[0] = result;
-        dst_reg++;
-    }
+inline void calculate_sign(const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -18,8 +18,10 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_sign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode);
+inline void llk_math_eltwise_unary_sfpu_sign(
+    uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -14,19 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign() {
-    // All params are in FP16 format
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        vFloat result = vConst1;
-        v_if(v < 0.0f) { result = vConstNeg1; }
-        v_elseif(v > 0.0f) { result = vConst1; }
-        v_else { result = vConst0; }
-        v_endif;
-
-        dst_reg[0] = result;
-        dst_reg++;
-    }
+inline void calculate_sign(const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -18,8 +18,10 @@ inline void llk_math_eltwise_unary_sfpu_sign_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_sign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode);
+inline void llk_math_eltwise_unary_sfpu_sign(
+    uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/5424)

### Problem description
Ckernel sfpu functions are implemented both in third party llk layer and metal llk api layer. The goal is to remove any duplicates and have llk api layer to call the implementation in third party. This PR is concerned with the clean up (i.e. removal of duplicates) of the calculate_sign API located at:
- tt_metal/hw/ckernels/<device>/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h

### What's changed
Removed duplicate implementation for all architectures (i.e. bh, wh and gs). This API now calls the corresponding third party function _calculate_sign_ that implements the functionality. Added test case in the sfpu_compute test suite for llks.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12812742474)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12812747142) (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
