### PR TITLE
Disable C++20 module scanning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 ############################################
 # Project setup
 ############################################
-include(cmake/compilers.cmake)
 
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(version)
@@ -79,6 +78,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     endif()
 endif()
 
+include(compilers)
 CHECK_COMPILERS()
 
 if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE IN_LIST CMAKE_CONFIGURATION_TYPES)
@@ -90,6 +90,9 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DDEBUG")
 set(CMAKE_CXX_FLAGS_CI "-O3 -DDEBUG")
+
+# We're not currently using C++20 modules, so don't bother scanning for them
+set(CMAKE_CXX_SCAN_FOR_MODULES FALSE)
 
 ############################################################################################################################
 # Project Options


### PR DESCRIPTION
### Ticket
None

### Problem description
TT-MLIR doesn't have the necessary tool to scan for C++20 modules and nobody has a need for it yet anyway.

### What's changed
Disable automatic scanning for C++20 module dependencies.

