### PR TITLE
Add unit_test file for binary_sharded and binary_backward_sharded ops

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -369,6 +369,7 @@ on:
           - eltwise.binary.gt.gt_forge
           - eltwise.binary.le.le_tensor_pytorch2
           - eltwise.binary.fmod.fmod
+          - eltwise.binary.fmod.fmod_sharded
           - eltwise.binary.fmod.fmod_unary
           - eltwise.binary.fmod.fmod_unary_sharded
           - eltwise.binary.floor_divide.floor_divide_pytorch2

--- a/tests/sweep_framework/sweep_utils/sharding_utils.py
+++ b/tests/sweep_framework/sweep_utils/sharding_utils.py
@@ -10,7 +10,9 @@ import math
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import _gen_reshape_args_from_volume
 
 
-def gen_sharded_spec_unary(num_shapes, max_tensor_size_per_core=62 * 1024, layouts=["TILE_LAYOUT", "ROW_MAJOR_LAYOUT"]):
+def gen_sharded_spec_unary(
+    num_shapes, max_tensor_size_per_core=62 * 1024, layouts=["TILE_LAYOUT", "ROW_MAJOR_LAYOUT"], ranks=[4, 3, 2]
+):
     # device.compute_with_storage_grid_size()
     Y = 8
     X = 8
