### PR TITLE
Minimalistic All Gather Async

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -74,7 +74,7 @@ def run_with_trace(
             cluster_axis=cluster_axis,
             mesh_device=mesh_device,
             topology=ttnn.Topology.Linear,
-            multi_device_global_semaphore=ccl_semaphore_handles,
+            multi_device_global_semaphore=ccl_semaphore_handles[0] if type(ccl_semaphore_handles) == list else ccl_semaphore_handles,
             num_links=num_links,
             memory_config=output_mem_config,
             subdevice_id=worker_sub_device_id,
@@ -105,7 +105,7 @@ def run_with_trace(
                 cluster_axis=cluster_axis,
                 mesh_device=mesh_device,
                 topology=ttnn.Topology.Linear,
-                multi_device_global_semaphore=ccl_semaphore_handles,
+                multi_device_global_semaphore=ccl_semaphore_handles[i] if type(ccl_semaphore_handles) == list else ccl_semaphore_handles,
                 num_links=num_links,
                 memory_config=output_mem_config,
                 subdevice_id=worker_sub_device_id,
@@ -149,6 +149,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
     function_level_defaults,
     enable_async,
     input_shard_spec: ttnn.ShardSpec = None,
+    output_shard_spec: ttnn.ShardSpec = None,
     num_all_gather_instances: int = 1,
     num_iters: int = 1,
     cluster_axis: int = 0,
@@ -200,8 +201,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
         else (num_all_gather_instances, num_devices_per_line)
     )
 
-    output_shard_spec = None
-    if input_shard_spec is not None:
+    if input_shard_spec is not None and output_shard_spec is None:
         output_shard_shape = list(input_shard_spec.shape)
         if dim == len(per_chip_output_shape) - 1:
             output_shard_shape[1] *= num_devices_per_line
@@ -246,60 +246,65 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
             mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
         # create global semaphore handles
-        ccl_semaphore_handles = create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0)
+        ccl_semaphore_handles = [
+            create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+        ]
 
-    # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
-    if trace_mode:
-        ttnn_tensor_out = run_with_trace(
-            input_tensor=ttnn_tensor,
-            dim=dim,
-            cluster_axis=cluster_axis,
-            mesh_device=mesh_device,
-            num_links=num_links,
-            output_mem_config=output_mem_config,
-            ccl_semaphore_handles=ccl_semaphore_handles,
-            worker_sub_device_id=worker_sub_device_id,
-            enable_persistent_fabric=enable_persistent_fabric,
-            all_gather_topology=ttnn.Topology.Linear,
-            num_iter=num_iters,
-            use_all_gather_async=use_all_gather_async,
-        )
-    else:
-        for _ in range(num_iters):
-            if use_all_gather_async:
-                logger.info("Running all-gather async")
-                ttnn_tensor_out = ttnn.experimental.all_gather_async(
-                    ttnn_tensor,
-                    dim,
-                    cluster_axis=cluster_axis,
-                    mesh_device=mesh_device,
-                    topology=ttnn.Topology.Linear,
-                    multi_device_global_semaphore=ccl_semaphore_handles,
-                    num_links=num_links,
-                    memory_config=output_mem_config,
-                    subdevice_id=worker_sub_device_id,
-                    enable_persistent_fabric_mode=enable_persistent_fabric,
-                )
-            else:
-                ttnn_tensor_out = ttnn.all_gather(
-                    ttnn_tensor,
-                    dim=dim,
-                    cluster_axis=cluster_axis,
-                    mesh_device=mesh_device,
-                    num_links=num_links,
-                    memory_config=output_mem_config,
-                    topology=ttnn.Topology.Linear,
-                )
+    try:
+        # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
+        if trace_mode:
+            ttnn_tensor_out = run_with_trace(
+                input_tensor=ttnn_tensor,
+                dim=dim,
+                cluster_axis=cluster_axis,
+                mesh_device=mesh_device,
+                num_links=num_links,
+                output_mem_config=output_mem_config,
+                ccl_semaphore_handles=ccl_semaphore_handles,
+                worker_sub_device_id=worker_sub_device_id,
+                enable_persistent_fabric=enable_persistent_fabric,
+                all_gather_topology=ttnn.Topology.Linear,
+                num_iter=num_iters,
+                use_all_gather_async=use_all_gather_async,
+            )
 
-            if enable_persistent_fabric:
-                ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
-        ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
+        else:
+            for i in range(num_iters):
+                if use_all_gather_async:
+                    logger.info("Running all-gather async")
+                    ttnn_tensor_out = ttnn.experimental.all_gather_async(
+                        ttnn_tensor,
+                        dim,
+                        cluster_axis=cluster_axis,
+                        mesh_device=mesh_device,
+                        topology=ttnn.Topology.Linear,
+                        multi_device_global_semaphore=ccl_semaphore_handles[i],
+                        num_links=num_links,
+                        memory_config=output_mem_config,
+                        subdevice_id=worker_sub_device_id,
+                        enable_persistent_fabric_mode=enable_persistent_fabric,
+                    )
+                else:
+                    ttnn_tensor_out = ttnn.all_gather(
+                        ttnn_tensor,
+                        dim=dim,
+                        cluster_axis=cluster_axis,
+                        mesh_device=mesh_device,
+                        num_links=num_links,
+                        memory_config=output_mem_config,
+                        topology=ttnn.Topology.Linear,
+                    )
+            ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
 
-    if enable_persistent_fabric and teardown_persistent_fabric:
-        logger.info("Tearing down persistent fabric interface")
-        mesh_device.reset_sub_device_stall_group()
-        teardown_fabric_interface(mesh_device)
-        logger.info("Done tearing down persistent fabric interface")
+    except Exception as e:
+        logger.error(f"Exception: {e}")
+        raise e
+    finally:
+        if enable_persistent_fabric and teardown_persistent_fabric:
+            logger.info("Tearing down persistent fabric interface")
+            mesh_device.reset_sub_device_stall_group()
+            teardown_fabric_interface(mesh_device)
+            logger.info("Done tearing down persistent fabric interface")
 
     # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor_out)
     tt_output_tensor = ttnn.to_torch(

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -74,7 +74,9 @@ def run_with_trace(
             cluster_axis=cluster_axis,
             mesh_device=mesh_device,
             topology=ttnn.Topology.Linear,
-            multi_device_global_semaphore=ccl_semaphore_handles[0] if type(ccl_semaphore_handles) == list else ccl_semaphore_handles,
+            multi_device_global_semaphore=ccl_semaphore_handles[0]
+            if type(ccl_semaphore_handles) == list
+            else ccl_semaphore_handles,
             num_links=num_links,
             memory_config=output_mem_config,
             subdevice_id=worker_sub_device_id,
@@ -105,7 +107,9 @@ def run_with_trace(
                 cluster_axis=cluster_axis,
                 mesh_device=mesh_device,
                 topology=ttnn.Topology.Linear,
-                multi_device_global_semaphore=ccl_semaphore_handles[i] if type(ccl_semaphore_handles) == list else ccl_semaphore_handles,
+                multi_device_global_semaphore=ccl_semaphore_handles[i]
+                if type(ccl_semaphore_handles) == list
+                else ccl_semaphore_handles,
                 num_links=num_links,
                 memory_config=output_mem_config,
                 subdevice_id=worker_sub_device_id,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -223,6 +223,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
         mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=shard_dims),
     )
     ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+    ttnn_tensor = ttnn.to_memory_config(ttnn_tensor, input_mem_config)
 
     sub_device_stall_group = []
     if use_all_gather_async:
@@ -249,7 +250,6 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
         ccl_semaphore_handles = [
             create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
         ]
-
     try:
         # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
         if trace_mode:

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -78,9 +78,8 @@ def get_core_range_set(output_core_grid):
 @pytest.mark.parametrize(
     "num_devices, num_links",
     [
-        (4, 1),
+        (4, 2),
     ],
-    # [(4, 3), (4, 2)], Multi-links fails https://github.com/tenstorrent/tt-metal/issues/16699
 )
 @pytest.mark.parametrize(
     "input_dtype",

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -25,6 +25,54 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import (
 )
 
 
+PREFETCHER_NOC1_RING = [
+    (6, 6),
+    (6, 7),
+    (6, 9),
+    (6, 0),
+    (6, 1),
+    (6, 2),
+    (6, 4),
+    (6, 5),
+    (5, 5),
+    (5, 6),
+    (5, 7),
+    (5, 9),
+    (5, 0),
+    (5, 1),
+    (5, 2),
+    (5, 4),
+    (1, 4),
+    (1, 5),
+    (1, 9),
+    (1, 0),
+    (2, 0),
+    (2, 4),
+    (2, 5),
+    (2, 9),
+]
+
+
+def get_core_range_set(output_core_grid):
+    if isinstance(output_core_grid, ttnn.CoreGrid):
+        output_core_range_set = ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(output_core_grid.x - 1, output_core_grid.y - 1)),
+            ]
+        )
+    else:
+        output_core_range_set = ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(x, y),
+                    ttnn.CoreCoord(x, y),
+                )
+                for x, y in output_core_grid
+            ]
+        )
+    return output_core_range_set
+
+
 # Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
@@ -37,13 +85,13 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import (
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttnn.bfloat16,  # hang??
-        # ttnn.bfloat8_b,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize("shard_grid_orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize(
-    "tensor_mem_layout, output_shape, dim, input_shard_shape,shard_grid,layout",
+    "tensor_mem_layout, output_shape, dim, input_shard_shape,input_shard_grid,output_shard_shape, output_shard_grid, layout",
     (
         (  # AllGather after SDPA (~160 us)
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -51,6 +99,13 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import (
             1,
             (32, 128),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (32, 128),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(5, 1)),
+                }
+            ),
             ttnn.TILE_LAYOUT,
         ),
         (  # AllGather after Binary Mult+Silu (~160 us)
@@ -59,6 +114,8 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import (
             3,
             (32, 32),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 4))}),
+            (32, 160),
+            get_core_range_set(PREFETCHER_NOC1_RING),
             ttnn.TILE_LAYOUT,
         ),
     ),
