### PR TITLE
Remove ttnn::Shape from tt-train

### DIFF
--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -86,7 +86,7 @@ int main() {
             optimizer.zero_grad();
             auto output = (*model)(data);
             auto loss = ttml::ops::mse_loss(output, targets);
-            fmt::print("Loss shape: {}\n", loss->get_value().shape());
+            fmt::print("Loss shape: {}\n", loss->get_value().get_logical_shape());
             auto mesh_shape = device->shape();
             ttml::core::MeshToXTensorVariant<float> identity_composer =
                 ttml::core::VectorMeshToXTensor<float>(mesh_shape);

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -538,8 +538,8 @@ int main(int argc, char **argv) {
 
                 auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
                     data, ttml::core::create_shape({batch_size, 1, 1, sequence_length}), device, Layout::ROW_MAJOR));
-                auto targets_tensor = ttml::autograd::create_tensor(
-                    ttml::core::from_vector<int32_t, DataType::INT32>(targets, {batch_size * sequence_length}, device));
+                auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<int32_t, DataType::INT32>(
+                    targets, ttnn::SimpleShape({batch_size * sequence_length}), device));
                 return {data_tensor, targets_tensor};
             };
 
@@ -632,7 +632,7 @@ int main(int argc, char **argv) {
             loss->backward();
             ttml::autograd::ctx().reset_graph();
 
-            auto samples = features->get_value().get_shape()[0];
+            auto samples = features->get_value().get_logical_shape()[0];
             gradient_accumulator_helper.update(loss_float, samples);
 
             // synchronize gradients for multi-device case, no-op if single device

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -14,7 +14,7 @@ void print_tensor(const tt::tt_metal::Tensor& tensor) {
     // but we are using TILE layout. The printed format WILL NOT be correct. But good enough for a demo
 
     // Get the shape of the tensor
-    auto shape = tensor.shape();
+    auto shape = tensor.get_logical_shape();
     // compyte the size of the tensor
     size_t size = 1;
     for (size_t i = 0; i < shape.size(); i++) size *= shape[i];

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -110,13 +110,13 @@ void Tensor::set_value(const tt::tt_metal::Tensor& value) {
 
 void Tensor::set_grad(const tt::tt_metal::Tensor& grad) {
     if (core::is_tensor_initialized(grad)) {
-        auto grad_shape = grad.get_shape();
-        auto value_shape = m_value.get_tensor().get_shape();
+        auto grad_shape = grad.get_logical_shape();
+        auto value_shape = m_value.get_tensor().get_logical_shape();
         if (grad_shape != value_shape) {
             throw std::logic_error(fmt::format(
                 "Shapes of gradients are not equal. Expected: {}, got: {}",
-                m_value.get_tensor().get_shape(),
-                grad.get_shape()));
+                m_value.get_tensor().get_logical_shape(),
+                grad.get_logical_shape()));
         }
     }
     m_grad = grad;

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -34,18 +34,18 @@ Tensor::Tensor(const tt::tt_metal::Tensor& value, bool requires_grad) : m_value(
 
 void Tensor::add_grad(const tt::tt_metal::Tensor& grad) {
     if (!is_grad_initialized()) {
-        auto value_shape = m_value.get_tensor().get_shape();
-        if (grad.get_shape() != value_shape) {
-            throw std::logic_error(
-                fmt::format("Shapes of gradients are not equal. Expected: {}, got: {}", value_shape, grad.get_shape()));
+        auto value_shape = m_value.get_tensor().get_logical_shape();
+        if (grad.get_logical_shape() != value_shape) {
+            throw std::logic_error(fmt::format(
+                "Shapes of gradients are not equal. Expected: {}, got: {}", value_shape, grad.get_logical_shape()));
         }
 
         m_grad = grad;
         return;
     }
 
-    const auto& grad_shape = grad.get_shape();
-    const auto& m_grad_shape = m_grad.get_shape();
+    const auto& grad_shape = grad.get_logical_shape();
+    const auto& m_grad_shape = m_grad.get_logical_shape();
     if (grad_shape != m_grad_shape) {
         throw std::logic_error(
             fmt::format("Shapes of gradients are not equal. Expected: {}, got: {}", m_grad_shape, grad_shape));

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -31,7 +31,7 @@ T get_median(std::vector<T>& vec) {
 
 template <typename T>
 void print_tensor_stats_(const tt::tt_metal::Tensor& tensor, const std::string& name) {
-    auto tensor_shape = tensor.get_shape();
+    auto tensor_shape = tensor.get_logical_shape();
     auto tensor_vec = tensor.to_vector<T>();
 
     auto median = get_median(tensor_vec);
@@ -84,10 +84,13 @@ tt::tt_metal::OwnedBuffer create_owned_buffer_from_vector_of_floats(
 
 template <typename T>
 tt::tt_metal::Tensor ttml_create_owned_tensor(
-    std::vector<T>&& data, const ttnn::Shape& shape, tt::tt_metal::DataType data_type, tt::tt_metal::Layout layout) {
+    std::vector<T>&& data,
+    const ttnn::SimpleShape& shape,
+    tt::tt_metal::DataType data_type,
+    tt::tt_metal::Layout layout) {
     auto buffer = tt::tt_metal::owned_buffer::create(std::move(data));
     auto storage = OwnedStorage{std::move(buffer)};
-    return {std::move(storage), shape.logical_shape(), data_type, layout};
+    return {std::move(storage), shape, data_type, layout};
 }
 
 }  // namespace
@@ -102,21 +105,21 @@ tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor) {
 }
 
 tt::tt_metal::Tensor empty(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, const MemoryConfig& memory_config) {
-    return ttnn::empty(shape.logical_shape(), DataType::BFLOAT16, Layout::TILE, device, memory_config);
+    const ttnn::SimpleShape& shape, ttnn::distributed::MeshDevice* device, const MemoryConfig& memory_config) {
+    return ttnn::empty(shape, DataType::BFLOAT16, Layout::TILE, device, memory_config);
 }
 
 tt::tt_metal::Tensor full(
-    const ttnn::Shape& shape, float value, ttnn::distributed::MeshDevice* device, DataType dtype) {
-    return ttnn::full(shape.logical_shape(), value, dtype, Layout::TILE, std::ref(*device));
+    const ttnn::SimpleShape& shape, float value, ttnn::distributed::MeshDevice* device, DataType dtype) {
+    return ttnn::full(shape, value, dtype, Layout::TILE, std::ref(*device));
 }
 
-tt::tt_metal::Tensor zeros(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, DataType dtype) {
-    return core::full(shape.logical_shape(), 0.F, device, dtype);
+tt::tt_metal::Tensor zeros(const ttnn::SimpleShape& shape, ttnn::distributed::MeshDevice* device, DataType dtype) {
+    return core::full(shape, 0.F, device, dtype);
 }
 
-tt::tt_metal::Tensor ones(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, DataType dtype) {
-    return core::full(shape.logical_shape(), 1.F, device, dtype);
+tt::tt_metal::Tensor ones(const ttnn::SimpleShape& shape, ttnn::distributed::MeshDevice* device, DataType dtype) {
+    return core::full(shape, 1.F, device, dtype);
 }
 
 template <class T, DataType TensorType>
@@ -171,24 +174,26 @@ template tt::tt_metal::Tensor from_xtensors_to_host<int32_t, tt::tt_metal::DataT
 
 template <>
 tt::tt_metal::Tensor from_vector<float, DataType::BFLOAT16>(
-    const std::vector<float>& buffer, const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, Layout layout) {
+    const std::vector<float>& buffer,
+    const ttnn::SimpleShape& shape,
+    ttnn::distributed::MeshDevice* device,
+    Layout layout) {
     assert(device != nullptr);
     const DataType data_type = DataType::BFLOAT16;
     MemoryConfig output_mem_config{};
-    auto logical_shape = shape.logical_shape();
-    size_t volume = logical_shape.volume();
+    size_t volume = shape.volume();
     if (buffer.size() != volume) {
         throw std::logic_error(
             fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
     }
     auto owned_buffer = create_owned_buffer_from_vector_of_floats(buffer, data_type);
     // remove possible paddings from the shape (it conflicts with ROW MAJOR)
-    auto output = tt::tt_metal::Tensor(OwnedStorage{owned_buffer}, logical_shape, data_type, Layout::ROW_MAJOR);
+    auto output = tt::tt_metal::Tensor(OwnedStorage{owned_buffer}, shape, data_type, Layout::ROW_MAJOR);
 
     const size_t MAX_TILE_DIMENSION = 16384;
     // Temporary workaround for the issue with tilize for large size
     // https://github.com/tenstorrent/tt-metal/issues/15950
-    if (logical_shape[-1] >= MAX_TILE_DIMENSION && layout == Layout::TILE) {
+    if (shape[-1] >= MAX_TILE_DIMENSION && layout == Layout::TILE) {
         output = ttnn::to_layout(output, Layout::TILE, std::nullopt, output_mem_config, device);
         output = ttnn::to_device(output, device, output_mem_config);
     } else {
@@ -205,7 +210,10 @@ tt::tt_metal::Tensor from_vector<float, DataType::BFLOAT16>(
 // it is expected that tilize will be fixed in the after next tt-metal main update
 template <>
 tt::tt_metal::Tensor from_vector<float, DataType::FLOAT32>(
-    const std::vector<float>& buffer, const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, Layout layout) {
+    const std::vector<float>& buffer,
+    const ttnn::SimpleShape& shape,
+    ttnn::distributed::MeshDevice* device,
+    Layout layout) {
     auto tensor = from_vector<float, DataType::BFLOAT16>(buffer, shape, device, layout);
     return ttnn::typecast(tensor, DataType::FLOAT32);
 }
@@ -216,12 +224,11 @@ From vector uint32 doesn't support tilize_with_zero_padding on device
 template <>
 tt::tt_metal::Tensor from_vector<uint32_t, DataType::UINT32>(
     const std::vector<uint32_t>& buffer,
-    const ttnn::Shape& shape,
+    const ttnn::SimpleShape& shape,
     ttnn::distributed::MeshDevice* device,
     Layout layout) {
     MemoryConfig output_mem_config{};
-    auto logical_shape = shape.logical_shape();
-    auto volume = logical_shape.volume();
+    auto volume = shape.volume();
     if (buffer.size() != volume) {
         throw std::logic_error(
             fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
@@ -229,7 +236,7 @@ tt::tt_metal::Tensor from_vector<uint32_t, DataType::UINT32>(
 
     // remove possible paddings from the shape (it conflicts with ROW MAJOR)
     std::vector<uint32_t> buffer_copy = buffer;
-    auto output = ttml_create_owned_tensor(std::move(buffer_copy), logical_shape, DataType::UINT32, Layout::ROW_MAJOR);
+    auto output = ttml_create_owned_tensor(std::move(buffer_copy), shape, DataType::UINT32, Layout::ROW_MAJOR);
     if (device != nullptr) {
         if (layout != Layout::ROW_MAJOR) {
             output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config, device);
@@ -246,12 +253,11 @@ From vector int32 doesn't support tilize_with_zero_padding on device
 template <>
 tt::tt_metal::Tensor from_vector<int32_t, DataType::INT32>(
     const std::vector<int32_t>& buffer,
-    const ttnn::Shape& shape,
+    const ttnn::SimpleShape& shape,
     ttnn::distributed::MeshDevice* device,
     Layout layout) {
     MemoryConfig output_mem_config{};
-    auto logical_shape = shape.logical_shape();
-    auto volume = logical_shape.volume();
+    auto volume = shape.volume();
     if (buffer.size() != volume) {
         throw std::logic_error(
             fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
@@ -259,7 +265,7 @@ tt::tt_metal::Tensor from_vector<int32_t, DataType::INT32>(
 
     // remove possible paddings from the shape (it conflicts with ROW MAJOR)
     std::vector<int32_t> buffer_copy = buffer;
-    auto output = ttml_create_owned_tensor(std::move(buffer_copy), logical_shape, DataType::INT32, Layout::ROW_MAJOR);
+    auto output = ttml_create_owned_tensor(std::move(buffer_copy), shape, DataType::INT32, Layout::ROW_MAJOR);
     if (device != nullptr) {
         if (layout != Layout::ROW_MAJOR) {
             output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config, device);
@@ -274,8 +280,8 @@ bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor) {
     return tensor.tensor_attributes != nullptr;
 }
 
-ttnn::Shape create_shape(const std::array<uint32_t, 4>& args) {
-    return ttnn::Shape{args};
+ttnn::SimpleShape create_shape(const std::array<uint32_t, 4>& args) {
+    return ttnn::SimpleShape{args};
 }
 
 void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name) {

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -18,18 +18,21 @@ tt::tt_metal::Tensor zeros_like(const tt::tt_metal::Tensor& tensor);
 tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor);
 
 tt::tt_metal::Tensor empty(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, const MemoryConfig& memory_config);
+    const ttnn::SimpleShape& shape, ttnn::distributed::MeshDevice* device, const MemoryConfig& memory_config);
 tt::tt_metal::Tensor full(
-    const ttnn::Shape& shape, float value, ttnn::distributed::MeshDevice* device, DataType dtype = DataType::BFLOAT16);
+    const ttnn::SimpleShape& shape,
+    float value,
+    ttnn::distributed::MeshDevice* device,
+    DataType dtype = DataType::BFLOAT16);
 tt::tt_metal::Tensor zeros(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, DataType dtype = DataType::BFLOAT16);
+    const ttnn::SimpleShape& shape, ttnn::distributed::MeshDevice* device, DataType dtype = DataType::BFLOAT16);
 tt::tt_metal::Tensor ones(
-    const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, DataType dtype = DataType::BFLOAT16);
+    const ttnn::SimpleShape& shape, ttnn::distributed::MeshDevice* device, DataType dtype = DataType::BFLOAT16);
 
 template <class VectorType = float, DataType TensorType = DataType::BFLOAT16>
 [[nodiscard]] tt::tt_metal::Tensor from_vector(
     const std::vector<VectorType>& buffer,
-    const ttnn::Shape& shape,
+    const ttnn::SimpleShape& shape,
     ttnn::distributed::MeshDevice* device,
     Layout layout = Layout::TILE);
 
@@ -44,7 +47,7 @@ template <class T = float>
 
 [[nodiscard]] bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor);
 
-[[nodiscard]] ttnn::Shape create_shape(const std::array<uint32_t, 4>& args);
+[[nodiscard]] ttnn::SimpleShape create_shape(const std::array<uint32_t, 4>& args);
 
 template <class T = float, DataType TensorType = DataType::BFLOAT16>
 [[nodiscard]] tt::tt_metal::Tensor from_xtensor(
@@ -57,7 +60,7 @@ template <class T = float, DataType TensorType = DataType::BFLOAT16>
 template <class T = float>
 [[nodiscard]] xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
     auto vec = tensor.to_vector<T>();
-    const auto& shape = tensor.get_shape().logical_shape();
+    const auto& shape = tensor.get_logical_shape();
     std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
     // adapt creates view of the vector, but return will copy this data anyway (by creation of xt::array)
     return xt::adapt(std::move(vec), shape_vec);

--- a/tt-train/sources/ttml/init/tensor_initializers.cpp
+++ b/tt-train/sources/ttml/init/tensor_initializers.cpp
@@ -11,64 +11,64 @@
 #include "core/tt_tensor_utils.hpp"
 #include "cpu_initializers.hpp"
 namespace ttml::init {
-void uniform_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, UniformRange range) {
+void uniform_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, UniformRange range) {
     auto* device = &autograd::ctx().get_device();
     assert(device);
-    size_t volume = shape.logical_shape().volume();
+    size_t volume = shape.volume();
     std::vector<float> vec(volume);
     uniform_init(vec, range);
 
     t->set_value(ttml::core::from_vector(vec, shape, device));
 }
 
-void normal_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, NormalParams params) {
+void normal_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, NormalParams params) {
     auto* device = &autograd::ctx().get_device();
     assert(device);
-    size_t volume = shape.logical_shape().volume();
+    size_t volume = shape.volume();
     std::vector<float> vec(volume);
     normal_init(vec, params);
     t->set_value(ttml::core::from_vector(vec, shape, device));
 }
 
-void constant_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, float value) {
+void constant_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, float value) {
     auto* device = &autograd::ctx().get_device();
     t->set_value(core::full(shape, value, device));
 }
 
-void xavier_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, FanParams params) {
+void xavier_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, FanParams params) {
     auto* device = &autograd::ctx().get_device();
     assert(device);
-    size_t volume = shape.logical_shape().volume();
+    size_t volume = shape.volume();
     std::vector<float> vec(volume);
     xavier_uniform_init(vec, params);
 
     t->set_value(ttml::core::from_vector(vec, shape, device));
 }
 
-void xavier_normal_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, FanParams params) {
+void xavier_normal_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, FanParams params) {
     auto* device = &autograd::ctx().get_device();
     assert(device);
-    size_t volume = shape.logical_shape().volume();
+    size_t volume = shape.volume();
     std::vector<float> vec(volume);
     xavier_normal_init(vec, params);
 
     t->set_value(ttml::core::from_vector(vec, shape, device));
 }
 
-void kaiming_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, int fan_in) {
+void kaiming_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, int fan_in) {
     auto* device = &autograd::ctx().get_device();
     assert(device);
-    size_t volume = shape.logical_shape().volume();
+    size_t volume = shape.volume();
     std::vector<float> vec(volume);
     kaiming_uniform_init(vec, fan_in);
 
     t->set_value(ttml::core::from_vector(vec, shape, device));
 }
 
-void kaiming_normal_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, int fan_out) {
+void kaiming_normal_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, int fan_out) {
     auto* device = &autograd::ctx().get_device();
     assert(device);
-    size_t volume = shape.logical_shape().volume();
+    size_t volume = shape.volume();
     std::vector<float> vec(volume);
     kaiming_normal_init(vec, fan_out);
 

--- a/tt-train/sources/ttml/init/tensor_initializers.hpp
+++ b/tt-train/sources/ttml/init/tensor_initializers.hpp
@@ -9,18 +9,18 @@
 
 namespace ttml::init {
 
-void uniform_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, UniformRange range);
+void uniform_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, UniformRange range);
 
-void normal_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, NormalParams params);
+void normal_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, NormalParams params);
 
-void constant_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, float value);
+void constant_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, float value);
 
-void xavier_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, FanParams params);
+void xavier_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, FanParams params);
 
-void xavier_normal_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, FanParams params);
+void xavier_normal_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, FanParams params);
 
-void kaiming_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, int fan_in);
+void kaiming_uniform_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, int fan_in);
 
-void kaiming_normal_init(ttml::autograd::TensorPtr& t, const ttnn::Shape& shape, int fan_out);
+void kaiming_normal_init(ttml::autograd::TensorPtr& t, const ttnn::SimpleShape& shape, int fan_out);
 
 }  // namespace ttml::init

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -65,9 +65,9 @@ void weights_initialization(Transformer& model) {
     for (auto& [name, tensor_ptr] : params) {
         const auto& tensor = tensor_ptr->get_value();
         if (name.find("weight") != std::string::npos) {
-            init::normal_init(tensor_ptr, tensor.shape(), {0.F, 0.02F});
+            init::normal_init(tensor_ptr, tensor.get_logical_shape(), {0.F, 0.02F});
         } else if (name.find("bias") != std::string::npos) {
-            init::constant_init(tensor_ptr, tensor.shape(), 0.F);
+            init::constant_init(tensor_ptr, tensor.get_logical_shape(), 0.F);
         }
     }
 }

--- a/tt-train/sources/ttml/modules/embedding_module.cpp
+++ b/tt-train/sources/ttml/modules/embedding_module.cpp
@@ -37,7 +37,7 @@ Embedding::Embedding(uint32_t num_embeddings, uint32_t embedding_dim) {
 }
 
 autograd::TensorPtr Embedding::operator()(const autograd::TensorPtr& tensor) {
-    auto sentence_size = tensor->get_value().get_shape()[-1];
+    auto sentence_size = tensor->get_value().get_logical_shape()[-1];
     if (sentence_size % TILE_HEIGHT != 0 || sentence_size % TILE_WIDTH != 0) {
         throw std::logic_error(fmt::format(
             "sentence_size must be a multiple of TILE_HEIGHT and TILE_WIDTH, current sentence_size {}", sentence_size));

--- a/tt-train/sources/ttml/ops/embedding_op.cpp
+++ b/tt-train/sources/ttml/ops/embedding_op.cpp
@@ -18,7 +18,7 @@ autograd::TensorPtr embedding_op(const autograd::TensorPtr& tensor, const autogr
     weight_tensor = ttnn::untilize(weight_tensor);
 
     auto embeddings = ttnn::embedding(tensor->get_value(), weight_tensor, /* pad_token */ std::nullopt, Layout::TILE);
-    auto embeddings_shape = embeddings.get_shape();
+    auto embeddings_shape = embeddings.get_logical_shape();
     auto batch_size = embeddings_shape[0];
     auto sentence_size = embeddings_shape[1];
     auto embedding_dim = embeddings_shape[2];
@@ -27,9 +27,9 @@ autograd::TensorPtr embedding_op(const autograd::TensorPtr& tensor, const autogr
 
     autograd::GradFunction grad = [tensor, weight, out]() {
         auto out_grad = out->get_grad();
-        auto tensor_shape = tensor->get_value().get_shape();
+        auto tensor_shape = tensor->get_value().get_logical_shape();
         out_grad = ttnn::reshape(
-            out_grad, core::create_shape({1, 1, tensor_shape[0] * tensor_shape[-1], out_grad.get_shape()[-1]}));
+            out_grad, core::create_shape({1, 1, tensor_shape[0] * tensor_shape[-1], out_grad.get_logical_shape()[-1]}));
         auto weight_grad = ttnn::embedding_bw(tensor->get_value(), weight->get_value(), out_grad);
         weight->add_grad(weight_grad);
     };

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -22,7 +22,7 @@ namespace ttml::ops {
 // it works only for 4D tensors and for the last dimension
 autograd::TensorPtr layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
-    auto tensor_shape = tensor->get_value().get_shape();
+    auto tensor_shape = tensor->get_value().get_logical_shape();
     auto mean = core::empty(
         core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1}),
         &autograd::ctx().get_device(),
@@ -78,7 +78,7 @@ autograd::TensorPtr layernorm(
 
 autograd::TensorPtr composite_layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
-    auto tensor_shape = tensor->get_value().get_shape();
+    auto tensor_shape = tensor->get_value().get_logical_shape();
 
     auto shape = core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1});
     auto mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
@@ -137,7 +137,7 @@ autograd::TensorPtr composite_layernorm(
         // dtensor = (dnorm - dnorm.mean(-1, keepdim=True) - norm * (dnorm * norm).mean(-1, keepdim=True)) * rstd
 
         // dnorm.mean(-1, keepdim=True)
-        auto dnorm_shape = dtensor_normalized.get_shape();
+        auto dnorm_shape = dtensor_normalized.get_logical_shape();
         auto shape = core::create_shape({dnorm_shape[0], dnorm_shape[1], dnorm_shape[2], 1});
         auto dnorm_mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
         ttnn::moreh_mean(

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -45,24 +45,24 @@ void ttnn_linear_backward(
     const autograd::TensorPtr& out,
     const ttnn::WormholeComputeKernelConfig& config) {
     const auto& tensor_value = tensor->get_value();
-    auto volume_without_features = tensor_value.get_logical_volume() / tensor_value.get_shape()[-1];
+    auto volume_without_features = tensor_value.get_logical_volume() / tensor_value.get_logical_shape()[-1];
     auto reshaped_tensor =
-        ttnn::reshape(tensor_value, ttnn::Shape({volume_without_features, tensor_value.get_shape()[-1]}));
+        ttnn::reshape(tensor_value, ttnn::SimpleShape({volume_without_features, tensor_value.get_logical_shape()[-1]}));
 
-    auto reshaped_grad =
-        ttnn::reshape(out->get_grad(), ttnn::Shape({volume_without_features, out->get_grad().get_shape()[-1]}));
+    auto reshaped_grad = ttnn::reshape(
+        out->get_grad(), ttnn::SimpleShape({volume_without_features, out->get_grad().get_logical_shape()[-1]}));
     auto reshaped_weight_grad =
         matmul(reshaped_grad, reshaped_tensor, /* transpose_a */ true, /* transpose_b */ false, config);
     auto reshaped_tensor_grad =
         matmul(reshaped_grad, weight->get_value(), /* transpose_a */ false, /* transpose_b */ false, config);
     if (bias) {
         auto reshaped_bias_grad = ttnn_fixed::sum_over_dim(reshaped_grad, /* axis */ 0);
-        auto bias_grad = ttnn::reshape(reshaped_bias_grad, bias->get_value().get_shape());
+        auto bias_grad = ttnn::reshape(reshaped_bias_grad, bias->get_value().get_logical_shape());
         bias->add_grad(bias_grad);
     }
-    auto weight_grad = ttnn::reshape(reshaped_weight_grad, weight->get_value().get_shape());
+    auto weight_grad = ttnn::reshape(reshaped_weight_grad, weight->get_value().get_logical_shape());
 
-    auto tensor_grad = ttnn::reshape(reshaped_tensor_grad, tensor_value.get_shape());
+    auto tensor_grad = ttnn::reshape(reshaped_tensor_grad, tensor_value.get_logical_shape());
 
     tensor->add_grad(tensor_grad);
     weight->add_grad(weight_grad);
@@ -127,8 +127,8 @@ autograd::TensorPtr linear_op(
         /* core_grid */ ttnn::CoreGrid{7, 8}));
 
     autograd::GradFunction grad = [weight, bias, tensor, out]() {
-        auto tensor_shape = tensor->get_value().get_shape();
-        auto grad_shape = out->get_grad().get_shape();
+        auto tensor_shape = tensor->get_value().get_logical_shape();
+        auto grad_shape = out->get_grad().get_logical_shape();
         // for some reason, reshape produces wrong values when last dimensions not divisible by TILE
         if (tensor_shape[-2] % TILE_HEIGHT != 0 ||
             tensor_shape[-1] % TILE_WIDTH != 0 && grad_shape[-1] % TILE_WIDTH != 0) {

--- a/tt-train/sources/ttml/ops/losses.cpp
+++ b/tt-train/sources/ttml/ops/losses.cpp
@@ -98,11 +98,7 @@ autograd::TensorPtr nll_loss(
             /* ignore_index */ -100,
             /* memory_config */ std::nullopt,
             /* compute_kernel_config */ core::ComputeKernelConfig::precise());
-<<<<<<< HEAD
         grad = ttnn::reshape(grad, prediction->get_value().get_logical_shape());
-=======
-        grad = ttnn::reshape(grad, prediction->get_value().get_shape());
->>>>>>> origin/main
         prediction->add_grad(grad);
     };
     auto links = autograd::get_links(prediction);

--- a/tt-train/sources/ttml/ops/multi_head_utils.cpp
+++ b/tt-train/sources/ttml/ops/multi_head_utils.cpp
@@ -53,7 +53,7 @@ std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> heads_
 }
 
 autograd::TensorPtr heads_fusion(const autograd::TensorPtr& x) {
-    auto x_shape = x->get_value().get_shape();
+    auto x_shape = x->get_value().get_logical_shape();
 
     uint32_t batch_size = x_shape[0];
     uint32_t num_heads = x_shape[1];

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -104,7 +104,7 @@ autograd::TensorPtr mean(const autograd::TensorPtr& tensor) {
         std::nullopt,
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
     autograd::GradFunction grad = [tensor, out]() {
-        auto resulting_shape = tensor->get_value().get_shape();
+        auto resulting_shape = tensor->get_value().get_logical_shape();
         auto res = ttnn::moreh_mean_backward(
             out->get_grad(),
             std::nullopt,
@@ -122,7 +122,7 @@ autograd::TensorPtr mean(const autograd::TensorPtr& tensor) {
 }
 
 autograd::TensorPtr broadcast_batch(const autograd::TensorPtr& tensor, uint32_t new_batch_dim) {
-    if (new_batch_dim == 1 || tensor->get_value().shape()[0] == new_batch_dim) {
+    if (new_batch_dim == 1 || tensor->get_value().get_logical_shape()[0] == new_batch_dim) {
         return tensor;
     }
     auto out = ttml::autograd::create_tensor();

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -27,6 +27,12 @@ std::span<const uint8_t> to_bytes(T& value) {
     return std::span<const uint8_t>(ptr, sizeof(T));
 }
 
+template <>
+std::span<const uint8_t> to_bytes(SimpleShape& value) {
+    auto ptr = reinterpret_cast<const uint8_t*>(value.view().data());
+    return std::span<const uint8_t>(ptr, sizeof(value[0]) * value.rank());
+}
+
 template <typename T>
 void from_bytes(std::span<const uint8_t> bytes, T& value) {
     static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
@@ -41,6 +47,19 @@ void from_bytes(std::span<const uint8_t> bytes, T& value) {
     std::memcpy(&value, bytes.data(), sizeof(T));
 }
 
+template <>
+void from_bytes(std::span<const uint8_t> bytes, ttnn::SimpleShape& value) {
+    if (bytes.size() % sizeof(uint32_t) != 0) {
+        std::ostringstream oss;
+        oss << "Invalid byte size for conversion to type T. Expected divisible by" << sizeof(uint32_t)
+            << " Actual: " << bytes.size() << ", type: " << typeid(ttnn::SimpleShape).name();
+        throw std::invalid_argument(oss.str());
+    }
+    ttnn::SmallVector<uint32_t> data(bytes.size() / sizeof(uint32_t));
+    std::memcpy(data.data(), bytes.data(), bytes.size());
+    value = ttnn::SimpleShape(std::move(data));
+}
+
 template <typename T>
 void get_enum(MsgPackFile& file, std::string_view name, T& value) {
     int int_value = 0;
@@ -49,7 +68,7 @@ void get_enum(MsgPackFile& file, std::string_view name, T& value) {
 }
 
 void write_ttnn_tensor(MsgPackFile& file, std::string_view name, const tt::tt_metal::Tensor& tensor) {
-    auto shape = tensor.get_shape();
+    auto shape = tensor.get_logical_shape();
     auto data_type = tensor.get_dtype();
     auto layout = tensor.get_layout();
     auto storage_type = tensor.storage_type();
@@ -89,7 +108,7 @@ void read_ttnn_tensor(MsgPackFile& file, std::string_view name, tt::tt_metal::Te
     auto shape = core::create_shape({1, 1, 1, 1});
     std::vector<uint8_t> bytes;
     file.get(std::string(name) + "/shape", bytes);
-    from_bytes<ttnn::Shape>(bytes, shape);
+    from_bytes<ttnn::SimpleShape>(bytes, shape);
 
     get_enum(file, std::string(name) + "/data_type", data_type);
     get_enum(file, std::string(name) + "/layout", layout);

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -28,7 +28,7 @@ std::span<const uint8_t> to_bytes(T& value) {
 }
 
 template <>
-std::span<const uint8_t> to_bytes(SimpleShape& value) {
+std::span<const uint8_t> to_bytes(ttnn::SimpleShape& value) {
     auto ptr = reinterpret_cast<const uint8_t*>(value.view().data());
     return std::span<const uint8_t>(ptr, sizeof(value[0]) * value.rank());
 }

--- a/tt-train/tests/autograd/autograd_test.cpp
+++ b/tt-train/tests/autograd/autograd_test.cpp
@@ -95,8 +95,8 @@ TEST_F(AutogradTest, BroadCastBatchTest) {
     res->backward();
     auto t1_back = ttml::core::to_vector(t1->get_grad());
     auto batch_shape = ttml::core::create_shape({4, 1, 1, 4});
-    auto new_shape = res->get_value().get_shape();
-    auto back_shape = t1->get_grad().get_shape();
+    auto new_shape = res->get_value().get_logical_shape();
+    auto back_shape = t1->get_grad().get_logical_shape();
 
     for (size_t i = 0; i < 4; i++) {
         EXPECT_EQ(new_shape[i], batch_shape[i]);

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -192,7 +192,7 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis3Matmul) {
 
     auto gathered_ta =
         ttnn::all_gather(tensor_a, 3 /*, {0, 4}, 1 ,std::nullopt, std::nullopt, std::nullopt, std::nullopt*/);
-    fmt::print("gathered_ta shape: {}\n", gathered_ta.get_shape().logical_shape());
+    fmt::print("gathered_ta shape: {}\n", gathered_ta.get_logical_shape());
     auto mul_tensor = ttnn::matmul(
         gathered_ta,
         tensor_b,

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -187,7 +187,7 @@ TEST_F(TensorUtilsTest, TestOnes_1) {
     auto* device = &ttml::autograd::ctx().get_device();
     auto shape = ttml::core::create_shape({1, 2, 3, 4});
     auto tensor_zeros = ttml::core::zeros(shape, device);
-    auto tensor_ones = ttml::core::ones(tensor_zeros.get_shape(), device);
+    auto tensor_ones = ttml::core::ones(tensor_zeros.get_logical_shape(), device);
     auto tensor_vec = ttml::core::to_vector(tensor_ones);
     for (auto& val : tensor_vec) {
         EXPECT_EQ(val, 1.F);
@@ -246,7 +246,7 @@ TEST_F(TensorUtilsTest, TestFloatXtensor) {
     auto shape = ttml::core::create_shape({1, 1, 1, 3});
 
     xt::xarray<float> xtensor =
-        ttml::core::span_to_xtensor_view(std::span<float>{test_data.data(), test_data.size()}, shape.logical_shape());
+        ttml::core::span_to_xtensor_view(std::span<float>{test_data.data(), test_data.size()}, shape);
     auto tensor = ttml::core::from_xtensor(xtensor, device);
 
     auto xtensor_back = ttml::core::to_xtensor(tensor);
@@ -259,8 +259,8 @@ TEST_F(TensorUtilsTest, TestUint32XTensor) {
     std::vector<uint32_t> test_data = {30, 20, 2};
 
     auto shape = ttml::core::create_shape({1, 1, 1, 3});
-    xt::xarray<uint32_t> xtensor = ttml::core::span_to_xtensor_view(
-        std::span<uint32_t>{test_data.data(), test_data.size()}, shape.logical_shape());
+    xt::xarray<uint32_t> xtensor =
+        ttml::core::span_to_xtensor_view(std::span<uint32_t>{test_data.data(), test_data.size()}, shape);
     auto tensor = ttml::core::from_xtensor<uint32_t, DataType::UINT32>(xtensor, device);
 
     auto xtensor_back = ttml::core::to_xtensor<uint32_t>(tensor);

--- a/tt-train/tests/model/gpt2s_test.cpp
+++ b/tt-train/tests/model/gpt2s_test.cpp
@@ -13,8 +13,8 @@
 enum class ExpectedResult { OK, ERROR };
 
 struct MatmulInput {
-    ttnn::Shape shape_a;
-    ttnn::Shape shape_b;
+    ttnn::SmallVector<uint32_t> shape_a;
+    ttnn::SmallVector<uint32_t> shape_b;
     bool transpose_a{false};
     bool transpose_b{false};
 };
@@ -71,8 +71,8 @@ TEST_F(GPT2SBatch64Test, Matmul) {
     auto run_matmul = [](auto& a, auto& b, bool transpose_a, bool transpose_b) {
         fmt::println(
             "Running matmul with shapes {} and {}, tranpose_a {} transpose_b {}",
-            a.get_shape(),
-            b.get_shape(),
+            a.get_logical_shape(),
+            b.get_logical_shape(),
             transpose_a,
             transpose_b);
         [[maybe_unused]] auto c = ttnn::matmul(
@@ -93,8 +93,8 @@ TEST_F(GPT2SBatch64Test, Matmul) {
         auto [shape_a, shape_b, transpose_a, transpose_b] = input;
 
         auto* device = &ttml::autograd::ctx().get_device();
-        auto a = ttml::core::empty(shape_a, device, {});
-        auto b = ttml::core::empty(shape_b, device, {});
+        auto a = ttml::core::empty(ttnn::SimpleShape(shape_a), device, {});
+        auto b = ttml::core::empty(ttnn::SimpleShape(shape_b), device, {});
 
         if (expected_result == ExpectedResult::OK) {
             EXPECT_NO_THROW(run_matmul(a, b, transpose_a, transpose_b));

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -128,8 +128,8 @@ void train_test(bool use_moreh_adamw = false, bool memory_efficient = false) {
             fmt::print("dataloader host only step time {} ms\n", (double)duration / 1000.);
             auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
                 data, ttml::core::create_shape({batch_size, 1, 1, sequence_length}), device, Layout::ROW_MAJOR));
-            auto targets_tensor = ttml::autograd::create_tensor(
-                ttml::core::from_vector<int32_t, DataType::INT32>(targets, {batch_size * sequence_length}, device));
+            auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<int32_t, DataType::INT32>(
+                targets, ttnn::SimpleShape({batch_size * sequence_length}), device));
             end_timer = std::chrono::high_resolution_clock::now();
             duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();
             fmt::print("dataloader step time {} ms\n", (double)duration / 1000.);

--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -23,7 +23,7 @@ protected:
 };
 
 void compare_tensors(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) {
-    ASSERT_EQ(t1.get_shape(), t2.get_shape());
+    ASSERT_EQ(t1.get_logical_shape(), t2.get_logical_shape());
     auto t1_vec = ttml::core::to_vector(t1);
     auto t2_vec = ttml::core::to_vector(t2);
     ASSERT_EQ(t1_vec.size(), t2_vec.size());
@@ -38,7 +38,7 @@ void compare_tensors(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) 
 }
 
 bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) {
-    if (t1.get_shape() != t2.get_shape()) {
+    if (t1.get_logical_shape() != t2.get_logical_shape()) {
         return false;
     }
 

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -152,14 +152,14 @@ TEST_F(TrivialTnnFixedTest, TestSumOverBatch_0) {
 
     auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
-    auto tensor_shape = tensor.get_shape();
+    auto tensor_shape = tensor.get_logical_shape();
     EXPECT_EQ(tensor_shape[0], batch_size);
     EXPECT_EQ(tensor_shape[1], 1U);
     EXPECT_EQ(tensor_shape[2], 1U);
     EXPECT_EQ(tensor_shape[3], features);
 
     auto result = ttml::ttnn_fixed::sum_over_batch(tensor);
-    const auto& result_shape = result.get_shape();
+    const auto& result_shape = result.get_logical_shape();
     ASSERT_EQ(result_shape.rank(), 4U);
     EXPECT_EQ(result_shape[0], 1U);
     EXPECT_EQ(result_shape[1], 1U);
@@ -184,7 +184,7 @@ TEST_F(TrivialTnnFixedTest, TestDivide) {
     auto rhs_tensor = ttml::core::from_vector(rhs, shape, device);
 
     auto result = ttml::ttnn_fixed::divide(lhs_tensor, rhs_tensor);
-    const auto& result_shape = result.get_shape();
+    const auto& result_shape = result.get_logical_shape();
     ASSERT_EQ(result_shape.rank(), 4U);
     EXPECT_EQ(result_shape[0], batch_size);
     EXPECT_EQ(result_shape[1], 1U);
@@ -213,14 +213,14 @@ TEST_F(TrivialTnnFixedTest, TestSumOverBatch_1) {
 
     auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
-    auto tensor_shape = tensor.get_shape();
+    auto tensor_shape = tensor.get_logical_shape();
     EXPECT_EQ(tensor_shape[0], batch_size);
     EXPECT_EQ(tensor_shape[1], 1U);
     EXPECT_EQ(tensor_shape[2], 1U);
     EXPECT_EQ(tensor_shape[3], features);
 
     auto result = ttml::ttnn_fixed::sum_over_batch(tensor);
-    const auto& result_shape = result.get_shape();
+    const auto& result_shape = result.get_logical_shape();
     ASSERT_EQ(result_shape.rank(), 4U);
     EXPECT_EQ(result_shape[0], 1U);
     EXPECT_EQ(result_shape[1], 1U);


### PR DESCRIPTION
### Ticket

### Problem description
We're continuing to remove ttnn::Shape/LegacyShape from the codebase

### What's changed
Removed ttnn::Shape usages from tt-train

### Checklist
- [x] Post commit CI passes
- [x] New/Existing tests provide coverage for changes
