### PR TITLE
#12662: pad generic reduce op input

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -937,11 +937,6 @@ def test_transpose_unpadded(shape, dims, layout, dtype, pad_value, device):
 
     tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=layout, device=device)
     tt_output = ttnn.transpose(tt_input, dims[0], dims[1], pad_value=pad_value)
-    if pad_value is not None:
-        a = ttnn.min(
-            tt_output
-        )  # if min becomes padding aware, this will fail, so feel free to delete this test then @future op writer
-        assert ttnn.to_torch(a) == float("-inf")
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)
 

--- a/tests/ttnn/unit_tests/operations/test_max.py
+++ b/tests/ttnn/unit_tests/operations/test_max.py
@@ -98,6 +98,7 @@ def test_max_global(device, batch_size, h, w):
         ((32, 32, 32, 64), -4),
         ((2, 32, 32, 64), -3),
         ((32, 32, 64), -3),
+        ((1, 2, 3, 4), -1),
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -167,9 +167,6 @@ def test_permute_pad_value(device, pad_value):
 
     tt_input = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
     tt_output = ttnn.permute(tt_input, (3, 2, 1, 0), pad_value=pad_value)
-    if pad_value is not None:
-        a = ttnn.min(tt_output)
-        assert ttnn.to_torch(a) == float("-inf")
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)
 

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -28,7 +28,7 @@ protected:
     }
 };
 
-TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne_BROKEN) {
+TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     std::vector<float> data(24, -1.F);
@@ -43,10 +43,10 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeOne_BROKEN) {
             all_equal = false;
         }
     }
-    EXPECT_FALSE(all_equal);
+    EXPECT_TRUE(all_equal);
 }
 
-TEST_F(TrivialTnnFixedTest, TestMaxNegativeBatch_BROKEN) {
+TEST_F(TrivialTnnFixedTest, TestMaxNegativeBatch) {
     auto* device = &ttml::autograd::ctx().get_device();
 
     auto shape = ttml::core::create_shape({4, 1, 1, 4});
@@ -66,7 +66,7 @@ TEST_F(TrivialTnnFixedTest, TestMaxNegativeBatch_BROKEN) {
             all_equal = false;
         }
     }
-    EXPECT_FALSE(all_equal);
+    EXPECT_TRUE(all_equal);
 }
 
 TEST_F(TrivialTnnFixedTest, TestStableSoftmax_0) {

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -16,13 +16,8 @@ Tensor pool_2d(const Tensor& input, const MemoryConfig& memory_config, const std
     switch (pool) {
         case PoolType::AVG: {
             uint32_t height_without_padding = input.get_logical_shape()[-2];
-            return ttnn::sum(
-                input,
-                int(input_shape.rank() - 2),
-                true,
-                memory_config,
-                std::nullopt,
-                1 / float(height_without_padding));
+            return ttnn::operations::reduction::pool_sum(
+                input, int(input_shape.rank() - 2), memory_config, std::nullopt, 1 / float(height_without_padding));
         }
         default: TT_THROW("Undefined pool type");
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -194,7 +194,6 @@ static Tensor reduce_impl(
     if (reshape) {
         output_tensor = ttnn::reshape(output_tensor, ttnn::SimpleShape{output_shape});
     }
-
     return output_tensor;
 }
 
@@ -251,6 +250,22 @@ Tensor Reduce<reduce_type>::invoke(
         return std_var_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config);
     }
     return reduce_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, true);
+}
+
+Tensor pool_sum(
+    const Tensor& input_tensor_arg,
+    int dim,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    float scalar) {
+    return reduce_impl<ReduceType::Sum>(
+        input_tensor_arg,
+        ttnn::SmallVector<int>({dim}),
+        /*keepdim=*/true,
+        memory_config_arg,
+        compute_kernel_config,
+        scalar,
+        /*reshape=*/true);
 }
 
 template class Reduce<ReduceType::Sum>;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -245,7 +245,8 @@ Tensor Reduce<reduce_type>::invoke(
     float pad_value = reduce_type == ReduceType::Max
                           ? -std::numeric_limits<float>::infinity()
                           : (reduce_type == ReduceType::Min ? std::numeric_limits<float>::infinity() : 0);
-    Tensor input_tensor = ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value);
+    bool is_tiled = input_tensor_arg.get_layout() == TILE_LAYOUT;
+    auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
     if constexpr (reduce_type == ReduceType::Std || reduce_type == ReduceType::Var) {
         return std_var_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -33,6 +33,14 @@ struct Reduce {
         float scalar = 1.0f);
 };
 
+// Entry point for pool op, which uses non-standard tensors that cannot be padded.
+Tensor pool_sum(
+    const Tensor& input_tensor_arg,
+    int dim_arg,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    float scalar);
+
 }  // namespace operations::reduction
 
 // Generic reductions


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/12662

### Problem description
- generic reduces did not properly pad the input

### What's changed
- use the new fill_implicit_tile_padding op to pad the input

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12909062606
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12909070579 (re-run worked)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12897415148
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12909066305 lines up with main https://github.com/tenstorrent/tt-metal/actions/runs/12905740650
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
