### PR TITLE
Address some CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18..3.30)
+cmake_minimum_required(VERSION 3.18...3.30)
 
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -25,6 +25,8 @@ CPMAddPackage(
     NAME yaml-cpp
     GITHUB_REPOSITORY jbeder/yaml-cpp
     GIT_TAG 0.8.0
+    PATCHES
+        yaml-cpp.patch
     OPTIONS
         "YAML_CPP_BUILD_TESTS OFF"
         "YAML_CPP_BUILD_TOOLS OFF"
@@ -84,19 +86,27 @@ CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.0.1)
 # range-v3 : https://github.com/ericniebler/range-v3
 ############################################################################################################################
 
-CPMAddPackage(NAME range-v3 GITHUB_REPOSITORY ericniebler/range-v3 GIT_TAG 0.12.0)
+CPMAddPackage(
+    NAME range-v3
+    GITHUB_REPOSITORY ericniebler/range-v3
+    GIT_TAG 0.12.0
+    PATCHES
+        range-v3.patch
+    OPTIONS
+        "CMAKE_BUILD_TYPE Release"
+)
 
 ############################################################################################################################
 # pybind11 : https://github.com/pybind/pybind11
 ############################################################################################################################
 
-CPMAddPackage(NAME pybind11 GITHUB_REPOSITORY pybind/pybind11 GIT_TAG b8f28551cc3a98ea9fbfc15c05b513c8f2d23e84)
+CPMAddPackage(NAME pybind11 GITHUB_REPOSITORY pybind/pybind11 GIT_TAG v2.13.6)
 
 ############################################################################################################################
 # nlohmann/json : https://github.com/nlohmann/json
 ############################################################################################################################
 
-CPMAddPackage(NAME json GITHUB_REPOSITORY nlohmann/json GIT_TAG v3.9.1)
+CPMAddPackage(NAME json GITHUB_REPOSITORY nlohmann/json GIT_TAG v3.11.3)
 
 ############################################################################################################################
 # xtensor : https://github.com/xtensor-stack/xtensor

--- a/dependencies/range-v3.patch
+++ b/dependencies/range-v3.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e4be356..979c58b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,7 @@
+ # Distributed under the Boost Software License, Version 1.0.
+ # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+-cmake_minimum_required(VERSION 3.6)
++cmake_minimum_required(VERSION 3.6...3.30)
+ get_directory_property(is_subproject PARENT_DIRECTORY)
+
+ if(NOT is_subproject)

--- a/dependencies/yaml-cpp.patch
+++ b/dependencies/yaml-cpp.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46dc180..1ae92e2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,6 @@
+-# 3.5 is actually available almost everywhere, but this a good minimum
+-cmake_minimum_required(VERSION 3.4)
++# 3.5 is actually available almost everywhere, but this a good minimum.
++# 3.14 as the upper policy limit avoids CMake deprecation warnings.
++cmake_minimum_required(VERSION 3.4...3.14)
+
+ # enable MSVC_RUNTIME_LIBRARY target property
+ # see https://cmake.org/cmake/help/latest/policy/CMP0091.html


### PR DESCRIPTION
### Ticket
#14001

### Problem description
The CMake output is littered with warnings, which makes it difficult to see actual errors.

### What's changed
Addressed some of the warnings.  Still more to do. To be continued...
Mostly addressed by telling CMake that we've tested the CMake files against newer CMake version and it's okay to enable the policies introduced since the minimum supported version.
In some cases this was done by grabbing a newer release of the library, and in others we patch the `cmake_minimum_required` line ourselves as we pull it in.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12918179996
