### PR TITLE
 #16913: Add Model Updates to the Release assets

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -149,6 +149,8 @@ jobs:
           name: eager-dist-${{ matrix.os }}-any
       - name: Create VERSION
         run: echo ${{ needs.create-tag.outputs.version }} > VERSION
+      - name: Copy Model Updates
+        run: cp models/MODEL_UPDATES.md MODEL_UPDATES.md
       - name : Download release notes
         uses: actions/download-artifact@v4
         with:
@@ -174,6 +176,7 @@ jobs:
             CHANGELOG.txt
             README.md
             INSTALLING.md
+            MODEL_UPDATES.md
             ttnn-*+*.whl
           fail_on_unmatched_files: true
   create-docker-release-image:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -149,8 +149,6 @@ jobs:
           name: eager-dist-${{ matrix.os }}-any
       - name: Create VERSION
         run: echo ${{ needs.create-tag.outputs.version }} > VERSION
-      - name: Copy Model Updates
-        run: cp models/MODEL_UPDATES.md MODEL_UPDATES.md
       - name : Download release notes
         uses: actions/download-artifact@v4
         with:
@@ -176,7 +174,7 @@ jobs:
             CHANGELOG.txt
             README.md
             INSTALLING.md
-            MODEL_UPDATES.md
+            models/MODEL_UPDATES.md
             ttnn-*+*.whl
           fail_on_unmatched_files: true
   create-docker-release-image:


### PR DESCRIPTION
### Ticket
#16913 

### Problem description

The users would like to know what models changes affect the current release.

### What's changed
Added the MODEL_UPDATES.md file that the Models team keeps up-to-date to the Release Assets.
The file's location is: https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_UPDATES.md

### Checklist
- [ ] Post commit CI passes
- [x] Package and Release workflow passes - 
https://github.com/tenstorrent/tt-metal/actions/runs/12873666211
https://github.com/tenstorrent/tt-metal/releases/tag/v0.55.0-rc7
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
