### PR TITLE
Minor tweaks for BH cache invalidate

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1696,9 +1696,8 @@ inline void noc_async_write_multicast_exclude_region(
  */
 void noc_async_read_barrier(uint8_t noc = noc_index) {
     WAYPOINT("NRBW");
-    do {
-        invalidate_l1_cache();
-    } while (!ncrisc_noc_reads_flushed(noc));
+    while (!ncrisc_noc_reads_flushed(noc));
+    invalidate_l1_cache();
     WAYPOINT("NRBD");
 }
 
@@ -1992,10 +1991,9 @@ FORCE_INLINE
 void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTW");
 #ifndef ARCH_GRAYSKULL
-    do {
-        invalidate_l1_cache();
-    } while (!ncrisc_noc_read_with_transaction_id_flushed(noc, trid));
+    while (!ncrisc_noc_read_with_transaction_id_flushed(noc, trid));
 #endif
+    invalidate_l1_cache();
     WAYPOINT("NBTD");
 }
 


### PR DESCRIPTION
### Ticket
None

### Problem description
No need to invalidate the cache inside a spin loop reading registers.
However, still worth keeping the invalidate after a read barrier as the cost is low and not having a barrier there leaves that to the client code which is error prone and hard to debug.

### What's changed
Moved the invalidate outside the spin loops in read barrier paths

### Checklist
- [ ] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
