### PR TITLE
#15976: Ensure reports insert all devices into the devices table

### DIFF
--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -121,7 +121,7 @@ def get_devices(object_value):
     devices = set()
     if isinstance(object_value, ttnn.Tensor):
         if ttnn.is_tensor_storage_on_device(object_value) and object_value.is_allocated():
-            devices.add(object_value.device())
+            devices.update(object_value.devices())
     elif isinstance(object_value, ttnn.Device):
         devices.add(object_value)
     elif isinstance(object_value, (list, tuple)):


### PR DESCRIPTION
### Ticket
Link to Github Issue [#15976]

### Problem description

When generating reports, the `devices` table in the `db.sqlite` db only contained one device, even when running on machines with multiple devices. This occurred even when the debug output when running Pytest showed the multiple devices were found and in use. 

### What's changed

The logic in the `ttnn.ttnn.decorators.get_devices` function is being changed to called `object_value.devices()` instead of `object_value.device()`.

The `object_value` arg can be of multiple types. In the case of an instance of `ttnn.Tensor`, the `object_value` object has two relevant methods: `object_value.device()` and `object_value.devices()`. The function with the singular name always returns just one device object, and with the plural name, it returns a list of devices objects.

This `get_devices` function could only ever return 1 device when called with a Tensor object. The code that inserts the devices into the devices table depends on the return value from this function, so it was only writing one device record.

When changing it to use the plural `object_value.devices()` function call, the set returned by `get_devices()` has the other devices, and the `ttnn.ttnn.database.insert_devices` function works as expected, with no other changes required, when iterating over the items in the `devices` set.

### Testing

I have done testing primarily by running `pytest models/demos/llama/tests/test_llama_attention.py` on a machine with two devices. I have the `TTNN_CONFIG_OVERRIDES` env var set to enable the detailed buffer report.

Prior to this change it would add 1 record only, for device 0, to the `devices` table. With this change, I observe that it successfully adds the two device records that I expect to the `devices` table, one for device 0 and one for device 1, and the `pytest` command finishes tests without any errors.

### Checklist
- [X] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
