### PR TITLE
#0: Add support for tracing some sub-devices while others are still running programs

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -50,6 +50,18 @@ TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms
     EnqueueProgram(device->command_queue(), incrementer_program, false);
     EndTraceCapture(device, device->command_queue().id(), tid_2);
 
+    // Capture trace on one sub-device while another sub-device is running a program
+    EnqueueProgram(device->command_queue(), waiter_program, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    auto tid_3 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), syncer_program, false);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_3);
+    EnqueueProgram(device->command_queue(), syncer_program, false);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
+
     for (uint32_t i = 0; i < num_iters; i++) {
         // Regular program execution
         EnqueueProgram(device->command_queue(), waiter_program, false);
@@ -63,6 +75,9 @@ TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms
         // Partial trace execution
         EnqueueProgram(device->command_queue(), waiter_program, false);
         ReplayTrace(device, device->command_queue().id(), tid_2, false);
+
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        ReplayTrace(device, device->command_queue().id(), tid_3, false);
     }
     Synchronize(device);
     detail::DumpDeviceProfileResults(device);

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -244,7 +244,6 @@ public:
     virtual void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) = 0;
     virtual void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) = 0;
     virtual void clear_loaded_sub_device_manager() = 0;
-    virtual LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) = 0;
     virtual CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const = 0;
     virtual const std::vector<SubDeviceId> &get_sub_device_ids() const = 0;
     virtual const std::vector<SubDeviceId> &get_sub_device_stall_group() const = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -232,7 +232,6 @@ public:
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void clear_loaded_sub_device_manager() override;
-    LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) override;
     CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const override;
     const std::vector<SubDeviceId> &get_sub_device_ids() const override;
     const std::vector<SubDeviceId> &get_sub_device_stall_group() const override;

