### PR TITLE
#16310: update digamma 

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/digamma/digamma.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/digamma/digamma.py
@@ -47,7 +47,7 @@ def run(
     torch.manual_seed(0)
 
     torch_input_tensor = gen_func_with_cast_tt(
-        partial(torch_random, low=0.0001, high=100, dtype=torch.float32), input_dtype
+        partial(torch_random, low=1, high=100, dtype=torch.float32), input_dtype
     )(input_shape)
     golden_function = ttnn.get_golden_function(ttnn.digamma)
     torch_output_tensor = golden_function(torch_input_tensor)

--- a/tests/sweep_framework/sweeps/eltwise/unary/digamma/digamma_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/digamma/digamma_sharded.py
@@ -7,7 +7,6 @@ from functools import partial
 
 import json
 import torch
-import random
 import ttnn
 import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
@@ -20,11 +19,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 120
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -66,8 +60,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     (
         input_shape,
@@ -92,7 +85,7 @@ def run(
     )
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=0.0001, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=1, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
     golden_function = ttnn.get_golden_function(ttnn.digamma)
     torch_output_tensor = golden_function(torch_input_tensor_a)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -23,7 +23,7 @@
 #include "ttnn/types.hpp"
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include <tt-metalium/hal_exp.hpp>
-
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 namespace ttnn::operations::unary {
 
 Tensor _deg2rad(const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config) {
@@ -155,11 +155,12 @@ Tensor _cosh(const Tensor& input_a, const std::optional<MemoryConfig>& output_me
 // TODO: In future will uplift the op once the floor and tan has supported.
 // digamma support for the range of (1, inf)
 Tensor _digamma(const Tensor& input_a, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor t_log_out = ttnn::log(input_a, output_mem_config);  // negative log is not useful here
+    Tensor input = input_a.dtype() == DataType::BFLOAT8_B ? ttnn::fill_implicit_tile_padding(input_a, 1.0f) : input_a;
+    Tensor t_log_out = ttnn::log(input, output_mem_config);  // negative log is not useful here
 
     // 1/2(z)
-    Tensor output = ttnn::multiply(ttnn::reciprocal(input_a, output_mem_config), 0.5f, std::nullopt, output_mem_config);
-    Tensor tmp = ttnn::square(ttnn::reciprocal(input_a, output_mem_config), output_mem_config);
+    Tensor output = ttnn::multiply(ttnn::reciprocal(input, output_mem_config), 0.5f, std::nullopt, output_mem_config);
+    Tensor tmp = ttnn::square(ttnn::reciprocal(input, output_mem_config), output_mem_config);
     Tensor val_square = tmp;
     // (1/12) * x^2
     output = ttnn::subtract(output, ttnn::multiply(tmp, 0.083333333f), std::nullopt, output_mem_config);


### PR DESCRIPTION
### Ticket
Link to Github Issue #16310 

### Problem description
ttnn.digamma gives low pcc with most input combinations

### What's changed

- Updated the digamma to handle padding for bflaot8_b
- If the input data type is bfloat8_b, we set the padding value to 1 to prevent flushing issues caused by the shared exponent.

### Checklist
- [x] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/13520175508)

