### PR TITLE
Removing Power of 2 Limit from Packet Queue

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
@@ -194,14 +194,14 @@ void kernel_main() {
         // === parse packet payload ===
         uint32_t curr_packet_payload_words = curr_packet_size_words-1;
         if constexpr (!disable_data_check) {
-            uint32_t words_before_wrap = input_queue->get_queue_words_before_rptr_cleared_wrap();
+            uint32_t words_before_wrap = input_queue->get_queue_words_before_rptr_cleared_wrap<true>();
             uint32_t words_after_wrap = 0;
             if (words_before_wrap < curr_packet_payload_words) {
                 words_after_wrap = curr_packet_payload_words - words_before_wrap;
             } else {
                 words_before_wrap = curr_packet_payload_words;
             }
-            if (!check_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(input_queue->get_queue_rptr_cleared_addr_bytes()),
+            if (!check_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(input_queue->get_queue_rptr_cleared_addr_bytes<true>()),
                                    words_before_wrap,
                                    (curr_packet_tag & 0xFFFF0000)+1,
                                    mismatch_addr, mismatch_val, expected_val)) {
@@ -214,7 +214,7 @@ void kernel_main() {
             input_queue->input_queue_advance_words_cleared<rx_rptr_update_network_type, false>(words_before_wrap);
             words_cleared += words_before_wrap;
             if (words_after_wrap > 0) {
-                if (!check_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(input_queue->get_queue_rptr_cleared_addr_bytes()),
+                if (!check_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(input_queue->get_queue_rptr_cleared_addr_bytes<true>()),
                                        words_after_wrap,
                                        (curr_packet_tag & 0xFFFF0000) + 1 + words_before_wrap,
                                        mismatch_addr, mismatch_val, expected_val)) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
@@ -13,15 +13,10 @@ constexpr uint32_t endpoint_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_src_endpoints = get_compile_time_arg_val(1);
 constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(2);
 
-static_assert(is_power_of_2(num_src_endpoints), "num_src_endpoints must be a power of 2");
-static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
-
 constexpr uint32_t input_queue_id = 0;
 
 constexpr uint32_t queue_start_addr_words = get_compile_time_arg_val(3);
 constexpr uint32_t queue_size_words = get_compile_time_arg_val(4);
-
-static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_tx_x = get_compile_time_arg_val(5);
 constexpr uint32_t remote_tx_y = get_compile_time_arg_val(6);
@@ -49,6 +44,12 @@ constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(16);
 constexpr uint32_t timeout_cycles = get_compile_time_arg_val(17);
 
 constexpr uint32_t disable_header_check = get_compile_time_arg_val(18);
+
+#ifdef POW2_CB
+static_assert(is_power_of_2(num_src_endpoints), "num_src_endpoints must be a power of 2");
+static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
+static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
+#endif
 
 // predicts size and payload of packets from each destination, should have
 // the same random seed as the corresponding traffic_gen_tx

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -10,18 +10,14 @@
 constexpr uint32_t src_endpoint_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(1);
 
-static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
-
 constexpr uint32_t queue_start_addr_words = get_compile_time_arg_val(2);
 constexpr uint32_t queue_size_words = get_compile_time_arg_val(3);
 constexpr uint32_t queue_size_bytes = queue_size_words * PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_rx_queue_start_addr_words = get_compile_time_arg_val(4);
 constexpr uint32_t remote_rx_queue_size_words = get_compile_time_arg_val(5);
 
-static_assert(is_power_of_2(remote_rx_queue_size_words), "remote_rx_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_rx_x = get_compile_time_arg_val(6);
 constexpr uint32_t remote_rx_y = get_compile_time_arg_val(7);
@@ -42,7 +38,6 @@ constexpr uint64_t total_data_words = ((uint64_t)total_data_kb) * 1024 / PACKET_
 
 constexpr uint32_t max_packet_size_words = get_compile_time_arg_val(14);
 
-static_assert(is_power_of_2(max_packet_size_words), "max_packet_size_words must be a power of 2");
 static_assert(max_packet_size_words < queue_size_words, "max_packet_size_words must be less than queue_size_words");
 static_assert(max_packet_size_words > 2, "max_packet_size_words must be greater than 2");
 
@@ -59,6 +54,13 @@ constexpr uint32_t data_sent_per_iter_high = get_compile_time_arg_val(21);
 
 constexpr uint32_t input_queue_id = 0;
 constexpr uint32_t output_queue_id = 1;
+
+static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
+#ifdef POW2_CB
+static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_rx_queue_size_words), "remote_rx_queue_size_words must be a power of 2");
+#endif
+static_assert(is_power_of_2(max_packet_size_words), "max_packet_size_words must be a power of 2");
 
 packet_input_queue_state_t input_queue;
 using input_queue_network_sequence = NetworkTypeSequence<DispatchRemoteNetworkType::NONE>;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -80,15 +80,15 @@ inline bool input_queue_handler() {
         return true;
     }
 
-    uint32_t free_words = input_queue_ptr->get_queue_data_num_words_free();
+    uint32_t free_words = input_queue_ptr->get_queue_data_num_words_free<true>();
     if (free_words == 0) {
         return false;
     }
 
     // Each call to input_queue_handler initializes only up to the end
     // of the queue buffer, so we don't need to handle wrapping.
-    uint32_t byte_wr_addr = input_queue_ptr->get_queue_wptr_addr_bytes();
-    uint32_t words_to_init = std::min(free_words, input_queue_ptr->get_queue_words_before_wptr_wrap());
+    uint32_t byte_wr_addr = input_queue_ptr->get_queue_wptr_addr_bytes<true>();
+    uint32_t words_to_init = std::min(free_words, input_queue_ptr->get_queue_words_before_wptr_wrap<true>());
     uint32_t words_initialized = 0;
 
     while (words_initialized < words_to_init) {

--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -133,6 +133,8 @@ class RunTimeOptions {
 
     bool skip_deleting_built_cache = false;
 
+    bool enable_dispatch_dynamic_queue_sizing = true;
+
     RunTimeOptions();
 
 public:
@@ -306,6 +308,8 @@ public:
     inline tt_metal::DispatchCoreConfig get_dispatch_core_config() { return dispatch_core_config; }
 
     inline bool get_skip_deleting_built_cache() { return skip_deleting_built_cache; }
+
+    inline bool get_enable_dispatch_dynamic_queue_sizing() { return enable_dispatch_dynamic_queue_sizing; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -12,8 +12,6 @@ constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
-
 constexpr uint32_t demux_fan_out = get_compile_time_arg_val(3);
 
 // FIXME imatosevic - is there a way to do this without explicit indexes?
@@ -69,11 +67,6 @@ constexpr uint32_t remote_tx_queue_size_words[MAX_SWITCH_FAN_OUT] =
         get_compile_time_arg_val(13),
         get_compile_time_arg_val(15)
     };
-
-static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((demux_fan_out < 2) || is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((demux_fan_out < 3) || is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((demux_fan_out < 4) || is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_rx_x = get_compile_time_arg_val(16);
 constexpr uint32_t remote_rx_y = get_compile_time_arg_val(17);
@@ -176,6 +169,13 @@ constexpr uint32_t output_depacketize_remove_header[MAX_SWITCH_FAN_OUT] =
         (get_compile_time_arg_val(29) >> 24) & 0x1
     };
 
+#ifdef POW2_CB
+static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
+static_assert((demux_fan_out < 2) || is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
+static_assert((demux_fan_out < 3) || is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
+static_assert((demux_fan_out < 4) || is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
+#endif
 
 packet_input_queue_state_t input_queue;
 using input_queue_network_sequence = NetworkTypeSequence<remote_rx_network_type>;

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -15,8 +15,6 @@ constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
-
 constexpr uint32_t mux_fan_in = get_compile_time_arg_val(3);
 
 // FIXME imatosevic - is there a way to do this without explicit indexes?
@@ -59,8 +57,6 @@ constexpr DispatchRemoteNetworkType remote_rx_network_type[MAX_SWITCH_FAN_IN] =
 
 constexpr uint32_t remote_tx_queue_start_addr_words = get_compile_time_arg_val(8);
 constexpr uint32_t remote_tx_queue_size_words = get_compile_time_arg_val(9);
-
-static_assert(is_power_of_2(remote_tx_queue_size_words), "remote_tx_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_tx_x = get_compile_time_arg_val(10);
 constexpr uint32_t remote_tx_y = get_compile_time_arg_val(11);
@@ -133,6 +129,11 @@ constexpr uint32_t input_packetize_dest_endpoint[MAX_SWITCH_FAN_IN] =
         (get_compile_time_arg_val(24) >> 16) & 0xFF,
         (get_compile_time_arg_val(24) >> 24) & 0xFF
     };
+
+#ifdef POW2_CB
+static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_tx_queue_size_words), "remote_tx_queue_size_words must be a power of 2");
+#endif
 
 packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
 using input_queue_network_sequence = NetworkTypeSequence<remote_rx_network_type[0], remote_rx_network_type[1], remote_rx_network_type[2], remote_rx_network_type[3]>;

--- a/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
@@ -10,7 +10,6 @@ constexpr uint32_t tunnel_lanes = get_compile_time_arg_val(1);
 constexpr uint32_t in_queue_start_addr_words = get_compile_time_arg_val(2);
 constexpr uint32_t in_queue_size_words = get_compile_time_arg_val(3);
 constexpr uint32_t in_queue_size_bytes = in_queue_size_words * PACKET_WORD_SIZE_BYTES;
-static_assert(is_power_of_2(in_queue_size_words), "in_queue_size_words must be a power of 2");
 static_assert(tunnel_lanes <= MAX_TUNNEL_LANES, "cannot have more than 2 tunnel directions.");
 static_assert(tunnel_lanes, "tunnel directions cannot be 0. 1 => Unidirectional. 2 => Bidirectional");
 
@@ -98,17 +97,6 @@ constexpr uint32_t remote_receiver_queue_size_words[MAX_TUNNEL_LANES] =
         get_compile_time_arg_val(33)
     };
 
-static_assert(is_power_of_2(remote_receiver_queue_size_words[0]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[1]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[2]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[3]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[4]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[5]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[6]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[7]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[8]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[9]), "remote_receiver_queue_size_words must be a power of 2");
-
 constexpr uint32_t remote_sender_x[MAX_TUNNEL_LANES] =
     {
         (get_compile_time_arg_val(34) & 0xFF),
@@ -174,6 +162,20 @@ tt_l1_ptr uint32_t* const kernel_status = reinterpret_cast<tt_l1_ptr uint32_t*>(
 
 constexpr uint32_t timeout_cycles = get_compile_time_arg_val(46);
 constexpr uint32_t inner_stop_mux_d_bypass = get_compile_time_arg_val(47);
+
+#ifdef POW2_CB
+static_assert(is_power_of_2(in_queue_size_words), "in_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[0]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[1]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[2]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[3]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[4]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[5]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[6]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[7]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[8]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[9]), "remote_receiver_queue_size_words must be a power of 2");
+#endif
 
 packet_input_queue_state_t input_queues[MAX_TUNNEL_LANES];
 using input_queue_network_sequence = NetworkTypeSequence<remote_sender_network_type[0],

--- a/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
@@ -10,8 +10,6 @@ constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
-
 constexpr uint32_t router_lanes = get_compile_time_arg_val(3);
 
 // FIXME imatosevic - is there a way to do this without explicit indexes?
@@ -67,11 +65,6 @@ constexpr uint32_t remote_tx_queue_size_words[MAX_SWITCH_FAN_OUT] =
         get_compile_time_arg_val(13),
         get_compile_time_arg_val(15)
     };
-
-static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((router_lanes < 2) || is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((router_lanes < 3) || is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((router_lanes < 4) || is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
 
 constexpr uint8_t remote_rx_x[MAX_SWITCH_FAN_OUT] =
     {
@@ -201,6 +194,14 @@ constexpr uint8_t input_packetize_dest_endpoint[MAX_SWITCH_FAN_IN] =
         (get_compile_time_arg_val(35) >> 16) & 0xFF,
         (get_compile_time_arg_val(35) >> 24) & 0xFF
     };
+
+#ifdef POW2_CB
+static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
+static_assert((router_lanes < 2) || is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
+static_assert((router_lanes < 3) || is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
+static_assert((router_lanes < 4) || is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
+#endif
 
 packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
 using input_queue_network_sequence = NetworkTypeSequence<remote_rx_network_type[0], remote_rx_network_type[1], remote_rx_network_type[2], remote_rx_network_type[3]>;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -198,6 +198,12 @@ void RunTimeOptions::ParseWatcherEnv() {
             watcher_disabled_features.find(watcher_noc_sanitize_str) == watcher_disabled_features.end(),
             "TT_METAL_WATCHER_DEBUG_DELAY requires TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=0");
     }
+
+    if (getenv("TT_METAL_DISPATCH_STATIC_QUEUE_SIZING")) {
+        this->enable_dispatch_dynamic_queue_sizing = false;
+    } else {
+        this->enable_dispatch_dynamic_queue_sizing = true;
+    }
 }
 
 void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14427

### Problem description
Remove power of 2 limit from packet queue

### What's changed
- Registers are being used as credit words now instead of pointer offset
- Added pointer calculations for non power of 2 queue sizes
- Power of 2 AND mask can be enabled using define `POW2_CB`
- Static asserts to only check for power of 2 if `POW2_CB` is defined


### Checklist
- [ ] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12805418839
https://github.com/tenstorrent/tt-metal/actions/runs/12805416411
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
