### PR TITLE
Remove all usages of get_legacy_shape() from the codebase

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/examples.rst
+++ b/docs/source/ttnn/ttnn/dependencies/examples.rst
@@ -91,7 +91,7 @@ Lastly, we run ``exp`` on TT Accelerator device (supplying it with output from `
 
         # Move TT Tensor tt_relu_out to host and convert it to PyTorch tensor py_relu_out
         tt_relu_out = tt_relu_out.cpu()
-        py_relu_out = torch.Tensor(tt_relu_out.data()).reshape(tt_relu_out.get_legacy_shape())
+        py_relu_out = torch.Tensor(tt_relu_out.data()).reshape(tt_relu_out.get_padded_shape())
 
         # Execute pow using PyTorch (since pow is not available from tt_lib)
         py_pow_out = torch.pow(py_relu_out, py_tensor_exp)

--- a/docs/source/ttnn/ttnn/dependencies/examples.rst
+++ b/docs/source/ttnn/ttnn/dependencies/examples.rst
@@ -91,7 +91,7 @@ Lastly, we run ``exp`` on TT Accelerator device (supplying it with output from `
 
         # Move TT Tensor tt_relu_out to host and convert it to PyTorch tensor py_relu_out
         tt_relu_out = tt_relu_out.cpu()
-        py_relu_out = torch.Tensor(tt_relu_out.data()).reshape(tt_relu_out.get_padded_shape())
+        py_relu_out = torch.Tensor(tt_relu_out.data()).reshape(tt_relu_out.shape)
 
         # Execute pow using PyTorch (since pow is not available from tt_lib)
         py_pow_out = torch.pow(py_relu_out, py_tensor_exp)

--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -32,7 +32,7 @@ Tensor encoder(
     const Parameters& parameters,
     std::size_t encoder_index,
     const std::uint32_t head_size) {
-    auto batch_size = hidden_states.get_legacy_shape()[0];
+    auto batch_size = hidden_states.get_padded_shape()[0];
 
     auto fused_qkv_matmul_program_config = ttnn::operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig{
         .compute_with_storage_grid_size = {12, batch_size},

--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -377,7 +377,7 @@ int main() {
             {config.batch_size,
              config.input_hw.first + 2 * config.pad_hw.first,
              config.input_hw.second + 2 * config.pad_hw.second});
-        tt::tt_metal::LegacyShape output_tensor_shape = config.get_output_shape().value;
+        auto output_tensor_shape = config.get_output_shape().value;
         ttnn::SimpleShape filter_tensor_shape({config.window_hw.first, config.window_hw.second});
 
         Tensor input_padded_tensor =

--- a/tests/tt_metal/llrt/test_libs/conv_pattern.hpp
+++ b/tests/tt_metal/llrt/test_libs/conv_pattern.hpp
@@ -32,7 +32,7 @@ public:
 template <typename T>
 std::vector<std::vector<T>> move_act_dram_to_l1(tt::deprecated::Tensor<T>& input_nhwc, ConvParameters conv_params) {
     std::vector<std::vector<T>> output;
-    auto in_shape = input_nhwc.get_legacy_shape();
+    auto in_shape = input_nhwc.get_padded_shape();
     auto input_values = input_nhwc.get_values();
 
     std::vector<std::pair<int, int>> increments;
@@ -205,7 +205,7 @@ std::vector<T> flatten(std::vector<std::vector<T>>& act_matrix) {
 template <typename T>
 std::vector<std::vector<T>> move_weights_dram_to_l1(tt::deprecated::Tensor<T>& input_nhwc) {
     std::vector<std::vector<T>> output;
-    std::array<uint32_t, 4> in_shape = input_nhwc.get_legacy_shape();
+    std::array<uint32_t, 4> in_shape = input_nhwc.get_padded_shape();
     const auto& input_nhwc_values = input_nhwc.get_values();
 
     for (auto w = 0; w < in_shape[0]; w++) {
@@ -227,7 +227,7 @@ std::vector<std::vector<T>> move_weights_dram_to_l1(tt::deprecated::Tensor<T>& i
 template <typename T>
 std::vector<std::vector<T>> move_weights_dram_to_l1_mm(tt::deprecated::Tensor<T>& input_nhwc) {
     std::vector<std::vector<T>> output;
-    std::array<uint32_t, 4> in_shape = input_nhwc.get_legacy_shape();
+    std::array<uint32_t, 4> in_shape = input_nhwc.get_padded_shape();
     const auto& input_nhwc_values = input_nhwc.get_values();
     uint32_t num_rows = in_shape[1] * in_shape[2] * in_shape[3];
     for (auto i = 0; i < num_rows; i++) {

--- a/tests/tt_metal/test_utils/deprecated/tensor.hpp
+++ b/tests/tt_metal/test_utils/deprecated/tensor.hpp
@@ -31,7 +31,7 @@ public:
         this->strides = {shape[1] * shape[2] * shape[3], shape[2] * shape[3], shape[3], 1};
     }
     const std::vector<T>& get_values() const { return this->values; }
-    const std::array<uint32_t, 4>& get_legacy_shape() const { return this->shape; }
+    const std::array<uint32_t, 4>& get_padded_shape() const { return this->shape; }
     const std::array<uint32_t, 4>& get_strides() const { return this->strides; }
     uint32_t get_volume() const { return shape[0] * shape[1] * shape[2] * shape[3]; }
 
@@ -43,7 +43,7 @@ private:
 
 template <class T>
 void print(const Tensor<T>& tensor) {
-    auto tensor_shape = tensor.get_legacy_shape();
+    auto tensor_shape = tensor.get_padded_shape();
     auto tensor_strides = tensor.get_strides();
     auto tensor_data = tensor.get_values();
 
@@ -105,7 +105,7 @@ Tensor<T> initialize_tensor(
 // {0, 2, 3, 1} -> NHWC
 template <class T>
 Tensor<T> permute(const Tensor<T>& input, std::array<int, 4> dims) {
-    auto in_shape = input.get_legacy_shape();
+    auto in_shape = input.get_padded_shape();
     std::array<uint32_t, 4> out_shape = {in_shape[dims[0]], in_shape[dims[1]], in_shape[dims[2]], in_shape[dims[3]]};
     auto output_volume = out_shape[0] * out_shape[1] * out_shape[2] * out_shape[3];
     std::vector<T> out = std::vector<T>(output_volume);
@@ -130,7 +130,7 @@ Tensor<T> permute(const Tensor<T>& input, std::array<int, 4> dims) {
 
 template <class T>
 Tensor<T> permute_nhwc_to_nchw(const Tensor<T>& input) {
-    std::array<uint32_t, 4> in_shape = input.get_legacy_shape();
+    std::array<uint32_t, 4> in_shape = input.get_padded_shape();
     std::array<uint32_t, 4> out_shape = {in_shape[0], in_shape[3], in_shape[1], in_shape[2]};
     auto output_volume = out_shape[0] * out_shape[1] * out_shape[2] * out_shape[3];
     std::vector<T> out = std::vector<T>(output_volume, 0);
@@ -154,7 +154,7 @@ Tensor<T> permute_nhwc_to_nchw(const Tensor<T>& input) {
 
 template <class T>
 Tensor<T> pad(Tensor<T>& input, std::array<std::array<uint32_t, 2>, 4> pad_size, T val = 0) {
-    auto in_shape = input.get_legacy_shape();
+    auto in_shape = input.get_padded_shape();
     std::array<uint32_t, 4> out_shape = {
         in_shape[0] + pad_size[0][0] + pad_size[0][1],
         in_shape[1] + pad_size[1][0] + pad_size[1][1],

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -94,7 +94,7 @@ AllGatherConfig::AllGatherConfig(
         // See issue #6448
         int outer_dims_size = 1;
         for (std::size_t i = 0; i < dim; i++) {
-            outer_dims_size *= input_tensor.get_legacy_shape()[i];
+            outer_dims_size *= input_tensor.get_padded_shape()[i];
         }
         if (outer_dims_size > 1) {
             this->enable_bidirectional = false;

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -364,7 +364,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     log_trace(tt::LogOp, "max_buffer_per_chunk: {}", max_buffer_per_chunk);
     log_trace(tt::LogOp, "max_pages_per_chunk: {}", max_pages_per_chunk);
     bool rm = input_tensor.get_layout() == Layout::ROW_MAJOR;
-    bool width = input_tensor.get_legacy_shape().rank() - 1 == dim;
+    bool width = input_tensor.get_padded_shape().rank() - 1 == dim;
     tt::DataFormat df = datatype_to_dataformat_converter(input_tensor.get_dtype());
 
     std::map<string, string> worker_defines;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -373,30 +373,31 @@ RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::RingReduceScatterBaseTensor
     uint32_t half_cb_n_pages) :
     LegacyCclTensorSlicer() {
     TT_ASSERT(max_slice_size_in_bytes > 0);
-    TT_ASSERT(input_tensor.get_legacy_shape().size() == 4);
+    TT_ASSERT(input_tensor.get_padded_shape().rank() == 4);
     this->row_major = input_tensor.get_layout() == Layout::ROW_MAJOR;
-    this->slice_dim_is_width = input_tensor.get_legacy_shape().rank() - 1 == slice_dim;
+    this->slice_dim_is_width = input_tensor.get_padded_shape().rank() - 1 == slice_dim;
     this->is_sharded = input_tensor.is_sharded();
 
     this->input_page_size = input_tensor.buffer()->page_size();
     log_trace(tt::LogOp, "input_page_size={}", input_page_size);
     if (row_major) {
-        this->num_cols = input_tensor.get_legacy_shape()[-1];
-        auto input_shape = input_tensor.get_legacy_shape();
-        auto output_shape = output_tensor.get_legacy_shape();
+        this->num_cols = input_tensor.get_padded_shape()[-1];
+        auto input_shape = input_tensor.get_padded_shape();
+        auto output_shape = output_tensor.get_padded_shape();
         this->num_rows =
-            std::accumulate(input_shape.begin() + slice_dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>());
+            std::accumulate(input_shape.cbegin() + slice_dim, input_shape.cend() - 1, 1, std::multiplies<uint32_t>());
         this->row_offset =
-            std::accumulate(output_shape.begin() + slice_dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) -
+            std::accumulate(
+                output_shape.cbegin() + slice_dim, output_shape.cend() - 1, 1, std::multiplies<uint32_t>()) -
             num_rows;
     } else {
         auto input_tile = input_tensor.get_tensor_spec().tile();
-        const uint32_t num_tiles_x = input_tensor.get_legacy_shape()[-1] / input_tile.get_width();
-        uint32_t num_tiles_y = (input_tensor.get_legacy_shape()[-2] / input_tile.get_height());
+        const uint32_t num_tiles_x = input_tensor.get_padded_shape()[-1] / input_tile.get_width();
+        uint32_t num_tiles_y = (input_tensor.get_padded_shape()[-2] / input_tile.get_height());
         for (std::size_t i = 0;
-             input_tensor.get_legacy_shape().rank() > 2 && i < input_tensor.get_legacy_shape().rank() - 2;
+             input_tensor.get_padded_shape().rank() > 2 && i < input_tensor.get_padded_shape().rank() - 2;
              i++) {
-            num_tiles_y *= input_tensor.get_legacy_shape()[i];
+            num_tiles_y *= input_tensor.get_padded_shape()[i];
         }
         TT_ASSERT(num_tiles_x >= ring_size);
         this->tensor_slice_shape.x = slice_dim == 3 ? (num_tiles_x / ring_size) : num_tiles_x;
@@ -422,7 +423,7 @@ RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::RingReduceScatterBaseTensor
         log_trace(tt::LogOp, "\tmax_slice_size_in_bytes={}", max_slice_size_in_bytes);
         log_trace(tt::LogOp, "\tinput_page_size={}", input_page_size);
         this->worker_slice_shapes = DERIVED_SLICER_T::create_worker_slice_shapes_for_tile_layout(
-            input_tensor.get_legacy_shape(),
+            input_tensor.get_padded_shape(),
             this->tensor_slice_shape,
             total_num_workers,
             max_slice_size_in_bytes / input_page_size,
@@ -431,15 +432,15 @@ RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::RingReduceScatterBaseTensor
 
     if (row_major) {
         this->flattened_tensor_shape = tt_xy_pair{
-            input_tensor.get_legacy_shape()[3],
-            input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[1] *
-                input_tensor.get_legacy_shape()[2]};
+            input_tensor.get_padded_shape()[3],
+            input_tensor.get_padded_shape()[0] * input_tensor.get_padded_shape()[1] *
+                input_tensor.get_padded_shape()[2]};
     } else {
         auto input_tile = input_tensor.get_tensor_spec().tile();
         this->flattened_tensor_shape = tt_xy_pair{
-            input_tensor.get_legacy_shape()[3] / input_tile.get_width(),
-            (input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[1] *
-             input_tensor.get_legacy_shape()[2]) /
+            input_tensor.get_padded_shape()[3] / input_tile.get_width(),
+            (input_tensor.get_padded_shape()[0] * input_tensor.get_padded_shape()[1] *
+             input_tensor.get_padded_shape()[2]) /
                 input_tile.get_height()};
     }
 
@@ -588,8 +589,8 @@ RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::create_worker_slice_shapes_
 }
 
 std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::create_worker_slice_shapes_for_tile_layout(
-    tt::tt_metal::LegacyShape const& tensor_shape,
-    tt_xy_pair const& tensor_slice_shape_in_tiles,
+    const ttnn::SimpleShape& tensor_shape,
+    const tt_xy_pair& tensor_slice_shape_in_tiles,
     uint32_t num_workers,
     uint32_t max_slice_size_in_pages,
     uint32_t half_cb_n_pages) {
@@ -794,8 +795,8 @@ std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::create_worker_slice_shape
 }
 
 std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::create_worker_slice_shapes_for_tile_layout(
-    tt::tt_metal::LegacyShape const& tensor_shape,
-    tt_xy_pair const& tensor_slice_shape_in_tiles,
+    const ttnn::SimpleShape& tensor_shape,
+    const tt_xy_pair& tensor_slice_shape_in_tiles,
     uint32_t num_workers,
     uint32_t max_slice_size_in_pages,
     uint32_t half_cb_n_pages) {
@@ -1136,12 +1137,12 @@ GenericWrappedTensorSlicer::GenericWrappedTensorSlicer(
 
 tt_xy_pair GenericWrappedTensorSlicer::calculate_tensor_slice_shape(
     const Tensor& input_tensor, int slice_dim, uint32_t partition_size) {
-    const uint32_t num_tiles_x = input_tensor.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
-    uint32_t num_tiles_y = (input_tensor.get_legacy_shape()[-2] / tt::constants::TILE_HEIGHT);
+    const uint32_t num_tiles_x = input_tensor.get_padded_shape()[-1] / tt::constants::TILE_WIDTH;
+    uint32_t num_tiles_y = (input_tensor.get_padded_shape()[-2] / tt::constants::TILE_HEIGHT);
     for (std::size_t i = 0;
-         input_tensor.get_legacy_shape().rank() > 2 && i < input_tensor.get_legacy_shape().rank() - 2;
+         input_tensor.get_padded_shape().rank() > 2 && i < input_tensor.get_padded_shape().rank() - 2;
          i++) {
-        num_tiles_y *= input_tensor.get_legacy_shape()[i];
+        num_tiles_y *= input_tensor.get_padded_shape()[i];
     }
     TT_ASSERT(num_tiles_x >= partition_size);
     tt_xy_pair tensor_slice_shape;
@@ -1172,7 +1173,7 @@ void GenericWrappedTensorSlicer::initialize(
 
     // Calculate worker slice shapes (tile layout)
     this->worker_slice_shapes = create_worker_slice_shapes_for_tile_layout(
-        input_tensor.get_legacy_shape(),
+        input_tensor.get_padded_shape(),
         this->tensor_slice_shape,
         total_num_workers,
         max_slice_size_in_bytes / this->input_page_size,
@@ -1180,8 +1181,8 @@ void GenericWrappedTensorSlicer::initialize(
 
     // Flattened tensor shape (tile layout)
     this->flattened_tensor_shape = tt_xy_pair{
-        input_tensor.get_legacy_shape()[3] / tt::constants::TILE_WIDTH,
-        (input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[1] * input_tensor.get_legacy_shape()[2]) /
+        input_tensor.get_padded_shape()[3] / tt::constants::TILE_WIDTH,
+        (input_tensor.get_padded_shape()[0] * input_tensor.get_padded_shape()[1] * input_tensor.get_padded_shape()[2]) /
             tt::constants::TILE_HEIGHT};
 
     this->worker_slice_offsets = compute_worker_slice_offsets(this->worker_slice_shapes, this->tensor_slice_shape);
@@ -1205,8 +1206,8 @@ std::vector<tt_xy_pair> GenericWrappedTensorSlicer::compute_worker_slice_offsets
 }
 
 std::vector<tt_xy_pair> GenericWrappedTensorSlicer::create_worker_slice_shapes_for_tile_layout(
-    tt::tt_metal::LegacyShape const& tensor_shape,
-    tt_xy_pair const& tensor_slice_shape_in_tiles,
+    const ttnn::SimpleShape& tensor_shape,
+    const tt_xy_pair& tensor_slice_shape_in_tiles,
     uint32_t num_workers,
     uint32_t max_slice_size_in_pages,
     uint32_t half_cb_n_pages) {
@@ -1261,9 +1262,6 @@ std::vector<tt_xy_pair> GenericWrappedTensorSlicer::create_worker_slice_shapes_f
 
     return worker_slice_shapes;
 }
-
-
-
 
 GenericWrappedTensorSlicerV2::GenericWrappedTensorSlicerV2(
     const Tensor& input_tensor,
@@ -1327,7 +1325,7 @@ void GenericWrappedTensorSlicerV2::initialize(
     TT_FATAL(!this->row_major, "Row major not supported yet");
 
     // Record the input tensor shape
-    auto input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
     this->tensor_shape = Shape4D<uint32_t>(input_shape[0], input_shape[1], input_shape[2]/tt::constants::TILE_HEIGHT, input_shape[3]/tt::constants::TILE_WIDTH);
 
     // Calculate tensor slice shape

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -384,7 +384,7 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
         std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape);
 
     static std::vector<tt_xy_pair> create_worker_slice_shapes_for_tile_layout(
-        tt::tt_metal::LegacyShape const& tensor_shape,
+        ttnn::SimpleShape const& tensor_shape,
         tt_xy_pair const& tensor_slice_shape_in_tiles,
         uint32_t num_workers,
         uint32_t max_slice_size_in_pages,
@@ -423,7 +423,7 @@ class RingReduceScatterTensorSlicer : public RingReduceScatterBaseTensorSlicer<R
         std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape);
 
     static std::vector<tt_xy_pair> create_worker_slice_shapes_for_tile_layout(
-        tt::tt_metal::LegacyShape const& tensor_shape,
+        ttnn::SimpleShape const& tensor_shape,
         tt_xy_pair const& tensor_slice_shape_in_tiles,
         uint32_t num_workers,
         uint32_t max_slice_size_in_pages,
@@ -451,7 +451,7 @@ class RingReduceScatterWrappedTensorSlicer : public RingReduceScatterBaseTensorS
         std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape);
 
     static std::vector<tt_xy_pair> create_worker_slice_shapes_for_tile_layout(
-        tt::tt_metal::LegacyShape const& tensor_shape,
+        ttnn::SimpleShape const& tensor_shape,
         tt_xy_pair const& tensor_slice_shape_in_tiles,
         uint32_t num_workers,
         uint32_t max_slice_size_in_pages,
@@ -603,7 +603,7 @@ public:
 
     // method to create worker slice shapes in a tile layout
     std::vector<tt_xy_pair> create_worker_slice_shapes_for_tile_layout(
-        const tt::tt_metal::LegacyShape& tensor_shape,
+        const ttnn::SimpleShape& tensor_shape,
         tt_xy_pair const& tensor_slice_shape_in_tiles,
         uint32_t num_workers,
         uint32_t max_slice_size_in_pages,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -1419,12 +1419,12 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_reader_kernel_rt_args
 
     // If we are on device zero, we send n-1 chunks in ascending order
     auto& input_tensor = this->op_config.get_input_tensor(0);
-    TT_ASSERT(input_tensor.get_legacy_shape().size() == 4, "Only 4D tensors are supported for ccl");
+    TT_ASSERT(input_tensor.get_padded_shape().size() == 4, "Only 4D tensors are supported for ccl");
     ttnn::ccl::Shape4D<uint32_t> input_tensor_shape = {
-        input_tensor.get_legacy_shape()[0],
-        input_tensor.get_legacy_shape()[1],
-        input_tensor.get_legacy_shape()[2],
-        input_tensor.get_legacy_shape()[3]};
+        input_tensor.get_padded_shape()[0],
+        input_tensor.get_padded_shape()[1],
+        input_tensor.get_padded_shape()[2],
+        input_tensor.get_padded_shape()[3]};
 
     std::vector<uint32_t> args = {
         static_cast<uint32_t>(input_tensor.buffer()->address()),
@@ -1496,12 +1496,12 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_writer_kernel_rt_args
 
     // If we are on device zero, we send n-1 chunks in ascending order
     auto& output_tensor = this->op_config.get_output_tensor(0);
-    TT_ASSERT(output_tensor.get_legacy_shape().size() == 4, "Only 4D tensors are supported for ccl");
+    TT_ASSERT(output_tensor.get_padded_shape().size() == 4, "Only 4D tensors are supported for ccl");
     ttnn::ccl::Shape4D<uint32_t> output_tensor_shape = {
-        output_tensor.get_legacy_shape()[0],
-        output_tensor.get_legacy_shape()[1],
-        output_tensor.get_legacy_shape()[2],
-        output_tensor.get_legacy_shape()[3]};
+        output_tensor.get_padded_shape()[0],
+        output_tensor.get_padded_shape()[1],
+        output_tensor.get_padded_shape()[2],
+        output_tensor.get_padded_shape()[3]};
 
     std::vector<uint32_t> args = {
         static_cast<uint32_t>(output_tensor.buffer()->address()),

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -639,8 +639,8 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
     const std::optional<size_t> user_defined_num_buffers_per_channel) {
     log_trace(tt::LogOp, "reduce_scatter_with_workers entry");
     TT_ASSERT(
-        input_tensor.get_legacy_shape()[scatter_split_dim] ==
-            output_tensor.get_legacy_shape()[scatter_split_dim] * ring_size,
+        input_tensor.get_padded_shape()[scatter_split_dim] ==
+            output_tensor.get_padded_shape()[scatter_split_dim] * ring_size,
         "Input and output tensor shapes must match");
     TT_ASSERT(
         input_tensor.buffer()->num_pages() % ring_size == 0,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -51,11 +51,11 @@ ReduceScatter create_reduce_scatter_struct(
 void ReduceScatter::validate(const std::vector<Tensor>& input_tensors) const {
     for (auto const& t : input_tensors) {
         TT_FATAL(
-            t.get_legacy_shape()[this->scatter_dim] / this->ring_size > 0,
+            t.get_padded_shape()[this->scatter_dim] / this->ring_size > 0,
             "Reduce scatter input tensor shape on dim {} must be divisible by ring size",
             this->scatter_dim);
         TT_FATAL(
-            t.get_legacy_shape()[this->scatter_dim] % this->ring_size == 0,
+            t.get_padded_shape()[this->scatter_dim] % this->ring_size == 0,
             "Reduce scatter input tensor shape on dim {} must be divisible by ring size",
             this->scatter_dim);
     }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -587,8 +587,8 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_line_start_sender_
 
     // If we are on device zero, we send n-1 chunks in ascending order
     auto &input_tensor = this->op_config.get_input_tensor(0);
-    TT_ASSERT(input_tensor.get_legacy_shape().size() == 4, "Only 4D tensors are supported for reduce scatter");
-    ttnn::ccl::Shape4D<uint32_t> input_tensor_shape = {input_tensor.get_legacy_shape()[0], input_tensor.get_legacy_shape()[1],input_tensor.get_legacy_shape()[2],input_tensor.get_legacy_shape()[3]};
+    TT_ASSERT(input_tensor.get_padded_shape().size() == 4, "Only 4D tensors are supported for reduce scatter");
+    ttnn::ccl::Shape4D<uint32_t> input_tensor_shape = {input_tensor.get_padded_shape()[0], input_tensor.get_padded_shape()[1],input_tensor.get_padded_shape()[2],input_tensor.get_padded_shape()[3]};
 
     std::vector<uint32_t> args = {
         static_cast<uint32_t>(input_tensor.buffer()->address()),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -599,7 +599,7 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool, bool> get_conv_padded_i
         uint32_t input_num_cores_nhw = get_num_cores_nhw_from_parallel_config(parallel_config);
         uint32_t input_num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
 
-        // TT_ASSERT(input_tensor.get_legacy_shape() == input_tensor.get_shape());
+        // TT_ASSERT(input_tensor.get_padded_shape() == input_tensor.get_shape());
         const auto& input_shape = input_tensor.get_logical_shape();
         uint32_t tensor_height = input_shape[0] * input_shape[1] * input_shape[2];
         uint32_t round_up_size = tt::constants::TILE_HEIGHT;
@@ -742,13 +742,13 @@ void validate_weight_and_bias_tensors(
     TT_ASSERT(weight_tensor.get_layout() == Layout::ROW_MAJOR);
     TT_ASSERT(weight_tensor.get_logical_shape().rank() == 4);
     // TODO: enable this assert
-    // TT_ASSERT(weight_tensor.get_shape() == weight_tensor.get_legacy_shape());
+    // TT_ASSERT(weight_tensor.get_shape() == weight_tensor.get_padded_shape());
     if (bias_tensor.has_value()) {
         TT_ASSERT(!ttnn::has_storage_type_of(bias_tensor.value(), ttnn::DEVICE_STORAGE_TYPE));
         TT_ASSERT(bias_tensor.value().get_logical_shape().rank() == 4);
         TT_ASSERT(bias_tensor.value().get_layout() == Layout::ROW_MAJOR);
         // TODO: enable this assert
-        // TT_ASSERT(bias_tensor.value().get_shape() == bias_tensor.value().get_legacy_shape());
+        // TT_ASSERT(bias_tensor.value().get_shape() == bias_tensor.value().get_padded_shape());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -26,7 +26,7 @@ namespace optimized_conv_op_utils {
 using namespace tt;
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(
-    const tt::tt_metal::LegacyShape& conv_activation_shape,
+    const ttnn::SimpleShape& conv_activation_shape,
     const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
     uint32_t num_cores_nhw,
     uint32_t act_block_h_ntiles) {
@@ -168,7 +168,7 @@ void OptimizedConvNew::validate(
             optimized_conv_op_utils::div_up(parallelization_config.per_core_out_matrix_width, TILE_WIDTH);
         auto [act_matrix_shape, act_matrix_shape_unpadded] =
             optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(
-                input_tensor_a.get_legacy_shape(),
+                input_tensor_a.get_padded_shape(),
                 sliding_window_config,
                 parallelization_config.num_cores_nhw,
                 out_block_h_ntiles);
@@ -298,7 +298,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
     const auto weights_dtype = input_tensor_b.dtype();
     const auto output_dtype = output_tensor.dtype();
 
-    const auto weights_shape = input_tensor_b.get_legacy_shape();
+    const auto weights_shape = input_tensor_b.get_padded_shape();
 
     auto program_with_cbs = multi_core_optimized_conv_sharded_v2_new(
         input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -338,7 +338,7 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(
-    const tt::tt_metal::LegacyShape& conv_activation_shape,
+    const ttnn::SimpleShape& conv_activation_shape,
     const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
     uint32_t num_cores_nhw,
     uint32_t act_block_h_ntiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -59,7 +59,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     tt_metal::IDevice* device = a.device();
     TT_FATAL(a.get_layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
     TT_FATAL(a.memory_config().is_sharded(), "Conv activation must be sharded.");
-    TT_FATAL(output_channels <= b.get_legacy_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
+    TT_FATAL(output_channels <= b.get_padded_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
     uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
     uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
     uint32_t weight_block_w_ntiles =
@@ -141,10 +141,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
 
     // Tensor b has weights and it should be tiled layout after converting conv weights into weight matrix
     TT_FATAL(b.get_layout() == Layout::TILE, "Conv weights should be in tiled layout");
-    TT_FATAL(b.get_legacy_shape()[0] == 1, "Conv weight matrix shape is invalid");
-    TT_FATAL(b.get_legacy_shape()[1] == 1, "Conv weight matrix shape is invalid");
-    uint32_t weight_matrix_height = b.get_legacy_shape()[2];
-    uint32_t weight_matrix_width = b.get_legacy_shape()[3];
+    TT_FATAL(b.get_padded_shape()[0] == 1, "Conv weight matrix shape is invalid");
+    TT_FATAL(b.get_padded_shape()[1] == 1, "Conv weight matrix shape is invalid");
+    uint32_t weight_matrix_height = b.get_padded_shape()[2];
+    uint32_t weight_matrix_width = b.get_padded_shape()[3];
     uint32_t weight_matrix_height_ntiles = weight_matrix_height / TILE_HEIGHT;
     uint32_t weight_matrix_width_ntiles = weight_matrix_width / TILE_WIDTH;
 
@@ -227,7 +227,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     // Compute the 2d matrix shape
     auto [act_matrix_shape, act_matrix_shape_unpadded] =
         optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(
-            ashape_with_channels_padded.value,
+            ashape_with_channels_padded.padded_shape(),
             sliding_window_config,
             parallelization_config.num_cores_nhw,
             out_block_h_ntiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -90,7 +90,7 @@ Tensor create_tensor_from_owned_buffer(
 template <typename T>
 Tensor to_weight_special_padding_tile_layout(
     const Tensor& conv_weight_tensor, uint32_t in1_block_h, uint32_t in1_block_w, DataType output_dtype) {
-    auto w_shape = conv_weight_tensor.get_legacy_shape();
+    auto w_shape = conv_weight_tensor.get_padded_shape();
     auto compute = [&w_shape, &in1_block_h, &in1_block_w, &output_dtype](const auto& input_buffer) {
         uint32_t in1_block_h_datums = in1_block_h * constants::TILE_HEIGHT;
         uint32_t in1_block_w_datums = in1_block_w * constants::TILE_WIDTH;
@@ -127,7 +127,7 @@ Tensor to_weight_special_padding_tile_layout(
 template <typename T>
 Tensor to_weight_tile_layout(
     const Tensor& conv_weight_tensor, uint32_t in1_block_h, uint32_t in1_block_w, DataType output_dtype) {
-    auto w_shape = conv_weight_tensor.get_legacy_shape();
+    auto w_shape = conv_weight_tensor.get_padded_shape();
     auto compute = [&w_shape, &in1_block_h, &in1_block_w, &output_dtype](const auto& input_buffer) {
         auto weight_matrix_cols = w_shape[0];
         // width padding
@@ -184,7 +184,7 @@ Tensor convert_conv_weight_tensor_to_tiled_layout(
 template <typename T>
 Tensor to_weight_tile_layout_block_sharded(
     const Tensor& conv_weight_tensor, uint32_t num_channel_shards, DataType output_dtype) {
-    auto w_shape = conv_weight_tensor.get_legacy_shape();
+    auto w_shape = conv_weight_tensor.get_padded_shape();
     auto compute = [&w_shape, &num_channel_shards, &output_dtype](const auto& input_buffer) {
         auto weight_matrix_cols = w_shape[0];
         TT_ASSERT(weight_matrix_cols % num_channel_shards == 0);
@@ -252,7 +252,7 @@ Tensor convert_conv_weight_tensor_to_tiled_layout_block_sharded(
 template <typename T>
 Tensor to_bias_tile_layout_block_sharded(
     const Tensor& conv_bias_tensor, uint32_t num_channel_shards, DataType output_dtype) {
-    auto b_shape = conv_bias_tensor.get_legacy_shape();
+    auto b_shape = conv_bias_tensor.get_padded_shape();
     TT_ASSERT(b_shape[0] == 1 && b_shape[1] == 1 && b_shape[2] == 1);
     auto compute = [&b_shape, &num_channel_shards, &output_dtype](const auto& input_buffer) {
         auto bias_matrix_cols = b_shape[3];

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -23,7 +23,7 @@ namespace conv_transpose2d {
 
 template <typename T>
 Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel = true) {
-    auto in_w_shape = conv_weight_tensor.get_legacy_shape();
+    auto in_w_shape = conv_weight_tensor.get_padded_shape();
     auto dtype = conv_weight_tensor.dtype();
     // in_w_shape = {in_channels, out_channels, kernel_height, kernel_width}
     // out_w_shape = {out_channels, in_channels, kernel_height, kernel_width}

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -32,25 +32,25 @@ Tensor BcastOperation::invoke(
             auto& input_tensor_a = input_tensors.at(0);
             auto& input_tensor_b = input_tensors.at(1);
             if (bcast_dim == BcastOpDim::W) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[-2] == input_tensor_b.get_legacy_shape()[-2], "Error");
+                TT_FATAL(input_tensor_a.get_padded_shape()[-2] == input_tensor_b.get_padded_shape()[-2], "Error");
                 if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH, "Error");
+                    TT_FATAL(input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH, "Error");
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
-                        input_tensor_b.get_legacy_shape()[-1] == 1 ||
-                            input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH,
+                        input_tensor_b.get_padded_shape()[-1] == 1 ||
+                            input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH,
                         "Error");
                 } else {
                     TT_THROW("Unsupported layout");
                 }
             } else if (bcast_dim == BcastOpDim::H) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[-1] == input_tensor_b.get_legacy_shape()[-1], "Error");
+                TT_FATAL(input_tensor_a.get_padded_shape()[-1] == input_tensor_b.get_padded_shape()[-1], "Error");
                 if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
+                    TT_FATAL(input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT, "Error");
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
-                        input_tensor_b.get_legacy_shape()[-2] == 1 ||
-                            input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT,
+                        input_tensor_b.get_padded_shape()[-2] == 1 ||
+                            input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT,
                         "Error");
                 } else {
                     TT_THROW("Unsupported layout");
@@ -58,14 +58,14 @@ Tensor BcastOperation::invoke(
             } else if (bcast_dim == BcastOpDim::HW) {
                 if (input_tensor_b.get_layout() == Layout::TILE) {
                     TT_FATAL(
-                        input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT &&
-                            input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH,
+                        input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT &&
+                            input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH,
                         "Error");
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
-                        (input_tensor_b.get_legacy_shape()[-2] == 1 && input_tensor_b.get_legacy_shape()[-1] == 1) ||
-                            (input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT &&
-                             input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH),
+                        (input_tensor_b.get_padded_shape()[-2] == 1 && input_tensor_b.get_padded_shape()[-1] == 1) ||
+                            (input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT &&
+                             input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH),
                         "Error");
                 }
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -42,8 +42,8 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(
         "Operands to bcast need to be on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to bcast need to be on the same device!");
 
-    const auto input_shape_a = input_tensor_a.get_legacy_shape();
-    const auto input_shape_b = input_tensor_b.get_legacy_shape();
+    const auto input_shape_a = input_tensor_a.get_padded_shape();
+    const auto input_shape_b = input_tensor_b.get_padded_shape();
 
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Error");
     TT_FATAL(input_tensor_b.get_layout() == Layout::TILE, "Error");
@@ -56,7 +56,7 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(
             out_tensor.get_logical_shape() == output_spec_required.at(0).logical_shape(),
             "The input tensors need a shape of {}, however the output tensor is only {}",
             output_spec_required.at(0).logical_shape(),
-            out_tensor.get_legacy_shape());
+            out_tensor.get_padded_shape());
     }
     if (this->in_place) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
@@ -196,7 +196,7 @@ operation::ProgramWithCallbacks EltwiseBinaryBroadcast::create_program(
 const operation::Hash EltwiseBinaryBroadcast::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
     auto parallelization_strategy = this->get_parallelization_strategy(input_tensors);
     bool bcast_scalar =
-        (input_tensors.at(1).get_legacy_shape()[-2] * input_tensors.at(1).get_legacy_shape()[-1] == 1) &&
+        (input_tensors.at(1).get_padded_shape()[-2] * input_tensors.at(1).get_padded_shape()[-1] == 1) &&
         this->dim == BcastOpDim::HW;
     return operation::hash_operation<EltwiseBinaryBroadcast>(
         *this,
@@ -216,13 +216,13 @@ BcastOpParallelizationStrategy EltwiseBinaryBroadcast::get_parallelization_strat
     const auto& input_tensor_b = input_tensors.at(1);
 
     uint32_t num_tiles = input_tensor_a.volume() / TILE_HW;
-    uint32_t Ht = input_tensor_a.get_legacy_shape()[-2] / TILE_HEIGHT;
-    uint32_t Wt = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t Ht = input_tensor_a.get_padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t Wt = input_tensor_a.get_padded_shape()[-1] / TILE_WIDTH;
 
     if (this->dim == BcastOpDim::H) {
         if (input_tensor_a.is_sharded()) {
-            if (input_tensor_a.get_legacy_shape()[0] == input_tensor_b.get_legacy_shape()[0] ||
-                input_tensor_a.get_legacy_shape()[0] > 1 and input_tensor_b.get_legacy_shape()[0] == 1) {
+            if (input_tensor_a.get_padded_shape()[0] == input_tensor_b.get_padded_shape()[0] ||
+                input_tensor_a.get_padded_shape()[0] > 1 and input_tensor_b.get_padded_shape()[0] == 1) {
                 return BcastOpParallelizationStrategy::MULTI_CORE_H_SHARDED_OPTIMISED;
             } else {
                 return BcastOpParallelizationStrategy::MULTI_CORE_H_SHARDED;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
@@ -18,8 +18,8 @@ using namespace tt::constants;
 namespace ttnn::operations::data_movement {
 operation::ProgramWithCallbacks bcast_multi_core_h(
     const Tensor& a, const Tensor& b, const Tensor& output, BcastOpMath bcast_math) {
-    const auto ashape = a.get_legacy_shape();
-    const auto bshape = b.get_legacy_shape();
+    const auto ashape = a.get_padded_shape();
+    const auto bshape = b.get_padded_shape();
     uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1;
     uint32_t C = ashape.rank() >= 3 ? ashape[-3] : 1;
     uint32_t H = ashape[-2];
@@ -198,8 +198,8 @@ operation::ProgramWithCallbacks bcast_multi_core_h(
 
             auto dst_dram_buffer = output_tensors.at(0).buffer();
 
-            const auto ashape = input_tensors.at(0).get_legacy_shape();
-            const auto bshape = input_tensors.at(1).get_legacy_shape();
+            const auto ashape = input_tensors.at(0).get_padded_shape();
+            const auto bshape = input_tensors.at(1).get_padded_shape();
             uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1;
             uint32_t C = ashape.rank() >= 3 ? ashape[-3] : 1;
             uint32_t H = ashape[-2];

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
@@ -17,8 +17,8 @@ using namespace tt::constants;
 namespace ttnn::operations::data_movement {
 operation::ProgramWithCallbacks bcast_sharded_h(
     const Tensor& a, const Tensor& b, const Tensor& output, BcastOpMath bcast_math /*, BcastOpDim bcast_dim*/) {
-    const auto ashape = a.get_legacy_shape();
-    const auto bshape = b.get_legacy_shape();
+    const auto ashape = a.get_padded_shape();
+    const auto bshape = b.get_padded_shape();
     uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1, C = ashape.rank() >= 3 ? ashape[-3] : 1, H = ashape[-2],
              W = ashape[-1];
     uint32_t bN = bshape.rank() >= 4 ? bshape[-4] : 1, bC = bshape.rank() >= 3 ? bshape[-3] : 1, bH = bshape[-2],
@@ -94,7 +94,7 @@ operation::ProgramWithCallbacks bcast_sharded_h(
             .set_globally_allocated_address(*output.buffer());
     auto out_cb = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
 
-    uint32_t num_input_tiles = (b.get_legacy_shape()[-1] * output.element_size() + TILE_HW - 1) / TILE_HW;
+    uint32_t num_input_tiles = (b.get_padded_shape()[-1] * output.element_size() + TILE_HW - 1) / TILE_HW;
     uint32_t src1_cb_index = CBIndex::c_1;
     tt_metal::CircularBufferConfig src1_cb_config =
         tt_metal::CircularBufferConfig(num_input_tiles * input1_tile_size, {{src1_cb_index, b_df}})
@@ -202,9 +202,9 @@ operation::ProgramWithCallbacks bcast_sharded_h(
         auto all_cores = shard_spec.grid;
         uint32_t ncores = shard_spec.num_cores();
         uint32_t Wt = 0, Ht = 0;
-        const auto ashape = input_tensors.at(0).get_legacy_shape();
+        const auto ashape = input_tensors.at(0).get_padded_shape();
         uint32_t N = ashape[0], C = ashape[1], H = ashape[2], W = ashape[3];
-        uint32_t bN = input_tensors.at(1).get_legacy_shape()[0];
+        uint32_t bN = input_tensors.at(1).get_padded_shape()[0];
         uint32_t NC = N * C;
         if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             Wt = shard_spec.shape[1] / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -17,8 +17,8 @@ using namespace tt::constants;
 namespace ttnn::operations::data_movement {
 operation::ProgramWithCallbacks bcast_sharded_h_optimised(
     const Tensor& a, const Tensor& b, const Tensor& output, BcastOpMath bcast_math /*, BcastOpDim bcast_dim*/) {
-    const auto ashape = a.get_legacy_shape();
-    const auto bshape = b.get_legacy_shape();
+    const auto ashape = a.get_padded_shape();
+    const auto bshape = b.get_padded_shape();
     uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1, C = ashape.rank() >= 3 ? ashape[-3] : 1, H = ashape[-2],
              W = ashape[-1];
     uint32_t bN = bshape.rank() >= 4 ? bshape[-4] : 1, bC = bshape.rank() >= 3 ? bshape[-3] : 1, bH = bshape[-2],
@@ -215,9 +215,9 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(
         auto all_cores = shard_spec.grid;
         uint32_t ncores = shard_spec.num_cores();
         uint32_t Wt = 0, Ht = 0;
-        const auto ashape = input_tensors.at(0).get_legacy_shape();
+        const auto ashape = input_tensors.at(0).get_padded_shape();
         uint32_t N = ashape[0], C = ashape[1], H = ashape[2], W = ashape[3];
-        uint32_t bN = input_tensors.at(1).get_legacy_shape()[0];
+        uint32_t bN = input_tensors.at(1).get_padded_shape()[0];
         uint32_t NC = N * C;
         if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             Wt = shard_spec.shape[1] / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -19,8 +19,8 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 operation::ProgramWithCallbacks bcast_multi_core_hw(
     const Tensor& a, const Tensor& b, const Tensor& output, BcastOpMath bcast_math, bool inplace) {
-    const auto ashape = a.get_legacy_shape();
-    const auto bshape = b.get_legacy_shape();
+    const auto ashape = a.get_padded_shape();
+    const auto bshape = b.get_padded_shape();
     uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1;
     uint32_t C = ashape.rank() >= 3 ? ashape[-3] : 1;
     uint32_t H = ashape[-2];
@@ -237,8 +237,8 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(
 
         auto dst_buffer = output_tensor.buffer();
 
-        const auto ashape = input_tensors.at(0).get_legacy_shape();
-        const auto bshape = input_tensors.at(1).get_legacy_shape();
+        const auto ashape = input_tensors.at(0).get_padded_shape();
+        const auto bshape = input_tensors.at(1).get_padded_shape();
         uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1;
         uint32_t C = ashape.rank() >= 3 ? ashape[-3] : 1;
         uint32_t H = ashape[-2];

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
@@ -17,8 +17,8 @@ using namespace tt::constants;
 namespace ttnn::operations::data_movement {
 operation::ProgramWithCallbacks bcast_multi_core_w(
     const Tensor& a, const Tensor& b, const Tensor& output, BcastOpMath bcast_math) {
-    const auto ashape = a.get_legacy_shape();
-    const auto bshape = b.get_legacy_shape();
+    const auto ashape = a.get_padded_shape();
+    const auto bshape = b.get_padded_shape();
     uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1;
     uint32_t C = ashape.rank() >= 3 ? ashape[-3] : 1;
     uint32_t H = ashape[-2];
@@ -198,8 +198,8 @@ operation::ProgramWithCallbacks bcast_multi_core_w(
 
             auto dst_dram_buffer = output_tensors.at(0).buffer();
 
-            const auto ashape = input_tensors.at(0).get_legacy_shape();
-            const auto bshape = input_tensors.at(1).get_legacy_shape();
+            const auto ashape = input_tensors.at(0).get_padded_shape();
+            const auto bshape = input_tensors.at(1).get_padded_shape();
             uint32_t N = ashape.rank() >= 4 ? ashape[-4] : 1;
             uint32_t C = ashape.rank() >= 3 ? ashape[-3] : 1;
             uint32_t H = ashape[-2];

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -126,7 +126,11 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     // padding-oblivious entry point is uplifted to the slice
                     // op.
                     untilized_tensor = operation::run(
-                        SliceDeviceOperation{begins, ends, steps, output_memory_config},
+                        SliceDeviceOperation{
+                            ttnn::SimpleShape(begins),
+                            ttnn::SimpleShape(ends),
+                            ttnn::SimpleShape(steps),
+                            output_memory_config},
                         {untilized_tensor},
                         {},
                         {std::nullopt},
@@ -275,7 +279,7 @@ ttnn::Tensor ConcatOperation::invoke(
     const ttnn::Tensor& first_tensor = input_tensors.front();
     const int rank = first_tensor.get_shape().rank();
 
-    dim = first_tensor.get_legacy_shape().get_normalized_index(dim);
+    dim = first_tensor.get_padded_shape().get_normalized_index(dim);
 
     TT_FATAL(
         dim >= 0 and dim < rank,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -27,7 +27,7 @@ ConcatOpParallelizationStrategy ConcatDeviceOperation::get_parallelization_strat
 
 void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& first_input = input_tensors[0];
-    tt::tt_metal::LegacyShape shape_first = first_input.get_legacy_shape();
+    auto shape_first = first_input.get_padded_shape();
     TT_FATAL(this->dim < shape_first.rank(), "ConcatDeviceOperation dim specified is larger than input tensor rank.");
     shape_first[this->dim] = 0;
     bool shard_first = input_tensors[0].is_sharded();
@@ -40,7 +40,7 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
         TT_FATAL(in_ref.device() == first_input.device(), "Operands to concat need to be on the same device.");
         TT_FATAL(in_ref.get_layout() == first_input.get_layout(), "All Tensors should have same layouts.");
         TT_FATAL(in_ref.get_dtype() == first_input.get_dtype(), "All Tensors should have same dtypes.");
-        tt::tt_metal::LegacyShape curr_shape = in_ref.get_legacy_shape();
+        auto curr_shape = in_ref.get_padded_shape();
         TT_FATAL(curr_shape.rank() == shape_first.rank(), "Input tensor ranks must be equal");
         curr_shape[this->dim] = 0;
         // last tensor can support without any kernel changes
@@ -150,8 +150,8 @@ Tensor concat_impl(
                 return {ttnn::operations::experimental::auto_format::AutoFormat::move_tensor_to_mem_config(
                     input_tensors[0], output_mem_config)};
             }
-            uint32_t ref_rank = input_tensors[0].get_legacy_shape().rank();
-            uint32_t normalized_dim = input_tensors[0].get_legacy_shape().get_normalized_index(dim);
+            uint32_t ref_rank = input_tensors[0].get_padded_shape().rank();
+            uint32_t normalized_dim = input_tensors[0].get_padded_shape().get_normalized_index(dim);
 
             if (input_tensors[0].is_sharded()) {
                 return operation::run(
@@ -172,7 +172,7 @@ Tensor concat_impl(
                 // this should be dead code when instantiating layout to match the input
                 for (const auto& input_tensor : input_tensors) {
                     if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
-                        const auto& input_shape = input_tensor.get_legacy_shape();
+                        const auto& input_shape = input_tensor.get_padded_shape();
                         if (input_shape.rank() < 2 || input_shape[-2] % TILE_HEIGHT != 0 ||
                             input_shape[-1] % TILE_WIDTH != 0) {
                             target_layout = Layout::ROW_MAJOR;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -38,8 +38,8 @@ tt_metal::operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_height_multi
     TT_FATAL(groups == 1 || dim == 3, "Sharded concat RM only supports groups > 1 when dim=3");
 
     TT_FATAL(
-        input_tensors.size() == 2 && input_tensors[0].get_legacy_shape()[-1] % groups == 0 &&
-            input_tensors[0].get_legacy_shape()[-1] % groups == 0,
+        input_tensors.size() == 2 && input_tensors[0].get_padded_shape()[-1] % groups == 0 &&
+            input_tensors[0].get_padded_shape()[-1] % groups == 0,
         "Input channels must both be evenly divisible by groups");
 
     tt_metal::Program program = tt_metal::CreateProgram();
@@ -50,7 +50,7 @@ tt_metal::operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_height_multi
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
-    uint32_t num_output_rows = output.get_legacy_shape()[-2];
+    uint32_t num_output_rows = output.get_padded_shape()[-2];
     uint32_t num_input_tensors = input_tensors.size();
 
     std::vector<CBHandle> cb_input(num_input_tensors);
@@ -366,7 +366,7 @@ tt_metal::operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     // CoreRangeSet all_cores({CoreRange(CoreCoord(0,0), compute_with_storage_grid_size)});
 
-    uint32_t num_output_rows = output.get_legacy_shape()[-1];
+    uint32_t num_output_rows = output.get_padded_shape()[-1];
     uint32_t num_input_tensors = input_tensors.size();
 
     std::vector<CBHandle> cb_input(num_input_tensors);
@@ -457,7 +457,7 @@ tt_metal::operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
             auto dst_buffer = output_tensors.at(0).buffer();
             auto cores = corerange_to_cores(all_cores, std::nullopt, row_wise);
             auto input_cores = input_tensors[0].shard_spec().value().grid;
-            uint32_t num_output_rows = output_tensors[0].get_legacy_shape()[-1];
+            uint32_t num_output_rows = output_tensors[0].get_padded_shape()[-1];
             uint32_t num_output_rows_per_core = div_up(num_output_rows, input_cores.num_cores());
             for (auto core : cores) {
                 uint32_t curr_num_input_tensors;
@@ -526,9 +526,9 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
     uint32_t num_output_pages;
     uint32_t single_page_size;
     if (rm_layout) {
-        num_output_pages = output.volume() / output.get_legacy_shape()[-1];
+        num_output_pages = output.volume() / output.get_padded_shape()[-1];
         single_page_size =
-            tt::align(output.element_size() * output.get_legacy_shape()[-1], output.buffer()->alignment());
+            tt::align(output.element_size() * output.get_padded_shape()[-1], output.buffer()->alignment());
     } else {
         num_output_pages = output.volume() / TILE_HW;
         single_page_size = tt_metal::detail::TileSize(cb_data_format);
@@ -552,7 +552,7 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
             .set_page_size(src0_cb_index, single_page_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t num_dims = output.get_legacy_shape().rank();
+    uint32_t num_dims = output.get_padded_shape().rank();
 
     std::vector<uint32_t> src_addr(num_input_tensors);
     std::vector<bool> is_dram(num_input_tensors);
@@ -574,11 +574,11 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
     }
 
     for (uint32_t i = dim + 1; i < num_dims; ++i) {
-        num_accum_pages *= output.get_legacy_shape()[i];
+        num_accum_pages *= output.get_padded_shape()[i];
     }
     if (rm_layout) {
         if (num_dims > 1 && dim < num_dims - 1) {
-            num_accum_pages /= output.get_legacy_shape()[-1];
+            num_accum_pages /= output.get_padded_shape()[-1];
         }
     } else {
         if (dim < num_dims - 2) {
@@ -599,7 +599,7 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
             if (dim == num_dims - 1) {
                 num_pages_per_block[i] = num_accum_pages;
             } else {
-                uint32_t dim_pages = input_tensors[i].get_legacy_shape()[dim];
+                uint32_t dim_pages = input_tensors[i].get_padded_shape()[dim];
                 num_pages_per_block[i] = num_accum_pages * dim_pages;
                 num_output_pages_per_block += num_accum_pages * dim_pages;
             }
@@ -612,7 +612,7 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
             auto buffer = input_tensors[i].buffer();
             src_addr[i] = buffer->address();
             is_dram[i] = buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-            uint32_t dim_pages = input_tensors[i].get_legacy_shape()[dim] / scale_factor;
+            uint32_t dim_pages = input_tensors[i].get_padded_shape()[dim] / scale_factor;
             num_pages_per_block[i] = num_accum_pages * dim_pages;
             num_output_pages_per_block += num_accum_pages * dim_pages;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -29,7 +29,7 @@ void CopyDeviceOperation::validate_with_output_tensors(
         "Copy does not currently support sharding");
     if (input_tensors.size() == 2) {
         const auto& dst_tensor = input_tensors[1];
-        TT_FATAL(input_tensor_a.get_legacy_shape() == dst_tensor.get_legacy_shape(), "Error");
+        TT_FATAL(input_tensor_a.get_padded_shape() == dst_tensor.get_padded_shape(), "Error");
         TT_FATAL(input_tensor_a.get_layout() == dst_tensor.get_layout(), "Error");
         TT_FATAL(input_tensor_a.memory_config().memory_layout == dst_tensor.memory_config().memory_layout, "Error");
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -26,13 +26,13 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor& input, const Tenso
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
     uint32_t input_unit_size = tilized ? tt::tt_metal::detail::TileSize(input_cb_data_format)
-                                       : input.get_legacy_shape()[-1] * input.element_size();
+                                       : input.get_padded_shape()[-1] * input.element_size();
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     uint32_t output_unit_size = tilized ? tt::tt_metal::detail::TileSize(output_cb_data_format)
-                                        : output.get_legacy_shape()[-1] * output.element_size();
+                                        : output.get_padded_shape()[-1] * output.element_size();
     bool convert_dtype = input_cb_data_format != output_cb_data_format;
 
-    uint32_t num_units = tilized ? output.volume() / TILE_HW : output.volume() / output.get_legacy_shape()[-1];
+    uint32_t num_units = tilized ? output.volume() / TILE_HW : output.volume() / output.get_padded_shape()[-1];
 
     tt::tt_metal::IDevice* device = output.device();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/data_transfer/data_transfer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_transfer/data_transfer.cpp
@@ -20,7 +20,7 @@ Tensor DataTransferToDeviceOperation::invoke(
     TT_FATAL(device != nullptr, "Error");
 
     if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(input_tensor.get_legacy_shape()[-1] * input_tensor.element_size() % sizeof(uint32_t) == 0, "Error");
+        TT_FATAL(input_tensor.get_padded_shape()[-1] * input_tensor.element_size() % sizeof(uint32_t) == 0, "Error");
     }
 
     if (input_tensor.storage_type() == StorageType::DEVICE && input_tensor.device() == device) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -17,7 +17,7 @@ Fold::program_factory_t Fold::select_program_factory(
 void validate_fold(const std::vector<Tensor>& input_tensors, bool is_sharded, uint32_t stride_h, uint32_t stride_w) {
     const Tensor& input_tensor = input_tensors.at(0);
 
-    const Shape& input_shape = Shape(input_tensor.get_legacy_shape());
+    const Shape& input_shape = Shape(input_tensor.get_padded_shape());
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Fold: Expect input tensor to be stored on device.");
     TT_FATAL(input_tensor.buffer() != nullptr, "Fold: Expect input tensor to be allocated on a device buffer.");

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -29,7 +29,7 @@ Fold::MultiCore::cached_program_t fold_multi_core(
     uint32_t num_dst_pixels = num_pixels / (stride_h * stride_w);
 
     // chunk consists of channel values of stride_w neighboring pixels along the W dimension
-    uint32_t width = input.get_legacy_shape()[2];
+    uint32_t width = input.get_padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t row_size = width * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;
@@ -115,7 +115,7 @@ void Fold::MultiCore::override_runtime_arguments(
     uint32_t num_pixels = shard_shape[0];
     uint32_t num_dst_pixels = num_pixels / (stride_h * stride_w);
 
-    uint32_t width = input_tensor.get_legacy_shape()[2];
+    uint32_t width = input_tensor.get_padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t row_size = width * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_op_multi_core.cpp
@@ -26,7 +26,7 @@ cached_program_t fold_multi_core(const Tensor& input, const Tensor& output, uint
     uint32_t num_dst_pixels = num_pixels / (stride_h * stride_w);
 
     // chunk consists of channel values of stride_w neighboring pixels along the W dimension
-    uint32_t width = input.get_legacy_shape()[2];
+    uint32_t width = input.get_padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t row_size = width * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;
@@ -112,7 +112,7 @@ void Fold::MultiCore::override_runtime_arguments(
     uint32_t num_pixels = shard_shape[0];
     uint32_t num_dst_pixels = num_pixels / (stride_h * stride_w);
 
-    uint32_t width = input_tensor.get_legacy_shape()[2];
+    uint32_t width = input_tensor.get_padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t row_size = width * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_op_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_op_single_core.cpp
@@ -19,11 +19,11 @@ cached_program_t fold_single_core(const Tensor& input, const Tensor& output, uin
 
     DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
 
-    uint32_t pixel_size = input.get_legacy_shape()[-1] * input.element_size();
-    uint32_t num_pixels = input.volume() / input.get_legacy_shape()[-1];
+    uint32_t pixel_size = input.get_padded_shape()[-1] * input.element_size();
+    uint32_t num_pixels = input.volume() / input.get_padded_shape()[-1];
 
     // chunk consists of channel values of stride_w neighboring pixels along the W dimension
-    uint32_t width = input.get_legacy_shape()[2];
+    uint32_t width = input.get_padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t row_size = width * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
@@ -22,11 +22,11 @@ Fold::SingleCore::cached_program_t fold_single_core(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
 
-    uint32_t pixel_size = input.get_legacy_shape()[-1] * input.element_size();
-    uint32_t num_pixels = input.volume() / input.get_legacy_shape()[-1];
+    uint32_t pixel_size = input.get_padded_shape()[-1] * input.element_size();
+    uint32_t num_pixels = input.volume() / input.get_padded_shape()[-1];
 
     // chunk consists of channel values of stride_w neighboring pixels along the W dimension
-    uint32_t width = input.get_legacy_shape()[2];
+    uint32_t width = input.get_padded_shape()[2];
     uint32_t chunk_size = stride_w * pixel_size;
     uint32_t row_size = width * pixel_size;
     uint32_t dst_pixel_size = stride_h * chunk_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
@@ -12,8 +12,8 @@ void IndexedFill::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(1);
     const auto& input_tensor_b = input_tensors.at(2);
     const auto& batch_ids = input_tensors.at(0);
-    auto input_tensor_a_shape = input_tensor_a.get_legacy_shape();
-    auto input_tensor_b_shape = input_tensor_b.get_legacy_shape();
+    auto input_tensor_a_shape = input_tensor_a.get_padded_shape();
+    auto input_tensor_b_shape = input_tensor_b.get_padded_shape();
     TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Currently only supporting row major layout");
     TT_FATAL(input_tensor_b.get_layout() == input_tensor_a.get_layout(), "Inputs must be same layout");
     TT_FATAL(
@@ -21,7 +21,7 @@ void IndexedFill::validate(const std::vector<Tensor>& input_tensors) const {
             input_tensor_a_shape[3] == input_tensor_b_shape[3],
         "Dims except batch dim must be the same on inputs");
     TT_FATAL(
-        input_tensor_b_shape[0] == batch_ids.get_legacy_shape()[-1],
+        input_tensor_b_shape[0] == batch_ids.get_padded_shape()[-1],
         "Second input and batch ids must be same outer dim");
     TT_FATAL(batch_ids.get_layout() == Layout::ROW_MAJOR, "Batch IDs must be ROW MAJOR");
     TT_FATAL(this->dim == 0, "Currently only supporting batch dimension");

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
@@ -27,10 +27,10 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(
         tt::tt_metal::num_cores_to_corerangeset(num_cores_x * num_cores_y, compute_with_storage_grid_size);
     CoreRangeSet all_cores(set_of_core_ranges);
 
-    uint32_t B = input_a.get_legacy_shape()[0];
-    uint32_t b = input_b.get_legacy_shape()[0];
+    uint32_t B = input_a.get_padded_shape()[0];
+    uint32_t b = input_b.get_padded_shape()[0];
 
-    TT_ASSERT(batch_ids.get_legacy_shape()[-1] == b);
+    TT_ASSERT(batch_ids.get_padded_shape()[-1] == b);
 
     // parallelize across batch
     uint32_t num_units = B;
@@ -39,7 +39,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_a.get_dtype());
 
-    uint32_t page_size = input_a.get_legacy_shape()[-1] * input_a.element_size();
+    uint32_t page_size = input_a.get_padded_shape()[-1] * input_a.element_size();
     uint32_t rounded_page_size = round_up_to_mul32(page_size);
     tt::tt_metal::CircularBufferConfig cb_src0_config =
         tt::tt_metal::CircularBufferConfig(2 * rounded_page_size, {{cb_index, cb_data_format}})
@@ -91,7 +91,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(
 
     auto cores = grid_to_cores(num_cores_x * num_cores_y, num_cores_x, num_cores_y, false);
 
-    uint32_t batch_size_in_sticks = input_a.get_legacy_shape()[1] * input_a.get_legacy_shape()[2];
+    uint32_t batch_size_in_sticks = input_a.get_padded_shape()[1] * input_a.get_padded_shape()[2];
 
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
@@ -122,9 +122,9 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(
         auto input_b = input_tensors.at(2);
         auto batch_ids = input_tensors.at(0);
         uint32_t core_id = 0;
-        uint32_t B = input_a.get_legacy_shape()[0];
-        uint32_t b = input_b.get_legacy_shape()[0];
-        uint32_t batch_size_in_sticks = input_a.get_legacy_shape()[1] * input_a.get_legacy_shape()[2];
+        uint32_t B = input_a.get_padded_shape()[0];
+        uint32_t b = input_b.get_padded_shape()[0];
+        uint32_t batch_size_in_sticks = input_a.get_padded_shape()[1] * input_a.get_padded_shape()[2];
         for (const auto& core : cores) {
             uint32_t local_b = (core_id < B) ? b : 0;
             uint32_t local_batch_size_in_sticks = (core_id < B) ? batch_size_in_sticks : 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor& input
 
     uint32_t page_size = input.buffer()->page_size();
 
-    uint32_t num_pages = tilized ? output.volume() / TILE_HW : output.volume() / output.get_legacy_shape()[-1];
+    uint32_t num_pages = tilized ? output.volume() / TILE_HW : output.volume() / output.get_padded_shape()[-1];
     tt::tt_metal::IDevice* device = output.device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_y = compute_with_storage_grid_size.y;

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -47,7 +47,7 @@ static inline Tensor move(uint8_t queue_id, const Tensor& input_tensor, const st
 
     DeallocateBuffer(*input_tensor.buffer());
     auto output_tensor = create_device_tensor(
-        input_tensor.get_legacy_shape(),
+        input_tensor.get_padded_shape(),
         input_tensor.get_dtype(),
         input_tensor.get_layout(),
         input_tensor.device(),
@@ -148,7 +148,7 @@ static inline Tensor move_sharded(
             auto shard_spec = input_tensor.shard_spec().value();
             auto shard_shape = shard_spec.shape;
             auto shard_grid = shard_spec.grid;
-            auto input_shape = input_tensor.get_legacy_shape();
+            auto input_shape = input_tensor.get_padded_shape();
             auto input_dtype = input_tensor.get_dtype();
             auto input_layout = input_tensor.get_layout();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -47,13 +47,15 @@ static inline Tensor move(uint8_t queue_id, const Tensor& input_tensor, const st
 
     DeallocateBuffer(*input_tensor.buffer());
     auto output_tensor = create_device_tensor(
-        input_tensor.get_padded_shape(),
-        input_tensor.get_dtype(),
-        input_tensor.get_layout(),
-        input_tensor.device(),
-        output_mem_config);
-
-    bool tilized = input_tensor.get_layout() == Layout::TILE;
+        TensorSpec(
+            input_tensor.get_logical_shape(),
+            TensorLayout::fromPaddedShape(
+                input_tensor.get_dtype(),
+                PageConfig(input_tensor.get_layout()),
+                output_mem_config,
+                input_tensor.get_logical_shape(),
+                input_tensor.get_padded_shape())),
+        input_tensor.device());
 
     // get_parallelization_strategy
     bool move_within_same_mem_space = input_mem_config.buffer_type == output_mem_config.buffer_type;
@@ -148,7 +150,6 @@ static inline Tensor move_sharded(
             auto shard_spec = input_tensor.shard_spec().value();
             auto shard_shape = shard_spec.shape;
             auto shard_grid = shard_spec.grid;
-            auto input_shape = input_tensor.get_padded_shape();
             auto input_dtype = input_tensor.get_dtype();
             auto input_layout = input_tensor.get_layout();
 
@@ -156,8 +157,16 @@ static inline Tensor move_sharded(
             // log_debug(LogOp, "OUTPUT SHARD SPEC: {}", out_shard_spec);
             auto shard_mem_config = output_mem_config;
             shard_mem_config.shard_spec = shard_spec;
-            auto output_tensor =
-                create_device_tensor(input_shape, input_dtype, input_layout, input_tensor.device(), shard_mem_config);
+            auto output_tensor = create_device_tensor(
+                TensorSpec(
+                    input_tensor.get_logical_shape(),
+                    TensorLayout::fromPaddedShape(
+                        input_dtype,
+                        PageConfig(input_layout),
+                        shard_mem_config,
+                        input_tensor.get_logical_shape(),
+                        input_tensor.get_padded_shape())),
+                input_tensor.device());
             if (input_tensor.buffer()->address() == output_tensor.buffer()->address()) {
                 tt::log_debug(
                     tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.cpp
@@ -12,7 +12,7 @@ namespace operations::data_movement {
 
 void NonZeroIndices::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
-    auto input_tensor_a_shape = input_tensor_a.get_legacy_shape();
+    auto input_tensor_a_shape = input_tensor_a.get_padded_shape();
     TT_FATAL(
         input_tensor_a_shape[0] == 1 and input_tensor_a_shape[1] == 1 and input_tensor_a_shape[2] == 1,
         "Input should be 1D");

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -27,8 +27,8 @@ operation::ProgramWithCallbacks non_zero_indices_single_core(
     uint32_t alignment_base = 32 / input.element_size();
     // we want per core to be aligned to aligment_base per core
 
-    uint32_t aligned_elements = tt::div_up(input.get_legacy_shape()[-1], alignment_base) * alignment_base;
-    uint32_t actual_elements = input.get_legacy_shape()[-1];
+    uint32_t aligned_elements = tt::div_up(input.get_padded_shape()[-1], alignment_base) * alignment_base;
+    uint32_t actual_elements = input.get_padded_shape()[-1];
 
     CoreCoord core = {0, 0};
 
@@ -101,8 +101,8 @@ operation::ProgramWithCallbacks non_zero_indices_single_core(
         auto output_1 = output_tensors.at(1);
         auto input = input_tensors.at(1);
         uint32_t alignment_base = 32 / input.element_size();
-        uint32_t aligned_elements = tt::div_up(input.get_legacy_shape()[-1], alignment_base) * alignment_base;
-        uint32_t actual_elements = input.get_legacy_shape()[-1];
+        uint32_t aligned_elements = tt::div_up(input.get_padded_shape()[-1], alignment_base) * alignment_base;
+        uint32_t actual_elements = input.get_padded_shape()[-1];
         auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, kernel_id, core);
         runtime_args[0] = input.buffer()->address();
         runtime_args[1] = output_0.buffer()->address();

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -29,7 +29,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
 
     auto output_shape = output_padded_shape;
 
-    uint32_t unpadded_row_size_nbytes = a.get_legacy_shape()[3] * a.element_size();
+    uint32_t unpadded_row_size_nbytes = a.get_padded_shape()[3] * a.element_size();
     uint32_t padded_row_size_nbytes = output_shape[3] * a.element_size();  // Assuming output is same datatype as input
     TT_ASSERT(
         unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
@@ -100,13 +100,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
     {
         log_debug("src0_buffer_addr: {}", src0_buffer->address());
         log_debug("dst_buffer_addr: {}", dst_buffer->address());
-        log_debug("a.shape[0]: {}", a.get_legacy_shape()[0]);
+        log_debug("a.shape[0]: {}", a.get_padded_shape()[0]);
         log_debug("out.shape[0]: {}", output_shape[0]);
-        log_debug("a.shape[1]: {}", a.get_legacy_shape()[1]);
+        log_debug("a.shape[1]: {}", a.get_padded_shape()[1]);
         log_debug("out.shape[1]: {}", output_shape[1]);
-        log_debug("a.shape[2]: {}", a.get_legacy_shape()[2]);
+        log_debug("a.shape[2]: {}", a.get_padded_shape()[2]);
         log_debug("out.shape[2]: {}", output_shape[2]);
-        log_debug("s.shape[3]: {}", a.get_legacy_shape()[3]);
+        log_debug("s.shape[3]: {}", a.get_padded_shape()[3]);
         log_debug("out.shape[3]: {}", output_shape[3]);
         log_debug("unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
         log_debug("padded_row_size_nbytes: {}", padded_row_size_nbytes);
@@ -122,13 +122,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
     const std::array reader_rt_args = {
         src0_buffer->address(),
         dst_buffer->address(),
-        a.get_legacy_shape()[0],
+        a.get_padded_shape()[0],
         output_shape[0],
-        a.get_legacy_shape()[1],
+        a.get_padded_shape()[1],
         output_shape[1],
-        a.get_legacy_shape()[2],
+        a.get_padded_shape()[2],
         output_shape[2],
-        a.get_legacy_shape()[3],
+        a.get_padded_shape()[3],
         output_shape[3],
         unpadded_row_size_nbytes,
         padded_row_size_nbytes,
@@ -142,11 +142,11 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
         std::uint32_t{0},
         std::uint32_t{0},
         output_shape[2],
-        a.get_legacy_shape()[2],
+        a.get_padded_shape()[2],
         unpadded_row_size_nbytes,
         padded_row_size_nbytes,
         std::uint32_t{0},
-        output.get_legacy_shape()[0]};
+        output.get_padded_shape()[0]};
     const auto& writer_rt_args = reader_rt_args;
     tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, cores, reader_rt_args);
     tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, cores, writer_rt_args);
@@ -220,16 +220,16 @@ operation::ProgramWithCallbacks pad_tile(
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
-    uint32_t num_unpadded_Xt = a.get_legacy_shape()[3] / TILE_WIDTH;
+    uint32_t num_unpadded_Xt = a.get_padded_shape()[3] / TILE_WIDTH;
     uint32_t num_total_Xt = output_shape[3] / TILE_WIDTH;
     uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
-    uint32_t num_unpadded_Yt = a.get_legacy_shape()[2] / TILE_HEIGHT;
+    uint32_t num_unpadded_Yt = a.get_padded_shape()[2] / TILE_HEIGHT;
     uint32_t num_total_Yt = output_shape[2] / TILE_HEIGHT;
     uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
-    uint32_t num_unpadded_Z = a.get_legacy_shape()[1];
+    uint32_t num_unpadded_Z = a.get_padded_shape()[1];
     uint32_t num_total_Z = output_shape[1];
     uint32_t num_padded_Zt = (num_total_Z - num_unpadded_Z) * num_total_Yt * num_total_Xt;
-    uint32_t num_unpadded_W = a.get_legacy_shape()[0];
+    uint32_t num_unpadded_W = a.get_padded_shape()[0];
     uint32_t num_total_W = output_shape[0];
     uint32_t num_padded_Wt = (num_total_W - num_unpadded_W) * num_total_Z * num_total_Yt * num_total_Xt;
 
@@ -457,7 +457,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
 
     auto output_shape = output_padded_shape;
 
-    uint32_t unpadded_row_size_nbytes = a.get_legacy_shape()[3] * a.element_size();
+    uint32_t unpadded_row_size_nbytes = a.get_padded_shape()[3] * a.element_size();
     uint32_t padded_row_size_nbytes = output_shape[3] * a.element_size();  // Assuming output is same datatype as input
     TT_ASSERT(
         unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
@@ -560,13 +560,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
         tt::log_debug("ntiles_per_core_w: {}", ntiles_per_core_w);
         tt::log_debug("src0_buffer_addr: {}", src0_buffer->address());
         tt::log_debug("dst_buffer_addr: {}", dst_buffer->address());
-        tt::log_debug("a.shape[0]: {}", a.get_legacy_shape()[0]);
+        tt::log_debug("a.shape[0]: {}", a.get_padded_shape()[0]);
         tt::log_debug("out.shape[0]: {}", output_shape[0]);
-        tt::log_debug("a.shape[1]: {}", a.get_legacy_shape()[1]);
+        tt::log_debug("a.shape[1]: {}", a.get_padded_shape()[1]);
         tt::log_debug("out.shape[1]: {}", output_shape[1]);
-        tt::log_debug("a.shape[2]: {}", a.get_legacy_shape()[2]);
+        tt::log_debug("a.shape[2]: {}", a.get_padded_shape()[2]);
         tt::log_debug("out.shape[2]: {}", output_shape[2]);
-        tt::log_debug("s.shape[3]: {}", a.get_legacy_shape()[3]);
+        tt::log_debug("s.shape[3]: {}", a.get_padded_shape()[3]);
         tt::log_debug("out.shape[3]: {}", output_shape[3]);
         tt::log_debug("unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
         tt::log_debug("padded_row_size_nbytes: {}", padded_row_size_nbytes);
@@ -589,7 +589,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
     int32_t rem_nbatch =
         nbatch;  // per core h, there are ncores_per_batch_h cores, ie each batch ncores_h = ncores_per_batch_h
     for (int32_t b = 0; b < nbatch; ++b) {
-        int32_t rem_src_nsticks = a.get_legacy_shape()[2];
+        int32_t rem_src_nsticks = a.get_padded_shape()[2];
         for (uint32_t j = 0; j < ncores_per_batch_h; ++j) {
             uint32_t num_local_unpadded_nsticks = local_nsticks;
             if (rem_src_nsticks - local_nsticks >= 0) {
@@ -619,13 +619,13 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
                 const std::array reader_rt_args = {
                     src0_buffer->address(),
                     dst_buffer->address(),
-                    a.get_legacy_shape()[0],
+                    a.get_padded_shape()[0],
                     output_shape[0],
-                    a.get_legacy_shape()[1],
+                    a.get_padded_shape()[1],
                     output_shape[1],
-                    a.get_legacy_shape()[2],
+                    a.get_padded_shape()[2],
                     output_shape[2],
-                    a.get_legacy_shape()[3],
+                    a.get_padded_shape()[3],
                     output_shape[3],
                     curr_stick_size_nbytes,
                     (uint32_t)dst_nbytes_per_core_w,
@@ -707,8 +707,8 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     uint32_t num_w_sticks_per_core_group_2) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t W_bytes = W * input_tensor.element_size();
@@ -1030,8 +1030,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t W_bytes = W * input_tensor.element_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::data_movement {
 
 void RepeatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors[0];
-    tt::tt_metal::LegacyShape input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
     TT_FATAL(this->repeat_dim < input_shape.rank(), "Repeat dim specified is larger than input tensor rank.");
     if (input_tensor.get_layout() == Layout::ROW_MAJOR && this->repeat_dim == input_shape.rank() - 1) {
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory.cpp
@@ -28,9 +28,9 @@ operation::ProgramWithCallbacks repeat_multi_core(
     uint32_t num_output_pages;
     uint32_t single_page_size;
     if (rm_layout) {
-        num_output_pages = output.volume() / output.get_legacy_shape()[-1];
+        num_output_pages = output.volume() / output.get_padded_shape()[-1];
         single_page_size =
-            tt::align(output.element_size() * output.get_legacy_shape()[-1], output.buffer()->alignment());
+            tt::align(output.element_size() * output.get_padded_shape()[-1], output.buffer()->alignment());
     } else {
         num_output_pages = output.volume() / TILE_HW;
         single_page_size = tt::tt_metal::detail::TileSize(cb_data_format);
@@ -52,7 +52,7 @@ operation::ProgramWithCallbacks repeat_multi_core(
             .set_page_size(src0_cb_index, single_page_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t num_dims = output.get_legacy_shape().rank();
+    uint32_t num_dims = output.get_padded_shape().rank();
 
     auto input_buffer = input_tensor.buffer();
     uint32_t src_addr = input_buffer->address();
@@ -73,11 +73,11 @@ operation::ProgramWithCallbacks repeat_multi_core(
     }
 
     for (uint32_t i = repeat_dim + 1; i < num_dims; ++i) {
-        num_accum_pages *= output.get_legacy_shape()[i];
+        num_accum_pages *= output.get_padded_shape()[i];
     }
     if (rm_layout) {
         if (num_dims > 1 && repeat_dim < num_dims - 1) {
-            num_accum_pages /= output.get_legacy_shape()[-1];
+            num_accum_pages /= output.get_padded_shape()[-1];
         }
     } else {
         if (repeat_dim < num_dims - 2) {
@@ -91,11 +91,11 @@ operation::ProgramWithCallbacks repeat_multi_core(
         if (repeat_dim == num_dims - 1) {
             num_pages_per_block = num_accum_pages;
         } else {
-            uint32_t dim_pages = input_tensor.get_legacy_shape()[repeat_dim];
+            uint32_t dim_pages = input_tensor.get_padded_shape()[repeat_dim];
             num_pages_per_block = num_accum_pages * dim_pages;
         }
     } else {
-        uint32_t dim_pages = input_tensor.get_legacy_shape()[repeat_dim] / scale_factor;
+        uint32_t dim_pages = input_tensor.get_padded_shape()[repeat_dim] / scale_factor;
         num_pages_per_block = num_accum_pages * dim_pages;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -37,11 +37,11 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) 
         uint32_t ROW_MAJOR_WIDTH = 8;
         auto padded_output_shape = output_shape.padded_shape();
         TT_FATAL(
-            input_tensor_a.get_legacy_shape()[3] % ROW_MAJOR_WIDTH == 0 &&
+            input_tensor_a.get_padded_shape()[3] % ROW_MAJOR_WIDTH == 0 &&
                 padded_output_shape[3] % ROW_MAJOR_WIDTH == 0,
             "Operand/target width must be a multiple of 8");
-        uint32_t num_old_sticks = input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] *
-                                  input_tensor_a.get_legacy_shape()[2];
+        uint32_t num_old_sticks = input_tensor_a.get_padded_shape()[0] * input_tensor_a.get_padded_shape()[1] *
+                                  input_tensor_a.get_padded_shape()[2];
         uint32_t num_new_sticks = padded_output_shape[0] * padded_output_shape[1] * padded_output_shape[2];
     } else {
         TT_THROW("Unsupported layout for reshape");

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_program_factory.cpp
@@ -29,7 +29,7 @@ operation::ProgramWithCallbacks reshape_tile_single_core(const Tensor& a, Tensor
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -75,7 +75,7 @@ operation::ProgramWithCallbacks reshape_tile_single_core(const Tensor& a, Tensor
         unary_reader_kernel_id,
         core,
         {src0_buffer->address(),
-         a.get_legacy_shape()[3] / tt::constants::TILE_WIDTH,
+         a.get_padded_shape()[3] / tt::constants::TILE_WIDTH,
          (uint32_t)output_shape[0],
          (uint32_t)output_shape[1],
          (uint32_t)output_shape[2] / tt::constants::TILE_HEIGHT,
@@ -120,8 +120,8 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     bool split_work_by_old_sticks) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t old_stick_size = input_shape[3] * input_tensor.element_size();
     uint32_t new_stick_size = output_shape[3] * output_tensor.element_size();
@@ -214,16 +214,16 @@ operation::ProgramWithCallbacks reshape_rm_multi_core(const Tensor& a, Tensor& o
 
     tt::tt_metal::IDevice* device = a.device();
 
-    tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
-    uint32_t num_old_sticks = a.get_legacy_shape()[0] * a.get_legacy_shape()[1] * a.get_legacy_shape()[2];
+    uint32_t num_old_sticks = a.get_padded_shape()[0] * a.get_padded_shape()[1] * a.get_padded_shape()[2];
     uint32_t num_new_sticks = output_shape[0] * output_shape[1] * output_shape[2];
 
-    uint32_t old_stick_size = a.get_legacy_shape()[3] * a.element_size();
+    uint32_t old_stick_size = a.get_padded_shape()[3] * a.element_size();
     uint32_t new_stick_size = output_shape[3] * output.element_size();
 
     TT_FATAL(
@@ -333,10 +333,10 @@ operation::ProgramWithCallbacks reshape_rm_multi_core(const Tensor& a, Tensor& o
         auto output_shape = dst_tensor.shape();
 
         uint32_t num_old_sticks =
-            src_tensor.get_legacy_shape()[0] * src_tensor.get_legacy_shape()[1] * src_tensor.get_legacy_shape()[2];
+            src_tensor.get_padded_shape()[0] * src_tensor.get_padded_shape()[1] * src_tensor.get_padded_shape()[2];
         uint32_t num_new_sticks = output_shape[0] * output_shape[1] * output_shape[2];
 
-        uint32_t old_stick_size = src_tensor.get_legacy_shape()[3] * src_tensor.element_size();
+        uint32_t old_stick_size = src_tensor.get_padded_shape()[3] * src_tensor.element_size();
         uint32_t new_stick_size = output_shape[3] * dst_tensor.element_size();
 
         bool split_work_by_old_sticks = old_stick_size > new_stick_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -77,10 +77,10 @@ ttnn::Tensor ReshapeOperation::invoke(
     }
     uint32_t ROW_MAJOR_WIDTH = 8;
     if (input_tensor.get_layout() == Layout::ROW_MAJOR &&
-        (input_tensor.get_legacy_shape()[3] % ROW_MAJOR_WIDTH != 0 || padded_output_shape[3] % ROW_MAJOR_WIDTH != 0) &&
+        (input_tensor.get_padded_shape()[3] % ROW_MAJOR_WIDTH != 0 || padded_output_shape[3] % ROW_MAJOR_WIDTH != 0) &&
         ((padded_output_shape.volume() / padded_output_shape[-1]) % TILE_HEIGHT != 0 ||
-         padded_output_shape[-1] % TILE_WIDTH != 0 || input_tensor.get_legacy_shape()[-1] % TILE_WIDTH != 0 ||
-         (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % TILE_HEIGHT != 0)) {
+         padded_output_shape[-1] % TILE_WIDTH != 0 || input_tensor.get_padded_shape()[-1] % TILE_WIDTH != 0 ||
+         (input_tensor.volume() / input_tensor.get_padded_shape()[-1]) % TILE_HEIGHT != 0)) {
         TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16, "Error");
 
         return detail::manual_insertion(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -48,25 +48,25 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
         num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
         num_units_per_shard_width = shard_spec.shape[1] / TILE_WIDTH;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.get_legacy_shape()[-1] / TILE_WIDTH;
+        num_units_per_row = input.get_padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        uint32_t num_units_height = input.volume() / input.get_legacy_shape()[-1] / TILE_HEIGHT / num_slices;
+        uint32_t num_units_height = input.volume() / input.get_padded_shape()[-1] / TILE_HEIGHT / num_slices;
         num_units_per_shard_height_last =
             num_units_per_shard_height - (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =
             num_units_per_shard_width - (tt::round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
         padded_offset_bytes = (num_units_per_shard_width - num_units_per_shard_width_last) * input_unit_size;
     } else {
-        num_units = (input.volume() / input.get_legacy_shape()[-1] / shard_spec.shape[0]) *
-                    (input.get_legacy_shape()[-1] / shard_spec.shape[1]);
+        num_units = (input.volume() / input.get_padded_shape()[-1] / shard_spec.shape[0]) *
+                    (input.get_padded_shape()[-1] / shard_spec.shape[1]);
         input_unit_size = shard_spec.shape[1] * input.element_size();
         output_unit_size = shard_spec.shape[1] * output.element_size();
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.get_legacy_shape()[-1] * input.element_size();
+        num_units_per_row = input.get_padded_shape()[-1] * input.element_size();
         num_units_offset = 1;
-        uint32_t num_units_height = input.volume() / input.get_legacy_shape()[-1];
+        uint32_t num_units_height = input.volume() / input.get_padded_shape()[-1];
         num_units_per_shard_height_last =
             num_units_per_shard_height - (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         // TODO: Use a different variable name. Units refers to pages, but this is being used as size

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.cpp
@@ -45,8 +45,8 @@ ttnn::Tensor InterleavedToShardedOperation::invoke(
             if constexpr (std::is_same_v<GridType, CoreCoord>) {
                 grid_size = grid;
                 uint32_t num_cores = 0;
-                uint32_t total_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
-                uint32_t total_width = input_tensor.get_legacy_shape()[-1];
+                uint32_t total_height = input_tensor.volume() / input_tensor.get_padded_shape()[-1];
+                uint32_t total_width = input_tensor.get_padded_shape()[-1];
                 switch (shard_scheme) {
                     case TensorMemoryLayout::HEIGHT_SHARDED:
                         num_cores = tt::div_up(total_height, shard_shape[0]);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -453,7 +453,7 @@ operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, 
         total_size = output_shard_spec.numel() / TILE_HW * unit_size;
     } else {
         unit_size = output_shard_spec.shape[1] * output.element_size();
-        page_size = output.get_legacy_shape()[-1] * output.element_size();
+        page_size = output.get_padded_shape()[-1] * output.element_size();
         total_size = output_shard_shape[0] * unit_size;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -14,8 +14,8 @@ uint32_t calculate_starting_idx_h(const Tensor& tensor, uint32_t num_slices, uin
         return 0;
     }
 
-    uint32_t num_tiles_height = tensor.volume() / tensor.get_legacy_shape()[-1] / tt::constants::TILE_HEIGHT;
-    uint32_t num_tiles_width = tensor.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
+    uint32_t num_tiles_height = tensor.volume() / tensor.get_padded_shape()[-1] / tt::constants::TILE_HEIGHT;
+    uint32_t num_tiles_width = tensor.get_padded_shape()[-1] / tt::constants::TILE_WIDTH;
     uint32_t total_num_tiles = num_tiles_height * num_tiles_width;
 
     uint32_t num_tiles_per_slice = total_num_tiles / num_slices;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -45,24 +45,24 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
         num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
         num_units_per_shard_width = shard_spec.shape[1] / TILE_WIDTH;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = output.get_legacy_shape()[-1] / TILE_WIDTH;
+        num_units_per_row = output.get_padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        num_units_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT / num_slices;
+        num_units_height = output.volume() / output.get_padded_shape()[-1] / TILE_HEIGHT / num_slices;
         num_units_per_shard_height_last =
             num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =
             num_units_per_shard_width - (round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
     } else {
-        num_units = (output.volume() / output.get_legacy_shape()[-1] / shard_spec.shape[0]) *
-                    (input.get_legacy_shape()[-1] / shard_spec.shape[1]);
+        num_units = (output.volume() / output.get_padded_shape()[-1] / shard_spec.shape[0]) *
+                    (input.get_padded_shape()[-1] / shard_spec.shape[1]);
         input_unit_size = shard_spec.shape[1] * input.element_size();
         output_unit_size = shard_spec.shape[1] * output.element_size();
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = output.get_legacy_shape()[-1] * output.element_size();
+        num_units_per_row = output.get_padded_shape()[-1] * output.element_size();
         num_units_offset = 1;
-        num_units_height = input.volume() / input.get_legacy_shape()[-1];
+        num_units_height = input.volume() / input.get_padded_shape()[-1];
         num_units_per_shard_height_last =
             num_units_per_shard_height - (round_up(num_units_height, num_units_per_shard_height) - num_units_height);
         num_units_per_shard_width_last =

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -23,7 +23,7 @@ void InterleavedToShardedPartialDeviceOperation::validate(const std::vector<Tens
         num_slices);
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Currently, only tile layout is supported for partial I->S");
     TT_FATAL(
-        (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % num_slices == 0,
+        (input_tensor.volume() / input_tensor.get_padded_shape()[-1]) % num_slices == 0,
         "Total height of a tensor must be divisible by num_slices!");
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
@@ -45,7 +45,7 @@ void InterleavedToShardedPartialDeviceOperation::validate(const std::vector<Tens
 std::vector<ttnn::TensorSpec> InterleavedToShardedPartialDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    tt::tt_metal::LegacyShape shape = input_tensor.get_legacy_shape();
+    auto shape = input_tensor.get_padded_shape();
 
     uint32_t total_height = input_tensor.volume() / shape[-1];
     uint32_t new_height = total_height / this->num_slices;
@@ -57,14 +57,7 @@ std::vector<ttnn::TensorSpec> InterleavedToShardedPartialDeviceOperation::comput
     auto mem_config = this->output_mem_config;
     mem_config.shard_spec = this->shard_spec;
 
-    return {TensorSpec(
-        shape.logical_shape(),
-        TensorLayout::fromPaddedShape(
-            output_dtype,
-            PageConfig(input_tensor.get_layout()),
-            mem_config,
-            shape.logical_shape(),
-            shape.padded_shape()))};
+    return {TensorSpec(shape, TensorLayout(output_dtype, PageConfig(input_tensor.get_layout()), mem_config))};
 }
 
 operation::ProgramWithCallbacks InterleavedToShardedPartialDeviceOperation::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
@@ -31,10 +31,10 @@ ttnn::Tensor InterleavedToShardedPartialOperation::invoke(
             if constexpr (std::is_same_v<GridType, CoreCoord>) {
                 grid_size = grid;
                 uint32_t num_cores = 0;
-                uint32_t total_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
+                uint32_t total_height = input_tensor.volume() / input_tensor.get_padded_shape()[-1];
                 total_height /= num_slices;
 
-                uint32_t total_width = input_tensor.get_legacy_shape()[-1];
+                uint32_t total_width = input_tensor.get_padded_shape()[-1];
                 switch (shard_scheme) {
                     case TensorMemoryLayout::HEIGHT_SHARDED:
                         num_cores = tt::div_up(total_height, shard_shape[0]);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
@@ -24,7 +24,7 @@ void ShardedToInterleavedPartialDeviceOperation::validate(const std::vector<Tens
         num_slices);
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Currently, only tile layout is supported for partial I->S");
     TT_FATAL(
-        (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % num_slices == 0,
+        (input_tensor.volume() / input_tensor.get_padded_shape()[-1]) % num_slices == 0,
         "Total height of a tensor must be divisible by num_slices!");
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
@@ -32,8 +32,8 @@ void ShardedToInterleavedPartialDeviceOperation::validate(const std::vector<Tens
 
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Error");
     if (input_tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
-        if (input_tensor.get_legacy_shape()[-1] % shard_spec.shape[1] != 0 ||
-            ((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % shard_spec.shape[0]) != 0) {
+        if (input_tensor.get_padded_shape()[-1] % shard_spec.shape[1] != 0 ||
+            ((input_tensor.volume() / input_tensor.get_padded_shape()[-1]) % shard_spec.shape[0]) != 0) {
             TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1, "Error");
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -10,14 +10,14 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
-inline __attribute__((always_inline)) uint32_t get_upper_dims_compressed(const tt::tt_metal::LegacyShape& shape) {
-    return std::accumulate(shape.begin(), shape.end() - 2, 1, std::multiplies<uint32_t>{});
+inline __attribute__((always_inline)) uint32_t get_upper_dims_compressed(const ttnn::SimpleShape& shape) {
+    return std::accumulate(shape.cbegin(), shape.cend() - 2, 1, std::multiplies<uint32_t>{});
 }
 
 inline __attribute__((always_inline)) uint32_t get_upper_start_offset(const Tensor& tensor, const Shape& slice_start) {
     // offset for every dim except last 2
     uint32_t start_offset = 0;
-    const auto& shape = tensor.get_legacy_shape();
+    const auto& shape = tensor.get_padded_shape();
 
     uint32_t num_pages = tensor.volume();
     if (tensor.get_layout() == Layout::TILE) {
@@ -40,7 +40,7 @@ inline __attribute__((always_inline)) uint32_t get_upper_start_offset(const Tens
 uint32_t get_tiled_start_offset(const Tensor& input_tensor, const Shape& slice_start) {
     using namespace tt::constants;
     uint32_t num_input_pages = input_tensor.volume() / (TILE_HW);
-    const auto& shape = input_tensor.get_legacy_shape();
+    const auto& shape = input_tensor.get_padded_shape();
     uint32_t upper_dims_compressed = get_upper_dims_compressed(shape);
     uint32_t num_pages_width = num_input_pages / (upper_dims_compressed * (shape[-2] / TILE_HEIGHT));
 
@@ -54,8 +54,8 @@ uint32_t get_tiled_start_offset(const Tensor& input_tensor, const Shape& slice_s
 uint32_t get_rm_start_offset(const Tensor& tensor, const Shape& slice_start) {
     uint32_t start_offset = 0;
 
-    if (tensor.get_legacy_shape().rank() >= 2) {
-        const auto& shape = tensor.get_legacy_shape();
+    if (tensor.get_padded_shape().rank() >= 2) {
+        const auto& shape = tensor.get_padded_shape();
         uint32_t num_pages = tensor.volume() / shape[-1];
         uint32_t upper_dims_compressed = get_upper_dims_compressed(shape);
         start_offset = get_upper_start_offset(tensor, slice_start);
@@ -68,22 +68,22 @@ uint32_t get_rm_start_offset(const Tensor& tensor, const Shape& slice_start) {
 void SliceDeviceOperation::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     using namespace tt::constants;
-    const bool has_step = std::any_of(this->step.begin(), this->step.end(), [](uint32_t s) { return s != 1; });
+    const bool has_step = std::any_of(this->step.cbegin(), this->step.cend(), [](uint32_t s) { return s != 1; });
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Error");
     TT_FATAL(
-        input_tensor_a.get_legacy_shape().rank() == this->slice_start.rank() &&
+        input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() &&
             this->slice_start.rank() == this->slice_end.rank(),
         "Error");
-    for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
-        TT_FATAL(this->slice_start[i] < input_tensor_a.get_legacy_shape()[i], "Error");
+    for (uint32_t i = 0; i < input_tensor_a.get_padded_shape().rank(); i++) {
+        TT_FATAL(this->slice_start[i] < input_tensor_a.get_padded_shape()[i], "Error");
         TT_FATAL(
-            this->slice_end[i] <= input_tensor_a.get_legacy_shape()[i],
+            this->slice_end[i] <= input_tensor_a.get_padded_shape()[i],
             "Ends {} must be less than or equal to the shape of the tensor {}",
             this->slice_end[i],
-            input_tensor_a.get_legacy_shape()[i]);
+            input_tensor_a.get_padded_shape()[i]);
         // Check if start shape is <= end shape
         TT_FATAL(this->slice_start[i] <= this->slice_end[i], "Error");
     }
@@ -118,7 +118,7 @@ void SliceDeviceOperation::validate_with_output_tensors(
             "Can only unpad tilized tensor with full tiles");
     } else if (input_tensor_a.get_layout() == Layout::ROW_MAJOR) {
         if (has_step) {
-            for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
+            for (uint32_t i = 0; i < input_tensor_a.get_padded_shape().rank(); i++) {
                 TT_FATAL(step[i] > 0, "Step({}) = {} should be positive", i, step[i]);
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
@@ -15,9 +15,9 @@ uint32_t get_rm_start_offset(const Tensor& tensor, const Shape& slice_start);
 uint32_t get_tiled_start_offset(const Tensor& input_tensor, const Shape& slice_start);
 
 struct SliceDeviceOperation {
-    const tt::tt_metal::LegacyShape slice_start;
-    const tt::tt_metal::LegacyShape slice_end;
-    const tt::tt_metal::LegacyShape step;
+    const ttnn::SimpleShape slice_start;
+    const ttnn::SimpleShape slice_end;
+    const ttnn::SimpleShape step;
     const tt::tt_metal::MemoryConfig output_mem_config;
 
     void validate_with_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -18,7 +18,7 @@ namespace ttnn::operations::data_movement::detail {
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_start,
     uint32_t num_cores_total,
     uint32_t num_cores,
     uint32_t num_cores_y,
@@ -31,8 +31,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
@@ -140,16 +140,16 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 operation::ProgramWithCallbacks slice_rm_multi_core(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end) {
-    const tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end) {
+    const ttnn::SimpleShape output_shape = output.get_padded_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    uint32_t num_unpadded_sticks = output.volume() / output.get_legacy_shape()[-1];
+    uint32_t num_unpadded_sticks = output.volume() / output.get_padded_shape()[-1];
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -164,7 +164,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
-    uint32_t padded_row_size_bytes = a.get_legacy_shape()[-1] * a.element_size();
+    uint32_t padded_row_size_bytes = a.get_padded_shape()[-1] * a.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
@@ -243,7 +243,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
             uint32_t num_cores_x = compute_with_storage_grid_size.x;
             uint32_t num_cores_y = compute_with_storage_grid_size.y;
             uint32_t num_cores_total = num_cores_x * num_cores_y;
-            uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_legacy_shape()[-1];
+            uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_padded_shape()[-1];
             auto
                 [num_cores,
                  all_cores,
@@ -283,14 +283,14 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 operation::ProgramWithCallbacks slice_rm_strided_single_core_n_dims(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end,
-    const tt::tt_metal::LegacyShape& step) {
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end,
+    const ttnn::SimpleShape& step) {
     // TODO: multi core implementation - work division is not trivial as we need to determine the N/C/H/W start and end
     // points for each split, and base that off stride
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-    const tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
-    const tt::tt_metal::LegacyShape input_shape = a.get_legacy_shape();
+    const auto output_shape = output.get_padded_shape();
+    const auto input_shape = a.get_padded_shape();
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
     uint32_t src_is_dram = a.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
@@ -339,10 +339,10 @@ operation::ProgramWithCallbacks slice_rm_strided_single_core_n_dims(
     reader_runtime_args.reserve(1 + (4 * input_shape.rank()));
     reader_runtime_args.push_back(a.buffer()->address());
 
-    reader_runtime_args.insert(reader_runtime_args.end(), input_shape.begin(), input_shape.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), output_tensor_start.begin(), output_tensor_start.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), output_tensor_end.begin(), output_tensor_end.end());
-    reader_runtime_args.insert(reader_runtime_args.end(), step.begin(), step.end());
+    reader_runtime_args.insert(reader_runtime_args.end(), input_shape.cbegin(), input_shape.cend());
+    reader_runtime_args.insert(reader_runtime_args.end(), output_tensor_start.cbegin(), output_tensor_start.cend());
+    reader_runtime_args.insert(reader_runtime_args.end(), output_tensor_end.cbegin(), output_tensor_end.cend());
+    reader_runtime_args.insert(reader_runtime_args.end(), step.cbegin(), step.cend());
 
     tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
 
@@ -404,7 +404,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_start,
     uint32_t num_cores_unpadded,
     bool row_major,
     uint32_t num_cores_x_unpadded,
@@ -416,8 +416,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     tt::tt_metal::IDevice* device = input_tensor.device();
 
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
@@ -563,17 +563,17 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 operation::ProgramWithCallbacks slice_rm_multi_core_sharded(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end) {
-    const tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end) {
+    const ttnn::SimpleShape output_shape = output.get_padded_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    uint32_t num_padded_sticks = a.volume() / a.get_legacy_shape()[-1];
-    uint32_t num_unpadded_sticks = output.volume() / output.get_legacy_shape()[-1];
+    uint32_t num_padded_sticks = a.volume() / a.get_padded_shape()[-1];
+    uint32_t num_unpadded_sticks = output.volume() / output.get_padded_shape()[-1];
 
     // stick sizes
     uint32_t W_padded = a.shape()[-1];
@@ -697,7 +697,7 @@ template <bool initialize_args>
 inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     const Tensor& input_tensor,
     const Tensor& output_tensor,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_start,
     const uint32_t& num_cores_total,
     const uint32_t& num_cores,
     const std::vector<CoreCoord>& cores,
@@ -711,8 +711,8 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     std::vector<uint32_t>& accumulated_total_per_dim) {
     const auto input_buffer = input_tensor.buffer();
     const auto output_buffer = output_tensor.buffer();
-    const auto& input_shape = input_tensor.get_legacy_shape();
-    const auto& output_shape = output_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
+    const auto& output_shape = output_tensor.get_padded_shape();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
@@ -842,9 +842,9 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
 operation::ProgramWithCallbacks slice_tile_multi_core(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end) {
-    const tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end) {
+    const auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -877,7 +877,7 @@ operation::ProgramWithCallbacks slice_tile_multi_core(
             .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(a.get_legacy_shape().rank());
+    std::uint32_t num_dims = static_cast<std::uint32_t>(a.get_padded_shape().rank());
 
     // Reader compile-time args
     // Data is 32 byte aligned
@@ -971,9 +971,9 @@ operation::ProgramWithCallbacks slice_tile_multi_core(
 operation::ProgramWithCallbacks slice_multi_core(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end,
-    const tt::tt_metal::LegacyShape& step) {
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end,
+    const ttnn::SimpleShape& step) {
     bool has_step = false;
     for (int i = 0; i < step.size(); i++) {
         if (step[i] != 1) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
@@ -10,8 +10,8 @@ namespace ttnn::operations::data_movement::detail {
 tt::tt_metal::operation::ProgramWithCallbacks slice_multi_core(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end,
-    const tt::tt_metal::LegacyShape& step);
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end,
+    const ttnn::SimpleShape& step);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -189,9 +189,9 @@ ttnn::Tensor SliceOperation::invoke(
 
         auto res = operation::run(
                        SliceDeviceOperation{
-                           tt::tt_metal::LegacyShape(modified_begins),
-                           tt::tt_metal::LegacyShape(padded_ends),
-                           tt::tt_metal::LegacyShape(modified_step),
+                           ttnn::SimpleShape(modified_begins),
+                           ttnn::SimpleShape(padded_ends),
+                           ttnn::SimpleShape(modified_step),
                            memory_config},
                        {input},
                        {},
@@ -312,7 +312,8 @@ ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
         }
 
         input = operation::run(
-            SliceDeviceOperation{begins, padded_ends, step, memory_config},
+            SliceDeviceOperation{
+                ttnn::SimpleShape(begins), ttnn::SimpleShape(padded_ends), ttnn::SimpleShape(step), memory_config},
             {input},
             {},
             {optional_output_tensor},

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.cpp
@@ -27,21 +27,21 @@ void SplitDeviceOperation::validate(const std::vector<Tensor>& input_tensors) co
         this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Split does not currently support sharding");
 
-    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1, "shape[0] must be 1 (batch 1 only)");
+    TT_FATAL(input_tensor.get_padded_shape()[0] == 1, "shape[0] must be 1 (batch 1 only)");
     TT_FATAL(
-        input_tensor.get_legacy_shape()[this->dim] % this->num_splits == 0,
+        input_tensor.get_padded_shape()[this->dim] % this->num_splits == 0,
         "Dim being split must be evenly divisible by number of splits");
     TT_FATAL(
-        this->dim <= input_tensor.get_legacy_shape().rank() && this->dim >= 0,
+        this->dim <= input_tensor.get_padded_shape().rank() && this->dim >= 0,
         "Dim being split must be from 0 to rank - 1");
-    TT_FATAL(input_tensor.get_legacy_shape().rank() == 4, "Tensor needs to be rank 4");
+    TT_FATAL(input_tensor.get_padded_shape().rank() == 4, "Tensor needs to be rank 4");
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Tensor needs to be in TILE Layout");
 }
 
 std::vector<ttnn::TensorSpec> SplitDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    auto input_shape_array = input_tensor.get_legacy_shape().to_array_4D();
+    auto input_shape_array = input_tensor.get_padded_shape().to_array_4D();
     auto output_shape_array = input_shape_array;
     output_shape_array[this->dim] /= this->num_splits;
     TensorSpec spec(

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -87,7 +87,7 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
     uint32_t dim = 3;
     uint32_t num_chunks = 2;
 
-    auto input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
 
     Program program{};
     tt::tt_metal::IDevice* device = input_tensor.device();

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -97,7 +97,7 @@ std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor& input_ten
 }
 
 std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor& input_tensor, const MemoryConfig& mem_config) {
-    const auto shape = input_tensor.get_legacy_shape();
+    const auto shape = input_tensor.get_padded_shape();
     const bool pre_post_reshape = shape[0] > 1;
 
     if (!pre_post_reshape) {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -18,7 +18,7 @@ void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
 
     TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0, "Error");
 
-    auto width = input_tensor_a.get_legacy_shape()[-1];
+    auto width = input_tensor_a.get_padded_shape()[-1];
     uint32_t stick_s = width;
     uint32_t num_sticks = input_tensor_a.volume() / width;
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
@@ -26,7 +26,7 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& outp
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
-    auto output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -39,7 +39,7 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& outp
 
     uint32_t num_tiles = a.volume() / TILE_HW;
 
-    auto width = a.get_legacy_shape()[-1];
+    auto width = a.get_padded_shape()[-1];
     uint32_t stick_s = width;
     uint32_t num_sticks = a.volume() / width;
     uint32_t stick_size = stick_s * a.element_size();  // Assuming bfloat16 dataformat
@@ -165,9 +165,9 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
     int32_t ntiles = a.volume() / TILE_HW;
-    uint32_t ntiles_per_block = a.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t ntiles_per_block = a.get_padded_shape()[-1] / TILE_WIDTH;
     uint32_t nblocks = std::ceil((float)ntiles / ntiles_per_block);
-    uint32_t block_size_nbytes = a.get_legacy_shape()[-1] * a.element_size();
+    uint32_t block_size_nbytes = a.get_padded_shape()[-1] * a.element_size();
 
     IDevice* device = a.device();
     auto grid_size = device->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -14,7 +14,7 @@ namespace ttnn::operations::data_movement {
 
 void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_shape = input_tensor_a.get_legacy_shape();
+    const auto& input_shape = input_tensor_a.get_padded_shape();
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
@@ -50,7 +50,7 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
         TT_FATAL(
             this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout,
             "Output tensor must have the same memory layout as input tensor");
-        for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
+        for (uint32_t i = 0; i < input_tensor_a.get_padded_shape().rank(); i++) {
             if (i != input_shape.rank() - 2) {
                 TT_FATAL(input_shape[i] == this->output_padded_shape[i], "Error");
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -80,7 +80,7 @@ uint32_t get_packed_value(const Tensor tensor, const ttnn::PadValue pad_value) {
 
 operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value) {
-    auto output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -99,8 +99,8 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
 
     int32_t num_tiles = output.volume() / TILE_HW;
 
-    auto true_input_shape = a.get_legacy_shape();
-    auto true_output_shape = output.get_legacy_shape();
+    auto true_input_shape = a.get_padded_shape();
+    auto true_output_shape = output.get_padded_shape();
 
     auto input_w = true_input_shape.rank() >= 4 ? true_input_shape[-4] : 1;
     auto input_z = true_input_shape.rank() >= 3 ? true_input_shape[-3] : 1;
@@ -271,8 +271,8 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
 
-    uint32_t num_blocks = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
-    uint32_t num_tiles_per_row = output.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t num_blocks = output.volume() / output.get_padded_shape()[-1] / TILE_HEIGHT;
+    uint32_t num_tiles_per_row = output.get_padded_shape()[-1] / TILE_WIDTH;
 
     bool enough_space = enough_available_space(a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
     if (!enough_space) {
@@ -284,8 +284,8 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
 
     bool has_cliff = core_range_cliff.size() > 0;
 
-    uint32_t unpadded_row_size_bytes = a.get_legacy_shape()[-1] * a.element_size();     // Assuming bfloat16 dataformat
-    uint32_t padded_row_size_bytes = output.get_legacy_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
+    uint32_t unpadded_row_size_bytes = a.get_padded_shape()[-1] * a.element_size();     // Assuming bfloat16 dataformat
+    uint32_t padded_row_size_bytes = output.get_padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
     auto [src0_cb_index, cb_src0] = create_cb(
         tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);
@@ -455,7 +455,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
 
     auto all_cores = output_shard_spec.grid;
 
-    uint32_t num_batches = output.volume() / (output.get_legacy_shape()[-2] * output.get_legacy_shape()[-1]);
+    uint32_t num_batches = output.volume() / (output.get_padded_shape()[-2] * output.get_padded_shape()[-1]);
 
     uint32_t num_input_rows = input_shard_spec.shape[0];
     uint32_t input_shard_width_bytes = input_shard_spec.shape[1] * a.element_size();
@@ -463,7 +463,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
     uint32_t ntiles_per_batch = ntiles_per_core / num_batches;
     uint32_t ntiles_per_block = output_shard_spec.shape[1] / TILE_WIDTH;
     uint32_t nblocks_per_core = output_shard_spec.shape[0] / TILE_HEIGHT;
-    uint32_t num_padded_rows = output.get_legacy_shape()[-2] - a.get_legacy_shape()[-2];
+    uint32_t num_padded_rows = output.get_padded_shape()[-2] - a.get_padded_shape()[-2];
 
     auto [src0_cb_index, cb_src0] = create_cb(
         tt::CBIndex::c_1,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -35,8 +35,8 @@ void override_runtime_args_mc_cn(
     uint32_t num_tiles_per_core_group_2) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
 
@@ -224,8 +224,8 @@ void override_runtime_args_mc_hc(
     uint32_t num_tiles_per_core_group_2) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t HW = H * W;
@@ -324,8 +324,8 @@ void override_runtime_args_mc_hc_rm(
     uint32_t num_w_sticks_per_core_group_2) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t W_bytes = W * input_tensor.element_size();
@@ -625,7 +625,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
 
 operation::ProgramWithCallbacks transpose_hc_multi_core(
     const Tensor& a, Tensor& output, const std::optional<float>& pad_value) {
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     if (a.get_layout() == Layout::TILE && !a.is_sharded()) {
         return transpose_hc_multi_core_tiled_interleaved(a, output, pad_value);
     }
@@ -660,7 +660,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, row_major ? NCH : num_tensor_tiles);
 
-    tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -852,8 +852,8 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     const Tensor& input_tensor, Tensor& output_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t W_bytes = W * input_tensor.element_size();
@@ -925,8 +925,8 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     const Tensor& input_tensor, Tensor& output_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t W_bytes = W * input_tensor.element_size();
@@ -1167,7 +1167,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor& a,
 
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
 
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t W = a.shape()[3], H = a.shape()[2], C = a.shape()[1], N = a.shape()[0];
     uint32_t total_height = N * C * H;
     uint32_t stick_size_bytes = W * a.element_size();
@@ -1196,7 +1196,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor& a,
     tt::log_debug("all_cores: {}", all_cores);
     tt::log_debug("num_cores: {}", num_cores);
 
-    tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
 
@@ -1316,8 +1316,8 @@ void override_runtime_args_wh(
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_tiles_per_core_group_2) {
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], NC = input_shape[1] * input_shape[0];
     uint32_t HW = H * W;
@@ -1795,7 +1795,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor& a,
     uint32_t num_cores = all_cores.num_cores();
     uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
 
-    tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
 
@@ -1987,7 +1987,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded_rm(const Tensor&
 
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
 
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t W = a.shape()[3], H = a.shape()[2], C = a.shape()[1], N = a.shape()[0];
     uint32_t total_height = N * C * H;
     uint32_t stick_size_bytes = W * a.element_size();
@@ -2054,7 +2054,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded_rm(const Tensor&
     tt::log_debug("all_cores: {}", all_cores);
     tt::log_debug("num_cores: {}", num_cores);
 
-    tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
 
     // sharded cb
     uint32_t src0_cb_index = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -59,7 +59,7 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column_subgrid(
 
     uint32_t max_tiles = 1;
     uint32_t ntiles_per_block = ntiles / ncores;
-    uint32_t stick_s = a.get_legacy_shape()[-1];
+    uint32_t stick_s = a.get_padded_shape()[-1];
     uint32_t ntiles_per_row = stick_s / TILE_WIDTH;
     uint32_t stick_size = stick_s * output.element_size();
     uint32_t ntiles_per_column = ntiles / ntiles_per_row;
@@ -245,7 +245,7 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
     // buffering each
     uint32_t max_tiles = 1;
 
-    uint32_t stick_s = a.get_legacy_shape()[-1];
+    uint32_t stick_s = a.get_padded_shape()[-1];
     uint32_t ntiles_per_row = stick_s / TILE_WIDTH;
     uint32_t stick_size = stick_s * output.element_size();
     uint32_t ntiles_per_column = ntiles / ntiles_per_row;
@@ -464,10 +464,10 @@ operation::ProgramWithCallbacks untilize_multi_core(
     IDevice* device = a.device();
 
     uint32_t ntiles = a.volume() / TILE_HW;
-    uint32_t stick_s = a.get_legacy_shape()[-1];
-    uint32_t ntiles_per_block = a.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t stick_s = a.get_padded_shape()[-1];
+    uint32_t ntiles_per_block = a.get_padded_shape()[-1] / TILE_WIDTH;
     uint32_t nblocks = std::ceil((float)ntiles / ntiles_per_block);
-    uint32_t block_size_nbytes = a.get_legacy_shape()[-1] * output.element_size();
+    uint32_t block_size_nbytes = a.get_padded_shape()[-1] * output.element_size();
 
     uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - a.device()->get_base_allocator_addr(HalMemType::L1);
     uint32_t max_tiles =
@@ -519,12 +519,12 @@ operation::ProgramWithCallbacks untilize_multi_core(
 
         num_rows_block = shard_spec.shape[0];
         block_row_size = shard_spec.shape[1] * output.element_size();  // in0_block_w * TILE_WIDTH * dtype_nbytes
-        output_row_size = output.get_legacy_shape()[-1] * output.element_size();  // output row size bytes
+        output_row_size = output.get_padded_shape()[-1] * output.element_size();  // output row size bytes
         last_block_row_size_unpadded =
             block_row_size -
-            (tt::round_up(output.get_legacy_shape()[-1], shard_spec.shape[1]) - output.get_legacy_shape()[-1]) *
+            (tt::round_up(output.get_padded_shape()[-1], shard_spec.shape[1]) - output.get_padded_shape()[-1]) *
                 output.element_size();
-        uint32_t num_output_rows = output.volume() / output.get_legacy_shape()[-1];
+        uint32_t num_output_rows = output.volume() / output.get_padded_shape()[-1];
         num_output_rows_unpadded =
             num_rows_block - (tt::round_up(num_output_rows, shard_spec.shape[0]) - num_output_rows);
         end_core = (*shard_spec.grid.ranges().begin()).end_coord;
@@ -890,10 +890,10 @@ operation::ProgramWithCallbacks untilize_single_core(
 
     int32_t num_tiles = a.volume() / TILE_HW;
 
-    uint32_t num_sticks = a.volume() / a.get_legacy_shape()[-1];
-    uint32_t stick_size = a.get_legacy_shape()[-1] * output.element_size();
+    uint32_t num_sticks = a.volume() / a.get_padded_shape()[-1];
+    uint32_t stick_size = a.get_padded_shape()[-1] * output.element_size();
 
-    uint32_t stick_s = a.get_legacy_shape()[-1];
+    uint32_t stick_s = a.get_padded_shape()[-1];
     uint32_t num_tiles_in_row = stick_s / TILE_WIDTH;
     // Ensure we don't intrude into storage space
     uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - a.device()->get_base_allocator_addr(HalMemType::L1);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
@@ -33,7 +33,7 @@ void UntilizeWithHaloV2::validate(const std::vector<Tensor>& input_tensors) cons
 
 std::vector<ttnn::TensorSpec> UntilizeWithHaloV2::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
     auto output_shape = input_shape;
 
     uint32_t nbatch = input_shape[0];
@@ -68,14 +68,7 @@ std::vector<ttnn::TensorSpec> UntilizeWithHaloV2::compute_output_specs(const std
     auto out_mem_config = out_mem_config_;
     out_mem_config.shard_spec->shape[0] = tt::div_up(output_shape[0] * output_shape[2], ncores_nhw_);
     out_mem_config.shard_spec->shape[1] = input_tensor.memory_config().shard_spec->shape[1];
-    return {TensorSpec(
-        output_shape.logical_shape(),
-        TensorLayout::fromPaddedShape(
-            output_dtype,
-            PageConfig(Layout::ROW_MAJOR),
-            out_mem_config,
-            output_shape.logical_shape(),
-            output_shape.padded_shape()))};
+    return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config))};
 }
 
 operation::ProgramWithCallbacks UntilizeWithHaloV2::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
@@ -39,8 +39,8 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
 
     bool skip_untilize = input_tensor.get_layout() == Layout::ROW_MAJOR;
 
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
+    auto output_shape = output_tensor.get_padded_shape();
 
     tt::DataFormat in_df = datatype_to_dataformat_converter(input_tensor.get_dtype());
     tt::DataFormat out_df = datatype_to_dataformat_converter(output_tensor.get_dtype());

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -26,7 +26,7 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
             TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
             TT_FATAL(
                 input_tensor_a.volume() /
-                        (input_tensor_a.get_legacy_shape()[-2] * input_tensor_a.get_legacy_shape()[-1]) ==
+                        (input_tensor_a.get_padded_shape()[-2] * input_tensor_a.get_padded_shape()[-1]) ==
                     1,
                 "Can only write unbatched output interleaved");
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
@@ -37,13 +37,13 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             auto output_shape = this->compute_output_specs(input_tensors).at(0).padded_shape();
             for (uint32_t i = 0; i < output_shape.rank() - 2; i++) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[i] == output_shape[i], "Error");
+                TT_FATAL(input_tensor_a.get_padded_shape()[i] == output_shape[i], "Error");
             }
             if (output_mem_config.is_sharded()) {
                 TT_FATAL(
                     this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Error");
                 TT_FATAL(
-                    input_tensor_a.get_legacy_shape()[-1] == output_shape[-1] ||
+                    input_tensor_a.get_padded_shape()[-1] == output_shape[-1] ||
                         (tt::div_up(output_shape[-1], input_tensor_a.shard_spec().value().shape[1]) ==
                          input_tensor_a.shard_spec().value().grid.num_cores()),
                     "Error");
@@ -51,11 +51,11 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
                 TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
                 TT_FATAL(
                     input_tensor_a.volume() /
-                            (input_tensor_a.get_legacy_shape()[-2] * input_tensor_a.get_legacy_shape()[-1]) ==
+                            (input_tensor_a.get_padded_shape()[-2] * input_tensor_a.get_padded_shape()[-1]) ==
                         1,
                     "Can only write unbatched output interleaved");
                 TT_FATAL(
-                    input_tensor_a.get_legacy_shape()[-1] - output_shape[-1] <
+                    input_tensor_a.get_padded_shape()[-1] - output_shape[-1] <
                         input_tensor_a.shard_spec().value().shape[1],
                     "Error");
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -22,8 +22,8 @@ namespace ttnn::operations::data_movement::detail {
 
 operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
-    const auto& input_shape = a.get_legacy_shape();
-    const auto& output_shape = output.get_legacy_shape();
+    const auto& input_shape = a.get_padded_shape();
+    const auto& output_shape = output.get_padded_shape();
 
     tt::tt_metal::Program program{};
 
@@ -221,7 +221,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     CoreCoord grid_size = device->compute_with_storage_grid_size();
 
     uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.volume() / input_shape[-1] / TILE_HEIGHT;
-    uint32_t num_tiles_per_row = a.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t num_tiles_per_row = a.get_padded_shape()[-1] / TILE_WIDTH;
 
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(grid_size, num_blocks);
@@ -408,7 +408,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     // Special handling for tensors of W=16 and H%32==0
     // In this case skip untilizing on compute and in writer kernel just copy face0 and face2,
     // and skip face1 and face3.
-    bool unpad_tensor_w_16 = output.get_legacy_shape()[-1] == 16 && output.get_legacy_shape()[-2] % TILE_HEIGHT == 0;
+    bool unpad_tensor_w_16 = output.get_padded_shape()[-1] == 16 && output.get_padded_shape()[-2] % TILE_HEIGHT == 0;
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
@@ -434,26 +434,26 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     uint32_t ncores = all_cores.num_cores();
     uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;
     uint32_t nblocks_per_core = shard_spec.shape[0] / TILE_HEIGHT;
-    uint32_t batch = a.volume() / (a.get_legacy_shape()[-2] * a.get_legacy_shape()[-1]);
+    uint32_t batch = a.volume() / (a.get_padded_shape()[-2] * a.get_padded_shape()[-1]);
     uint32_t ntiles_per_batch = ntiles_per_block * nblocks_per_core / batch;
 
     num_rows_block = out_shard_spec.shape[0];
     block_row_size = out_shard_spec.shape[1] * output.element_size();         // in0_block_w * TILE_WIDTH * dtype_nbytes
-    output_row_size = output.get_legacy_shape()[-1] * output.element_size();  // output row size bytes
+    output_row_size = output.get_padded_shape()[-1] * output.element_size();  // output row size bytes
     last_block_row_size_unpadded =
         block_row_size -
-        (tt::round_up(output.get_legacy_shape()[-1], out_shard_spec.shape[1]) - output.get_legacy_shape()[-1]) *
+        (tt::round_up(output.get_padded_shape()[-1], out_shard_spec.shape[1]) - output.get_padded_shape()[-1]) *
             output.element_size();
-    uint32_t num_output_rows = output.volume() / output.get_legacy_shape()[-1];
+    uint32_t num_output_rows = output.volume() / output.get_padded_shape()[-1];
     num_output_rows_unpadded =
         num_rows_block - (tt::round_up(num_output_rows, out_shard_spec.shape[0]) - num_output_rows);
     if (a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        last_idx = tt::div_up(output.get_legacy_shape()[-1], out_shard_spec.shape[1]) - 1;
+        last_idx = tt::div_up(output.get_padded_shape()[-1], out_shard_spec.shape[1]) - 1;
     } else if (a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         last_idx = tt::div_up(num_output_rows, out_shard_spec.shape[0]) - 1;
     } else {
         end_core = {
-            tt::div_up(output.get_legacy_shape()[-1], out_shard_spec.shape[1]) - 1,
+            tt::div_up(output.get_padded_shape()[-1], out_shard_spec.shape[1]) - 1,
             tt::div_up(num_output_rows, out_shard_spec.shape[0]) - 1};
     }
     if (!row_major) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -478,9 +478,9 @@ Tensor _floor_div(const Tensor& input_a, const Tensor& input_b, const std::optio
 Tensor _scatter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     tt::tt_metal::Array4D start_index = {0, 0, 0, 0};
     Tensor index_pad = ttnn::pad(
-        0, ttnn::ones_like(input_a), input_b.get_legacy_shape().to_array_4D(), start_index, 0, false, std::nullopt);
+        0, ttnn::ones_like(input_a), input_b.get_padded_shape().to_array_4D(), start_index, 0, false, std::nullopt);
     Tensor temp_a =
-        ttnn::pad(0, input_a, input_b.get_legacy_shape().to_array_4D(), start_index, 0, false, std::nullopt);
+        ttnn::pad(0, input_a, input_b.get_padded_shape().to_array_4D(), start_index, 0, false, std::nullopt);
     return ttnn::where(index_pad, temp_a, input_b);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
@@ -123,8 +123,8 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
         if (block_or_width_sharded) {
             block_size = block_width * block_height;
             end_core = (*shard_spec.value().grid.ranges().begin()).end_coord;
-            output_width = output.get_legacy_shape()[-1] / TILE_WIDTH;
-            uint32_t output_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
+            output_width = output.get_padded_shape()[-1] / TILE_WIDTH;
+            uint32_t output_height = output.volume() / output.get_padded_shape()[-1] / TILE_HEIGHT;
             last_unpadded_block_height = block_height - (round_up(output_height, block_height) - output_height);
             last_unpadded_block_width = block_width - (round_up(output_width, block_width) - output_width);
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -872,7 +872,7 @@ Tensor _rpow(const Tensor& a, float k, const std::optional<MemoryConfig>& output
 using HWFunctionT = std::function<Tensor(const Tensor& y, const std::optional<MemoryConfig>&)>;
 Tensor _make_global_from_hw_impl(
     const HWFunctionT& fn, const Tensor& y, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL(y.get_legacy_shape().rank() == 4, "Cannot support non-rank 4 Tensor");
+    TT_FATAL(y.get_padded_shape().rank() == 4, "Cannot support non-rank 4 Tensor");
 
     // format to HW
     Tensor y_hw = ttnn::reshape_on_device(
@@ -880,19 +880,19 @@ Tensor _make_global_from_hw_impl(
         ttnn::SimpleShape{
             1,
             1,
-            y.get_legacy_shape()[2],
-            y.get_legacy_shape()[3] * y.get_legacy_shape()[1] * y.get_legacy_shape()[0]});
+            y.get_padded_shape()[2],
+            y.get_padded_shape()[3] * y.get_padded_shape()[1] * y.get_padded_shape()[0]});
 
     // compute @fn
     Tensor z_0 = fn(y_hw, output_mem_config);
-    TT_FATAL(y_hw.get_legacy_shape() == z_0.get_legacy_shape(), "shape match");
+    TT_FATAL(y_hw.get_padded_shape() == z_0.get_padded_shape(), "shape match");
     y_hw.deallocate();
 
     // reformat
     Tensor z_1 = ttnn::reshape_on_device(
         z_0,
         ttnn::SimpleShape{
-            y.get_legacy_shape()[0], y.get_legacy_shape()[1], y.get_legacy_shape()[2], y.get_legacy_shape()[3]});
+            y.get_padded_shape()[0], y.get_padded_shape()[1], y.get_padded_shape()[2], y.get_padded_shape()[3]});
     z_0.deallocate();
 
     return z_1;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -188,7 +188,7 @@ tensor_return_value_t UnaryDeviceOperation::create_output_tensors(
 tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     auto program_factory = select_program_factory(args, tensor_args);
     operation::Hash hash = operation::hash_operation<UnaryDeviceOperation>(
@@ -196,7 +196,7 @@ tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
         program_factory.index(),
         input_tensor.dtype(),
         std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
-        compute_volume(input_shape));
+        input_shape.volume());
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -28,28 +28,28 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharded inputs");
     TT_FATAL(weights.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharded weights");
 
-    TT_FATAL(weights.get_legacy_shape()[0] == 1 && weights.get_legacy_shape()[1] == 1, "First two dimensions for the weights must be 1");
+    TT_FATAL(weights.get_padded_shape()[0] == 1 && weights.get_padded_shape()[1] == 1, "First two dimensions for the weights must be 1");
     if (this->tilized) {
-        TT_FATAL(a.get_legacy_shape()[-1] % TILE_HEIGHT == 0, "Input tensor width {} must be a multiple of tile height {} to have the output tensor tilized", a.get_legacy_shape()[-1], TILE_HEIGHT);
-        TT_FATAL(weights.get_legacy_shape()[-1] % TILE_WIDTH == 0, "Number of columns in table {} must be factor of tile width {}", weights.get_legacy_shape()[-1], TILE_WIDTH);
+        TT_FATAL(a.get_padded_shape()[-1] % TILE_HEIGHT == 0, "Input tensor width {} must be a multiple of tile height {} to have the output tensor tilized", a.get_padded_shape()[-1], TILE_HEIGHT);
+        TT_FATAL(weights.get_padded_shape()[-1] % TILE_WIDTH == 0, "Number of columns in table {} must be factor of tile width {}", weights.get_padded_shape()[-1], TILE_WIDTH);
         if (is_sharded(this->output_mem_config.memory_layout)) {
             const auto& shard_spec = this->output_mem_config.shard_spec;
             TT_FATAL(shard_spec.has_value(), "Sharded memory config must have a shard spec");
             TT_FATAL(shard_spec->shape[0] % TILE_HEIGHT == 0, "Shard height {} must be a multiple of tile height {} to have the output tensor tilized", shard_spec->shape[0], TILE_HEIGHT);
             TT_FATAL(shard_spec->shape[1] % TILE_WIDTH == 0, "Shard width {} must be a multiple of tile width {} to have the output tensor tilized", shard_spec->shape[1], TILE_WIDTH);
             TT_FATAL(a.volume() % shard_spec->shape[0] == 0, "Input tensor volume {} must be a multiple of shard height {}", a.volume(), shard_spec->shape[0]);
-            TT_FATAL(weights.get_legacy_shape()[-1] % shard_spec->shape[1] == 0, "Number of columns in table {} must be factor of shard width {}", weights.get_legacy_shape()[-1], shard_spec->shape[1]);
+            TT_FATAL(weights.get_padded_shape()[-1] % shard_spec->shape[1] == 0, "Number of columns in table {} must be factor of shard width {}", weights.get_padded_shape()[-1], shard_spec->shape[1]);
         }
     } else {
         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding only supports interleaved RM outputs");
         TT_FATAL(!is_block_float(this->output_dtype), "Output cannot be a block float dtype when not tilized");
     }
     if(a.get_layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(a.get_legacy_shape()[1] == 1 && a.get_legacy_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
+        TT_FATAL(a.get_padded_shape()[1] == 1 && a.get_padded_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
     }
     switch (this->embeddings_type) {
         case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value(), "Pad token must be specified when PADDED Embeddings Type is specified"); break;
-        case EmbeddingsType::BINARY: TT_FATAL(weights.get_legacy_shape()[-2] == 2, "Weight tensor must have 2 embeddings for BINARY Embeddings Type"); break;
+        case EmbeddingsType::BINARY: TT_FATAL(weights.get_padded_shape()[-2] == 2, "Weight tensor must have 2 embeddings for BINARY Embeddings Type"); break;
         default: TT_FATAL(!this->pad_token.has_value(), "Pad token must not be specified when PADDED Embeddings Type is not specified");
     }
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -106,14 +106,14 @@ operation::ProgramWithCallbacks embeddings_fused(
     uint32_t weights_element_size_bytes = weights.element_size();
 
     // row major, page size is last dim
-    uint32_t input_page_size = a.get_legacy_shape()[-1] * input_element_size_bytes;
-    uint32_t weight_page_size = weights.get_legacy_shape()[-1] * weights_element_size_bytes;
+    uint32_t input_page_size = a.get_padded_shape()[-1] * input_element_size_bytes;
+    uint32_t weight_page_size = weights.get_padded_shape()[-1] * weights_element_size_bytes;
 
     // weights shape is [1, 1, num_embeddings, num_dim]
-    uint32_t num_embeddings = weights.get_legacy_shape()[-2];
+    uint32_t num_embeddings = weights.get_padded_shape()[-2];
 
-    uint32_t batch_size = a.get_legacy_shape()[0];
-    uint32_t num_output_rows_per_batch = a.get_legacy_shape()[-1];
+    uint32_t batch_size = a.get_padded_shape()[0];
+    uint32_t num_output_rows_per_batch = a.get_padded_shape()[-1];
     uint32_t num_output_rows = num_output_rows_per_batch * batch_size;
     // Note: num_blocks is just blocks along height
     uint32_t num_blocks = num_output_rows / TILE_HEIGHT;
@@ -142,7 +142,7 @@ operation::ProgramWithCallbacks embeddings_fused(
             num_blocks_per_core_group_1,
             num_blocks_per_core_group_2) =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
-        num_tiles_per_block = weights.get_legacy_shape()[-1] / TILE_WIDTH;
+        num_tiles_per_block = weights.get_padded_shape()[-1] / TILE_WIDTH;
         row_major = false;
     }
     uint32_t g1_numcores = core_group_1.num_cores();
@@ -403,15 +403,15 @@ operation::ProgramWithCallbacks embeddings_rm(
     uint32_t output_element_size_bytes = output.element_size();
 
     // row major, page size is last dim
-    uint32_t input_page_size = a.get_legacy_shape()[-1] * input_element_size_bytes;
-    uint32_t weight_page_size = weights.get_legacy_shape()[-1] * weights_element_size_bytes;
-    uint32_t output_page_size = output.get_legacy_shape()[-1] * output_element_size_bytes;
+    uint32_t input_page_size = a.get_padded_shape()[-1] * input_element_size_bytes;
+    uint32_t weight_page_size = weights.get_padded_shape()[-1] * weights_element_size_bytes;
+    uint32_t output_page_size = output.get_padded_shape()[-1] * output_element_size_bytes;
 
     // weights shape is [1, 1, num_embeddings, num_dim]
-    uint32_t num_embeddings = weights.get_legacy_shape()[-2];
+    uint32_t num_embeddings = weights.get_padded_shape()[-2];
 
-    uint32_t batch_size = a.get_legacy_shape()[0];
-    uint32_t num_output_rows_per_batch = a.get_legacy_shape()[-1];
+    uint32_t batch_size = a.get_padded_shape()[0];
+    uint32_t num_output_rows_per_batch = a.get_padded_shape()[-1];
     uint32_t num_output_rows = num_output_rows_per_batch * batch_size;
     auto alignment = a.buffer()->alignment();
     uint32_t block_height = (alignment / input_element_size_bytes);
@@ -626,17 +626,17 @@ operation::ProgramWithCallbacks embeddings_tilized_indices(
 
     // row major, page size is last dim
     uint32_t input_page_size = a.get_logical_shape()[-1] * input_element_size_bytes;
-    uint32_t weight_page_size = weights.get_legacy_shape()[-1] * weights_element_size_bytes;
-    uint32_t output_page_size = output.get_legacy_shape()[-1] * output_element_size_bytes;
+    uint32_t weight_page_size = weights.get_padded_shape()[-1] * weights_element_size_bytes;
+    uint32_t output_page_size = output.get_padded_shape()[-1] * output_element_size_bytes;
 
     // weights shape is [1, 1, num_embeddings, num_dim]
-    uint32_t num_embeddings = weights.get_legacy_shape()[-2];
+    uint32_t num_embeddings = weights.get_padded_shape()[-2];
 
     uint32_t batch_size = a.get_logical_shape()[0];  // num rows
     uint32_t num_cols = a.get_logical_shape()[-1];
     uint32_t volume = num_cols * batch_size;
 
-    auto num_embedding_dims = weights.get_legacy_shape()[-1];
+    auto num_embedding_dims = weights.get_padded_shape()[-1];
 
     // setup problem and grid size
     uint32_t start_core_x = 0;

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -48,7 +48,7 @@ ttnn::Tensor EmbeddingOperation::invoke(
 
     // If layout is row major, OR if the input tensor is not a multiple of TILE_HEIGHT, then we cannot use tilized
     bool fused_tilized = false;
-    if (input_tensor.get_legacy_shape()[-1] % TILE_HEIGHT == 0 && weight.get_legacy_shape()[-1] % TILE_WIDTH == 0) {
+    if (input_tensor.get_padded_shape()[-1] % TILE_HEIGHT == 0 && weight.get_padded_shape()[-1] % TILE_WIDTH == 0) {
         if (layout.has_value()) {
             if (layout.value() == ttnn::TILE_LAYOUT) {
                 fused_tilized = true;

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -18,8 +18,8 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
 
     const auto &index_tensor = input_tensors.at(0);
     const auto &grad_tensor = input_tensors.at(1);
-    const auto &index_tensor_shape = index_tensor.get_legacy_shape();
-    const auto &grad_tensor_shape = grad_tensor.get_legacy_shape();
+    const auto &index_tensor_shape = index_tensor.get_padded_shape();
+    const auto &grad_tensor_shape = grad_tensor.get_padded_shape();
 
     TT_FATAL(
         index_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -49,7 +49,7 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
     tt::DataFormat index_cb_data_format = datatype_to_dataformat_converter(index_tensor.get_dtype());
     uint32_t index_single_page_size =
         INPUT_SIZE * index_element_size_bytes;  // Only need 32 at most at a time, which is less than full page size
-    uint32_t index_page_size = index_tensor.get_legacy_shape()[-1] * index_element_size_bytes;
+    uint32_t index_page_size = index_tensor.get_padded_shape()[-1] * index_element_size_bytes;
 
     tt::DataFormat mask_cb_data_format = tt::DataFormat::UInt8;
     uint32_t mask_single_page_size = INPUT_SIZE * 1;  // UInt8 is 1 byte per element
@@ -57,11 +57,11 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
-    uint32_t embedding_dim = grad_tensor.get_legacy_shape()[-1];
+    uint32_t embedding_dim = grad_tensor.get_padded_shape()[-1];
     uint32_t embedding_tiles = embedding_dim / TILE_WIDTH;
 
-    uint32_t batch_size = index_tensor.get_legacy_shape()[0];
-    uint32_t seq_len_tiles = index_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t batch_size = index_tensor.get_padded_shape()[0];
+    uint32_t seq_len_tiles = index_tensor.get_padded_shape()[-1] / TILE_WIDTH;
     uint32_t input_height_tiles = batch_size * seq_len_tiles;
 
     uint32_t num_embeddings_tiles = num_embeddings / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -79,7 +79,7 @@ Tensor AutoFormat::format_input_tensor(
     }
 
     Tensor formatted_input = input;
-    auto shape = formatted_input.get_legacy_shape();
+    auto shape = formatted_input.get_padded_shape();
 
     // TODO: Profile if it is faster to put host tensor to device and then pad/convert if possible
     // Device side conversions

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -38,7 +38,7 @@ void AllGatherMatmul::validate(
     // All Gather Matmul validate
     TT_FATAL(this->all_gather_struct.dim == 3, "AllGatherMatmul requires dim=3 for the AllGather operaitons.");
     TT_FATAL(
-        input_tensor.get_legacy_shape()[0] == 1 && input_tensor.get_legacy_shape()[1] == 1,
+        input_tensor.get_padded_shape()[0] == 1 && input_tensor.get_padded_shape()[1] == 1,
         "AllGatherMatmul requires input tensor to have batch size of 1.");
     std::visit(
         [&](const auto& config) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -100,7 +100,7 @@ DatacopyParams setup_datacopy(
     bool datacopy_output_is_dram = datacopy_output_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
 
     uint32_t last_output_page_offset = (ring_size - 1) * tensor_slicer.output_page_offset;
-    uint32_t num_rows = input_tensor.get_legacy_shape()[2] / tile_size;
+    uint32_t num_rows = input_tensor.get_padded_shape()[2] / tile_size;
     bool is_clockwise_dir = true;  // Specifically for the first half of the all gather
 
     uint32_t datacopy_buffer_size = 200;
@@ -113,8 +113,8 @@ DatacopyParams setup_datacopy(
         static_cast<uint32_t>(page_size),
         static_cast<uint32_t>(ring_index),
         static_cast<uint32_t>(ring_size),
-        static_cast<uint32_t>(all_gather_output_tensor.get_legacy_shape()[3] / tile_size),  // tesnor width
-        static_cast<uint32_t>(all_gather_output_tensor.get_legacy_shape()[2] / tile_size),  // tensor height
+        static_cast<uint32_t>(all_gather_output_tensor.get_padded_shape()[3] / tile_size),  // tesnor width
+        static_cast<uint32_t>(all_gather_output_tensor.get_padded_shape()[2] / tile_size),  // tensor height
         static_cast<uint32_t>(tensor_slicer.num_cols),  // tensor slice width in tiles
         static_cast<uint32_t>(num_rows),                // tnesor slice height in tiles
         static_cast<uint32_t>(tensor_slicer.output_page_offset),
@@ -223,7 +223,7 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
         ttnn::ccl::InterleavedRingAllGatherTensorSlicer(input_tensor, all_gather_output_tensor, dim, ring_index);
     bool is_clockwise_direction = true;
     const uint32_t num_transfers = 4;
-    const uint32_t weight_tensor_width = weight_tensor.get_legacy_shape()[3] / 32;
+    const uint32_t weight_tensor_width = weight_tensor.get_padded_shape()[3] / 32;
 
     ////////////////////////////////////////////////////////
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -81,11 +81,11 @@ ReduceScatterAsync create_reduce_scatter_struct(
 void ReduceScatterAsync::validate(const std::vector<Tensor>& input_tensors) const {
     for (auto const& t : input_tensors) {
         TT_FATAL(
-            t.get_legacy_shape()[this->scatter_dim] / this->ring_size > 0,
+            t.get_padded_shape()[this->scatter_dim] / this->ring_size > 0,
             "Reduce scatter input tensor shape on dim {} must be divisible by ring size",
             this->scatter_dim);
         TT_FATAL(
-            t.get_legacy_shape()[this->scatter_dim] % this->ring_size == 0,
+            t.get_padded_shape()[this->scatter_dim] % this->ring_size == 0,
             "Reduce scatter input tensor shape on dim {} must be divisible by ring size",
             this->scatter_dim);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -119,7 +119,7 @@ tensor_return_value_t DropoutDeviceOperation::create_output_tensors(
 tt::stl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
     auto args_without_seed = args;
     args_without_seed.seed = 0;
     auto program_factory = select_program_factory(args, tensor_args);
@@ -128,7 +128,7 @@ tt::stl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
         program_factory.index(),
         input_tensor.dtype(),
         std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
-        compute_volume(input_shape));
+        input_shape.volume());
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
@@ -72,7 +72,7 @@ ttnn::Tensor AttnMatmulFromCacheOperation::invoke(
     std::optional<Tensor> optional_output_tensor) {
     TT_FATAL(num_tokens > 0, "Number of tokens must be at least 1!");
     TT_FATAL(
-        num_tokens <= input_tensor_b.get_legacy_shape()[2],
+        num_tokens <= input_tensor_b.get_padded_shape()[2],
         "Number of tokens must be smaller or equal to the max cache length (B.shape[2])!");
     const uint32_t num_tokens_rounded_up_to_32 = ((num_tokens - 1) / 32 + 1) * 32;
     auto arch = input_tensor_a.storage_type() == StorageType::DEVICE

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_pybind.cpp
@@ -54,7 +54,7 @@ void bind_attn_matmul_from_cache(pybind11::module& module) {
         module,
         ttnn::experimental::attn_matmul_from_cache,
         R"doc(
-            Performs the same matmul as attn_matmul, but fuses additional functionality for reading in in1. For in1, read num_tokens (rounded up to 32) from full cache along in1.get_legacy_shape()[2] (num_tokens must be > 0 and <= max_cache_len). For example, 64 tokens will be read for 32 < token_idx <= 64. Additional option to apply transpose_hw to in1 for pre-attention matmul with transpose_hw=true. For post-attention matmul, transpose_hw should be false.
+            Performs the same matmul as attn_matmul, but fuses additional functionality for reading in in1. For in1, read num_tokens (rounded up to 32) from full cache along in1.get_padded_shape()[2] (num_tokens must be > 0 and <= max_cache_len). For example, 64 tokens will be read for 32 < token_idx <= 64. Additional option to apply transpose_hw to in1 for pre-attention matmul with transpose_hw=true. For post-attention matmul, transpose_hw should be false.
         )doc",
         ttnn::pybind_overload_t{
             [](const OperationType& self,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -31,8 +31,8 @@ void AttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_tensor
         "Operands to matmul need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
-    const auto ashape = input_tensor_a.get_legacy_shape();
-    const auto bshape = input_tensor_b.get_legacy_shape();
+    const auto ashape = input_tensor_a.get_padded_shape();
+    const auto bshape = input_tensor_b.get_padded_shape();
     TT_FATAL((ashape[0] == 1), "Input q_len must be 1!");
     TT_FATAL((bshape[1] == 1), "Number of kv_heads must be 1!");  // TODO: May need to uplift to support falcon-40B
     TT_FATAL((ashape[2] == bshape[0]), "Num of users must match!");
@@ -74,8 +74,8 @@ std::vector<ttnn::TensorSpec> AttnMatmulDeviceOperation::compute_output_specs(
     // output: [q_len, q_heads, batch, kv_len]
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
-    const auto ashape = input_tensor_a.get_legacy_shape();
-    const auto bshape = input_tensor_b.get_legacy_shape();
+    const auto ashape = input_tensor_a.get_padded_shape();
+    const auto bshape = input_tensor_b.get_padded_shape();
 
     uint32_t N = bshape[3];
     if (this->transpose_hw.value_or(false)) {

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -25,7 +25,7 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(
     ttnn::DeviceComputeKernelConfig compute_kernel_config) {
     tt::tt_metal::Program program{};
 
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
@@ -61,7 +61,7 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
     tt::tt_metal::Buffer* src1_buffer = b.buffer();
 
-    auto cshape = output.get_legacy_shape();
+    auto cshape = output.get_padded_shape();
 
     // A block of work is one MtNt
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -264,8 +264,8 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(
 
             auto dst_dram_buffer = output_tensors.at(0).buffer();
 
-            auto ashape = input_tensors.at(0).get_legacy_shape();
-            auto bshape = input_tensors.at(1).get_legacy_shape();
+            auto ashape = input_tensors.at(0).get_padded_shape();
+            auto bshape = input_tensors.at(1).get_padded_shape();
 
             // C = torch.matmul(A.transpose(0, 2) * B).transpose(0, 2)
             // MN = MK*KN

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -32,8 +32,8 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
         "Operands to matmul need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
-    const auto ashape = input_tensor_a.get_legacy_shape();
-    const auto bshape = input_tensor_b.get_legacy_shape();
+    const auto ashape = input_tensor_a.get_padded_shape();
+    const auto bshape = input_tensor_b.get_padded_shape();
     TT_FATAL((ashape[0] == 1), "Input q_len must be 1!");
     TT_FATAL((ashape[1] % bshape[1] == 0), "Number of q_heads must be divisible by kv_heads!");
     TT_FATAL((ashape[2] == bshape[0]), "Num of users must match!");

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -27,7 +27,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
     ttnn::DeviceComputeKernelConfig compute_kernel_config) {
     tt::tt_metal::Program program{};
 
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
@@ -324,7 +324,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(
         tt::tt_metal::Buffer* src1_buffer = b.buffer();
         tt::tt_metal::Buffer* dst_buffer = output.buffer();
 
-        const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+        const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
 
         tt::tt_metal::IDevice* device = a.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
@@ -40,7 +40,7 @@ ttnn::Tensor GroupAttnMatmulOperation::invoke(
 
     // Need to cache on out_subblock_w because it must be a compile time arg for optimal use of templated pack_untilize
     // APIs
-    const uint32_t Nt = input_tensor_b.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
+    const uint32_t Nt = input_tensor_b.get_padded_shape()[-1] / tt::constants::TILE_WIDTH;
     constexpr uint32_t HALF_DST_MAX = 8;  // 8 is the max number of tiles for half DST (assuming out_subblock_h == 1)
     constexpr uint32_t HALF_DST_MAX_FP32 = 4;  // max dst tiles are 4 for fp32
     uint32_t out_subblock_w;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -52,12 +52,12 @@ void PagedUpdateCacheDeviceOperation::validate(
     };
 
     const auto validateTensorShapes = [](const Tensor& cache_tensor, const Tensor& input_tensor) {
-        TT_FATAL(input_tensor.get_legacy_shape()[0] == 1, "Dim 0 of input tensor must be 1");
+        TT_FATAL(input_tensor.get_padded_shape()[0] == 1, "Dim 0 of input tensor must be 1");
         TT_FATAL(
             cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
             "Only interleaved cache is supported");
         TT_FATAL(
-            input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1],
+            input_tensor.get_padded_shape()[-1] == cache_tensor.get_padded_shape()[-1],
             "Last dim of input tensor must match last dim of cache tensor");
     };
 
@@ -69,11 +69,11 @@ void PagedUpdateCacheDeviceOperation::validate(
         if (!paged_cache) {
             if (share_cache) {
                 TT_FATAL(
-                    cache_tensor.get_legacy_shape()[0] == 1,
+                    cache_tensor.get_padded_shape()[0] == 1,
                     "Share cache feature expects cache tensor to have batch of 1");
             } else {
                 TT_FATAL(
-                    input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[0],
+                    input_tensor.get_padded_shape()[1] == cache_tensor.get_padded_shape()[0],
                     "Expect batch in input tensor match the batch in cache tensor");
             }
         } else {
@@ -84,10 +84,10 @@ void PagedUpdateCacheDeviceOperation::validate(
             TT_FATAL(page_table.get_dtype() == DataType::INT32, "Error");
             TT_FATAL(page_table.get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(
-                page_table.get_legacy_shape()[0] == input_tensor.get_legacy_shape()[1],
+                page_table.get_padded_shape()[0] == input_tensor.get_padded_shape()[1],
                 "Batch size between page_table and input_tensor must match");
             TT_FATAL(
-                page_table.get_legacy_shape()[1] <= cache_tensor.get_legacy_shape()[0],
+                page_table.get_padded_shape()[1] <= cache_tensor.get_padded_shape()[0],
                 "max_num_blocks_per_seq must be less than max_num_blocks");
         }
     };
@@ -104,7 +104,7 @@ void PagedUpdateCacheDeviceOperation::validate(
             const auto& update_idxs_tensor = optional_input_tensors.at(0).value();
             TT_FATAL(update_idxs_tensor.get_dtype() == DataType::INT32, "Error");
             TT_FATAL(update_idxs_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
-            num_indices = update_idxs_tensor.get_legacy_shape()[0];
+            num_indices = update_idxs_tensor.get_padded_shape()[0];
 
             TT_FATAL(update_idxs_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
             TT_FATAL(update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Error");
@@ -112,16 +112,16 @@ void PagedUpdateCacheDeviceOperation::validate(
             num_indices = update_idxs.size();
         }
 
-        TT_FATAL(input_tensor.get_legacy_shape()[1] == num_indices, "Number of update_idxs should match batch size");
+        TT_FATAL(input_tensor.get_padded_shape()[1] == num_indices, "Number of update_idxs should match batch size");
     };
 
     const auto validateSharding = [](const Tensor& input_tensor) {
         TT_FATAL(input_tensor.is_sharded(), "Error");
         if (input_tensor.is_sharded()) {
             TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_padded_shape()[-1], "Error");
             TT_FATAL(
-                (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) %
+                (input_tensor.volume() / input_tensor.get_padded_shape()[-1]) %
                         input_tensor.shard_spec().value().shape[0] ==
                     0,
                 "Error");
@@ -163,9 +163,9 @@ void PagedUpdateCacheDeviceOperation::validate(
         TT_FATAL(page_table_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         TT_FATAL(page_table_tensor.get_dtype() == DataType::INT32, "Error");
 
-        auto cache_shape = cache_tensor.get_legacy_shape();
-        auto input_shape = input_tensor.get_legacy_shape();
-        auto page_table_shape = page_table_tensor.get_legacy_shape();
+        auto cache_shape = cache_tensor.get_padded_shape();
+        auto input_shape = input_tensor.get_padded_shape();
+        auto page_table_shape = page_table_tensor.get_padded_shape();
 
         TT_FATAL(batch_idx <= cache_shape[0], "Error");
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
@@ -27,15 +27,15 @@ operation::ProgramWithCallbacks paged_fill_cache_multi_core(
     // input_tensor: [1, num_heads, input_seq_len, head_dim]
     // cache_tensor: [max_num_blocks, 1, block_size, head_dim]
     // page_table_tensor: [b, max_num_blocks_per_seq]
-    const uint32_t num_heads = input_tensor.get_legacy_shape()[1];
-    const uint32_t input_seq_len = input_tensor.get_legacy_shape()[2];
+    const uint32_t num_heads = input_tensor.get_padded_shape()[1];
+    const uint32_t input_seq_len = input_tensor.get_padded_shape()[2];
 
-    const uint32_t max_num_blocks = cache_tensor.get_legacy_shape()[0];
-    const uint32_t block_size = cache_tensor.get_legacy_shape()[2];
-    const uint32_t head_dim = cache_tensor.get_legacy_shape()[3];
+    const uint32_t max_num_blocks = cache_tensor.get_padded_shape()[0];
+    const uint32_t block_size = cache_tensor.get_padded_shape()[2];
+    const uint32_t head_dim = cache_tensor.get_padded_shape()[3];
 
-    const uint32_t batch = page_table_tensor.get_legacy_shape()[0];
-    const uint32_t max_num_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
+    const uint32_t batch = page_table_tensor.get_padded_shape()[0];
+    const uint32_t max_num_blocks_per_seq = page_table_tensor.get_padded_shape()[1];
 
     const uint32_t input_seq_len_t = input_seq_len / TILE_HEIGHT;
     const uint32_t Wt = head_dim / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fused_update_cache_program_factory.cpp
@@ -194,30 +194,30 @@ operation::ProgramWithCallbacks paged_fused_update_cache_multi_core(
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
 
-        batch_size = page_table_tensor.get_legacy_shape()[0];
-        block_size = cache_tensor1.get_legacy_shape()[2];
+        batch_size = page_table_tensor.get_padded_shape()[0];
+        block_size = cache_tensor1.get_padded_shape()[2];
         block_size_t = block_size / TILE_HEIGHT;
-        max_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
-        page_table_stick_size = page_table_tensor.get_legacy_shape()[-1] * page_table_tensor.element_size();
+        max_blocks_per_seq = page_table_tensor.get_padded_shape()[1];
+        page_table_stick_size = page_table_tensor.get_padded_shape()[-1] * page_table_tensor.element_size();
 
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.get_dtype());
 
         page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     }
 
-    uint32_t Wt = cache_tensor1.get_legacy_shape()[-1] / TILE_WIDTH;
-    uint32_t St = cache_tensor1.get_legacy_shape()[-2] / TILE_HEIGHT;
-    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor1.get_legacy_shape()[-1] * sizeof(float)
-                                       : cache_tensor1.get_legacy_shape()[-1] * 2;  // 2 bytes for bfloat16
+    uint32_t Wt = cache_tensor1.get_padded_shape()[-1] / TILE_WIDTH;
+    uint32_t St = cache_tensor1.get_padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor1.get_padded_shape()[-1] * sizeof(float)
+                                       : cache_tensor1.get_padded_shape()[-1] * 2;  // 2 bytes for bfloat16
     uint32_t cache_total_num_tiles = cache_tensor1.volume() / TILE_HW;
     uint32_t cache_batch_num_tiles =
         share_cache ? 0
                     : cache_total_num_tiles /
-                          cache_tensor1.get_legacy_shape()[0];  // if share cache, we can set cache batch num tiles to 0
+                          cache_tensor1.get_padded_shape()[0];  // if share cache, we can set cache batch num tiles to 0
                                                                 // so batch offset would be 0 in future calculations
     uint32_t num_tiles = input_tensor1.volume() / TILE_HW;
-    uint32_t B = input_tensor1.get_legacy_shape()[1];
-    uint32_t num_heads = cache_tensor1.get_legacy_shape()[1];
+    uint32_t B = input_tensor1.get_padded_shape()[1];
+    uint32_t num_heads = cache_tensor1.get_padded_shape()[1];
 
     log_debug("cache_cb_data_format: {}", cache_cb_data_format);
     log_debug("input_cb_data_format: {}", input_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
@@ -80,30 +80,30 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(
     if (is_paged_cache) {
         const auto& page_table_tensor = page_table.value();
 
-        batch_size = page_table_tensor.get_legacy_shape()[0];
-        block_size = cache_tensor.get_legacy_shape()[2];
+        batch_size = page_table_tensor.get_padded_shape()[0];
+        block_size = cache_tensor.get_padded_shape()[2];
         block_size_t = block_size / TILE_HEIGHT;
-        max_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
-        page_table_stick_size = page_table_tensor.get_legacy_shape()[-1] * page_table_tensor.element_size();
+        max_blocks_per_seq = page_table_tensor.get_padded_shape()[1];
+        page_table_stick_size = page_table_tensor.get_padded_shape()[-1] * page_table_tensor.element_size();
 
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.get_dtype());
 
         page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     }
 
-    uint32_t Wt = cache_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-    uint32_t St = cache_tensor.get_legacy_shape()[-2] / TILE_HEIGHT;
-    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.get_legacy_shape()[-1] * sizeof(float)
-                                       : cache_tensor.get_legacy_shape()[-1] * 2;  // 2 bytes for bfloat16
+    uint32_t Wt = cache_tensor.get_padded_shape()[-1] / TILE_WIDTH;
+    uint32_t St = cache_tensor.get_padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.get_padded_shape()[-1] * sizeof(float)
+                                       : cache_tensor.get_padded_shape()[-1] * 2;  // 2 bytes for bfloat16
     uint32_t cache_total_num_tiles = cache_tensor.volume() / TILE_HW;
     uint32_t cache_batch_num_tiles =
         share_cache ? 0
                     : cache_total_num_tiles /
-                          cache_tensor.get_legacy_shape()[0];  // if share cache, we can set cache batch num tiles to 0
+                          cache_tensor.get_padded_shape()[0];  // if share cache, we can set cache batch num tiles to 0
                                                                // so batch offset would be 0 in future calculations
     uint32_t num_tiles = input_tensor.volume() / TILE_HW;
-    uint32_t B = input_tensor.get_legacy_shape()[1];
-    uint32_t num_heads = cache_tensor.get_legacy_shape()[1];
+    uint32_t B = input_tensor.get_padded_shape()[1];
+    uint32_t num_heads = cache_tensor.get_padded_shape()[1];
 
     log_debug("cache_cb_data_format: {}", cache_cb_data_format);
     log_debug("input_cb_data_format: {}", input_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
@@ -16,7 +16,7 @@ void PlusOne::validate_with_output_tensors(
     TT_FATAL(input_tensor_a.get_dtype() == DataType::INT32, "Only INT32 is supported for inputs!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for inputs!");
 
-    auto input_shape = input_tensor_a.get_legacy_shape();
+    auto input_shape = input_tensor_a.get_padded_shape();
     TT_FATAL(input_shape.size() == 1, "must have 1 dimension");
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -30,7 +30,7 @@ operation::ProgramWithCallbacks plusone_single_core(const Tensor& input) {
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_units);
 
-    const auto& input_shape = input.get_legacy_shape();
+    const auto& input_shape = input.get_padded_shape();
     const uint32_t W = input_shape[0];
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -36,7 +36,7 @@ Tensor ArgmaxOperation::invoke(
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input = input_tensors.at(0);
-            auto input_shape = input.get_legacy_shape();
+            auto input_shape = input.get_padded_shape();
             TT_FATAL(input_shape.rank() == 4, "supported for rank-4 tensors at this time");
 
             Tensor input_a = create_mask(input, output_memory_config);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
@@ -37,7 +37,7 @@ void HCSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
         "Unsupported data format for output!");
 
     constexpr uint32_t latent = 32;
-    const auto ashape = input_tensor_a.get_legacy_shape();
+    const auto ashape = input_tensor_a.get_padded_shape();
     TT_FATAL((ashape[0] == 1 and ashape[1] == 1), "Dim 1 and 2 are expected to be 1 in input a!");
     TT_FATAL((ashape[2] % TILE_HEIGHT == 0), "Batch size must be divisible by 32 for input a!");
     TT_FATAL((ashape[3] % TILE_WIDTH == 0), "Final dim must be a multiple of 32!");

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
@@ -27,8 +27,8 @@ operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(
     TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
     const bool output_is_dram = out_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
 
-    auto ashape = a.get_legacy_shape();
-    auto num_output_blocks_total = a.get_legacy_shape()[-1] / (TILE_WIDTH * TILE_WIDTH);
+    auto ashape = a.get_padded_shape();
+    auto num_output_blocks_total = a.get_padded_shape()[-1] / (TILE_WIDTH * TILE_WIDTH);
 
     const bool row_major = false;
     const auto

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
@@ -18,9 +18,9 @@ void PrefixScan::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& bx = input_tensors[1];
     TT_FATAL(a.dtype() == bx.dtype(), "Expected input tensors to have the same data type");
     TT_FATAL(a.layout() == Layout::TILE && bx.layout() == Layout::TILE, "Expected input tensors to be tile layout");
-    TT_FATAL(a.get_legacy_shape() == bx.get_legacy_shape(), "Expected input tensors to have the same shape");
+    TT_FATAL(a.get_padded_shape() == bx.get_padded_shape(), "Expected input tensors to have the same shape");
 
-    const auto& shape = a.get_legacy_shape();
+    const auto& shape = a.get_padded_shape();
     TT_FATAL(shape.rank() == 4, "Expected input tensors to be rank 4");
     TT_FATAL(shape[0] == 1 && shape[1] == 1, "Dimension 0 and 1 should be size 1");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
@@ -52,8 +52,8 @@ void RepeatAndInterleaveEltwiseMul::validate(const std::vector<Tensor>& input_te
         this->dtype == tt::tt_metal::DataType::BFLOAT16 || this->dtype == tt::tt_metal::DataType::BFLOAT8_B,
         "Unsupported data format for output!");
 
-    const auto ashape = input_tensor_a.get_legacy_shape();
-    const auto bshape = input_tensor_b.get_legacy_shape();
+    const auto ashape = input_tensor_a.get_padded_shape();
+    const auto bshape = input_tensor_b.get_padded_shape();
     TT_FATAL((ashape[0] == 1 and ashape[1] == 1), "Batch not supported for input a!");
     TT_FATAL((bshape[0] == 1 and bshape[1] == 1), "Batch not supported for input b!");
     TT_FATAL((ashape[2] % TILE_HEIGHT == 0), "Num of users must be multiple of 32 for input a!");

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -19,7 +19,7 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(
     const uint32_t hidden_size,
     MathFidelity math_fidelity,
     CoreCoord compute_with_storage_grid_size) {
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
 
     tt::tt_metal::IDevice* device = a.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::experimental::transformer {
 void ConcatenateHeadsDeviceOperation::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto batch_size = input_tensor.get_legacy_shape()[0];
+    const auto batch_size = input_tensor.get_padded_shape()[0];
     // TODO: See issue #1744
     TT_FATAL(batch_size >= 7 && batch_size <= 9, "Input batch size must be between 7 to 9 for bert large TM ops!");
 
@@ -23,8 +23,7 @@ void ConcatenateHeadsDeviceOperation::validate_with_output_tensors(
         "Unsupported data format");
 
     TT_FATAL(
-        (input_tensor.get_legacy_shape() == tt::tt_metal::LegacyShape({batch_size, 16, 384, 64})),
-        "Unsupported input shape");
+        (input_tensor.get_padded_shape() == ttnn::SimpleShape({batch_size, 16, 384, 64})), "Unsupported input shape");
 
     TT_FATAL(output_tensors.size() == 1, "Must have 1 output tensors");
     const auto& optional_output_tensor = output_tensors.at(0);
@@ -34,7 +33,7 @@ void ConcatenateHeadsDeviceOperation::validate_with_output_tensors(
             "Output dtype must be same as input dtype!");
 
         TT_FATAL(
-            optional_output_tensor.value().get_legacy_shape() == tt::tt_metal::LegacyShape({batch_size, 1, 384, 1024}),
+            optional_output_tensor.value().get_padded_shape() == ttnn::SimpleShape({batch_size, 1, 384, 1024}),
             "Output shape must be (batch_size, 1, 384, 1024)!");
     }
 }
@@ -64,7 +63,7 @@ operation::ProgramWithCallbacks ConcatenateHeadsDeviceOperation::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    const auto batch_size = input_tensor.get_legacy_shape()[0];
+    const auto batch_size = input_tensor.get_padded_shape()[0];
 
     auto device_compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.hpp
@@ -13,7 +13,7 @@ using namespace tt;
 
 operation::ProgramWithCallbacks concatenate_heads_multi_core(
     const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
 
     tt_metal::IDevice* device = a.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.cpp
@@ -23,13 +23,13 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> CreateQKVHeadsOperation::in
     const MemoryConfig output_mem_config = memory_config.value_or(input_tensor.memory_config());
     const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_q_heads);
     TT_FATAL(
-        input_tensor.get_legacy_shape()[3] % (num_q_heads + (2 * num_kv_heads_val)) == 0,
+        input_tensor.get_padded_shape()[3] % (num_q_heads + (2 * num_kv_heads_val)) == 0,
         "Flattened hidden dimension {} must be a multiple of the combined Q {}, K {} and V {} heads",
-        input_tensor.get_legacy_shape()[3],
+        input_tensor.get_padded_shape()[3],
         num_q_heads,
         num_kv_heads_val,
         num_kv_heads_val);
-    const uint32_t head_dim = input_tensor.get_legacy_shape()[3] / (num_q_heads + (2 * num_kv_heads_val));
+    const uint32_t head_dim = input_tensor.get_padded_shape()[3] / (num_q_heads + (2 * num_kv_heads_val));
     auto optional_outputs = std::vector<std::optional<Tensor>>{};
     if (optional_output_tensors.has_value()) {
         optional_outputs = {optional_output_tensors.value().begin(), optional_output_tensors.value().end()};

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -20,7 +20,7 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
         "Unsupported data format");
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     TT_FATAL(input_tensor.is_sharded(), "Operands to TM must be sharded");
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_padded_shape();
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
 
     auto bbox = input_tensor.shard_spec().value().grid.bounding_box();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -31,7 +31,7 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
     const uint32_t tiles_per_group =
         elements_per_group / TILE_WIDTH;  // head_dim % TILE_WIDTH == 0 so guaranteed to fit evenly
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     TT_FATAL(
         input_shape[3] % elements_per_group == 0,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.cpp
@@ -23,11 +23,11 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> CreateQKVHeadsSeparateTenso
     std::optional<std::array<Tensor, 3>> optional_output_tensors) {
     const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_q_heads);
     TT_FATAL(
-        input_tensor_q.get_legacy_shape()[3] % num_q_heads == 0,
+        input_tensor_q.get_padded_shape()[3] % num_q_heads == 0,
         "Flattened Q hidden dimension {} must be a multiple of Q heads {}",
-        input_tensor_q.get_legacy_shape()[3],
+        input_tensor_q.get_padded_shape()[3],
         num_q_heads);
-    const uint32_t head_dim = input_tensor_q.get_legacy_shape()[3] / (num_q_heads);
+    const uint32_t head_dim = input_tensor_q.get_padded_shape()[3] / (num_q_heads);
     auto optional_outputs = std::vector<std::optional<Tensor>>{};
     if (optional_output_tensors.has_value()) {
         optional_outputs = {optional_output_tensors.value().begin(), optional_output_tensors.value().end()};

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -54,8 +54,8 @@ void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Te
         this->num_kv_heads,
         num_w_cores);
 
-    const auto q_input_shape = q_input_tensor.get_legacy_shape();
-    const auto kv_input_shape = kv_input_tensor.get_legacy_shape();
+    const auto q_input_shape = q_input_tensor.get_padded_shape();
+    const auto kv_input_shape = kv_input_tensor.get_padded_shape();
     TT_FATAL(q_input_shape[1] == 1 && kv_input_shape[1] == 1, "Unsupported input shape");
     TT_FATAL(
         q_input_shape[0] == kv_input_shape[0],

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_program_factory.cpp
@@ -20,8 +20,8 @@ static inline operation::ProgramWithCallbacks create_qkv_separate(
     const uint32_t head_dim,
     std::vector<Tensor>& output,
     bool transpose_k) {
-    const auto& q_shape = input_tensor_q.get_legacy_shape();
-    const auto& kv_shape = input_tensor_kv.get_legacy_shape();
+    const auto& q_shape = input_tensor_q.get_padded_shape();
+    const auto& kv_shape = input_tensor_kv.get_padded_shape();
     auto shard_spec = input_tensor_q.shard_spec().value();
     auto all_cores = shard_spec.grid;
     auto bbox = all_cores.bounding_box();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
@@ -17,7 +17,7 @@ using namespace tt;
 
 operation::ProgramWithCallbacks multi_core_nlp_concat_heads(
     const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
 
     tt_metal::IDevice* device = a.device();
 
@@ -52,7 +52,7 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads(
         all_cores = a.shard_spec().value().grid;
         num_cores = all_cores.num_cores();
         core_group_1 = all_cores;
-        num_blocks_per_core_group_1 = a.shard_spec().value().shape[0] / a.get_legacy_shape()[-2];
+        num_blocks_per_core_group_1 = a.shard_spec().value().shape[0] / a.get_padded_shape()[-2];
         per_tensor_tiles = a.shard_spec().value().shape[0] * a.shard_spec().value().shape[1] / TILE_HW;
         row_major = a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
     } else {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -12,7 +12,7 @@ namespace ttnn::operations::experimental::transformer {
 // NLP ConcatHeads op for decode
 void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_padded_shape();
 
     // input tensor and shape
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
@@ -31,8 +31,8 @@ void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     TT_FATAL(input_tensor.is_sharded(), "Error");
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     auto shard_spec = input_tensor.shard_spec().value();
-    TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
-    TT_FATAL(shard_spec.shape[0] == input_tensor.get_legacy_shape()[-2], "Error");
+    TT_FATAL(shard_spec.shape[1] == input_tensor.get_padded_shape()[-1], "Error");
+    TT_FATAL(shard_spec.shape[0] == input_tensor.get_padded_shape()[-2], "Error");
     auto num_cores = shard_spec.grid.num_cores();
     TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");
     if (this->on_subcoregrids) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -18,7 +18,7 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(
     const Tensor& input_tensor, Tensor& output, CoreCoord compute_with_storage_grid_size) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
     const uint32_t head_dim = input_shape[-1];
     const uint32_t batch = input_shape[1];
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -13,7 +13,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     using namespace tt::constants;
     const auto& input_tensor = tensor_args.input_tensor_q;
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_padded_shape();
 
     // NOTE: Checks for head_dim and shape[3] is done in nlp_create_qkv_heads because it's needed to infer head_dim
     TT_FATAL(
@@ -32,7 +32,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_shape[1] == 1, "Unsupported input sequence length {} is not equal to 1", input_shape[1]);
     if (input_tensor.is_sharded()) {
         TT_FATAL(
-            input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1],
+            input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_padded_shape()[-1],
             "Error");
         TT_FATAL(
             operation_attributes.output_mem_config.is_sharded() &&
@@ -75,7 +75,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
 
     if (tensor_args.input_tensor_kv.has_value()) {
         const auto& input_tensor_kv = tensor_args.input_tensor_kv.value();
-        const auto input_shape_kv = input_tensor_kv.get_legacy_shape();
+        const auto input_shape_kv = input_tensor_kv.get_padded_shape();
 
         TT_FATAL(input_tensor_kv.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
         TT_FATAL(input_tensor_kv.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
@@ -90,7 +90,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(input_tensor.is_sharded(), "Error");
             TT_FATAL(
                 input_tensor_kv.shard_spec().value().shape[0] ==
-                    input_tensor_kv.volume() / input_tensor_kv.get_legacy_shape()[-1],
+                    input_tensor_kv.volume() / input_tensor_kv.get_padded_shape()[-1],
                 "Error");
             TT_FATAL(input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
             TT_FATAL(input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim, "Error");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -27,7 +27,7 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     auto& output = tensor_return_value;
     CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     tt_metal::IDevice* device = input_tensor.device();
 
@@ -55,7 +55,7 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     uint32_t in0_w_tiles = input_shape[3] / TILE_WIDTH;
     uint32_t in1_w_tiles = 0;
     if (read_from_input_tensor_kv) {
-        in1_w_tiles = input_tensor_kv.value().get_legacy_shape()[3] / TILE_WIDTH;
+        in1_w_tiles = input_tensor_kv.value().get_padded_shape()[3] / TILE_WIDTH;
     }
 
     // Per output tensor args
@@ -336,7 +336,7 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     tt_metal::IDevice* device = input_tensor.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
@@ -20,18 +20,18 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsOperation::in
     const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_q_heads);
     uint32_t head_dim;
     if (input_tensor_kv.has_value()) {
-        TT_FATAL(input_tensor_q.get_legacy_shape()[3] % num_q_heads == 0, "Unsupported input shape");
+        TT_FATAL(input_tensor_q.get_padded_shape()[3] % num_q_heads == 0, "Unsupported input shape");
         TT_FATAL(
-            input_tensor_kv.value().get_legacy_shape()[3] % (2 * num_kv_heads_val) == 0, "Unsupported input shape");
-        head_dim = input_tensor_q.get_legacy_shape()[3] / num_q_heads;
+            input_tensor_kv.value().get_padded_shape()[3] % (2 * num_kv_heads_val) == 0, "Unsupported input shape");
+        head_dim = input_tensor_q.get_padded_shape()[3] / num_q_heads;
         TT_FATAL(
-            input_tensor_kv.value().get_legacy_shape()[3] / (2 * num_kv_heads_val) == head_dim,
+            input_tensor_kv.value().get_padded_shape()[3] / (2 * num_kv_heads_val) == head_dim,
             "Head dims must be the same for Q and K, V");
     } else {
         TT_FATAL(
-            input_tensor_q.get_legacy_shape()[3] % (num_q_heads + 2 * num_kv_heads_val) == 0,
+            input_tensor_q.get_padded_shape()[3] % (num_q_heads + 2 * num_kv_heads_val) == 0,
             "Unsupported input shape");
-        head_dim = input_tensor_q.get_legacy_shape()[3] / (num_q_heads + 2 * num_kv_heads_val);
+        head_dim = input_tensor_q.get_padded_shape()[3] / (num_q_heads + 2 * num_kv_heads_val);
     }
 
     return ttnn::prim::nlp_create_qkv_heads(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -41,7 +41,7 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
             "Current input memory layout is {}. It must be width sharded",
             QKV_memcfg.memory_layout);
         TT_FATAL(
-            input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1],
+            input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_padded_shape()[-1],
             "Shard shape must be correct");
         TT_FATAL(
             input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleav
     CoreCoord compute_with_storage_grid_size) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     tt_metal::IDevice* device = input_tensor.device();
 
@@ -76,7 +76,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleav
     auto q_shard_spec = output[0].shard_spec().value();
     auto q_cores = q_shard_spec.grid;
     auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
-    auto in_shape = input_tensor.get_legacy_shape();
+    auto in_shape = input_tensor.get_padded_shape();
     auto in_num_tiles = in_shape[-2] * in_shape[-1] / TILE_HW;
 
     uint32_t q_output_cb_index = CBIndex::c_16;
@@ -216,7 +216,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
     CoreCoord compute_with_storage_grid_size) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     tt_metal::IDevice* device = input_tensor.device();
 
@@ -473,7 +473,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
     CoreCoord compute_with_storage_grid_size) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
 
     tt_metal::IDevice* device = input_tensor.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
@@ -27,8 +27,9 @@ namespace ttnn::operations::experimental::transformer {
             input_tensor.is_sharded() ? (input_tensor.shard_spec().value().grid.ranges().size() > 1) : false;
 
         // Infer head_dim
-        TT_FATAL(input_tensor.get_legacy_shape()[3] % (num_heads + 2 * num_kv_heads_val) == 0, "Unsupported input shape");
-        uint32_t head_dim = input_tensor.get_legacy_shape()[3] / (num_heads + 2 * num_kv_heads_val);
+        TT_FATAL(
+            input_tensor.get_padded_shape()[3] % (num_heads + 2 * num_kv_heads_val) == 0, "Unsupported input shape");
+        uint32_t head_dim = input_tensor.get_padded_shape()[3] / (num_heads + 2 * num_kv_heads_val);
         auto optional_outputs = std::vector<std::optional<Tensor>>{};
         if (optional_output_tensors.has_value()) {
             optional_outputs = {optional_output_tensors.value().begin(), optional_output_tensors.value().end()};

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::transformer {
 // Hard-coded for Falcon7B
 void NlpCreateHeadsFalcon7BDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_padded_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
@@ -25,9 +25,7 @@ void NlpCreateHeadsFalcon7BDeviceOperation::validate(const std::vector<Tensor>& 
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
     TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0, "Error");
-    TT_FATAL(
-        (input_shape == tt::tt_metal::LegacyShape({input_shape[0], 1, input_shape[2], 4672})),
-        "Unsupported input shape");
+    TT_FATAL((input_shape == ttnn::SimpleShape({input_shape[0], 1, input_shape[2], 4672})), "Unsupported input shape");
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
@@ -16,7 +16,7 @@ using namespace tt::tt_metal;
 
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_falcon7b(
     const Tensor& a, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
 
     tt_metal::IDevice* device = a.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::transformer {
 // Hard-coded for Segformer
 void NlpCreateHeadsSegformerDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_padded_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_program_factory.cpp
@@ -16,7 +16,7 @@ using namespace tt::tt_metal;
 
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_segformer(
     const Tensor& a, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
 
     tt_metal::IDevice* device = a.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::transformer {
 // Hard-coded for Vit
 void NlpCreateHeadsVitDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_padded_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
@@ -25,9 +25,7 @@ void NlpCreateHeadsVitDeviceOperation::validate(const std::vector<Tensor>& input
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
     TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0, "Error");
-    TT_FATAL(
-        (input_shape == tt::tt_metal::LegacyShape({input_shape[0], 1, input_shape[2], 2304})),
-        "Unsupported input shape");
+    TT_FATAL((input_shape == ttnn::SimpleShape({input_shape[0], 1, input_shape[2], 2304})), "Unsupported input shape");
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_program_factory.cpp
@@ -16,7 +16,7 @@ using namespace tt::tt_metal;
 
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_vit(
     const Tensor& a, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
 
     tt_metal::IDevice* device = a.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -17,18 +17,18 @@ void NlpKVCacheLoadSliceDeviceOperation::validate(const std::vector<Tensor>& inp
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Error");
 
-    for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
-        TT_FATAL(this->output_tensor_start[i] < input_tensor_a.get_legacy_shape()[i], "Error");
-        TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_legacy_shape()[i], "Error");
+    for (uint32_t i = 0; i < input_tensor_a.get_padded_shape().rank(); i++) {
+        TT_FATAL(this->output_tensor_start[i] < input_tensor_a.get_padded_shape()[i], "Error");
+        TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_padded_shape()[i], "Error");
 
         // Check if start shape is <= end shape
         TT_FATAL(this->output_tensor_start[i] <= this->output_tensor_end[i], "Error");
     }
 
     SimpleShape output_tensor_shape = this->compute_output_specs(input_tensors)[0].padded_shape();
-    auto num_dims = input_tensor_a.get_legacy_shape().rank();
+    auto num_dims = input_tensor_a.get_padded_shape().rank();
     TT_FATAL(num_dims == 4, "Input tensor must be 4D");
-    const auto input_shape = input_tensor_a.get_legacy_shape();
+    const auto input_shape = input_tensor_a.get_padded_shape();
     auto dim0 = input_shape[0];
     auto dim1 = input_shape[1];
     auto fused_batch_heads = dim0 * dim1;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.hpp
@@ -15,14 +15,14 @@ namespace ttnn::operations::experimental::transformer {
 operation::ProgramWithCallbacks multi_core_nlp_kv_cache_load_slice(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end);
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end);
 
 struct NlpKVCacheLoadSliceDeviceOperation {
-    const tt::tt_metal::LegacyShape output_tensor_start;
-    const tt::tt_metal::LegacyShape output_tensor_end;
-    const tt::tt_metal::LegacyShape output_shape;
-    const tt::tt_metal::LegacyShape input_shape;
+    const ttnn::SimpleShape output_tensor_start;
+    const ttnn::SimpleShape output_tensor_end;
+    const ttnn::SimpleShape output_shape;
+    const ttnn::SimpleShape input_shape;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_program_factory.cpp
@@ -19,12 +19,12 @@ using namespace tt;
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_unpad_runtime_args_tile_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_start,
     uint32_t num_cores_total,
     uint32_t num_cores_x,
     uint32_t num_tiles_per_core) {
     auto input_buffer = input_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
 
     std::vector<uint32_t> common_reader_kernel_args = {input_buffer->address(), 0};
 
@@ -54,10 +54,10 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_unpad_r
 operation::ProgramWithCallbacks multi_core_nlp_kv_cache_load_slice(
     const Tensor& a,
     Tensor& output,
-    const tt::tt_metal::LegacyShape& output_tensor_start,
-    const tt::tt_metal::LegacyShape& output_tensor_end) {
-    const tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
-    const tt::tt_metal::LegacyShape input_shape = a.get_legacy_shape();
+    const ttnn::SimpleShape& output_tensor_start,
+    const ttnn::SimpleShape& output_tensor_end) {
+    const auto output_shape = output.get_padded_shape();
+    const auto input_shape = a.get_padded_shape();
 
     tt_metal::Program program = tt_metal::CreateProgram();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.cpp
@@ -18,31 +18,31 @@ ttnn::Tensor NLPKVCacheLoadSliceOperation::invoke(
     const uint32_t seq_len_end,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
-    auto input_tensor_shape = input_tensor.get_legacy_shape();
+    auto input_tensor_shape = input_tensor.get_padded_shape();
     auto dim0 = input_tensor_shape[0];
     auto dim1 = input_tensor_shape[1];
     auto head_dim = input_tensor_shape[3];
 
-    const tt::tt_metal::LegacyShape output_tensor_start = {
+    const ttnn::SimpleShape output_tensor_start({
         0,
         0,
         seq_len_start,
         0,
-    };
+    });
 
-    const tt::tt_metal::LegacyShape output_tensor_end = {
+    const ttnn::SimpleShape output_tensor_end({
         dim0 - 1,
         dim1 - 1,
         seq_len_end - 1,
         head_dim - 1,
-    };
+    });
 
-    const tt::tt_metal::LegacyShape output_tensor_shape = {
+    const ttnn::SimpleShape output_tensor_shape({
         output_tensor_end[0] - output_tensor_start[0] + 1,
         output_tensor_end[1] - output_tensor_start[1] + 1,
         output_tensor_end[2] - output_tensor_start[2] + 1,
         output_tensor_end[3] - output_tensor_start[3] + 1,
-    };
+    });
     return operation::run(
                NlpKVCacheLoadSliceDeviceOperation{
                    output_tensor_start, output_tensor_end, output_tensor_shape, input_tensor_shape},

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -30,26 +30,26 @@ void RotaryEmbedding::validate(const std::vector<Tensor>& input_tensors) const {
         TT_FATAL((input.get_layout() == Layout::TILE), "Inputs to rotary embedding must be tilized");
     }
 
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] % (TILE_WIDTH * 2) == 0, "Input X dim must be divisible into tiles");
-    uint32_t seq_len = input_tensor.get_legacy_shape()[-2];
-    uint32_t B = input_tensor.get_legacy_shape()[0];
-    uint32_t X = input_tensor.get_legacy_shape()[-1];
+    TT_FATAL(input_tensor.get_padded_shape()[-1] % (TILE_WIDTH * 2) == 0, "Input X dim must be divisible into tiles");
+    uint32_t seq_len = input_tensor.get_padded_shape()[-2];
+    uint32_t B = input_tensor.get_padded_shape()[0];
+    uint32_t X = input_tensor.get_padded_shape()[-1];
     TT_FATAL(cos.get_dtype() == sin.get_dtype(), "Cos and Sin dtypes must match");
-    TT_FATAL(cos.get_legacy_shape() == sin.get_legacy_shape(), "Cos and Sin dims must match");
+    TT_FATAL(cos.get_padded_shape() == sin.get_padded_shape(), "Cos and Sin dims must match");
     TT_FATAL(
-        cos.get_legacy_shape()[0] == 1 && cos.get_legacy_shape()[1] == 1 && cos.get_legacy_shape()[-1] == X,
+        cos.get_padded_shape()[0] == 1 && cos.get_padded_shape()[1] == 1 && cos.get_padded_shape()[-1] == X,
         "Cos dims must match input dims");
     if (this->token_idx.has_value()) {
-        TT_FATAL(cos.get_legacy_shape()[-2] >= token_idx, "Cos dims must match input dims");
+        TT_FATAL(cos.get_padded_shape()[-2] >= token_idx, "Cos dims must match input dims");
     } else {
-        TT_FATAL(cos.get_legacy_shape()[-2] >= seq_len, "Cos dims must match input dims");
+        TT_FATAL(cos.get_padded_shape()[-2] >= seq_len, "Cos dims must match input dims");
     }
     if (input_tensor.is_sharded()) {
         TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
-        TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
+        TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_padded_shape()[-1], "Error");
         // Require even work division for now
         TT_FATAL(
-            (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) %
+            (input_tensor.volume() / input_tensor.get_padded_shape()[-1]) %
                     input_tensor.shard_spec().value().shape[0] ==
                 0,
             "Error");
@@ -76,7 +76,7 @@ std::vector<ttnn::TensorSpec> RotaryEmbedding::compute_output_specs(const std::v
         if (input_tensor.is_sharded()) {
             shard_spec = input_tensor.shard_spec().value();
         } else {
-            uint32_t num_blocks = input_tensor.volume() / input_tensor.get_legacy_shape()[-1] / TILE_HEIGHT;
+            uint32_t num_blocks = input_tensor.volume() / input_tensor.get_padded_shape()[-1] / TILE_HEIGHT;
             auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
             uint32_t num_grid_cores = core_grid.x * core_grid.y;
             uint32_t num_cores = 0;
@@ -88,7 +88,7 @@ std::vector<ttnn::TensorSpec> RotaryEmbedding::compute_output_specs(const std::v
             }
             uint32_t Ht = div_up(num_blocks, num_cores);
             shard_spec.grid = num_cores_to_corerangeset(num_cores, core_grid, true);
-            shard_spec.shape = {Ht * TILE_HEIGHT, input_tensor.get_legacy_shape()[-1]};
+            shard_spec.shape = {Ht * TILE_HEIGHT, input_tensor.get_padded_shape()[-1]};
             shard_spec.orientation = ShardOrientation::ROW_MAJOR;
         }
         auto mem_config = this->output_mem_config;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -44,12 +44,12 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
     uint32_t output_single_tile_size = tt_metal::detail::TileSize(output_cb_data_format);
 
     uint32_t num_tiles = input.volume() / TILE_HW;
-    uint32_t num_rows = input.volume() / input.get_legacy_shape()[-1] / TILE_HEIGHT;
-    uint32_t Ht = input.get_legacy_shape()[-2] / TILE_HEIGHT;
-    uint32_t Wt = input.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t num_rows = input.volume() / input.get_padded_shape()[-1] / TILE_HEIGHT;
+    uint32_t Ht = input.get_padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t Wt = input.get_padded_shape()[-1] / TILE_WIDTH;
     uint32_t half_Wt = Wt / 2;
     uint32_t HtWt = Ht * Wt;
-    uint32_t Wbytes = input.get_legacy_shape()[-1] * sizeof(bfloat16);
+    uint32_t Wbytes = input.get_padded_shape()[-1] * sizeof(bfloat16);
 
     tt_metal::IDevice* device = input.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
@@ -20,46 +20,46 @@ ttnn::Tensor RotaryEmbeddingOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     TT_FATAL(
-        input_tensor.get_legacy_shape()[-1] % (tt::constants::TILE_WIDTH * 2) == 0,
+        input_tensor.get_padded_shape()[-1] % (tt::constants::TILE_WIDTH * 2) == 0,
         "Input X dimension ({}) must be divisible by {} for tiling.",
-        input_tensor.get_legacy_shape()[-1],
+        input_tensor.get_padded_shape()[-1],
         tt::constants::TILE_WIDTH * 2);
 
-    uint32_t seq_len = input_tensor.get_legacy_shape()[-2];
-    uint32_t B = input_tensor.get_legacy_shape()[0];
-    uint32_t X = input_tensor.get_legacy_shape()[-1];
+    uint32_t seq_len = input_tensor.get_padded_shape()[-2];
+    uint32_t B = input_tensor.get_padded_shape()[0];
+    uint32_t X = input_tensor.get_padded_shape()[-1];
 
     TT_FATAL(
-        cos_cache.get_legacy_shape() == sin_cache.get_legacy_shape(),
+        cos_cache.get_padded_shape() == sin_cache.get_padded_shape(),
         "Cosine and Sine cache dimensions must match. Cos cache dimensions: {}, Sin cache dimensions: {}.",
-        cos_cache.get_legacy_shape(),
-        sin_cache.get_legacy_shape());
+        cos_cache.get_padded_shape(),
+        sin_cache.get_padded_shape());
 
     TT_FATAL(
-        cos_cache.get_legacy_shape()[0] == 1 && cos_cache.get_legacy_shape()[1] == 1 &&
-            cos_cache.get_legacy_shape()[-1] == X,
+        cos_cache.get_padded_shape()[0] == 1 && cos_cache.get_padded_shape()[1] == 1 &&
+            cos_cache.get_padded_shape()[-1] == X,
         "Cosine cache dimensions must match input dimensions. Expected (1, 1, {}), but got {}.",
         X,
-        cos_cache.get_legacy_shape());
+        cos_cache.get_padded_shape());
 
     if (token_index.has_value()) {
-        seq_len = input_tensor.get_legacy_shape()[0];
+        seq_len = input_tensor.get_padded_shape()[0];
         TT_FATAL(
             seq_len == 1,
             "When token index is provided, sequence length must be 1. Current sequence length: {}.",
             seq_len);
 
         TT_FATAL(
-            cos_cache.get_legacy_shape()[-2] >= token_index,
+            cos_cache.get_padded_shape()[-2] >= token_index,
             "Cosine cache dimensions must cover the token index. Token index: {}, Cos cache dimension: {}.",
             token_index.value(),
-            cos_cache.get_legacy_shape()[-2]);
+            cos_cache.get_padded_shape()[-2]);
     } else {
         TT_FATAL(
-            cos_cache.get_legacy_shape()[-2] >= seq_len,
+            cos_cache.get_padded_shape()[-2] >= seq_len,
             "Cosine cache dimensions must cover the sequence length. Sequence length: {}, Cos cache dimension: {}.",
             seq_len,
-            cos_cache.get_legacy_shape()[-2]);
+            cos_cache.get_padded_shape()[-2]);
     }
 
     auto arch = input_tensor.storage_type() == StorageType::DEVICE

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
@@ -18,7 +18,7 @@ void RotateHalf::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to rotate half need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to rotate half need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to rotate half must be tilized");
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] % (TILE_WIDTH * 2) == 0, "Input X dim must be divisible into tiles");
+    TT_FATAL(input_tensor.get_padded_shape()[-1] % (TILE_WIDTH * 2) == 0, "Input X dim must be divisible into tiles");
     TT_FATAL(
         input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
         "RotateHalf does not currently support sharding");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/single_core/rotate_half_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/single_core/rotate_half_program_factory.cpp
@@ -27,8 +27,8 @@ operation::ProgramWithCallbacks rotate_half_single_core(const Tensor& input, Ten
     uint32_t scalar_single_tile_size = tt_metal::detail::TileSize(scalar_cb_data_format);
 
     uint32_t num_tiles = input.volume() / TILE_HW;
-    uint32_t num_rows = input.volume() / input.get_legacy_shape()[-1] / TILE_HEIGHT;
-    uint32_t half_row_size = input.get_legacy_shape()[-1] / TILE_WIDTH / 2;
+    uint32_t num_rows = input.volume() / input.get_padded_shape()[-1] / TILE_HEIGHT;
+    uint32_t half_row_size = input.get_padded_shape()[-1] / TILE_WIDTH / 2;
 
     tt_metal::IDevice* device = input.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.cpp
@@ -17,9 +17,9 @@ Tensor RotateHalfOperation::invoke(const Tensor& input_tensor, const std::option
         static_cast<int>(input_tensor.storage_type()));
 
     TT_FATAL(
-        input_tensor.get_legacy_shape()[-1] % (tt::constants::TILE_WIDTH * 2) == 0,
+        input_tensor.get_padded_shape()[-1] % (tt::constants::TILE_WIDTH * 2) == 0,
         "Input X dimension ({}) must be divisible by {} for tiling.",
-        input_tensor.get_legacy_shape()[-1],
+        input_tensor.get_padded_shape()[-1],
         tt::constants::TILE_WIDTH * 2);
 
     ttnn::SimpleShape pad_shape =

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -13,11 +13,10 @@ namespace ttnn::operations::experimental::transformer {
 void SplitFusedQKVAndSplitHeadsDeviceOperation::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto batch_size = input_tensor.get_legacy_shape()[0];
+    const auto batch_size = input_tensor.get_padded_shape()[0];
     // TODO: See issue #1744
     TT_FATAL(
-        (input_tensor.get_legacy_shape() == tt::tt_metal::LegacyShape({batch_size, 1, 384, 3072})),
-        "Unsupported input shape");
+        (input_tensor.get_padded_shape() == ttnn::SimpleShape({batch_size, 1, 384, 3072})), "Unsupported input shape");
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_program_factory.hpp
@@ -14,7 +14,7 @@ using namespace tt_metal;
 
 operation::ProgramWithCallbacks multi_core_split_query_key_value_and_split_heads(
     const Tensor& a, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
-    const auto& ashape = a.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
 
     tt_metal::IDevice* device = a.device();
 
@@ -222,7 +222,7 @@ operation::ProgramWithCallbacks multi_core_split_query_key_value_and_split_heads
     uint32_t num_h_cores = rm ? bbox.end_coord.y + 1 : bbox.end_coord.x + 1;
     uint32_t num_w_cores = rm ? bbox.end_coord.x + 1 : bbox.end_coord.y + 1;
     // tensor shape
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t M = shape[2] * shape[0];  // 4608
     uint32_t K = shape[3];             // 3072
     uint32_t Mt = M / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -616,7 +616,7 @@ static bool nearly_equal(::bfloat16 a, ::bfloat16 b, Args... args) {
 
 template <typename DataType, typename... Args>
 static bool allclose(const Tensor& tensor_a, const Tensor& tensor_b, Args... args) {
-    if (tensor_a.get_legacy_shape() != tensor_b.get_legacy_shape()) {
+    if (tensor_a.get_padded_shape() != tensor_b.get_padded_shape()) {
         return false;
     }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
@@ -35,9 +35,9 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
             cache_tensor.get_dtype() == DataType::BFLOAT8_B,
         "Error");
 
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1], "Error");
-    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1, "Error");
-    TT_FATAL(input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[1], "Error");
+    TT_FATAL(input_tensor.get_padded_shape()[-1] == cache_tensor.get_padded_shape()[-1], "Error");
+    TT_FATAL(input_tensor.get_padded_shape()[0] == 1, "Error");
+    TT_FATAL(input_tensor.get_padded_shape()[1] == cache_tensor.get_padded_shape()[1], "Error");
     TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     if (this->op_type == UpdateCacheOpType::FILL) {
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
@@ -49,9 +49,9 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
         // robust logic in reader/writer loops to handle generic blocking of work For sharded, we infer number of tiles
         // each core handles from shard so no issues there
         if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED and
-            input_tensor.get_legacy_shape()[1] > 1) {
+            input_tensor.get_padded_shape()[1] > 1) {
             const uint32_t num_blocks_of_work =
-                input_tensor.get_legacy_shape()[1] * input_tensor.get_legacy_shape()[-2] / TILE_HEIGHT;
+                input_tensor.get_padded_shape()[1] * input_tensor.get_padded_shape()[-2] / TILE_HEIGHT;
             const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
             TT_FATAL(
                 (num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y), "Error");
@@ -59,15 +59,15 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
 
         if (input_tensor.is_sharded()) {
             TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_padded_shape()[-1], "Error");
             // Require even work division along seq_len and also only 1 head per core
             TT_FATAL(
-                input_tensor.get_legacy_shape()[-2] % input_tensor.shard_spec().value().shape[0] == 0,
+                input_tensor.get_padded_shape()[-2] % input_tensor.shard_spec().value().shape[0] == 0,
                 "Seq len must be divisible by shard height!");
         }
 
-        TT_FATAL(this->batch_idx < cache_tensor.get_legacy_shape()[0], "Error");
-        TT_FATAL(input_tensor.get_legacy_shape()[-2] <= cache_tensor.get_legacy_shape()[-2], "Error");
+        TT_FATAL(this->batch_idx < cache_tensor.get_padded_shape()[0], "Error");
+        TT_FATAL(input_tensor.get_padded_shape()[-2] <= cache_tensor.get_padded_shape()[-2], "Error");
     } else if (this->op_type == UpdateCacheOpType::UPDATE) {
         if (input_tensor.device()->arch() == tt::ARCH::GRAYSKULL) {
             TT_FATAL(
@@ -77,20 +77,20 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
         }
         if (input_tensor.is_sharded()) {
             TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_padded_shape()[-1], "Error");
             // Require even work division for now
             TT_FATAL(
-                (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) %
+                (input_tensor.volume() / input_tensor.get_padded_shape()[-1]) %
                         input_tensor.shard_spec().value().shape[0] ==
                     0,
                 "Error");
         } else {
             TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         }
-        TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-2], "Error");
+        TT_FATAL(cache_tensor.get_padded_shape()[0] <= input_tensor.get_padded_shape()[-2], "Error");
         // batch offset is only valid if num_user less than 32 and batch_offset + num_user <= 32
-        if (cache_tensor.get_legacy_shape()[0] < 32) {
-            TT_FATAL(this->batch_offset + cache_tensor.get_legacy_shape()[0] <= 32, "Error");
+        if (cache_tensor.get_padded_shape()[0] < 32) {
+            TT_FATAL(this->batch_offset + cache_tensor.get_padded_shape()[0] <= 32, "Error");
         } else {
             TT_FATAL(this->batch_offset == 0, "Error");
         }

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -38,11 +38,11 @@ operation::ProgramWithCallbacks update_cache_multi_core(
     tt::DataFormat interm_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     uint32_t interm_single_tile_size = tt::tt_metal::detail::TileSize(interm_cb_data_format);
 
-    uint32_t Wt = cache_tensor.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
+    uint32_t Wt = cache_tensor.get_padded_shape()[-1] / tt::constants::TILE_WIDTH;
 
     // Width size after untilize
-    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.get_legacy_shape()[-1] * sizeof(float)
-                                       : cache_tensor.get_legacy_shape()[-1] * sizeof(::bfloat16);
+    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.get_padded_shape()[-1] * sizeof(float)
+                                       : cache_tensor.get_padded_shape()[-1] * sizeof(::bfloat16);
 
     tt::log_debug("cache_cb_data_format: {}", cache_cb_data_format);
     tt::log_debug("input_cb_data_format: {}", input_cb_data_format);
@@ -51,15 +51,15 @@ operation::ProgramWithCallbacks update_cache_multi_core(
     tt::log_debug("Wt: {}", Wt);
 
     uint32_t cache_total_num_tiles = cache_tensor.volume() / TILE_HW;
-    uint32_t cache_batch_num_tiles = cache_total_num_tiles / cache_tensor.get_legacy_shape()[0];
-    uint32_t cache_head_num_tiles = cache_batch_num_tiles / cache_tensor.get_legacy_shape()[1];
+    uint32_t cache_batch_num_tiles = cache_total_num_tiles / cache_tensor.get_padded_shape()[0];
+    uint32_t cache_head_num_tiles = cache_batch_num_tiles / cache_tensor.get_padded_shape()[1];
 
     uint32_t num_tiles = input_tensor.volume() / tt::constants::TILE_HW;
 
-    uint32_t B = input_tensor.get_legacy_shape()[-2];
-    uint32_t Bcache = cache_tensor.get_legacy_shape()[0];
+    uint32_t B = input_tensor.get_padded_shape()[-2];
+    uint32_t Bcache = cache_tensor.get_padded_shape()[0];
     const uint32_t granularity = std::min(static_cast<uint32_t>(2), Bcache);  // granularity = 2 best for performance
-    uint32_t num_batched_heads = input_tensor.get_legacy_shape()[1] * B / tt::constants::TILE_HEIGHT;
+    uint32_t num_batched_heads = input_tensor.get_padded_shape()[1] * B / tt::constants::TILE_HEIGHT;
     uint32_t tile_update_offset = update_idx % tt::constants::TILE_HEIGHT * Wbytes;
     uint32_t batch_read_offset = batch_offset * Wbytes;  // Offset to read from input tensor
 
@@ -331,12 +331,12 @@ operation::ProgramWithCallbacks fill_cache_multi_core(
     // For either case, assume that work doesn't spill over to next head, so we just increment by Wt within
     // reader/writer
     uint32_t num_blocks_of_work =
-        input_tensor.get_legacy_shape()[1] * input_tensor.get_legacy_shape()[-2] / TILE_HEIGHT;
+        input_tensor.get_padded_shape()[1] * input_tensor.get_padded_shape()[-2] / TILE_HEIGHT;
 
-    uint32_t Wt = cache_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-    uint32_t input_Ht = input_tensor.get_legacy_shape()[-2] / TILE_HEIGHT;  // seq_len
-    uint32_t cache_HtWt = cache_tensor.get_legacy_shape()[-2] * Wt / TILE_HEIGHT;
-    uint32_t cache_CHtWt = cache_tensor.get_legacy_shape()[1] * cache_HtWt;
+    uint32_t Wt = cache_tensor.get_padded_shape()[-1] / TILE_WIDTH;
+    uint32_t input_Ht = input_tensor.get_padded_shape()[-2] / TILE_HEIGHT;  // seq_len
+    uint32_t cache_HtWt = cache_tensor.get_padded_shape()[-2] * Wt / TILE_HEIGHT;
+    uint32_t cache_CHtWt = cache_tensor.get_padded_shape()[1] * cache_HtWt;
     uint32_t update_idxt = update_idx / TILE_HEIGHT;
     uint32_t start_idx = batch_idx * cache_CHtWt + update_idxt * Wt;
     tt::tt_metal::IDevice* device = input_tensor.device();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -21,7 +21,7 @@ namespace matmul {
 operation::ProgramWithCallbacks matmul_multi_core(const Tensor& a, const Tensor& b, Tensor& output, bool bcast_batch) {
     tt_metal::Program program{};
 
-    const tt::tt_metal::LegacyShape &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
 
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor& a, const Tensor&
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
-    const tt::tt_metal::LegacyShape& cshape = output.get_legacy_shape();  // C=A*B, N1MK*11KN->N1MN
+    const auto& cshape = output.get_padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2120,7 +2120,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler,
     const std::optional<const tt::tt_metal::v1::experimental::GlobalCircularBuffer>& global_cb,
     uint32_t num_global_cb_receivers) {
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
     auto in0_tile = a.get_tensor_spec().tile();
     auto in1_tile = b.get_tensor_spec().tile();
     // cannot use the output tensor tile directly as that might be changed by user override

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1312,7 +1312,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     std::optional<UnaryWithParam> fused_activation,
     bool untilize_out,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler) {
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
     auto in0_tile = a.get_tensor_spec().tile();
     auto in1_tile = b.get_tensor_spec().tile();
     auto in0_tile_shape = in0_tile.get_tile_shape();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -903,7 +903,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
     bool skip_compute,
     bool skip_in0_mcast,
     bool skip_write_back) {
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
     auto in0_tile = a.get_tensor_spec().tile();
     auto in1_tile = b.get_tensor_spec().tile();
     auto in0_tile_shape = in0_tile.get_tile_shape();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -491,8 +491,8 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
     uint32_t per_core_N,
     bool fuse_batch,
     bool untilize_out) {
-    const auto& ashape = a.get_legacy_shape();
-    const auto& bshape = b.get_legacy_shape();
+    const auto& ashape = a.get_padded_shape();
+    const auto& bshape = b.get_padded_shape();
     auto in0_tile_shape = a.get_tensor_spec().tile().get_tile_shape();
     auto in1_tile_shape = b.get_tensor_spec().tile().get_tile_shape();
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -244,7 +244,7 @@ namespace matmul {
 
 operation::ProgramWithCallbacks matmul_multi_core_reuse(
     const Tensor& a, const Tensor& b, Tensor& output, bool bcast_batch) {
-    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
 
     tt::DataFormat in0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     tt::DataFormat in1_cb_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
@@ -285,7 +285,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt::tt_metal::LegacyShape cshape = output.get_legacy_shape();  // C=A*B, N1MK*11KN->N1MN
+    auto cshape = output.get_padded_shape();  // C=A*B, N1MK*11KN->N1MN
     tt_metal::Buffer* out_buffer = output.buffer();
     TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -22,7 +22,7 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto input_shape = input.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
     const auto input_rank = input_shape.rank();
 
     const auto H = input_shape[-2];
@@ -33,7 +33,7 @@ MorehAbsPowOperation::MorehAbsPowFactory::cached_program_t MorehAbsPowOperation:
 
     const auto num_units = input.volume() / H / W * Ht;
 
-    const auto origin_w = input_shape.without_padding()[input_rank - 1];
+    const auto origin_w = input.get_logical_shape()[input_rank - 1];
 
     auto [floored_p, decimal, p_is_negative] = get_floored_p_and_decimal_and_p_is_negative(p);
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
@@ -12,7 +12,7 @@ MorehArangeOperation::ProgramFactory::cached_program_t MorehArangeOperation::Pro
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     auto dtype = output.get_dtype();
-    auto W = output.get_legacy_shape()[-1];
+    auto W = output.get_padded_shape()[-1];
     auto Wt = tt::div_up(W, tt::constants::TILE_WIDTH);
 
     auto start = operation_attributes.start;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_program_factory.cpp
@@ -32,8 +32,8 @@ MorehCumsumDeviceOperation::ProgramFactory::cached_program_t MorehCumsumDeviceOp
     ////////////////////////////////////////////////////////////////////////////
     const auto cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
 
-    const auto& input_shape = input.get_legacy_shape();
-    const auto& input_shape_without_padding = input_shape.without_padding();
+    const auto& input_shape = input.get_padded_shape();
+    const auto& input_shape_without_padding = input.get_logical_shape();
 
     const auto N = input_shape[0];
     const auto C = input_shape[1];

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
@@ -21,8 +21,8 @@ void MorehDotOperation::validate(const operation_attributes_t& operation_attribu
     TT_FATAL(is_1d_tensor(input_a), "Invalid input tensor dimensions.");
     TT_FATAL(is_1d_tensor(input_b), "Invalid input tensor dimensions.");
 
-    const auto& a_shape_wo_padding = input_a.get_legacy_shape().without_padding();
-    const auto& b_shape_wo_padding = input_b.get_legacy_shape().without_padding();
+    const auto& a_shape_wo_padding = input_a.get_logical_shape();
+    const auto& b_shape_wo_padding = input_b.get_logical_shape();
     TT_FATAL(a_shape_wo_padding[3] == b_shape_wo_padding[3], "Shape without padding must be the same.");
 
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
@@ -14,8 +14,8 @@ MorehDotBackwardOperation::program_factory_t MorehDotBackwardOperation::select_p
 }
 
 void grad_tensor_validate(const Tensor& tensor, const Tensor& grad_tensor) {
-    const auto& tensor_shape = tensor.get_legacy_shape().without_padding();
-    const auto& grad_tensor_shape = grad_tensor.get_legacy_shape().without_padding();
+    const auto& tensor_shape = tensor.get_logical_shape();
+    const auto& grad_tensor_shape = grad_tensor.get_logical_shape();
     TT_FATAL(tensor_shape == grad_tensor_shape, "Tensor shape and grad tensor shape should be the same.");
     TT_FATAL(grad_tensor.storage_type() == StorageType::DEVICE, "Operands to dot backward need to be on device!");
     TT_FATAL(grad_tensor.device() == tensor.device(), "Operands to dot backward need to be on the same device!");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
@@ -33,14 +33,14 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto output_grad_shape = output_grad.get_legacy_shape();
+    const auto output_grad_shape = output_grad.get_padded_shape();
 
     const auto n = output_grad_shape[0];
     const auto c = output_grad_shape[1];
     const auto h = output_grad_shape[2];
     const auto w = output_grad_shape[3];
 
-    const auto origin_output_grad_shape = output_grad_shape.without_padding();
+    const auto origin_output_grad_shape = output_grad.get_logical_shape();
 
     const auto origin_h = origin_output_grad_shape[2];
     const auto origin_w = origin_output_grad_shape[3];

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -337,7 +337,7 @@ void expand_to_max_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape
 }
 
 void validate_input_with_dim(const Tensor& input, const int64_t& dim) {
-    auto input_shape = input.get_legacy_shape();
+    auto input_shape = input.get_padded_shape();
     auto input_shape_wo_padding = input.get_logical_shape();
     const auto input_rank = input_shape.rank();
     log_debug(LogOp, "{}:{} input_rank {}", __func__, __LINE__, input_rank);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
@@ -38,9 +38,9 @@ void MorehLayerNormOperation::validate_inputs(
 
     TT_FATAL(normalized_dims > 0, "normalized_dims should > 0. Got {}", normalized_dims);
     TT_FATAL(
-        normalized_dims <= input.get_legacy_shape().rank(),
+        normalized_dims <= input.get_padded_shape().rank(),
         "normalized_dims should <= input rank ({}). Got: {}",
-        input.get_legacy_shape().rank(),
+        input.get_padded_shape().rank(),
         normalized_dims);
 
     if (gamma.has_value()) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
@@ -23,8 +23,8 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
     Program program{};
     auto& output_grad = tensor_args.output_grad;
 
-    const auto& bias_grad_shape = bias_grad.get_legacy_shape().without_padding();
-    const auto& output_grad_shape_wo_padding = output_grad.get_legacy_shape().without_padding();
+    const auto& bias_grad_shape = bias_grad.get_logical_shape();
+    const auto& output_grad_shape_wo_padding = output_grad.get_logical_shape();
 
     auto bias_grad_memory_config = operation_attributes.bias_grad_memory_config;
     auto compute_kernel_config = operation_attributes.compute_kernel_config;
@@ -36,7 +36,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
     const uint32_t mask_w =
         do_mask_w ? output_grad_shape_wo_padding[-1] % constants::TILE_WIDTH : constants::TILE_WIDTH;
 
-    const auto& output_grad_shape = output_grad.get_legacy_shape();
+    const auto& output_grad_shape = output_grad.get_padded_shape();
     uint32_t batch_num = output_grad.volume() / output_grad_shape[-2] / output_grad_shape[-1];
     uint32_t Ht = output_grad_shape[-2] / constants::TILE_HEIGHT;
     uint32_t Wt = output_grad_shape[-1] / constants::TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
@@ -21,8 +21,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
 
     auto& output_grad = tensor_args.output_grad;
 
-    const auto& bias_grad_shape = bias_grad.get_legacy_shape().without_padding();
-    const auto& output_grad_shape_wo_padding = output_grad.get_legacy_shape().without_padding();
+    const auto& output_grad_shape_wo_padding = output_grad.get_logical_shape();
 
     auto bias_grad_memory_config = operation_attributes.bias_grad_memory_config;
     auto compute_kernel_config = operation_attributes.compute_kernel_config;
@@ -34,7 +33,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
     const uint32_t mask_w =
         do_mask_w ? output_grad_shape_wo_padding[-1] % constants::TILE_WIDTH : constants::TILE_WIDTH;
 
-    const auto& output_grad_shape = output_grad.get_legacy_shape();
+    const auto& output_grad_shape = output_grad.get_padded_shape();
     uint32_t batch_num = output_grad.volume() / output_grad_shape[-2] / output_grad_shape[-1];
     uint32_t Ht = output_grad_shape[-2] / constants::TILE_HEIGHT;
     uint32_t Wt = output_grad_shape[-1] / constants::TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
@@ -18,7 +18,7 @@ std::tuple<bool, bool, bool> MorehLinearBackward::get_required_outputs(const std
     return {are_required_outputs[0], are_required_outputs[1], are_required_outputs[2]};
 }
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const tt::tt_metal::LegacyShape& shape) {
+void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -61,8 +61,7 @@ inline void moreh_linear_backward_validate(
     }
 }
 
-ttnn::SmallVector<int64_t> find_reduce_dim(
-    const tt::tt_metal::LegacyShape& a_shape, const tt::tt_metal::LegacyShape& b_shape) {
+ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::SimpleShape& a_shape, const ttnn::SimpleShape& b_shape) {
     ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
@@ -84,8 +83,8 @@ ttnn::SmallVector<int64_t> find_reduce_dim(
 
 bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     // check batch dims
-    const auto& a_shape = tensor_a.get_shape().value;
-    const auto& b_shape = tensor_b.get_shape().value;
+    const auto& a_shape = tensor_a.get_padded_shape();
+    const auto& b_shape = tensor_b.get_padded_shape();
     ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
@@ -164,7 +163,7 @@ std::vector<std::optional<Tensor>> MorehLinearBackward::invoke(
                 compute_kernel_config);
             TT_FATAL(weight_grad.has_value(), "weight_grad tensor should not be std::nullopt");
             ttnn::SmallVector<int64_t> dims =
-                find_reduce_dim(temp_weight_grad.get_legacy_shape(), weight_grad.value().get_legacy_shape());
+                find_reduce_dim(temp_weight_grad.get_padded_shape(), weight_grad.value().get_padded_shape());
             ttnn::moreh_sum(
                 temp_weight_grad, dims, true, weight_grad.value(), weight_grad_memory_config, compute_kernel_config);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -29,14 +29,12 @@ void MorehMatmulOperation::validate_inputs(
     check_tensor(bias, "moreh_matmul", "bias", {DataType::BFLOAT16});
 
     // check matrix dims
-    const auto& input_shape = input.get_shape().value.without_padding();
-    const auto& other_shape = other.get_shape().value.without_padding();
-    const auto& input_wo_shape = input_shape.without_padding();
-    const auto& other_wo_shape = other_shape.without_padding();
-    uint32_t input_m = (transpose_input) ? (input_wo_shape[-1]) : (input_wo_shape[-2]);
-    uint32_t input_k = (transpose_input) ? (input_wo_shape[-2]) : (input_wo_shape[-1]);
-    uint32_t other_k = (transpose_other) ? (other_wo_shape[-1]) : (other_wo_shape[-2]);
-    uint32_t other_n = (transpose_other) ? (other_wo_shape[-2]) : (other_wo_shape[-1]);
+    const auto& input_shape = input.get_logical_shape();
+    const auto& other_shape = other.get_logical_shape();
+    uint32_t input_m = (transpose_input) ? (input_shape[-1]) : (input_shape[-2]);
+    uint32_t input_k = (transpose_input) ? (input_shape[-2]) : (input_shape[-1]);
+    uint32_t other_k = (transpose_other) ? (other_shape[-1]) : (other_shape[-2]);
+    uint32_t other_n = (transpose_other) ? (other_shape[-2]) : (other_shape[-1]);
 
     TT_FATAL(input_k == other_k, "k must be the same. input_k {}, other_k {}", input_k, other_k);
 
@@ -58,10 +56,9 @@ void MorehMatmulOperation::validate_inputs(
 
     // check output dims
     if (output.has_value()) {
-        const auto& output_shape = output.value().get_legacy_shape().without_padding();
-        const auto& output_wo_shape = output_shape.without_padding();
-        uint32_t output_m = output_wo_shape[-2];
-        uint32_t output_n = output_wo_shape[-1];
+        const auto& output_shape = output.value().get_logical_shape();
+        uint32_t output_m = output_shape[-2];
+        uint32_t output_n = output_shape[-1];
         TT_FATAL(input_m == output_m, "m must be the same. input_m {}, output_m {}", input_m, output_m);
         TT_FATAL(other_n == output_n, "n must be the same. other_n {}, output_n {}", other_n, output_n);
 
@@ -80,7 +77,7 @@ void MorehMatmulOperation::validate_inputs(
 
     // check bias size
     if (bias.has_value()) {
-        const auto& bias_wo_shape = bias.value().get_legacy_shape().without_padding();
+        const auto& bias_wo_shape = bias.value().get_logical_shape();
         uint32_t bias_rank = bias_wo_shape.rank();
         uint32_t bias_w = bias_wo_shape[-1];
         TT_FATAL(bias_rank == 2, "bias rank {} must be 2 (tilized).", bias_rank);
@@ -119,12 +116,12 @@ MorehMatmulOperation::program_factory_t MorehMatmulOperation::select_program_fac
 
 MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_shape = tensor_args.input.get_shape().value;
-    const auto& other_shape = tensor_args.other.get_shape().value;
+    const auto& input_shape = tensor_args.input.get_padded_shape();
+    const auto& other_shape = tensor_args.other.get_padded_shape();
     bool transpose_input = operation_attributes.transpose_input;
     bool transpose_other = operation_attributes.transpose_other;
-    const auto& input_shape_wo_padding = input_shape.without_padding();
-    const auto& other_shape_wo_padding = other_shape.without_padding();
+    const auto& input_shape_wo_padding = tensor_args.input.get_logical_shape();
+    const auto& other_shape_wo_padding = tensor_args.other.get_logical_shape();
 
     auto h = (transpose_input) ? (input_shape[-1]) : (input_shape[-2]);
     auto w = (transpose_other) ? (other_shape[-2]) : (other_shape[-1]);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
@@ -74,9 +74,8 @@ struct MorehMatmulOperation {
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const tt::tt_metal::LegacyShape& shape);
-ttnn::SmallVector<int64_t> find_reduce_dim(
-    const tt::tt_metal::LegacyShape& a_shape, const tt::tt_metal::LegacyShape& b_shape);
+void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape& shape);
+ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::SimpleShape& a_shape, const ttnn::SimpleShape& b_shape);
 bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b);
 
 }  // namespace ttnn::operations::moreh::moreh_matmul

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -9,7 +9,7 @@
 
 namespace ttnn::operations::moreh::moreh_matmul {
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const tt::tt_metal::LegacyShape& shape) {
+void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -28,8 +28,7 @@ void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const tt::tt_metal::Legacy
     }
 }
 
-ttnn::SmallVector<int64_t> find_reduce_dim(
-    const tt::tt_metal::LegacyShape& a_shape, const tt::tt_metal::LegacyShape& b_shape) {
+ttnn::SmallVector<int64_t> find_reduce_dim(const ttnn::SimpleShape& a_shape, const ttnn::SimpleShape& b_shape) {
     ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
@@ -51,8 +50,8 @@ ttnn::SmallVector<int64_t> find_reduce_dim(
 
 bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b) {
     // check batch dims
-    const auto& a_shape = tensor_a.get_shape().value;
-    const auto& b_shape = tensor_b.get_shape().value;
+    const auto& a_shape = tensor_a.get_padded_shape();
+    const auto& b_shape = tensor_b.get_padded_shape();
     ttnn::SmallVector<uint32_t> a_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     ttnn::SmallVector<uint32_t> b_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(a_dim, a_shape);
@@ -136,9 +135,8 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     const auto num_output_tiles{output.volume() / tt::constants::TILE_HW};
 
     // input tensor
-    const auto& input_shape = input.get_shape().value;
-    const auto& input_shape_wo_padding = input_shape.without_padding();
-    const auto input_rank = input_shape.rank();
+    const auto& input_shape = input.get_padded_shape();
+    const auto& input_shape_wo_padding = input.get_logical_shape();
     log_debug(tt::LogOp, "input dim");
     ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(input_dim, input_shape);
@@ -148,9 +146,8 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     get_tensor_stride(input_stride, input_dim);
 
     // other tensor
-    const auto& other_shape = other.get_shape().value;
-    const auto& other_shape_wo_padding = other_shape.without_padding();
-    const auto other_rank = other_shape.rank();
+    const auto& other_shape = other.get_padded_shape();
+    const auto& other_shape_wo_padding = other.get_logical_shape();
     log_debug(tt::LogOp, "other dim");
     ttnn::SmallVector<uint32_t> other_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(other_dim, other_shape);
@@ -165,9 +162,7 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     get_not_bcast(input_not_bcast, input_dim, other_not_bcast, other_dim);
 
     // output tensor
-    const auto& output_shape = output.get_shape().value;
-    const auto& output_shape_wo_padding = output_shape.without_padding();
-    const auto output_rank = output_shape.rank();
+    const auto& output_shape = output.get_padded_shape();
     log_debug(tt::LogOp, "output dim");
     ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
     get_tensor_dim(output_dim, output_shape);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.cpp
@@ -12,7 +12,7 @@ namespace ttnn::operations::moreh::moreh_matmul {
 
 inline bool is_dot_forward(const Tensor& input, const Tensor& other, bool transpose_input, bool transpose_other) {
     // TODO: non-4d support for dot.
-    if (input.get_legacy_shape().rank() != 4 || other.get_legacy_shape().rank() != 4) {
+    if (input.get_padded_shape().rank() != 4 || other.get_padded_shape().rank() != 4) {
         return false;
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -14,41 +14,34 @@
 
 using namespace tt::tt_metal;
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const tt::tt_metal::LegacyShape& shape) {
+void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
 
         // last 2-dim
         if (idx == rank - 1 || idx == rank - 2) {
-            dim[i] = shape[idx] / tt::constants::TILE_HEIGHT;
+            dim[i] = (shape[idx] + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
         } else {
             dim[i] = shape[idx];
         }
     }
 }
 
-tt::tt_metal::LegacyShape get_output_grad_shape(
+ttnn::SimpleShape get_output_grad_shape(
     const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim) {
     if (keepdim) {
-        return output_grad.get_shape().value;
+        return output_grad.get_logical_shape();
     }
 
-    auto shape = input_grad.get_shape();
+    auto shape = input_grad.get_logical_shape();
     auto rank = shape.rank();
-    auto padding = shape.value.padding();
     for (auto dim : dims) {
         TT_FATAL(dim < rank, "dim {} < rank {}", dim, rank);
-        bool is_tile_dim = (dim == rank - 1 || dim == rank - 2);
-        if (is_tile_dim) {
-            shape.value[dim] = tt::constants::TILE_HEIGHT;
-            padding[dim] = Padding::PadDimension{0, 31};
-        } else {
-            shape.value[dim] = 1;
-        }
+        shape[dim] = 1;
     }
 
-    return tt::tt_metal::LegacyShape(shape.value, padding);
+    return shape;
 }
 
 namespace ttnn::operations::moreh::moreh_mean_backward {
@@ -76,14 +69,12 @@ MorehMeanBackwardOperation::MorehMeanBackwardFactory::create(
     const auto cb_data_format = datatype_to_dataformat_converter(output_grad.get_dtype());
     const auto single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
 
-    const auto& input_grad_shape = input_grad.get_legacy_shape();
-    const auto& input_grad_shape_wo_padding = input_grad_shape.without_padding();
+    const auto& input_grad_shape = input_grad.get_logical_shape();
     const uint32_t input_grad_rank = input_grad_shape.rank();
 
     ttnn::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
     get_tensor_dim(input_grad_dim, input_grad_shape);
     const auto& output_grad_shape = get_output_grad_shape(output_grad, input_grad, dims, keepdim);
-    const auto& output_grad_shape_wo_padding = output_grad_shape.without_padding();
 
     ttnn::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
     get_tensor_dim(output_grad_dim, output_grad_shape);
@@ -94,7 +85,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardFactory::create(
         bool is_tile_dim = (idx == input_grad_rank - 1 || idx == input_grad_rank - 2);
 
         if (is_tile_dim) {
-            need_bcast_dim[i] = (output_grad_shape_wo_padding[idx] != input_grad_shape_wo_padding[idx]);
+            need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);
         } else {
             need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);
         }
@@ -177,7 +168,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardFactory::create(
     ////////////////////////////////////////////////////////////////////////////
     uint32_t num_dim = 1;
     for (auto dim : dims) {
-        num_dim *= input_grad_shape_wo_padding[dim];
+        num_dim *= input_grad_shape[dim];
     }
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
@@ -20,7 +20,7 @@ std::tuple<uint32_t, float, bool> get_floored_p_and_decimal_and_p_is_negative(fl
 }
 
 inline void validate_input_tensor_with_dim(const Tensor& input, int64_t dim) {
-    const auto input_rank = input.get_legacy_shape().rank();
+    const auto input_rank = input.get_padded_shape().rank();
     TT_FATAL(
         (dim >= 0 && dim <= tt::tt_metal::MAX_NUM_DIMENSIONS),
         "dim must be between 0 and {}.",
@@ -110,7 +110,7 @@ void MorehNormOperation::validate_inputs(
 MorehNormOperation::program_factory_t MorehNormOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto dim = operation_attributes.dim;
-    const auto input_rank = tensor_args.input.get_legacy_shape().rank();
+    const auto input_rank = tensor_args.input.get_padded_shape().rank();
     auto INF = std::numeric_limits<float>::infinity();
     if (dim == input_rank - 1) {
         return ProgramFactoryWOther{};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_h_other.cpp
@@ -23,7 +23,7 @@ MorehNormOperation::ProgramFactoryHOther::cached_program_t MorehNormOperation::P
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto input_shape = input.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
     const auto input_rank = input_shape.rank();
 
     const auto H = input_shape[-2];
@@ -34,7 +34,7 @@ MorehNormOperation::ProgramFactoryHOther::cached_program_t MorehNormOperation::P
 
     const auto num_units = input.volume() / H / W * Wt;
 
-    const auto origin_h = input_shape.without_padding()[-2];
+    const auto origin_h = input.get_logical_shape()[-2];
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_nc_other.cpp
@@ -24,7 +24,7 @@ MorehNormOperation::ProgramFactoryNCOther::cached_program_t MorehNormOperation::
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto input_shape = input.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
     const auto input_rank = static_cast<decltype(dim)>(input_shape.rank());
 
     const auto H = input_shape[-2];

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_program_factory_w_other.cpp
@@ -25,7 +25,7 @@ MorehNormOperation::ProgramFactoryWOther::cached_program_t MorehNormOperation::P
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto input_shape = input.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
     const auto input_rank = input_shape.rank();
 
     const auto H = input_shape[-2];
@@ -36,7 +36,7 @@ MorehNormOperation::ProgramFactoryWOther::cached_program_t MorehNormOperation::P
 
     const auto num_units = input.volume() / H / W * Ht;
 
-    const auto origin_w = input_shape.without_padding()[input_rank - 1];
+    const auto origin_w = input.get_logical_shape()[input_rank - 1];
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.cpp
@@ -18,7 +18,7 @@ Tensor MorehNorm::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     if (!dim.has_value()) {
-        ttnn::SmallVector<int64_t> dims(input.get_legacy_shape().rank());
+        ttnn::SmallVector<int64_t> dims(input.get_padded_shape().rank());
         std::iota(dims.begin(), dims.end(), 0);
         dim = std::make_optional(dims);
     }
@@ -35,7 +35,7 @@ Tensor MorehNorm::invoke(
 
     auto dims = std::get<ttnn::SmallVector<int64_t>>(dim.value());
     if (dims.empty()) {
-        ttnn::SmallVector<int64_t> all_dims(input.get_legacy_shape().rank());
+        ttnn::SmallVector<int64_t> all_dims(input.get_padded_shape().rank());
         std::iota(all_dims.begin(), all_dims.end(), 0);
         dims = all_dims;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
@@ -64,7 +64,7 @@ MorehNormBackwardOperation::invoke(
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    ttnn::SmallVector<int64_t> dims = get_dim(dim, input.get_legacy_shape().rank());
+    ttnn::SmallVector<int64_t> dims = get_dim(dim, input.get_padded_shape().rank());
     std::sort(dims.begin(), dims.end());
     return {
         operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
@@ -30,8 +30,8 @@
 namespace ttnn::operations::moreh::moreh_norm_backward {
 
 std::tuple<uint32_t, float, bool> get_floored_p_and_decimal_and_p_is_negative(float p);
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const Shape& shape);
-tt::tt_metal::LegacyShape get_output_grad_shape(
+void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape& shape);
+ttnn::SimpleShape get_output_grad_shape(
     const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim);
 
 struct MorehNormBackwardOperation {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -18,38 +18,31 @@ std::tuple<uint32_t, float, bool> get_floored_p_and_decimal_and_p_is_negative(fl
     return std::make_tuple(static_cast<uint32_t>(floored_p), decimal, p_is_negative);
 }
 
-void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const tt::tt_metal::LegacyShape& shape) {
+void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::SimpleShape& shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
         if (idx == rank - 1 || idx == rank - 2) {
-            dim[i] = shape[idx] / tt::constants::TILE_HEIGHT;
+            dim[i] = (shape[idx] + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
         } else {
             dim[i] = shape[idx];
         }
     }
 }
 
-tt::tt_metal::LegacyShape get_output_grad_shape(
+ttnn::SimpleShape get_output_grad_shape(
     const Tensor& output_grad, const Tensor& input_grad, const ttnn::SmallVector<int64_t>& dims, const bool& keepdim) {
     if (keepdim) {
-        return output_grad.get_legacy_shape();
+        return output_grad.get_logical_shape();
     }
 
-    auto shape = input_grad.get_legacy_shape();
+    auto shape = input_grad.get_logical_shape();
     auto rank = shape.rank();
-    auto padding = shape.padding();
     for (auto dim : dims) {
         TT_FATAL(dim < rank, "dim {} < rank {}", dim, rank);
-        bool is_tile_dim = (dim == rank - 1 || dim == rank - 2);
-        if (is_tile_dim) {
-            shape[dim] = tt::constants::TILE_HEIGHT;
-            padding[dim] = Padding::PadDimension{0, 31};
-        } else {
-            shape[dim] = 1;
-        }
+        shape[dim] = 1;
     }
-    return tt::tt_metal::LegacyShape(shape, padding);
+    return shape;
 }
 
 MorehNormBackwardOperation::ProgramFactory::cached_program_t MorehNormBackwardOperation::ProgramFactory::create(
@@ -69,15 +62,13 @@ MorehNormBackwardOperation::ProgramFactory::cached_program_t MorehNormBackwardOp
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto& input_grad_shape = input_grad.get_legacy_shape();
-    const auto& input_grad_shape_wo_padding = input_grad_shape.without_padding();
+    const auto& input_grad_shape = input_grad.get_logical_shape();
     const auto input_grad_rank = input_grad_shape.rank();
 
     ttnn::SmallVector<uint32_t> input_grad_dim(input_grad_rank, 1);
     get_tensor_dim(input_grad_dim, input_grad_shape);
-    tt::tt_metal::LegacyShape output_grad_shape =
+    auto output_grad_shape =
         get_output_grad_shape(output_grad, input_grad, operation_attributes.dims, operation_attributes.keepdim);
-    const auto output_grad_shape_wo_padding = output_grad_shape.without_padding();
 
     ttnn::SmallVector<uint32_t> output_grad_dim(input_grad_rank, 1);
     get_tensor_dim(output_grad_dim, output_grad_shape);
@@ -88,7 +79,7 @@ MorehNormBackwardOperation::ProgramFactory::cached_program_t MorehNormBackwardOp
         bool is_tile_dim = (idx == input_grad_rank - 1 || idx == input_grad_rank - 2);
 
         if (is_tile_dim) {
-            need_bcast_dim[i] = (output_grad_shape_wo_padding[idx] != input_grad_shape_wo_padding[idx]);
+            need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);
         } else {
             need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
@@ -15,7 +15,7 @@ Tensor MorehSum::invoke(
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    ttnn::SmallVector<int64_t> dims = get_dim(dim, input.get_legacy_shape().rank());
+    ttnn::SmallVector<int64_t> dims = get_dim(dim, input.get_padded_shape().rank());
     std::sort(dims.begin(), dims.end());
 
     auto temp_input = input;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -26,10 +26,10 @@ void MorehSumBackwardOperation::validate_inputs(
     }
 
     check_tensor(input, "moreh_sum_backward", "input");
-    const auto& input_shape = input.value().get_legacy_shape();
-    auto input_shape_wo_padding = input_shape.without_padding();
+    const auto& input_shape = input.value().get_padded_shape();
+    auto input_shape_wo_padding = input.value().get_logical_shape();
     auto input_rank = input_shape.rank();
-    auto output_grad_shape_wo_padding = output_grad.get_legacy_shape().without_padding();
+    auto output_grad_shape_wo_padding = output_grad.get_logical_shape();
 
     // validate output_grad shape
     if (keepdim) {
@@ -76,7 +76,7 @@ void MorehSumBackwardOperation::validate_inputs(
 
     // validate input_grad shape
     if (input_grad.has_value()) {
-        const auto& input_grad_shape = input_grad.value().get_legacy_shape();
+        const auto& input_grad_shape = input_grad.value().get_padded_shape();
         TT_FATAL(input_shape == input_grad_shape, "both shape between input and input_grad should be the same");
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
@@ -28,23 +28,23 @@ void GroupNorm::validate(
     TT_FATAL(a.get_dtype() == DataType::BFLOAT16, "Error");
     TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-    TT_FATAL(a.get_legacy_shape()[3] % this->num_groups == 0, "channel must be divisible by num_groups!");
-    TT_FATAL(a.get_legacy_shape()[1] == 1, "input tensor shape[1] must be 1!");
+    TT_FATAL(a.get_padded_shape()[3] % this->num_groups == 0, "channel must be divisible by num_groups!");
+    TT_FATAL(a.get_padded_shape()[1] == 1, "input tensor shape[1] must be 1!");
 
     if (gamma.has_value()) {
         if (gamma.value().get_layout() == Layout::TILE) {
             TT_FATAL(
-                a.get_legacy_shape()[3] == gamma.value().get_legacy_shape()[3],
+                a.get_padded_shape()[3] == gamma.value().get_padded_shape()[3],
                 "{} != {}",
-                a.get_legacy_shape()[3],
-                gamma.value().get_legacy_shape()[3]);
+                a.get_padded_shape()[3],
+                gamma.value().get_padded_shape()[3]);
             TT_FATAL(a.device() == gamma.value().device(), "Error");
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(gamma.value().get_legacy_shape()[2] == TILE_HEIGHT, "Error");
+            TT_FATAL(gamma.value().get_padded_shape()[2] == TILE_HEIGHT, "Error");
         } else {
             TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR, "Error");
-            TT_FATAL((gamma.value().get_legacy_shape()[3] == TILE_WIDTH), "Error");
+            TT_FATAL((gamma.value().get_padded_shape()[3] == TILE_WIDTH), "Error");
             TT_FATAL(a.device() == gamma.value().device(), "Error");
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -57,14 +57,14 @@ void GroupNorm::validate(
 
     if (beta.has_value()) {
         if (beta.value().get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[3] == beta.value().get_legacy_shape()[3], "Error");
+            TT_FATAL(a.get_padded_shape()[3] == beta.value().get_padded_shape()[3], "Error");
             TT_FATAL(a.device() == beta.value().device(), "Error");
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(beta.value().get_legacy_shape()[2] == TILE_HEIGHT, "Error");
+            TT_FATAL(beta.value().get_padded_shape()[2] == TILE_HEIGHT, "Error");
         } else {
             TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR, "Error");
-            TT_FATAL(beta.value().get_legacy_shape()[3] == TILE_WIDTH, "Error");
+            TT_FATAL(beta.value().get_padded_shape()[3] == TILE_WIDTH, "Error");
             TT_FATAL(a.device() == beta.value().device(), "Error");
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -74,9 +74,9 @@ void GroupNorm::validate(
 
     if (input_mask.has_value()) {
         TT_FATAL(input_mask.value().get_layout() == Layout::TILE, "Error");
-        TT_FATAL(input_mask.value().get_legacy_shape()[1] == this->num_groups, "Error");
-        TT_FATAL(input_mask.value().get_legacy_shape()[2] == TILE_HEIGHT, "Error");
-        TT_FATAL(input_mask.value().get_legacy_shape()[3] % TILE_WIDTH == 0, "Error");
+        TT_FATAL(input_mask.value().get_padded_shape()[1] == this->num_groups, "Error");
+        TT_FATAL(input_mask.value().get_padded_shape()[2] == TILE_HEIGHT, "Error");
+        TT_FATAL(input_mask.value().get_padded_shape()[3] % TILE_WIDTH == 0, "Error");
     }
 }
 std::vector<TensorSpec> GroupNorm::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
@@ -112,7 +112,7 @@ operation::ProgramWithCallbacks GroupNorm::create_program(
     uint32_t num_cores_y = this->program_config.compute_with_storage_grid_size.y;
     bool inplace = this->program_config.inplace;
     CoreCoord grid_size = CoreCoord(num_cores_x, num_cores_y);
-    uint32_t batch = a.get_legacy_shape()[0];
+    uint32_t batch = a.get_padded_shape()[0];
 
     return groupnorm_multi_core_sharded(
         a,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -141,7 +141,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         TT_ASSERT(beta.value().get_layout() == Layout::ROW_MAJOR);
     }
 
-    bool is_height_sharding = a.get_legacy_shape()[3] == a.shard_spec().value().shape[1];
+    bool is_height_sharding = a.get_padded_shape()[3] == a.shard_spec().value().shape[1];
     // convert data format
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
@@ -176,7 +176,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     bool tilize_in = a.get_layout() == Layout::ROW_MAJOR;
     bool untilize_out = output.get_layout() == Layout::ROW_MAJOR;
     // tensor shape
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t H = shape[2] * num_batches;
     uint32_t Ht = H / TILE_HEIGHT;
     uint32_t W = shape[3];
@@ -293,7 +293,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
 
     if (input_mask.has_value()) {
         TT_ASSERT(
-            input_mask.value().get_legacy_shape()[3] == block_wt * TILE_WIDTH &&
+            input_mask.value().get_padded_shape()[3] == block_wt * TILE_WIDTH &&
             "input mask must have the same width as block_wt");
     }
 
@@ -548,7 +548,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         (std::uint32_t)block_wt};
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[3] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_padded_shape()[3] * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         if (gamma_stick_size_is_power_of_two) {
@@ -559,7 +559,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
             writer_mcast_sender_compile_time_args.push_back(gamma_stick_size);
         }
     } else if (beta.has_value() and beta.value().get_layout() == Layout::ROW_MAJOR) {
-        auto beta_stick_size = beta.value().get_legacy_shape()[3] * beta.value().element_size();
+        auto beta_stick_size = beta.value().get_padded_shape()[3] * beta.value().element_size();
         bool beta_stick_size_is_power_of_two = is_power_of_two_at_least_32(beta_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);
         if (beta_stick_size_is_power_of_two) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -39,7 +39,7 @@ void LayerNorm::validate(
 
     if (b.has_value()) {
         TT_FATAL(b.value().get_layout() == Layout::TILE, "layot is not tile!");
-        TT_FATAL(a.get_legacy_shape() == b.value().get_legacy_shape(), "shape is not same!");
+        TT_FATAL(a.get_padded_shape() == b.value().get_padded_shape(), "shape is not same!");
         TT_FATAL(b.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         TT_FATAL(a.device() == b.value().device(), "device is not same!");
     }
@@ -47,19 +47,19 @@ void LayerNorm::validate(
     if (gamma.has_value()) {
         if (gamma.value().get_layout() == Layout::TILE) {
             TT_FATAL(
-                a.get_legacy_shape()[-1] == gamma.value().get_legacy_shape()[-1],
+                a.get_padded_shape()[-1] == gamma.value().get_padded_shape()[-1],
                 "{} != {}",
-                a.get_legacy_shape()[-1],
-                gamma.value().get_legacy_shape()[-1]);
+                a.get_padded_shape()[-1],
+                gamma.value().get_padded_shape()[-1]);
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == gamma.value().device(), "Error");
-            TT_FATAL(gamma.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(gamma.value().get_padded_shape()[-2] == TILE_HEIGHT, "Error");
         } else {
             TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(
-                (gamma.value().get_legacy_shape()[-1] == TILE_WIDTH &&
-                 gamma.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH),
+                (gamma.value().get_padded_shape()[-1] == TILE_WIDTH &&
+                 gamma.value().volume() / TILE_WIDTH == a.get_padded_shape()[-1] / TILE_WIDTH),
                 "Error");
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -76,16 +76,16 @@ void LayerNorm::validate(
 
     if (beta.has_value()) {
         if (beta.value().get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[-1] == beta.value().get_legacy_shape()[-1], "Error");
+            TT_FATAL(a.get_padded_shape()[-1] == beta.value().get_padded_shape()[-1], "Error");
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == beta.value().device(), "Error");
-            TT_FATAL(beta.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(beta.value().get_padded_shape()[-2] == TILE_HEIGHT, "Error");
         } else {
             TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(
-                (beta.value().get_legacy_shape()[-1] == TILE_WIDTH &&
-                 beta.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH),
+                (beta.value().get_padded_shape()[-1] == TILE_WIDTH &&
+                 beta.value().volume() / TILE_WIDTH == a.get_padded_shape()[-1] / TILE_WIDTH),
                 "Error");
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -110,10 +110,10 @@ void LayerNorm::validate(
     }
     if (this->distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER ||
         this->distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER) {
-        TT_FATAL(a.get_legacy_shape()[-2] == TILE_HEIGHT, "Only activations with batch size = 32 are supported");
+        TT_FATAL(a.get_padded_shape()[-2] == TILE_HEIGHT, "Only activations with batch size = 32 are supported");
         if (b.has_value()) {
             TT_FATAL(
-                b.value().get_legacy_shape()[-2] == TILE_HEIGHT,
+                b.value().get_padded_shape()[-2] == TILE_HEIGHT,
                 "Only residual tensors with batch size = 32 are supported");
         }
     }
@@ -129,11 +129,11 @@ void LayerNorm::validate(
         TT_FATAL(stats.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         if (this->norm_type == LayerNormType::LAYERNORM) {
             TT_FATAL(
-                stats.value().get_legacy_shape()[-1] % (2 * TILE_WIDTH) == 0,
+                stats.value().get_padded_shape()[-1] % (2 * TILE_WIDTH) == 0,
                 "Stats is expected to have E(x) and E(x^2) for each device stacked interleaved in the last dimension");
         } else {
             TT_FATAL(
-                stats.value().get_legacy_shape()[-1] % TILE_WIDTH == 0,
+                stats.value().get_padded_shape()[-1] % TILE_WIDTH == 0,
                 "Stats is expected to have E(x) for each device stacked in the last dimension");
         }
     }
@@ -148,7 +148,7 @@ void LayerNorm::validate(
                 TT_FATAL(a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
 
                 // tensor shape
-                const auto shape = a.get_legacy_shape();
+                const auto shape = a.get_padded_shape();
                 uint32_t M = a.volume() / shape[-1];
                 uint32_t K = shape[-1];
                 uint32_t Mt = M / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
     DeviceComputeKernelConfig compute_kernel_config) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     bool rms_norm = norm_type == LayerNormType::RMSNORM;
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t W = shape[-1], H = shape[-2];
     uint32_t HW = H * W;
     uint32_t NC = a.volume() / HW;
@@ -216,7 +216,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
                                                       (std::uint32_t)block_size};
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[-1] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_padded_shape()[-1] * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         reader_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         if (gamma_stick_size_is_power_of_two) {
@@ -227,7 +227,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
             reader_compile_time_args.push_back(gamma_stick_size);
         }
     } else if (beta.has_value() and beta.value().get_layout() == Layout::ROW_MAJOR) {
-        auto beta_stick_size = beta.value().get_legacy_shape()[-1] * beta.value().element_size();
+        auto beta_stick_size = beta.value().get_padded_shape()[-1] * beta.value().element_size();
         bool beta_stick_size_is_power_of_two = is_power_of_two_at_least_32(beta_stick_size);
         reader_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);
         if (beta_stick_size_is_power_of_two) {
@@ -541,7 +541,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     tt::log_debug("fp32_dest_acc_en: {}", fp32_dest_acc_en);
 
     // tensor shape
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t M = a.volume() / shape[-1];
     uint32_t K = shape[-1];
     uint32_t Mt = M / TILE_WIDTH;
@@ -623,7 +623,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     uint32_t post_all_gather_stats_block_tiles = 1;
     uint32_t num_distributed_devices = 1;
     if (is_post_all_gather && stats.has_value()) {
-        post_all_gather_stats_block_tiles = stats.value().get_legacy_shape()[-1] / TILE_WIDTH;
+        post_all_gather_stats_block_tiles = stats.value().get_padded_shape()[-1] / TILE_WIDTH;
         num_distributed_devices = post_all_gather_stats_block_tiles / pre_all_gather_stats_block_tiles;
     }
 
@@ -1032,7 +1032,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         (std::uint32_t)block_wt};
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[-1] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_padded_shape()[-1] * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         writer_mcast_receiver_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
@@ -1046,7 +1046,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             writer_mcast_receiver_compile_time_args.push_back(gamma_stick_size);
         }
     } else if (beta.has_value() and beta.value().get_layout() == Layout::ROW_MAJOR) {
-        auto beta_stick_size = beta.value().get_legacy_shape()[-1] * beta.value().element_size();
+        auto beta_stick_size = beta.value().get_padded_shape()[-1] * beta.value().element_size();
         bool beta_stick_size_is_power_of_two = is_power_of_two_at_least_32(beta_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);
         writer_mcast_receiver_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -39,10 +39,10 @@ void LayerNormPostAllGather::validate(
     }
 
     // stats has 2 or 1 tile columns per device if layernorm or rmsnorm
-    TT_FATAL(stats.get_legacy_shape()[-1] % TILE_WIDTH == 0, "Error");
-    TT_FATAL(stats.get_legacy_shape()[0] == a.get_legacy_shape()[0], "Error");
-    TT_FATAL(stats.get_legacy_shape()[1] == a.get_legacy_shape()[1], "Error");
-    TT_FATAL(stats.get_legacy_shape()[2] == a.get_legacy_shape()[2], "Error");
+    TT_FATAL(stats.get_padded_shape()[-1] % TILE_WIDTH == 0, "Error");
+    TT_FATAL(stats.get_padded_shape()[0] == a.get_padded_shape()[0], "Error");
+    TT_FATAL(stats.get_padded_shape()[1] == a.get_padded_shape()[1], "Error");
+    TT_FATAL(stats.get_padded_shape()[2] == a.get_padded_shape()[2], "Error");
     // TODO: How to check if number of tile columns is correct? Would have to know # of devices and is_rmsnorm
 
     TT_FATAL(gamma.has_value(), "Error");
@@ -51,18 +51,18 @@ void LayerNormPostAllGather::validate(
     TT_FATAL(gamma_tensor.get_layout() == Layout::ROW_MAJOR, "Error");  // Only support packed RM right now
     if (gamma_tensor.get_layout() == Layout::TILE) {
         TT_FATAL(
-            a.get_legacy_shape()[-1] == gamma.value().get_legacy_shape()[-1],
+            a.get_padded_shape()[-1] == gamma.value().get_padded_shape()[-1],
             "{} != {}",
-            a.get_legacy_shape()[-1],
-            gamma.value().get_legacy_shape()[-1]);
+            a.get_padded_shape()[-1],
+            gamma.value().get_padded_shape()[-1]);
         TT_FATAL(gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         TT_FATAL(a.device() == gamma.value().device(), "Error");
-        TT_FATAL(gamma.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
+        TT_FATAL(gamma.value().get_padded_shape()[-2] == TILE_HEIGHT, "Error");
     } else {
         TT_FATAL(gamma_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
         TT_FATAL(
-            (gamma_tensor.get_legacy_shape()[-1] == TILE_WIDTH &&
-             gamma_tensor.volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH),
+            (gamma_tensor.get_padded_shape()[-1] == TILE_WIDTH &&
+             gamma_tensor.volume() / TILE_WIDTH == a.get_padded_shape()[-1] / TILE_WIDTH),
             "Error");
         TT_FATAL(gamma_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         TT_FATAL(a.device() == gamma_tensor.device(), "Error");
@@ -77,16 +77,16 @@ void LayerNormPostAllGather::validate(
         TT_FATAL(gamma_tensor.get_layout() == beta_tensor.get_layout(), "Gamma and beta must have the same layout!");
         TT_FATAL(beta_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
         if (beta_tensor.get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[-1] == beta_tensor.get_legacy_shape()[-1], "Error");
+            TT_FATAL(a.get_padded_shape()[-1] == beta_tensor.get_padded_shape()[-1], "Error");
             TT_FATAL(
                 beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == beta_tensor.device(), "Error");
-            TT_FATAL(beta.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
+            TT_FATAL(beta.value().get_padded_shape()[-2] == TILE_HEIGHT, "Error");
         } else {
             TT_FATAL(beta_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(
-                (beta_tensor.get_legacy_shape()[-1] == TILE_WIDTH &&
-                 beta_tensor.volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH),
+                (beta_tensor.get_padded_shape()[-1] == TILE_WIDTH &&
+                 beta_tensor.volume() / TILE_WIDTH == a.get_padded_shape()[-1] / TILE_WIDTH),
                 "Error");
             TT_FATAL(
                 beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
     ttnn::DeviceComputeKernelConfig compute_kernel_config) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const bool is_rmsnorm = norm_type == LayerNormDistributedType::RMSNORM;
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     const uint32_t W = shape[-1], H = shape[-2];
     const uint32_t HW = H * W;
     const uint32_t NC = a.volume() / HW;
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
 
     const uint32_t Wt = W / TILE_WIDTH;
     const uint32_t Ht = H / TILE_HEIGHT;
-    const uint32_t stats_tiles_cols = stats.get_legacy_shape()[-1] / TILE_WIDTH;
+    const uint32_t stats_tiles_cols = stats.get_padded_shape()[-1] / TILE_WIDTH;
     const uint32_t tile_cols_per_device = is_rmsnorm ? 1 : 2;
     const uint32_t num_devices = stats_tiles_cols / tile_cols_per_device;
     TT_FATAL(num_devices > 0, "Number of devices must be greater than 0");
@@ -251,7 +251,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
     };
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[-1] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_padded_shape()[-1] * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         TT_FATAL(gamma_stick_size_is_power_of_two, "Only power of 2 gammas are supported");
         reader_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -52,7 +52,7 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     DeviceComputeKernelConfig compute_kernel_config) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const bool is_rmsnorm = norm_type == LayerNormDistributedType::RMSNORM;
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     const uint32_t W = shape[-1], H = shape[-2];
     const uint32_t HW = H * W;
     const uint32_t NC = a.volume() / HW;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -40,7 +40,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     DeviceComputeKernelConfig compute_kernel_config,
     bool numeric_stable) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
-    const auto shape = input_tensor.get_legacy_shape();
+    const auto shape = input_tensor.get_padded_shape();
     uint32_t W = shape[-1], H = (input_tensor.volume() / (shape[0] * shape[-1])), NC = shape[0];
     uint32_t HW = H * W;
 
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
 
     uint32_t mask_H = H;
     if (mask.has_value()) {
-        mask_H = mask.value().get_legacy_shape()[2];
+        mask_H = mask.value().get_padded_shape()[2];
     }
     uint32_t mask_Ht = mask_H / TILE_HEIGHT;
 
@@ -158,7 +158,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     }
     if (causal_mask) {
         uint32_t num_tiles_causal_mask =
-            mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
+            mask.value().get_padded_shape()[-1] * mask.value().get_padded_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
         reader_compile_time_args.push_back(num_tiles_causal_mask);
     }
 
@@ -386,7 +386,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
             auto dst_buffer_address =
                 output_tensors.size() == 1 ? output_tensors.at(0).buffer()->address() : src_buffer_address;
 
-            const auto shape = input_tensors.at(0).get_legacy_shape();
+            const auto shape = input_tensors.at(0).get_padded_shape();
             uint32_t W = shape[-1], H = (input_tensors.at(0).volume() / (shape[0] * shape[-1])), NC = shape[0];
             uint32_t HW = H * W;
 
@@ -591,7 +591,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
 
     // tensor shape
     const auto shard_orient = input_tensor.shard_spec().value().orientation;
-    const auto shape = input_tensor.get_legacy_shape();
+    const auto shape = input_tensor.get_padded_shape();
     uint32_t M = shape[2] * shape[0];
     uint32_t K = shape[3] * shape[1];
     uint32_t Mt = M / TILE_WIDTH;
@@ -601,7 +601,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
 
     uint32_t mask_H = shape[2];
     if (mask.has_value()) {
-        mask_H = mask->get_legacy_shape()[2];
+        mask_H = mask->get_padded_shape()[2];
     }
     uint32_t mask_Ht = mask_H / TILE_HEIGHT;
     // block
@@ -682,7 +682,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     // hw_dims_only_causal_mask does not support RM Layout atm
     bool use_row_major_kernel = (mask.has_value() and mask->get_layout() == Layout::ROW_MAJOR);
     if (use_row_major_kernel) {
-        auto mask_stick_size = mask->get_legacy_shape()[3] * mask->element_size();
+        auto mask_stick_size = mask->get_padded_shape()[3] * mask->element_size();
         bool mask_stick_size_is_power_of_two = is_power_of_two_at_least_32(mask_stick_size);
         reader_compile_time_args.push_back((std::uint32_t)mask_stick_size_is_power_of_two);
         if (mask_stick_size_is_power_of_two) {
@@ -827,7 +827,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     uint32_t num_tiles_in_attn_mask = 0;
     uint32_t num_tiles_of_attn_mask_needed_per_core = 0;
     if (hw_dims_only_causal_mask) {
-        num_tiles_in_attn_mask = mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_HW;
+        num_tiles_in_attn_mask = mask.value().get_padded_shape()[-1] * mask.value().get_padded_shape()[-2] / TILE_HW;
         num_tiles_of_attn_mask_needed_per_core = block_ht * block_wt;
     }
     uint32_t num_cores_per_batch_index = 0;
@@ -860,11 +860,11 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
                         num_cores_per_batch_index = 0;
                         if (mask.has_value()) {
                             if (causal_mask) {
-                                mask_start_tile_id += mask->get_legacy_shape()[-1] * mask->get_legacy_shape()[-2] /
+                                mask_start_tile_id += mask->get_padded_shape()[-1] * mask->get_padded_shape()[-2] /
                                                       TILE_WIDTH / TILE_HEIGHT;
                             } else {
-                                mask_start_tile_id += use_row_major_kernel ? mask->get_legacy_shape()[-2]
-                                                                           : mask->get_legacy_shape()[-1] / TILE_WIDTH;
+                                mask_start_tile_id += use_row_major_kernel ? mask->get_padded_shape()[-2]
+                                                                           : mask->get_padded_shape()[-1] / TILE_WIDTH;
                             }
                         }
                     }
@@ -899,11 +899,11 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
                         num_cores_per_batch_index = 0;
                         if (mask.has_value()) {
                             if (causal_mask) {
-                                mask_start_tile_id += mask->get_legacy_shape()[-1] * mask->get_legacy_shape()[-2] /
+                                mask_start_tile_id += mask->get_padded_shape()[-1] * mask->get_padded_shape()[-2] /
                                                       TILE_WIDTH / TILE_HEIGHT;
                             } else {
-                                mask_start_tile_id += use_row_major_kernel ? mask->get_legacy_shape()[-2]
-                                                                           : mask->get_legacy_shape()[-1] / TILE_WIDTH;
+                                mask_start_tile_id += use_row_major_kernel ? mask->get_padded_shape()[-2]
+                                                                           : mask->get_padded_shape()[-1] / TILE_WIDTH;
                             }
                         }
                     }

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_op.cpp
@@ -32,13 +32,13 @@ void Downsample::validate(const std::vector<Tensor>& input_tensors) const {
 
 std::vector<TensorSpec> Downsample::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    TT_ASSERT(input_tensor.get_legacy_shape()[0] == 1 && input_tensor.get_legacy_shape()[1] == 1);
-    uint32_t input_height = input_tensor.get_legacy_shape()[2];
+    TT_ASSERT(input_tensor.get_padded_shape()[0] == 1 && input_tensor.get_padded_shape()[1] == 1);
+    uint32_t input_height = input_tensor.get_padded_shape()[2];
     auto [img_batch_size, img_height, img_width, img_stride_h, img_stride_w] = this->downsample_params;
     TT_ASSERT(input_height >= img_batch_size * img_height * img_width);
     uint32_t output_height = img_batch_size * ceil((double)img_height / (double)img_stride_h) *
                              ceil((double)img_width / (double)img_stride_w);
-    uint32_t output_width = input_tensor.get_legacy_shape()[3];
+    uint32_t output_width = input_tensor.get_padded_shape()[3];
     auto output_shape = SimpleShape({1, 1, output_height, output_width});
 
     auto [num_cores_height_sliced, num_cores_width_sliced] = detail::get_num_cores_height_width_sliced(

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_program_factory.cpp
@@ -350,8 +350,8 @@ operation::ProgramWithCallbacks downsample_single_core(
     auto [img_batch_size, img_height, img_width, img_stride_h, img_stride_w] = downsample_params;
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
 
-    TT_ASSERT(a.get_legacy_shape()[0] == 1 && a.get_legacy_shape()[1] == 1);
-    TT_ASSERT(output.get_legacy_shape()[0] == 1 && output.get_legacy_shape()[1] == 1);
+    TT_ASSERT(a.get_padded_shape()[0] == 1 && a.get_padded_shape()[1] == 1);
+    TT_ASSERT(output.get_padded_shape()[0] == 1 && output.get_padded_shape()[1] == 1);
 
     tt::tt_metal::IDevice* device = a.device();
 
@@ -385,11 +385,11 @@ operation::ProgramWithCallbacks downsample_single_core(
     auto core_range = all_cores;
 
     uint32_t input_height =
-        a.get_legacy_shape()[2];  // input height == flattened face of input image, multiple images are stacked in H dim
-    uint32_t input_width = a.get_legacy_shape()[3];         // input width == input image # of channels
-    uint32_t output_height = output.get_legacy_shape()[2];  // output height == flattened face of output image, multiple
+        a.get_padded_shape()[2];  // input height == flattened face of input image, multiple images are stacked in H dim
+    uint32_t input_width = a.get_padded_shape()[3];         // input width == input image # of channels
+    uint32_t output_height = output.get_padded_shape()[2];  // output height == flattened face of output image, multiple
                                                             // images are stacked in H dim
-    uint32_t output_width = output.get_legacy_shape()[3];
+    uint32_t output_width = output.get_padded_shape()[3];
     TT_ASSERT(input_width == output_width);
 
     uint32_t input_height_unpadded = img_batch_size * img_height * img_width;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -43,8 +43,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     auto reader_indices_buffer = reader_indices.device_buffer();
     tt::tt_metal::Buffer* dst_dram_buffer = output.buffer();
 
-    const tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
-    const tt::tt_metal::LegacyShape output_shape = output.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
+    const auto output_shape = output.get_padded_shape();
 
     tt::DataFormat in_df = datatype_to_dataformat_converter(input.get_dtype());
     tt::DataFormat out_df = datatype_to_dataformat_converter(output.get_dtype());

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -29,7 +29,7 @@ void validate_pool2d(
     TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
     TT_FATAL(out_mem_config.is_sharded(), "Output memory config needs to be sharded");
 
-    const tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
     TT_FATAL(
         (input_shape[3] % tt::constants::TILE_WIDTH == 0) || (input_shape[3] == 16),
         "Input channels ({}) should be padded to nearest TILE_WIDTH ({}) or should be 16",
@@ -66,7 +66,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
     // NOTE: Only for RM
     // NOTE2: Assuming { N, 1, H * W, C }
     // NOTE3: Assuming output data type is same as input
-    const auto input_shape = input.get_legacy_shape();
+    const auto input_shape = input.get_padded_shape();
 
     // confirm that the output size supplied to the function matches
     uint32_t out_h = sliding_window_config.get_output_shape()[1];
@@ -97,7 +97,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
         TT_FATAL(ncores == sliding_window_config.num_cores_nhw, "Number of cores should match");
         uint32_t out_nhw_per_core = output_shape[0] * output_shape[1] * output_shape[2] / ncores;
         CoreRangeSet shard_grid = sliding_window_config.core_range_set;
-        std::array<uint32_t, 2> shard_shape = {out_nhw_per_core, input.get_legacy_shape()[-1]};
+        std::array<uint32_t, 2> shard_shape = {out_nhw_per_core, input.get_padded_shape()[-1]};
         mem_config.shard_spec = ShardSpec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -12,7 +12,7 @@ namespace tt_metal {
 template <PoolType pool>
 Tensor pool_2d(const Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& output_dtype) {
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
-    auto input_shape = input.get_legacy_shape();
+    auto input_shape = input.get_padded_shape();
     switch (pool) {
         case PoolType::AVG: {
             uint32_t height_without_padding = input.get_logical_shape()[-2];
@@ -28,14 +28,8 @@ Tensor global_avg_pool2d(
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
     auto output = input;
 
-    tt::tt_metal::LegacyShape in_shape = input.get_legacy_shape();
-    auto input_padding = in_shape.padding();
-    TT_FATAL(input_padding[1].front == 0 and input_padding[1].back == 0, "Padding along second dim is not supported");
-    auto output_padding = Padding(
-        {input_padding[0], {0, 0}, {0, input_padding[2].back * in_shape[1]}, input_padding[3]},
-        input_padding.pad_value());
-    auto output_shape =
-        tt::tt_metal::LegacyShape({in_shape[0], 1, in_shape[1] * in_shape[2], in_shape[3]}, output_padding);
+    auto in_shape = input.get_padded_shape();
+    ttnn::SimpleShape output_shape({in_shape[0], 1, in_shape[1] * in_shape[2], in_shape[3]});
     output = ttnn::experimental::view(output, output_shape);
 
     output = pool_2d<PoolType::AVG>(output, memory_config, output_dtype);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -29,9 +29,9 @@ using namespace tt;
 using sliding_window::SlidingWindowConfig;
 
 Tensor HaloTensorCreation(const Tensor& input) {
-    int batch_size = input.get_legacy_shape()[0];
-    int input_height = input.get_legacy_shape()[1];
-    int input_width = input.get_legacy_shape()[2];
+    int batch_size = input.get_padded_shape()[0];
+    int input_height = input.get_padded_shape()[1];
+    int input_width = input.get_padded_shape()[2];
     int num_cores_nhw = input.shard_spec().value().num_cores();
     int num_cores_c = 1;
 
@@ -69,23 +69,23 @@ operation::ProgramWithCallbacks bilinear_multi_core(
     Program program = CreateProgram();
     IDevice* device = input.device();
 
-    auto input_shape = input.get_legacy_shape();
-    auto output_shape = output.get_legacy_shape();
+    auto input_shape = input.get_padded_shape();
+    auto output_shape = output.get_padded_shape();
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
 
     // NOTE: input is assumed to have channels last format: {N, H, W, C}, {N, 1, H * W, C}, {1, 1, N * H * W, C}
     // NOTE: Bfp8_b/TILE is not yet supported
-    uint32_t input_stick_nbytes = input.get_legacy_shape()[-1] * input.element_size();
-    uint32_t output_stick_nbytes = output.get_legacy_shape()[-1] * output.element_size();
+    uint32_t input_stick_nbytes = input.get_padded_shape()[-1] * input.element_size();
+    uint32_t output_stick_nbytes = output.get_padded_shape()[-1] * output.element_size();
     TT_FATAL(input_stick_nbytes == output_stick_nbytes, "Input and output sticks should have same size");
 
-    uint32_t output_nsticks = output.volume() / output.get_legacy_shape()[-1];
-    uint32_t input_nsticks = input.volume() / input.get_legacy_shape()[-1];
+    uint32_t output_nsticks = output.volume() / output.get_padded_shape()[-1];
+    uint32_t input_nsticks = input.volume() / input.get_padded_shape()[-1];
 
-    uint32_t in_w = input.get_legacy_shape()[2];
-    uint32_t out_w = output.get_legacy_shape()[2];
+    uint32_t in_w = input.get_padded_shape()[2];
+    uint32_t out_w = output.get_padded_shape()[2];
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -134,15 +134,15 @@ operation::ProgramWithCallbacks upsample_multi_core(
     // NOTE: input is assumed to have channels last format: {N, H, W, C}, {N, 1, H * W, C}, {1, 1, N * H * W, C}
     // NOTE: Bfp8_b/TILE is not yet supported
 
-    uint32_t input_stick_nbytes = input.get_legacy_shape()[-1] * input.element_size();
-    uint32_t output_stick_nbytes = output.get_legacy_shape()[-1] * output.element_size();
+    uint32_t input_stick_nbytes = input.get_padded_shape()[-1] * input.element_size();
+    uint32_t output_stick_nbytes = output.get_padded_shape()[-1] * output.element_size();
     TT_FATAL(input_stick_nbytes == output_stick_nbytes, "Input and output sticks should have same size");
 
-    uint32_t output_nsticks = output.volume() / output.get_legacy_shape()[-1];
-    uint32_t input_nsticks = input.volume() / input.get_legacy_shape()[-1];
+    uint32_t output_nsticks = output.volume() / output.get_padded_shape()[-1];
+    uint32_t input_nsticks = input.volume() / input.get_padded_shape()[-1];
 
-    uint32_t in_w = input.get_legacy_shape()[2];
-    uint32_t out_w = output.get_legacy_shape()[2];
+    uint32_t in_w = input.get_padded_shape()[2];
+    uint32_t out_w = output.get_padded_shape()[2];
 
     auto shard_spec = input.shard_spec().value();
     auto all_cores = shard_spec.grid;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -224,8 +224,8 @@ operation::ProgramWithCallbacks upsample_multi_core(
         config_tensor = create_config_tensor(
             device,
             shard_spec,
-            input.legacy_shape()[0],
-            input.legacy_shape()[1],
+            input.get_padded_shape()[0],
+            input.get_padded_shape()[1],
             in_w,
             scale_factor_h,
             scale_factor_w,

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
@@ -25,14 +25,14 @@ operation::ProgramWithCallbacks upsample_single_core(
     CoreRange core({0, 0}, {0, 0});
 
     tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
-    uint32_t input_unit_size = input.get_legacy_shape()[-1] * input.element_size();
+    uint32_t input_unit_size = input.get_padded_shape()[-1] * input.element_size();
     tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
-    uint32_t output_unit_size = output.get_legacy_shape()[-1] * output.element_size();
+    uint32_t output_unit_size = output.get_padded_shape()[-1] * output.element_size();
 
-    uint32_t output_num_units = output.volume() / output.get_legacy_shape()[-1];  // N*H*W for outout
-    uint32_t input_num_units = input.volume() / input.get_legacy_shape()[-1];     // N*H*W for input
+    uint32_t output_num_units = output.volume() / output.get_padded_shape()[-1];  // N*H*W for outout
+    uint32_t input_num_units = input.volume() / input.get_padded_shape()[-1];     // N*H*W for input
 
-    auto output_shape = output.get_legacy_shape();
+    auto output_shape = output.get_padded_shape();
     // This should allocate a DRAM buffer on the device
     tt_metal::IDevice* device = output.device();
 

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
@@ -44,7 +44,7 @@ void DramPrefetcher::validate(const std::vector<Tensor>& input_tensors) const {
 
         // Check that all tensors' k is divisible by number of cores in global CB receiver
         TT_FATAL(
-            tensor.get_legacy_shape()[1] % num_receiver_cores == 0,
+            tensor.get_padded_shape()[1] % num_receiver_cores == 0,
             "All tensors' k must be divisible by the number of receiver cores = {}.",
             num_receiver_cores);
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
@@ -36,14 +36,14 @@ void ArgMax::validate_with_output_tensors(
     }
 
     if (this->dim.has_value()) {
-        const uint32_t input_rank = input_tensor_a.get_legacy_shape().rank();
+        const uint32_t input_rank = input_tensor_a.get_padded_shape().rank();
         const uint32_t normalized_dim = dim.value() < 0 ? dim.value() + input_rank : dim.value();
 
         // TODO: Add support for normalized_dim = 0, 1, 2
         TT_FATAL(normalized_dim == (input_rank - 1), "Only argmax on last dim is supported!");
     }
 
-    auto input_shape = input_tensor_a.get_legacy_shape();
+    auto input_shape = input_tensor_a.get_padded_shape();
     TT_FATAL(input_shape[0] == 1, "dim 0 must be 1");
     TT_FATAL(input_shape[1] == 1, "dim 1 must be 1");
 }
@@ -77,7 +77,7 @@ operation::ProgramWithCallbacks ArgMax::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
-    const auto normalized_dim = dim.has_value() ? *dim + input_tensor.get_legacy_shape().rank() * (*dim < 0) : dim;
+    const auto normalized_dim = dim.has_value() ? *dim + input_tensor.get_padded_shape().rank() * (*dim < 0) : dim;
     if (use_multicore) {
         return detail::argmax_multi_core(input_tensor, output_tensor, normalized_dim);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -34,7 +34,7 @@ operation::ProgramWithCallbacks argmax_single_core(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_units);
 
-    const auto& input_shape = input.get_legacy_shape();
+    const auto& input_shape = input.get_padded_shape();
     const uint32_t B = input_shape[0];
     const uint32_t C = input_shape[1];
     const uint32_t H = input_shape[2];
@@ -132,7 +132,7 @@ operation::ProgramWithCallbacks argmax_multi_core(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_units);
 
-    const auto& input_shape = input.get_legacy_shape();
+    const auto& input_shape = input.get_padded_shape();
     const uint32_t B = input_shape[0];
     const uint32_t C = input_shape[1];
     const uint32_t H = input_shape[2];

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -20,7 +20,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
     ReduceOpMath reduce_op,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     float scaler) {
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
 
     uint32_t Wt = W / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -21,7 +21,7 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     ReduceOpMath reduce_op,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     float scaler) {
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     uint32_t HW = H * W;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -19,7 +19,7 @@ operation::ProgramWithCallbacks reduce_single_core_hw(
     ReduceOpMath reduce_op,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     float scaler) {
-    const auto shape = a.get_legacy_shape();
+    const auto shape = a.get_padded_shape();
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     uint32_t HW = H * W;
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_op.cpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::reduction {
 
 void MoeDeviceOperation::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    auto input_shape = input_tensors.at(0).get_legacy_shape();
+    auto input_shape = input_tensors.at(0).get_padded_shape();
     TT_FATAL(input_shape.rank() == 4, "Input shape must be 4D, got {}", input_shape.rank());
     TT_FATAL(this->k == 32, "K must be equal to 32, pad with -infinity if necessary to get 32, got {}", this->k);
 
@@ -31,8 +31,8 @@ void MoeDeviceOperation::validate_with_output_tensors(
     TT_FATAL(this->output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
     TT_FATAL(input_tensors.at(0).get_layout() == Layout::TILE, "The input must be in tiled format");
 
-    auto topk_shape = input_tensors.at(2).get_legacy_shape();
-    auto expert_shape = input_tensors.at(1).get_legacy_shape();
+    auto topk_shape = input_tensors.at(2).get_padded_shape();
+    auto expert_shape = input_tensors.at(1).get_padded_shape();
 
     TT_FATAL(topk_shape[-1] == this->k, "Topk shape inner dim must be equal to k, got {}", topk_shape[-1]);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -57,7 +57,7 @@ operation::ProgramWithCallbacks moe_single_core_interleaved(
     uint32_t num_out_tiles = out_tensor.volume() / tt::constants::TILE_HW;
     uint32_t scale_tiles = 1;
 
-    auto input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
     uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tt::constants::TILE_HEIGHT;
     uint32_t Wt = input_shape[3] / tt::constants::TILE_WIDTH;
     // for streaming in input

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -22,9 +22,9 @@ void Prod::validate(const std::vector<Tensor>& inputs) const {
     const auto& input = inputs.at(0);
     const auto& output = inputs.at(1);
 
-    auto input_shape = input.get_legacy_shape();
+    auto input_shape = input.get_padded_shape();
     TT_FATAL((input_shape.rank() == 4), "rank should be 4");
-    const auto& output_shape = output.get_legacy_shape();
+    const auto& output_shape = output.get_padded_shape();
     auto input_shape_wo_padding = input.get_logical_shape();
     const auto& output_shape_wo_padding = output.get_logical_shape();
 
@@ -57,19 +57,18 @@ operation::ProgramWithCallbacks Prod::create_program(
     return prod_nc_format(input, output, dim);
 }
 
-tt::tt_metal::LegacyShape compute_output_shape(const tt::tt_metal::LegacyShape& input_shape, const int64_t& dim) {
+ttnn::SimpleShape compute_output_shape(const ttnn::SimpleShape& input_shape, const int64_t& dim) {
     auto output_shape = input_shape;
-    auto padding = output_shape.padding();
     switch (dim) {
         case 0:
         case 1: output_shape[dim] = 1; break;
     }
 
-    return {tt::tt_metal::LegacyShape(output_shape, padding)};
+    return output_shape;
 }
 
 inline Tensor create_output_tensor(
-    const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_shape, const MemoryConfig& mem_config) {
+    const Tensor& input_tensor, const ttnn::SimpleShape& output_shape, const MemoryConfig& mem_config) {
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE);
     return create_device_tensor(
         output_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config);
@@ -83,11 +82,10 @@ Tensor prod_(const Tensor& input, const Tensor& output, const int64_t& dim) {
 
 // output creation inside
 Tensor prod_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_config) {
-    const auto& input_shape = input.get_legacy_shape();
-    const auto& output_shape = compute_output_shape(input_shape, dim);
+    const auto& input_shape = input.get_padded_shape();
+    auto output_shape = compute_output_shape(input_shape, dim);
     auto output = create_output_tensor(input, output_shape, mem_config);
 
-    const auto& output_shape_wo_padding = output.get_legacy_shape().without_padding();
     operation::run(Prod{.dim = dim}, {input, output});
     return output;
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -36,8 +36,8 @@ inline Tensor prod_all(const Tensor& input_a, const MemoryConfig& output_mem_con
     auto formatted_input_tensor = input_a;
     if (formatted_input_tensor.get_layout() == Layout::ROW_MAJOR) {
         auto a_pad_shape = AutoFormat::pad_to_tile_shape(input_a.get_padded_shape(), false, false, true, true);
-        auto out_shape = input_a.get_legacy_shape();
-        out_shape = {out_shape[0], out_shape[1], out_shape[2], out_shape[3]};
+        auto out_shape = input_a.get_padded_shape();
+        out_shape = ttnn::SimpleShape({out_shape[0], out_shape[1], out_shape[2], out_shape[3]});
         if (!AutoFormat::check_input_tensor_format(input_a, a_pad_shape)) {
             formatted_input_tensor =
                 AutoFormat::format_input_tensor(input_a, input_a.device(), a_pad_shape, 1.0, Layout::TILE);
@@ -52,8 +52,8 @@ inline Tensor prod_nc(const Tensor& temp, int64_t dim, const MemoryConfig& outpu
     auto formatted_input_tensor = temp;
     if (formatted_input_tensor.get_layout() == Layout::ROW_MAJOR) {
         auto a_pad_shape = AutoFormat::pad_to_tile_shape(temp.get_padded_shape(), false, false, true, true);
-        auto out_shape = temp.get_legacy_shape();
-        out_shape = {out_shape[0], out_shape[1], out_shape[2], out_shape[3]};
+        auto out_shape = temp.get_padded_shape();
+        out_shape = ttnn::SimpleShape({out_shape[0], out_shape[1], out_shape[2], out_shape[3]});
         if (!AutoFormat::check_input_tensor_format(temp, a_pad_shape)) {
             formatted_input_tensor =
                 AutoFormat::format_input_tensor(temp, temp.device(), a_pad_shape, 1.0, Layout::TILE);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -41,7 +41,7 @@ namespace ttnn::operations::reduction {
 
 void TopK::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    auto input_shape = input_tensors.at(0).get_legacy_shape();
+    auto input_shape = input_tensors.at(0).get_padded_shape();
     TT_FATAL(input_shape.rank() == 4, "Input shape must be 4D, got {}", input_shape.rank());
     TT_FATAL(this->k == 32, "K must be equal to 32, pad with -infinity if necessary to get 32, got {}", this->k);
     TT_FATAL(this->dim == -1 || this->dim == 3, "Only the last dim is supported right now, got {}", this->dim);
@@ -120,7 +120,7 @@ std::vector<Tensor> TopK::create_output_tensors(
 operation::ProgramWithCallbacks TopK::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    if (input_tensor.get_legacy_shape()[dim] < topk_utils::multi_core_min_width) {
+    if (input_tensor.get_padded_shape()[dim] < topk_utils::multi_core_min_width) {
         return detail::topk_single_core_interleaved(
             input_tensor, this->k, this->dim, output_tensors.at(0), output_tensors.at(1));
     } else {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -34,7 +34,7 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     uint32_t num_input_tiles = input_tensor.volume() / TILE_HW;
     uint32_t num_value_tiles = value_tensor.volume() / TILE_HW;
 
-    auto input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
     uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / TILE_HEIGHT;
     uint32_t Wt = input_shape[3] / TILE_WIDTH;
     // for streaming in input
@@ -227,7 +227,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     uint32_t num_value_tiles = value_tensor.volume() / TILE_HW;
     auto device = input_tensor.device();
 
-    auto input_shape = input_tensor.get_legacy_shape();
+    auto input_shape = input_tensor.get_padded_shape();
     uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / TILE_HEIGHT;
     const auto& [num_cores, local_topk_input_size, rem, final_topk_input_size] = cores_utilized(
         input_shape[dim],

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -34,7 +34,7 @@ void HaloDeviceOperation::validate(const std::vector<Tensor>& input_tensors) con
 
 std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input = input_tensors.at(0);
-    const auto& input_shape = input.get_legacy_shape();
+    const auto& input_shape = input.get_padded_shape();
     ttnn::SimpleShape output_shape = ttnn::SimpleShape(input_shape.to_array_4D());
 
     uint32_t nbatch = input_shape[0];

--- a/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
@@ -14,7 +14,7 @@ struct ConcatenateHeads : public ttnn::operations::experimental::transformer::NL
     void validate(const std::vector<Tensor>& input_tensors) const {
         const auto& input_tensor = input_tensors.at(0);
         const auto head_size = input_tensor.get_shape()[-1];
-        const auto padded_head_size = input_tensor.get_legacy_shape()[-1];
+        const auto padded_head_size = input_tensor.get_padded_shape()[-1];
         const auto input_logical_shape = input_tensor.get_logical_shape();
 
         TT_FATAL(input_logical_shape.rank() == 4, "Input tensor must have rank 4. Shape: {}", input_logical_shape);
@@ -52,7 +52,7 @@ struct ConcatenateHeads : public ttnn::operations::experimental::transformer::NL
         if (this->output_mem_config.is_sharded()) {
             ShardSpec shard_spec = input_tensor.shard_spec().value();
             uint32_t num_cores = shard_spec.num_cores();
-            uint32_t heads_per_shard = shard_spec.shape[0] / input_tensor.get_legacy_shape()[-2];
+            uint32_t heads_per_shard = shard_spec.shape[0] / input_tensor.get_padded_shape()[-2];
             shard_spec.shape = {shard_spec.shape[0] / heads_per_shard, shard_spec.shape[1] * heads_per_shard};
             auto mem_config = this->output_mem_config;
             mem_config.shard_spec = shard_spec;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -34,7 +34,7 @@ void ScaledDotProductAttention::validate(
 
     auto validate_padding = [&](const Tensor& tensor) {
         auto logical_shape = tensor.get_logical_shape();
-        auto legacy_shape = tensor.get_legacy_shape();
+        auto legacy_shape = tensor.get_padded_shape();
         TT_FATAL(logical_shape[0] == legacy_shape[0], "Padding is not supported on the batch dimension");
         TT_FATAL(logical_shape[1] == legacy_shape[1], "Padding is not supported on the num_heads dimension");
         TT_FATAL(logical_shape[3] == legacy_shape[3], "Padding is not supported on the head_dim dimension");
@@ -275,7 +275,7 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
 
     auto scale = this->scale;
     if (not scale.has_value()) {
-        scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.get_legacy_shape()[-1]));
+        scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.get_padded_shape()[-1]));
     }
 
     std::size_t q_chunk_size = this->get_q_chunk_size();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -121,7 +121,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         const auto& page_table_tensor = page_table.value();
         block_size = k_shape[2];  // K's sequence dimension represents block size
         block_size_t = block_size / TILE_HEIGHT;
-        max_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
+        max_blocks_per_seq = page_table_tensor.get_padded_shape()[1];
         page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
         TT_FATAL(
             page_table_stick_size % 32 == 0,

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -570,11 +570,6 @@ std::vector<IDevice*> Tensor::get_workers(bool blocking) const {
 }
 
 // Getters - Spin until tensor is populated before querying tensor metadata
-tt::tt_metal::LegacyShape Tensor::get_legacy_shape() const {
-    wait_for_tensor_metadata_populated();
-    return legacy_shape();
-}
-
 ttnn::Shape Tensor::get_shape() const {
     wait_for_tensor_metadata_populated();
     return shape();
@@ -603,7 +598,10 @@ const ttnn::SimpleShape& Tensor::get_padded_shape() const {
     return padded_shape();
 }
 
-tt::tt_metal::Padding Tensor::get_padding() const { return get_legacy_shape().padding(); }
+tt::tt_metal::Padding Tensor::get_padding() const {
+    wait_for_tensor_metadata_populated();
+    return tensor_attributes->tensor_spec.shape().value.padding();
+}
 
 const Storage& Tensor::get_storage() const {
     this->wait_for_tensor_data_populated();

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -228,8 +228,6 @@ struct Tensor {
     const ttnn::SimpleShape& get_padded_shape() const;
     const TensorSpec& get_tensor_spec() const;
 
-    // [[deprecated("Use get_shape() instead.")]]
-    tt::tt_metal::LegacyShape get_legacy_shape() const;
     ttnn::Shape get_shape() const;
     tt::tt_metal::Padding get_padding() const;
 
@@ -237,9 +235,6 @@ struct Tensor {
     // Non-Blocking Getters. Query attributes directly, without waiting for worker completion
     // ======================================================================================
     inline const Storage& storage() const { return this->tensor_attributes->storage; };
-    inline tt::tt_metal::LegacyShape legacy_shape() const {
-        return this->tensor_attributes->tensor_spec.shape().value;
-    };
     inline ttnn::Shape shape() const { return this->tensor_attributes->tensor_spec.shape(); };
     inline const ttnn::SimpleShape& logical_shape() const {
         return this->tensor_attributes->tensor_spec.logical_shape();

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -1230,7 +1230,7 @@ Tensor pad<bfloat4_b>(
 template <typename T>
 Tensor unpad(
     const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
-    const auto input_shape = tensor.get_legacy_shape();
+    const auto input_shape = tensor.get_padded_shape();
     const auto input_strides = tensor.strides();
 
     // Validate inputs and compute output shape

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -308,7 +308,7 @@ Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const ttnn::SimpleShap
 
     for (auto index = -3; index >= -static_cast<int>(input_tensor.get_padded_shape().rank()); index--) {
         TT_ASSERT(
-            input_tensor.get_legacy_shape().without_padding()[index] == output_tensor_shape[index],
+            input_tensor.get_logical_shape()[index] == output_tensor_shape[index],
             "Input shape must match output shape apart from last 2 dims");
     }
     TT_ASSERT(

--- a/ttnn/tools/profiler/op_profiler.hpp
+++ b/ttnn/tools/profiler/op_profiler.hpp
@@ -225,7 +225,7 @@ static inline json get_tensor_json(const Tensor& tensor) {
         ret["storage_type"] = fmt::format("{}", magic_enum::enum_name(tensor.storage_type()));
     }
 
-    auto tensor_shape = tensor.get_legacy_shape();
+    auto tensor_shape = tensor.get_padded_shape();
     ret["shape"]["W"] = tensor_shape.rank() >= 4 ? tensor_shape[-4] : 1;
     ret["shape"]["Z"] = tensor_shape.rank() >= 3 ? tensor_shape[-3] : 1;
     ret["shape"]["Y"] = tensor_shape.rank() >= 2 ? tensor_shape[-2] : 1;


### PR DESCRIPTION
### Ticket

### Problem description
We're continuing to remove Shape/LegacyShape from the codebase

### What's changed
Removed all usages of `get_legacy_shape()` method from the codebase

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12924730910)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12924742988)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12924739709)
- [x] [T3K frequent tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12924746368)
- [x] [T3K unit tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12924751282)
- [x] [Nightly model and ttnn CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12924755491)
- [x] New/Existing tests provide coverage for changes
