### PR TITLE
#17064: Update metal_Bert to use from_torch for converting weights, instead of old style conversions

### DIFF
--- a/models/demos/metal_BERT_large_11/README.md
+++ b/models/demos/metal_BERT_large_11/README.md
@@ -1,9 +1,5 @@
 # metal_BERT_large 11 Demo
 
->[!WARNING]
->
-> This model demo does not work on N150 Wormhole cards.
-
 ## How to Run
 
 ### Batch support for all architectures
@@ -12,7 +8,8 @@ The optimized demos will parallelize batch on one of the device grid dimensions.
 
 For E150 (unharvested) Grayskull, the model demo supports batch 2 - 12, so you can use `batch_12` for `BATCH_SIZE` for the following commands.
 
-For Wormhole N300, the model demo supports batch 2 - 7, so you can use `batch_7` for `BATCH_SIZE` for the following commands.
+For Wormhole N150/N300, the model demo supports batch 2 - 7, so you can use `batch_7` for `BATCH_SIZE` for the following commands.
+For batch 8, N150 is default supported, and N300 is supported when using ethernet dispatch, `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml`.
 
 Replace `BATCH_SIZE` with the appropriate size depending on your device.
 Use `pytest --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py::test_demo -k BATCH_SIZE` to run the demo for Grayskull.