@@ -66,12 +123,15 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_reduce_async import (
 @pytest.mark.parametrize("replication_factor", [8])
 @pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 17068032}], indirect=True)
 def test_line_all_gather_sharded_on_TG_rows_llama(
     mesh_device,
     num_devices,
     output_shape,
     input_shard_shape,
-    shard_grid,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
     shard_grid_orientation,
     tensor_mem_layout,
     dim,
@@ -82,23 +142,30 @@ def test_line_all_gather_sharded_on_TG_rows_llama(
     function_level_defaults,
     enable_async,
     replication_factor,
-    num_iters=10,
+    num_iters=100,
 ):
     if len(mesh_device.get_devices()) != 32:
         pytest.skip("Not TG!")
     input_shard_spec = ttnn.ShardSpec(
-        shard_grid,
+        input_shard_grid,
         input_shard_shape,
         shard_grid_orientation,
     )
 
-    logger.warning("sharding not used due to issue #16699")
+    if output_shard_grid is not None and output_shard_shape is not None:
+        output_shard_spec = ttnn.ShardSpec(
+            output_shard_grid,
+            output_shard_shape,
+            shard_grid_orientation,
+        )
+    else:
+        output_shard_spec = None
 
     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
         mesh_device,
         num_devices,
         output_shape,
-        ttnn.TensorMemoryLayout.INTERLEAVED,  # tensor_mem_layout,
+        tensor_mem_layout,
         dim,
         num_links,
         input_dtype,
@@ -108,9 +175,11 @@ def test_line_all_gather_sharded_on_TG_rows_llama(
         function_level_defaults,
         enable_async=enable_async,
         num_iters=num_iters,
-        # input_shard_spec=input_shard_spec,
+        input_shard_spec=input_shard_spec,
+        output_shard_spec=output_shard_spec,
         num_all_gather_instances=replication_factor,
         cluster_axis=1,
+        trace_mode=True,
         use_all_gather_async=True,
         enable_persistent_fabric=True,
         create_persistent_fabric=True,

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -285,7 +285,7 @@ def test_line_reduce_scatter_sharded_on_TG_rows_llama(
 @pytest.mark.parametrize(
     "num_devices, num_links, per_chip_output_shape, layout",
     [
-        (4, 2, [1, 1, 32, 1280], ttnn.TILE_LAYOUT),  # AllReduce after QKV (~110 us)
+        (4, 1, [1, 1, 32, 1280], ttnn.TILE_LAYOUT),  # AllReduce after QKV (~110 us)
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -465,44 +465,6 @@ def test_all_gather(
             None,
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
-        (
-            4,
-            [1, 1, 32, 3840],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 32),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 4))}),
-            (32, 160),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 5))}),
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ),
-        (  # AllGather after Binary Mult
-            4,
-            [1, 1, 32, 3840],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 32),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 4))}),
-            (32, 160),
-            get_core_range_set(PREFETCHER_NOC1_RING),
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ),
-        (  # AllGather after SDPA
-            4,
-            [1, 32, 32, 128],
-            1,
-            ttnn.TILE_LAYOUT,
-            (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 7))}),
-            (32, 128),
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
-                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(5, 1)),
-                }
-            ),
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ),
     ],
 )
 @pytest.mark.parametrize("num_links", [2])

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -180,7 +180,9 @@ def run_all_gather_impl(
         mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0)
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
 
     logger.info(f"Output shape: {output_shape}")
     logger.info(f"dim: {dim}")
@@ -273,7 +275,7 @@ def run_all_gather_impl(
             num_links,
             output_mem_config,
             enable_persistent_fabric,
-            multi_device_global_semaphore=ccl_semaphore_handles,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
             num_iter=num_iters,
             subdevice_id=worker_sub_device_id,
         )
@@ -288,7 +290,7 @@ def run_all_gather_impl(
                     mesh_device=mesh_device,
                     memory_config=output_mem_config,
                     topology=all_gather_topology,
-                    multi_device_global_semaphore=ccl_semaphore_handles,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i],
                     subdevice_id=worker_sub_device_id,
                     enable_persistent_fabric_mode=enable_persistent_fabric,
                     num_preferred_links=num_links,
@@ -298,7 +300,7 @@ def run_all_gather_impl(
                 tt_out_tensor = ttnn.experimental.all_gather_async(
                     input_tensor_mesh_list[i],
                     dim,
-                    multi_device_global_semaphore=ccl_semaphore_handles,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i],
                     num_links=num_links,
                     memory_config=output_mem_config,
                     topology=all_gather_topology,
@@ -307,9 +309,9 @@ def run_all_gather_impl(
                 )
             tt_out_tensor_list.append(tt_out_tensor)
 
-            logger.info(f"Waiting for op {i}")
-            ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
-            logger.info(f"Done iteration {i}")
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
 
     passed = True
     for tensor_index in range(len(tt_out_tensor_list)):
@@ -326,6 +328,12 @@ def run_all_gather_impl(
             if not eq:
                 logger.error(f"output mismatch for tensor {i}")
                 passed = False
+
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
 
     if enable_persistent_fabric and teardown_persistent_fabric:
         mesh_device.reset_sub_device_stall_group()

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -505,7 +505,7 @@ def test_all_gather(
         ),
     ],
 )
-@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
     "input_dtype",
     [

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -18,52 +18,10 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_gather_TG_post_commit import 
     run_line_all_gather_on_TG_with_mesh_tensor_along_rows,
 )
 
-PREFETCHER_NOC1_RING = [
-    (6, 6),
-    (6, 7),
-    (6, 9),
-    (6, 0),
-    (6, 1),
-    (6, 2),
-    (6, 4),
-    (6, 5),
-    (5, 5),
-    (5, 6),
-    (5, 7),
-    (5, 9),
-    (5, 0),
-    (5, 1),
-    (5, 2),
-    (5, 4),
-    (1, 4),
-    (1, 5),
-    (1, 9),
-    (1, 0),
-    (2, 0),
-    (2, 4),
-    (2, 5),
-    (2, 9),
-]
-
-
-def get_core_range_set(output_core_grid):
-    if isinstance(output_core_grid, ttnn.CoreGrid):
-        output_core_range_set = ttnn.CoreRangeSet(
-            [
-                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(output_core_grid.x - 1, output_core_grid.y - 1)),
-            ]
-        )
-    else:
-        output_core_range_set = ttnn.CoreRangeSet(
-            [
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(x, y),
-                    ttnn.CoreCoord(x, y),
-                )
-                for x, y in output_core_grid
-            ]
-        )
-    return output_core_range_set
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_async_TG_llama import (
+    PREFETCHER_NOC1_RING,
+    get_core_range_set,
+)
 
 
 def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, input_dtype, layout):

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -349,7 +349,6 @@ def run_all_gather_impl(
     "num_devices, num_links, output_shape, dim, layout",
     [
         # (4, 1, [1, 1, 64, 512], 3, ttnn.TILE_LAYOUT),
-        (4, 3, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),
         # (4, 1, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
         # (4, 1, [1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
         (4, 1, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -320,6 +320,7 @@ def run_all_gather_impl(
     "num_devices, num_links, output_shape, dim, layout",
     [
         (4, 1, [1, 1, 64, 512], 3, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),
         # (4, 1, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
         # (4, 1, [1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
         (4, 1, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CCL_EXPERIMENTAL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/all_gather_async_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/device/all_gather_async_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/device/all_gather_async_program.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_reduce_async/all_reduce_async.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_reduce_async/all_reduce_async_pybind.cpp
     CACHE INTERNAL

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -114,6 +114,10 @@ operation::ProgramWithCallbacks AllGatherAsync::create_program(
     auto input_tensor_shape = input_tensors[0].get_padded_shape();
     auto input_tensor_buffer_layout = input_tensors[0].buffer()->buffer_layout();
     auto input_tensor_page_layout = input_tensors[0].layout();
+    auto input_tensor_memory_config = input_tensors[0].memory_config();
+    auto output_tensor_memory_config = output_tensors[0].memory_config();
+    uint32_t input_shard_num_cores = input_tensor_memory_config.shard_spec->grid.num_cores();
+    uint32_t output_shard_num_cores = output_tensor_memory_config.shard_spec->grid.num_cores();
 
     if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
         input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
@@ -122,6 +126,39 @@ operation::ProgramWithCallbacks AllGatherAsync::create_program(
             tt::LogOp,
             "Detected all gather specialized shape. all_gather_async_minimal_interleaved_dim3_1_1_32_any is called");
         return all_gather_async_minimal_interleaved_dim3_1_1_32_any(
+            input_tensors[0],
+            this->forward_device,
+            this->backward_device,
+            output_tensors[0],
+            this->dim,
+            this->num_links,
+            this->ring_size,
+            this->ring_index,
+            this->topology,
+            this->semaphore,
+            this->enable_persistent_fabric_mode);
+    }
+
+    tt::log_debug(tt::LogOp, "input_tensor_memory_config: {}", input_tensor_memory_config);
+    tt::log_debug(tt::LogOp, "output_tensor_memory_config: {}", output_tensor_memory_config);
+    tt::log_debug(tt::LogOp, "input_shard_num_cores: {}", input_shard_num_cores);
+    tt::log_debug(tt::LogOp, "output_shard_num_cores: {}", output_shard_num_cores);
+    tt::log_debug(
+        tt::LogOp, "input_tensor_memory_config.shard_spec->shape: {}", input_tensor_memory_config.shard_spec->shape);
+    tt::log_debug(
+        tt::LogOp, "output_tensor_memory_config.shard_spec->shape: {}", output_tensor_memory_config.shard_spec->shape);
+
+    if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
+        input_tensor_shape[3] == 960 && input_tensor_memory_config.buffer_type == BufferType::L1 &&
+        output_tensor_memory_config.buffer_type == BufferType::L1 &&
+        input_tensor_memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED &&
+        output_tensor_memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED &&
+        input_tensor_memory_config.shard_spec->shape == Shape{32, 32} &&
+        output_tensor_memory_config.shard_spec->shape == Shape{32, 160} && input_shard_num_cores == 30 &&
+        output_shard_num_cores == 24) {
+        tt::log_info(
+            tt::LogOp, "Detected all gather specialized shape. all_gather_async_llama_post_binary_matmul is called");
+        return all_gather_async_llama_post_binary_matmul(
             input_tensors[0],
             this->forward_device,
             this->backward_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -107,126 +107,166 @@ std::vector<ttnn::TensorSpec> AllGatherAsync::compute_output_specs(const std::ve
         TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), output_mem_config))};
 }
 
+AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor) const {
+    auto input_tensor_shape = input_tensor.get_padded_shape();
+    auto input_tensor_buffer_layout = input_tensor.buffer()->buffer_layout();
+    auto input_tensor_page_layout = input_tensor.layout();
+    auto input_tensor_memory_config = input_tensor.memory_config();
+    bool input_is_sharded = input_tensor_memory_config.shard_spec.has_value();
+    bool output_is_sharded = output_mem_config.shard_spec.has_value();
+    uint32_t input_shard_num_cores = 0;
+    uint32_t output_shard_num_cores = 0;
+    if (input_is_sharded) {
+        input_shard_num_cores = input_tensor_memory_config.shard_spec->grid.num_cores();
+        log_trace(
+            tt::LogOp,
+            "[select_version] input_tensor_memory_config.shard_spec->shape: {}",
+            input_tensor_memory_config.shard_spec->shape);
+    }
+    if (output_is_sharded) {
+        output_shard_num_cores = output_mem_config.shard_spec->grid.num_cores();
+        log_trace(tt::LogOp, "[select_version] output_mem_config.shard_spec->shape: {}", output_mem_config.shard_spec->shape);
+    }
+
+    log_trace(tt::LogOp, "[select_version] input_tensor_shape: {}", input_tensor_shape);
+    log_trace(tt::LogOp, "[select_version] input_tensor_memory_config: {}", input_tensor_memory_config);
+    log_trace(tt::LogOp, "[select_version] output_mem_config: {}", output_mem_config);
+    log_trace(tt::LogOp, "[select_version] input_shard_num_cores: {}", input_shard_num_cores);
+    log_trace(tt::LogOp, "[select_version] output_shard_num_cores: {}", output_shard_num_cores);
+
+    // Check for minimal interleaved case
+    if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
+        input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
+        input_tensor_page_layout == tt::tt_metal::Layout::TILE && this->enable_persistent_fabric_mode) {
+        return AllGatherAsyncVersion::MINIMAL_INTERLEAVED_32;
+    }
+
+    log_trace(tt::LogOp, "[select_version] input_is_sharded: {}", input_is_sharded);
+    log_trace(tt::LogOp, "[select_version] output_is_sharded: {}", output_is_sharded);
+
+    if (input_is_sharded && output_is_sharded) {
+        // Check for first llama post binary matmul case
+        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
+            input_tensor_shape[3] == 960 && input_tensor_memory_config.buffer_type == BufferType::L1 &&
+            output_mem_config.buffer_type == BufferType::L1 &&
+            input_tensor_memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED &&
+            output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED &&
+            input_tensor_memory_config.shard_spec->shape[0] == 32 &&
+            input_tensor_memory_config.shard_spec->shape[1] == 32 &&
+            output_mem_config.shard_spec->shape[0] == 32 &&
+            output_mem_config.shard_spec->shape[1] == 160 && input_shard_num_cores == 30 &&
+            output_shard_num_cores == 24) {
+            return AllGatherAsyncVersion::LLAMA_POST_BINARY_MATMUL;
+        }
+
+        // Check for second llama post binary matmul case
+        if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 8 && input_tensor_shape[2] == 32 &&
+            input_tensor_shape[3] == 128 && input_tensor_memory_config.buffer_type == BufferType::L1 &&
+            output_mem_config.buffer_type == BufferType::L1 &&
+            input_tensor_memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+            output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+            input_tensor_memory_config.shard_spec->shape[0] == 32 &&
+            input_tensor_memory_config.shard_spec->shape[1] == 128 &&
+            output_mem_config.shard_spec->shape[0] == 32 &&
+            output_mem_config.shard_spec->shape[1] == 128 && input_shard_num_cores == 8 &&
+            output_shard_num_cores == 32) {
+            log_trace(tt::LogOp, "All conditions matched for LLAMA_POST_BINARY_MATMUL case");
+            return AllGatherAsyncVersion::LLAMA_POST_BINARY_MATMUL;
+        }
+    }
+    log_trace(tt::LogOp, "All conditions matched for generic case");
+    return AllGatherAsyncVersion::GENERIC;
+}
+
 operation::ProgramWithCallbacks AllGatherAsync::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     tt::log_debug(tt::LogOp, "DEBUG: create_program is called");
 
