### PR TITLE
Add output dtype to layernorm / rms norm

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -88,7 +88,7 @@ def compute_pre_allgather_stats(tt_input_tensor, core_grid, input_width, is_rmsn
 
 
 def compute_post_allgather_output(
-    tt_input_tensor, tt_weights, tt_stats_tensor, eps, is_rmsnorm, core_grid, input_width
+    tt_input_tensor, tt_weights, tt_stats_tensor, eps, is_rmsnorm, core_grid, input_width, output_df
 ):
     SHARDED_NORM_PRGM_CFG = ttnn.LayerNormShardedMultiCoreProgramConfig(
         compute_with_storage_grid_size=(core_grid[1], core_grid[0]),
@@ -105,6 +105,7 @@ def compute_post_allgather_output(
             weight=tt_weights,
             program_config=SHARDED_NORM_PRGM_CFG,
             stats=tt_stats_tensor,
+            dtype=output_df,
         )
     else:
         return ttnn.layer_norm_post_all_gather(
@@ -113,6 +114,7 @@ def compute_post_allgather_output(
             weight=tt_weights,
             program_config=SHARDED_NORM_PRGM_CFG,
             stats=tt_stats_tensor,
+            dtype=output_df,
         )
 
 
@@ -316,9 +318,10 @@ def test_pre_allgather_layernorm_1d_reduce(
 @pytest.mark.parametrize("input_width", [2048])
 @pytest.mark.parametrize("num_devices", [4, 8])
 @pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("output_df", [ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize("weights_df", [ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))
-@pytest.mark.parametrize("core_grid", ((4, 8),))
+@pytest.mark.parametrize("core_grid", ((2, 8),))
 def test_post_allgather_layernorm(
     device,
     use_program_cache,
@@ -326,6 +329,7 @@ def test_post_allgather_layernorm(
     num_devices,
     is_rmsnorm,
     input_df,
+    output_df,
     weights_df,
     seed,
     eps,
@@ -377,7 +381,7 @@ def test_post_allgather_layernorm(
             torch_weight_chunks[d], device, weights_df, core_grid, input_width, is_weight=True
         )
         tt_output_tensor = compute_post_allgather_output(
-            tt_input_tensor, tt_weights, tt_device_stats, eps, is_rmsnorm, core_grid, input_width
+            tt_input_tensor, tt_weights, tt_device_stats, eps, is_rmsnorm, core_grid, input_width, output_df
         )
         tt_output_torch = ttnn.to_torch(tt_output_tensor).to(torch.bfloat16)
 

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -466,7 +466,7 @@ def test_simulated_distributed_layernorm(
             torch_weight_chunks[d], device, weights_df, core_grid, input_width, is_weight=True
         )
         tt_output_tensor = compute_post_allgather_output(
-            tt_input_tensor, tt_weights, tt_global_stats, eps, is_rmsnorm, core_grid, input_width
+            tt_input_tensor, tt_weights, tt_global_stats, eps, is_rmsnorm, core_grid, input_width, input_df
         )
         tt_output_chunks.append(ttnn.to_torch(tt_output_tensor).to(torch.bfloat16))
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -244,7 +244,9 @@ std::vector<TensorSpec> LayerNorm::compute_output_specs(const std::vector<Tensor
                 auto mem_config = this->output_mem_config;
                 mem_config.shard_spec = input_tensor.shard_spec().value();
                 return {TensorSpec(
-                    output_shape, TensorLayout(input_tensor.get_dtype(), PageConfig(Layout::TILE), mem_config))};
+                    output_shape,
+                    TensorLayout(
+                        this->dtype.value_or(input_tensor.get_dtype()), PageConfig(Layout::TILE), mem_config))};
             } else {
                 return {TensorSpec(
                     output_shape, TensorLayout(input_tensor.get_dtype(), PageConfig(Layout::TILE), output_mem_config))};

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
@@ -48,6 +48,7 @@ struct LayerNorm {
     MemoryConfig output_mem_config;
     LayerNormProgramConfig program_config;
     const DeviceComputeKernelConfig compute_kernel_config;
+    std::optional<DataType> dtype;
 
     void validate(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -100,7 +100,7 @@ std::vector<TensorSpec> LayerNormPostAllGather::compute_output_specs(const std::
     auto& input_tensor = input_tensors.at(0);
     return {TensorSpec(
         input_tensor.get_logical_shape(),
-        TensorLayout(input_tensor.get_dtype(), PageConfig(Layout::TILE), memory_config))};
+        TensorLayout(this->dtype.value_or(input_tensor.get_dtype()), PageConfig(Layout::TILE), memory_config))};
 }
 
 operation::ProgramWithCallbacks LayerNormPostAllGather::create_program(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.hpp
@@ -31,6 +31,7 @@ struct LayerNormPostAllGather {
     float eps;
     MemoryConfig memory_config;
     const DeviceComputeKernelConfig compute_kernel_config;
+    std::optional<DataType> dtype;
 
     void validate(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
@@ -44,7 +44,8 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
             py::arg("bias") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
-            py::arg("program_config") = std::nullopt});
+            py::arg("program_config") = std::nullopt,
+            py::arg("dtype") = std::nullopt});
 }
 
 void bind_normalization_layernorm_distributed(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
@@ -17,7 +17,8 @@ ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
     const std::optional<const ttnn::Tensor>& bias,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const LayerNormProgramConfig>& program_config) {
+    const std::optional<const LayerNormProgramConfig>& program_config,
+    const std::optional<const DataType>& dtype) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
@@ -31,7 +32,8 @@ ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
                        .eps = epsilon,
                        .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
                        .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
-                       .compute_kernel_config = kernel_config_val},
+                       .compute_kernel_config = kernel_config_val,
+                       .dtype = dtype},
                    {input_tensor},
                    {std::nullopt, weight, bias, stats})
             .at(0);
@@ -41,7 +43,8 @@ ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
                        .norm_type = LayerNormDistributedType::LAYERNORM,
                        .eps = epsilon,
                        .memory_config = memory_config.value_or(input_tensor.memory_config()),
-                       .compute_kernel_config = kernel_config_val},
+                       .compute_kernel_config = kernel_config_val,
+                       .dtype = dtype},
                    {input_tensor, stats},
                    {weight, bias})
             .at(0);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp
