### PR TITLE
#16078: Fix back-to-back calls of ttnn.close_device()

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1031,6 +1031,10 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
 }
 
 void Device::push_work(std::function<void()> work, bool blocking) {
+    if (not this->initialized_) {
+        log_warning("Attempting to push work to Device {} which is not initialized. Ignoring...", this->id_);
+        return;
+    }
     this->work_executor_.push_work(std::move(work), blocking);
 }
 
@@ -1523,6 +1527,10 @@ bool Device::can_use_passthrough_scheduling() const {
 }
 
 void Device::synchronize() {
+    if (not this->initialized_) {
+        log_warning("Attempting to synchronize Device {} which is not initialized. Ignoring...", this->id_);
+        return;
+    }
     this->work_executor_.synchronize();
 }
 


### PR DESCRIPTION

### Ticket
https://github.com/tenstorrent/tt-metal/issues/16078

### Problem description
Repeated ttnn.close_device() calls on the same device causes an error.

### What's changed
Issue was with the ttnn.synchronize_device() call inside of ttnn.close_device(). Add a warning message and skip for metal Device.synchronize() if the Device is not initialized.

Metal DevicePool close_device function already checks for whether the device is initialized, so no fix needed there.

### Checklist
- [x] Post commit CI passes - Running now: https://github.com/tenstorrent/tt-metal/actions/runs/12820717260
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
