### PR TITLE
Bring Taskflow from CPM

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -104,7 +104,7 @@ jobs:
     - uses: lukka/get-cmake@b516803a3c5fac40e2e922349d15cdebdba01e60
       if: steps.changed-cmake-files.outputs.any_changed == 'true'
       with:
-        cmakeVersion: "~3.16.0"
+        cmakeVersion: "~3.18.0"
     - name: Check CMake version
       if: steps.changed-cmake-files.outputs.any_changed == 'true'
       run: cmake --version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "tt_metal/third_party/taskflow"]
-	path = tt_metal/third_party/taskflow
-	url = https://github.com/taskflow/taskflow
 [submodule "tt_metal/third_party/tracy"]
 	path = tt_metal/third_party/tracy
 	url = https://github.com/tenstorrent-metal/tracy.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16..3.30)
+cmake_minimum_required(VERSION 3.18..3.30)
 
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -31,8 +31,6 @@ Note the current compatability matrix:
 ```sh
 sudo ./install_dependencies.sh
 ```
-- Note: `CMake 3.16` is the targetted required version of `CMake` as it aligns with the default from `Ubuntu 20.04`. Some advanced build configurations like unity builds require `CMake 3.20`.
-  - To install `CMake 3.20` see: https://github.com/tenstorrent/tt-metal/blob/4d7730d3e2d22c51d62baa1bfed861b557d9a3c0/dockerfile/ubuntu-20.04-amd64.Dockerfile#L9-L14
 ---
 
 ### Step 3. Install and start using TT-NN and TT-Metalium!

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -127,8 +127,9 @@ if(benchmark_ADDED)
     )
 endif()
 
-# TODO(afuller): Move this to CPM and use upstream's CMake file, AFTER we move to Ubuntu 22.04 and drop 20.04 and bump
-#                our minimum CMake version accordingly.  Taskflow's CMake wants v3.18+
-add_library(Taskflow INTERFACE)
+############################################################################################################################
+# taskflow : https://github.com/taskflow/taskflow
+############################################################################################################################
+
+CPMAddPackage(NAME taskflow GITHUB_REPOSITORY taskflow/taskflow GIT_TAG v3.7.0)
 add_library(Taskflow::Taskflow ALIAS Taskflow)
-target_include_directories(Taskflow SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/tt_metal/third_party/taskflow)


### PR DESCRIPTION
### Problem description
Submodules stink, and require manual integration.

### What's changed
Bring in Taskflow from CPM package manager, and have it automatically configured for build in the CMake project.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12825224332)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
