### PR TITLE
#0: Update pgm_dispatch_golden.json

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.py
@@ -20,7 +20,7 @@ golden = json.load(
     )
 )
 
-THRESHOLD = 4
+THRESHOLD_PCT = 5
 
 parser = argparse.ArgumentParser(description="Compare benchmark JSON to golden")
 parser.add_argument("json", help="JSON file to compare", type=argparse.FileType("r"))
@@ -59,12 +59,15 @@ for name, benchmark in golden_benchmarks.items():
 
     golden_time = benchmark["IterationTime"] * 1000000
     result_time = result["IterationTime"] * 1000000
-    if result_time / golden_time > (1 + THRESHOLD / 100):
-        print(f"Error:Test {name} expected value {golden_time:.2f}us but got {result_time:.2f}us")
-        exit_code = 1
-    if golden_time / result_time > (1 + THRESHOLD / 100):
+    result_diff_pct = result_time / golden_time * 100 - 100
+    if result_diff_pct > THRESHOLD_PCT:
         print(
-            f"Consider adjusting baselines. Test {name} got value {result_time:.2f}us but expected {golden_time:.2f}us."
+            f"Error:Test {name} expected value {golden_time:.2f}us but got {result_time:.2f}us ({result_diff_pct:.2f}% worse)"
+        )
+        exit_code = 1
+    if result_diff_pct < -THRESHOLD_PCT:
+        print(
+            f"Consider adjusting baselines. Test {name} got value {result_time:.2f}us but expected {golden_time:.2f}us ({-result_diff_pct:.2f}% better)."
         )
 
 for name in result_benchmarks:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/pgm_dispatch_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/pgm_dispatch_golden.json
