### PR TITLE
Minor fixes for CB initialization

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -40,7 +40,11 @@ constexpr uint32_t RISCV_IC_TRISC1_MASK = 0x4;
 constexpr uint32_t RISCV_IC_TRISC2_MASK = 0x8;
 constexpr uint32_t RISCV_IC_TRISC_ALL_MASK = RISCV_IC_TRISC0_MASK | RISCV_IC_TRISC1_MASK | RISCV_IC_TRISC2_MASK;
 
+#ifdef NCRISC_HAS_IRAM
 constexpr uint32_t num_cbs_to_early_init = 4;  // safe small number to overlap w/ ncrisc copy
+#else
+constexpr uint32_t num_cbs_to_early_init = 0;
+#endif
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 uint32_t ncrisc_kernel_start_offset16;
@@ -331,8 +335,10 @@ inline void finish_ncrisc_copy_and_run(dispatch_core_processor_masks enables) {
 
         l1_to_ncrisc_iram_copy_wait();
 
+#ifdef NCRISC_HAS_IRAM
         // Note: only ncrisc is in reset, so just deasserts ncrisc
         deassert_all_reset();
+#endif
     }
 }
 

--- a/tt_metal/hw/inc/circular_buffer_init.h
+++ b/tt_metal/hw/inc/circular_buffer_init.h
@@ -13,7 +13,7 @@
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
-inline void setup_local_cb_read_write_interfaces(
+FORCE_INLINE void setup_local_cb_read_write_interfaces(
     uint32_t tt_l1_ptr* cb_l1_base,
     uint32_t start_cb_index,
     uint32_t max_cb_index,

--- a/tt_metal/hw/inc/risc_attribs.h
+++ b/tt_metal/hw/inc/risc_attribs.h
@@ -36,7 +36,7 @@ inline __attribute__((always_inline)) uint64_t tt_l1_load(volatile tt_uint64_t* 
 
 // In certain cases enabling watcher can cause the code size to be too large. Give an option to
 // disable inlining if we need to.
-#if defined(WATCHER_NOINLINE)
+#if defined(WATCHER_ENABLED) && defined(WATCHER_NOINLINE)
 #define FORCE_INLINE
 #else
 #define FORCE_INLINE inline __attribute__((always_inline))


### PR DESCRIPTION
### Ticket
None

### Problem description
Multiple issues found when looking into CB init performance

### What's changed
Fix watcher no inline to not disable inlining when watcher is not enabled
Force CB init to be inlined
Don't early init on BH

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
