### PR TITLE
#16888: Fix Conv2D when output is in Row Major

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -435,7 +435,6 @@ def test_conv_features(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 2 * 16384}], indirect=True)
 @pytest.mark.parametrize("groups", [1, 2])
 @pytest.mark.parametrize("stride", [2])
@@ -515,7 +514,6 @@ def test_conv_features_multi_device(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize("stride", [1])
 @pytest.mark.parametrize(
@@ -719,7 +717,6 @@ def test_conv_ws(
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
 @pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
-@skip_for_grayskull()
 def test_conv_for_segformer_512x512(
     device,
     torch_tensor_map,
@@ -772,7 +769,6 @@ def test_conv_for_segformer_512x512(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override",
@@ -892,7 +888,6 @@ def test_resnet50_conv_wh(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override",
@@ -954,7 +949,6 @@ def test_conv_mem_config_wh(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override",
@@ -1213,7 +1207,6 @@ def test_sd_conv(
         )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override",
@@ -1372,7 +1365,6 @@ def test_sd_conv_wh(
         )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant",
@@ -1464,7 +1456,6 @@ def test_unet_conv_wh(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "batch_size",
     [1],
@@ -1564,7 +1555,6 @@ def test_unet_conv_groups_2_wh(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "batch_size",
     [1],
@@ -1661,7 +1651,6 @@ def test_unet_conv_groups_4_6_wh(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "batch_size",
     [1],
@@ -1887,7 +1876,8 @@ def test_conv_core_nondivis(
 
 
 # The following test takes various shape sizes from resnet50, unet and stable diffusion and tests for different number of groups - all the way to num_groups = num_in_channels (depthwise conv)
-@skip_for_grayskull()
+
+
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize("stride", [1])
 @pytest.mark.parametrize("batch_size", [1])
@@ -1971,7 +1961,8 @@ def test_conv_dilation(
 
 
 # The following test takes various shape sizes from resnet50, unet and stable diffusion and tests for different number of groups - all the way to num_groups = num_in_channels (depthwise conv)
-@skip_for_grayskull()
+
+
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, input_channels, output_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, groups, shard_layout, config_override, use_shallow_conv_variant",
@@ -2258,7 +2249,6 @@ def test_swin_s_conv(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, dilation, shard_layout",
@@ -2357,7 +2347,6 @@ def test_model_k_256x256(
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
 @pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
-@skip_for_grayskull()
 def test_conv_for_vanilla_unet(
     device,
     torch_tensor_map,
@@ -2409,7 +2398,6 @@ def test_conv_for_vanilla_unet(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_shallow_conv_with_tiled_input(device):
     out_channels, in_channels, kernel_h, kernel_w = 7, 3, 3, 3

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -85,6 +85,17 @@ def run_conv(
     else:
         total_batch_size = batch_size
 
+    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
+        pytest.skip("Row major layout not compatible with bfloat8_b")
+    if (
+        shard_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+        and output_channels > 256
+        and output_layout == ttnn.ROW_MAJOR_LAYOUT
+    ):
+        pytest.xfail(
+            "Untilize_out is not supported when out_c > 256 for Height Sharded. https://github.com/tenstorrent/tt-metal/issues/18633"
+        )
+
     torch.manual_seed(0)
     conv_input_shape = (total_batch_size, input_channels, input_height, input_width)
     conv_weight_shape = (output_channels, input_channels // groups, filter_height, filter_width)
@@ -761,109 +772,6 @@ def test_conv_for_segformer_512x512(
     )
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="This is test is for Grayskull only. Skipping")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-@pytest.mark.parametrize(
-    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override",
-    (
-        # unique convs in rn50 (complete list)
-        # first conv post folding and input_channels padding to tile width
-        # (64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True), act_block_h_ntiles % 2 == 0
-        # rn50 layer1
-        (64, 64, 56, 56, 1, 1, 1, 1, 0, 0, HS, None),
-        (64, 64, 56, 56, 1, 1, 2, 2, 0, 0, HS, None),
-        (64, 64, 56, 56, 3, 3, 1, 1, 1, 1, HS, None),
-        # rn50 layer2
-        (128, 128, 56, 56, 3, 3, 2, 2, 1, 1, HS, None),
-        (128, 128, 28, 28, 3, 3, 1, 1, 1, 1, HS, None),
-        # rn50 layer3
-        (256, 256, 28, 28, 3, 3, 2, 2, 1, 1, BS, None),
-        (256, 256, 14, 14, 3, 3, 1, 1, 1, 1, BS, None),
-        # rn50 layer4
-        (512, 512, 14, 14, 3, 3, 2, 2, 1, 1, BS, None),
-        (512, 512, 7, 7, 3, 3, 1, 1, 1, 1, BS, None),
-        ## 1x1s2
-        # (256, 256, 28, 28, 1, 1, 2, 2, 0, 0, HS, {"num_cores_nhw": 98}),
-    ),
-)
-@pytest.mark.parametrize(
-    "batch_size",
-    [8, 16, 20],
-)
-@pytest.mark.parametrize(
-    "weights_dtype",
-    [ttnn.bfloat16, ttnn.bfloat8_b],
-)
-@pytest.mark.parametrize(
-    "activations_dtype",
-    [ttnn.bfloat16, ttnn.bfloat8_b],
-)
-@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
-@pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
-def test_resnet50_conv_gs(
-    device,
-    torch_tensor_map,
-    use_program_cache,
-    math_fidelity,
-    activations_dtype,
-    weights_dtype,
-    batch_size,
-    output_channels,
-    input_channels,
-    input_height,
-    input_width,
-    filter_height,
-    filter_width,
-    stride_h,
-    stride_w,
-    pad_h,
-    pad_w,
-    shard_layout,
-    config_override,
-    auto_shard,
-):
-    if batch_size > 8 and (activations_dtype != ttnn.bfloat8_b or weights_dtype != ttnn.bfloat8_b):
-        pytest.skip("Batch > 8 must be run fully bfp8")
-    if batch_size == 20 and input_channels >= 128 and filter_width > 1:
-        pytest.skip("L1 Allocation error")
-    if (
-        activations_dtype == ttnn.bfloat16
-        and batch_size == 20
-        and (
-            output_channels == 64
-            or (
-                stride_h == 2
-                and (output_channels == 256 or (output_channels == 128 and weights_dtype == ttnn.bfloat16))
-            )
-        )
-    ):
-        pytest.skip("Skipping test because it won't fit in L1!")
-
-    run_conv(
-        device,
-        torch_tensor_map,
-        math_fidelity,
-        activations_dtype,
-        weights_dtype,
-        batch_size,
-        output_channels,
-        input_channels,
-        input_height,
-        input_width,
-        filter_height,
-        filter_width,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        config_override=config_override,
-        use_shallow_conv_variant=input_channels == 16,
-        debug=not (batch_size == 20 and input_height == 115),
-        auto_shard=auto_shard,
-        shard_layout=shard_layout,
-    )
-
-
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
@@ -1364,8 +1272,8 @@ def test_sd_conv(
     [ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
-    [ttnn.bfloat16, ttnn.bfloat8_b],
+    "activations_dtype, output_layout",
+    [(ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT), (ttnn.bfloat8_b, ttnn.TILE_LAYOUT)],
 )
 @pytest.mark.parametrize(
     "fp32_accum",
@@ -1395,6 +1303,7 @@ def test_sd_conv_wh(
     pad_w,
     shard_layout,
     config_override,
+    output_layout,
 ):
     if device.core_grid.y == 7:
         pytest.skip("This test is not supported for N300")
@@ -1459,116 +1368,8 @@ def test_sd_conv_wh(
             use_shallow_conv_variant=(input_channels == 16),
             fp32_accum=fp32_accum,
             packer_l1_acc=True,
+            output_layout=output_layout,
         )
-
-
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-@pytest.mark.parametrize(
-    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant",
-    (
-        # unet convs with batch size 2
-        # unique convs in unet (complete list)
-        (2, 16, 3, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 64}, True),
-        (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 64}, True),
-        (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, True),
-        (2, 32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, True),
-        (2, 32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, True),
-        (2, 32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, True),
-        # fails. mismatch. It passes when input_channels=64. Probably an issue with padding when input_channels % 32 != 0.
-        (
-            2,
-            16,
-            48,
-            528,
-            80,
-            3,
-            3,
-            1,
-            1,
-            1,
-            1,
-            HS,
-            {"act_block_h": 32},
-            False,
-        ),
-        (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (2, 16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}, False),
-        (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}, False),
-        (2, 1, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 8 * 32}, False),
-    ),
-)
-@pytest.mark.parametrize(
-    "weights_dtype",
-    [ttnn.bfloat8_b],
-)
-@pytest.mark.parametrize(
-    "activations_dtype",
-    [ttnn.bfloat8_b, ttnn.bfloat16],
-)
-@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
-@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-@pytest.mark.parametrize("auto_shard", [True, BS], ids=["auto_shard", "no_auto_shard"])
-def test_unet_conv(
-    device,
-    torch_tensor_map,
-    use_program_cache,
-    math_fidelity,
-    activations_dtype,
-    weights_dtype,
-    batch_size,
-    output_channels,
-    input_channels,
-    input_height,
-    input_width,
-    filter_height,
-    filter_width,
-    stride_h,
-    stride_w,
-    pad_h,
-    pad_w,
-    shard_layout,
-    config_override,
-    use_shallow_conv_variant,
-    output_layout,
-    auto_shard,
-):
-    if is_blackhole():
-        pytest.skip("This test is for Grayskull only")
-
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and activations_dtype == ttnn.bfloat8_b:
-        pytest.skip("Row major layout not compatible with bfloat8_b")
-    if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
-        pytest.skip("OOM")
-    run_conv(
-        device,
-        torch_tensor_map,
-        math_fidelity,
-        activations_dtype,
-        weights_dtype,
-        batch_size,
-        output_channels,
-        input_channels,
-        input_height,
-        input_width,
-        filter_height,
-        filter_width,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        config_override,
-        shard_layout=shard_layout,
-        use_shallow_conv_variant=use_shallow_conv_variant,
-        output_layout=output_layout,
-        auto_shard=auto_shard,
-    )
 
 
 @skip_for_grayskull()
@@ -1602,11 +1403,10 @@ def test_unet_conv(
     [ttnn.bfloat8_b, ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
-    [ttnn.bfloat8_b, ttnn.bfloat16],
+    "activations_dtype, output_layout",
+    [(ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT), (ttnn.bfloat8_b, ttnn.TILE_LAYOUT)],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
-@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
 def test_unet_conv_wh(
     device,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -988,7 +988,7 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
 
         // MATMUL PARTIALs CB
         uint32_t matmul_partials_cb_size = partials_block_num_bytes;
-        if (interm_dtype == conv_config.dtype) {
+        if (untilize_out == false && interm_dtype == conv_config.dtype) {
             matmul_partials_cb_size = 0;
         } else {
             tt::log_debug(tt::LogOp, "Matmul partial CB Size: {}", matmul_partials_cb_size);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -226,26 +226,17 @@ std::vector<TensorSpec> OptimizedConvNew::compute_output_specs(const std::vector
                     dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
         } else if (this->memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             uint32_t total_height_tiles = padded_output_shape.volume() / padded_output_shape[-1] / TILE_HEIGHT;
-
-            std::array<uint32_t, 2> physical_shard_shape = {
-                tt::div_up(this->parallelization_config.per_core_out_matrix_height, TILE_HEIGHT) * TILE_HEIGHT,
-                tt::div_up(this->parallelization_config.per_core_out_matrix_width, TILE_WIDTH) * TILE_WIDTH};
-            auto shard_shape = physical_shard_shape;
-
+            std::array<uint32_t, 2> shard_shape = {
+                this->parallelization_config.per_core_out_matrix_height_ntile * TILE_HEIGHT,
+                this->parallelization_config.per_core_out_matrix_width_ntile * TILE_WIDTH};
             auto shard_grid = this->memory_config.shard_spec.value().grid;
-            auto shard_spec = ShardSpec{
-                shard_grid, shard_shape, physical_shard_shape, this->memory_config.shard_spec.value().orientation};
+            auto shard_spec = ShardSpec{shard_grid, shard_shape, this->memory_config.shard_spec.value().orientation};
             auto mem_config = this->memory_config;
             mem_config.shard_spec = shard_spec;
-            tt::log_debug(tt::LogOp, "Output shape: {}", output_shape);
-            tt::log_debug(tt::LogOp, "Padded output shape: {}", padded_output_shape);
-            tt::log_debug(tt::LogOp, "Output layout: {}", output_layout);
-            tt::log_debug(tt::LogOp, "Memory config: {}", mem_config);
-
-            auto returnTensorSpec =
-                std::vector{TensorSpec(output_shape, TensorLayout(dtype, PageConfig(output_layout), mem_config))};
-            tt::log_debug(tt::LogOp, "Return TensorSpec: {}", returnTensorSpec[0]);
-            return returnTensorSpec;
+            return {TensorSpec(
+                output_shape,
+                TensorLayout::fromPaddedShape(
+                    dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
         } else if (this->memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             auto shard_grid = this->memory_config.shard_spec.value().grid;
             auto shard_spec = ShardSpec{

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -45,7 +45,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     bool enable_subblock_padding);
 
 // TODO: Add namespace for utilities?
-std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharded_input_v2(
+std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharded_input_v2(
     tt_metal::Program& program,
     const Tensor& input,
     CoreRange core,
@@ -84,6 +84,8 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
     uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
 
     CBHandle cb_sharded_act = 0;
+    CBHandle cb_output = 0;
+    CBHandle cb_matmul_partials = 0;
     if (input.memory_config().is_sharded()) {
         uint32_t num_bytes_for_df = datum_size(act_df);
         auto shard_shape = input.shard_spec().value().shape;
@@ -178,7 +180,6 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
         num_cb0_tilized_tiles,
         tilized_act_tile_size);
 
-    CBHandle cb_output = 0;
     if (untilize_out) {
         cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
         auto output_shard_shape = output.shard_spec().value().shape;
@@ -186,7 +187,7 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
             CircularBufferConfig(
                 num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
                 .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
-        auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+        cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
         log_debug(
             LogOp,
             "Matmul Partials CB: {}, npages: {}, pagesize: {}",
@@ -230,6 +231,7 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
                     out_tile_size);
             }
             cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_matmul_partials_config);
+            cb_matmul_partials = cb_output;
         } else {
             // Separate buffer if not same data format
             cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
@@ -237,7 +239,7 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
                 CircularBufferConfig(
                     num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
                     .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
-            auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+            cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
             log_debug(
                 LogOp,
                 "Matmul Partials CB: {}, npages: {}, pagesize: {}",
@@ -269,11 +271,11 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
         log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", cb_indices.bias_cb, bias_ntiles, bias_pagesize);
     }
 
-    return {cb_sharded_act, cb_output};
+    return {cb_sharded_act, cb_output, cb_matmul_partials};
 }
 
 // TODO: Add namespace for utilities?
-std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthwise_sharded_input(
+std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthwise_sharded_input(
     tt_metal::Program& program,
     const Tensor& input,
     CoreRange core,
@@ -392,7 +394,7 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthw
     }
     cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
 
-    return {cb_sharded_act, cb_output};
+    return {cb_sharded_act, cb_output, cb_matmul_partials};
 }
 
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
@@ -1180,7 +1182,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
     bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
 
-    std::tuple<CBHandle, CBHandle> input_output_cbs = {0, 0};
+    std::tuple<CBHandle, CBHandle, CBHandle> input_output_cbs = {0, 0, 0};
     if (is_conv_1d_depthwise_conv) {
         input_output_cbs = create_CBs_for_depthwise_sharded_input(
             program,
@@ -1238,6 +1240,15 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     }
     CBHandle cb_sharded_act = std::get<0>(input_output_cbs);
     CBHandle cb_output = std::get<1>(input_output_cbs);
+    CBHandle cb_matmul_partials = std::get<2>(input_output_cbs);
+    CircularBufferConfig cb_config_output = GetCircularBufferConfig(program, cb_output);
+    CircularBufferConfig cb_config_matmul_partials = GetCircularBufferConfig(program, cb_matmul_partials);
+    bool partials_cb_uses_output = false;
+    if (cb_config_matmul_partials.globally_allocated_address().has_value() &&
+        cb_config_output.globally_allocated_address().has_value()) {
+        partials_cb_uses_output = cb_config_matmul_partials.globally_allocated_address().value() ==
+                                  cb_config_output.globally_allocated_address().value();
+    }
 
     string reader_kernel;
     string compute_kernel;
@@ -1512,7 +1523,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         cb_indices.tilize_mode_tilized_act_cb,
 
         cb_indices.out0_cb,
-        cb_indices.temp_sum_cb};
+        cb_indices.temp_sum_cb,
+        partials_cb_uses_output};
 
     auto writer_mcast_noc = tt::tt_metal::NOC::NOC_0;
     auto reader_noc =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -570,33 +570,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     std::map<string, string> writer_mcast_sender_defines;
     std::map<string, string> compute_defines;
 
-    compute_defines["WIDTH_SHARDED"] = "1";
-
-    if (output.memory_config().is_sharded()) {
-        writer_defines["SHARDED_OUT"] = "1";
-        writer_mcast_sender_defines["SHARDED_OUT"] = "1";
-    }
-    if (output_num_cores == 1) {
-        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
-    }
-    if (has_bias) {
-        writer_defines["FUSE_BIAS"] = "1";
-        writer_mcast_sender_defines["FUSE_BIAS"] = "1";
-        compute_defines["FUSE_BIAS"] = "1";
-    }
-
-    if (fuse_relu) {
-        compute_defines["PACK_RELU"] = "1";
-    }
-
-    if (split_reader) {
-        reader_defines["SPLIT_READER"] = "1";
-        compute_defines["SPLIT_READER"] = "1";
-    }
-
-    if (packer_l1_acc) {
-        compute_defines["PACKER_L1_ACC"] = "1";
-    }
     uint32_t num_output_tiles = per_core_out_matrix_height_ntiles * p_config.per_core_out_matrix_width_ntile;
     uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
     uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
@@ -778,6 +751,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         cb_indices.tilize_mode_tilized_act_cb,
         cb_indices.out0_cb,
         0,
+        partials_cb_uses_output,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
 
     };

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -20,14 +20,6 @@
 #define DEBUG_PRINT 0
 // #include "debug_macros.h"
 
-// SliceRange srt = SliceRange{.h0 = 0, .h1 = 4, .hs = 1, .w0 = 0, .w1 = 8, .ws = 1};
-// SliceRange srr = SliceRange{.h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1};
-// SliceRange srr1 = SliceRange{.h0 = 1, .h1 = 2, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1};
-// SliceRange src = SliceRange{.h0 = 0, .h1 = 32, .hs = 1, .w0 = 0, .w1 = 1, .ws = 1};
-// SliceRange row_range = SliceRange{.h0 = 0, .h1 = 1, .hs = 1, .w0 = 0, .w1 = 16, .ws = 1};
-// SliceRange col_range = SliceRange{.h0 = 0, .h1 = 16, .hs = 1, .w0 = 0, .w1 = 1, .ws = 1};
-// SliceRange sq_range = SliceRange{.h0 = 0, .h1 = 4, .hs = 1, .w0 = 0, .w1 = 4, .ws = 1};
-
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
     tilize_init_short(in_cb_id, in_block_w, out_cb_id);
@@ -103,9 +95,10 @@ void MAIN {
     constexpr uint32_t matmul_partials_cb = get_compile_time_arg_val(22);
     constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
+    constexpr bool partials_cb_uses_output = get_compile_time_arg_val(26);
 
 #ifdef WIDTH_SHARDED
-    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(26);
+    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(27);
 #endif
 
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
@@ -136,10 +129,8 @@ void MAIN {
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
-    UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;
-           const bool use_partials_for_out = (partials_cb_read_ptr == get_local_cb_interface(out_cb_id).fifo_rd_ptr);)
-    PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;
-         const bool use_partials_for_out = (partials_cb_write_ptr == get_local_cb_interface(out_cb_id).fifo_wr_ptr);)
+    UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
+    PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
     // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
@@ -158,12 +149,10 @@ void MAIN {
             // for each output block we start we relu disabled so that intermediate results are not relu'd
             PACK((llk_pack_relu_config(ReluType::NO_RELU)));
 #endif
-            UNPACK(
-                if (use_partials_for_out) partials_cb_read_ptr =
-                    get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr);
-            PACK(
-                if (use_partials_for_out) partials_cb_write_ptr =
-                    get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr);
+            if constexpr (partials_cb_uses_output) {
+                UNPACK(partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
+                PACK(partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
+            }
             uint32_t curr_matmul_out_cb = matmul_partials_cb;
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
 #ifdef WIDTH_SHARDED
@@ -322,12 +311,10 @@ void MAIN {
                     in0_index_subblock_offset += in0_subblock_num_tiles;
                 }
                 if (curr_matmul_out_cb == matmul_partials_cb) {
-                    UNPACK(
-                        if (!use_partials_for_out) get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr =
-                            partials_cb_read_ptr);
-                    PACK(
-                        if (!use_partials_for_out) get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr =
-                            partials_cb_write_ptr);
+                    if constexpr (!partials_cb_uses_output) {
+                        UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr;)
+                        PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr;)
+                    }
                 }
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
@@ -380,10 +367,8 @@ void MAIN {
                 cb_pop_front(mm_in0_cb_id, in0_block_num_tiles);
                 cb_pop_front(in1_cb_id, in1_block_num_tiles);
             }  // for in0_num_blocks_w
-            if constexpr (matmul_partials_cb == mm_out_cb_id) {
-                UNPACK(
-                    if (use_partials_for_out) get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr =
-                        partials_cb_read_ptr);
+            if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
+                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
             }
 #ifdef FUSE_BIAS
 #ifdef PACK_RELU
@@ -433,7 +418,7 @@ void MAIN {
                     in1_index_subblock_offset += out_subblock_w;
                 }  // for in1_num_subblocks
             }  // in0_num_subblocks
-            if (untilize_out) {
+            if constexpr (untilize_out) {
                 UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
                 PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -24,6 +24,9 @@
 // SliceRange srr = SliceRange{.h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1};
 // SliceRange srr1 = SliceRange{.h0 = 1, .h1 = 2, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1};
 // SliceRange src = SliceRange{.h0 = 0, .h1 = 32, .hs = 1, .w0 = 0, .w1 = 1, .ws = 1};
+// SliceRange row_range = SliceRange{.h0 = 0, .h1 = 1, .hs = 1, .w0 = 0, .w1 = 16, .ws = 1};
+// SliceRange col_range = SliceRange{.h0 = 0, .h1 = 16, .hs = 1, .w0 = 0, .w1 = 1, .ws = 1};
+// SliceRange sq_range = SliceRange{.h0 = 0, .h1 = 4, .hs = 1, .w0 = 0, .w1 = 4, .ws = 1};
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
@@ -133,6 +136,10 @@ void MAIN {
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
+    UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;
+           const bool use_partials_for_out = (partials_cb_read_ptr == get_local_cb_interface(out_cb_id).fifo_rd_ptr);)
+    PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;
+         const bool use_partials_for_out = (partials_cb_write_ptr == get_local_cb_interface(out_cb_id).fifo_wr_ptr);)
     // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
@@ -151,9 +158,12 @@ void MAIN {
             // for each output block we start we relu disabled so that intermediate results are not relu'd
             PACK((llk_pack_relu_config(ReluType::NO_RELU)));
 #endif
-
-            UNPACK(const uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr);
-            PACK(const uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr);
+            UNPACK(
+                if (use_partials_for_out) partials_cb_read_ptr =
+                    get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr);
+            PACK(
+                if (use_partials_for_out) partials_cb_write_ptr =
+                    get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr);
             uint32_t curr_matmul_out_cb = matmul_partials_cb;
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
 #ifdef WIDTH_SHARDED
@@ -311,7 +321,14 @@ void MAIN {
                     }  // for in1_num_subblocks
                     in0_index_subblock_offset += in0_subblock_num_tiles;
                 }
-
+                if (curr_matmul_out_cb == matmul_partials_cb) {
+                    UNPACK(
+                        if (!use_partials_for_out) get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr =
+                            partials_cb_read_ptr);
+                    PACK(
+                        if (!use_partials_for_out) get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr =
+                            partials_cb_write_ptr);
+                }
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
                 if (in0_block_w_i < in0_num_blocks_w - 1) {
@@ -364,7 +381,9 @@ void MAIN {
                 cb_pop_front(in1_cb_id, in1_block_num_tiles);
             }  // for in0_num_blocks_w
             if constexpr (matmul_partials_cb == mm_out_cb_id) {
-                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                UNPACK(
+                    if (use_partials_for_out) get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr =
+                        partials_cb_read_ptr);
             }
 #ifdef FUSE_BIAS
 #ifdef PACK_RELU
@@ -414,6 +433,10 @@ void MAIN {
                     in1_index_subblock_offset += out_subblock_w;
                 }  // for in1_num_subblocks
             }  // in0_num_subblocks
+            if (untilize_out) {
+                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+            }
 #endif
             if constexpr (untilize_out) {
 #if defined PACKER_L1_ACC and not defined FUSE_BIAS


### PR DESCRIPTION
### Ticket
#16888 

### Problem description
Lots of test cases fail when output is in Row Major. 

### What's changed
Matmul_partials_cb is the input CB to the untilize block. Matmul_partials_cb may be directly mapped to the output buffer, or have its own memory allocated. 

If it's mapped to the output buffer, `use_partials_for_out == True`, then the read & write pointers have to be incremented after every in0 height block.

If it has it's own memory allocated,   `use_partials_for_out == False`, then the read & write pointers have to be reset to the original position.

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13467167167)
- [x] Blackhole Post commit (if applicable) [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13565830704)
- [x] Model regression CI testing [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13565834806) 
- [ ] Device performance regression CI testing passes (if applicable)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13565844287)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
