### PR TITLE
Do not build UMD tests

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
         "cacheVariables": {
           "TT_METAL_BUILD_TESTS": {"value": "TRUE"},
           "TTNN_BUILD_TESTS": {"value": "TRUE"},
-          "TT_UMD_BUILD_TESTS": {"value": "TRUE"},
+          "TT_UMD_BUILD_TESTS": {"value": "FALSE"},
           "BUILD_PROGRAMMING_EXAMPLES": {"value": "TRUE"},
           "BUILD_TT_TRAIN": {"value": "TRUE"},
           "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"},


### PR DESCRIPTION
### Ticket
None

### Problem description
UMD tests still require ARCH_NAME and generally aren't needed at Metalium layer. Turning them off means we can build without ARCH_NAME

### What's changed
Disabled UMD tests by default when using the default Preset.

