### PR TITLE
Add nightly APC run in debug mode

### DIFF
--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -19,4 +19,4 @@ jobs:
   nightly-debug:
     uses: ./.github/workflows/all-post-commit-tests.yaml
     with:
-      build-type: Debug
+      build-type: RelWithDebInfo

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -1,0 +1,22 @@
+name: "apc nightly debug run"
+
+on:
+  schedule:
+    # Runs nightly at 12:00 AM UTC
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
+  packages: write
+
+jobs:
+  nightly-debug:
+    uses: ./.github/workflows/all-post-commit-tests.yaml
+    with:
+      build-type: Debug


### PR DESCRIPTION
### Problem description
There are several TT_ASSERT call sites that fail, yet test cases pass, because we run in Release mode.

### What's changed
Run APC in debug mode once per day, to help flag these issues sooner.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