-    auto input_tensor_shape = input_tensors[0].get_padded_shape();
-    auto input_tensor_buffer_layout = input_tensors[0].buffer()->buffer_layout();
-    auto input_tensor_page_layout = input_tensors[0].layout();
+    AllGatherAsyncVersion version = select_version(input_tensors[0]);
 
-    if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
-        input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
-        input_tensor_page_layout == tt::tt_metal::Layout::TILE && this->enable_persistent_fabric_mode) {
-        tt::log_info(
-            tt::LogOp,
-            "Detected all gather specialized shape. all_gather_async_minimal_interleaved_dim3_1_1_32_any is called");
-        return all_gather_async_minimal_interleaved_dim3_1_1_32_any(
-            input_tensors[0],
-            this->forward_device,
-            this->backward_device,
-            output_tensors[0],
-            this->dim,
-            this->num_links,
-            this->ring_size,
-            this->ring_index,
-            this->topology,
-            this->semaphore,
-            this->enable_persistent_fabric_mode);
+    log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));
+
+    switch (version) {
+        case AllGatherAsyncVersion::MINIMAL_INTERLEAVED_32:
+            log_trace(
+                tt::LogOp,
+                "Detected all gather specialized shape. all_gather_async_minimal_interleaved_dim3_1_1_32_any is "
+                "called");
+            return all_gather_async_minimal_interleaved_dim3_1_1_32_any(
+                input_tensors[0],
+                this->forward_device,
+                this->backward_device,
+                output_tensors[0],
+                this->dim,
+                this->num_links,
+                this->ring_size,
+                this->ring_index,
+                this->topology,
+                this->semaphore,
+                this->sub_device_id,
+                this->enable_persistent_fabric_mode);
+
+        case AllGatherAsyncVersion::LLAMA_POST_BINARY_MATMUL:
+            log_trace(
+                tt::LogOp,
+                "Detected all gather specialized shape. all_gather_async_llama_post_binary_matmul is called");
+            return all_gather_async_llama_post_binary_matmul(
+                input_tensors[0],
+                this->forward_device,
+                this->backward_device,
+                output_tensors[0],
+                this->dim,
+                this->num_links,
+                this->ring_size,
+                this->ring_index,
+                this->topology,
+                this->semaphore,
+                this->sub_device_id,
+                this->enable_persistent_fabric_mode);
+
+        case AllGatherAsyncVersion::GENERIC:
+        default:
+            log_trace(tt::LogOp, "Running generic all_gather_async_multi_core_with_workers");
+            return all_gather_async_multi_core_with_workers(
+                input_tensors[0],
+                this->forward_device,
+                this->backward_device,
+                output_tensors[0],
+                this->dim,
+                this->num_links,
+                this->ring_size,
+                this->ring_index,
+                this->topology,
+                this->semaphore,
+                this->sub_device_id,
+                this->enable_persistent_fabric_mode);
     }
-
-    auto input_tensor_memory_config = input_tensors[0].memory_config();
-    auto output_tensor_memory_config = output_tensors[0].memory_config();
-    uint32_t input_shard_num_cores = input_tensor_memory_config.shard_spec->grid.num_cores();
-    uint32_t output_shard_num_cores = output_tensor_memory_config.shard_spec->grid.num_cores();
-
-    tt::log_debug(tt::LogOp, "input_tensor_shape: {}", input_tensor_shape);
-    tt::log_debug(tt::LogOp, "input_tensor_memory_config: {}", input_tensor_memory_config);
-    tt::log_debug(tt::LogOp, "output_tensor_memory_config: {}", output_tensor_memory_config);
-    tt::log_debug(tt::LogOp, "input_shard_num_cores: {}", input_shard_num_cores);
-    tt::log_debug(tt::LogOp, "output_shard_num_cores: {}", output_shard_num_cores);
-    tt::log_debug(
-        tt::LogOp, "input_tensor_memory_config.shard_spec->shape: {}", input_tensor_memory_config.shard_spec->shape);
-    tt::log_debug(
-        tt::LogOp, "output_tensor_memory_config.shard_spec->shape: {}", output_tensor_memory_config.shard_spec->shape);
-
-    if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
-        input_tensor_shape[3] == 960 && input_tensor_memory_config.buffer_type == BufferType::L1 &&
-        output_tensor_memory_config.buffer_type == BufferType::L1 &&
-        input_tensor_memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED &&
-        output_tensor_memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED &&
-        input_tensor_memory_config.shard_spec->shape == Shape{32, 32} &&
-        output_tensor_memory_config.shard_spec->shape == Shape{32, 160} && input_shard_num_cores == 30 &&
-        output_shard_num_cores == 24) {
-        tt::log_info(
-            tt::LogOp,
-            "Detected all gather specialized shape. all_gather_async_llama_post_binary_matmul is called with input "
-            "shape {}, input cores {}",
-            input_tensor_shape,
-            input_shard_num_cores);
-        return all_gather_async_llama_post_binary_matmul(
-            input_tensors[0],
-            this->forward_device,
-            this->backward_device,
-            output_tensors[0],
-            this->dim,
-            this->num_links,
-            this->ring_size,
-            this->ring_index,
-            this->topology,
-            this->semaphore,
-            this->enable_persistent_fabric_mode);
-    }
-
-    if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 8 && input_tensor_shape[2] == 32 &&
-        input_tensor_shape[3] == 128 && input_tensor_memory_config.buffer_type == BufferType::L1 &&
-        output_tensor_memory_config.buffer_type == BufferType::L1 &&
-        input_tensor_memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
-        output_tensor_memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
-        input_tensor_memory_config.shard_spec->shape == Shape{32, 128} &&
-        output_tensor_memory_config.shard_spec->shape == Shape{32, 128} && input_shard_num_cores == 8 &&
-        output_shard_num_cores == 32) {
-        tt::log_info(
-            tt::LogOp,
-            "Detected all gather specialized shape. all_gather_async_llama_post_binary_matmul is called with input "
-            "shape {}, input cores {}",
-            input_tensor_shape,
-            input_shard_num_cores);
-        return all_gather_async_llama_post_binary_matmul(
-            input_tensors[0],
-            this->forward_device,
-            this->backward_device,
-            output_tensors[0],
-            this->dim,
-            this->num_links,
-            this->ring_size,
-            this->ring_index,
-            this->topology,
-            this->semaphore,
-            this->enable_persistent_fabric_mode);
-    }
-
-    tt::log_info(tt::LogOp, "Running generic all_gather_async_multi_core_with_workers");
-    return all_gather_async_multi_core_with_workers(
-        input_tensors[0],
-        this->forward_device,
-        this->backward_device,
-        output_tensors[0],
-        this->dim,
-        this->num_links,
-        this->ring_size,
-        this->ring_index,
-        this->topology,
-        this->semaphore,
-        this->sub_device_id,
-        this->enable_persistent_fabric_mode);
 }
 
 const operation::Hash AllGatherAsync::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