@@ -23,11 +20,11 @@ Our second demo is designed to run SQuADV2 dataset, run this with `pytest --disa
 
 The table below summarizes the information above.
 
-| Batch size | Supported on Grayskull (E150) | Supported on Wormhole (N300)         |
-|------------|-------------------------------|--------------------------------------|
-| 7          | :x:                           | :white_check_mark:                   |
-| 8          | :x:                           | See under construction section below |
-| 12         | :white_check_mark:            | :x:                                  |
+| Batch size | Supported on Grayskull (E150) | Supported on Wormhole (N150) | Supported on Wormhole (N300)           |
+|------------|-------------------------------|------------------------------|----------------------------------------|
+| 7          | :white_check_mark:            | :white_check_mark:           | :white_check_mark:                     |
+| 8          | :white_check_mark:            | :white_check_mark:           | :white_check_mark: (With Eth Dispatch) |
+| 12         | :white_check_mark:            | :x:                          | :x:                                    |
 
 ## Inputs
 
@@ -42,21 +39,3 @@ The entry point to metal bert model is `TtBertBatchDram` in `bert_model.py`. The
 For fast model loading, we have cached preprocessed weights for TT tensors on Weka. These weights are directly read in and loaded to device.
 
 If your machine does not have access to Weka, during model loading it will preprocess and convert the pytorch weights from huggingface to TT tensors before placing on device.
-
-## Under construction
-
-> [!NOTE]
->
-> This section is under construction and is not guaranteed to work under all conditions.
->
-> If you are using Wormhole, you must set the `WH_ARCH_YAML` environment variable to use  the following batch sizes:
->
-> - `batch_8`
->
-> ```
-> export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
-> ```
-
-We currently do not have demos that show batch sizes other than 7 or 12.
-
-N300 can also theoretically support batch 8, if `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` is added to the environment variables, `batch_8` can be added to the command.

--- a/models/demos/metal_BERT_large_11/tt/bert_model.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_model.py
@@ -52,26 +52,20 @@ class TtBertBatchDram:
             ).to(device, self.model_config["QA_LINEAR_BIAS_MEMCFG"])
         else:
             weight = pad_weight(torch.transpose(state_dict["qa_outputs.weight"], -2, -1))
-            weight = (
-                ttnn.Tensor(
-                    weight.reshape(-1).tolist(),
-                    weight.shape,
-                    model_config["QA_LINEAR_WEIGHTS_DTYPE"],
-                    ttnn.ROW_MAJOR_LAYOUT,
-                )
-                .to(ttnn.TILE_LAYOUT)
-                .to(device, model_config["QA_LINEAR_WEIGHTS_MEMCFG"])
+            weight = ttnn.from_torch(
+                weight,
+                model_config["QA_LINEAR_WEIGHTS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=model_config["QA_LINEAR_WEIGHTS_MEMCFG"],
             )
             bias = pad_weight(state_dict["qa_outputs.bias"])
-            bias = (
-                ttnn.Tensor(
-                    bias.reshape(-1).tolist(),
-                    bias.shape,
-                    model_config["QA_LINEAR_BIAS_DTYPE"],
-                    ttnn.ROW_MAJOR_LAYOUT,
-                )
-                .to(ttnn.TILE_LAYOUT)
-                .to(device, model_config["QA_LINEAR_BIAS_MEMCFG"])
+            bias = ttnn.from_torch(
+                bias,
+                model_config["QA_LINEAR_BIAS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=model_config["QA_LINEAR_BIAS_MEMCFG"],
             )
 
         # QA linear

--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -5,7 +5,6 @@
 from typing import List, Optional, Tuple, Union
 import torch
 import ttnn
-from models.utility_functions import torch2tt_tensor
 
 
 class TtEmbeddings:
@@ -50,44 +49,44 @@ class TtEmbeddings:
                 )
             ).to(device, self.model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"])
         else:
-            self.word_embeddings_weight = torch2tt_tensor(
+            self.word_embeddings_weight = ttnn.from_torch(
                 state_dict[f"{base_address}.word_embeddings.weight"],
-                device,
-                ttnn.ROW_MAJOR_LAYOUT,
-                model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
                 model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
             )
 
-            self.position_embeddings_weight = torch2tt_tensor(
+            self.position_embeddings_weight = ttnn.from_torch(
                 state_dict[f"{base_address}.position_embeddings.weight"],
-                device,
-                ttnn.ROW_MAJOR_LAYOUT,
-                model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
                 model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
             )
 
-            self.token_type_embeddings_weight = torch2tt_tensor(
+            self.token_type_embeddings_weight = ttnn.from_torch(
                 state_dict[f"{base_address}.token_type_embeddings.weight"],
-                device,
-                ttnn.ROW_MAJOR_LAYOUT,
-                model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
                 model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
             )
 
-            self.layerNorm_gamma = torch2tt_tensor(
+            self.layerNorm_gamma = ttnn.from_torch(
                 state_dict[f"{base_address}.LayerNorm.weight"].reshape([1, 1, -1, 32]),
-                device,
-                ttnn.ROW_MAJOR_LAYOUT,
-                model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"],
                 model_config["EMBEDDINGS_LAYERNORM_GAMMA_DTYPE"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"],
             )
 
-            self.layerNorm_beta = torch2tt_tensor(
+            self.layerNorm_beta = ttnn.from_torch(
                 state_dict[f"{base_address}.LayerNorm.bias"].reshape([1, 1, -1, 32]),
-                device,
-                ttnn.ROW_MAJOR_LAYOUT,
-                model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"],
                 model_config["EMBEDDINGS_LAYERNORM_BETA_DTYPE"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"],
             )
 
         self.layerNorm_eps = config.layer_norm_eps

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -122,25 +122,19 @@ class TtFeedForwardModel:
             encoder0_ff1_weight_shape = encoder0_ff1_weight.shape
             encoder0_ff1_bias_shape = encoder0_ff1_bias.shape
 
-            encoder0_ff1_weight = (
-                ttnn.Tensor(
-                    encoder0_ff1_weight.reshape(-1).tolist(),
-                    encoder0_ff1_weight.shape,
-                    model_config["OP9_FF1_MM_WEIGHTS_DTYPE"],
-                    ttnn.ROW_MAJOR_LAYOUT,
-                )
-                .to(ttnn.TILE_LAYOUT)
-                .to(device, model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"])
+            encoder0_ff1_weight = ttnn.from_torch(
+                encoder0_ff1_weight,
+                model_config["OP9_FF1_MM_WEIGHTS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"],
             )
-            encoder0_ff1_bias = (
-                ttnn.Tensor(
-                    encoder0_ff1_bias.reshape(-1).tolist(),
-                    encoder0_ff1_bias.shape,
-                    model_config["OP9_FF1_MM_BIAS_DTYPE"],
-                    ttnn.ROW_MAJOR_LAYOUT,
-                )
-                .to(ttnn.TILE_LAYOUT)
-                .to(device, model_config["OP9_FF1_MM_BIAS_MEMCFG"])
+            encoder0_ff1_bias = ttnn.from_torch(
+                encoder0_ff1_bias,
+                model_config["OP9_FF1_MM_BIAS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=model_config["OP9_FF1_MM_BIAS_MEMCFG"],
             )
 
             # FF2 params
@@ -156,25 +150,19 @@ class TtFeedForwardModel:
             encoder0_ff2_weight_shape = encoder0_ff2_weight.shape
             encoder0_ff2_bias_shape = encoder0_ff2_bias.shape
 
-            encoder0_ff2_weight = (
-                ttnn.Tensor(
-                    encoder0_ff2_weight.reshape(-1).tolist(),
-                    encoder0_ff2_weight.shape,
-                    model_config["OP10_FF2_MM_WEIGHTS_DTYPE"],
-                    ttnn.ROW_MAJOR_LAYOUT,
-                )
-                .to(ttnn.TILE_LAYOUT)
-                .to(device, model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"])
+            encoder0_ff2_weight = ttnn.from_torch(
+                encoder0_ff2_weight,
+                model_config["OP10_FF2_MM_WEIGHTS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"],
             )
-            encoder0_ff2_bias = (
-                ttnn.Tensor(
-                    encoder0_ff2_bias.reshape(-1).tolist(),
-                    encoder0_ff2_bias.shape,
-                    model_config["OP10_FF2_MM_BIAS_DTYPE"],
-                    ttnn.ROW_MAJOR_LAYOUT,
-                )
-                .to(ttnn.TILE_LAYOUT)
-                .to(device, model_config["OP10_FF2_MM_BIAS_MEMCFG"])
+            encoder0_ff2_bias = ttnn.from_torch(
+                encoder0_ff2_bias,
+                model_config["OP10_FF2_MM_BIAS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=model_config["OP10_FF2_MM_BIAS_MEMCFG"],
             )
 
         self.ffn = feed_forward(

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -9,7 +9,6 @@ import torch
 from typing import Optional
 import ttnn
 from tt_lib.utils import pad_weight
-from models.utility_functions import torch2tt_tensor
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
 
 
@@ -223,20 +222,20 @@ class TtMultiHeadAttentionModel:
             qkv_weight = pad_weight(qkv_weight)
             qkv_bias = pad_weight(qkv_bias)
 
-            qkv_weight = torch2tt_tensor(
+            qkv_weight = ttnn.from_torch(
                 qkv_weight,
-                device,
-                tt_layout=ttnn.TILE_LAYOUT,
-                tt_memory_config=model_config["OP1_FUSED_QKV_MM_WEIGHTS_MEMCFG"],
-                tt_dtype=model_config["OP1_FUSED_QKV_MM_WEIGHTS_DTYPE"],
+                model_config["OP1_FUSED_QKV_MM_WEIGHTS_DTYPE"],
+                layout=ttnn.Layout.TILE,
+                device=device,
+                memory_config=model_config["OP1_FUSED_QKV_MM_WEIGHTS_MEMCFG"],
             )
 
-            qkv_bias = torch2tt_tensor(
+            qkv_bias = ttnn.from_torch(
                 qkv_bias,
-                device,
-                tt_layout=ttnn.TILE_LAYOUT,
-                tt_memory_config=model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"],
-                tt_dtype=model_config["OP1_FUSED_QKV_MM_BIAS_DTYPE"],
+                model_config["OP1_FUSED_QKV_MM_BIAS_DTYPE"],
+                layout=ttnn.Layout.TILE,
+                device=device,
+                memory_config=model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"],
             )
 
         # Hidden dim


### PR DESCRIPTION
Update Metal BERT README with updated functional information for different arches

### Ticket
https://github.com/tenstorrent/tt-metal/issues/17064
https://github.com/tenstorrent/tt-metal/issues/17049

### Problem description
Error in conversion from torch to TT tensor. This was due to deprecated support for creating block floats in RM, and wasn't caught on CI because CI has cached weights on disk that gets loaded, so doesn't need to do the conversion.

### What's changed
Change weights conversion to use from_torch, and update README with updated arch support.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
