### PR TITLE
#0: fix stackoverflow in eth tun

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -34,8 +34,8 @@ void EthTunnelerKernel::GenerateStaticConfigs() {
         case 1:
         case 2: static_config_.in_queue_size_words = 65536 >> 4; break;
         case 3:
-        case 4:
-        case 5: static_config_.in_queue_size_words = 32768 >> 4; break;
+        case 4: static_config_.in_queue_size_words = 32768 >> 4; break;
+        case 5:
         default: static_config_.in_queue_size_words = 16384 >> 4; break;
     }
     static_config_.kernel_status_buf_addr_arg = 0;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15474

### Problem description
TG and TGG unit tests hung because of my prior change

### What's changed
Fixed incorrect tunneler size

### Checklist
- [ ] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12855670102
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
TGG: https://github.com/tenstorrent/tt-metal/actions/runs/12855658656
TG: https://github.com/tenstorrent/tt-metal/actions/runs/12850499870
