### PR TITLE
#0: fix blachole scheduled post-commit

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -2,6 +2,12 @@ name: "Blackhole post-commit tests"
 
 on:
   workflow_call:
+    inputs:
+      runner-label:
+          description: 'Optional: BH'
+          required: false
+          type: string
+          default: 'BH'
   workflow_dispatch:
     inputs:
       runner-label:


### PR DESCRIPTION
### Ticket
Link to Github Issue
Fix broken blackhole post-commit scheduled call.
Previous PR did not include a default value for scheduled blackhole post-commit runs which use workflow_call, only workflow_dispatch


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