@@ -1,10 +1,10 @@
 {
   "context": {
-    "date": "2025-01-09T04:11:21+00:00",
-    "host_name": "tt-metal-ci-vm-113",
-    "executable": "build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch",
+    "date": "2025-01-17T16:56:47+00:00",
+    "host_name": "tt-metal-ci-vm-43",
+    "executable": "./build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_wormhole_b0",
     "num_cpus": 14,
-    "mhz_per_cpu": 3000,
+    "mhz_per_cpu": 2300,
     "cpu_scaling_enabled": false,
     "caches": [
       {
@@ -32,7 +32,7 @@
         "num_sharing": 1
       }
     ],
-    "load_avg": [3.94,3.54,3.45],
+    "load_avg": [4.39,5.26,5.61],
     "library_version": "v1.9.1",
     "library_build_type": "debug",
     "json_schema_version": 1
@@ -48,10 +48,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.6601730769230776e+07,
-      "cpu_time": 2.6529615384615623e+04,
+      "real_time": 2.6494769230769232e+07,
+      "cpu_time": 2.0596538461538039e+04,
       "time_unit": "ns",
-      "IterationTime": 2.6601730769230771e-06
+      "IterationTime": 2.6494769230769229e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/512/manual_time",
@@ -63,10 +63,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.6662653846153855e+07,
-      "cpu_time": 2.9320423076923271e+04,
+      "real_time": 2.6651384615384620e+07,
+      "cpu_time": 2.2721692307693131e+04,
       "time_unit": "ns",
-      "IterationTime": 2.6662653846153855e-06
+      "IterationTime": 2.6651384615384620e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/1024/manual_time",
@@ -78,10 +78,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.7040115384615388e+07,
-      "cpu_time": 2.6867692307692872e+04,
+      "real_time": 2.6904692307692297e+07,
+      "cpu_time": 2.8205307692306626e+04,
       "time_unit": "ns",
-      "IterationTime": 2.7040115384615389e-06
+      "IterationTime": 2.6904692307692295e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/2048/manual_time",
@@ -92,11 +92,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7484519999999996e+07,
-      "cpu_time": 3.2514400000001053e+04,
+      "iterations": 26,
+      "real_time": 2.7378846153846145e+07,
+      "cpu_time": 2.3096076923077111e+04,
       "time_unit": "ns",
-      "IterationTime": 2.7484519999999995e-06
+      "IterationTime": 2.7378846153846142e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/4096/manual_time",
@@ -108,10 +108,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9502333333333332e+07,
-      "cpu_time": 3.1982499999999582e+04,
+      "real_time": 2.9401541666666668e+07,
+      "cpu_time": 2.6805833333333008e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9502333333333336e-06
+      "IterationTime": 2.9401541666666664e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/8192/manual_time",
@@ -123,10 +123,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2264636363636371e+07,
-      "cpu_time": 3.0213227272727047e+04,
+      "real_time": 3.2257409090909090e+07,
+      "cpu_time": 2.3160909090905432e+04,
       "time_unit": "ns",
-      "IterationTime": 3.2264636363636365e-06
+      "IterationTime": 3.2257409090909090e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/12288/manual_time",
@@ -138,10 +138,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5457300000000007e+07,
-      "cpu_time": 2.7025499999999702e+04,
+      "real_time": 3.5200850000000015e+07,
+      "cpu_time": 2.6384099999998689e+04,
       "time_unit": "ns",
-      "IterationTime": 3.5457300000000010e-06
+      "IterationTime": 3.5200850000000006e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/256/manual_time",
@@ -153,10 +153,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.6600615384615388e+07,
-      "cpu_time": 2.6969230769229129e+04,
+      "real_time": 2.6499461538461540e+07,
+      "cpu_time": 2.4073692307694600e+04,
       "time_unit": "ns",
-      "IterationTime": 2.6600615384615387e-06
+      "IterationTime": 2.6499461538461540e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/512/manual_time",
@@ -168,10 +168,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.6661999999999996e+07,
-      "cpu_time": 2.9010769230769078e+04,
+      "real_time": 2.6654807692307692e+07,
+      "cpu_time": 2.8629230769230748e+04,
       "time_unit": "ns",
-      "IterationTime": 2.6662000000000000e-06
+      "IterationTime": 2.6654807692307692e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/1024/manual_time",
@@ -183,10 +183,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 26,
-      "real_time": 2.7037230769230768e+07,
-      "cpu_time": 2.8008461538459465e+04,
+      "real_time": 2.6903423076923072e+07,
+      "cpu_time": 3.0917307692309631e+04,
       "time_unit": "ns",
-      "IterationTime": 2.7037230769230769e-06
+      "IterationTime": 2.6903423076923073e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/2048/manual_time",
@@ -197,11 +197,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7480999999999996e+07,
-      "cpu_time": 2.6100800000001811e+04,
+      "iterations": 26,
+      "real_time": 2.7379461538461544e+07,
+      "cpu_time": 2.7465384615382300e+04,
       "time_unit": "ns",
-      "IterationTime": 2.7481000000000000e-06
+      "IterationTime": 2.7379461538461543e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/4096/manual_time",
@@ -213,10 +213,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9546208333333332e+07,
-      "cpu_time": 2.9264208333323884e+04,
+      "real_time": 2.9450708333333325e+07,
+      "cpu_time": 2.4538749999997166e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9546208333333334e-06
+      "IterationTime": 2.9450708333333324e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/8192/manual_time",
@@ -228,10 +228,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2266181818181813e+07,
-      "cpu_time": 3.3103636363632482e+04,
+      "real_time": 3.2266045454545461e+07,
+      "cpu_time": 2.8030545454547286e+04,
       "time_unit": "ns",
-      "IterationTime": 3.2266181818181812e-06
+      "IterationTime": 3.2266045454545459e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/12288/manual_time",
@@ -243,10 +243,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5458250000000000e+07,
-      "cpu_time": 2.8790499999997719e+04,
+      "real_time": 3.5203950000000000e+07,
+      "cpu_time": 2.7262549999995670e+04,
       "time_unit": "ns",
-      "IterationTime": 3.5458250000000005e-06
+      "IterationTime": 3.5203949999999999e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/256/manual_time",
@@ -258,10 +258,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9081833333333343e+07,
-      "cpu_time": 3.2849583333327544e+04,
+      "real_time": 2.9074625000000004e+07,
+      "cpu_time": 2.9213041666670269e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9081833333333341e-06
+      "IterationTime": 2.9074625000000009e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/512/manual_time",
@@ -273,10 +273,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9061874999999996e+07,
-      "cpu_time": 2.3948333333329021e+04,
+      "real_time": 2.9200083333333328e+07,
+      "cpu_time": 4.7710416666670491e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9061875000000002e-06
+      "IterationTime": 2.9200083333333329e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/1024/manual_time",
@@ -288,10 +288,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 24,
-      "real_time": 2.9620666666666668e+07,
-      "cpu_time": 1.8642083333334875e+04,
+      "real_time": 2.9543250000000000e+07,
+      "cpu_time": 4.0839166666658173e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9620666666666670e-06
+      "IterationTime": 2.9543250000000003e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/2048/manual_time",
@@ -303,10 +303,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1900636363636371e+07,
-      "cpu_time": 1.9765909090908481e+04,
+      "real_time": 3.2074727272727277e+07,
+      "cpu_time": 4.4844545454543600e+04,
       "time_unit": "ns",
-      "IterationTime": 3.1900636363636371e-06
+      "IterationTime": 3.2074727272727282e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/4096/manual_time",
@@ -318,10 +318,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.6285473684210517e+07,
-      "cpu_time": 1.9697894736834136e+04,
+      "real_time": 3.6720315789473690e+07,
+      "cpu_time": 4.4466684210530657e+04,
       "time_unit": "ns",
-      "IterationTime": 3.6285473684210520e-06
+      "IterationTime": 3.6720315789473688e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/8192/manual_time",
@@ -333,10 +333,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.4888687500000000e+07,
-      "cpu_time": 2.0452499999989992e+04,
+      "real_time": 4.4607375000000007e+07,
+      "cpu_time": 4.2113625000006483e+04,
       "time_unit": "ns",
-      "IterationTime": 4.4888687500000007e-06
+      "IterationTime": 4.4607375000000004e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/12288/manual_time",
@@ -348,10 +348,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.3077538461538471e+07,
-      "cpu_time": 2.0974615384613451e+04,
+      "real_time": 5.3098769230769224e+07,
+      "cpu_time": 4.4189230769243492e+04,
       "time_unit": "ns",
-      "IterationTime": 5.3077538461538473e-06
+      "IterationTime": 5.3098769230769216e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/256/manual_time",
@@ -362,11 +362,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 2.9786217391304359e+07,
-      "cpu_time": 1.8034347826086880e+04,
+      "iterations": 24,
+      "real_time": 2.9743041666666660e+07,
+      "cpu_time": 4.3664166666660771e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9786217391304358e-06
+      "IterationTime": 2.9743041666666663e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/512/manual_time",
@@ -378,10 +378,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 2.9976434782608692e+07,
-      "cpu_time": 1.8719999999993815e+04,
+      "real_time": 2.9946304347826093e+07,
+      "cpu_time": 4.0358260869561462e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9976434782608691e-06
+      "IterationTime": 2.9946304347826095e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/1024/manual_time",
@@ -393,10 +393,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1497181818181824e+07,
-      "cpu_time": 1.7748636363622660e+04,
+      "real_time": 3.1493227272727266e+07,
+      "cpu_time": 3.6386818181814589e+04,
       "time_unit": "ns",
-      "IterationTime": 3.1497181818181825e-06
+      "IterationTime": 3.1493227272727264e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/2048/manual_time",
@@ -408,10 +408,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3541809523809530e+07,
-      "cpu_time": 1.9074285714290727e+04,
+      "real_time": 3.3653666666666664e+07,
+      "cpu_time": 4.1210047619044148e+04,
       "time_unit": "ns",
-      "IterationTime": 3.3541809523809530e-06
+      "IterationTime": 3.3653666666666662e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/4096/manual_time",
@@ -423,10 +423,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9276611111111104e+07,
-      "cpu_time": 1.9366111111097776e+04,
+      "real_time": 3.9724111111111112e+07,
+      "cpu_time": 9.9917055555565079e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9276611111111110e-06
+      "IterationTime": 3.9724111111111117e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/8192/manual_time",
@@ -438,10 +438,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.0548714285714269e+07,
-      "cpu_time": 2.2192857142856934e+04,
+      "real_time": 5.0512642857142866e+07,
+      "cpu_time": 3.3647499999979656e+04,
       "time_unit": "ns",
-      "IterationTime": 5.0548714285714268e-06
+      "IterationTime": 5.0512642857142870e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/12288/manual_time",
@@ -453,10 +453,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.1927818181818195e+07,
-      "cpu_time": 2.0989090909105038e+04,
+      "real_time": 6.1927636363636367e+07,
+      "cpu_time": 1.0503009090909934e+05,
       "time_unit": "ns",
-      "IterationTime": 6.1927818181818191e-06
+      "IterationTime": 6.1927636363636364e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/256/manual_time",
@@ -468,10 +468,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.1035782608695649e+07,
-      "cpu_time": 2.0630000000009397e+04,
+      "real_time": 3.1038695652173914e+07,
+      "cpu_time": 3.1146086956530151e+04,
       "time_unit": "ns",
-      "IterationTime": 3.1035782608695646e-06
+      "IterationTime": 3.1038695652173915e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/512/manual_time",
@@ -483,10 +483,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1509136363636360e+07,
-      "cpu_time": 1.9522272727279244e+04,
+      "real_time": 3.1697545454545453e+07,
+      "cpu_time": 8.8209090909099148e+04,
       "time_unit": "ns",
-      "IterationTime": 3.1509136363636356e-06
+      "IterationTime": 3.1697545454545453e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/1024/manual_time",
@@ -498,10 +498,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3216047619047623e+07,
-      "cpu_time": 2.0791904761896520e+04,
+      "real_time": 3.3257476190476187e+07,
+      "cpu_time": 4.0305714285704395e+04,
       "time_unit": "ns",
-      "IterationTime": 3.3216047619047624e-06
+      "IterationTime": 3.3257476190476183e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/2048/manual_time",
@@ -513,10 +513,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5498700000000007e+07,
-      "cpu_time": 2.3626999999981635e+04,
+      "real_time": 3.5562349999999993e+07,
+      "cpu_time": 8.5739499999992753e+04,
       "time_unit": "ns",
-      "IterationTime": 3.5498700000000001e-06
+      "IterationTime": 3.5562349999999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/4096/manual_time",
@@ -528,10 +528,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.2882687499999993e+07,
-      "cpu_time": 2.0096874999986358e+04,
+      "real_time": 4.2622812499999993e+07,
+      "cpu_time": 5.3711937499978376e+04,
       "time_unit": "ns",
-      "IterationTime": 4.2882687499999996e-06
+      "IterationTime": 4.2622812499999994e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/8192/manual_time",
@@ -543,10 +543,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7862833333333336e+07,
-      "cpu_time": 2.1122500000007411e+04,
+      "real_time": 5.8369333333333336e+07,
+      "cpu_time": 1.1940258333331677e+05,
       "time_unit": "ns",
-      "IterationTime": 5.7862833333333324e-06
+      "IterationTime": 5.8369333333333325e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/12288/manual_time",
@@ -558,10 +558,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 10,
-      "real_time": 7.0889399999999985e+07,
-      "cpu_time": 2.2058999999963191e+04,
+      "real_time": 7.0861799999999985e+07,
+      "cpu_time": 5.1345600000018974e+04,
       "time_unit": "ns",
-      "IterationTime": 7.0889399999999977e-06
+      "IterationTime": 7.0861799999999995e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/256/manual_time",
@@ -573,10 +573,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1258272727272723e+07,
-      "cpu_time": 1.9471363636376765e+04,
+      "real_time": 3.1423181818181816e+07,
+      "cpu_time": 4.2891909090903013e+04,
       "time_unit": "ns",
-      "IterationTime": 3.1258272727272727e-06
+      "IterationTime": 3.1423181818181819e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/512/manual_time",
@@ -588,10 +588,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.1511727272727266e+07,
-      "cpu_time": 2.0960454545461038e+04,
+      "real_time": 3.1646272727272734e+07,
+      "cpu_time": 4.7515909090911635e+04,
       "time_unit": "ns",
-      "IterationTime": 3.1511727272727267e-06
+      "IterationTime": 3.1646272727272735e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/1024/manual_time",
@@ -603,10 +603,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3215523809523821e+07,
-      "cpu_time": 1.9576714285715218e+04,
+      "real_time": 3.3245095238095243e+07,
+      "cpu_time": 5.0539523809554164e+04,
       "time_unit": "ns",
-      "IterationTime": 3.3215523809523816e-06
+      "IterationTime": 3.3245095238095242e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/2048/manual_time",
@@ -618,10 +618,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5499300000000000e+07,
-      "cpu_time": 2.0137499999983709e+04,
+      "real_time": 3.5636550000000000e+07,
+      "cpu_time": 5.8394999999977765e+04,
       "time_unit": "ns",
-      "IterationTime": 3.5499299999999997e-06
+      "IterationTime": 3.5636549999999997e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/4096/manual_time",
@@ -633,10 +633,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.2964999999999993e+07,
-      "cpu_time": 1.9405624999996318e+04,
+      "real_time": 4.3118812500000000e+07,
+      "cpu_time": 7.7396875000024229e+04,
       "time_unit": "ns",
-      "IterationTime": 4.2964999999999986e-06
+      "IterationTime": 4.3118812499999997e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/8192/manual_time",
@@ -648,10 +648,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7888499999999993e+07,
-      "cpu_time": 2.1857583333321589e+04,
+      "real_time": 5.7919749999999993e+07,
+      "cpu_time": 6.9252416666628254e+04,
       "time_unit": "ns",
-      "IterationTime": 5.7888499999999988e-06
+      "IterationTime": 5.7919749999999989e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/12288/manual_time",
@@ -663,10 +663,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 10,
-      "real_time": 7.1722800000000000e+07,
-      "cpu_time": 2.2666000000004518e+04,
+      "real_time": 7.1725100000000015e+07,
+      "cpu_time": 6.1048199999991222e+04,
       "time_unit": "ns",
-      "IterationTime": 7.1722800000000011e-06
+      "IterationTime": 7.1725100000000011e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/256/manual_time",
@@ -678,10 +678,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4409450000000000e+07,
-      "cpu_time": 2.1440000000017004e+04,
+      "real_time": 3.4283800000000000e+07,
+      "cpu_time": 2.9298450000014855e+04,
       "time_unit": "ns",
-      "IterationTime": 3.4409450000000001e-06
+      "IterationTime": 3.4283800000000004e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/512/manual_time",
@@ -693,10 +693,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4891450000000000e+07,
-      "cpu_time": 2.0419500000001812e+04,
+      "real_time": 3.4856300000000000e+07,
+      "cpu_time": 2.7753999999990956e+04,
       "time_unit": "ns",
-      "IterationTime": 3.4891449999999999e-06
+      "IterationTime": 3.4856300000000001e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/1024/manual_time",
@@ -708,10 +708,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.6722578947368421e+07,
-      "cpu_time": 2.3342105263171747e+04,
+      "real_time": 3.6593526315789476e+07,
+      "cpu_time": 2.1718947368389392e+04,
       "time_unit": "ns",
-      "IterationTime": 3.6722578947368423e-06
+      "IterationTime": 3.6593526315789477e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/2048/manual_time",
@@ -723,10 +723,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8818166666666672e+07,
-      "cpu_time": 1.7538333333326031e+04,
+      "real_time": 3.8749222222222224e+07,
+      "cpu_time": 2.3881111111092836e+04,
       "time_unit": "ns",
-      "IterationTime": 3.8818166666666674e-06
+      "IterationTime": 3.8749222222222228e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/4096/manual_time",
@@ -738,10 +738,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.6130466666666672e+07,
-      "cpu_time": 2.2618666666692396e+04,
+      "real_time": 4.6184066666666679e+07,
+      "cpu_time": 2.5615133333308411e+04,
       "time_unit": "ns",
-      "IterationTime": 4.6130466666666677e-06
+      "IterationTime": 4.6184066666666674e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/8192/manual_time",
@@ -753,10 +753,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0477666666666657e+07,
-      "cpu_time": 2.2935833333311468e+04,
+      "real_time": 6.0121749999999993e+07,
+      "cpu_time": 2.8316499999977063e+04,
       "time_unit": "ns",
-      "IterationTime": 6.0477666666666665e-06
+      "IterationTime": 6.0121749999999989e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/256/manual_time",
@@ -768,10 +768,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4445250000000007e+07,
-      "cpu_time": 2.0422500000005784e+04,
+      "real_time": 3.4327900000000000e+07,
+      "cpu_time": 2.3169999999961277e+04,
       "time_unit": "ns",
-      "IterationTime": 3.4445250000000003e-06
+      "IterationTime": 3.4327899999999997e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/512/manual_time",
@@ -783,10 +783,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4943850000000000e+07,
-      "cpu_time": 2.3140050000014511e+04,
+      "real_time": 3.4675300000000000e+07,
+      "cpu_time": 2.3919499999980333e+04,
       "time_unit": "ns",
-      "IterationTime": 3.4943850000000002e-06
+      "IterationTime": 3.4675299999999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/1024/manual_time",
@@ -798,10 +798,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.6802842105263159e+07,
-      "cpu_time": 2.4169473684197914e+04,
+      "real_time": 3.6655000000000007e+07,
+      "cpu_time": 2.4812105263166392e+04,
       "time_unit": "ns",
-      "IterationTime": 3.6802842105263156e-06
+      "IterationTime": 3.6655000000000007e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/2048/manual_time",
@@ -813,10 +813,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8862111111111112e+07,
-      "cpu_time": 2.2654444444479715e+04,
+      "real_time": 3.8975333333333343e+07,
+      "cpu_time": 2.6436166666668174e+04,
       "time_unit": "ns",
-      "IterationTime": 3.8862111111111116e-06
+      "IterationTime": 3.8975333333333338e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/4096/manual_time",
@@ -828,10 +828,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.6398400000000000e+07,
-      "cpu_time": 2.4521333333341980e+04,
+      "real_time": 4.6451800000000000e+07,
+      "cpu_time": 2.7250400000037680e+04,
       "time_unit": "ns",
-      "IterationTime": 4.6398400000000003e-06
+      "IterationTime": 4.6451800000000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/8192/manual_time",
@@ -843,10 +843,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 10,
-      "real_time": 7.0176900000000000e+07,
-      "cpu_time": 3.7319000000035630e+04,
+      "real_time": 7.0194100000000000e+07,
+      "cpu_time": 2.6641999999998945e+04,
       "time_unit": "ns",
-      "IterationTime": 7.0176900000000007e-06
+      "IterationTime": 7.0194099999999991e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/256/manual_time",
@@ -858,10 +858,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4329300000000000e+07,
-      "cpu_time": 2.6831500000001899e+04,
+      "real_time": 3.4173100000000000e+07,
+      "cpu_time": 2.8216499999977888e+04,
       "time_unit": "ns",
-      "IterationTime": 3.4329300000000006e-06
+      "IterationTime": 3.4173100000000006e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/512/manual_time",
@@ -873,10 +873,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.4846250000000000e+07,
-      "cpu_time": 2.3221500000003558e+04,
+      "real_time": 3.4499650000000007e+07,
+      "cpu_time": 2.3998999999985670e+04,
       "time_unit": "ns",
-      "IterationTime": 3.4846250000000005e-06
+      "IterationTime": 3.4499650000000001e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/1024/manual_time",
@@ -888,10 +888,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.6379210526315793e+07,
-      "cpu_time": 2.5060526315784078e+04,
+      "real_time": 3.6347105263157904e+07,
+      "cpu_time": 3.0493157894717628e+04,
       "time_unit": "ns",
-      "IterationTime": 3.6379210526315792e-06
+      "IterationTime": 3.6347105263157891e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/2048/manual_time",
@@ -903,10 +903,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8741000000000000e+07,
-      "cpu_time": 2.9632777777788273e+04,
+      "real_time": 3.8743833333333328e+07,
+      "cpu_time": 3.1388388888892790e+04,
       "time_unit": "ns",
-      "IterationTime": 3.8740999999999999e-06
+      "IterationTime": 3.8743833333333330e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/4096/manual_time",
@@ -918,10 +918,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.6045733333333328e+07,
-      "cpu_time": 2.5187999999983407e+04,
+      "real_time": 4.6062400000000000e+07,
+      "cpu_time": 2.9480866666631300e+04,
       "time_unit": "ns",
-      "IterationTime": 4.6045733333333325e-06
+      "IterationTime": 4.6062400000000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/8192/manual_time",
@@ -933,10 +933,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0181916666666657e+07,
-      "cpu_time": 2.5623333333335551e+04,
+      "real_time": 5.9961083333333336e+07,
+      "cpu_time": 3.0550333333397477e+04,
       "time_unit": "ns",
-      "IterationTime": 6.0181916666666661e-06
+      "IterationTime": 5.9961083333333326e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/256/manual_time",
@@ -948,10 +948,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.6965916666666664e+07,
-      "cpu_time": 3.0022499999985779e+04,
+      "real_time": 5.7078166666666657e+07,
+      "cpu_time": 3.2859166666658151e+04,
       "time_unit": "ns",
-      "IterationTime": 5.6965916666666665e-06
+      "IterationTime": 5.7078166666666665e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/512/manual_time",
@@ -963,10 +963,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7102916666666664e+07,
-      "cpu_time": 2.4605083333314091e+04,
+      "real_time": 5.7209000000000007e+07,
+      "cpu_time": 2.9685000000038523e+04,
       "time_unit": "ns",
-      "IterationTime": 5.7102916666666668e-06
+      "IterationTime": 5.7209000000000006e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/1024/manual_time",
@@ -978,10 +978,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7337416666666664e+07,
-      "cpu_time": 2.5089166666658613e+04,
+      "real_time": 5.7399249999999993e+07,
+      "cpu_time": 2.5737500000122538e+04,
       "time_unit": "ns",
-      "IterationTime": 5.7337416666666674e-06
+      "IterationTime": 5.7399249999999991e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/2048/manual_time",
@@ -993,10 +993,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7963250000000000e+07,
-      "cpu_time": 2.3686666666744572e+04,
+      "real_time": 5.7875000000000007e+07,
+      "cpu_time": 2.7013333333325561e+04,
       "time_unit": "ns",
-      "IterationTime": 5.7963249999999999e-06
+      "IterationTime": 5.7875000000000009e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/4096/manual_time",
@@ -1008,10 +1008,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0335916666666679e+07,
-      "cpu_time": 2.6460000000098444e+04,
+      "real_time": 5.9965083333333336e+07,
+      "cpu_time": 2.4397416666636458e+04,
       "time_unit": "ns",
-      "IterationTime": 6.0335916666666668e-06
+      "IterationTime": 5.9965083333333335e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/8192/manual_time",
@@ -1023,10 +1023,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.3152999999999993e+07,
-      "cpu_time": 2.5967272727230167e+04,
+      "real_time": 6.2861727272727273e+07,
+      "cpu_time": 3.0689909090982193e+04,
       "time_unit": "ns",
-      "IterationTime": 6.3152999999999986e-06
+      "IterationTime": 6.2861727272727267e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/256/manual_time",
@@ -1037,11 +1037,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.0664705882352926e+07,
-      "cpu_time": 2.3229411764697928e+04,
+      "iterations": 19,
+      "real_time": 3.7281368421052635e+07,
+      "cpu_time": 2.4861000000080636e+04,
       "time_unit": "ns",
-      "IterationTime": 4.0664705882352934e-06
+      "IterationTime": 3.7281368421052637e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/512/manual_time",
@@ -1052,11 +1052,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.0751000000000000e+07,
-      "cpu_time": 1.8595294117590092e+04,
+      "iterations": 19,
+      "real_time": 3.7376789473684222e+07,
+      "cpu_time": 2.3242631579004810e+04,
       "time_unit": "ns",
-      "IterationTime": 4.0751000000000002e-06
+      "IterationTime": 3.7376789473684223e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/1024/manual_time",
@@ -1067,11 +1067,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.0919647058823526e+07,
-      "cpu_time": 1.9589411764667708e+04,
+      "iterations": 19,
+      "real_time": 3.7566263157894745e+07,
+      "cpu_time": 2.2553157894777378e+04,
       "time_unit": "ns",
-      "IterationTime": 4.0919647058823527e-06
+      "IterationTime": 3.7566263157894741e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/2048/manual_time",
@@ -1082,11 +1082,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.1250000000000000e+07,
-      "cpu_time": 1.8734117647098588e+04,
+      "iterations": 18,
+      "real_time": 3.7914833333333336e+07,
+      "cpu_time": 2.5673888888929258e+04,
       "time_unit": "ns",
-      "IterationTime": 4.1249999999999995e-06
+      "IterationTime": 3.7914833333333333e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/4096/manual_time",
@@ -1097,11 +1097,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.2031705882352941e+07,
-      "cpu_time": 1.9504705882307109e+04,
+      "iterations": 18,
+      "real_time": 3.8644611111111112e+07,
+      "cpu_time": 2.6162166666645862e+04,
       "time_unit": "ns",
-      "IterationTime": 4.2031705882352942e-06
+      "IterationTime": 3.8644611111111113e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/8192/manual_time",
@@ -1112,11 +1112,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 16,
-      "real_time": 4.3414874999999993e+07,
-      "cpu_time": 2.0875000000031287e+04,
+      "iterations": 17,
+      "real_time": 4.0085117647058822e+07,
+      "cpu_time": 2.8428882352843029e+04,
       "time_unit": "ns",
-      "IterationTime": 4.3414874999999990e-06
+      "IterationTime": 4.0085117647058823e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/256/manual_time",
@@ -1127,11 +1127,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 16,
-      "real_time": 4.4419812500000000e+07,
-      "cpu_time": 2.2358125000065953e+04,
+      "iterations": 17,
+      "real_time": 4.1121411764705874e+07,
+      "cpu_time": 2.4378294117610720e+04,
       "time_unit": "ns",
-      "IterationTime": 4.4419812500000004e-06
+      "IterationTime": 4.1121411764705881e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/512/manual_time",
@@ -1142,11 +1142,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 16,
-      "real_time": 4.4587125000000015e+07,
-      "cpu_time": 3.0499374999992669e+04,
+      "iterations": 17,
+      "real_time": 4.1249882352941178e+07,
+      "cpu_time": 2.8883588235306026e+04,
       "time_unit": "ns",
-      "IterationTime": 4.4587125000000011e-06
+      "IterationTime": 4.1249882352941179e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/1024/manual_time",
@@ -1157,11 +1157,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 16,
-      "real_time": 4.5051875000000000e+07,
-      "cpu_time": 2.8043187500048640e+04,
+      "iterations": 17,
+      "real_time": 4.1722588235294119e+07,
+      "cpu_time": 3.0934117647037972e+04,
       "time_unit": "ns",
-      "IterationTime": 4.5051874999999996e-06
+      "IterationTime": 4.1722588235294118e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/2048/manual_time",
@@ -1172,11 +1172,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 15,
-      "real_time": 4.6239599999999993e+07,
-      "cpu_time": 2.4698000000000775e+04,
+      "iterations": 16,
+      "real_time": 4.2884812500000007e+07,
+      "cpu_time": 2.4670625000000611e+04,
       "time_unit": "ns",
-      "IterationTime": 4.6239599999999990e-06
+      "IterationTime": 4.2884812500000009e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/4096/manual_time",
@@ -1188,10 +1188,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.0309142857142866e+07,
-      "cpu_time": 2.8640714285670703e+04,
+      "real_time": 4.8333214285714291e+07,
+      "cpu_time": 2.8474999999948483e+04,
       "time_unit": "ns",
-      "IterationTime": 5.0309142857142864e-06
+      "IterationTime": 4.8333214285714289e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/8192/manual_time",
@@ -1202,11 +1202,11 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 9,
-      "real_time": 7.5753333333333328e+07,
-      "cpu_time": 2.9659999999943746e+04,
+      "iterations": 10,
+      "real_time": 7.2488000000000000e+07,
+      "cpu_time": 3.1404100000109735e+04,
       "time_unit": "ns",
-      "IterationTime": 7.5753333333333318e-06
+      "IterationTime": 7.2488000000000000e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/256/manual_time",
@@ -1218,10 +1218,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.5158076923076920e+07,
-      "cpu_time": 3.0777692307637495e+04,
+      "real_time": 5.5709769230769239e+07,
+      "cpu_time": 3.2229538461500888e+04,
       "time_unit": "ns",
-      "IterationTime": 5.5158076923076925e-06
+      "IterationTime": 5.5709769230769241e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/512/manual_time",
@@ -1233,10 +1233,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.5646153846153855e+07,
-      "cpu_time": 2.8697769230790782e+04,
+      "real_time": 5.5833307692307703e+07,
+      "cpu_time": 2.7304076922973760e+04,
       "time_unit": "ns",
-      "IterationTime": 5.5646153846153855e-06
+      "IterationTime": 5.5833307692307696e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/1024/manual_time",
@@ -1248,10 +1248,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.8108750000000007e+07,
-      "cpu_time": 3.1109166666561567e+04,
+      "real_time": 5.6855083333333343e+07,
+      "cpu_time": 3.0315000000058488e+04,
       "time_unit": "ns",
-      "IterationTime": 5.8108750000000005e-06
+      "IterationTime": 5.6855083333333342e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/2048/manual_time",
@@ -1263,10 +1263,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 6.0329833333333336e+07,
-      "cpu_time": 2.0452499999971489e+04,
+      "real_time": 5.9175833333333343e+07,
+      "cpu_time": 3.1801666666719797e+04,
       "time_unit": "ns",
-      "IterationTime": 6.0329833333333338e-06
+      "IterationTime": 5.9175833333333349e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/4096/manual_time",
@@ -1278,10 +1278,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6633000000000000e+07,
-      "cpu_time": 3.5582727272786098e+04,
+      "real_time": 6.6591818181818180e+07,
+      "cpu_time": 3.1083636363666239e+04,
       "time_unit": "ns",
-      "IterationTime": 6.6633000000000002e-06
+      "IterationTime": 6.6591818181818178e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/8192/manual_time",
@@ -1293,10 +1293,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 9,
-      "real_time": 8.1320000000000015e+07,
-      "cpu_time": 4.0972222222200748e+04,
+      "real_time": 8.1234111111111119e+07,
+      "cpu_time": 5.2923333333312585e+04,
       "time_unit": "ns",
-      "IterationTime": 8.1320000000000011e-06
+      "IterationTime": 8.1234111111111114e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/256/manual_time",
@@ -1308,10 +1308,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1741200000000000e+08,
-      "cpu_time": 4.6771833333162744e+04,
+      "real_time": 1.1727500000000000e+08,
+      "cpu_time": 3.1236666666600853e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1741199999999999e-05
+      "IterationTime": 1.1727500000000001e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/512/manual_time",
@@ -1323,10 +1323,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1782149999999999e+08,
-      "cpu_time": 2.9501666666931214e+04,
+      "real_time": 1.1769966666666669e+08,
+      "cpu_time": 2.9133333333319912e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1782149999999999e-05
+      "IterationTime": 1.1769966666666667e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/1024/manual_time",
@@ -1338,10 +1338,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1959916666666667e+08,
-      "cpu_time": 7.2574999999612060e+04,
+      "real_time": 1.1948250000000001e+08,
+      "cpu_time": 2.9984999999991636e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1959916666666667e-05
+      "IterationTime": 1.1948250000000000e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/2048/manual_time",
@@ -1353,10 +1353,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2209416666666667e+08,
-      "cpu_time": 3.8238333333495691e+04,
+      "real_time": 1.2199600000000000e+08,
+      "cpu_time": 3.0728499999928736e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2209416666666667e-05
+      "IterationTime": 1.2199599999999999e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/4096/manual_time",
@@ -1368,10 +1368,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2919520000000000e+08,
-      "cpu_time": 4.1432000000440894e+04,
+      "real_time": 1.2908500000000000e+08,
+      "cpu_time": 3.4230199999996097e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2919520000000000e-05
+      "IterationTime": 1.2908500000000002e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/8192/manual_time",
@@ -1383,10 +1383,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.4323059999999997e+08,
-      "cpu_time": 5.3293999999937114e+04,
+      "real_time": 1.4312580000000000e+08,
+      "cpu_time": 3.3862000000084437e+04,
       "time_unit": "ns",
-      "IterationTime": 1.4323059999999999e-05
+      "IterationTime": 1.4312579999999998e-05
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/256/manual_time",
@@ -1398,10 +1398,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9846777777777776e+07,
-      "cpu_time": 3.2133888888847334e+04,
+      "real_time": 3.9372777777777776e+07,
+      "cpu_time": 2.4686111111036109e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9846777777777773e-06
+      "IterationTime": 3.9372777777777776e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/512/manual_time",
@@ -1413,10 +1413,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9938888888888896e+07,
-      "cpu_time": 3.4000555555419647e+04,
+      "real_time": 3.9470555555555552e+07,
+      "cpu_time": 2.3968000000114858e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9938888888888894e-06
+      "IterationTime": 3.9470555555555550e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/1024/manual_time",
@@ -1428,10 +1428,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.0120999999999993e+07,
-      "cpu_time": 3.1871235293997015e+04,
+      "real_time": 3.9660235294117637e+07,
+      "cpu_time": 2.9934647058758950e+04,
       "time_unit": "ns",
-      "IterationTime": 4.0121000000000001e-06
+      "IterationTime": 3.9660235294117638e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/2048/manual_time",
@@ -1443,10 +1443,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.0639058823529415e+07,
-      "cpu_time": 3.3751764705873953e+04,
+      "real_time": 4.0209352941176474e+07,
+      "cpu_time": 3.2502470588306500e+04,
       "time_unit": "ns",
-      "IterationTime": 4.0639058823529418e-06
+      "IterationTime": 4.0209352941176480e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/4096/manual_time",
@@ -1458,10 +1458,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.2631812499999993e+07,
-      "cpu_time": 2.2928124999932465e+04,
+      "real_time": 4.2636875000000007e+07,
+      "cpu_time": 3.6813749999975444e+04,
       "time_unit": "ns",
-      "IterationTime": 4.2631812499999988e-06
+      "IterationTime": 4.2636875000000003e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/8192/manual_time",
@@ -1473,10 +1473,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.5801333333333336e+07,
-      "cpu_time": 2.5240666666803692e+04,
+      "real_time": 4.5246066666666664e+07,
+      "cpu_time": 3.7125333333420938e+04,
       "time_unit": "ns",
-      "IterationTime": 4.5801333333333330e-06
+      "IterationTime": 4.5246066666666667e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/256/manual_time",
@@ -1488,10 +1488,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1285058823529415e+07,
-      "cpu_time": 2.2585352941169556e+04,
+      "real_time": 4.1275941176470578e+07,
+      "cpu_time": 4.2547058823567553e+04,
       "time_unit": "ns",
-      "IterationTime": 4.1285058823529412e-06
+      "IterationTime": 4.1275941176470576e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/512/manual_time",
@@ -1503,10 +1503,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1379176470588244e+07,
-      "cpu_time": 2.3659999999882959e+04,
+      "real_time": 4.1354058823529415e+07,
+      "cpu_time": 2.8828823529385558e+04,
       "time_unit": "ns",
-      "IterationTime": 4.1379176470588239e-06
+      "IterationTime": 4.1354058823529410e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/1024/manual_time",
@@ -1518,10 +1518,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1582117647058822e+07,
-      "cpu_time": 3.2424705882259357e+04,
+      "real_time": 4.1539705882352941e+07,
+      "cpu_time": 2.9073882352919863e+04,
       "time_unit": "ns",
-      "IterationTime": 4.1582117647058827e-06
+      "IterationTime": 4.1539705882352939e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/2048/manual_time",
@@ -1533,10 +1533,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1956352941176474e+07,
-      "cpu_time": 2.7511764705762434e+04,
+      "real_time": 4.1931411764705889e+07,
+      "cpu_time": 2.4168647058786519e+04,
       "time_unit": "ns",
-      "IterationTime": 4.1956352941176474e-06
+      "IterationTime": 4.1931411764705886e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/4096/manual_time",
@@ -1548,10 +1548,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.3004125000000007e+07,
-      "cpu_time": 2.6398124999937878e+04,
+      "real_time": 4.2677312499999993e+07,
+      "cpu_time": 3.1756374999858395e+04,
       "time_unit": "ns",
-      "IterationTime": 4.3004125000000004e-06
+      "IterationTime": 4.2677312499999995e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/8192/manual_time",
@@ -1563,10 +1563,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.5527999999999993e+07,
-      "cpu_time": 2.6297333333265746e+04,
+      "real_time": 4.5233333333333343e+07,
+      "cpu_time": 2.3038000000023352e+04,
       "time_unit": "ns",
-      "IterationTime": 4.5527999999999990e-06
+      "IterationTime": 4.5233333333333338e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/256/manual_time",
@@ -1578,10 +1578,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1524766666666664e+08,
-      "cpu_time": 2.6369999999905267e+04,
+      "real_time": 1.1456350000000000e+08,
+      "cpu_time": 2.8674999999959520e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1524766666666667e-05
+      "IterationTime": 1.1456349999999999e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/512/manual_time",
@@ -1593,10 +1593,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1574033333333333e+08,
-      "cpu_time": 2.4333333333477942e+04,
+      "real_time": 1.1507766666666667e+08,
+      "cpu_time": 3.3813333333299051e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1574033333333335e-05
+      "IterationTime": 1.1507766666666667e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/1024/manual_time",
@@ -1608,10 +1608,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1764433333333333e+08,
-      "cpu_time": 2.4313333333007376e+04,
+      "real_time": 1.1711516666666669e+08,
+      "cpu_time": 2.8506166665683471e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1764433333333332e-05
+      "IterationTime": 1.1711516666666668e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/2048/manual_time",
@@ -1623,10 +1623,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2013483333333333e+08,
-      "cpu_time": 2.6438333333563452e+04,
+      "real_time": 1.1960183333333333e+08,
+      "cpu_time": 6.6521666666356323e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2013483333333333e-05
+      "IterationTime": 1.1960183333333334e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/4096/manual_time",
@@ -1638,10 +1638,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2723566666666667e+08,
-      "cpu_time": 2.4175000000070668e+04,
+      "real_time": 1.2681200000000000e+08,
+      "cpu_time": 3.0216666666878682e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2723566666666668e-05
+      "IterationTime": 1.2681200000000000e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/8192/manual_time",
@@ -1653,10 +1653,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.5994525000000000e+08,
-      "cpu_time": 2.7784999998559102e+04,
+      "real_time": 1.5939875000000000e+08,
+      "cpu_time": 3.1940250000417334e+04,
       "time_unit": "ns",
-      "IterationTime": 1.5994525000000003e-05
+      "IterationTime": 1.5939875000000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/256/manual_time",
@@ -1668,10 +1668,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2403200000000000e+08,
-      "cpu_time": 2.7731666666142017e+04,
+      "real_time": 1.2457133333333333e+08,
+      "cpu_time": 2.9838333333032100e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2403199999999998e-05
+      "IterationTime": 1.2457133333333333e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/512/manual_time",
@@ -1683,10 +1683,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2482033333333336e+08,
-      "cpu_time": 5.6040000000479042e+04,
+      "real_time": 1.2539166666666667e+08,
+      "cpu_time": 3.1493666665956727e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2482033333333334e-05
+      "IterationTime": 1.2539166666666665e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/1024/manual_time",
@@ -1698,10 +1698,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2640816666666664e+08,
-      "cpu_time": 3.8410000000747379e+04,
+      "real_time": 1.2698399999999999e+08,
+      "cpu_time": 4.5024833333684452e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2640816666666664e-05
+      "IterationTime": 1.2698399999999997e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/2048/manual_time",
@@ -1713,10 +1713,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.3163460000000003e+08,
-      "cpu_time": 2.6059999999006322e+04,
+      "real_time": 1.3205300000000003e+08,
+      "cpu_time": 2.9402000001255143e+04,
       "time_unit": "ns",
-      "IterationTime": 1.3163460000000003e-05
+      "IterationTime": 1.3205300000000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/4096/manual_time",
@@ -1728,10 +1728,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.7612950000000000e+08,
-      "cpu_time": 2.7122500000587024e+04,
+      "real_time": 1.7611825000000000e+08,
+      "cpu_time": 3.3650499998927327e+04,
       "time_unit": "ns",
-      "IterationTime": 1.7612949999999999e-05
+      "IterationTime": 1.7611824999999998e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/8192/manual_time",
@@ -1743,10 +1743,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 2.9200850000000000e+08,
-      "cpu_time": 4.6969999999646461e+04,
+      "real_time": 2.9206850000000000e+08,
+      "cpu_time": 3.5454999999018357e+04,
       "time_unit": "ns",
-      "IterationTime": 2.9200849999999997e-05
+      "IterationTime": 2.9206850000000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/256/manual_time",
@@ -1758,10 +1758,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 7.4630000000000000e+08,
-      "cpu_time": 4.9730000000636210e+04,
+      "real_time": 7.4780400000000000e+08,
+      "cpu_time": 5.9509999999818319e+04,
       "time_unit": "ns",
-      "IterationTime": 7.4629999999999995e-05
+      "IterationTime": 7.4780400000000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/512/manual_time",
@@ -1773,10 +1773,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 7.4840300000000000e+08,
-      "cpu_time": 5.2229999994324317e+04,
+      "real_time": 7.5008900000000000e+08,
+      "cpu_time": 7.9950999996469822e+04,
       "time_unit": "ns",
-      "IterationTime": 7.4840300000000002e-05
+      "IterationTime": 7.5008900000000006e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/1024/manual_time",
@@ -1788,10 +1788,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 7.5336900000000000e+08,
-      "cpu_time": 6.1159999994231388e+04,
+      "real_time": 7.5495400000000000e+08,
+      "cpu_time": 3.9229999998724452e+04,
       "time_unit": "ns",
-      "IterationTime": 7.5336899999999994e-05
+      "IterationTime": 7.5495399999999995e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/2048/manual_time",
@@ -1803,10 +1803,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 7.6541000000000000e+08,
-      "cpu_time": 6.1379999998223415e+04,
+      "real_time": 7.6649600000000000e+08,
+      "cpu_time": 3.8760999998999068e+04,
       "time_unit": "ns",
-      "IterationTime": 7.6540999999999998e-05
+      "IterationTime": 7.6649599999999992e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/4096/manual_time",
@@ -1818,10 +1818,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 8.1861000000000000e+08,
-      "cpu_time": 5.8789999997088671e+04,
+      "real_time": 8.1797200000000000e+08,
+      "cpu_time": 6.6988999996908664e+04,
       "time_unit": "ns",
-      "IterationTime": 8.1860999999999994e-05
+      "IterationTime": 8.1797200000000003e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/8192/manual_time",
@@ -1833,10 +1833,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.5095220000000000e+09,
-      "cpu_time": 6.5339999999025618e+04,
+      "real_time": 1.5088870000000000e+09,
+      "cpu_time": 3.6631000000397762e+04,
       "time_unit": "ns",
-      "IterationTime": 1.5095220000000000e-04
+      "IterationTime": 1.5088870000000000e-04
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/256/manual_time",
@@ -1848,10 +1848,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 8.5681100000000000e+08,
-      "cpu_time": 6.8460999997910229e+04,
+      "real_time": 8.5869800000000000e+08,
+      "cpu_time": 3.5448999994969199e+04,
       "time_unit": "ns",
-      "IterationTime": 8.5681100000000002e-05
+      "IterationTime": 8.5869799999999989e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/512/manual_time",
@@ -1863,10 +1863,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 8.5953100000000000e+08,
-      "cpu_time": 3.9960000002281507e+04,
+      "real_time": 8.6172900000000000e+08,
+      "cpu_time": 4.1000000003066365e+04,
       "time_unit": "ns",
-      "IterationTime": 8.5953100000000002e-05
+      "IterationTime": 8.6172899999999996e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/1024/manual_time",
@@ -1878,10 +1878,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 8.6593400000000000e+08,
-      "cpu_time": 6.1980000005235066e+04,
+      "real_time": 8.6809200000000000e+08,
+      "cpu_time": 5.9870000001183143e+04,
       "time_unit": "ns",
-      "IterationTime": 8.6593400000000003e-05
+      "IterationTime": 8.6809200000000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/2048/manual_time",
@@ -1893,10 +1893,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 8.8192400000000000e+08,
-      "cpu_time": 3.2000000004472895e+04,
+      "real_time": 8.8342200000000000e+08,
+      "cpu_time": 4.0369999993572492e+04,
       "time_unit": "ns",
-      "IterationTime": 8.8192399999999999e-05
+      "IterationTime": 8.8342200000000003e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/4096/manual_time",
@@ -1908,10 +1908,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 9.5221200000000000e+08,
-      "cpu_time": 3.6610000002212924e+04,
+      "real_time": 9.5136000000000000e+08,
+      "cpu_time": 3.8769999996191022e+04,
       "time_unit": "ns",
-      "IterationTime": 9.5221199999999989e-05
+      "IterationTime": 9.5136000000000005e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/8192/manual_time",
@@ -1923,10 +1923,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.7597450000000000e+09,
-      "cpu_time": 6.0560000001430584e+04,
+      "real_time": 1.7592110000000000e+09,
+      "cpu_time": 5.1519999999527499e+04,
       "time_unit": "ns",
-      "IterationTime": 1.7597449999999997e-04
+      "IterationTime": 1.7592110000000001e-04
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/256/manual_time",
@@ -1938,10 +1938,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9592777777777776e+07,
-      "cpu_time": 2.7309444444512112e+04,
+      "real_time": 3.9583888888888896e+07,
+      "cpu_time": 2.9735444444709301e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9592777777777775e-06
+      "IterationTime": 3.9583888888888895e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/512/manual_time",
@@ -1953,10 +1953,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9590499999999985e+07,
-      "cpu_time": 2.7111666666554709e+04,
+      "real_time": 3.9583444444444448e+07,
+      "cpu_time": 2.8216666666796504e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9590499999999990e-06
+      "IterationTime": 3.9583444444444447e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/1024/manual_time",
@@ -1968,10 +1968,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9585444444444440e+07,
-      "cpu_time": 2.6895000000119278e+04,
+      "real_time": 3.9607222222222231e+07,
+      "cpu_time": 6.5466666666698839e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9585444444444443e-06
+      "IterationTime": 3.9607222222222229e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/2048/manual_time",
@@ -1983,10 +1983,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9583166666666657e+07,
-      "cpu_time": 2.7538333333391543e+04,
+      "real_time": 3.9578944444444448e+07,
+      "cpu_time": 2.6129444444775472e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9583166666666666e-06
+      "IterationTime": 3.9578944444444445e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/4096/manual_time",
@@ -1998,10 +1998,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9602500000000000e+07,
-      "cpu_time": 3.0801111111126524e+04,
+      "real_time": 3.9594333333333336e+07,
+      "cpu_time": 3.0937388888929720e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9602499999999999e-06
+      "IterationTime": 3.9594333333333340e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/8192/manual_time",
@@ -2013,10 +2013,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9588166666666672e+07,
-      "cpu_time": 2.8473388888746362e+04,
+      "real_time": 3.9589888888888888e+07,
+      "cpu_time": 3.2294666666703932e+04,
       "time_unit": "ns",
-      "IterationTime": 3.9588166666666677e-06
+      "IterationTime": 3.9589888888888891e-06
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/256/manual_time",
@@ -2028,10 +2028,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.5150599999999997e+08,
-      "cpu_time": 3.4743999999875537e+04,
+      "real_time": 1.5149680000000000e+08,
+      "cpu_time": 3.3385999999779873e+04,
       "time_unit": "ns",
-      "IterationTime": 1.5150599999999999e-05
+      "IterationTime": 1.5149679999999999e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/512/manual_time",
@@ -2043,10 +2043,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.5150260000000000e+08,
-      "cpu_time": 3.8549999999304418e+04,
+      "real_time": 1.5149260000000000e+08,
+      "cpu_time": 3.1833999999264506e+04,
       "time_unit": "ns",
-      "IterationTime": 1.5150260000000000e-05
+      "IterationTime": 1.5149259999999998e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/1024/manual_time",
@@ -2058,10 +2058,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.5151260000000000e+08,
-      "cpu_time": 4.0822599999046361e+04,
+      "real_time": 1.5149380000000000e+08,
+      "cpu_time": 3.0017999999643052e+04,
       "time_unit": "ns",
-      "IterationTime": 1.5151259999999999e-05
+      "IterationTime": 1.5149379999999998e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/2048/manual_time",
@@ -2073,10 +2073,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.5151060000000000e+08,
-      "cpu_time": 3.7933999999495427e+04,
+      "real_time": 1.5149899999999997e+08,
+      "cpu_time": 3.0529600000761548e+04,
       "time_unit": "ns",
-      "IterationTime": 1.5151060000000000e-05
+      "IterationTime": 1.5149899999999999e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/4096/manual_time",
@@ -2088,10 +2088,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.9537200000000003e+08,
-      "cpu_time": 4.6939999998940606e+04,
+      "real_time": 1.9401900000000000e+08,
+      "cpu_time": 3.3119500001177468e+04,
       "time_unit": "ns",
-      "IterationTime": 1.9537200000000003e-05
+      "IterationTime": 1.9401899999999998e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/8192/manual_time",
@@ -2103,10 +2103,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 3.0045750000000006e+08,
-      "cpu_time": 6.5375000001921537e+04,
+      "real_time": 2.9977750000000006e+08,
+      "cpu_time": 4.1705000001002190e+04,
       "time_unit": "ns",
-      "IterationTime": 3.0045750000000006e-05
+      "IterationTime": 2.9977749999999999e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/256/manual_time",
@@ -2118,10 +2118,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.1301980000000000e+09,
-      "cpu_time": 5.2300000000116139e+04,
+      "real_time": 1.1300640000000000e+09,
+      "cpu_time": 4.5010000000900167e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1301980000000000e-04
+      "IterationTime": 1.1300640000000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/512/manual_time",
@@ -2133,10 +2133,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.1301540000000000e+09,
-      "cpu_time": 6.7409999999767926e+04,
+      "real_time": 1.1301880000000000e+09,
+      "cpu_time": 5.4261000002497894e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1301540000000002e-04
+      "IterationTime": 1.1301879999999998e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/1024/manual_time",
@@ -2148,10 +2148,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.1301960000000000e+09,
-      "cpu_time": 5.7210000001362001e+04,
+      "real_time": 1.1300930000000000e+09,
+      "cpu_time": 4.7519999995415674e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1301960000000001e-04
+      "IterationTime": 1.1300930000000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/2048/manual_time",
@@ -2163,10 +2163,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.1301650000000000e+09,
-      "cpu_time": 6.5230000004135036e+04,
+      "real_time": 1.1301800000000000e+09,
+      "cpu_time": 4.5689999993214769e+04,
       "time_unit": "ns",
-      "IterationTime": 1.1301650000000000e-04
+      "IterationTime": 1.1301799999999999e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/4096/manual_time",
@@ -2178,10 +2178,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.2159380000000000e+09,
-      "cpu_time": 5.6770000000483378e+04,
+      "real_time": 1.2113500000000000e+09,
+      "cpu_time": 4.0750000003697554e+04,
       "time_unit": "ns",
-      "IterationTime": 1.2159379999999999e-04
+      "IterationTime": 1.2113499999999998e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/8192/manual_time",
@@ -2193,10 +2193,10 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.7595660000000000e+09,
-      "cpu_time": 6.3640000000475542e+04,
+      "real_time": 1.7555520000000000e+09,
+      "cpu_time": 7.4441999998953179e+04,
       "time_unit": "ns",
-      "IterationTime": 1.7595660000000000e-04
+      "IterationTime": 1.7555520000000000e-04
     }
   ]
 }


### PR DESCRIPTION


### Problem description
one_processors_all_cores_1_rta and all_processors_all_cores_1_rta show improvements always. Otherwise sometimes the test flakes due to performance issues in the 4-5% range.

### What's changed
Since this golden file was created, the performance of one_processors_all_cores_1_rta and all_processors_all_cores_1_rta seems to have improved, so update the baseline file from a newer CI run.

Also increase the threshold to 5, since all the test flakes have been less than 5% off, and update the comparison script to show the percent difference.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
