### PR TITLE
Remove mystery unused zlib dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,6 @@ target_link_libraries(
     metal_common_libs
     INTERFACE
         dl
-        z
         pthread
         atomic
         hwloc


### PR DESCRIPTION
### Problem description
Linking tt_metal would fail in Anaconda, without the zlib.so being present in the system.
However, it appears nothing is using zlib.
So why are we globally linking it to all targets?

### What's changed
Don't link zlib.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12916349029)
- [x] New/Existing tests provide coverage for changes
