### PR TITLE
Remove global `node_id_to_kernel`

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -38,7 +38,8 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {}) noexcept;
 
     IDevice* get_active_device(chip_id_t device_id) const;
-    std::vector<IDevice* > get_all_active_devices() const;
+    std::vector<IDevice*> get_all_active_devices() const;
+    std::set<chip_id_t> get_all_active_device_ids() const;
     bool close_device(chip_id_t device_id);
     void close_devices(const std::vector<IDevice*>& devices);
     bool is_device_active(chip_id_t id) const;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -848,7 +848,7 @@ void Device::compile_command_queue_programs() {
     auto command_queue_program_ptr = std::make_unique<Program>();
     auto mmio_command_queue_program_ptr = std::make_unique<Program>();
     if (this->is_mmio_capable()) {
-        auto command_queue_program_ptr = create_and_compile_cq_program(this);
+        auto command_queue_program_ptr = dispatch::create_and_compile_cq_program(this);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
         // Since devices could be set up in any order, on mmio device do a pass and populate cores for tunnelers.
         if (tt::Cluster::instance().get_mmio_device_tunnel_count(this->id_) > 0) {
@@ -864,7 +864,7 @@ void Device::compile_command_queue_programs() {
             }
         }
     } else {
-        auto command_queue_program_ptr = create_and_compile_cq_program(this);
+        auto command_queue_program_ptr = dispatch::create_and_compile_cq_program(this);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
     }
 }
@@ -909,7 +909,7 @@ void Device::configure_command_queue_programs() {
     }
 
     // Write device-side cq pointers
