### PR TITLE
#16758: Move mesh_composer call to after ttnn.from_device in ttnn.to_torch

### DIFF
--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -297,11 +297,11 @@ def to_torch(
         tensor([[-0.3008, -0.8438,  0.3242],
                 [ 0.9023, -0.5820,  0.5312]], dtype=torch.bfloat16)
     """
-    if mesh_composer:
-        return mesh_composer.compose(tensor)
-
     if ttnn.is_tensor_storage_on_device(tensor):
         tensor = ttnn.from_device(tensor, cq_id=cq_id)
+
+    if mesh_composer:
+        return mesh_composer.compose(tensor)
 
     if tensor.storage_type() == ttnn.DEVICE_STORAGE_TYPE:
         raise RuntimeError("ttnn.Tensor cannot be on device when converting to torch.Tensor!")


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16758)

### Problem description
Inside `ttnn.to_torch`, need to call `ttnn.from_device` first to leverage multi-threaded code.

### What's changed
- Use `ttnn.from_device` to convert multi-device tensors first
- This fixes pref regression for falcon demo tests

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12937796660
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/12937815510
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
