### PR TITLE
Collection of small watcher fixes

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -42,7 +42,7 @@ protected:
     // Running with dprint + watcher enabled can make the code size blow up, so let's force watcher
     // disabled for DPRINT tests.
     void SetUp() override {
-        // The core range (physical) needs to be set >= the set of all cores
+        // The core range (virtual) needs to be set >= the set of all cores
         // used by all tests using this fixture, so set dprint enabled for
         // all cores and all devices
         tt::llrt::RunTimeOptions::get_instance().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, true);

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -17,7 +17,7 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-// Some machines will run this test on different physical cores, so wildcard the exact coordinates.
+// Some machines will run this test on different virtual cores, so wildcard the exact coordinates.
 const std::string golden_output =
     R"(DPRINT server timed out on Device *, worker core (x=*,y=*), riscv 4, waiting on a RAISE signal: 1
 )";

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -21,7 +21,7 @@ using namespace tt::tt_metal;
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 static void UpdateGoldenOutput(std::vector<string>& golden_output, const IDevice* device, const string& risc) {
-    // Using wildcard characters in lieu of actual values for the physical coordinates as physical coordinates can vary
+    // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
     // by machine
     const string& device_core_risc = std::to_string(device->id()) + ":(x=*,y=*):" + risc + ": ";
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -17,26 +17,26 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     Program program = Program();
 
     // Depending on riscv type, choose one core to run the test on (since the test hangs the board).
-    CoreCoord logical_core, phys_core;
+    CoreCoord logical_core, virtual_core;
     if (riscv_type == DebugErisc) {
         if (device->get_active_ethernet_cores(true).empty()) {
             log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_active_ethernet_cores(true).begin());
-        phys_core = device->ethernet_core_from_logical_core(logical_core);
+        virtual_core = device->ethernet_core_from_logical_core(logical_core);
     } else if (riscv_type == DebugIErisc) {
         if (device->get_inactive_ethernet_cores().empty()) {
             log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_inactive_ethernet_cores().begin());
-        phys_core = device->ethernet_core_from_logical_core(logical_core);
+        virtual_core = device->ethernet_core_from_logical_core(logical_core);
     } else {
         logical_core = CoreCoord{0, 0};
-        phys_core = device->worker_core_from_logical_core(logical_core);
+        virtual_core = device->worker_core_from_logical_core(logical_core);
     }
-    log_info(LogTest, "Running test on device {} core {}...", device->id(), phys_core.str());
+    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
 
     // Set up the kernel on the correct risc
     KernelHandle assert_kernel;
@@ -163,8 +163,8 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
         (riscv_type == DebugErisc) ? "ethnet" : "worker",
         logical_core.x,
         logical_core.y,
-        phys_core.x,
-        phys_core.y,
+        virtual_core.x,
+        virtual_core.y,
         risc,
         line_num,
         kernel);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -31,8 +31,9 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
         // Only force a retrain on odd-numbered eth cores
         if (eth_core.y % 2) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(eth_core);
-            tt::llrt::write_hex_vec_to_core(device->id(), phys_core, reset_val, eth_l1_mem::address_map::RETRAIN_FORCE_ADDR);
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
+            tt::llrt::write_hex_vec_to_core(
+                device->id(), virtual_core, reset_val, eth_l1_mem::address_map::RETRAIN_FORCE_ADDR);
         }
     }
 
@@ -40,9 +41,12 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
     vector<string> expected_strings;
     for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
-        CoreCoord phys_core = device->ethernet_core_from_logical_core(eth_core);
+        CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
         expected_strings.push_back(fmt::format(
-            "\tDevice {} Ethernet Core {} retraining events: {}", device->id(), phys_core, (eth_core.y % 2) ? 1 : 0));
+            "\tDevice {} Ethernet Core {} retraining events: {}",
+            device->id(),
+            virtual_core,
+            (eth_core.y % 2) ? 1 : 0));
     }
 
     // Close devices to trigger watcher check on teardown.

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -23,10 +23,17 @@ typedef enum sanitization_features {
     SanitizeAddress,
     SanitizeAlignmentL1Write,
     SanitizeAlignmentL1Read,
-    SanitizeZeroL1Write
+    SanitizeZeroL1Write,
+    SanitizeMailboxWrite
 } watcher_features_t;
 
 void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bool is_eth_core, watcher_features_t feature, bool use_ncrisc = false) {
+    // It's not simple to check the watcher server status from the finish loop for slow dispatch, so just run these
+    // tests in FD.
+    if (fixture->IsSlowDispatch()) {
+        GTEST_SKIP();
+    }
+
     // Set up program
     Program program = Program();
     CoreCoord phys_core;
@@ -41,6 +48,12 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     uint32_t num_tiles = 50;
     uint32_t l1_buffer_size = single_tile_size * num_tiles;
     uint32_t l1_buffer_addr = 400 * 1024;
+
+    // For ethernet core, need to have smaller buffer at a different address
+    if (is_eth_core) {
+        l1_buffer_size = 1024;
+        l1_buffer_addr = 200 * 1024;
+    }
 
     tt_metal::InterleavedBufferConfig l1_config{
         .device = device, .size = l1_buffer_size, .page_size = l1_buffer_size, .buffer_type = tt_metal::BufferType::L1};
@@ -103,6 +116,12 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
             l1_buffer_size--;
             break;
         case SanitizeZeroL1Write: output_l1_buffer_addr = 0; break;
+        case SanitizeMailboxWrite:
+            // This is illegal because we'd be writing to the mailbox memory
+            l1_buffer_addr = hal.get_dev_addr(
+                (is_eth_core) ? HalProgrammableCoreType::ACTIVE_ETH : HalProgrammableCoreType::TENSIX,
+                HalL1MemAddrType::MAILBOX);
+            break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -144,7 +163,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     switch(feature) {
         case SanitizeAddress:
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write 102400 "
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Unknown core w/ physical coords {} [addr=0x{:08x}] (NOC target "
                 "address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
                 device->id(),
@@ -154,13 +173,14 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 phys_core.x,
                 phys_core.y,
                 (is_eth_core) ? "erisc" : "brisc",
+                l1_buffer_size,
                 l1_buffer_addr,
                 output_buf_noc_xy.str(),
                 output_l1_buffer_addr);
             break;
         case SanitizeAlignmentL1Write: {
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write 102399 "
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Tensix core w/ physical coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
@@ -171,6 +191,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 phys_core.y,
                 risc_name,
                 noc,
+                l1_buffer_size,
                 l1_buffer_addr,
                 target_core,
                 output_l1_buffer_addr);
@@ -178,7 +199,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         }
         case SanitizeAlignmentL1Read: {
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read 102399 "
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read {} "
                 "bytes to local L1[{:#08x}] from Tensix core w/ physical coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
@@ -189,15 +210,16 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 phys_core.y,
                 risc_name,
                 noc,
+                l1_buffer_size,
                 l1_buffer_addr,
                 target_core,
                 input_l1_buffer_addr);
         } break;
         case SanitizeZeroL1Write: {
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write 102400 "
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
                 "bytes from local L1[{:#08x}] to Tensix core w/ physical coords {} L1[addr=0x{:08x}] (NOC target "
-                "address underflow).",
+                "overwrites mailboxes).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x,
@@ -206,9 +228,27 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 phys_core.y,
                 risc_name,
                 noc,
+                l1_buffer_size,
                 l1_buffer_addr,
                 target_core,
                 output_l1_buffer_addr);
