### PR TITLE
move device checking outside of invalidate code func

### DIFF
--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -31,6 +31,9 @@ def run_sum(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
+
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -90,12 +90,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if not test_vector["keepdim"]:
         return True, "keepdim = false is not supported"
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 
@@ -116,6 +110,9 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
+++ b/tests/sweep_framework/sweeps/reduction/backward/prod_bw/prod_bw.py
@@ -87,14 +87,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if not isinstance(test_vector["dim"], int):
         return True, "dim can only be integer value"
 
-    device = ttnn.open_device(device_id=0)
-    if (
-        test_vector["input_a_dtype"] == ttnn.float32 or test_vector["grad_dtype"] == ttnn.float32
-    ) and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 
@@ -117,6 +109,9 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if (input_a_dtype == ttnn.float32 or grad_dtype == ttnn.float32) and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=0, high=100, dtype=torch.float32), input_a_dtype

--- a/tests/sweep_framework/sweeps/reduction/mean/mean.py
+++ b/tests/sweep_framework/sweeps/reduction/mean/mean.py
@@ -78,12 +78,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if not test_vector["keepdim"]:
         return True, "keepdim = false is not supported"
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 
@@ -104,6 +98,9 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/reduction/std/std.py
+++ b/tests/sweep_framework/sweeps/reduction/std/std.py
@@ -78,12 +78,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if not test_vector["keepdim"]:
         return True, "keepdim = false is not supported"
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 
@@ -104,6 +98,9 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/reduction/sum.py
+++ b/tests/sweep_framework/sweeps/reduction/sum.py
@@ -75,12 +75,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if not test_vector["keepdim"]:
         return True, "keepdim = false is not supported"
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -112,12 +112,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     ):
         return True, "Row major is only supported for fp32 & fp16"
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 
@@ -139,6 +133,9 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     input_shape = sanitize_shape(input_shape, "topk")
 

--- a/tests/sweep_framework/sweeps/reduction/var/var.py
+++ b/tests/sweep_framework/sweeps/reduction/var/var.py
@@ -81,12 +81,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if len(test_vector["input_shape"]) < 2:
         return True, "For var with scalar(1-D) input, degrees of freedom will be <= 0."
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 
@@ -107,6 +101,9 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16901)

### Problem description
sweep test hangs

### What's changed
move device checking outside of invalidate code func

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/12871486717
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
- [x] Sweep tests: https://github.com/tenstorrent/tt-metal/actions/runs/12871453570, https://github.com/tenstorrent/tt-metal/actions/runs/12871446661, https://github.com/tenstorrent/tt-metal/actions/runs/12871442885, https://github.com/tenstorrent/tt-metal/actions/runs/12871437746, https://github.com/tenstorrent/tt-metal/actions/runs/12871431262, https://github.com/tenstorrent/tt-metal/actions/runs/12871431262, https://github.com/tenstorrent/tt-metal/actions/runs/12871420836
