### PR TITLE
Remove outdated TG llama tests from CI (old codebase)

### DIFF
--- a/.github/workflows/tg-frequent-tests-impl.yaml
+++ b/.github/workflows/tg-frequent-tests-impl.yaml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         test-group: [
           { name: "TG Llama3 frequent tests", arch: wormhole_b0, model: llama3, timeout: 90, owner_id: U06F3ER8X9A}, # Stuti Raizada
-          { name: "TG Llama3-70B (old) frequent tests", arch: wormhole_b0, model: llama3-70b-old, timeout: 90, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "TG resnet50 frequent tests", arch: wormhole_b0, model: resnet50, timeout: 90, owner_id: U013121KDH9}, # Austin Ho
           { name: "TG unit/distributed frequent tests", arch: wormhole_b0, model: unit, timeout: 90, owner_id: XXXXX}, # Add owner
         ]

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -36,14 +36,7 @@ run_tg_llama3_tests() {
 
 run_tg_tests() {
 
-  if [[ "$1" == "llama3-70b-old" ]]; then
-    echo "LOG_METAL: running llama3_70b (old) run_tg_frequent_tests"
-    pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py --timeout=300 ; fail+=$?
-    pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py --timeout=480 ; fail+=$?
-    pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py --timeout=600 ; fail+=$?
-    pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py --timeout=800 ; fail+=$?
-
-  elif [[ "$1" == "llama3" ]]; then
+  if [[ "$1" == "llama3" ]]; then
     echo "LOG_METAL: running Llama3 run_tg_frequent_tests"
     run_tg_llama3_tests
 

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -4,7 +4,6 @@ run_tg_llm_tests() {
 
   echo "LOG_METAL: Running run_t3000_llama2_70b_tests"
   pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py -m "model_perf_t3000" --timeout=600 ; fail+=$?
-  pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py -m "model_perf_tg" --timeout=600 ; fail+=$?
 
   # Merge all the generated reports
   env python3 models/perf/merge_perf_results.py; fail+=$?

--- a/tests/scripts/tg/run_tg_nightly_tests.sh
+++ b/tests/scripts/tg/run_tg_nightly_tests.sh
@@ -1,21 +1,18 @@
 #!/bin/bash
 
-run_tg_llama3_70b_tests() {
+run_tg_tests() {
   # Record the start time
   fail=0
   start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_tg_llama3_70b_tests"
+  echo "LOG_METAL: Running run_tg_tests"
 
   pytest -n auto tests/nightly/tg/ccl --timeout=180 ; fail+=$?
-
-  # Falcon40B prefill 60 layer end to end with 10 loops; we need 8x8 grid size
-  pytest tests/nightly/tg/models/demos/tg/llama3_70b ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
-  echo "LOG_METAL: run_tg_llama3_70b_tests $duration seconds to complete"
+  echo "LOG_METAL: run_tg_tests $duration seconds to complete"
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi


### PR DESCRIPTION
### What's changed
Removed all CI tests running TG llama on the old codebase since it's outdated and we are only developing on the new codebase now.

Running TG piplelines: https://github.com/tenstorrent/tt-metal/actions/runs/12933778923

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
