### PR TITLE
Cleanup of various issues

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -252,8 +252,8 @@ public:
     virtual uint32_t num_sub_devices() const = 0;
 
     // TODO #15944: Temporary api until migration to actual fabric is complete
-    virtual std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
-    virtual std::optional<SubDeviceId> get_fabric_sub_device_id() const = 0;
+    virtual std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
+        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
 
     virtual uint32_t get_completion_queue_reader_core() const = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -242,8 +242,8 @@ public:
     uint32_t num_sub_devices() const override;
 
     // TODO #15944: Temporary api until migration to actual fabric is complete
-    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
-    std::optional<SubDeviceId> get_fabric_sub_device_id() const override;
+    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
+        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
 
     uint32_t get_completion_queue_reader_core() const override { return completion_queue_reader_core_; }
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -216,8 +216,8 @@ public:
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
     // TODO #16526: Temporary api until migration to actual fabric is complete
-    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
-    std::optional<SubDeviceId> get_fabric_sub_device_id() const override;
+    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
+        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
     uint32_t get_completion_queue_reader_core() const override;
     bool is_mmio_capable() const override;
     std::vector<std::vector<chip_id_t>> get_tunnels_from_mmio() const override;

--- a/tt_metal/api/tt-metalium/program_impl.hpp
+++ b/tt_metal/api/tt-metalium/program_impl.hpp
@@ -65,8 +65,7 @@ namespace detail{
     void ValidateCircularBufferRegion(const Program &program, const IDevice* device);
     KernelHandle AddKernel (Program &program, const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType core_type);
     std::shared_ptr<Kernel> GetKernel(const Program &program, KernelHandle kernel_id);
-    std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CBHandle id);
-    void AddConfigBuffer(Program &program, const std::shared_ptr<Buffer>& config_buffer);
+    std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program& program, CBHandle id);
 
     class Internal_;
 }
@@ -228,7 +227,6 @@ class Program {
     std::unordered_map<uint64_t, ProgramCommandSequence> &get_cached_program_command_sequences() noexcept;
     bool kernel_binary_always_stored_in_ringbuffer();
 
-    friend void detail::AddConfigBuffer(Program &program, const std::shared_ptr<Buffer>& config_buffer);
     friend void program_dispatch::assemble_device_commands(
         ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device, SubDeviceId sub_device_id);
     template<typename T> friend void program_dispatch::finalize_program_offsets(T&, IDevice*);

--- a/tt_metal/api/tt-metalium/sub_device_manager.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager.hpp
@@ -68,10 +68,6 @@ public:
     void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids);
     void reset_sub_device_stall_group();
 