--- a/tt_metal/api/tt-metalium/launch_message_ring_buffer_state.hpp
+++ b/tt_metal/api/tt-metalium/launch_message_ring_buffer_state.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+
+namespace tt::tt_metal {
+
+// Used to track the position of the current launch message to write to in the launch message ring buffer on the cores
+// we dispatch programs to.
+// The multicast cores and unicast cores are tracked separately to not need to modify state when we only need to
+// dispatch to one of the core groups.
+class LaunchMessageRingBufferState {
+public:
+    void inc_mcast_wptr(uint32_t inc_val);
+
+    void inc_unicast_wptr(uint32_t inc_val);
+
+    void set_mcast_wptr(uint32_t val);
+
+    void set_unicast_wptr(uint32_t val);
+
+    uint32_t get_mcast_wptr() const;
+
+    uint32_t get_unicast_wptr() const;
+
+    void reset();
+
+private:
+    uint32_t multicast_cores_launch_message_wptr_ = 0;
+    uint32_t unicast_cores_launch_message_wptr_ = 0;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -209,7 +209,6 @@ public:
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void clear_loaded_sub_device_manager() override;
-    LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) override;
     CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const override;
     const std::vector<SubDeviceId>& get_sub_device_ids() const override;
     const std::vector<SubDeviceId>& get_sub_device_stall_group() const override;

--- a/tt_metal/api/tt-metalium/sub_device_manager.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager.hpp
@@ -17,7 +17,6 @@
 
 namespace tt::tt_metal {
 
-class LaunchMessageRingBufferState;
 class TraceBuffer;
 
 inline namespace v0 {
@@ -61,9 +60,6 @@ public:
     void release_trace(uint32_t tid);
     std::shared_ptr<TraceBuffer> get_trace(uint32_t tid);
 
-    void reset_worker_launch_message_buffer_state();
-    LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id);
-
     uint8_t num_sub_devices() const;
     bool has_allocations() const;
     DeviceAddr local_l1_size() const;
@@ -83,7 +79,6 @@ private:
     void populate_num_cores();
     void populate_sub_allocators();
     void populate_noc_data();
-    void populate_worker_launch_message_buffer_state();
 
     static std::atomic<uint64_t> next_sub_device_manager_id_;
 
@@ -108,8 +103,6 @@ private:
     std::vector<uint8_t> noc_unicast_data_start_index_;
 
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
-
-    std::vector<LaunchMessageRingBufferState> worker_launch_message_buffer_state_;
 
     // TODO #15944: Temporary until migration to actual fabric is complete
     std::optional<SubDeviceId> fabric_sub_device_id_ = std::nullopt;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -587,10 +587,6 @@ SubDeviceManagerId MeshDevice::get_default_sub_device_manager_id() const {
     TT_THROW("get_default_sub_device_manager_id() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->get_default_sub_device_manager_id();
 }
-LaunchMessageRingBufferState& MeshDevice::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
-    TT_THROW("get_worker_launch_message_buffer_state() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->get_worker_launch_message_buffer_state(sub_device_id);
-}
 CoreCoord MeshDevice::virtual_program_dispatch_core(uint8_t cq_id) const {
     TT_THROW("virtual_program_dispatch_core() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->virtual_program_dispatch_core(cq_id);

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -21,6 +21,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/program/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/command_queue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/launch_message_ring_buffer_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/data_collection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/topology.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1716,11 +1716,6 @@ uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data,
     }
 }
 
-LaunchMessageRingBufferState& Device::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_worker_launch_message_buffer_state(
-        sub_device_id);
-}
-
 CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
     return this->hw_command_queues_[cq_id]->virtual_enqueue_program_dispatch_core;
 }

--- a/tt_metal/impl/dispatch/launch_message_ring_buffer_state.cpp
+++ b/tt_metal/impl/dispatch/launch_message_ring_buffer_state.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <launch_message_ring_buffer_state.hpp>
+
+#include <cstdint>
+
+#include <dev_msgs.h>
+
+namespace tt::tt_metal {
+
+void LaunchMessageRingBufferState::inc_mcast_wptr(uint32_t inc_val) {
+    multicast_cores_launch_message_wptr_ =
+        (multicast_cores_launch_message_wptr_ + inc_val) & (launch_msg_buffer_num_entries - 1);
+}
+
+void LaunchMessageRingBufferState::inc_unicast_wptr(uint32_t inc_val) {
+    unicast_cores_launch_message_wptr_ =
+        (unicast_cores_launch_message_wptr_ + inc_val) & (launch_msg_buffer_num_entries - 1);
+}
+
+void LaunchMessageRingBufferState::set_mcast_wptr(uint32_t val) {
+    multicast_cores_launch_message_wptr_ = val & (launch_msg_buffer_num_entries - 1);
+}
+
+void LaunchMessageRingBufferState::set_unicast_wptr(uint32_t val) {
+    unicast_cores_launch_message_wptr_ = val & (launch_msg_buffer_num_entries - 1);
+}
+
+uint32_t LaunchMessageRingBufferState::get_mcast_wptr() const { return multicast_cores_launch_message_wptr_; }
+
+uint32_t LaunchMessageRingBufferState::get_unicast_wptr() const { return unicast_cores_launch_message_wptr_; }
+
+void LaunchMessageRingBufferState::reset() {
+    multicast_cores_launch_message_wptr_ = 0;
+    unicast_cores_launch_message_wptr_ = 0;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/module.mk
+++ b/tt_metal/impl/module.mk
@@ -19,6 +19,7 @@ TT_METAL_IMPL_SRCS = \
 	tt_metal/impl/program/program.cpp \
 	tt_metal/impl/dispatch/debug_tools.cpp \
 	tt_metal/impl/dispatch/command_queue.cpp \
+	tt_metal/impl/dispatch/launch_message_ring_buffer_state.cpp \
 	tt_metal/impl/debug/dprint_server.cpp \
 	tt_metal/impl/debug/watcher_server.cpp \
 	tt_metal/impl/trace/trace.cpp

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -40,7 +40,6 @@ SubDeviceManager::SubDeviceManager(
     this->populate_num_cores();
     this->populate_sub_allocators();
     this->populate_noc_data();
-    this->populate_worker_launch_message_buffer_state();
 }
 
 SubDeviceManager::SubDeviceManager(IDevice* device, std::unique_ptr<Allocator>&& global_allocator) :
@@ -63,7 +62,6 @@ SubDeviceManager::SubDeviceManager(IDevice* device, std::unique_ptr<Allocator>&&
     this->populate_num_cores();
     this->sub_device_allocators_.push_back(std::move(global_allocator));
     this->populate_noc_data();
-    this->populate_worker_launch_message_buffer_state();
 }
 
 SubDeviceManager::~SubDeviceManager() {
@@ -141,18 +139,6 @@ std::shared_ptr<TraceBuffer> SubDeviceManager::get_trace(uint32_t tid) {
         return trace->second;
     }
     return nullptr;
-}
-
-void SubDeviceManager::reset_worker_launch_message_buffer_state() {
-    std::for_each(
-        worker_launch_message_buffer_state_.begin(),
-        worker_launch_message_buffer_state_.end(),
-        std::mem_fn(&LaunchMessageRingBufferState::reset));
-}
-
-LaunchMessageRingBufferState& SubDeviceManager::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
-    auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return worker_launch_message_buffer_state_[sub_device_index];
 }
 
 bool SubDeviceManager::has_allocations() const {
@@ -364,11 +350,6 @@ void SubDeviceManager::populate_noc_data() {
             idx,
             dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES);
     }
-}
-
-void SubDeviceManager::populate_worker_launch_message_buffer_state() {
-    worker_launch_message_buffer_state_.resize(this->num_sub_devices());
-    this->reset_worker_launch_message_buffer_state();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -60,20 +60,11 @@ std::tuple<SubDeviceManagerId, SubDeviceId> SubDeviceManagerTracker::create_sub_
 
 void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDeviceManager>& sub_device_manager) {
     auto num_sub_devices = sub_device_manager->num_sub_devices();
-    // TODO: This could be further optimized by combining all of these into a single prefetch entry
-    // Currently each one will be pushed into its own prefetch entry
     for (uint8_t cq_id = 0; cq_id < device_->num_hw_cqs(); ++cq_id) {
         auto& hw_cq = device_->hw_command_queue(cq_id);
         // Only need to reset launch messages once, so reset on cq 0
-        TT_FATAL(!hw_cq.sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
-        hw_cq.reset_worker_state(cq_id == 0);
-        hw_cq.set_num_worker_sems_on_dispatch(num_sub_devices);
-        hw_cq.set_go_signal_noc_data_on_dispatch(sub_device_manager->noc_mcast_unicast_data());
-        hw_cq.reset_config_buffer_mgr(num_sub_devices);
+        hw_cq.reset_worker_state(cq_id == 0, num_sub_devices, sub_device_manager->noc_mcast_unicast_data());
     }
-    // Reset the launch_message ring buffer state seen on host
-    sub_device_manager->reset_worker_launch_message_buffer_state();
-
     sub_device_manager->reset_sub_device_stall_group();
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
If user has a persistent program on a sub-device, they would need to capture the trace of the other sub-devices without the persistent program running. Allowing traces to be captured while other programs are running on other sub-devices makes it easier on the user to not have to special case/refactor code.

### What's changed
Move worker_launch_message_buffer_state from device/sub-device manager to SystemMemoryManager.
Update record_begin to copy expected_num_workers_completed, worker_launch_message_buffer_state, config_buffer_mgr to temporaries, and then restore their values in record_end. This allows us to capture trace without affecting any host tracked state after record_end finishes.
Remove command to wait on device and reset the counter in record_begin. This is not needed since we are only modifying state on host during capture, and enqueue_trace will issue the wait/counter reset

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12816641518)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