+    log_trace(tt::LogOp, "compute_program_hash is called");
+    AllGatherAsyncVersion version = select_version(input_tensors[0]);
+    log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));
     auto input_shape = input_tensors[0].get_padded_shape();
     auto input_memory_layout = input_tensors[0].get_layout();
     auto input_dtype = input_tensors[0].get_dtype();
     auto input_memory_config = input_tensors[0].memory_config();
+    if (version == AllGatherAsyncVersion::GENERIC) {
+        // Generic version should hash semaphore address as well
+        uint32_t semaphore_address = this->semaphore.address();
+        return operation::hash_operation<AllGatherAsync>(
+            this->dim,
+            this->num_links,
+            this->ring_size,
+            this->ring_index,
+            this->output_mem_config,
+            this->topology,
+            input_shape,
+            input_memory_layout,
+            input_dtype,
+            input_memory_config,
+            semaphore_address);
+    }
     return operation::hash_operation<AllGatherAsync>(
         this->dim,
         this->num_links,
@@ -239,8 +279,6 @@ const operation::Hash AllGatherAsync::compute_program_hash(const std::vector<Ten
         input_dtype,
         input_memory_config);
 }
-
-
 
 namespace operations {
 namespace experimental {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -117,7 +117,7 @@ operation::ProgramWithCallbacks AllGatherAsync::create_program(
 
     if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
         input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
-        input_tensor_page_layout == tt::tt_metal::Layout::TILE) {
+        input_tensor_page_layout == tt::tt_metal::Layout::TILE && this->enable_persistent_fabric_mode) {
         tt::log_info(
             tt::LogOp,
             "Detected all gather specialized shape. all_gather_async_minimal_interleaved_dim3_1_1_32_any is called");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -101,6 +101,8 @@ AllGatherAsync create_all_gather_async_struct(
 }  // namespace ccl
 
 // All Gather Variants
+std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
+    size_t num_links, size_t num_workers_per_link, bool persistent_fabric_mode, IDevice* device);
 operation::ProgramWithCallbacks all_gather_async_multi_core_with_workers(
     const Tensor& input_tensor,
     std::optional<IDevice*> forward_device,
@@ -113,6 +115,18 @@ operation::ProgramWithCallbacks all_gather_async_multi_core_with_workers(
     ccl::Topology topology,
     const GlobalSemaphore semaphore,
     const std::optional<SubDeviceId>& sub_device_id,
+    bool enable_persistent_fabric_mode);
+operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32_any(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore semaphore,
     bool enable_persistent_fabric_mode);
 
 namespace operations {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -128,6 +128,18 @@ operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32
     ccl::Topology topology,
     const GlobalSemaphore semaphore,
     bool enable_persistent_fabric_mode);
+operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore semaphore,
+    bool enable_persistent_fabric_mode);
 
 namespace operations {
 namespace experimental {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -134,7 +134,7 @@ operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const GlobalSemaphore semaphore,
+    const GlobalSemaphore& semaphore,
     const std::optional<SubDeviceId>& sub_device_id,
     bool enable_persistent_fabric_mode);
 operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
@@ -147,7 +147,7 @@ operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const GlobalSemaphore semaphore,
+    const GlobalSemaphore& semaphore,
     const std::optional<SubDeviceId>& sub_device_id,
     bool enable_persistent_fabric_mode);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -217,20 +217,24 @@ operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32
         writer_rt_args.push_back(forward_fabric_connection.has_value());
         if (forward_fabric_connection.has_value()) {
             auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, {core}, 0);
             auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
             append_worker_to_fabric_edm_sender_rt_args(
                 forward_fabric_connection.value(),
                 sender_worker_flow_control_semaphore_id,
+                sender_worker_teardown_semaphore_id,
                 sender_worker_buffer_index_semaphore_id,
                 writer_rt_args);
         }
         writer_rt_args.push_back(backward_fabric_connection.has_value());
         if (backward_fabric_connection.has_value()) {
             auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, {core}, 0);
             auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
             append_worker_to_fabric_edm_sender_rt_args(
                 backward_fabric_connection.value(),
                 sender_worker_flow_control_semaphore_id,
+                sender_worker_teardown_semaphore_id,
                 sender_worker_buffer_index_semaphore_id,
                 writer_rt_args);
         }
@@ -504,20 +508,24 @@ operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
         writer_rt_args.push_back(forward_fabric_connection.has_value());
         if (forward_fabric_connection.has_value()) {
             auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, {core}, 0);
             auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
             append_worker_to_fabric_edm_sender_rt_args(
                 forward_fabric_connection.value(),
                 sender_worker_flow_control_semaphore_id,
+                sender_worker_teardown_semaphore_id,
                 sender_worker_buffer_index_semaphore_id,
                 writer_rt_args);
         }
         writer_rt_args.push_back(backward_fabric_connection.has_value());
         if (backward_fabric_connection.has_value()) {
             auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, {core}, 0);
             auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
             append_worker_to_fabric_edm_sender_rt_args(
                 backward_fabric_connection.value(),
                 sender_worker_flow_control_semaphore_id,
+                sender_worker_teardown_semaphore_id,
                 sender_worker_buffer_index_semaphore_id,
                 writer_rt_args);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -263,4 +263,291 @@ operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
+operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore semaphore,
+    bool enable_persistent_fabric_mode) {
+    tt::tt_metal::Program program{};
+    const bool enable_async_output_tensor = false;
+    TT_FATAL(
+        enable_persistent_fabric_mode,
+        "only persistent fabric mode is supported for all_gather_async_llama_post_binary_matmul");
+
+    IDevice* device = input_tensor.device();
+    bool is_first_chip = ring_index == 0;
+    bool is_last_chip = ring_index == ring_size - 1;
+    log_trace(
+        tt::LogOp,
+        "DEBUG: device: {}, is_first_chip: {}, is_last_chip: {}",
+        input_tensor.device()->id(),
+        is_first_chip,
+        is_last_chip);
+
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
+        ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+            device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+
+    // Get OP Config, topology config
+    std::vector<Tensor> input_tensors = {input_tensor};
+    std::vector<Tensor> output_tensors = {output_tensor};
+    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
+    LineTopology line_topology(ring_size, ring_index);
+    const size_t num_targets_forward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+    const size_t num_targets_backward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+
+    // Get worker cores, assuming 1 worker per link
+    uint32_t num_workers_per_link = 1;
+    const auto [sender_worker_core_range, sender_worker_cores] =
+        choose_worker_cores(num_links, num_workers_per_link, enable_persistent_fabric_mode, device);
+
+    // Tensor Info
+    const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const auto input_tensor_cores = input_tensor.memory_config().shard_spec->grid;
+    const auto input_tensor_shard_shape = input_tensor.memory_config().shard_spec->shape;
+    const auto input_tensor_shard_num_pages = input_tensor_shard_shape[0] * input_tensor_shard_shape[1] / TILE_HW;
+    const auto output_tensor_cores = output_tensor.memory_config().shard_spec->grid;
+    const auto output_tensor_shard_shape = output_tensor.memory_config().shard_spec->shape;
+    const auto output_tensor_shard_num_pages = output_tensor_shard_shape[0] * output_tensor_shard_shape[1] / TILE_HW;
+
+    tt::log_debug(tt::LogOp, "input_tensor_num_pages: {}", input_tensor_num_pages);
+    tt::log_debug(tt::LogOp, "input_tensor_cores: {}", input_tensor_cores);
+    tt::log_debug(tt::LogOp, "input_tensor_shard_shape: {}", input_tensor_shard_shape);
+    tt::log_debug(tt::LogOp, "input_tensor_shard_num_pages: {}", input_tensor_shard_num_pages);
+    tt::log_debug(tt::LogOp, "output_tensor_cores: {}", output_tensor_cores);
+    tt::log_debug(tt::LogOp, "output_tensor_shard_shape: {}", output_tensor_shard_shape);
+    tt::log_debug(tt::LogOp, "output_tensor_shard_num_pages: {}", output_tensor_shard_num_pages);
+
+    // L1 Scratch CB Creation
+    const size_t packet_size_bytes = local_fabric_handle->get_edm_buffer_size_bytes();
+    uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
+    uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
+    uint32_t cb_num_pages = 3 * std::max(num_pages_per_packet, input_tensor_shard_num_pages);  // tripple buffering
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
+            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
+    CBHandle cb_src0_workers = CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
+    const auto reserved_packet_header_CB_index = tt::CB::c_in6;
+    static constexpr auto num_packet_headers_storable = 8;
+    static constexpr auto packet_header_size_bytes = sizeof(tt::fabric::PacketHeader);
+    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_packet_headers_storable * packet_header_size_bytes * 2,
+            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
+            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
+    auto reserved_packet_header_CB_handle =
+        CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+
+    // KERNEL CREATION
+    // Reader
+    auto reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
+    reader_kernel_config.compile_args = {
+        ring_index,                 // my_chip_id
+        src0_cb_index,              // cb0_id
+        op_config.get_page_size(),  // tensor0_page_size
+    };
+    log_trace(tt::LogOp, "Reader Compile Args:");
+    for (const auto& arg : reader_kernel_config.compile_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
+        "llama_post_binary_matmul_shape_reader.cpp",
+        sender_worker_core_range,
+        reader_kernel_config);
+
+    // Writer
+    auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
+    writer_kernel_config.compile_args = {
+        ring_index,                       // my_chip_id
+        reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+        num_packet_headers_storable,      // num_packet_headers_storable
+        src0_cb_index,                    // cb0_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_targets_forward_direction
+        num_targets_backward,             // num_targets_backward_direction
+    };
+    log_trace(tt::LogOp, "Writer Compile Args:");
+    for (const auto& arg : writer_kernel_config.compile_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
+        "llama_post_binary_matmul_shape_writer.cpp",
+        sender_worker_core_range,
+        writer_kernel_config);
+
+    // Kernel Runtime Args
+    CoreCoord drain_sync_core;  // the first worker of each chip is the drain sync core, which contains the output ready
+                                // semaphore
+    auto input_cores_vec = corerange_to_cores(input_tensor_cores, std::nullopt, true);
+    auto output_cores_vec = corerange_to_cores(output_tensor_cores, std::nullopt, true);
+    auto cores_per_device = output_cores_vec.size() / ring_size;
+    TT_FATAL(
+        output_cores_vec.size() % ring_size == 0,
+        "output sharded cores must be divisible by num_links for this work distribution scheme");
+    auto output_cores_this_device = std::vector<CoreCoord>(
+        output_cores_vec.begin() + ring_index * cores_per_device,
+        output_cores_vec.begin() + (ring_index + 1) * cores_per_device);
+
+    for (uint32_t link = 0; link < num_links; link++) {
+        CoreCoord core = sender_worker_cores[link];
+
+        // construct input and output core x and y
+        uint32_t base_pages_per_worker = input_tensor_num_pages / num_links;
+        uint32_t remainder = input_tensor_num_pages % num_links;
+        uint32_t input_tile_id_start = link * base_pages_per_worker + std::min(link, remainder);
+        uint32_t input_tile_id_end = (link + 1) * base_pages_per_worker + std::min(link + 1, remainder);
+
+        uint32_t worker_num_tiles_to_read = input_tile_id_end - input_tile_id_start;
+        uint32_t input_first_core_tile_start_offset = worker_num_tiles_to_read % input_tensor_shard_num_pages;
+        uint32_t output_first_core_tile_start_offset = worker_num_tiles_to_read % output_tensor_shard_num_pages;
+
+        std::vector<uint32_t> input_tensor_cores_x;
+        std::vector<uint32_t> input_tensor_cores_y;
+        std::vector<uint32_t> output_tensor_cores_x;
+        std::vector<uint32_t> output_tensor_cores_y;
+        for (uint32_t i = input_tile_id_start / input_tensor_shard_num_pages;
+             i < (input_tile_id_end + input_tensor_shard_num_pages - 1) / input_tensor_shard_num_pages;
+             i++) {
+            auto this_core = device->worker_core_from_logical_core(input_cores_vec[i]);
+            input_tensor_cores_x.push_back(this_core.x);
+            input_tensor_cores_y.push_back(this_core.y);
+        }
+        for (uint32_t i = input_tile_id_start / output_tensor_shard_num_pages;
+             i < (input_tile_id_end + output_tensor_shard_num_pages - 1) / output_tensor_shard_num_pages;
+             i++) {
+            auto this_core = device->worker_core_from_logical_core(output_cores_this_device[i]);
+            output_tensor_cores_x.push_back(this_core.x);
+            output_tensor_cores_y.push_back(this_core.y);
+        }
+
+        tt::log_debug(tt::LogOp, "input_tile_id_start: {}", input_tile_id_start);
+        tt::log_debug(tt::LogOp, "input_tile_id_end: {}", input_tile_id_end);
+        tt::log_debug(tt::LogOp, "worker_num_tiles_to_read: {}", worker_num_tiles_to_read);
+        tt::log_debug(tt::LogOp, "input_first_core_tile_start_offset: {}", input_first_core_tile_start_offset);
+        tt::log_debug(tt::LogOp, "output_first_core_tile_start_offset: {}", output_first_core_tile_start_offset);
+        tt::log_debug(tt::LogOp, "input_tensor_cores_x: {}", input_tensor_cores_x);
+        tt::log_debug(tt::LogOp, "input_tensor_cores_y: {}", input_tensor_cores_y);
+        tt::log_debug(tt::LogOp, "output_tensor_cores_x: {}", output_tensor_cores_x);
+        tt::log_debug(tt::LogOp, "output_tensor_cores_y: {}", output_tensor_cores_y);
+
+        if (link == 0) {
+            // drain sync core is the first worker core
+            drain_sync_core = device->worker_core_from_logical_core(core);
+        }
+        std::optional<ttnn::ccl::SenderWorkerAdapterSpec> forward_fabric_connection =
+            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+                ? std::nullopt
+                : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
+        std::optional<ttnn::ccl::SenderWorkerAdapterSpec> backward_fabric_connection =
+            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+                ? std::nullopt
+                : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
+
+        // Set reader runtime args
+        std::vector<uint32_t> reader_rt_args = {
+            input_tensor.buffer()->address(),    // tensor_address0
+            input_tensor_shard_num_pages,        // num_tiles_per_core
+            worker_num_tiles_to_read,            // num_tiles_to_read
+            input_first_core_tile_start_offset,  // first_core_tile_start_offset
+            input_tensor_cores_x.size(),         // num_cores
+        };
+        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_x.begin(), input_tensor_cores_x.end());
+        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_y.begin(), input_tensor_cores_y.end());
+        log_trace(tt::LogOp, "Reader Runtime Args:");
+        for (const auto& arg : reader_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+
+        // Set writer runtime args
+        bool wait_output_semaphore = (link == 0) && !enable_async_output_tensor;
+        bool reset_global_semaphore = (link == 0) && !enable_async_output_tensor;
+        uint32_t out_ready_sem_wait_value = ring_size * num_links;
+        std::vector<uint32_t> writer_rt_args = {
+            output_tensor.buffer()->address(),    // tensor_address0
+            output_tensor_shard_num_pages,        // num_tiles_per_core
+            worker_num_tiles_to_read,             // num_tiles_to_read
+            output_first_core_tile_start_offset,  // first_core_tile_start_offset
+            output_tensor_cores_x.size(),         // num_cores
+            wait_output_semaphore,                // wait_output_semaphore
+            reset_global_semaphore,               // reset_global_semaphore
+            semaphore.address(),                  // out_ready_sem_bank_addr (absolute address)
+            drain_sync_core.x,                    // out_ready_sem_noc0_x
+            drain_sync_core.y,                    // out_ready_sem_noc0_y
+            out_ready_sem_wait_value,             // out_ready_sem_wait_value
+        };
+        writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_x.begin(), output_tensor_cores_x.end());
+        writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_y.begin(), output_tensor_cores_y.end());
+        log_trace(tt::LogOp, "Writer Runtime Args:");
+        for (const auto& arg : writer_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        writer_rt_args.push_back(forward_fabric_connection.has_value());
+        if (forward_fabric_connection.has_value()) {
+            auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
+            append_worker_to_fabric_edm_sender_rt_args(
+                forward_fabric_connection.value(),
+                sender_worker_flow_control_semaphore_id,
+                sender_worker_buffer_index_semaphore_id,
+                writer_rt_args);
+        }
+        writer_rt_args.push_back(backward_fabric_connection.has_value());
+        if (backward_fabric_connection.has_value()) {
+            auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
+            append_worker_to_fabric_edm_sender_rt_args(
+                backward_fabric_connection.value(),
+                sender_worker_flow_control_semaphore_id,
+                sender_worker_buffer_index_semaphore_id,
+                writer_rt_args);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+    }
+
+    auto override_runtime_arguments_callback =
+        [worker_sender_reader_kernel_id, worker_sender_writer_kernel_id, semaphore, sender_worker_cores](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& input = input_tensors[0];
+            const auto& output = output_tensors[0];
+
+            // update senders
+            auto& worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
+            auto& worker_writer_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_writer_kernel_id);
+            for (const auto& core : sender_worker_cores) {
+                // reader
+                auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
+                worker_reader_sender_runtime_args[0] = input.buffer()->address();
+                // writer
+                auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
+                worker_writer_sender_runtime_args[0] = output.buffer()->address();
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+///
+#include <algorithm>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/buffer.hpp>
+#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/math.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+#include "cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+#include "cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
+#include "cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
+#include <sstream>
+#include <type_traits>
+#include <ranges>
+#include <optional>
+using namespace tt::constants;
+
+namespace ttnn {
+
+using namespace ccl;
+
+operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32_any(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore semaphore,
+    bool enable_persistent_fabric_mode) {
+    tt::tt_metal::Program program{};
+    const bool enable_async_output_tensor = false;
+    TT_FATAL(
+        enable_persistent_fabric_mode,
+        "only persistent fabric mode is supported for all_gather_async_minimal_interleaved_dim3_1_1_32_any");
+
+    IDevice* device = input_tensor.device();
+    bool is_first_chip = ring_index == 0;
+    bool is_last_chip = ring_index == ring_size - 1;
+    log_trace(
+        tt::LogOp,
+        "DEBUG: device: {}, is_first_chip: {}, is_last_chip: {}",
+        input_tensor.device()->id(),
+        is_first_chip,
+        is_last_chip);
+
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
+        ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+            device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+
+    // Get OP Config, topology config
+    std::vector<Tensor> input_tensors = {input_tensor};
+    std::vector<Tensor> output_tensors = {output_tensor};
+    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
+    LineTopology line_topology(ring_size, ring_index);
+    const size_t num_targets_forward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+    const size_t num_targets_backward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+
+    // Get worker cores, assuming 1 worker per link
+    uint32_t num_workers_per_link = 1;
+    const auto [sender_worker_core_range, sender_worker_cores] =
+        choose_worker_cores(num_links, num_workers_per_link, enable_persistent_fabric_mode, device);
+
+    // L1 Scratch CB Creation
+    const size_t packet_size_bytes = local_fabric_handle->get_edm_buffer_size_bytes();
+    uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
+    uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
+    uint32_t cb_num_pages = 3 * num_pages_per_packet;  // tripple buffering
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
+            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
+    CBHandle cb_src0_workers = CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
+    const auto reserved_packet_header_CB_index = tt::CB::c_in6;
+    static constexpr auto num_packet_headers_storable = 8;
+    static constexpr auto packet_header_size_bytes = sizeof(tt::fabric::PacketHeader);
+    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_packet_headers_storable * packet_header_size_bytes * 2,
+            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
+            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
+    auto reserved_packet_header_CB_handle =
+        CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+
+    // Tensor Info
+    const auto input_tensor_layout = input_tensor.buffer()->buffer_layout();
+    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
+    const auto input_tensor_page_layout = input_tensor.layout();
+    const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const auto output_tensor_layout = output_tensor.buffer()->buffer_layout();
+    const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
+    const auto output_tensor_page_layout = output_tensor.layout();
+
+    // KERNEL CREATION
+    // Reader
+    auto reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
+    reader_kernel_config.compile_args = {
+        ring_index,                                       // my_chip_id
+        static_cast<uint32_t>(input_tensor_layout),       // tensor0_layout
+        static_cast<uint32_t>(input_tensor_buffer_type),  // buffer0_type
+        static_cast<uint32_t>(input_tensor_page_layout),  // tensor0_page_layout
+        src0_cb_index,                                    // cb0_id
+        input_tensor_num_pages,                           // num_pages_read_total per chip
+        num_links,                                        // num_workers
+    };
+    log_trace(tt::LogOp, "Reader Compile Args:");
+    for (const auto& arg : reader_kernel_config.compile_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
+        "interleaved_dim3_1_1_32_any_reader.cpp",
+        sender_worker_core_range,
+        reader_kernel_config);
+
+    // Writer
+    auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
+    writer_kernel_config.compile_args = {
+        ring_index,                                        // my_chip_id
+        reserved_packet_header_CB_index,                   // reserved_packet_header_cb_id
+        num_packet_headers_storable,                       // num_packet_headers_storable
+        static_cast<uint32_t>(output_tensor_layout),       // tensor0_layout
+        static_cast<uint32_t>(output_tensor_buffer_type),  // buffer0_type
+        static_cast<uint32_t>(output_tensor_page_layout),  // tensor0_page_layout
+        src0_cb_index,                                     // cb0_id
+        input_tensor_num_pages,                            // num_pages_read_total per chip
+        num_links,                                         // num_workers
+        num_targets_forward,                               // num_targets_forward_direction
+        num_targets_backward,                              // num_targets_backward_direction
+    };
+    log_trace(tt::LogOp, "Writer Compile Args:");
+    for (const auto& arg : writer_kernel_config.compile_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
+        "interleaved_dim3_1_1_32_any_writer.cpp",
+        sender_worker_core_range,
+        writer_kernel_config);
+
+    // Kernel Runtime Args
+    CoreCoord drain_sync_core;  // the first worker of each chip is the drain sync core, which contains the output ready
+                                // semaphore
+    for (std::size_t link = 0; link < num_links; link++) {
+        CoreCoord core = sender_worker_cores[link];
+        if (link == 0) {
+            // drain sync core is the first worker core
+            drain_sync_core = device->worker_core_from_logical_core(core);
+        }
+        std::optional<ttnn::ccl::SenderWorkerAdapterSpec> forward_fabric_connection =
+            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+                ? std::nullopt
+                : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
+        std::optional<ttnn::ccl::SenderWorkerAdapterSpec> backward_fabric_connection =
+            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+                ? std::nullopt
+                : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
+
+        // Set reader runtime args
+        std::vector<uint32_t> reader_rt_args = {
+            input_tensor.buffer()->address(),  // tensor_address0
+            num_pages_per_packet,              // packet_size_in_pages
+            op_config.get_page_size(),         // tensor0_page_size
+        };
+        log_trace(tt::LogOp, "Reader Runtime Args:");
+        for (const auto& arg : reader_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+
+        // Set writer runtime args
+        bool wait_output_semaphore = (link == 0) && !enable_async_output_tensor;
+        bool reset_global_semaphore = (link == 0) && !enable_async_output_tensor;
+        uint32_t out_ready_sem_wait_value = ring_size * num_links;
+        std::vector<uint32_t> writer_rt_args = {
+            output_tensor.buffer()->address(),  // tensor_address0
+            num_pages_per_packet,               // packet_size_in_pages
+            op_config.get_page_size(),          // tensor0_page_size
+            wait_output_semaphore,              // wait_output_semaphore
+            reset_global_semaphore,             // reset_global_semaphore
+            semaphore.address(),                // out_ready_sem_bank_addr (absolute address)
+            drain_sync_core.x,                  // out_ready_sem_noc0_x
+            drain_sync_core.y,                  // out_ready_sem_noc0_y
+            out_ready_sem_wait_value,           // out_ready_sem_wait_value
+        };
+        log_trace(tt::LogOp, "Writer Runtime Args:");
+        for (const auto& arg : writer_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        writer_rt_args.push_back(forward_fabric_connection.has_value());
+        if (forward_fabric_connection.has_value()) {
+            auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
+            append_worker_to_fabric_edm_sender_rt_args(
+                forward_fabric_connection.value(),
+                sender_worker_flow_control_semaphore_id,
+                sender_worker_buffer_index_semaphore_id,
+                writer_rt_args);
+        }
+        writer_rt_args.push_back(backward_fabric_connection.has_value());
+        if (backward_fabric_connection.has_value()) {
+            auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+            auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
+            append_worker_to_fabric_edm_sender_rt_args(
+                backward_fabric_connection.value(),
+                sender_worker_flow_control_semaphore_id,
+                sender_worker_buffer_index_semaphore_id,
+                writer_rt_args);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+    }
+
+    auto override_runtime_arguments_callback =
+        [worker_sender_reader_kernel_id, worker_sender_writer_kernel_id, semaphore, sender_worker_cores](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& input = input_tensors[0];
+            const auto& output = output_tensors[0];
+
+            // update senders
+            auto& worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
+            auto& worker_writer_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_writer_kernel_id);
+            for (const auto& core : sender_worker_cores) {
+                // reader
+                auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
+                worker_reader_sender_runtime_args[0] = input.buffer()->address();
+                // writer
+                auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
+                worker_writer_sender_runtime_args[0] = output.buffer()->address();
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -64,7 +64,12 @@ operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32
 
     std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
         ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
-            device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+            device,
+            forward_device.value_or(nullptr),
+            backward_device.value_or(nullptr),
+            &program,
+            enable_persistent_fabric_mode,
+            num_links);
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
@@ -304,7 +309,12 @@ operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
 
     std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
         ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
-            device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+            device,
+            forward_device.value_or(nullptr),
+            backward_device.value_or(nullptr),
+            &program,
+            enable_persistent_fabric_mode,
+            num_links);
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -335,7 +335,8 @@ operation::ProgramWithCallbacks all_gather_async_llama_post_binary_matmul(
     const size_t packet_size_bytes = local_fabric_handle->get_edm_buffer_size_bytes();
     uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
     uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
-    uint32_t cb_num_pages = 3 * std::max(num_pages_per_packet, input_tensor_shard_num_pages);  // tripple buffering
+    uint32_t cb_base_num_pages = std::lcm(input_tensor_shard_num_pages, output_tensor_shard_num_pages);
+    uint32_t cb_num_pages = std::lcm(num_pages_per_packet, cb_base_num_pages);
     uint32_t src0_cb_index = tt::CB::c_in0;
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
     tt::tt_metal::CircularBufferConfig cb_src0_config =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_reader.cpp
@@ -1,28 +1,14 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
-//       that don't require macros to function
-
 #include "dataflow_api.h"
 #include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
-#include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
-
-#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
-
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
-
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
-#include "cpp/ttnn/tensor/enum_types.hpp"
 #include <cstdint>
 #include <utility>
+
+using address_t = uint32_t;
+using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_reader.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
+//       that don't require macros to function
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
+
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "cpp/ttnn/tensor/enum_types.hpp"
+#include <cstdint>
+#include <utility>
+
+using arg_idx_t = uint16_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint16_t my_chip_id = get_compile_time_arg_val(0);
+constexpr TensorMemoryLayout tensor0_layout = static_cast<TensorMemoryLayout>(get_compile_time_arg_val(1));
+constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(2));
+constexpr Layout tensor0_page_layout = static_cast<Layout>(get_compile_time_arg_val(3));
+constexpr uint32_t cb0_id = get_compile_time_arg_val(4);
+constexpr uint32_t num_pages_read_total = get_compile_time_arg_val(5);
+constexpr uint32_t num_workers = get_compile_time_arg_val(6);
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 0;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    const uint16_t packet_size_in_pages = get_arg_val<uint32_t>(arg_idx++);
+    uint16_t tensor0_page_size = get_arg_val<uint32_t>(arg_idx++);
+
+    // print every compile and runtime arg in uint32_t
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "tensor0_layout: " << (uint32_t)tensor0_layout << "\n";
+    DPRINT << "buffer0_type: " << (uint32_t)buffer0_type << "\n";
+    DPRINT << "tensor0_page_layout: " << (uint32_t)tensor0_page_layout << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "num_pages_read_total: " << (uint32_t)num_pages_read_total << "\n";
+    DPRINT << "num_workers: " << (uint32_t)num_workers << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+
+    // interleaved addrgen
+    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
+    auto tensor0_addrgen = InterleavedAddrGenFast<is_dram>{
+        .bank_base_address = tensor_address0, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
+
+    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
+
+    uint32_t tile_id = 0;
+    for (uint32_t i = 0; i < num_pages_read_total / packet_size_in_pages + 1; i++) {
+        DPRINT << "i: " << i << "\n";
+        cb_reserve_back(cb0_id, packet_size_in_pages);
+        const uint32_t l1_write_addr_base = get_write_ptr(cb0_id);
+        uint32_t l1_write_addr = l1_write_addr_base;
+
+        uint16_t num_pages_to_read = (i == num_pages_read_total / packet_size_in_pages)
+                                         ? num_pages_read_total % packet_size_in_pages
+                                         : packet_size_in_pages;
+        for (uint16_t j = 0; j < num_pages_to_read; j++) {
+            noc_async_read_tile(tile_id, tensor0_addrgen, l1_write_addr);
+            l1_write_addr += tensor0_page_size;
+            tile_id++;
+        }
+        DPRINT << "tile_id: " << tile_id << "\n";
+
+        noc_async_read_barrier();
+        cb_push_back(cb0_id, packet_size_in_pages);
+    }
+
+    DPRINT << "DONE \n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -1,28 +1,17 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
-//       that don't require macros to function
-
 #include "dataflow_api.h"
 #include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
-#include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
-
-#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
-
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
-
 #include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
 #include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
-#include "cpp/ttnn/tensor/enum_types.hpp"
+#include "minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
+
+using address_t = uint32_t;
+using tt::tt_metal::BufferType;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -37,50 +26,6 @@ constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(5);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(7);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(8);
-
-FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
-    uint64_t noc0_dest_noc_addr,
-    size_t packet_header_buffer_addr,
-    uint32_t num_targets_forward_direction,
-    uint32_t num_targets_backward_direction,
-    FabricConnectionManager& fabric_connection,
-    size_t& l1_read_addr,
-    uint32_t payload_size_bytes) {
-    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
-    const size_t payload_l1_address = l1_read_addr;
-
-    auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
-#ifdef DEBUG_PRINT_ENABLED
-    pkt_hdr->reserved2 = my_chip_id;
-#endif
-
-    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
-
-    noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
-    if (fabric_connection.has_forward_connection()) {
-        pkt_hdr->to_chip_multicast(
-            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
-        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
-            l1_read_addr, payload_size_bytes);
-        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
-    }
-
-    if (fabric_connection.has_backward_connection()) {
-        pkt_hdr->to_chip_multicast(
-            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
-        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-        fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
-            l1_read_addr, payload_size_bytes);
-        fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
-            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
-    }
-
-    l1_read_addr += payload_size_bytes;
-}
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -135,8 +80,28 @@ void kernel_main() {
     DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
 
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, num_packet_headers_storable);
-    auto packet_header_buffer_addr = get_write_ptr(reserved_packet_header_cb_id);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    DPRINT << "packet_header_buffer_addr_forward: " << (uint32_t)packet_header_buffer_addr_forward << "\n";
+    DPRINT << "packet_header_buffer_addr_backward: " << (uint32_t)packet_header_buffer_addr_backward << "\n";
+    DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
+
+    // pre-populate packet headers
+    volatile tt::fabric::PacketHeader* pkt_hdr_forward =
+        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_forward);
+    volatile tt::fabric::PacketHeader* pkt_hdr_backward =
+        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_backward);
+    pkt_hdr_forward->to_chip_multicast(
+        tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+    pkt_hdr_backward->to_chip_multicast(
+        tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
 
     // interleaved addrgen
     constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
@@ -171,9 +136,8 @@ void kernel_main() {
 
             write_and_advance_local_read_address_for_fabric_write(
                 noc0_dest_noc_addr,
-                packet_header_buffer_addr,
-                num_targets_forward_direction,
-                num_targets_backward_direction,
+                pkt_hdr_forward,
+                pkt_hdr_backward,
                 fabric_connection,
                 l1_read_addr,
                 contig_pages_advanced * tensor0_page_size);
@@ -186,7 +150,7 @@ void kernel_main() {
     }
 
     // 2. mcast output ready semaphore
-    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_seminc);
     pkt_hdr->to_atomic_inc();
     pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
         out_ready_sem_bank_addr,
@@ -200,7 +164,7 @@ void kernel_main() {
         pkt_hdr->to_chip_multicast(
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
@@ -208,7 +172,7 @@ void kernel_main() {
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
     }
     // increment locally
     uint64_t out_ready_sem_noc_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -94,11 +94,11 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
     bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
     bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
-    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
+//       that don't require macros to function
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
+
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "cpp/ttnn/tensor/enum_types.hpp"
+#include <cstdint>
+#include <utility>
+
+using arg_idx_t = uint16_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint16_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
+constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
+constexpr TensorMemoryLayout tensor0_layout = static_cast<TensorMemoryLayout>(get_compile_time_arg_val(3));
+constexpr BufferType buffer0_type = static_cast<BufferType>(get_compile_time_arg_val(4));
+constexpr Layout tensor0_page_layout = static_cast<Layout>(get_compile_time_arg_val(5));
+constexpr uint32_t cb0_id = get_compile_time_arg_val(6);
+constexpr uint32_t num_pages_read_total = get_compile_time_arg_val(7);
+constexpr uint32_t num_workers = get_compile_time_arg_val(8);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(9);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(10);
+
+FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
+    uint64_t noc0_dest_noc_addr,
+    size_t packet_header_buffer_addr,
+    uint32_t num_targets_forward_direction,
+    uint32_t num_targets_backward_direction,
+    FabricConnectionManager& fabric_connection,
+    size_t& l1_read_addr,
+    uint32_t payload_size_bytes) {
+    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
+    const size_t payload_l1_address = l1_read_addr;
+
+    auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+#ifdef DEBUG_PRINT_ENABLED
+    pkt_hdr->reserved2 = my_chip_id;
+#endif
+
+    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
+    pkt_hdr->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
+        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+
+    noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
+    if (fabric_connection.has_forward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
+            l1_read_addr, payload_size_bytes);
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+    }
+
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
+            l1_read_addr, payload_size_bytes);
+        fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+    }
+
+    l1_read_addr += payload_size_bytes;
+}
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 0;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    const uint16_t packet_size_in_pages = get_arg_val<uint32_t>(arg_idx++);
+    uint16_t tensor0_page_size = get_arg_val<uint32_t>(arg_idx++);
+    bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    size_t arg_for_fab = arg_idx;
+    auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
+
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "reserved_packet_header_cb_id: " << (uint32_t)reserved_packet_header_cb_id << "\n";
+    DPRINT << "num_packet_headers_storable: " << (uint32_t)num_packet_headers_storable << "\n";
+    DPRINT << "tensor0_layout: " << (uint32_t)tensor0_layout << "\n";
+    DPRINT << "buffer0_type: " << (uint32_t)buffer0_type << "\n";
+    DPRINT << "tensor0_page_layout: " << (uint32_t)tensor0_page_layout << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "num_pages_read_total: " << (uint32_t)num_pages_read_total << "\n";
+    DPRINT << "num_workers: " << (uint32_t)num_workers << "\n";
+    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << "\n";
+    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << "\n";
+    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << "\n";
+    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << "\n";
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << "\n";
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << "\n";
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << "\n";
+
+    DPRINT << "arg_for_fab: " << (uint32_t)arg_for_fab << "\n";
+    DPRINT << "fabric_connection arg 0" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 1" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 2" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 3" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+
+    // packet header cb
+    cb_reserve_back(reserved_packet_header_cb_id, num_packet_headers_storable);
+    auto packet_header_buffer_addr = get_write_ptr(reserved_packet_header_cb_id);
+
+    // interleaved addrgen
+    constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
+    auto tensor0_addrgen = InterleavedAddrGenFast<is_dram>{
+        .bank_base_address = tensor_address0, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.open();
+    }
+
+    // 1. mcast via fabric to remote tensor addresses
+    DPRINT << "num_targets_forward_direction: " << num_targets_forward_direction << "\n";
+    DPRINT << "num_targets_backward_direction: " << num_targets_backward_direction << "\n";
+    DPRINT << "my_chip_id: " << my_chip_id << "\n";
+
+    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
+    uint32_t tile_id = my_chip_id * num_pages_read_total;  // this is the write offset per chip
+    for (uint32_t i = 0; i < num_pages_read_total / packet_size_in_pages + 1; i++) {
+        DPRINT << "packet: " << i << "\n";
+        uint16_t num_pages_to_read = (i == num_pages_read_total / packet_size_in_pages)
+                                         ? num_pages_read_total % packet_size_in_pages
+                                         : packet_size_in_pages;
+
+        cb_wait_front(cb0_id, packet_size_in_pages);
+        size_t l1_read_addr = get_read_ptr(cb0_id);
+
+        uint16_t contig_pages_advanced = 1;  // always 1 for interleaved
+        for (uint16_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
+            uint64_t noc0_dest_noc_addr = get_noc_addr(tile_id, tensor0_addrgen, 0 /*offset*/, 0 /*noc_id*/);
+
+            DPRINT << "j: " << j << "\n";
+            DPRINT << "noc0_dest_noc_addr: " << noc0_dest_noc_addr << "\n";
+            DPRINT << "tile_id: " << tile_id << "\n";
+
+            write_and_advance_local_read_address_for_fabric_write(
+                noc0_dest_noc_addr,
+                packet_header_buffer_addr,
+                num_targets_forward_direction,
+                num_targets_backward_direction,
+                fabric_connection,
+                l1_read_addr,
+                contig_pages_advanced * tensor0_page_size);
+
+            tile_id++;
+        }
+        noc_async_writes_flushed();
+
+        cb_pop_front(cb0_id, packet_size_in_pages);
+    }
+
+    // 2. mcast output ready semaphore
+    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+    pkt_hdr->to_atomic_inc();
+    pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_bank_addr,
+        static_cast<uint16_t>(1),  // increment 1
+        32,
+        static_cast<uint8_t>(out_ready_sem_noc0_x),
+        static_cast<uint8_t>(out_ready_sem_noc0_y)});
+    // Write the mcast packet (forward)
+    if (fabric_connection.has_forward_connection()) {
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+    }
+    // Write the mcast packet (backward)
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+    }
+    // increment locally
+    uint64_t out_ready_sem_noc_addr =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+    DPRINT << "inc done\n";
+
+    // 3. wait for mcast output ready semaphore
+    if (wait_output_semaphore) {
+        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
+        DPRINT << "waitval done\n";
+    }
+
+    // 4. global semaphore reset
+    if (reset_global_semaphore) {
+        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
+        noc_inline_dw_write(dest_noc_addr, 0);
+        DPRINT << "reset done\n";
+    }
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.close();
+    }
+
+    noc_async_write_barrier();
+    DPRINT << "DONE \n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_reader.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
+//       that don't require macros to function
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
+
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "cpp/ttnn/tensor/enum_types.hpp"
+#include <cstdint>
+#include <utility>
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 0;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
+    tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+    tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+
+    // print every compile and runtime arg in uint32_t
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "num_tiles_per_core: " << (uint32_t)num_tiles_per_core << "\n";
+    DPRINT << "num_tiles_to_read: " << (uint32_t)num_tiles_to_read << "\n";
+    DPRINT << "first_core_tile_start_offset: " << (uint32_t)first_core_tile_start_offset << "\n";
+    DPRINT << "num_cores: " << (uint32_t)num_cores << "\n";
+    for (uint32_t i = 0; i < num_cores; i++) {
+        DPRINT << "core_noc_x[" << i << "]: " << (uint32_t)core_noc_x[i] << "\n";
+        DPRINT << "core_noc_y[" << i << "]: " << (uint32_t)core_noc_y[i] << "\n";
+    }
+
+    // interleaved addrgen
+
+    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
+
+    uint32_t tiles_read = 0;
+    uint32_t shard_tile_id = first_core_tile_start_offset;
+    uint32_t core_id = 0;
+    while (tiles_read < num_tiles_to_read) {
+        DPRINT << "tiles_read: " << tiles_read << "\n";
+        uint32_t num_tiles_to_read_this_core =
+            std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
+        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
+        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
+        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
+        read_addr += shard_tile_id * tensor0_page_size;
+
+        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
+        noc_async_read_barrier();
+
+        cb_push_back(cb0_id, num_tiles_to_read_this_core);
+        tiles_read += num_tiles_to_read_this_core;
+        shard_tile_id = 0;
+        core_id++;
+    }
+
+    DPRINT << "DONE \n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_reader.cpp
@@ -1,28 +1,13 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
-//       that don't require macros to function
-
 #include "dataflow_api.h"
 #include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
