### PR TITLE
Add missing include for types used

### DIFF
--- a/tt_metal/api/tt-metalium/env_lib.hpp
+++ b/tt_metal/api/tt-metalium/env_lib.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <vector>
 #include <string>


### PR DESCRIPTION
### Ticket
#16892

### Problem description
`uint64_t` is used, but the header isn't being included.

### What's changed
Added the missing header.

