### PR TITLE
This file seems to be kernel-only

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -922,7 +922,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = tt_metal/api/tt-metalium/dataflow_api.h \
+INPUT                  = tt_metal/hw/inc/dataflow_api.h \
                          tt_metal/hw/inc/ethernet/dataflow_api.h \
                          tt_metal/api/tt-metalium/host_api.hpp \
                          tt_metal/include/compute_kernel_api/eltwise_unary/erf_erfc.h \

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_master_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_master_test_kernel.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_slave_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_slave_test_kernel.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/tt_fabric/impl/kernels/tt_fabric_router.cpp
+++ b/tt_fabric/impl/kernels/tt_fabric_router.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // clang-format off
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 #include "hw/inc/tt_fabric.h"
 // clang-format on
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -69,7 +69,8 @@ extern uint32_t tt_l1_ptr* sem_l1_base[];
 #define DYNAMIC_NOC_DIRECTION(noc, direction) (noc == 1 ? 1 - direction : direction)
 
 static_assert(NUM_NOCS == 2);
-// "Scratch" in L1 has space allocated for 256 DRAM and L1 enteries, to store offsets and NOC XY data. (MEM_BANK_TO_NOC_XY_SCRATCH and MEM_BANK_OFFSET_SCRATCH)
+// "Scratch" in L1 has space allocated for 256 DRAM and L1 enteries, to store offsets and NOC XY data.
+// (MEM_BANK_TO_NOC_XY_SCRATCH and MEM_BANK_OFFSET_SCRATCH)
 static_assert((NUM_DRAM_BANKS + NUM_L1_BANKS) <= 256);
 
 namespace interleaved_addr_gen {
@@ -1264,7 +1265,6 @@ struct InterleavedPow2AddrGenFast {
             noc_nonposted_writes_num_issued[noc] += 1;
             noc_nonposted_writes_acked[noc] += 1;  // num_dests
         }
-
     }
 };
 
@@ -1999,9 +1999,9 @@ void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTD");
 }
 
-template<bool DRAM>
-FORCE_INLINE
-uint64_t get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_t noc = noc_index) {
+template <bool DRAM>
+FORCE_INLINE uint64_t
+get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_t noc = noc_index) {
     // Use addrgen tables to convert bank_ids to physical NOC coordinates
     uint64_t noc_addr = 0;
     if constexpr (DRAM) {

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -13,7 +13,7 @@
 
 #include "tools/profiler/kernel_profiler.hpp"
 #include "noc_nonblocking_api.h"
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 #include "tunneling.h"
 
 /**

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_sem_creator.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_sem_creator.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <cstdint>
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 #include "dataflow_api.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/kernels/barrier_sender.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 #include <array>
 #include "tt_metal/hw/inc/ethernet/dataflow_api.h"
 #include "cpp/ttnn/operations/ccl/kernels/edm/edm_handshake.hpp"

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 
 #include "debug/dprint.h"
-#include <tt-metalium/dataflow_api.h>
+#include "dataflow_api.h"
 #include "tt_metal/hw/inc/ethernet/tunneling.h"
 #include <tt-metalium/risc_attribs.h>
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"


### PR DESCRIPTION
### Ticket
none

### Problem description
Seems I moved this one in error; it's only consumed externally by kernels, not host-code.

### What's changed
Put dataflow_api.h back to where it was.
clang-format auto-reformatted the code since I've touched the file now 😄 

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12832562541
  - Passed except for Docs -- fixed in a follow-up commit