-    // TODO #15944: Temporary until migration to actual fabric is complete
-    void set_fabric_sub_device_id(SubDeviceId sub_device_id);
-    std::optional<SubDeviceId> fabric_sub_device_id() const;
-
 private:
     void validate_sub_devices() const;
     uint8_t get_sub_device_index(SubDeviceId sub_device_id) const;

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -225,13 +225,12 @@ CoreRangeSet CoreRangeSet::merge(const T& other) const {
     // By overallocating by one x entry, we can avoid needing to check for
     // boundary conditions when iterating, since there'll always be one
     // last false entry
-    bool grid[max_y + 1][max_x + 2];
-    memset(grid, 0, sizeof(grid));
+    std::vector<std::vector<uint8_t>> grid(max_y + 1, std::vector<uint8_t>(max_x + 2, 0));
 
     for (const auto& cr : crs) {
         for (unsigned y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
             for (unsigned x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
-                grid[y][x] = true;
+                grid[y][x] = 1;
             }
         }
     }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -612,10 +612,6 @@ uint32_t MeshDevice::num_sub_devices() const {
     TT_THROW("num_sub_devices() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->num_sub_devices();
 }
-std::optional<SubDeviceId> MeshDevice::get_fabric_sub_device_id() const {
-    TT_THROW("get_fabric_sub_device_id() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->get_fabric_sub_device_id();
-}
 uint32_t MeshDevice::get_completion_queue_reader_core() const {
     TT_THROW("get_completion_queue_reader_core() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->get_completion_queue_reader_core();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1756,10 +1756,6 @@ std::tuple<SubDeviceManagerId, SubDeviceId> Device::create_sub_device_manager_wi
     return sub_device_manager_tracker_->create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
 }
 
-std::optional<SubDeviceId> Device::get_fabric_sub_device_id() const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->fabric_sub_device_id();
-}
-
 void Device::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -227,8 +227,6 @@ class Program_ {
     std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
     std::vector<std::vector<uint8_t>> core_to_kernel_group_index_table_;
 
-    std::vector<std::shared_ptr<Buffer>> config_buffers_;
-
     std::vector<ProgramConfig> program_configs_;
     // Counts how much space is needed for each core + each launch buffer msg queue.
     std::vector<uint32_t> program_config_sizes_;
@@ -251,9 +249,6 @@ class Program_ {
     std::shared_ptr<CircularBuffer> get_circular_buffer(CBHandle cb_id) const;
 
     void add_semaphore(const CoreRangeSet & crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
-
-    friend void AddConfigBuffer(Program &program, const std::shared_ptr<Buffer>& config_buffer);
-    void add_config_buffer(const std::shared_ptr<Buffer>& config_buffer);
 
     // Ensures that statically allocated circular buffers do not grow into L1 buffer space
     void validate_circular_buffer_region(const IDevice* device);
@@ -295,10 +290,6 @@ std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CBHand
 // Checks that circular buffers do not grow into L1 buffer space
 void ValidateCircularBufferRegion(const Program &program, const IDevice* device) {
     program.pimpl_->validate_circular_buffer_region(device);
-}
-
-void AddConfigBuffer(Program &program, const std::shared_ptr<Buffer>& config_buffer) {
-    program.pimpl_->add_config_buffer(std::move(config_buffer));
 }
 
 void EnablePersistentKernelCache() { enable_persistent_kernel_cache = true; }
@@ -893,8 +884,6 @@ void detail::Program_::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore
 void Program::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type) {
     pimpl_->add_semaphore(crs, semaphore_id, init_value, core_type);
 }
-
-void detail::Program_::add_config_buffer(const std::shared_ptr<Buffer>& config_buffer) { config_buffers_.emplace_back(config_buffer); }
 
 std::vector<std::vector<CoreCoord>> detail::Program_::logical_cores() const {
     std::vector<std::vector<CoreCoord>> cores_in_program;

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -168,16 +168,6 @@ void SubDeviceManager::set_sub_device_stall_group(tt::stl::Span<const SubDeviceI
 
 void SubDeviceManager::reset_sub_device_stall_group() { this->set_sub_device_stall_group(sub_device_ids_); }
 
-void SubDeviceManager::set_fabric_sub_device_id(SubDeviceId fabric_sub_device_id) {
-    const auto& fabric_sub_device = this->sub_device(fabric_sub_device_id);
-    TT_FATAL(
-        fabric_sub_device.cores(HalProgrammableCoreType::TENSIX).num_cores() == 0,
-        "Fabric sub device must not have Tensix cores");
-    fabric_sub_device_id_ = fabric_sub_device_id;
-}
-
-std::optional<SubDeviceId> SubDeviceManager::fabric_sub_device_id() const { return fabric_sub_device_id_; }
-
 uint8_t SubDeviceManager::get_sub_device_index(SubDeviceId sub_device_id) const {
     auto sub_device_index = sub_device_id.to_index();
     TT_FATAL(

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -55,7 +55,6 @@ std::tuple<SubDeviceManagerId, SubDeviceId> SubDeviceManagerTracker::create_sub_
     new_sub_devices.push_back(fabric_sub_device);
     auto fabric_sub_device_id = SubDeviceId{static_cast<uint32_t>(new_sub_devices.size() - 1)};
     auto sub_device_manager_id = this->create_sub_device_manager(new_sub_devices, local_l1_size);
-    sub_device_managers_[sub_device_manager_id]->set_fabric_sub_device_id(fabric_sub_device_id);
     return {sub_device_manager_id, fabric_sub_device_id};
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
@@ -99,7 +99,8 @@ operation::ProgramWithCallbacks UntilizeWithHaloV2::create_program(
         remote_config,
         remote_read_,
         transpose_mcast_,
-        output_tensor)};
+        output_tensor,
+        /*capture_buffers=*/false)};
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.hpp
@@ -19,6 +19,8 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     const Tensor& remote_config,
     const bool remote_read,
     const bool transpose_mcast,
-    Tensor& output_tensor);
+    Tensor& output_tensor,
+    const bool capture_buffers);  // Used by halo op to cache internally created config buffers with the program
+                                  // Untilize with Halo V2 op takes them as inputs from the user, so doesn't capture
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -40,7 +40,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     // This should allocate a DRAM buffer on the device
     IDevice* device = input.device();
     tt::tt_metal::Buffer* src_dram_buffer = input.buffer();
-    tt::tt_metal::Buffer* reader_indices_buffer = reader_indices.buffer();
+    auto reader_indices_buffer = reader_indices.device_buffer();
     tt::tt_metal::Buffer* dst_dram_buffer = output.buffer();
 
     const tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
@@ -389,6 +389,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     auto compute_kernel = CreateKernel(program, compute_kernel_fname, core_range, compute_config);
 
+    // Capture reader_indices_buffer to cache this with the program
     return {
         std::move(program),
         {.reader0_kernel = reader0_kernel,
@@ -396,7 +397,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
          .raw_in_cb = raw_in_cb,
          .cb_out = cb_out,
          .ncores = ncores,
-         .ncores_w = ncores_w}};
+         .ncores_w = ncores_w,
+         .reader_indices_buffer = reader_indices_buffer}};
 }
 
 Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
@@ -430,8 +432,6 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
     log_debug(tt::LogOp, "reader_indices shape: {}", reader_indices.shape());
     auto reader_indices_on_device =
         sliding_window::move_config_tensor_to_device(reader_indices, parallel_config, is_block_sharded, input.device());
-
-    tt::tt_metal::detail::AddConfigBuffer(program, reader_indices_on_device.device_buffer());
 
     auto in_n = sliding_window_config.batch_size;
     auto in_h = sliding_window_config.input_hw.first;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -46,6 +46,7 @@ struct Pool2D {
             CBHandle cb_out;
             uint32_t ncores;
             uint32_t ncores_w;
+            std::shared_ptr<Buffer> reader_indices_buffer;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -121,10 +121,6 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
 
     Program program = CreateProgram();
 
-    tt::tt_metal::detail::AddConfigBuffer(program, pad_config_device_tensor.device_buffer());
-    tt::tt_metal::detail::AddConfigBuffer(program, local_config_device_tensor.device_buffer());
-    tt::tt_metal::detail::AddConfigBuffer(program, remote_config_device_tensor.device_buffer());
-
     return {data_movement::detail::untilize_with_halo_multi_core_v2(
         program,
         input_tensor,
@@ -136,7 +132,8 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         remote_config_device_tensor,
         remote_read_,
         transpose_mcast_,
-        output_tensor)};
+        output_tensor,
+        /*capture_buffers=*/true)};
 }
 
 Tensor halo_op(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11881

### Problem description
PR is for 3 different issues/cleanup. Could be split into multiple tiny prs if needed, but having it in one pr minimized ci testing. Each issue is addressed in a different commit.

1. Remove get_frabric_sub_device_id api/related funcs. This was originally added as a temporary api to see if "fabric" sub-device was created/used, but function never ended up being used.
2. AddConfigBuffer was a hack function added to program specifically for conv related functions where they wanted to cache some buffers with the same lifetime as the program. This can be achieved using the program cache instead of directly inserting it to a program object, since program object does not make use of this at all.
3. Build failure with newer clang because of VLA usage in CoreRangeSet::merge.

### What's changed
1. Remove get_frabric_sub_device_id api/related funcs
2. Remove AddConfigBuffer. Update cnn related ops to store the needed buffers in the program cache.
3. Switch VLA for vector.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12841126580
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12841146694
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
