### PR TITLE
[skip ci] Upload full source code during release

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -156,8 +156,7 @@ jobs:
       - name: Create archive with submodules
         uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a
         with:
-          output-files: |
-            tt-metalium.tar.gz
+          output-files: tt-metalium.tar.gz
       - name: Download eager Python packages
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -151,6 +151,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Create archive with submodules
+        uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a
+        with:
+          output-files: |
+            tt-metalium.tar.gz
       - name: Download eager Python packages
         uses: actions/download-artifact@v4
         with:
@@ -184,6 +191,7 @@ jobs:
             INSTALLING.md
             models/MODEL_UPDATES.md
             ttnn-*+*.whl
+            tt-metalium.tar.gz
           fail_on_unmatched_files: true
   create-docker-release-image:
     needs: [


### PR DESCRIPTION
### Problem description
The source tarballs that are in our releases are missing submodule source code, which is required for them to be functional.
Making matters worse, none of our submodules have releases, or release tarballs.

### What's changed
Add a third party action to generate a tarball of ALL the source code in our release, and upload it as part of our releases.
This new artifact "tt-metalium.tar.gz" should actually be usable.

### Checklist
- [x] [Workflow sort of works](https://github.com/tenstorrent/tt-metal/actions/runs/12925964343)
