### PR TITLE
[skip ci] : Update INSTALLING.md

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -128,7 +128,7 @@ system. (ie. Grayskull, Wormhole, etc)
 
 ```sh
 docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest-rc
-docker run --it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest-rc bash
+docker run -it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest-rc bash
 ```
 where `arch_name` is one of `grayskull`, `wormhole_b0`, or `blackhole`,
 depending on your Tenstorrent card type.


### PR DESCRIPTION
Fix a typo, docker run option `--it` -> `-it`. The `--it` option in the docker run command will cause an error because it is not a valid flag.