### PR TITLE
#0: Add WriteShard and ReadShard MeshBuffer APIs and resolve MeshBuffer dealloc issues

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -9,12 +9,43 @@
 #include <tt-metalium/mesh_device_view.hpp>
 
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
-#include "tt_metal/distributed/mesh_buffer.hpp"
+#include "tt_metal/distributed/distributed.hpp"
 
 namespace tt::tt_metal::distributed::test {
 namespace {
 
 using MeshBufferTest = T3000MultiDeviceFixture;
+
+struct DeviceLocalShardedBufferTestConfig {
+    Shape2D num_pages_per_core;
+    Shape2D num_cores;
+    Shape2D page_shape;
+    uint32_t element_size = 1;
+    TensorMemoryLayout mem_config = TensorMemoryLayout::HEIGHT_SHARDED;
+    ShardOrientation shard_orientation = ShardOrientation::ROW_MAJOR;
+
+    Shape2D tensor2d_shape() {
+        return {num_pages_per_core.height() * num_cores.height(), num_pages_per_core.width() * num_cores.width()};
+    }
+
+    uint32_t num_pages() { return tensor2d_shape().height() * tensor2d_shape().width(); }
+
+    std::array<uint32_t, 2> shard_shape() {
+        return {num_pages_per_core.height() * page_shape.height(), num_pages_per_core.width() * page_shape.width()};
+    }
+
+    CoreRangeSet shard_grid() {
+        return CoreRangeSet(std::set<CoreRange>(
+            {CoreRange(CoreCoord(0, 0), CoreCoord(this->num_cores.height() - 1, this->num_cores.width() - 1))}));
+    }
+
+    uint32_t page_size() { return page_shape.height() * page_shape.width() * element_size; }
+
+    ShardSpecBuffer shard_parameters() {
+        return ShardSpecBuffer(
+            this->shard_grid(), this->shard_shape(), this->shard_orientation, this->page_shape, this->tensor2d_shape());
+    }
+};
 
 TEST_F(MeshBufferTest, ConfigValidation) {
     const DeviceLocalBufferConfig device_local_config{
@@ -78,6 +109,10 @@ TEST_F(MeshBufferTest, ReplicatedBufferInitialization) {
 }
 
 TEST_F(MeshBufferTest, Deallocation) {
+    // Verify that a buffer is deallocated on the MeshDevice when it goes
+    // out of scope on host. Create a buffer with a certain config in limited
+    // scope. Record its address. Create another buffer with the same config
+    // outside the scope. Verify that addresses match.
     const DeviceLocalBufferConfig device_local_config{
         .page_size = 1024,
         .buffer_type = BufferType::DRAM,
@@ -85,15 +120,13 @@ TEST_F(MeshBufferTest, Deallocation) {
         .bottom_up = false};
 
     const ReplicatedBufferConfig buffer_config{.size = 16 << 10};
-    std::shared_ptr<Buffer> buffer;
-    Allocator* allocator = nullptr;
+    uint32_t expected_address = 0;
     {
         auto replicated_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
-        buffer = replicated_buffer->get_device_buffer(Coordinate{0, 0});
-        allocator = buffer->allocator();
-        EXPECT_TRUE(allocator->allocated_buffers.contains(buffer.get()));
+        expected_address = replicated_buffer->address();
     }
-    EXPECT_FALSE(allocator->allocated_buffers.contains(buffer.get()));
+    auto replicated_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+    EXPECT_EQ(replicated_buffer->address(), expected_address);
 }
 
 TEST_F(MeshBufferTest, GetDeviceBuffer) {
@@ -112,5 +145,113 @@ TEST_F(MeshBufferTest, GetDeviceBuffer) {
     EXPECT_NO_THROW(replicated_buffer->get_device_buffer(Coordinate{1, 3}));
 }
 
+TEST_F(MeshBufferTest, InterleavedShardsReadWrite) {
+    constexpr uint32_t NUM_ITERS = 100;
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", 0);
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+
+    for (auto buffer_type : {BufferType::L1, BufferType::DRAM}) {
+        DeviceLocalBufferConfig per_device_buffer_config{
+            .page_size = single_tile_size,
+            .buffer_type = BufferType::L1,
+            .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+            .bottom_up = false};
+
+        std::uniform_int_distribution<int> gen_num_tiles(1, 1024);
+        std::mt19937 rng(seed);
+        for (int i = 0; i < NUM_ITERS; i++) {
+            uint32_t num_random_tiles = gen_num_tiles(rng);
+            ReplicatedBufferConfig global_buffer_config = {
+                .size = num_random_tiles * single_tile_size,
+            };
+
+            std::shared_ptr<MeshBuffer> buf =
+                MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+            std::vector<uint32_t> src_vec(num_random_tiles * single_tile_size / sizeof(uint32_t), 0);
+            std::iota(src_vec.begin(), src_vec.end(), i);
+            for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+                for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+                    WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, Coordinate(logical_y, logical_x));
+                }
+            }
+
+            for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+                for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+                    std::vector<uint32_t> dst_vec = {};
+                    ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, Coordinate(logical_y, logical_x));
+                    EXPECT_EQ(dst_vec, src_vec);
+                }
+            }
+        }
+    }
+}
+
+class DeviceLocalMeshBufferShardingTest
+    : public MeshBufferTest,
+      public testing::WithParamInterface<
+          std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>, TensorMemoryLayout>> {};
+
+TEST_P(DeviceLocalMeshBufferShardingTest, ShardingTest) {
+    auto [num_pages_per_core, page_shape, shard_strategy] = GetParam();
+    CoreCoord core_grid_size = mesh_device_->compute_with_storage_grid_size();
+
+    DeviceLocalShardedBufferTestConfig test_config{
+        .num_pages_per_core = num_pages_per_core,
+        .num_cores = {core_grid_size.x, core_grid_size.y},
+        .page_shape = page_shape,
+        .mem_config = shard_strategy};
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = test_config.page_size(),
+        .buffer_type = BufferType::L1,
+        .buffer_layout = test_config.mem_config,
+        .shard_parameters = test_config.shard_parameters(),
+        .bottom_up = false};
+
+    uint32_t buf_size = test_config.num_pages() * test_config.page_size();
+    ReplicatedBufferConfig global_buffer_config{
+        .size = buf_size,
+    };
+
+    auto buf = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+    std::vector<uint32_t> src_vec(buf_size / sizeof(uint32_t), 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+            WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, Coordinate(logical_y, logical_x));
+        }
+    }
+
+    for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+            std::vector<uint32_t> dst_vec = {};
+            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, Coordinate(logical_y, logical_x));
+            EXPECT_EQ(dst_vec, src_vec);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DeviceLocalMeshBufferShardingTests,
+    DeviceLocalMeshBufferShardingTest,
+    ::testing::Combine(
+        // num_pages_per_core
+        ::testing::Values(
+            std::array<uint32_t, 2>{1, 1},
+            std::array<uint32_t, 2>{3, 137},
+            std::array<uint32_t, 2>{67, 4},
+            std::array<uint32_t, 2>{7, 11},
+            std::array<uint32_t, 2>{2, 2}),
+        // page_shape
+        ::testing::Values(
+            std::array<uint32_t, 2>{1, 1024},
+            std::array<uint32_t, 2>{1, 2048},
+            std::array<uint32_t, 2>{1, 4},
+            std::array<uint32_t, 2>{32, 32},
+            std::array<uint32_t, 2>{1, 120}),
+        // shard_strategy
+        ::testing::Values(
+            TensorMemoryLayout::HEIGHT_SHARDED, TensorMemoryLayout::WIDTH_SHARDED, TensorMemoryLayout::BLOCK_SHARDED)));
 }  // namespace
 }  // namespace tt::tt_metal::distributed::test