@@ -21,7 +23,7 @@ def gen_sharded_spec_unary(num_shapes, max_tensor_size_per_core=62 * 1024, layou
     spec_list = []
 
     for sharding_strategy, shard_orientation, rank, layout in itertools.product(
-        sharding_strategy_list, shard_orientation_list, [4, 3, 2], layouts
+        sharding_strategy_list, shard_orientation_list, ranks, layouts
     ):
         if sharding_strategy == "tensor_wh":
             tensor_hw_as_shard_shape = True

--- a/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_sharded.py
@@ -32,7 +32,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "xfail": {
         "input_spec": gen_sharded_spec_unary(
             16, max_tensor_size_per_core=20 * 1024, layouts=["TILE_LAYOUT"], ranks=[4]
         ),

--- a/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_sharded.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+import pytest
+import json
+import torch
+import random
+import ttnn
+import math
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import (
+    gen_sharded_spec_unary,
+    parse_sharding_spec,
+    invalidate_vector_sharding,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+from tests.sweep_framework.framework.permutations import *
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 120
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_spec": gen_sharded_spec_unary(
+            16, max_tensor_size_per_core=20 * 1024, layouts=["TILE_LAYOUT"], ranks=[4]
+        ),
+        "input_a_dtype": [ttnn.float32],
+        "input_b_dtype": [ttnn.float32],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    input_layout = test_vector["input_spec"]["input_layout"]
+    sharding_invalidated, output_str = invalidate_vector_sharding(test_vector["input_spec"])
+
+    if test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is not supported"
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
+    if input_layout == "ROW_MAJOR_LAYOUT" and (
+        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
+    ):
+        return True, "bfloat8_b is only supported on tiled layout"
+    if sharding_invalidated:
+        return sharding_invalidated, output_str
+
+    return False, None
+
+
+def run_fmod_sharded(input_shape, input_a_dtype, input_b_dtype, input_layout, sharded_config, device) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+    )(input_shape)
+
+    golden_function = ttnn.get_golden_function(ttnn.fmod)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.fmod(input_tensor_a, input_tensor_b, memory_config=sharded_config)
+    e2e_perf = stop_measuring_time(start_time)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+
+
+# This is a function for local execution of sweep test
+@pytest.mark.parametrize("params", list(permutations(parameters["nightly"])))
+def test_nightly(device, params):
+    invalidated, output_str = invalidate_vector(params)
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+        shard_height_mul_of_32,
+    ) = parse_sharding_spec(params["input_spec"])
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+        tile_layout=shard_height_mul_of_32,
+    )
+    if invalidated:
+        pytest.skip(output_str)
+
+    res, _ = run_fmod_sharded(
+        input_shape, params["input_a_dtype"], params["input_a_dtype"], input_layout, sharded_config, device=device
+    )
+
+    assert res[0], res[1]
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(input_spec, input_a_dtype, input_b_dtype, *, device) -> list:
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+        shard_height_mul_of_32,
+    ) = parse_sharding_spec(input_spec)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+        tile_layout=shard_height_mul_of_32,
+    )
+    return run_fmod_sharded(input_shape, input_a_dtype, input_b_dtype, input_layout, sharded_config, device=device)

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_backward_sharded.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_backward_sharded.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
+from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_rand_inf
+
+Y, X = (8, 8)
+
+
+def run_binary_bw_tests(
+    input_shape,
+    dtype,
+    dlayout,
+    sharding_strategy,
+    shard_orientation,
+    tensor_hw_as_shard_shape,
+    torch_op,
+    ttnn_op,
+    device,
+):
+    random.seed(0)
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    torch_grad_tensor = torch.Tensor(size=input_shape).uniform_(-50, 50).to(torch.bfloat16)
+    torch_input_tensor_a = torch.Tensor(size=input_shape).uniform_(-50, 50).to(torch.bfloat16)
+    torch_input_tensor_b = torch.Tensor(size=input_shape).uniform_(-50, 50).to(torch.bfloat16)
+
+    torch_input_tensor_a.requires_grad = True
+    torch_input_tensor_b.requires_grad = True
+
+    torch_output_tensors = torch_op(torch_grad_tensor, torch_input_tensor_a, torch_input_tensor_b)
+
+    sharded_config = ttnn.create_sharded_memory_config(
+        shape=input_shape,
+        core_grid=ttnn.CoreGrid(y=Y, x=X),
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    grad_tensor = ttnn.from_torch(
+        torch_grad_tensor,
+        dtype=dtype[0],
+        layout=dlayout,
+        device=device,
+        memory_config=sharded_config,
+    )
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=dtype[1],
+        layout=dlayout,
+        device=device,
+        memory_config=sharded_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=dtype[2],
+        layout=dlayout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    output_tensors = ttnn_op(grad_tensor, input_tensor_a, input_tensor_b, memory_config=sharded_config)
+    output_tensors = ttnn.to_torch(output_tensor)
+
+    passed = []
+    output_string = ""
+    for i in range(len(torch_output_tensors)):
+        output_tensor = ttnn.to_torch(output_tensors[i])
+        passed_, output_string_ = check_with_pcc(torch_output_tensors[i], output_tensor, 0.999)
+        passed.append(passed_)
+        output_string += output_string_ + ", "
+
+    if all(passed):
+        passed = True
+    else:
+        passed = False
+
+    output_string = output_string[:-2]
+    e2e_perf = stop_measuring_time(start_time)
+
+    assert passed, f"{output_string}"
+
+
+test_sweep_args = [
+    (
+        (256, 2, 5, 1536),
+        [ttnn.bfloat16, ttnn.bfloat16, ttnn.bfloat16],
+        ttnn.TILE_LAYOUT,
+        ttnn.ShardStrategy.BLOCK,
+        ttnn.ShardOrientation.COL_MAJOR,
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_binary_backward_add(
+    input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_binary_bw_tests(
+        input_shape,
+        dtype,
+        dlayout,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        ttnn.get_golden_function(ttnn.add_bw),
+        ttnn.add_bw,
+        device,
+    )

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_sharded.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_sharded.py
@@ -102,7 +102,7 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, Y, X, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_binary_fmod(
+def test_binary_fmod_sharded(
     input_shape, dtype, dlayout, Y, X, sharding_strategy, shard_orientation, hw_as_shard_shape, device
 ):
     run_binary_tests(

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_sharded.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_sharded.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+from functools import partial
+import random
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
+from models.utility_functions import torch_random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+
+def run_binary_tests(
+    input_shape,
+    dtype,
+    dlayout,
+    Y,
+    X,
+    sharding_strategy,
+    shard_orientation,
+    tensor_hw_as_shard_shape,
+    torch_op,
+    ttnn_op,
+    device,
+):
+    random.seed(0)
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), dtype[0]
+    )(input_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), dtype[1]
+    )(input_shape)
+
+    torch_input_tensor_a.requires_grad = True
+    torch_input_tensor_b.requires_grad = True
+
+    torch_output_tensor = torch_op(torch_input_tensor_a, torch_input_tensor_b)
+
+    sharded_config = ttnn.create_sharded_memory_config(
+        shape=input_shape,
+        core_grid=ttnn.CoreGrid(y=Y, x=X),
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=dtype[0],
+        layout=dlayout,
+        device=device,
+        memory_config=sharded_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=dtype[1],
+        layout=dlayout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b, memory_config=sharded_config)
+    output_tensor = ttnn.to_torch(output_tensor).to(torch.float32)
+
+    passed, output_string = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+
+    assert passed, f"{output_string}\n{torch_output_tensor}\n{output_tensor}"
+
+
+test_sweep_args = [
+    (
+        (256, 2, 5, 1536),
+        [ttnn.bfloat16, ttnn.bfloat16],
+        ttnn.TILE_LAYOUT,
+        8,
+        8,
+        ttnn.ShardStrategy.BLOCK,
+        ttnn.ShardOrientation.COL_MAJOR,
+        False,
+    ),
+    (
+        (1, 2, 128, 256),
+        [ttnn.float32, ttnn.float32],
+        ttnn.TILE_LAYOUT,
+        8,
+        8,
+        ttnn.ShardStrategy.BLOCK,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, Y, X, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_binary_fmod(
+    input_shape, dtype, dlayout, Y, X, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_binary_tests(
+        input_shape,
+        dtype,
+        dlayout,
+        Y,
+        X,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        ttnn.get_golden_function(ttnn.fmod),
+        ttnn.fmod,
+        device,
+    )


### PR DESCRIPTION
### Ticket
[Links to Github Issues]
(https://github.com/tenstorrent/tt-metal/issues/17015)
(https://github.com/tenstorrent/tt-metal/issues/17013)

### Problem description
Needed unit test file which covers binary_sharded and binary_backward_sharded ops for which the sharded memory config is in some way unsupported and for which it's not stated in the documentation that it should be unsupported. 

### What's changed
Added unit test file, `tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_sharded.py` with a test function for fmod_binary and `tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_binary_backward_sharded.py` with the test for add_bw binary.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12932210195)