### PR TITLE
#9945: Enable and fix SD device perf test

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -204,59 +204,17 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 
 
 @skip_for_grayskull()
-@pytest.mark.skip(reason="#9945: Skip for now since this breaks on WH because of di/dt")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_perf",
-    ((10.31),),
-)
-def test_stable_diffusion_device_perf(expected_perf):
-    subdir = "ttnn_stable_diffusion"
-    margin = 0.01
-    batch = 1
-    iterations = 1
-    command = f"pytest tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model.py::test_unet_2d_condition_model_512x512[batch_size=2-in_channels=4-input_height=64-input_width=64-device_params=l1_small_size_24576]"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
-    expected_perf_cols = {inference_time_key: expected_perf}
-
-    # back-up the value of WH_ARCH_YAML if exist
-    wh_arch_yaml_backup = None
-    if "WH_ARCH_YAML" in os.environ:
-        wh_arch_yaml_backup = os.environ["WH_ARCH_YAML"]
-
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-    post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
-    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
-    prep_device_perf_report(
-        model_name=f"stable_diffusion_{batch}batch",
-        batch_size=batch,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments="",
-    )
-
-    # set WH_ARCH_YAML back to the original value
-    if wh_arch_yaml_backup is not None:
-        os.environ["WH_ARCH_YAML"] = wh_arch_yaml_backup
-    else:
-        del os.environ["WH_ARCH_YAML"]
-
-
-@skip_for_grayskull()
-@pytest.mark.skip(reason="#9945: Skip for now since this breaks on WH because of di/dt")
-@pytest.mark.models_device_performance_bare_metal
-@pytest.mark.parametrize(
-    "expected_perf",
-    ((10.4),),
+    ((9.5),),
 )
 def test_stable_diffusion_device_perf_new_conv(expected_perf):
     subdir = "ttnn_stable_diffusion"
     margin = 0.01
     batch = 1
     iterations = 1
-    command = f"pytest tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model_new_conv.py::test_unet_2d_condition_model_512x512[batch_size=2-in_channels=4-input_height=64-input_width=64-device_params=l1_small_size_24576]"
+    command = f"pytest models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py::test_unet_2d_condition_model_512x512[2-4-64-64-device_params=l1_small_size_24576]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -206,10 +206,10 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 @skip_for_grayskull()
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
-    "expected_perf",
+    "expected_kernel_samples_per_second",
     ((9.5),),
 )
-def test_stable_diffusion_device_perf_new_conv(expected_perf):
+def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"
     margin = 0.01
     batch = 1
@@ -218,7 +218,7 @@ def test_stable_diffusion_device_perf_new_conv(expected_perf):
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
-    expected_perf_cols = {inference_time_key: expected_perf}
+    expected_perf_cols = {inference_time_key: expected_kernel_samples_per_second}
 
     # back-up the value of WH_ARCH_YAML if exist
     wh_arch_yaml_backup = None


### PR DESCRIPTION
### Ticket
#9945, #17134

### Problem description
 It was disabled a while ago since there was an ND hang. 

### What's changed
We had a couple of fw updates since, and matmuls were set to use subblock h/w = 1 to avoid potential hangs. The model passes 100k iterations locally and it is already on other CI pipelines.

I also removed the device perf meant to test the old unet2d model implementation that is not used anymore.

### Checklist
(Single card) Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/12990680955