@@ -21,7 +21,8 @@ struct ExecuteLayerNormPostAllGather {
         const std::optional<const ttnn::Tensor>& bias = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt);
+        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
+        const std::optional<const DataType>& dtype = std::nullopt);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -49,7 +49,8 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
             py::arg("bias") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
-            py::arg("program_config") = std::nullopt});
+            py::arg("program_config") = std::nullopt,
+            py::arg("dtype") = std::nullopt});
 }
 
 void bind_normalization_rms_norm_distributed(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
@@ -17,7 +17,8 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
     const std::optional<const ttnn::Tensor>& bias,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const LayerNormProgramConfig>& program_config) {
+    const std::optional<const LayerNormProgramConfig>& program_config,
+    const std::optional<const DataType>& dtype) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
@@ -31,7 +32,8 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
                        .eps = epsilon,
                        .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
                        .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
-                       .compute_kernel_config = kernel_config_val},
+                       .compute_kernel_config = kernel_config_val,
+                       .dtype = dtype},
                    {input_tensor},
                    {std::nullopt, weight, bias, stats})
             .at(0);
@@ -41,7 +43,8 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
                        .norm_type = LayerNormDistributedType::RMSNORM,
                        .eps = epsilon,
                        .memory_config = memory_config.value_or(input_tensor.memory_config()),
-                       .compute_kernel_config = kernel_config_val},
+                       .compute_kernel_config = kernel_config_val,
+                       .dtype = dtype},
                    {input_tensor, stats},
                    {weight, bias})
             .at(0);

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
@@ -21,7 +21,8 @@ struct ExecuteRMSNormPostAllGather {
         const std::optional<const ttnn::Tensor>& bias = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt);
+        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
+        const std::optional<const DataType>& dtype = std::nullopt);
 };
 
 }  // namespace operations::normalization


### PR DESCRIPTION
### What's changed
Added output dtype to distributed layernorm post all gather (layernorm and rms norm, both sharded and interleaved variants) to convert output to specified dtype.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12907623276
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
