### PR TITLE
#0: Remove SetLazyCommandQueueMode from Metal API

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -41,7 +41,6 @@ uint32_t page_count_g;
 uint32_t source_mem_g;
 uint32_t dram_channel_g;
 bool latency_g;
-bool lazy_g;
 bool time_just_finish_g;
 bool read_one_packet_g;
 bool page_size_as_runtime_arg_g;  // useful particularly on GS multi-dram tests (multiply)
@@ -82,9 +81,8 @@ void init(int argc, char** argv) {
         log_info(LogTest, "  -ty: when issuing a multicast write, Y of end core to write to (default {})", 0);
         log_info(LogTest, "  -wr: issue unicast write instead of read (default false)");
         log_info(LogTest, "  -c: when reading from dram, DRAM channel (default 0)");
-        log_info(LogTest, "  -f: time just the finish call (use w/ lazy mode) (default disabled)");
+        log_info(LogTest, "  -f: time just the finish call (default disabled)");
         log_info(LogTest, "  -o: use read_one_packet API.  restricts page size to 8K max (default {})", 0);
-        log_info(LogTest, "  -z: enable dispatch lazy mode (default disabled)");
         log_info(LogTest, "-link: link mcast transactions");
         log_info(LogTest, " -hr: hammer write_reg while executing (for PCIe test)");
         log_info(LogTest, " -hp: hammer hugepage PCIe memory while executing (for PCIe test)");
@@ -97,7 +95,6 @@ void init(int argc, char** argv) {
     uint32_t core_y = test_args::get_command_option_uint32(input_args, "-ry", 0);
     warmup_iterations_g = test_args::get_command_option_uint32(input_args, "-w", DEFAULT_WARMUP_ITERATIONS);
     iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
-    lazy_g = test_args::has_command_option(input_args, "-z");
     hammer_write_reg_g = test_args::has_command_option(input_args, "-hr");
     hammer_pcie_g = test_args::has_command_option(input_args, "-hp");
     hammer_pcie_type_g = test_args::get_command_option_uint32(input_args, "-hpt", 0);
@@ -330,7 +327,6 @@ int main(int argc, char** argv) {
                 api = "noc_async_" + read_write;
             }
             log_info(LogTest, "Using API: {}", api);
-            log_info(LogTest, "Lazy: {}", lazy_g);
             log_info(
                 LogTest,
                 "Page size ({}): {}",
@@ -351,10 +347,6 @@ int main(int argc, char** argv) {
                 EnqueueProgram(cq, program, false);
             }
             Finish(cq);
-
-            if (lazy_g) {
-                tt_metal::detail::SetLazyCommandQueueMode(true);
-            }
 
             auto start = std::chrono::system_clock::now();
             EnqueueProgram(cq, program, false);

--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -439,7 +439,6 @@ class EnqueueTerminateCommand : public Command {
 };
 
 namespace detail {
-inline bool LAZY_COMMAND_QUEUE_MODE = false;
 
 /*
  Used so the host knows how to properly copy data into user space from the completion queue (in hugepages)

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -330,8 +330,6 @@ bool ReadFromDeviceL1(
 
 bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
 
-void SetLazyCommandQueueMode(bool lazy);
-
 DeviceAddr AllocateBuffer(Buffer* buffer);
 
 void DeallocateBuffer(Buffer* buffer);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -82,11 +82,6 @@ Buffer& GetBufferObject(const std::variant<std::reference_wrapper<Buffer>, std::
         buffer);
 }
 
-void SetLazyCommandQueueMode(bool lazy) {
-    DispatchStateCheck(true);
-    LAZY_COMMAND_QUEUE_MODE = lazy;
-}
-
 void ValidateBufferRegion(
     const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer, const BufferRegion& region) {
     Buffer& buffer_obj = GetBufferObject(buffer);
@@ -2446,10 +2441,6 @@ void v1::EnqueueProgram(CommandQueueHandle cq, ProgramHandle &program, bool bloc
 
 void v1::Finish(CommandQueueHandle cq, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     v0::Finish(GetDevice(cq)->command_queue(GetId(cq)));
-}
-
-void v1::SetLazyCommandQueueMode(bool lazy) {
-    detail::SetLazyCommandQueueMode(lazy);
 }
 
 IDevice* v1::GetDevice(CommandQueueHandle cq) {

--- a/tt_metal/include/tt_metal/command_queue.hpp
+++ b/tt_metal/include/tt_metal/command_queue.hpp
@@ -68,13 +68,6 @@ void EnqueueProgram(CommandQueueHandle cq, ProgramHandle& program, bool blocking
 void Finish(CommandQueueHandle cq, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 /**
- * @brief Sets the command queue mode to lazy or immediate.
- *
- * @param lazy If true, sets the command queue to lazy mode.
- */
-void SetLazyCommandQueueMode(bool lazy);
-
-/**
  * @brief Retrieves the device associated with the command queue.
  *
  * @param cq The command queue to query.

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -604,11 +604,6 @@ void device_module(py::module& m_device) {
         py::arg("device"),
         py::arg("cq_id") = std::nullopt,
         py::arg("sub_device_ids") = std::vector<SubDeviceId>());
-    m_device.def("SetLazyCommandQueueMode", &tt::tt_metal::detail::SetLazyCommandQueueMode, R"doc(
-        If set to true, the host does not notify the device that there are commands available other than
-        the FinishCommand. Once set to false, all subsequent commands will immediately notify the device
-        that the write pointer has been updated.
-    )doc");
     m_device.def("DumpDeviceProfiler", DumpDeviceProfiler, py::arg("device"), R"doc(
         Dump device side profiling data.
 

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -98,7 +98,6 @@ EnableCompilationReports = ttnn._ttnn.device.EnableCompilationReports
 DisableCompilationReports = ttnn._ttnn.device.DisableCompilationReports
 EnableMemoryReports = ttnn._ttnn.device.EnableMemoryReports
 DisableMemoryReports = ttnn._ttnn.device.DisableMemoryReports
-SetLazyCommandQueueMode = ttnn._ttnn.device.SetLazyCommandQueueMode
 DeallocateBuffers = ttnn._ttnn.device.deallocate_buffers
 
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The code for setting CQ in lazy mode is dead. The API isn't functional.

The original implementation: https://github.com/tenstorrent/tt-metal/issues/4453.

### What's changed
Removed `SetLazyCommandQueueMode` and the associated plumbing in TTNN / usages in tests.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12848109265)
- [X] New/Existing tests provide coverage for changes