+        } break;
+        case SanitizeMailboxWrite: {
+            expected = fmt::format(
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast read {} "
+                "bytes to local L1[{:#08x}] from Tensix core w/ physical coords {} L1[addr=0x{:08x}] (Local L1 "
+                "overwrites mailboxes).",
+                device->id(),
+                (is_eth_core) ? "ethnet" : "worker",
+                core.x,
+                core.y,
+                phys_core.x,
+                phys_core.y,
+                (is_eth_core) ? "erisc" : "brisc",
+                l1_buffer_size,
+                l1_buffer_addr,
+                input_buf_noc_xy.str(),
+                input_l1_buffer_addr);
         } break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
@@ -225,17 +265,23 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     EXPECT_EQ(get_watcher_exception_message(), expected);
 }
 
-static void RunTestEth(WatcherFixture* fixture, IDevice* device) {
+static void RunTestEth(WatcherFixture* fixture, IDevice* device, watcher_features_t feature) {
+    if (fixture->IsSlowDispatch()) {
+        GTEST_SKIP();
+    }
     // Run on the first ethernet core (if there are any).
     if (device->get_active_ethernet_cores(true).empty()) {
         log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
         GTEST_SKIP();
     }
     CoreCoord core = *(device->get_active_ethernet_cores(true).begin());
-    RunTestOnCore(fixture, device, core, true, SanitizeAddress);
+    RunTestOnCore(fixture, device, core, true, feature);
 }
 
 static void RunTestIEth(WatcherFixture* fixture, IDevice* device) {
+    if (fixture->IsSlowDispatch()) {
+        GTEST_SKIP();
+    }
     // Run on the first ethernet core (if there are any).
     if (device->get_inactive_ethernet_cores().empty()) {
         log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
@@ -262,64 +308,45 @@ void CheckHostSanitization(IDevice* device) {
 }
 
 TEST_F(WatcherFixture, TensixTestWatcherSanitize) {
-    // Skip this test for slow dipatch for now. Due to how llrt currently sits below device, it's
-    // tricky to check watcher server status from the finish loop for slow dispatch. Once issue #4363
-    // is resolved, we should add a check for print server handing in slow dispatch as well.
-    if (this->slow_dispatch_)
-        GTEST_SKIP();
-
     CheckHostSanitization(this->devices_[0]);
 
     // Only run on device 0 because this test takes down the watcher server.
     this->RunTestOnDevice(
-        [](WatcherFixture *fixture, IDevice* device){
+        [](WatcherFixture* fixture, IDevice* device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, device, core, false, SanitizeAddress);
         },
-        this->devices_[0]
-    );
+        this->devices_[0]);
 }
 
 TEST_F(WatcherFixture, TensixTestWatcherSanitizeAlignmentL1Write) {
-    if (this->slow_dispatch_)
-        GTEST_SKIP();
     this->RunTestOnDevice(
-        [](WatcherFixture *fixture, IDevice* device){
+        [](WatcherFixture* fixture, IDevice* device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, device, core, false, SanitizeAlignmentL1Write);
         },
-        this->devices_[0]
-    );
+        this->devices_[0]);
 }
 
 TEST_F(WatcherFixture, TensixTestWatcherSanitizeAlignmentL1Read) {
-    if (this->slow_dispatch_)
-        GTEST_SKIP();
     this->RunTestOnDevice(
-        [](WatcherFixture *fixture, IDevice* device){
+        [](WatcherFixture* fixture, IDevice* device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, device, core, false, SanitizeAlignmentL1Read);
         },
-        this->devices_[0]
-    );
+        this->devices_[0]);
 }
 
 TEST_F(WatcherFixture, TensixTestWatcherSanitizeAlignmentL1ReadNCrisc) {
-    if (this->slow_dispatch_)
-        GTEST_SKIP();
     this->RunTestOnDevice(
-        [](WatcherFixture *fixture, IDevice* device){
+        [](WatcherFixture* fixture, IDevice* device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, device, core, false, SanitizeAlignmentL1Read, true);
         },
-        this->devices_[0]
-    );
+        this->devices_[0]);
 }
 
 TEST_F(WatcherFixture, TensixTestWatcherSanitizeZeroL1Write) {
-    if (this->slow_dispatch_) {
-        GTEST_SKIP();
-    }
     this->RunTestOnDevice(
         [](WatcherFixture* fixture, IDevice* device) {
             CoreCoord core{0, 0};
@@ -328,10 +355,25 @@ TEST_F(WatcherFixture, TensixTestWatcherSanitizeZeroL1Write) {
         this->devices_[0]);
 }
 
+TEST_F(WatcherFixture, TensixTestWatcherSanitizeMailboxWrite) {
+    this->RunTestOnDevice(
+        [](WatcherFixture* fixture, IDevice* device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, device, core, false, SanitizeMailboxWrite);
+        },
+        this->devices_[0]);
+}
+
 TEST_F(WatcherFixture, ActiveEthTestWatcherSanitizeEth) {
-    if (this->slow_dispatch_)
-        GTEST_SKIP();
-    this->RunTestOnDevice(RunTestEth, this->devices_[0]);
+    this->RunTestOnDevice(
+        [](WatcherFixture* fixture, IDevice* device) { RunTestEth(fixture, device, SanitizeAddress); },
+        this->devices_[0]);
+}
+
+TEST_F(WatcherFixture, ActiveEthTestWatcherSanitizeMailboxWrite) {
+    this->RunTestOnDevice(
+        [](WatcherFixture* fixture, IDevice* device) { RunTestEth(fixture, device, SanitizeMailboxWrite); },
+        this->devices_[0]);
 }
 
 TEST_F(WatcherFixture, IdleEthTestWatcherSanitizeIEth) {
@@ -339,7 +381,5 @@ TEST_F(WatcherFixture, IdleEthTestWatcherSanitizeIEth) {
         log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
-    if (this->slow_dispatch_)
-        GTEST_SKIP();
     this->RunTestOnDevice(RunTestIEth, this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -36,12 +36,12 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
 
     // Set up program
     Program program = Program();
-    CoreCoord phys_core;
+    CoreCoord virtual_core;
     if (is_eth_core)
-        phys_core = device->ethernet_core_from_logical_core(core);
+        virtual_core = device->ethernet_core_from_logical_core(core);
     else
-        phys_core = device->worker_core_from_logical_core(core);
-    log_info(LogTest, "Running test on device {} core {}...", device->id(), phys_core.str());
+        virtual_core = device->worker_core_from_logical_core(core);
+    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
 
     // Set up dram buffers
     uint32_t single_tile_size = 2 * 1024;
@@ -164,14 +164,14 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         case SanitizeAddress:
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast write {} "
-                "bytes from local L1[{:#08x}] to Unknown core w/ physical coords {} [addr=0x{:08x}] (NOC target "
+                "bytes from local L1[{:#08x}] to Unknown core w/ virtual coords {} [addr=0x{:08x}] (NOC target "
                 "address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x,
                 core.y,
-                phys_core.x,
-                phys_core.y,
+                virtual_core.x,
+                virtual_core.y,
                 (is_eth_core) ? "erisc" : "brisc",
                 l1_buffer_size,
                 l1_buffer_addr,
@@ -181,14 +181,14 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         case SanitizeAlignmentL1Write: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
-                "bytes from local L1[{:#08x}] to Tensix core w/ physical coords {} L1[addr=0x{:08x}] (invalid address "
+                "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x,
                 core.y,
-                phys_core.x,
-                phys_core.y,
+                virtual_core.x,
+                virtual_core.y,
                 risc_name,
                 noc,
                 l1_buffer_size,
@@ -200,14 +200,14 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         case SanitizeAlignmentL1Read: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read {} "
-                "bytes to local L1[{:#08x}] from Tensix core w/ physical coords {} L1[addr=0x{:08x}] (invalid address "
+                "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x,
                 core.y,
-                phys_core.x,
-                phys_core.y,
+                virtual_core.x,
+                virtual_core.y,
                 risc_name,
                 noc,
                 l1_buffer_size,
@@ -218,14 +218,14 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         case SanitizeZeroL1Write: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
-                "bytes from local L1[{:#08x}] to Tensix core w/ physical coords {} L1[addr=0x{:08x}] (NOC target "
+                "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (NOC target "
                 "overwrites mailboxes).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x,
                 core.y,
-                phys_core.x,
-                phys_core.y,
+                virtual_core.x,
+                virtual_core.y,
                 risc_name,
                 noc,
                 l1_buffer_size,
@@ -236,14 +236,14 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         case SanitizeMailboxWrite: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc0 tried to unicast read {} "
-                "bytes to local L1[{:#08x}] from Tensix core w/ physical coords {} L1[addr=0x{:08x}] (Local L1 "
+                "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (Local L1 "
                 "overwrites mailboxes).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x,
                 core.y,
-                phys_core.x,
-                phys_core.y,
+                virtual_core.x,
+                virtual_core.y,
                 (is_eth_core) ? "erisc" : "brisc",
                 l1_buffer_size,
                 l1_buffer_addr,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -47,12 +47,12 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 50;
     uint32_t l1_buffer_size = single_tile_size * num_tiles;
-    uint32_t l1_buffer_addr = 400 * 1024;
+    uint32_t l1_buffer_addr = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
 
     // For ethernet core, need to have smaller buffer at a different address
     if (is_eth_core) {
         l1_buffer_size = 1024;
-        l1_buffer_addr = 200 * 1024;
+        l1_buffer_addr = hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     }
 
     tt_metal::InterleavedBufferConfig l1_config{
@@ -103,8 +103,8 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     // depending on the flags passed in.
     switch(feature) {
         case SanitizeAddress:
-            output_buf_noc_xy.x = 16;
-            output_buf_noc_xy.y = 16;
+            output_buf_noc_xy.x = 26;
+            output_buf_noc_xy.y = 18;
             break;
         case SanitizeAlignmentL1Write:
             output_l1_buffer_addr++;  // This is illegal because reading DRAM->L1 needs DRAM alignment

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -129,11 +129,12 @@ void RunDelayTestOnCore(WatcherDelayFixture* fixture, IDevice* device, CoreCoord
         std::vector<uint32_t> read_vec;
 
         CoreCoord worker_core = fixture->delayed_cores[CoreType::WORKER][0]; // Just check that the first delayed core has the feedback set
-        CoreCoord phys_core = device->virtual_core_from_logical_core({0, 0}, CoreType::WORKER);
-        read_vec = tt::llrt::read_hex_vec_from_core (
+        CoreCoord virtual_core = device->virtual_core_from_logical_core({0, 0}, CoreType::WORKER);
+        read_vec = tt::llrt::read_hex_vec_from_core(
             device->id(),
-            phys_core,
-            device->get_dev_addr(phys_core, HalL1MemAddrType::WATCHER) + offsetof(watcher_msg_t, debug_insert_delays),
+            virtual_core,
+            device->get_dev_addr(virtual_core, HalL1MemAddrType::WATCHER) +
+                offsetof(watcher_msg_t, debug_insert_delays),
             sizeof(debug_insert_delays_msg_t));
 
         log_info(tt::LogTest, "Read back debug_insert_delays: 0x{:x}", read_vec[0]);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -112,24 +112,24 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
     vector<string> expected_strings;
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            CoreCoord phys_core = device->worker_core_from_logical_core({x, y});
+            CoreCoord virtual_core = device->worker_core_from_logical_core({x, y});
             for (auto &risc_str : {"brisc", "ncrisc", "trisc0", "trisc1", "trisc2"}) {
-                string expected = fmt::format("{}:{}", phys_core.str(), risc_str);
+                string expected = fmt::format("{}:{}", virtual_core.str(), risc_str);
                 expected_strings.push_back(expected);
             }
         }
     }
     if (has_eth_cores) {
         for (const auto& core : device->get_active_ethernet_cores(true)) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(core);
-            string expected = fmt::format("{}:erisc", phys_core.str());
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(core);
+            string expected = fmt::format("{}:erisc", virtual_core.str());
             expected_strings.push_back(expected);
         }
     }
     if (has_ieth_cores) {
         for (const auto& core : device->get_inactive_ethernet_cores()) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(core);
-            string expected = fmt::format("{}:ierisc", phys_core.str());
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(core);
+            string expected = fmt::format("{}:ierisc", virtual_core.str());
             expected_strings.push_back(expected);
         }
     }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -26,27 +26,26 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     Program program = Program();
 
     // Depending on riscv type, choose one core to run the test on.
-    CoreCoord logical_core, phys_core;
+    CoreCoord logical_core, virtual_core;
     if (riscv_type == DebugErisc) {
         if (device->get_active_ethernet_cores(true).empty()) {
             log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_active_ethernet_cores(true).begin());
-        phys_core = device->ethernet_core_from_logical_core(logical_core);
+        virtual_core = device->ethernet_core_from_logical_core(logical_core);
     } else if (riscv_type == DebugIErisc) {
         if (device->get_inactive_ethernet_cores().empty()) {
             log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_inactive_ethernet_cores().begin());
-        phys_core = device->ethernet_core_from_logical_core(logical_core);
+        virtual_core = device->ethernet_core_from_logical_core(logical_core);
     } else {
         logical_core = CoreCoord{0, 0};
-        phys_core = device->worker_core_from_logical_core(logical_core);
+        virtual_core = device->worker_core_from_logical_core(logical_core);
     }
-    log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, phys_core);
-
+    log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
 
     // Set up the kernel on the correct risc
     KernelHandle assert_kernel;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -128,7 +128,10 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
     fixture->RunProgram(device, program);
 
     // Check that the expected waypoints are in the watcher log, a set for each core.
-    auto check_core = [&](const CoreCoord &logical_core, const CoreCoord &phys_core, bool is_eth_core, bool is_active) {
+    auto check_core = [&](const CoreCoord& logical_core,
+                          const CoreCoord& virtual_core,
+                          bool is_eth_core,
+                          bool is_active) {
         vector<string> expected_waypoints;
         string expected;
         // Need to update the expected strings based on each core.
@@ -151,10 +154,11 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
                     device->id(),
                     logical_core.x,
                     logical_core.y,
-                    phys_core.x,
-                    phys_core.y,
+                    virtual_core.x,
+                    virtual_core.y,
                     waypoint,
-                    (device->arch() == ARCH::BLACKHOLE) ? "W" : "X", // TODO (#15448): Uplift this when watcher device reader accounts for variable num eth riscs
+                    (device->arch() == ARCH::BLACKHOLE) ? "W" : "X",  // TODO (#15448): Uplift this when watcher device
+                                                                      // reader accounts for variable num eth riscs
                     k_id_s);
             } else {
                 // Each different config has a different calculation for k_id, let's just do one. Fast Dispatch, one device.
@@ -172,8 +176,8 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
                     device->id(),
                     logical_core.x,
                     logical_core.y,
-                    phys_core.x,
-                    phys_core.y,
+                    virtual_core.x,
+                    virtual_core.y,
                     waypoint,
                     waypoint,
                     waypoint,
@@ -193,20 +197,20 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
             CoreCoord logical_core = {x, y};
-            CoreCoord phys_core = device->worker_core_from_logical_core(logical_core);
-            check_core(logical_core, phys_core, false, false);
+            CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
+            check_core(logical_core, virtual_core, false, false);
         }
     }
     if (has_eth_cores) {
         for (const auto& core : device->get_active_ethernet_cores(true)) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(core);
-            check_core(core, phys_core, true, true);
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(core);
+            check_core(core, virtual_core, true, true);
         }
     }
     if (has_idle_eth_cores) {
         for (const auto& core : device->get_inactive_ethernet_cores()) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(core);
-            check_core(core, phys_core, true, false);
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(core);
+            check_core(core, virtual_core, true, false);
         }
     }
 }

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -324,7 +324,9 @@ struct core_info_msg_t {
     volatile uint8_t virtual_harvested_y[MAX_HARVESTED_ROWS];
     volatile uint8_t noc_size_x;
     volatile uint8_t noc_size_y;
-    volatile uint8_t pad[27];
+    volatile uint8_t worker_grid_size_x;
+    volatile uint8_t worker_grid_size_y;
+    volatile uint8_t pad[25];
 };
 
 constexpr uint32_t launch_msg_buffer_num_entries = 4;

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -189,6 +189,7 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeNocMulticastInvalidRange = 8,
     DebugSanitizeNocAlignment = 9,
     DebugSanitizeNocMixedVirtualandPhysical = 10,