-#include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
-
-#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
-
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
-
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
-#include "cpp/ttnn/tensor/enum_types.hpp"
 #include <cstdint>
 #include <utility>
+
+using address_t = uint32_t;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
+//       that don't require macros to function
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
+
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "cpp/ttnn/tensor/enum_types.hpp"
+#include <cstdint>
+#include <utility>
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
+constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+
+FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
+    uint64_t noc0_dest_noc_addr,
+    size_t packet_header_buffer_addr,
+    uint32_t num_targets_forward_direction,
+    uint32_t num_targets_backward_direction,
+    FabricConnectionManager& fabric_connection,
+    size_t& l1_read_addr,
+    uint32_t payload_size_bytes) {
+    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
+    const size_t payload_l1_address = l1_read_addr;
+
+    auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+#ifdef DEBUG_PRINT_ENABLED
+    pkt_hdr->reserved2 = my_chip_id;
+#endif
+
+    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
+    pkt_hdr->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
+        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+
+    noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
+    if (fabric_connection.has_forward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
+            l1_read_addr, payload_size_bytes);
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+    }
+
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
+            l1_read_addr, payload_size_bytes);
+        fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+    }
+
+    l1_read_addr += payload_size_bytes;
+}
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 0;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
+    bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+    tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+    size_t arg_for_fab = arg_idx;
+    auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
+
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "reserved_packet_header_cb_id: " << (uint32_t)reserved_packet_header_cb_id << "\n";
+    DPRINT << "num_packet_headers_storable: " << (uint32_t)num_packet_headers_storable << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << "\n";
+    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "num_tiles_per_core: " << (uint32_t)num_tiles_per_core << "\n";
+    DPRINT << "num_tiles_to_read: " << (uint32_t)num_tiles_to_read << "\n";
+    DPRINT << "first_core_tile_start_offset: " << (uint32_t)first_core_tile_start_offset << "\n";
+    DPRINT << "num_cores: " << (uint32_t)num_cores << "\n";
+    for (uint32_t i = 0; i < num_cores; i++) {
+        DPRINT << "core_noc_x[" << i << "]: " << (uint32_t)core_noc_x[i] << "\n";
+        DPRINT << "core_noc_y[" << i << "]: " << (uint32_t)core_noc_y[i] << "\n";
+    }
+    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << "\n";
+    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << "\n";
+    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << "\n";
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << "\n";
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << "\n";
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << "\n";
+
+    DPRINT << "arg_for_fab: " << (uint32_t)arg_for_fab << "\n";
+    DPRINT << "fabric_connection arg 0" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 1" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 2" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 3" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+
+    // packet header cb
+    cb_reserve_back(reserved_packet_header_cb_id, num_packet_headers_storable);
+    auto packet_header_buffer_addr = get_write_ptr(reserved_packet_header_cb_id);
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.open();
+    }
+
+    // 1. mcast via fabric to remote tensor addresses
+    uint32_t tiles_read = 0;
+    uint32_t shard_tile_id = first_core_tile_start_offset;
+    uint32_t core_id = 0;
+    while (tiles_read < num_tiles_to_read) {
+        DPRINT << "tiles_read: " << tiles_read << "\n";
+        uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
+        num_tiles_to_read_this_core = 1;  // std::min(num_tiles_to_read-tiles_read, num_tiles_to_read_this_core);
+        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
+        size_t l1_read_addr = get_read_ptr(cb0_id);
+
+        uint64_t noc0_dest_noc_addr =
+            get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0 /*noc_id*/);
+        DPRINT << "core_noc_x[core_id]: " << (uint32_t)core_noc_x[core_id] << "\n";
+        DPRINT << "core_noc_y[core_id]: " << (uint32_t)core_noc_y[core_id] << "\n";
+        DPRINT << "noc0_dest_noc_addr_base: " << noc0_dest_noc_addr << "\n";
+        noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
+
+        DPRINT << "core_id: " << core_id << "\n";
+        DPRINT << "num_tiles_to_read_this_core: " << num_tiles_to_read_this_core << "\n";
+        DPRINT << "noc0_dest_noc_addr: " << noc0_dest_noc_addr << "\n";
+        DPRINT << "shard_tile_id: " << shard_tile_id << "\n";
+
+        write_and_advance_local_read_address_for_fabric_write(
+            noc0_dest_noc_addr,
+            packet_header_buffer_addr,
+            num_targets_forward_direction,
+            num_targets_backward_direction,
+            fabric_connection,
+            l1_read_addr,
+            num_tiles_to_read_this_core * tensor0_page_size);
+        noc_async_writes_flushed();
+
+        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        tiles_read += num_tiles_to_read_this_core;
+        shard_tile_id += num_tiles_to_read_this_core;
+        if (shard_tile_id >= num_tiles_per_core) {
+            shard_tile_id = 0;
+            core_id++;
+        }
+    }
+
+    // 2. mcast output ready semaphore
+    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+    pkt_hdr->to_atomic_inc();
+    pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_bank_addr,
+        static_cast<uint16_t>(1),  // increment 1
+        32,
+        static_cast<uint8_t>(out_ready_sem_noc0_x),
+        static_cast<uint8_t>(out_ready_sem_noc0_y)});
+    // Write the mcast packet (forward)
+    if (fabric_connection.has_forward_connection()) {
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+    }
+    // Write the mcast packet (backward)
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+    }
+    // increment locally
+    uint64_t out_ready_sem_noc_addr =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+    DPRINT << "inc done\n";
+
+    // 3. wait for mcast output ready semaphore
+    if (wait_output_semaphore) {
+        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
+        DPRINT << "waitval done\n";
+    }
+
+    // 4. global semaphore reset
+    if (reset_global_semaphore) {
+        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
+        noc_inline_dw_write(dest_noc_addr, 0);
+        DPRINT << "reset done\n";
+    }
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.close();
+    }
+
+    noc_async_write_barrier();
+    DPRINT << "DONE \n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
@@ -93,13 +93,13 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
     bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
     bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
