### PR TITLE
Enable ConvMnist and Mnist integration and performance tests.

### DIFF
--- a/models/demos/convnet_mnist/tests/test_performance.py
+++ b/models/demos/convnet_mnist/tests/test_performance.py
@@ -111,16 +111,15 @@ def test_convnet_mnist(
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 105.710],
+        [1, 10954.46],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
-@pytest.mark.skip("#16824: Failing when whole suite is run on all archs")
 def test_perf_device_bare_metal_convnet_mnist(batch_size, expected_perf):
     subdir = "ttnn_convnet_mnist"
     num_iterations = 1
     margin = 0.03
-    expected_perf = 2430 if is_grayskull() else 3358.0
+    expected_perf = 2430 if is_grayskull() else expected_perf
 
     command = f"pytest tests/ttnn/integration_tests/convnet_mnist/test_convnet_mnist.py"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/mnist/tests/test_perf_mnist.py
+++ b/models/demos/mnist/tests/test_perf_mnist.py
@@ -30,11 +30,11 @@ test_dataset = datasets.MNIST(root="./data", train=False, transform=None, downlo
 def get_expected_times(tt_mnist):
     if is_grayskull():
         return {
-            tt_mnist: (3.54, 0.005),
+            tt_mnist: (3.54, 0.006),
         }[tt_mnist]
     elif is_wormhole_b0():
         return {
-            tt_mnist: (3.89, 0.005),
+            tt_mnist: (3.89, 0.006),
         }[tt_mnist]
 
 
@@ -102,7 +102,6 @@ def test_performance_mnist(device, batch_size, tt_mnist, model_location_generato
     logger.info("Exit MNIST perf test")
 
 
-@pytest.mark.skip("#16824: Failing when whole suite is run on all archs")
 @pytest.mark.parametrize(
     "batch_size",
     [128],

--- a/tests/ttnn/integration_tests/convnet_mnist/test_convnet_mnist.py
+++ b/tests/ttnn/integration_tests/convnet_mnist/test_convnet_mnist.py
@@ -26,7 +26,6 @@ def model_location_generator(rel_path):
         return Path("/opt/tt-metal-models") / rel_path
 
 
-@pytest.mark.skip("#16824: Failing when whole suite is run on all archs")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_convnet_mnist(device, reset_seeds):
     model_path = model_location_generator("tt_dnn-models/ConvNetMNIST/")

--- a/tests/ttnn/integration_tests/mnist/test_mnist.py
+++ b/tests/ttnn/integration_tests/mnist/test_mnist.py
@@ -15,7 +15,6 @@ from models.demos.mnist.reference.mnist import MnistModel
 from models.demos.mnist.tt import tt_mnist
 
 
-@pytest.mark.skip("#16824: Failing when whole suite is run on all archs")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size",


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16824)

### Problem description
Re-enable ConvMnist and Mnist integration and performance tests.

### What's changed
ConvMnist and Mnist integration test failed on all cards are now fixed with the latest main.

### Checklist - 
CI links as of **07th Mar,2025**
- [x] Post commit CI passes - [link](https://github.com/tenstorrent/tt-metal/actions/runs/13713405845)
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes - [ConvMnist](https://github.com/tenstorrent/tt-metal/actions/runs/13713409872/job/38354093734#step:10:811), [Mnist](https://github.com/tenstorrent/tt-metal/actions/runs/13713409872/job/38354093734#step:10:1007)
- [ ] Device performance regression CI testing passes - [ConvMnist](https://github.com/tenstorrent/tt-metal/actions/runs/13713408301/job/38354149638#step:9:898), [Mnist](https://github.com/tenstorrent/tt-metal/actions/runs/13713408301/job/38354149638#step:9:1084)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes - [link](https://github.com/tenstorrent/tt-metal/actions/runs/13713412929) Apart from Device Perf, Both the models passed in rest of the relevant CIs.
- [ ] New/Existing tests provide coverage for changes
