### PR TITLE
#0: Link benchmark::benchmark into all perf tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -70,10 +70,8 @@ foreach(arch ${ARCHITECTURES})
             PRIVATE
                 yaml-cpp::yaml-cpp
                 tt_fabric
+                benchmark::benchmark
         )
-        if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")
-            target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
-        endif()
         target_include_directories(
             ${TEST_TARGET}
             BEFORE


### PR DESCRIPTION
### Problem description
Only the test_pgm_dispatch library is currently set up to use the benchmark:benchmark library.

### What's changed
More tests may start using the benchmarking library soon, so simplify the build script and link benchmark::benchmark everywhere.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
