### PR TITLE
Modify UNet Shallow to consume inputs in CHW-ordering

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/models/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -22,14 +22,14 @@ from models.experimental.functional_unet.tests.common import is_n300_with_eth_di
 @pytest.mark.parametrize("groups", [2])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_bottleneck(batch: int, groups: int, device: ttnn.Device, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
     torch_input, ttnn_input = create_unet_input_tensors(
-        batch, groups, pad_input=True, input_channels=32, input_height=66, input_width=10
+        batch, groups, input_channels=32, input_height=66, input_width=10
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(f"Created input tensors: shape={list(ttnn_input.shape)}")
@@ -56,7 +56,7 @@ def test_unet_bottleneck_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
@@ -66,7 +66,6 @@ def test_unet_bottleneck_multi_device(
     torch_input, ttnn_input = create_unet_input_tensors(
         num_devices * batch,
         groups,
-        pad_input=True,
         input_channels=32,
         input_height=66,
         input_width=10,

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -40,7 +40,7 @@ def test_unet_downblock(
     device: ttnn.Device,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
@@ -49,7 +49,6 @@ def test_unet_downblock(
     torch_input, ttnn_input = create_unet_input_tensors(
         batch,
         groups,
-        pad_input=True,
         input_channels=input_channels,
         input_height=input_height,
         input_width=input_width,
@@ -86,7 +85,7 @@ def test_unet_downblock_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
@@ -96,7 +95,6 @@ def test_unet_downblock_multi_device(
     torch_input, ttnn_input = create_unet_input_tensors(
         num_devices * batch,
         groups,
-        pad_input=True,
         input_channels=input_channels,
         input_height=input_height,
         input_width=input_width,

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -18,7 +18,7 @@ from models.experimental.functional_unet.tests.common import verify_with_pcc, UN
 @pytest.mark.parametrize("groups", [2])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -32,17 +32,17 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device=mesh_device, mesh_mapper=weights_mesh_mapper)
 
     num_devices = len(mesh_device.get_device_ids())
+    total_batch = num_devices * batch
     logger.info(f"Using {num_devices} devices for this test")
-
     torch_input, ttnn_input = create_unet_input_tensors(
-        num_devices * batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        total_batch, groups, channel_order="first", pad=False, fold=False, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(

--- a/models/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/models/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -18,13 +18,13 @@ from models.experimental.functional_unet.tests.common import verify_with_pcc
 @pytest.mark.parametrize("batch, groups", [(1, 2)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_output_layer(batch, groups, device, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False, input_channels=16)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, input_channels=16)
     torch_output = model.output_layer(torch_input)
 
     ttnn_input = ttnn.to_device(ttnn_input, device=device)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -32,7 +32,7 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 2, 1065.0),),
+    ((1, 2, 1035.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -76,7 +76,7 @@ def test_unet_perf_e2e(
 ):
     profiler.clear()
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
 
     profiler.start(f"initialize_ref_model")
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
@@ -159,7 +159,7 @@ def test_unet_data_parallel_perf_e2e(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
 
     profiler.start(f"initialize_ref_model")
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
@@ -173,7 +173,7 @@ def test_unet_data_parallel_perf_e2e(
     num_devices = len(mesh_device.get_device_ids())
     total_batch = num_devices * batch
     torch_input, ttnn_input = create_unet_input_tensors(
-        total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        total_batch, groups, channel_order="first", pad=False, fold=False, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(

--- a/models/experimental/functional_unet/tests/test_unet_preprocessing.py
+++ b/models/experimental/functional_unet/tests/test_unet_preprocessing.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import pytest
+import ttnn
+import torch
+
+from loguru import logger
+
+from models.experimental.functional_unet.tt.model_preprocessing import (
+    create_unet_input_tensors,
+    create_unet_model_parameters,
+)
+
+from models.experimental.functional_unet.tt import unet_shallow_torch
+from models.experimental.functional_unet.tt import unet_shallow_ttnn
+from models.experimental.functional_unet.tests.common import verify_with_pcc, UNET_FULL_MODEL_PCC
+
+
+def nearest_16(x):
+    return math.ceil(x / 16) * 16
+
+
+@pytest.mark.parametrize("batch", [1])
+@pytest.mark.parametrize("groups", [2, 4, 8])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+def test_unet_preprocessing(batch, groups, device, use_program_cache, reset_seeds):
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
+    logger.info(f"Created input tensor with shape {list(ttnn_input.shape)}")
+
+    assert list(torch_input.shape) == list(ttnn_input.shape), "Expected torch and TTNN input shapes to match"
+
+    min_channels = 16
+
+    def golden_fn(x):
+        N, C, H, W = x.shape
+        if C < min_channels:
+            x = torch.nn.functional.pad(x, (0, 0, 0, 0, 0, min_channels - C), mode="constant", value=0)
+        return x.permute(0, 2, 3, 1).reshape(1, 1, N * H * W, max(C, min_channels))
+
+    torch_output_tensor = golden_fn(torch_input)
+
+    input_sharded_memory_config = ttnn.create_sharded_memory_config(
+        [ttnn_input.shape[0], nearest_16(ttnn_input.shape[1]), ttnn_input.shape[2], ttnn_input.shape[3]],
+        ttnn.CoreGrid(x=8, y=6),
+        ttnn.ShardStrategy.HEIGHT,
+    )
+    ttnn_input = ttnn.to_device(ttnn_input, device=device, memory_config=input_sharded_memory_config)
+
+    ttnn_output_tensor = unet_shallow_ttnn.preprocess_unet_input_tensor(ttnn_input)  # 1, 1, NHW, C (padded up to 16)
+    logger.info(f"Preprocessing input tensor yielded the following shape: {list(ttnn_output_tensor.shape)}")
+
+    ttnn_output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    assert list(torch_output_tensor.shape) == list(
+        torch_output_tensor.shape
+    ), "Expected torch and TTNN input shapes to match"
+    verify_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.99999)

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -40,7 +40,7 @@ def test_unet_trace(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
 
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
@@ -123,7 +123,7 @@ def test_unet_trace_2cq(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
 
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
@@ -185,6 +185,8 @@ def test_unet_trace_2cq(
     assert input_trace_addr == l1_input_tensor.buffer_address()
     ttnn.end_trace_capture(device, tid, cq_id=0)
 
+    ttnn.synchronize_device(device)
+
     outputs = []
     start = time.time()
     for _ in range(iterations):
@@ -202,8 +204,6 @@ def test_unet_trace_2cq(
     end = time.time()
     logger.info(f"Average model time={1000.0 * (end-start) / iterations : .2f} ms")
     logger.info(f"Average model performance={iterations * batch / (end-start) : .2f} fps")
-
-    ttnn.DumpDeviceProfiler(device)
 
     logger.info(f"Running sanity check against reference model output")
     B, C, H, W = torch_output_tensor.shape
@@ -228,7 +228,7 @@ def buffer_address(tensor):
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
-    ((1, 2, 32),),
+    ((1, 2, 128),),
 )
 def test_unet_trace_2cq_multi_device(
     batch: int, groups: int, iterations: int, mesh_device, use_program_cache, reset_seeds, enable_async_mode
@@ -240,18 +240,19 @@ def test_unet_trace_2cq_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, device=mesh_device, mesh_mapper=weights_mesh_mapper)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device)
 
     num_devices = len(mesh_device.get_device_ids())
     logger.info(f"Using {num_devices} devices for this test")
 
     total_batch = num_devices * batch
     torch_input, ttnn_input = create_unet_input_tensors(
-        total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        total_batch, groups, channel_order="first", pad=False, fold=False, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
@@ -314,6 +315,8 @@ def test_unet_trace_2cq_multi_device(
     assert input_trace_addr == buffer_address(l1_input_tensor)
     ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
 
+    ttnn.synchronize_devices(mesh_device)
+
     outputs = []
     start = time.time()
     for _ in range(iterations):
@@ -327,10 +330,9 @@ def test_unet_trace_2cq_multi_device(
 
         ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
         outputs.append(output_tensor.cpu(blocking=False))
-
     ttnn.synchronize_devices(mesh_device)
-
     end = time.time()
+    logger.info(f"Average model time={1000.0 * (end-start) / iterations : .2f} ms")
     logger.info(f"Average model performance={iterations * total_batch / (end-start) : .2f} fps")
 
     logger.info(f"Running sanity check against reference model output")
@@ -344,7 +346,7 @@ def test_unet_trace_2cq_multi_device(
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 423936, "num_command_queues": 2}], indirect=True
+    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
@@ -358,7 +360,7 @@ def test_unet_trace_2cq_same_io(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
 
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
@@ -473,3 +475,167 @@ def test_unet_trace_2cq_same_io(
     B, C, H, W = torch_output_tensor.shape
     verify_with_pcc(torch_output_tensor, ttnn.to_torch(outputs[-1]).reshape(B, C, H, W), pcc=UNET_FULL_MODEL_PCC)
     ttnn.release_trace(device, tid)
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("enable_async_mode", (True, False), indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch, groups, iterations",
+    ((1, 2, 128),),
+)
+def test_unet_trace_2cq_same_io_multi_device(
+    batch: int,
+    groups: int,
+    iterations: int,
+    mesh_device,
+    enable_async_mode,
+    use_program_cache,
+    reset_seeds,
+):
+    if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
+        pytest.skip("Test is only valid for N300 or T3000")
+
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
+
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
+
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device)
+
+    num_devices = len(mesh_device.get_device_ids())
+    logger.info(f"Using {num_devices} devices for this test")
+
+    total_batch = num_devices * batch
+    torch_input, ttnn_input = create_unet_input_tensors(
+        total_batch, groups, channel_order="first", pad=False, fold=False, mesh_mapper=inputs_mesh_mapper
+    )
+    logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
+    logger.info(
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
+    )
+
+    torch_output_tensor = model(torch_input)
+
+    op_event = ttnn.create_event(mesh_device)
+    write_event = ttnn.create_event(mesh_device)
+    model_event = ttnn.create_event(mesh_device)
+    read_event = ttnn.create_event(mesh_device)
+
+    dram_grid_size = mesh_device.dram_grid_size()
+    dram_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        ),
+        [
+            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
+            ttnn_input.shape[-1],
+        ],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_dram_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+    )
+
+    input_tensor = ttnn.allocate_tensor_on_device(
+        ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, mesh_device, input_dram_memory_config
+    )
+    ttnn.record_event(0, op_event)
+    ttnn.record_event(1, read_event)
+
+    logger.info(f"Compiling model with warmup run")
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
+
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
+    ttnn.record_event(0, op_event)
+    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+    output_dram_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        ),
+        [output_tensor.shape[-2], output_tensor.shape[-1] // dram_grid_size.x],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_dram_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, output_dram_shard_spec
+    )
+    dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config)
+    logger.info(f"Done compile run")
+
+    logger.info(f"Capturing trace")
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
+    ttnn.record_event(0, op_event)
+
+    input_trace_addr = buffer_address(l1_input_tensor)
+    shape = l1_input_tensor.shape
+    dtype = l1_input_tensor.dtype
+    layout = l1_input_tensor.layout
+    output_tensor.deallocate(force=True)
+
+    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+
+    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
+    l1_input_tensor = ttnn.allocate_tensor_on_device(
+        shape, dtype, layout, mesh_device, ttnn_model.input_sharded_memory_config
+    )
+    assert input_trace_addr == buffer_address(l1_input_tensor)
+    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+    dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
+    ttnn.synchronize_devices(mesh_device)
+
+    outputs = []
+    start = time.time()
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    ttnn.record_event(1, write_event)
+    for _ in range(iterations - 1):
+        ttnn.wait_for_event(0, write_event)
+        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
+        ttnn.record_event(0, op_event)
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+        ttnn.wait_for_event(0, read_event)
+        dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
+        ttnn.record_event(0, model_event)
+        ttnn.wait_for_event(1, op_event)
+        ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(1, model_event)
+        outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
+        ttnn.record_event(1, read_event)
+    ttnn.wait_for_event(0, write_event)
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
+    ttnn.record_event(0, op_event)
+    ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.wait_for_event(0, read_event)
+    dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
+    ttnn.record_event(0, model_event)
+    ttnn.wait_for_event(1, model_event)
+    outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
+    ttnn.synchronize_devices(mesh_device)
+    end = time.time()
+    logger.info(f"Average model time={1000.0 * (end-start) / iterations : .2f} ms")
+    logger.info(f"Average model performance={iterations * groups * total_batch / (end-start) : .2f} fps")
+
+    logger.info(f"Running sanity check against reference model output")
+    B, C, H, W = torch_output_tensor.shape
+    verify_with_pcc(
+        torch_output_tensor,
+        ttnn.to_torch(outputs[-1], mesh_composer=output_mesh_composer).reshape(B, C, H, W),
+        pcc=UNET_FULL_MODEL_PCC,
+    )
+    ttnn.release_trace(mesh_device, tid)

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -43,7 +43,7 @@ def test_unet_upblock(
     device: ttnn.Device,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
@@ -52,7 +52,6 @@ def test_unet_upblock(
     torch_input, ttnn_input = create_unet_input_tensors(
         batch,
         groups,
-        pad_input=False,
         input_channels=input_channels,
         input_height=input_height,
         input_width=input_width,
@@ -60,7 +59,6 @@ def test_unet_upblock(
     torch_residual, ttnn_residual = create_unet_input_tensors(
         batch,
         groups,
-        pad_input=False,
         input_channels=residual_channels,
         input_height=input_height * 2,
         input_width=input_width * 2,
@@ -104,7 +102,7 @@ def test_unet_upblock_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
@@ -114,7 +112,6 @@ def test_unet_upblock_multi_device(
     torch_input, ttnn_input = create_unet_input_tensors(
         num_devices * batch,
         groups,
-        pad_input=False,
         input_channels=input_channels,
         input_height=input_height,
         input_width=input_width,
@@ -127,7 +124,6 @@ def test_unet_upblock_multi_device(
     torch_residual, ttnn_residual = create_unet_input_tensors(
         num_devices * batch,
         groups,
-        pad_input=False,
         input_channels=residual_channels,
         input_height=input_height * 2,
         input_width=input_width * 2,

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -5,36 +5,47 @@
 import torch
 import ttnn
 
+from typing import Literal
+
 from ttnn.model_preprocessing import infer_ttnn_module_args
 
 from models.experimental.functional_unet.tt import unet_shallow_torch
 
 
+def pad_channels_up_to_target(input_tensor, target=16):
+    assert len(input_tensor.shape) == 4, "Expected input tensor to rank 4"
+    N, C, H, W = input_tensor.shape
+    if C < target:
+        return torch.nn.functional.pad(input_tensor, (0, 0, 0, 0, 0, target - C), mode="constant", value=0)
+    else:
+        return input_tensor
+
+
 def create_unet_input_tensors(
-    batch: int, groups: int, pad_input=True, input_channels=4, input_height=1056, input_width=160, mesh_mapper=None
+    batch: int,
+    groups: int,
+    input_channels: int = 4,
+    input_height: int = 1056,
+    input_width: int = 160,
+    channel_order: Literal["first", "last"] = "last",
+    fold: bool = True,
+    pad: bool = True,
+    mesh_mapper=None,
 ):
     torch_input_tensor = torch.randn(batch, input_channels * groups, input_height, input_width)
-    ttnn_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
-    ttnn_input_tensor = ttnn_input_tensor.reshape(
-        ttnn_input_tensor.shape[0],
-        1,
-        ttnn_input_tensor.shape[1] * ttnn_input_tensor.shape[2],
-        ttnn_input_tensor.shape[3],
-    )
-    if pad_input:
-        pad, hpad = 16, 0
-        if ttnn_input_tensor.shape[-1] < pad or ttnn_input_tensor.shape[-2] < hpad:
-            ttnn_input_tensor = torch.nn.functional.pad(
-                ttnn_input_tensor,
-                (0, max(0, pad - ttnn_input_tensor.shape[-1]), 0, max(0, hpad - ttnn_input_tensor.shape[-2])),
-            )
+
+    # We almost always (unless running full model) want to ensure we have least 16 because conv2d requires it
+    ttnn_input_tensor = pad_channels_up_to_target(torch_input_tensor, 16) if pad else torch_input_tensor
+
+    ttnn_input_tensor = ttnn_input_tensor if channel_order == "first" else ttnn_input_tensor.permute(0, 2, 3, 1)
+
+    if fold:
+        if channel_order == "first":
+            raise RuntimeError("Cannot fold B x H x W when in channels first ordering")
+        ttnn_input_tensor = ttnn_input_tensor.reshape(batch, 1, input_height * input_width, -1)
+
     ttnn_input_tensor = ttnn.from_torch(ttnn_input_tensor, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper)
-    ttnn_input_tensor = ttnn_input_tensor.reshape(
-        1,
-        1,
-        ttnn_input_tensor.shape[0] * ttnn_input_tensor.shape[1] * ttnn_input_tensor.shape[2],
-        ttnn_input_tensor.shape[3],
-    )
+
     return torch_input_tensor, ttnn_input_tensor
 
 

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -84,6 +84,21 @@ def is_valid_device_for_unet(device):
         return 8 == device.core_grid.x and 8 == device.core_grid.y
 
 
+def preprocess_unet_input_tensor(input_tensor, min_channels=16):
+    N, C, H, W = input_tensor.shape
+    if C < min_channels:
+        channel_padding_needed = min_channels - C
+        nchw = ttnn.pad(input_tensor, ((0, 0), (0, channel_padding_needed), (0, 0), (0, 0)), value=0.0)
+        ttnn.deallocate(input_tensor)
+    else:
+        nchw = input_tensor
+
+    nhwc = ttnn.permute(nchw, (0, 2, 3, 1))  # N, C, H, W -> N, H, W, C
+    ttnn.deallocate(nchw)
+
+    return ttnn.reshape(nhwc, [1, 1, nhwc.shape[0] * nhwc.shape[1] * nhwc.shape[2], nhwc.shape[-1]])  # 1, 1, NHW, C
+
+
 class UNetConv2D:
     def __init__(
         self,
@@ -419,36 +434,18 @@ class UNet:
             activation_dtype=ttnn.bfloat16,
         )
 
-        self.parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
-            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            batch_size=self.downblock1.conv1.batch_size,
-            input_channels=self.downblock1.conv1.in_channels,
-            output_height=self.downblock1.conv2.input_height,
-            output_width=self.downblock1.conv2.input_width,
-            output_channels=self.downblock1.conv1.out_channels,
-            compute_grid_size=device.compute_with_storage_grid_size(),
-            block_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            is_out_tiled=True,
-            enable_channels_padding=True,
-        )
-        self.input_sharded_memory_config = ttnn._ttnn.operations.conv.create_sharded_memory_config_from_parallel_config(
-            tensor_shape=ttnn.Shape(
-                [
-                    1,
-                    1,
-                    self.downblock1.conv1.batch_size
-                    * self.downblock1.conv1.input_height
-                    * self.downblock1.conv1.input_width,
-                    nearest_16(self.downblock1.conv1.in_channels),
-                ]
-            ),
-            parallel_config=self.parallel_config,
-            tile_size=32,
+        self.input_sharded_memory_config = ttnn.create_sharded_memory_config(
+            [1, 16, 1056, 160],
+            ttnn.CoreGrid(x=8, y=6),
+            ttnn.ShardStrategy.HEIGHT,
         )
 
     def bottleneck(self, x):
         x = self.bnc(x)
         return self.bnc2(x)
+
+    def preprocess_input_tensor(self, x):
+        return preprocess_unet_input_tensor(x, 16)
 
     def postprocess_output_tensor(self, x):
         # Convert the output tensor (in TILE layout) to RM to prevent transferring padding back to host.
@@ -470,6 +467,8 @@ class UNet:
 
         if move_input_tensor_to_device:
             x = ttnn.to_device(x, device=self.device, memory_config=self.input_sharded_memory_config)
+
+        x = self.preprocess_input_tensor(x)
 
         x, c1_residual = self.downblock1(x)
         x, c2_residual = self.downblock2(x)

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_preprocessing.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_preprocessing.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_preprocessing.py


### PR DESCRIPTION
### Summary

This PR is the follow-on work from:

- https://github.com/tenstorrent/tt-metal/pull/16742

It updates the UNet Shallow interface to take inputs in CHW-ordering. End-to-end performance is 850 fps for N150 
when running:

```sh
pytest -sv models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq_same_io
```

And end-to-end performance on N300 is 1650 fps when running:

```sh
pytest -sv models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq_same_io_multi_device
```

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12875765696
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12875779428
- [x] Device performance regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12875772318
