### PR TITLE
Fixing variable name to build umd tests

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -250,7 +250,7 @@ if [ "$build_ttnn_tests" = "ON" ]; then
     cmake_args+=("-DTTNN_BUILD_TESTS=ON")
 fi
 
-if [ "$build_tt_umd_tests" = "ON" ]; then
+if [ "$build_umd_tests" = "ON" ]; then
     cmake_args+=("-DTT_UMD_BUILD_TESTS=ON")
 fi
 


### PR DESCRIPTION
Argument `--build-umd-tests` to `build_metal.sh` was not connected to cmake...