### PR TITLE
[Llama3] Send decode output logits to dram to reduce trace l1 usage and fix 8b-n150 memory crash

### DIFF
--- a/models/demos/llama3/tt/llama_model.py
+++ b/models/demos/llama3/tt/llama_model.py
@@ -306,7 +306,7 @@ class TtTransformer(LightweightModule):
         This method will take device tensors and any other args to run forward.
         It returns ttnn device tensors.
         """
-        return self.forward(
+        tt_logits = self.forward(
             x,
             current_pos,
             rot_mats=rot_mats,
@@ -314,6 +314,9 @@ class TtTransformer(LightweightModule):
             page_table=page_table,
             kv_cache=kv_cache,
         )
+        # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations
+        tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
+        return tt_logits
 
     def forward(
         self,

--- a/models/demos/llama3/tt/llama_model.py
+++ b/models/demos/llama3/tt/llama_model.py
@@ -315,7 +315,8 @@ class TtTransformer(LightweightModule):
             kv_cache=kv_cache,
         )
         # Send output logits to DRAM so L1 is not reserved for ttnn tracing and can be used by subsequent operations
-        tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
+        if not self.args.is_galaxy:
+            tt_logits = ttnn.to_memory_config(tt_logits, ttnn.DRAM_MEMORY_CONFIG)
         return tt_logits
 
     def forward(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16692

### Problem description
- Llama8B-N150 would crash with an out of l1 error when executing prefill with prompt lengths >= 2k after completing a decode trace
- This was due to the trace capture reserving a large amount of l1 space for the output logits, causing subsequent prefills (specifically, the first op in attention, the qkv matmul) to run out of l1

### What's changed
- Moved the decode output logits to DRAM so that subsequent operations could use the l1 space
- Note: this results in a ~1% drop in e2e perf for the n150/n300 llama3 text models

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