+    DebugSanitizeNocAddrMailbox = 11,
 };
 
 struct debug_assert_msg_t {

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -111,11 +111,18 @@ AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is
         }
     }
     if constexpr (COORDINATE_VIRTUALIZATION_ENABLED) {
-        // Check if NOC endpoint is valid in the Tensix Virtual Coordinate Space.
+        // Check if NOC endpoint is valid in the Tensix Virtual Coordinate Space. Use worker grid size instead of noc
+        // size because virtual coords are continuous.
         if (x >= NOC_0_X(noc_id, core_info->noc_size_x, (uint32_t)VIRTUAL_TENSIX_START_X) &&
-            x <= NOC_0_X(noc_id, core_info->noc_size_x, (uint32_t)VIRTUAL_TENSIX_START_X + core_info->noc_size_x - 1) &&
+            x <= NOC_0_X(
+                     noc_id,
+                     core_info->noc_size_x,
+                     (uint32_t)VIRTUAL_TENSIX_START_X + core_info->worker_grid_size_x - 1) &&
             y >= NOC_0_Y(noc_id, core_info->noc_size_y, (uint32_t)VIRTUAL_TENSIX_START_Y) &&
-            y <= NOC_0_Y(noc_id, core_info->noc_size_y, (uint32_t)VIRTUAL_TENSIX_START_Y + core_info->noc_size_y - 1)) {
+            y <= NOC_0_Y(
+                     noc_id,
+                     core_info->noc_size_y,
+                     (uint32_t)VIRTUAL_TENSIX_START_Y + core_info->worker_grid_size_y - 1)) {
             is_virtual_coord = true;
             return AddressableCoreType::TENSIX;
         }

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -56,8 +56,9 @@ static CoreDescriptorSet GetDispatchCores(tt::tt_metal::IDevice* device) {
     return dispatch_cores;
 }
 
-inline uint64_t GetDprintBufAddr(tt::tt_metal::IDevice* device, const CoreCoord& phys_core, int risc_id) {
-    dprint_buf_msg_t* buf = device->get_dev_addr<dprint_buf_msg_t*>(phys_core, tt::tt_metal::HalL1MemAddrType::DPRINT);
+inline uint64_t GetDprintBufAddr(tt::tt_metal::IDevice* device, const CoreCoord& virtual_core, int risc_id) {
+    dprint_buf_msg_t* buf =
+        device->get_dev_addr<dprint_buf_msg_t*>(virtual_core, tt::tt_metal::HalL1MemAddrType::DPRINT);
     return reinterpret_cast<uint64_t>(&(buf->data[risc_id]));
 }
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -443,15 +443,15 @@ static void PrintTypedUint32Array(
 
 // Writes a magic value at wpos ptr address for dprint buffer for a specific hart/core/chip
 // Used for debug print server startup sequence.
-void WriteInitMagic(IDevice* device, const CoreCoord& phys_core, int hart_id, bool enabled) {
+void WriteInitMagic(IDevice* device, const CoreCoord& virtual_core, int hart_id, bool enabled) {
     // compute the buffer address for the requested hart
-    uint64_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
+    uint64_t base_addr = GetDprintBufAddr(device, virtual_core, hart_id);
 
     // TODO(AP): this could use a cleanup - need a different mechanism to know if a kernel is running on device.
     // Force wait for first kernel launch by first writing a non-zero and waiting for a zero.
     std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
     initbuf[0] = uint32_t(enabled ? DEBUG_PRINT_SERVER_STARTING_MAGIC : DEBUG_PRINT_SERVER_DISABLED_MAGIC);
-    tt::llrt::write_hex_vec_to_core(device->id(), phys_core, initbuf, base_addr);
+    tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, initbuf, base_addr);
 
     // Prevent race conditions during runtime by waiting until the init value is actually written
     // DPrint is only used for debug purposes so this delay should not be a big issue.
@@ -461,7 +461,7 @@ void WriteInitMagic(IDevice* device, const CoreCoord& phys_core, int hart_id, bo
     // 4. now we will access wpos at the starting magic which is incorrect
     uint32_t num_tries = 100000;
     while (num_tries-- > 0) {
-        auto result = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, 4);
+        auto result = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, base_addr, 4);
         if (result[0] == DEBUG_PRINT_SERVER_STARTING_MAGIC && enabled) {
             return;
         } else if (result[0] == DEBUG_PRINT_SERVER_DISABLED_MAGIC && !enabled) {
@@ -475,11 +475,11 @@ void WriteInitMagic(IDevice* device, const CoreCoord& phys_core, int hart_id, bo
 // The assumption is that if our magic number was cleared,
 // it means there is a write in the queue and wpos/rpos are now valid
 // Note that this is not a bulletproof way to bootstrap the print server (TODO(AP))
-bool CheckInitMagicCleared(IDevice* device, const CoreCoord& phys_core, int hart_id) {
+bool CheckInitMagicCleared(IDevice* device, const CoreCoord& virtual_core, int hart_id) {
     // compute the buffer address for the requested hart
-    uint32_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
+    uint32_t base_addr = GetDprintBufAddr(device, virtual_core, hart_id);
 
-    auto result = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, 4);
+    auto result = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, base_addr, 4);
     return (result[0] != DEBUG_PRINT_SERVER_STARTING_MAGIC && result[0] != DEBUG_PRINT_SERVER_DISABLED_MAGIC);
 }  // CheckInitMagicCleared
 
@@ -581,7 +581,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
     chip_id_t device_id = device->id();
 
     // A set of all valid printable cores, used for checking the user input. Note that the coords
-    // here are physical.
+    // here are virtual.
     CoreDescriptorSet all_cores = GetAllCores(device);
     CoreDescriptorSet dispatch_cores = GetDispatchCores(device);
 
@@ -591,9 +591,9 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
     // skip prints entirely to prevent kernel code from hanging waiting for the print buffer to be
     // flushed from the host.
     for (auto& logical_core : all_cores) {
-        CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
         for (int hart_index = 0; hart_index < GetNumRiscs(logical_core); hart_index++) {
-            WriteInitMagic(device, phys_core, hart_index, false);
+            WriteInitMagic(device, virtual_core, hart_index, false);
         }
     }
 
@@ -659,12 +659,12 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
 
             // We should also validate that the cores the user specified are valid worker cores.
             for (auto& logical_core : print_cores) {
-                // Need to convert user-specified logical cores to physical cores, this can throw
+                // Need to convert user-specified logical cores to virtual cores, this can throw
                 // if the user gave bad coords.
-                CoreCoord phys_core;
+                CoreCoord virtual_core;
                 bool valid_logical_core = true;
                 try {
-                    phys_core = device->virtual_core_from_logical_core(logical_core, core_type);
+                    virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
                 } catch (std::runtime_error& error) {
                     valid_logical_core = false;
                 }
@@ -672,19 +672,19 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                     print_cores_sanitized.push_back({logical_core, core_type});
                     log_info(
                         tt::LogMetal,
-                        "DPRINT enabled on device {}, {} core {} (physical {}).",
+                        "DPRINT enabled on device {}, {} core {} (virtual {}).",
                         device->id(),
                         tt::llrt::get_core_type_name(core_type),
                         logical_core.str(),
-                        phys_core.str());
+                        virtual_core.str());
                 } else {
                     log_warning(
                         tt::LogMetal,
-                        "TT_METAL_DPRINT_CORES included {} core with logical coordinates {} (physical coordinates {}), "
+                        "TT_METAL_DPRINT_CORES included {} core with logical coordinates {} (virtual coordinates {}), "
                         "which is not a valid core on device {}. This coordinate will be ignored by the dprint server.",
                         tt::llrt::get_core_type_name(core_type),
                         logical_core.str(),
-                        valid_logical_core ? phys_core.str() : "INVALID",
+                        valid_logical_core ? virtual_core.str() : "INVALID",
                         device->id());
                 }
             }
@@ -695,10 +695,10 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
     uint32_t hart_mask =
         tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDprint);
     for (auto& logical_core : print_cores_sanitized) {
-        CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
         for (int hart_index = 0; hart_index < GetNumRiscs(logical_core); hart_index++) {
             if (hart_mask & (1 << hart_index)) {
-                WriteInitMagic(device, phys_core, hart_index, true);
+                WriteInitMagic(device, virtual_core, hart_index, true);
             }
         }
         if (dispatch_cores.count(logical_core)) {
@@ -744,18 +744,18 @@ void DebugPrintServerContext::DetachDevice(IDevice* device) {
         // Check all dprint-enabled cores on this device for outstanding prints.
         outstanding_prints = false;
         for (auto& logical_core : device_to_core_range_.at(device)) {
-            CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+            CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
             for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
                 if (risc_mask & (1 << risc_id)) {
                     // No need to check if risc is not dprint-enabled.
-                    if (!CheckInitMagicCleared(device, phys_core, risc_id)) {
+                    if (!CheckInitMagicCleared(device, virtual_core, risc_id)) {
                         continue;
                     }
 
                     // Check if rpos < wpos, indicating unprocessed prints.
                     constexpr int eightbytes = 8;
-                    uint32_t base_addr = GetDprintBufAddr(device, phys_core, risc_id);
-                    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, phys_core, base_addr, eightbytes);
+                    uint32_t base_addr = GetDprintBufAddr(device, virtual_core, risc_id);
+                    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, virtual_core, base_addr, eightbytes);
                     uint32_t wpos = from_dev[0], rpos = from_dev[1];
                     if (rpos < wpos) {
                         outstanding_prints = true;
@@ -806,9 +806,9 @@ void DebugPrintServerContext::DetachDevice(IDevice* device) {
     // When detaching a device, disable prints on it.
     CoreDescriptorSet all_cores = GetAllCores(device);
     for (auto& logical_core : all_cores) {
-        CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
         for (int hart_index = 0; hart_index < GetNumRiscs(logical_core); hart_index++) {
-            WriteInitMagic(device, phys_core, hart_index, false);
+            WriteInitMagic(device, virtual_core, hart_index, false);
         }
     }
     device_to_core_range_lock_.unlock();
@@ -836,13 +836,13 @@ void DebugPrintServerContext::ClearSignals() {
 bool DebugPrintServerContext::PeekOneHartNonBlocking(
     IDevice* device, const CoreDescriptor& logical_core, int hart_id, bool new_data_this_iter) {
     // If init magic isn't cleared for this risc, then dprint isn't enabled on it, don't read it.
-    CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-    if (!CheckInitMagicCleared(device, phys_core, hart_id)) {
+    CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+    if (!CheckInitMagicCleared(device, virtual_core, hart_id)) {
         return false;
     }
 
     // compute the buffer address for the requested hart
-    uint32_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
+    uint32_t base_addr = GetDprintBufAddr(device, virtual_core, hart_id);
     chip_id_t chip_id = device->id();
     HartKey hart_key{chip_id, logical_core, hart_id};
 
@@ -899,7 +899,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
     // Device is incrementing wpos
     // Host is reading wpos and incrementing local rpos up to wpos
     // Device is filling the buffer and in the end waits on host to write rpos
-    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, phys_core, base_addr, DPRINT_BUFFER_SIZE);
+    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, virtual_core, base_addr, DPRINT_BUFFER_SIZE);
     DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
     uint32_t rpos = l->aux.rpos;
     uint32_t wpos = l->aux.wpos;
@@ -1100,8 +1100,8 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                         rpos,
                         (uint32_t)code,
                         chip_id,
-                        phys_core.x,
-                        phys_core.y);
+                        virtual_core.x,
+                        virtual_core.y);
             }
 
             risc_to_prev_type_[hart_key] = code;
@@ -1123,7 +1123,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
         std::vector<uint32_t> rposbuf;
         rposbuf.push_back(rpos);
         uint32_t offs = DebugPrintMemLayout().rpos_offs();
-        tt::llrt::write_hex_vec_to_core(chip_id, phys_core, rposbuf, base_addr + offs);
+        tt::llrt::write_hex_vec_to_core(chip_id, virtual_core, rposbuf, base_addr + offs);
 
         // Return true to signal that some print data was read
         return true;

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -40,11 +40,11 @@ void PrintNocData(noc_data_t noc_data, const string& file_name) {
 }
 
 void DumpCoreNocData(IDevice* device, const CoreDescriptor& logical_core, noc_data_t& noc_data) {
-    CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+    CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
     for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
-        uint64_t addr = GetDprintBufAddr(device, phys_core, risc_id);
-        auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, addr, DPRINT_BUFFER_SIZE);
+        uint64_t addr = GetDprintBufAddr(device, virtual_core, risc_id);
+        auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, addr, DPRINT_BUFFER_SIZE);
         DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
         uint32_t* data = reinterpret_cast<uint32_t*>(l->data);
 
@@ -99,11 +99,11 @@ void ClearNocData(IDevice* device) {
 
     CoreDescriptorSet all_cores = GetAllCores(device);
     for (const CoreDescriptor& logical_core : all_cores) {
-        CoreCoord phys_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
         for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
-            uint64_t addr = GetDprintBufAddr(device, phys_core, risc_id);
+            uint64_t addr = GetDprintBufAddr(device, virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
-            tt::llrt::write_hex_vec_to_core(device->id(), phys_core, initbuf, addr);
+            tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, initbuf, addr);
         }
     }
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -81,7 +81,7 @@ static string get_noc_target_str(
         try {
             core_type = device->core_type_from_virtual_core(virtual_core);
         } catch (std::runtime_error& e) {
-            // We may not be able to get a core type if the physical coords are bad.
+            // We may not be able to get a core type if the virtual coords are bad.
             return {"Unknown", ""};
         }
         switch (core_type) {
@@ -103,21 +103,22 @@ static string get_noc_target_str(
     out += fmt::format("local L1[{:#08x}] {} ", san->l1_addr, string(san->is_write ? "to" : "from"));
 
     if (san->is_multicast) {
-        CoreCoord target_phys_noc_core_start = {
+        CoreCoord target_virtual_noc_core_start = {
             NOC_MCAST_ADDR_START_X(san->noc_addr), NOC_MCAST_ADDR_START_Y(san->noc_addr)};
-        CoreCoord target_phys_noc_core_end = {NOC_MCAST_ADDR_END_X(san->noc_addr), NOC_MCAST_ADDR_END_Y(san->noc_addr)};
-        auto type_and_mem = get_core_and_mem_type(device, target_phys_noc_core_start, noc);
+        CoreCoord target_virtual_noc_core_end = {
+            NOC_MCAST_ADDR_END_X(san->noc_addr), NOC_MCAST_ADDR_END_Y(san->noc_addr)};
+        auto type_and_mem = get_core_and_mem_type(device, target_virtual_noc_core_start, noc);
         out += fmt::format(
-            "{} core range w/ physical coords {}-{} {}",
+            "{} core range w/ virtual coords {}-{} {}",
             type_and_mem.first,
-            target_phys_noc_core_start.str(),
-            target_phys_noc_core_end.str(),
+            target_virtual_noc_core_start.str(),
+            target_virtual_noc_core_end.str(),
             type_and_mem.second);
     } else {
-        CoreCoord target_phys_noc_core = {NOC_UNICAST_ADDR_X(san->noc_addr), NOC_UNICAST_ADDR_Y(san->noc_addr)};
-        auto type_and_mem = get_core_and_mem_type(device, target_phys_noc_core, noc);
+        CoreCoord target_virtual_noc_core = {NOC_UNICAST_ADDR_X(san->noc_addr), NOC_UNICAST_ADDR_Y(san->noc_addr)};
+        auto type_and_mem = get_core_and_mem_type(device, target_virtual_noc_core, noc);
         out += fmt::format(
-            "{} core w/ physical coords {} {}", type_and_mem.first, target_phys_noc_core.str(), type_and_mem.second);
+            "{} core w/ virtual coords {} {}", type_and_mem.first, target_virtual_noc_core.str(), type_and_mem.second);
     }
 
     out += fmt::format("[addr=0x{:08x}]", NOC_LOCAL_ADDR(san->noc_addr));
@@ -141,10 +142,10 @@ WatcherDeviceReader::WatcherDeviceReader(
     if (device->arch() == ARCH::WORMHOLE_B0 && tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
         for (const CoreCoord& eth_core : device->get_active_ethernet_cores()) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(eth_core);
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
             read_data = tt::llrt::read_hex_vec_from_core(
                 device->id(),
-                phys_core,
+                virtual_core,
                 hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::RETRAIN_COUNT),
                 sizeof(uint32_t));
             logical_core_to_eth_link_retraining_count[eth_core] = read_data[0];
@@ -157,24 +158,25 @@ WatcherDeviceReader::~WatcherDeviceReader() {
     if (device->arch() == ARCH::WORMHOLE_B0 && tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
         for (const CoreCoord& eth_core : device->get_active_ethernet_cores()) {
-            CoreCoord phys_core = device->ethernet_core_from_logical_core(eth_core);
+            CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
             read_data = tt::llrt::read_hex_vec_from_core(
                 device->id(),
-                phys_core,
+                virtual_core,
                 hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::RETRAIN_COUNT),
                 sizeof(uint32_t));
             uint32_t num_events = read_data[0] - logical_core_to_eth_link_retraining_count[eth_core];
             if (num_events > 0) {
                 log_warning(
-                    "Device {} physical ethernet core {}: Watcher detected {} link retraining events.",
+                    "Device {} virtual ethernet core {}: Watcher detected {} link retraining events.",
                     device->id(),
-                    phys_core,
+                    virtual_core,
                     num_events);
             }
             fprintf(
                 f,
                 "%s\n",
-                fmt::format("\tDevice {} Ethernet Core {} retraining events: {}", device->id(), phys_core, num_events)
+                fmt::format(
+                    "\tDevice {} Ethernet Core {} retraining events: {}", device->id(), virtual_core, num_events)
                     .c_str());
         }
     }
@@ -212,7 +214,7 @@ void WatcherDeviceReader::Dump(FILE* file) {
     // Dump eth cores
     for (const CoreCoord& eth_core : device->ethernet_cores()) {
         CoreDescriptor logical_core = {eth_core, CoreType::ETH};
-        CoreCoord physical_core = device->ethernet_core_from_logical_core(eth_core);
+        CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
         if (device->is_active_ethernet_core(eth_core)) {
             DumpCore(logical_core, true);
         } else if (device->is_inactive_ethernet_core(eth_core)) {
@@ -285,17 +287,17 @@ void WatcherDeviceReader::Dump(FILE* file) {
 
         // Clear all pause flags
         for (auto& core_and_risc : paused_cores) {
-            const CoreCoord& phys_core = core_and_risc.first;
+            const CoreCoord& virtual_core = core_and_risc.first;
             riscv_id_t risc_id = core_and_risc.second;
 
-            uint64_t addr = GET_WATCHER_DEV_ADDR_FOR_CORE(device, phys_core, pause_status);
+            uint64_t addr = GET_WATCHER_DEV_ADDR_FOR_CORE(device, virtual_core, pause_status);
 
             // Clear only the one flag that we saved, in case another one was raised on device
             auto pause_data =
-                tt::llrt::read_hex_vec_from_core(device->id(), phys_core, addr, sizeof(debug_pause_msg_t));
+                tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, addr, sizeof(debug_pause_msg_t));
             auto pause_msg = reinterpret_cast<debug_pause_msg_t*>(&(pause_data[0]));
             pause_msg->flags[risc_id] = 0;
-            tt::llrt::write_hex_vec_to_core(device->id(), phys_core, pause_data, addr);
+            tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, pause_data, addr);
         }
     }
     fflush(f);
@@ -482,7 +484,7 @@ void WatcherDeviceReader::DumpNocSanitizeStatus(
             break;
         case DebugSanitizeNocMixedVirtualandPhysical:
             error_msg = get_noc_target_str(device, core, noc, san);
-            error_msg += " (mixing virtual and physical coordinates in Mcast).";
+            error_msg += " (mixing virtual and virtual coordinates in Mcast).";
             break;
         case DebugSanitizeNocAddrMailbox:
             error_msg = get_noc_target_str(device, core, noc, san);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -484,6 +484,10 @@ void WatcherDeviceReader::DumpNocSanitizeStatus(
             error_msg = get_noc_target_str(device, core, noc, san);
             error_msg += " (mixing virtual and physical coordinates in Mcast).";
             break;
+        case DebugSanitizeNocAddrMailbox:
+            error_msg = get_noc_target_str(device, core, noc, san);
+            error_msg += string(san->is_target ? " (NOC target" : " (Local L1") + " overwrites mailboxes).";
+            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -281,31 +281,32 @@ void watcher_init(IDevice* device) {
                 std::vector<CoreCoord> delayed_cores =
                     tt::llrt::RunTimeOptions::get_instance().get_feature_cores(delay_feature)[core_type];
                 for (tt_xy_pair logical_core : delayed_cores) {
-                    CoreCoord phys_core;
+                    CoreCoord virtual_core;
                     bool valid_logical_core = true;
                     try {
-                        phys_core = device->virtual_core_from_logical_core(logical_core, core_type);
+                        virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
                     } catch (std::runtime_error& error) {
                         valid_logical_core = false;
                     }
                     if (valid_logical_core) {
                         // Update the masks for the core
-                        if (debug_delays_val.find(phys_core) != debug_delays_val.end()) {
-                            debug_delays_val[phys_core].read_delay_riscv_mask |= delay_setup.read_delay_riscv_mask;
-                            debug_delays_val[phys_core].write_delay_riscv_mask |= delay_setup.write_delay_riscv_mask;
-                            debug_delays_val[phys_core].atomic_delay_riscv_mask |= delay_setup.atomic_delay_riscv_mask;
+                        if (debug_delays_val.find(virtual_core) != debug_delays_val.end()) {
+                            debug_delays_val[virtual_core].read_delay_riscv_mask |= delay_setup.read_delay_riscv_mask;
+                            debug_delays_val[virtual_core].write_delay_riscv_mask |= delay_setup.write_delay_riscv_mask;
+                            debug_delays_val[virtual_core].atomic_delay_riscv_mask |=
+                                delay_setup.atomic_delay_riscv_mask;
                         } else {
-                            debug_delays_val.insert({phys_core, delay_setup});
+                            debug_delays_val.insert({virtual_core, delay_setup});
                         }
                     } else {
                         log_warning(
                             tt::LogMetal,
-                            "TT_METAL_{}_CORES included {} core with logical coordinates {} (physical coordinates {}), "
+                            "TT_METAL_{}_CORES included {} core with logical coordinates {} (virtual coordinates {}), "
                             "which is not a valid core on device {}. This coordinate will be ignored by {} feature.",
                             tt::llrt::RunTimeDebugFeatureNames[delay_feature],
                             tt::llrt::get_core_type_name(core_type),
                             logical_core.str(),
-                            valid_logical_core ? phys_core.str() : "INVALID",
+                            valid_logical_core ? virtual_core.str() : "INVALID",
                             device->id(),
                             tt::llrt::RunTimeDebugFeatureNames[delay_feature]);
                     }
@@ -363,15 +364,15 @@ void watcher_init(IDevice* device) {
         } else {
             continue;
         }
-        CoreCoord physical_core = device->ethernet_core_from_logical_core(eth_core);
-        if (debug_delays_val.find(physical_core) != debug_delays_val.end()) {
-            data->debug_insert_delays = debug_delays_val[physical_core];
+        CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
+        if (debug_delays_val.find(virtual_core) != debug_delays_val.end()) {
+            data->debug_insert_delays = debug_delays_val[virtual_core];
         } else {
             data->debug_insert_delays = debug_delays_val_zero;
         }
         tt::llrt::write_hex_vec_to_core(
             device->id(),
-            physical_core,
+            virtual_core,
             watcher_init_val,
             is_active_eth_core ? GET_WATCHER_ERISC_DEV_ADDR() : GET_WATCHER_IERISC_DEV_ADDR());
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -730,6 +730,8 @@ void Device::initialize_and_launch_firmware() {
 
     core_info->noc_size_x = soc_d.grid_size.x;
     core_info->noc_size_y = soc_d.grid_size.y;
+    core_info->worker_grid_size_x = this->logical_grid_size().x;  // Grid size as virtual coords see it (workers only)
+    core_info->worker_grid_size_y = this->logical_grid_size().y;
 
     // Download to worker cores
     log_debug("Initializing firmware");


### PR DESCRIPTION
A collection of watcher bugfixes:
Fix local L1 santization on ethernet: https://github.com/tenstorrent/tt-metal/issues/16716
Fix mentions of physical coords in watcher/dprint: https://github.com/tenstorrent/tt-metal/issues/16474
Fix noc sanitization for virtual coords: https://github.com/tenstorrent/tt-metal/issues/16539

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12955305925
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