-    configure_dispatch_cores(this);
+    dispatch::configure_dispatch_cores(this);
 
     // Run the cq program
     program_dispatch::finalize_program_offsets(command_queue_program, this);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -358,7 +358,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     }
     this->using_fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
     if (this->using_fast_dispatch) {
-        populate_fd_kernels(devices_to_activate, this->num_hw_cqs);
+        dispatch::populate_fd_kernels(devices_to_activate, this->num_hw_cqs);
     }
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -8,6 +8,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void DemuxKernel::GenerateStaticConfigs() {
@@ -182,3 +184,5 @@ void DemuxKernel::CreateKernel() {
         {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[DEMUX], compile_args, defines, false, false, false);
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -6,6 +6,7 @@
 #include "eth_tunneler.hpp"
 
 #include <host_api.hpp>
+#include <memory>
 #include <tt_metal.hpp>
 
 namespace tt::tt_metal::dispatch {
@@ -29,7 +30,7 @@ void DemuxKernel::GenerateStaticConfigs() {
     static_config_.timeout_cycles = 0;
 
     for (int idx = 0; idx < downstream_kernels_.size(); idx++) {
-        FDKernel* k = downstream_kernels_[idx];
+        const auto& k = downstream_kernels_[idx];
         static_config_.remote_tx_queue_id[idx] = 0;
         static_config_.remote_tx_network_type[idx] = (uint32_t)DispatchRemoteNetworkType::NOC0;
         static_config_.output_depacketize_cb_log_page_size[idx] = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
@@ -42,16 +43,17 @@ void DemuxKernel::GenerateStaticConfigs() {
 void DemuxKernel::GenerateDependentConfigs() {
     // Upstream, expect EthTunneler or DEMUX
     TT_ASSERT(upstream_kernels_.size() == 1);
-    if (auto us = dynamic_cast<EthTunnelerKernel*>(upstream_kernels_[0])) {
+    if (const auto& us = std::dynamic_pointer_cast<EthTunnelerKernel>(upstream_kernels_[0])) {
         dependent_config_.remote_rx_x = us->GetVirtualCore().x;
         dependent_config_.remote_rx_y = us->GetVirtualCore().y;
         dependent_config_.remote_rx_queue_id = us->GetStaticConfig().vc_count.value() * 2 - 1;
-    } else if (auto us = dynamic_cast<DemuxKernel*>(upstream_kernels_[0])) {
+    } else if (const auto& us = std::dynamic_pointer_cast<DemuxKernel>(upstream_kernels_[0])) {
         dependent_config_.remote_rx_x = us->GetVirtualCore().x;
         dependent_config_.remote_rx_y = us->GetVirtualCore().y;
-        dependent_config_.remote_rx_queue_id = us->GetDownstreamPort(this) + 1;  // TODO: can this be cleaned up?
+        dependent_config_.remote_rx_queue_id =
+            us->GetDownstreamPort(this->shared_from_this()) + 1;  // TODO: can this be cleaned up?
         // TODO: why is just this one different? Just match previous implementation for now
-        if (us->GetDownstreamPort(this) == 1) {
+        if (us->GetDownstreamPort(this->shared_from_this()) == 1) {
             static_config_.endpoint_id_start_index =
                 static_config_.endpoint_id_start_index.value() + downstream_kernels_.size();
         }
@@ -63,11 +65,11 @@ void DemuxKernel::GenerateDependentConfigs() {
     TT_ASSERT(downstream_kernels_.size() <= MAX_SWITCH_FAN_OUT && downstream_kernels_.size() > 0);
     dependent_config_.output_depacketize = 0;  // Populated per downstream kernel
     for (int idx = 0; idx < downstream_kernels_.size(); idx++) {
-        FDKernel* k = downstream_kernels_[idx];
+        auto k = downstream_kernels_[idx];
         dependent_config_.remote_tx_x[idx] = k->GetVirtualCore().x;
         dependent_config_.remote_tx_y[idx] = k->GetVirtualCore().y;
         // Expect downstream to be either a DISPATCH or another DEMUX
-        if (auto dispatch_kernel = dynamic_cast<DispatchKernel*>(k)) {
+        if (const auto& dispatch_kernel = std::dynamic_pointer_cast<DispatchKernel>(k)) {
             dependent_config_.remote_tx_queue_start_addr_words[idx] =
                 dispatch_kernel->GetStaticConfig().dispatch_cb_base.value() >> 4;
             dependent_config_.remote_tx_queue_size_words[idx] =
@@ -83,7 +85,7 @@ void DemuxKernel::GenerateDependentConfigs() {
             uint64_t dest_endpoint_output_map = packet_switch_dest_pack(dest_map_array, 4);
             dependent_config_.dest_endpoint_output_map_hi = (uint32_t)(dest_endpoint_output_map >> 32);
             dependent_config_.dest_endpoint_output_map_lo = (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF);
-        } else if (auto demux_kernel = dynamic_cast<DemuxKernel*>(k)) {
+        } else if (const auto& demux_kernel = std::dynamic_pointer_cast<DemuxKernel>(k)) {
             dependent_config_.remote_tx_queue_start_addr_words[idx] =
                 demux_kernel->GetStaticConfig().rx_queue_start_addr_words.value();
             dependent_config_.remote_tx_queue_size_words[idx] = 0x1000;  // TODO: hard-coded on previous implementation

--- a/tt_metal/impl/dispatch/kernel_config/demux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.hpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+
 #include "fd_kernel.hpp"
+
+namespace tt::tt_metal::dispatch {
 
 typedef struct demux_static_config {
     std::optional<uint32_t> endpoint_id_start_index;
@@ -53,3 +56,5 @@ private:
     demux_dependent_config_t dependent_config_;
     int placement_cq_id_;  // TODO: remove channel hard-coding for dispatch core manager
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -10,6 +10,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void DispatchKernel::GenerateStaticConfigs() {
@@ -364,3 +366,5 @@ void DispatchKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, completion_q1_last_event_ptr, zero, GetCoreType());
     }
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct dispatch_static_config {
     std::optional<uint32_t> dispatch_cb_base;  // 0
     std::optional<uint32_t> dispatch_cb_log_page_size;
@@ -94,3 +96,5 @@ private:
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -6,6 +6,7 @@
 #include "prefetch.hpp"
 
 #include <host_api.hpp>
+#include <memory>
 #include <tt_metal.hpp>
 
 namespace tt::tt_metal::dispatch {
@@ -54,15 +55,15 @@ void DispatchSKernel::GenerateStaticConfigs() {
 void DispatchSKernel::GenerateDependentConfigs() {
     // Upstream
     TT_ASSERT(upstream_kernels_.size() == 1);
-    auto prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0]);
-    TT_ASSERT(prefetch_kernel);
+    const auto& prefetch_kernel = std::dynamic_pointer_cast<PrefetchKernel>(upstream_kernels_[0]);
+    TT_ASSERT(prefetch_kernel != nullptr);
     dependent_config_.upstream_logical_core = prefetch_kernel->GetLogicalCore();
     dependent_config_.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_dispatch_s_cb_sem_id;
 
     // Downstream
     TT_ASSERT(downstream_kernels_.size() == 1);
-    auto dispatch_kernel = dynamic_cast<DispatchKernel*>(downstream_kernels_[0]);
-    TT_ASSERT(dispatch_kernel);
+    const auto& dispatch_kernel = std::dynamic_pointer_cast<DispatchKernel>(downstream_kernels_[0]);
+    TT_ASSERT(dispatch_kernel != nullptr);
     dependent_config_.downstream_logical_core = dispatch_kernel->GetLogicalCore();
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -8,6 +8,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void DispatchSKernel::GenerateStaticConfigs() {
@@ -129,3 +131,5 @@ void DispatchSKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, dispatch_message_addr, zero, GetCoreType());
     }
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+
 #include "fd_kernel.hpp"
+
+namespace tt::tt_metal::dispatch {
 
 typedef struct dispatch_s_static_config {
     std::optional<uint32_t> cb_base;
@@ -43,3 +46,5 @@ private:
     dispatch_s_static_config_t static_config_;
     dispatch_s_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -6,6 +6,7 @@
 #include "eth_tunneler.hpp"
 
 #include <host_api.hpp>
+#include <memory>
 #include <tt_metal.hpp>
 
 namespace tt::tt_metal::dispatch {
@@ -68,7 +69,7 @@ void EthRouterKernel::GenerateStaticConfigs() {
             static_config_.output_depacketize_local_sem[idx] =
                 tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
             // Forwward VCs are the ones that don't connect to a prefetch
-            if (auto pk = dynamic_cast<PrefetchKernel*>(downstream_kernels_[idx])) {
+            if (const auto& pk = std::dynamic_pointer_cast<PrefetchKernel>(downstream_kernels_[idx])) {
                 static_config_.fwd_vc_count = this->static_config_.fwd_vc_count.value() - 1;
             }
         }
@@ -87,13 +88,13 @@ void EthRouterKernel::GenerateDependentConfigs() {
 
         // Downstream, expect US_TUNNELER_REMOTE
         TT_ASSERT(downstream_kernels_.size() == 1);
-        auto tunneler_kernel = dynamic_cast<EthTunnelerKernel*>(downstream_kernels_[0]);
-        TT_ASSERT(tunneler_kernel);
+        auto tunneler_kernel = std::dynamic_pointer_cast<EthTunnelerKernel>(downstream_kernels_[0]);
+        TT_ASSERT(tunneler_kernel != nullptr);
 
-        uint32_t router_id = tunneler_kernel->GetRouterId(this, true);
+        uint32_t router_id = tunneler_kernel->GetRouterId(this->shared_from_this(), true);
         for (int idx = 0; idx < upstream_kernels_.size(); idx++) {
-            auto prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[idx]);
-            TT_ASSERT(prefetch_kernel);
+            auto prefetch_kernel = std::dynamic_pointer_cast<PrefetchKernel>(upstream_kernels_[idx]);
+            TT_ASSERT(prefetch_kernel != nullptr);
             dependent_config_.remote_tx_x[idx] = tunneler_kernel->GetVirtualCore().x;
             dependent_config_.remote_tx_y[idx] = tunneler_kernel->GetVirtualCore().y;
             dependent_config_.remote_tx_queue_id[idx] = idx + MAX_SWITCH_FAN_IN * router_id;
@@ -121,26 +122,27 @@ void EthRouterKernel::GenerateDependentConfigs() {
     } else {
         // Upstream, expect US_TUNNELER_LOCAL
         TT_ASSERT(upstream_kernels_.size() == 1);
-        auto us_tunneler_kernel = dynamic_cast<EthTunnelerKernel*>(upstream_kernels_[0]);
-        TT_ASSERT(us_tunneler_kernel);
+        auto us_tunneler_kernel = std::dynamic_pointer_cast<EthTunnelerKernel>(upstream_kernels_[0]);
+        TT_ASSERT(us_tunneler_kernel != nullptr);
         // Upstream queues connect to the upstream tunneler, as many queues as we have VCs
         for (int idx = 0; idx < static_config_.vc_count.value(); idx++) {
             dependent_config_.remote_rx_x[idx] = us_tunneler_kernel->GetVirtualCore().x;
             dependent_config_.remote_rx_y[idx] = us_tunneler_kernel->GetVirtualCore().y;
             // Queue id starts counting after the input VCs
-            dependent_config_.remote_rx_queue_id[idx] = us_tunneler_kernel->GetRouterQueueIdOffset(this, false) + idx;
+            dependent_config_.remote_rx_queue_id[idx] =
+                us_tunneler_kernel->GetRouterQueueIdOffset(this->shared_from_this(), false) + idx;
             dependent_config_.remote_rx_network_type[idx] = (uint32_t)DispatchRemoteNetworkType::NOC0;
         }
 
         // Downstream, expect PREFETCH_D/US_TUNNELER_REMOTE
         TT_ASSERT(downstream_kernels_.size() <= MAX_SWITCH_FAN_OUT && downstream_kernels_.size() > 0);
-        std::vector<PrefetchKernel*> prefetch_kernels;
-        EthTunnelerKernel* ds_tunneler_kernel = nullptr;
-        for (auto k : downstream_kernels_) {
-            if (auto pk = dynamic_cast<PrefetchKernel*>(k)) {
-                prefetch_kernels.push_back(pk);
-            } else if (auto tk = dynamic_cast<EthTunnelerKernel*>(k)) {
-                ds_tunneler_kernel = tk;
+        std::vector<std::shared_ptr<PrefetchKernel>> prefetch_kernels;
+        std::shared_ptr<EthTunnelerKernel> ds_tunneler_kernel;
+        for (const auto& k : downstream_kernels_) {
+            if (auto pk = std::dynamic_pointer_cast<PrefetchKernel>(k)) {
+                prefetch_kernels.push_back(std::move(pk));
+            } else if (auto tk = std::dynamic_pointer_cast<EthTunnelerKernel>(k)) {
+                ds_tunneler_kernel = std::move(tk);
             } else {
                 TT_FATAL(false, "Unexpected kernel type downstream of ROUTER");
             }
@@ -148,7 +150,7 @@ void EthRouterKernel::GenerateDependentConfigs() {
 
         // Populate remote_tx_* for prefetch kernels, assume they are connected "first"
         uint32_t remote_idx = 0;
-        for (auto prefetch_kernel : prefetch_kernels) {
+        for (const auto& prefetch_kernel : prefetch_kernels) {
             dependent_config_.remote_tx_x[remote_idx] = prefetch_kernel->GetVirtualCore().x;
             dependent_config_.remote_tx_y[remote_idx] = prefetch_kernel->GetVirtualCore().y;
             dependent_config_.remote_tx_queue_id[remote_idx] = 0;  // Prefetch queue id always 0
@@ -169,7 +171,7 @@ void EthRouterKernel::GenerateDependentConfigs() {
                 dependent_config_.remote_tx_x[remote_idx] = ds_tunneler_kernel->GetVirtualCore().x;
                 dependent_config_.remote_tx_y[remote_idx] = ds_tunneler_kernel->GetVirtualCore().y;
                 dependent_config_.remote_tx_queue_id[remote_idx] =
-                    ds_tunneler_kernel->GetRouterQueueIdOffset(this, true) + idx;
+                    ds_tunneler_kernel->GetRouterQueueIdOffset(this->shared_from_this(), true) + idx;
                 dependent_config_.remote_tx_network_type[remote_idx] = (uint32_t)DispatchRemoteNetworkType::NOC0;
                 dependent_config_.remote_tx_queue_start_addr_words[remote_idx] =
                     ds_tunneler_kernel->GetStaticConfig().in_queue_start_addr_words.value() +

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -8,6 +8,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void EthRouterKernel::GenerateStaticConfigs() {
@@ -292,3 +294,5 @@ void EthRouterKernel::CreateKernel() {
         {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[PACKET_ROUTER_MUX], compile_args, defines, false, false, false);
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct eth_router_static_config {
     std::optional<uint32_t> vc_count;                   // Set from arch level
     std::optional<uint32_t> fwd_vc_count;               // # of VCs continuing on to the next chip
@@ -64,3 +66,5 @@ private:
     int placement_cq_id_;  // TODO: remove channel hard-coding for dispatch core manager
     bool as_mux_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -9,6 +9,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void EthTunnelerKernel::GenerateStaticConfigs() {
@@ -347,3 +349,5 @@ uint32_t EthTunnelerKernel::GetRouterId(FDKernel* k, bool upstream) {
     TT_ASSERT(false, "Couldn't find router kernel");
     return router_id;
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 #include "fd_kernel.hpp"
+#include <memory>
 
 namespace tt::tt_metal::dispatch {
 
@@ -52,8 +53,8 @@ public:
     const eth_tunneler_static_config_t& GetStaticConfig() { return static_config_; }
     bool IsRemote() { return is_remote_; }
     void SetVCCount(uint32_t vc_count) { static_config_.vc_count = vc_count; }
-    uint32_t GetRouterQueueIdOffset(FDKernel* k, bool upstream);
-    uint32_t GetRouterId(FDKernel* k, bool upstream);
+    uint32_t GetRouterQueueIdOffset(const std::shared_ptr<FDKernel>& k, bool upstream);
+    uint32_t GetRouterId(const std::shared_ptr<FDKernel>& k, bool upstream);
 
 private:
     eth_tunneler_static_config_t static_config_;

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct eth_tunneler_static_config {
     std::optional<uint32_t> endpoint_id_start_index;
     std::optional<uint32_t> vc_count;  // Set from arch level
@@ -58,3 +60,5 @@ private:
     eth_tunneler_dependent_config_t dependent_config_;
     bool is_remote_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -15,6 +15,8 @@
 #include "eth_router.hpp"
 #include "eth_tunneler.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 // Helper function to get upstream device in the tunnel from current device, not valid for mmio
@@ -147,3 +149,5 @@ void FDKernel::configure_kernel_variant(
                 .defines = defines});
     }
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -63,7 +63,7 @@ uint32_t FDKernel::GetTunnelStop(chip_id_t device_id) {
     return 0;
 }
 
-FDKernel* FDKernel::Generate(
+std::unique_ptr<FDKernel> FDKernel::Generate(
     int node_id,
     chip_id_t device_id,
     chip_id_t servicing_device_id,
@@ -72,28 +72,39 @@ FDKernel* FDKernel::Generate(
     DispatchWorkerType type) {
     switch (type) {
         case PREFETCH_HD:
-            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
+            return std::make_unique<PrefetchKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
         case PREFETCH_H:
-            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
+            return std::make_unique<PrefetchKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
         case PREFETCH_D:
-            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
+            return std::make_unique<PrefetchKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
         case DISPATCH_HD:
-            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
+            return std::make_unique<DispatchKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
         case DISPATCH_H:
-            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
+            return std::make_unique<DispatchKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
         case DISPATCH_D:
-            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
-        case DISPATCH_S: return new DispatchSKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection);
-        case MUX_D: return new MuxKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection);
-        case DEMUX: return new DemuxKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection);
+            return std::make_unique<DispatchKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
+        case DISPATCH_S:
+            return std::make_unique<DispatchSKernel>(node_id, device_id, servicing_device_id, cq_id, noc_selection);
+        case MUX_D: return std::make_unique<MuxKernel>(node_id, device_id, servicing_device_id, cq_id, noc_selection);
+        case DEMUX: return std::make_unique<DemuxKernel>(node_id, device_id, servicing_device_id, cq_id, noc_selection);
         case US_TUNNELER_REMOTE:
-            return new EthTunnelerKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true);
+            return std::make_unique<EthTunnelerKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true);
         case US_TUNNELER_LOCAL:
-            return new EthTunnelerKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false);
+            return std::make_unique<EthTunnelerKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, false);
         case PACKET_ROUTER_MUX:
-            return new EthRouterKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true);
+            return std::make_unique<EthRouterKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true);
         case PACKET_ROUTER_DEMUX:
-            return new EthRouterKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false);
+            return std::make_unique<EthRouterKernel>(
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, false);
         default: TT_FATAL(false, "Unrecognized dispatch kernel type: {}.", type); return nullptr;
     }
 }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -10,6 +10,8 @@
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
 #define UNUSED_SEM_ID 0
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct {
     NOC non_dispatch_noc;  // For communicating with workers/DRAM/host
     NOC upstream_noc;      // For communicating with upstream dispatch modules
@@ -130,3 +132,5 @@ protected:
     std::vector<FDKernel*> upstream_kernels_;
     std::vector<FDKernel*> downstream_kernels_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -9,6 +9,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void MuxKernel::GenerateStaticConfigs() {
@@ -149,3 +151,5 @@ void MuxKernel::CreateKernel() {
         {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[MUX_D], compile_args, defines, false, false, false);
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -7,6 +7,7 @@
 #include "eth_tunneler.hpp"
 
 #include <host_api.hpp>
+#include <memory>
 #include <tt_metal.hpp>
 
 namespace tt::tt_metal::dispatch {
@@ -45,18 +46,18 @@ void MuxKernel::GenerateDependentConfigs() {
     TT_ASSERT(upstream_kernels_.size() <= MAX_SWITCH_FAN_IN && upstream_kernels_.size() > 0);
     uint32_t num_upstream_dispatchers = 0;
     for (int idx = 0; idx < upstream_kernels_.size(); idx++) {
-        FDKernel* k = upstream_kernels_[idx];
+        auto k = upstream_kernels_[idx];
         dependent_config_.remote_rx_x[idx] = k->GetVirtualCore().x;
         dependent_config_.remote_rx_y[idx] = k->GetVirtualCore().y;
         dependent_config_.input_packetize_log_page_size[idx] =
             dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;  // Does this ever change?
-        if (auto dispatch_kernel = dynamic_cast<DispatchKernel*>(k)) {
+        if (auto dispatch_kernel = std::dynamic_pointer_cast<DispatchKernel>(k)) {
             dependent_config_.input_packetize[idx] = 0x1;
             dependent_config_.input_packetize_upstream_sem[idx] =
                 dispatch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
             dependent_config_.remote_rx_queue_id[idx] = 1;
             num_upstream_dispatchers++;
-        } else if (auto tunneler_kernel = dynamic_cast<EthTunnelerKernel*>(k)) {
+        } else if (auto tunneler_kernel = std::dynamic_pointer_cast<EthTunnelerKernel>(k)) {
             // Don't need to packetize input from tunneler
             dependent_config_.input_packetize[idx] = 0x0;
             dependent_config_.input_packetize_upstream_sem[idx] = 0;
@@ -73,9 +74,9 @@ void MuxKernel::GenerateDependentConfigs() {
 
     // Downstream, expect TUNNELER
     TT_ASSERT(downstream_kernels_.size() == 1);
-    FDKernel* ds = downstream_kernels_[0];
-    auto tunneler_kernel = dynamic_cast<EthTunnelerKernel*>(ds);
-    TT_ASSERT(ds);
+    const auto& ds = downstream_kernels_[0];
+    auto tunneler_kernel = std::dynamic_pointer_cast<EthTunnelerKernel>(ds);
+    TT_ASSERT(ds != nullptr);
     dependent_config_.remote_tx_queue_start_addr_words =
         tunneler_kernel->GetStaticConfig().in_queue_start_addr_words.value() +
         (tunneler_kernel->GetStaticConfig().vc_count.value() - 1) *

--- a/tt_metal/impl/dispatch/kernel_config/mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct mux_static_config {
     std::optional<uint32_t> reserved;
     std::optional<uint32_t> rx_queue_start_addr_words;
@@ -51,3 +53,5 @@ private:
     mux_static_config_t static_config_;
     mux_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -193,14 +193,14 @@ void PrefetchKernel::GenerateDependentConfigs() {
         }
         bool found_dispatch = false;
         bool found_dispatch_s = false;
-        for (FDKernel* k : downstream_kernels_) {
-            if (auto dispatch_kernel = dynamic_cast<DispatchKernel*>(k)) {
+        for (const auto& k : downstream_kernels_) {
+            if (auto dispatch_kernel = std::dynamic_pointer_cast<DispatchKernel>(k)) {
                 TT_ASSERT(!found_dispatch, "PREFETCH kernel has multiple downstream DISPATCH kernels.");
                 found_dispatch = true;
 
                 dependent_config_.downstream_logical_core = dispatch_kernel->GetLogicalCore();
                 dependent_config_.downstream_cb_sem_id = dispatch_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
-            } else if (auto dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(k)) {
+            } else if (auto dispatch_s_kernel = std::dynamic_pointer_cast<DispatchSKernel>(k)) {
                 TT_ASSERT(!found_dispatch_s, "PREFETCH kernel has multiple downstream DISPATCH kernels.");
                 found_dispatch_s = true;
 
@@ -228,11 +228,12 @@ void PrefetchKernel::GenerateDependentConfigs() {
 
         // Downstream, expect just one ROUTER
         TT_ASSERT(downstream_kernels_.size() == 1);
-        auto router_kernel = dynamic_cast<EthRouterKernel*>(downstream_kernels_[0]);
-        TT_ASSERT(router_kernel);
+        auto router_kernel = std::dynamic_pointer_cast<EthRouterKernel>(downstream_kernels_[0]);
+        TT_ASSERT(router_kernel != nullptr);
         dependent_config_.downstream_logical_core = router_kernel->GetLogicalCore();
         dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
-        uint32_t router_idx = router_kernel->GetUpstreamPort(this);  // Need the port that this connects to downstream
+        uint32_t router_idx =
+            router_kernel->GetUpstreamPort(this->shared_from_this());  // Need the port that this connects to downstream
         dependent_config_.downstream_cb_base =
             (router_kernel->GetStaticConfig().rx_queue_start_addr_words.value() << 4) +
             (router_kernel->GetStaticConfig().rx_queue_size_words.value() << 4) * router_idx;
@@ -241,10 +242,10 @@ void PrefetchKernel::GenerateDependentConfigs() {
     } else if (static_config_.is_d_variant.value()) {
         // Upstream, expect just one ROUTER
         TT_ASSERT(upstream_kernels_.size() == 1);
-        auto router_kernel = dynamic_cast<EthRouterKernel*>(upstream_kernels_[0]);
-        TT_ASSERT(router_kernel);
+        auto router_kernel = std::dynamic_pointer_cast<EthRouterKernel>(upstream_kernels_[0]);
+        TT_ASSERT(router_kernel != nullptr);
         dependent_config_.upstream_logical_core = router_kernel->GetLogicalCore();
-        int router_idx = router_kernel->GetDownstreamPort(this);
+        int router_idx = router_kernel->GetDownstreamPort(this->shared_from_this());
         dependent_config_.upstream_cb_sem_id =
             router_kernel->GetStaticConfig().output_depacketize_local_sem[router_idx];
 
@@ -256,14 +257,14 @@ void PrefetchKernel::GenerateDependentConfigs() {
         }
         bool found_dispatch = false;
         bool found_dispatch_s = false;
-        for (FDKernel* k : downstream_kernels_) {
-            if (auto dispatch_kernel = dynamic_cast<DispatchKernel*>(k)) {
+        for (const auto& k : downstream_kernels_) {
+            if (auto dispatch_kernel = std::dynamic_pointer_cast<DispatchKernel>(k)) {
                 TT_ASSERT(!found_dispatch, "PREFETCH kernel has multiple downstream DISPATCH kernels.");
                 found_dispatch = true;
 
                 dependent_config_.downstream_logical_core = dispatch_kernel->GetLogicalCore();
                 dependent_config_.downstream_cb_sem_id = dispatch_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
-            } else if (auto dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(k)) {
+            } else if (auto dispatch_s_kernel = std::dynamic_pointer_cast<DispatchSKernel>(k)) {
                 TT_ASSERT(!found_dispatch_s, "PREFETCH kernel has multiple downstream DISPATCH kernels.");
                 found_dispatch_s = true;
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -9,6 +9,8 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void PrefetchKernel::GenerateStaticConfigs() {
@@ -393,3 +395,5 @@ void PrefetchKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, prefetch_q_base, prefetch_q, GetCoreType());
     }
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct prefetch_static_config {
     std::optional<uint32_t> downstream_cb_log_page_size;
     std::optional<uint32_t> downstream_cb_pages;
@@ -90,3 +92,5 @@ private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
 };
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -18,6 +18,8 @@
 #define DISPATCH_MAX_UPSTREAM 4
 #define DISPATCH_MAX_DOWNSTREAM 4
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 typedef struct {
@@ -753,3 +755,5 @@ void configure_dispatch_cores(IDevice* device) {
         }
     }
 }
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -3,17 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 #include <device.hpp>
+#include <memory>
+#include "dispatch/kernel_config/fd_kernel.hpp"
 
 namespace tt::tt_metal::dispatch {
 
+using FDTopologyGraph = std::vector<std::shared_ptr<FDKernel>>;
+
 // Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use
 // a created Device to fill out the settings.
-void populate_fd_kernels(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs);
+FDTopologyGraph populate_fd_kernels(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs);
 
 // Fill out all settings for FD kernels on the given device, and add them to a Program and return it.
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(tt::tt_metal::IDevice* device);
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(
+    tt::tt_metal::IDevice* device, FDTopologyGraph& graph);
 
 // Performa additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
-void configure_dispatch_cores(tt::tt_metal::IDevice* device);
+void configure_dispatch_cores(tt::tt_metal::IDevice* device, FDTopologyGraph& graph);
 
 }  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include <device.hpp>
 
+namespace tt::tt_metal::dispatch {
+
 // Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use
 // a created Device to fill out the settings.
 void populate_fd_kernels(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs);
@@ -13,3 +15,5 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(tt::tt_meta
 
 // Performa additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
 void configure_dispatch_cores(tt::tt_metal::IDevice* device);
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/util/fd_topology_manager.hpp
+++ b/tt_metal/impl/dispatch/util/fd_topology_manager.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+#include "assert.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
+
+namespace tt::tt_metal::dispatch {
+
+// Keeps track of the FD Topology for activated device pools
+class FDTopologyManager {
+private:
+    // Similar to boost hash combine
+    struct ChipIdHash {
+        std::size_t operator()(const std::set<chip_id_t>& s) const {
+            std::size_t hash = 0;
+            for (const auto& id : s) {
+                hash ^= std::hash<chip_id_t>{}(id) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+            }
+            return hash;
+        }
+    };
+
+    ~FDTopologyManager() = default;
+    FDTopologyManager() = default;
+
+    std::unordered_map<std::set<chip_id_t>, FDTopologyGraph, ChipIdHash> topology;
+    std::mutex lock;
+
+public:
+    FDTopologyManager& operator=(const FDTopologyManager&) = delete;
+    FDTopologyManager& operator=(FDTopologyManager&& other) noexcept = delete;
+    FDTopologyManager(const FDTopologyManager&) = delete;
+    FDTopologyManager(FDTopologyManager&& other) noexcept = delete;
+
+    static FDTopologyManager& instance() noexcept {
+        static FDTopologyManager _inst;
+        return _inst;
+    }
+
+    // Initialize topology graph for given device_ids
+    void initialize_topology(const std::set<chip_id_t>& active_device_ids, uint32_t num_hw_cqs) {
+        std::lock_guard<std::mutex> guard(this->lock);
+        if (this->topology.contains(active_device_ids)) {
+            // Reset the topology for these devices. num_hw_cqs may be different
+            // need to track num_hw_cqs are well to re-use
+            this->topology.erase(active_device_ids);
+        }
+
+        topology[active_device_ids] = std::move(populate_fd_kernels(active_device_ids, num_hw_cqs));
+    }
+
+    // Delete all topologies
+    void reset() {
+        std::lock_guard<std::mutex> guard(this->lock);
+        this->topology.clear();
+    }
+
+    // Returns the topology for a pool of active devices configured by DevicePool
+    FDTopologyGraph& get_topology(const std::set<chip_id_t>& active_device_ids) {
+        if (this->topology.empty() || !this->topology.contains(active_device_ids)) {
+            TT_THROW("Topology is not configured for given devices. Need to call initialize_topology");
+        }
+        return this->topology[active_device_ids];
+    }
+};
+
+}  // namespace tt::tt_metal::dispatch


### PR DESCRIPTION
### Ticket
#16364

### Problem description
- Need to update FD test cases to use new FD topology features
- Currently all functions in topology are coded to use the global `node_id_to_kernel` which makes it not usable in test prefetcher / dispatcher

### What's changed
- Replaced the usage of raw pointers with smart pointers
- Uplifted `node_id_to_kernel` to `FDTopologyManager`. This internal class is accessed by the `DevicePool` and `Device` implementations.
- Topology functions now accept a parameter `node_id_to_kernel` which is essentially the FD Topology Graph
- Added get active device ids to `DevicePool`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
