### PR TITLE
#15824 Workaround LLK issue in max_pool

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
@@ -107,8 +107,7 @@ void MAIN {
     constexpr uint32_t num_output_tiles = in_ntiles_c / in_nblocks_c;
     tilizeA_B_reduce_init<true>(
         in_cb_id, in_scalar_cb_id, num_output_tiles, out_cb_id, num_faces_in_tile, window_size_hw);
-    pack_untilize_dst_init_short<in_ntiles_c>(
-        out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
+    pack_untilize_dst_init_short(out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
 
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core; ++i) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
@@ -107,6 +107,8 @@ void MAIN {
     constexpr uint32_t num_output_tiles = in_ntiles_c / in_nblocks_c;
     tilizeA_B_reduce_init<true>(
         in_cb_id, in_scalar_cb_id, num_output_tiles, out_cb_id, num_faces_in_tile, window_size_hw);
+    // Omitted pasing in_ntiles_c as template argument to pack_untilize_dst_init_short
+    // Workaround for tt-metal#15824
     pack_untilize_dst_init_short(out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
 
     cb_wait_front(in_scalar_cb_id, 1);


### PR DESCRIPTION
pack_untilize_dst is causing issues on GS and WH
in case where reduce op is called after max_pool.

Workaround is to use default value for block_ct_dim in pack_untilize_dst_init_short in max_pool kernel.

This doesn't affect correctness of max_pool op
and resolves the issue on subsequent reduce op.

Perf looks good on model device perf tests.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15824)

This issue should still be properly solved on LLK level, but given it's P0 in metal this should serve as a workaround until it does.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12829298444/job/35775107907
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
