### PR TITLE
Create an API for running and measuring the runtime of a ttnn op chain for use during forge compilation

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_cq_multi_dev.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_query_op_constraints.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_query_op_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reflect.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_to_and_from_json.cpp
 )

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <ostream>
-#include <string>
-
 #include <tt-metalium/constants.hpp>
 #include "gtest/gtest.h"
 #include <tt-metalium/event.hpp>
@@ -72,7 +69,7 @@ TEST_P(BinaryOpTraceRuntime, Add) {
         auto query = ttnn::graph::query_op_runtime(ttnn::add, device, input_spec_a, input_spec_b);
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        std::cout << "Runtime: " << query.runtime << " ns\n";
+        tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
     }
 }
 
@@ -86,7 +83,7 @@ TEST_P(BinaryOpTraceRuntime, AddChain) {
         auto query = ttnn::graph::query_op_runtime(add_chain, device, input_spec_a, input_spec_b);
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        std::cout << "Runtime: " << query.runtime << " ns\n";
+        tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -76,6 +76,20 @@ TEST_P(BinaryOpTraceRuntime, Add) {
     }
 }
 
+TEST_P(BinaryOpTraceRuntime, AddChain) {
+    const auto& input_spec_a = std::get<0>(GetParam());
+    const auto& input_spec_b = std::get<1>(GetParam());
+
+    {
+        auto add_chain = [](const auto& i0, const auto& i1) { return ttnn::add(i0, ttnn::add(i0, i1)); };
+        tt::tt_metal::IDevice* device = &getDevice();
+        auto query = ttnn::graph::query_op_runtime(add_chain, device, input_spec_a, input_spec_b);
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        std::cout << "Runtime: " << query.runtime << " ns\n";
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     QueryOpRuntime,
     BinaryOpTraceRuntime,

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -30,7 +30,7 @@ namespace test {
 // ============================================================================
 
 const auto g_interleaved_1_3_1024_1024_tiled = ttnn::TensorSpec(
-    ttnn::SimpleShape(tt::tt_metal::Array4D{1, 3, 1024, 1024}),
+    ttnn::SimpleShape({1, 3, 1024, 1024}),
     tt::tt_metal::TensorLayout(
         tt::tt_metal::DataType::BFLOAT16,
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
@@ -46,8 +46,8 @@ protected:
     }
 
     void TearDown() override {
-        TTNNFixture::TearDown();
         ttnn::close_device(*device_);
+        TTNNFixture::TearDown();
     }
 
     ttnn::IDevice& getDevice() { return *device_; }

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -90,34 +90,7 @@ TEST_P(BinaryOpTraceRuntime, AddChain) {
 INSTANTIATE_TEST_SUITE_P(
     QueryOpRuntime,
     BinaryOpTraceRuntime,
-    ::testing::Values(std::make_tuple(g_interleaved_1_3_1024_1024_tiled, g_interleaved_1_3_1024_1024_tiled)),
-    [](const testing::TestParamInfo<std::tuple<ttnn::TensorSpec, ttnn::TensorSpec>>& info) {
-        std::stringstream ss;
-
-        // print unique id for each test case
-        static int uid = 0;
-        ss << uid++;
-
-        // print tensor layout
-        using detail::operator<<;
-        ss << "_" << std::get<0>(info.param).tensor_layout();
-
-        // print tensor shape; operator<< exists but is too long to be used here
-        ss << "_";
-        detail::operator<<(ss, std::get<0>(info.param).logical_shape());
-
-        ss << "_";
-
-        // print tensor layout
-        using detail::operator<<;
-        ss << "_" << std::get<1>(info.param).tensor_layout();
-
-        // print tensor shape; operator<< exists but is too long to be used here
-        ss << "_";
-        detail::operator<<(ss, std::get<1>(info.param).logical_shape());
-
-        return ss.str();
-    });
+    ::testing::Values(std::make_tuple(g_interleaved_1_3_1024_1024_tiled, g_interleaved_1_3_1024_1024_tiled)));
 
 }  // namespace test
 }  // namespace binary

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -19,7 +19,7 @@ struct ResourceUsage {
     size_t l1_output_buffer_per_core = 0;
 };
 
-struct QueryResponse {
+struct ConstraintQueryResponse {
     ExecutionStatus status = ExecutionStatus::Error;
     ResourceUsage resource_usage;
     std::optional<std::string> error_message;
@@ -36,7 +36,7 @@ struct QueryResponse {
  * @param op The operation that will be invoked to capture the graph operations.
  * @param device A pointer to the Device object, which provides information about the compute grid size.
  * @param args The arguments that will be passed to the operation.
- * @return QueryResponse containing the execution status and resource usage constraints.
+ * @return ConstraintQueryResponse containing the execution status and resource usage constraints.
  *         - On success: ExecutionStatus::Success and the resource usage details.
  *         - On failure: ExecutionStatus::Error, zeroed resource usage, and an error message.
  */
@@ -76,12 +76,12 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
         size_t l1_output_buffer_per_core =
             extract_l1_output_buffer_allocation_size_per_core(op_trace, interleaved_storage_cores);
 
-        return QueryResponse{
+        return ConstraintQueryResponse{
             ExecutionStatus::Success, {cb_peak_size_per_core, l1_buffers_peak_per_core, l1_output_buffer_per_core}};
 
     } catch (const std::exception& e) {
         tt::log_debug(tt::LogOp, "op_constraints - error: {}", e.what());
-        return QueryResponse{ExecutionStatus::Error, {0, 0, 0}, e.what()};
+        return ConstraintQueryResponse{ExecutionStatus::Error, {0, 0, 0}, e.what()};
     }
 }
 

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -13,8 +13,6 @@
 
 namespace ttnn::graph {
 
-enum class ExecutionStatus { Success, Error };
-
 struct ResourceUsage {
     size_t cb_peak_size_per_core = 0;
     size_t l1_buffers_peak_per_core = 0;

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -31,7 +31,8 @@ static constexpr int NUM_TRACE_EXECUTIONS = 10;
  * @tparam Op The type of the operation or a callable op chain that will be invoked to capture the trace operations.
  * @tparam Args The types of the arguments that will be passed to the operation or op chain.
  * @param op The operation or op chain that will be traced and have its runtime measured.
- * @param device A pointer to the Device object, which provides information about the compute grid size.
+ * @param device A pointer to the Device object. Must be opened with trace region size set to a sufficiently high
+ * amount.
  * @param args The arguments that will be passed to the operation or callable op chain.
  * @return RuntimeQueryResponse containing the execution status and the runtime, in nanoseconds.
  *         - On success: ExecutionStatus::Success and the resource usage details.

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+namespace ttnn::graph {
+
+struct RuntimeQueryResponse {
+    ExecutionStatus status = ExecutionStatus::Error;
+    uint64_t runtime;
+    std::optional<std::string> error_message;
+};
+
+static constexpr int NUM_TRACE_EXECUTIONS = 10;
+
+/**
+ * @brief Extracts a trace of the graph operations and returns the trace execution runtime.
+ *
+ * This function runs trace capture by invoking the provided operation with the given arguments,
+ * then excutes the trace and returns the runtime of the trace in nanoseconds.
+ *
+ * @tparam Op The type of the operation or a callable op chain that will be invoked to capture the trace operations.
+ * @tparam Args The types of the arguments that will be passed to the operation or op chain.
+ * @param op The operation or op chain that will be traced and have its runtime measured.
+ * @param device A pointer to the Device object, which provides information about the compute grid size.
+ * @param args The arguments that will be passed to the operation or callable op chain.
+ * @return QueryResponse containing the execution status and the runtime, in nanoseconds.
+ *         - On success: ExecutionStatus::Success and the resource usage details.
+ *         - On failure: ExecutionStatus::Error, zeroed resource usage, and an error message.
+ */
+template <typename Op, typename... Args>
+auto query_op_runtime(Op op, IDevice* device, Args&&... args) {
+    try {
+        // helper lambda to transform TensorSpec to DeviceTensor
+        auto transform_arg = [device](auto&& arg) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
+                return create_device_tensor(arg, device);
+            } else {
+                return std::forward<decltype(arg)>(arg);
+            }
+        };
+        auto transformed_args = std::make_tuple(transform_arg(std::forward<Args>(args))...);
+
+        device->enable_async(false);
+        device->enable_program_cache();
+        {  // warm up the program cache - required for trace capture
+            std::apply(op, transformed_args);
+        }
+
+        // capture the trace
+        auto trace_id = ttnn::operations::core::begin_trace_capture(device, ttnn::DefaultQueueId);
+        std::apply(op, transformed_args);
+        ttnn::operations::core::end_trace_capture(device, trace_id, ttnn::DefaultQueueId);
+
+        device->synchronize();
+        uint64_t duration = 0;
+        for (int i = 0; i < NUM_TRACE_EXECUTIONS; ++i) {
+            auto start = std::chrono::high_resolution_clock::now();
+            ttnn::operations::core::execute_trace(device, trace_id, ttnn::DefaultQueueId, true);
+            auto end = std::chrono::high_resolution_clock::now();
+            duration += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+        }
+        ttnn::operations::core::release_trace(device, trace_id);
+
+        return RuntimeQueryResponse{ExecutionStatus::Success, duration / NUM_TRACE_EXECUTIONS};
+
+    } catch (const std::exception& e) {
+        tt::log_debug(tt::LogOp, "op_constraints - error: {}", e.what());
+        return RuntimeQueryResponse{ExecutionStatus::Error, 0, e.what()};
+    }
+}
+
+}  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -16,7 +16,7 @@ namespace ttnn::graph {
 
 struct RuntimeQueryResponse {
     ExecutionStatus status = ExecutionStatus::Error;
-    uint64_t runtime;
+    uint64_t runtime = 0;
     std::optional<std::string> error_message;
 };
 

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -51,7 +51,6 @@ auto query_op_runtime(Op op, IDevice* device, Args&&... args) {
         };
         auto transformed_args = std::make_tuple(transform_arg(std::forward<Args>(args))...);
 
-        device->enable_async(false);
         device->enable_program_cache();
         {  // warm up the program cache - required for trace capture
             std::apply(op, transformed_args);
@@ -66,7 +65,7 @@ auto query_op_runtime(Op op, IDevice* device, Args&&... args) {
         uint64_t duration = 0;
         for (int i = 0; i < NUM_TRACE_EXECUTIONS; ++i) {
             auto start = std::chrono::high_resolution_clock::now();
-            ttnn::operations::core::execute_trace(device, trace_id, ttnn::DefaultQueueId, true);
+            ttnn::operations::core::execute_trace(device, trace_id, ttnn::DefaultQueueId, /* blocking = */ true);
             auto end = std::chrono::high_resolution_clock::now();
             duration += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
         }

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -33,7 +33,7 @@ static constexpr int NUM_TRACE_EXECUTIONS = 10;
  * @param op The operation or op chain that will be traced and have its runtime measured.
  * @param device A pointer to the Device object, which provides information about the compute grid size.
  * @param args The arguments that will be passed to the operation or callable op chain.
- * @return QueryResponse containing the execution status and the runtime, in nanoseconds.
+ * @return RuntimeQueryResponse containing the execution status and the runtime, in nanoseconds.
  *         - On success: ExecutionStatus::Success and the resource usage details.
  *         - On failure: ExecutionStatus::Error, zeroed resource usage, and an error message.
  */

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -11,6 +11,8 @@
 
 namespace ttnn::graph {
 
+enum class ExecutionStatus { Success, Error };
+
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
 uint32_t extract_l1_output_buffer_allocation_size_per_core(
     const nlohmann::json& trace, size_t interleaved_storage_cores);


### PR DESCRIPTION
### Ticket
#16920 

### Problem description
Provide an API for the forge optimizer to run arbitrary ttnn ops **during** forge compilation and measure their runtime. These compile-time perf measurements are an alternative to offline perf models while those are being developed for each op.

API should:
- take an arbitrary callable of ttnn ops and an arbitrary set of arguments
- return the runtime of the callable by actually running it on the device
- should match the interface and nomenclature of the L1 constraints API
  - see PR #15046 and ticket #15291 

### What's changed
- Create a new `get_op_runtime()` API with identical interface to `get_op_constraints()`
- Use trace capture for perf measurement
  - Given an op chain, capture the trace of the op chain. Then execute the trace and report the runtime of the trace as the perf measurement
  - Enables end-to-end perf measurement without using a profiler-enabled build or any dependency on the device profiler
- Unit tests to demonstrate functionality for single op and a chain of ops. 

Note: the forge consumer for this API has not been built yet

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