--- a/tt_metal/distributed/distributed.hpp
+++ b/tt_metal/distributed/distributed.hpp
@@ -24,6 +24,28 @@ void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program& program, con
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
 
+template <typename DType>
+void WriteShard(
+    MeshCommandQueue& mesh_cq,
+    std::shared_ptr<MeshBuffer>& mesh_buffer,
+    std::vector<DType>& src,
+    const Coordinate& coord,
+    bool blocking = false) {
+    mesh_cq.enqueue_write_shard(mesh_buffer, src.data(), coord, blocking);
+}
+
+template <typename DType>
+void ReadShard(
+    MeshCommandQueue& mesh_cq,
+    std::vector<DType>& dst,
+    std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const Coordinate& coord,
+    bool blocking = true) {
+    auto shard = mesh_buffer->get_device_buffer(coord);
+    dst.resize(shard->page_size() * shard->num_pages() / sizeof(DType));
+    mesh_cq.enqueue_read_shard(dst.data(), mesh_buffer, coord, blocking);
+}
+
 void Finish(MeshCommandQueue& mesh_cq);
 
 }  // namespace distributed

--- a/tt_metal/distributed/mesh_command_queue.hpp
+++ b/tt_metal/distributed/mesh_command_queue.hpp
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <mesh_device.hpp>
+#include <tt-metalium/command_queue_interface.hpp>
 
+#include "tt_metal/distributed/mesh_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload.hpp"
 
 namespace tt::tt_metal::distributed {
@@ -21,6 +23,16 @@ private:
     void populate_dispatch_core_type();
     CoreCoord virtual_program_dispatch_core() const;
     CoreType dispatch_core_type() const;
+    void write_shard_to_device(
+        std::shared_ptr<Buffer>& shard_view,
+        const void* src,
+        std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void read_shard_from_device(
+        std::shared_ptr<Buffer>& shard_view,
+        void* dst,
+        std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
     tt::tt_metal::WorkerConfigBufferMgr config_buffer_mgr_;
     LaunchMessageRingBufferState worker_launch_message_buffer_state_;
     uint32_t expected_num_workers_completed_ = 0;
@@ -35,6 +47,10 @@ public:
     uint32_t id() const { return id_; }
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking);
+    void enqueue_write_shard(
+        std::shared_ptr<MeshBuffer>& mesh_buffer, void* host_data, const Coordinate& coord, bool blocking);
+    void enqueue_read_shard(
+        void* host_data, std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);
     void finish();
 };
 


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
- `MeshBuffer` deallocation on destruction is currently a nop on main (issue deallocate to address 0 when destroying any `MeshBuffer`)
- Basic IO functionality for `MeshBuffer` needs to be added 

### What's changed
- Resolve deallocation issue: Allocate the single device backing buffer when its created, and store this in the `MeshBuffer` object. The backing buffer gets deleted and automatically deallocated at the correct address when its destroyed
- Add `WriteShard` and `ReadShard` APIs. Multi-device sharding and replication builds on top of this (to be added in a separate PR).
- Add tests.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