-    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
@@ -1,28 +1,16 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: This should ideally be merged with `ccl_send_reader` when we are able to support compile time args
-//       that don't require macros to function
-
 #include "dataflow_api.h"
 #include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
-#include <tt-metalium/buffer_constants.hpp>
-#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
-
-#include "cpp/ttnn/operations/ccl/common/kernels/command_processor.hpp"
-
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
-#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
-
 #include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
-#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/io_descriptors.hpp"
 #include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
-#include "cpp/ttnn/tensor/enum_types.hpp"
+#include "minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
+
+using address_t = uint32_t;
 
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -36,50 +24,6 @@ constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
-
-FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
-    uint64_t noc0_dest_noc_addr,
-    size_t packet_header_buffer_addr,
-    uint32_t num_targets_forward_direction,
-    uint32_t num_targets_backward_direction,
-    FabricConnectionManager& fabric_connection,
-    size_t& l1_read_addr,
-    uint32_t payload_size_bytes) {
-    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
-    const size_t payload_l1_address = l1_read_addr;
-
-    auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
-#ifdef DEBUG_PRINT_ENABLED
-    pkt_hdr->reserved2 = my_chip_id;
-#endif
-
-    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
-
-    noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
-    if (fabric_connection.has_forward_connection()) {
-        pkt_hdr->to_chip_multicast(
-            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
-        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
-            l1_read_addr, payload_size_bytes);
-        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
-    }
-
-    if (fabric_connection.has_backward_connection()) {
-        pkt_hdr->to_chip_multicast(
-            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
-        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-        fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
-            l1_read_addr, payload_size_bytes);
-        fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
-            (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
-    }
-
-    l1_read_addr += payload_size_bytes;
-}
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -145,8 +89,28 @@ void kernel_main() {
     DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
 
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, num_packet_headers_storable);
-    auto packet_header_buffer_addr = get_write_ptr(reserved_packet_header_cb_id);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    DPRINT << "packet_header_buffer_addr_forward: " << (uint32_t)packet_header_buffer_addr_forward << "\n";
+    DPRINT << "packet_header_buffer_addr_backward: " << (uint32_t)packet_header_buffer_addr_backward << "\n";
+    DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
+
+    // pre-populate packet headers
+    volatile tt::fabric::PacketHeader* pkt_hdr_forward =
+        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_forward);
+    volatile tt::fabric::PacketHeader* pkt_hdr_backward =
+        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_backward);
+    pkt_hdr_forward->to_chip_multicast(
+        tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+    pkt_hdr_backward->to_chip_multicast(
+        tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open();
@@ -177,9 +141,8 @@ void kernel_main() {
 
         write_and_advance_local_read_address_for_fabric_write(
             noc0_dest_noc_addr,
-            packet_header_buffer_addr,
-            num_targets_forward_direction,
-            num_targets_backward_direction,
+            pkt_hdr_forward,
+            pkt_hdr_backward,
             fabric_connection,
             l1_read_addr,
             num_tiles_to_read_this_core * tensor0_page_size);
@@ -195,7 +158,7 @@ void kernel_main() {
     }
 
     // 2. mcast output ready semaphore
-    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_seminc);
     pkt_hdr->to_atomic_inc();
     pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
         out_ready_sem_bank_addr,
@@ -209,7 +172,7 @@ void kernel_main() {
         pkt_hdr->to_chip_multicast(
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
@@ -217,7 +180,7 @@ void kernel_main() {
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
     }
     // increment locally
     uint64_t out_ready_sem_noc_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
@@ -159,7 +159,7 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         DPRINT << "tiles_read: " << tiles_read << "\n";
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
-        num_tiles_to_read_this_core = 1;  // std::min(num_tiles_to_read-tiles_read, num_tiles_to_read_this_core);
+        num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
         cb_wait_front(cb0_id, num_tiles_to_read_this_core);
         size_t l1_read_addr = get_read_ptr(cb0_id);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include <cstdint>
+#include <utility>
+
+FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
+    uint64_t noc0_dest_noc_addr,
+    volatile tt::fabric::PacketHeader* pkt_hdr_forward,
+    volatile tt::fabric::PacketHeader* pkt_hdr_backward,
+    FabricConnectionManager& fabric_connection,
+    size_t& l1_read_addr,
+    uint32_t payload_size_bytes) {
+    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
+    const size_t payload_l1_address = l1_read_addr;
+
+    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
+    pkt_hdr_forward->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
+        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+    pkt_hdr_backward->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
+        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+
+    noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
+    if (fabric_connection.has_forward_connection()) {
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
+            l1_read_addr, payload_size_bytes);
+        fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
+            (uint32_t)pkt_hdr_forward, sizeof(tt::fabric::PacketHeader));
+    }
+
+    if (fabric_connection.has_backward_connection()) {
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
+            l1_read_addr, payload_size_bytes);
+        fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
+            (uint32_t)pkt_hdr_backward, sizeof(tt::fabric::PacketHeader));
+    }
+
+    noc_async_writes_flushed();
+
+    l1_read_addr += payload_size_bytes;
+}


### PR DESCRIPTION
### Minimalistic All Gather Async
![image](https://github.com/user-attachments/assets/9649cb28-c87a-4a16-b003-beabe0e5c6f6)

### Description
This pr contains the minimalistic all gather on the following shapes:
- [TG Llama] AllGather after SDPA
- [TG Llama] AllGather after Binary Mult+Silu
- Generic interleaved 1,1,32,x shape

In addition, it fixes the the following bugs:
- Semaphore address RT arg update for specialized all gather shapes
- Semaphore program hash for specialized all gather shapes

### Pipelines

- [x] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/13164662319
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13164675705
- [x] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13149463720