### PR TITLE
Clean up work executor class

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -24,9 +24,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiProducerLockBasedQueue) {
     // This leads to shared access of the work_executor and host side worker queue.
     // Test thread safety.
     IDevice* device = this->device_;
-    // Enable async engine and set queue setting to lock_based
     device->enable_async(true);
-    device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
 
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
@@ -102,9 +100,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
     // Writer cannot update location until reader has picked up data.
     // Use write_event to stall reader and read_event to stall writer.
     IDevice* device = this->device_;
-    // Enable async engine and set queue setting to lock_based
     device->enable_async(true);
-    device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
 
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -208,8 +208,6 @@ public:
     virtual void enable_async(bool enable) = 0;
     virtual void synchronize() = 0;
     virtual WorkExecutorMode get_worker_mode() = 0;
-    virtual void set_worker_queue_mode(const WorkerQueueMode& mode) = 0;
-    virtual WorkerQueueMode get_worker_queue_mode() = 0;
     virtual bool is_worker_queue_empty() const = 0;
     virtual bool can_use_passthrough_scheduling() const = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -200,10 +200,8 @@ public:
 
     void enable_async(bool enable) override;
     void synchronize() override;
-    WorkExecutorMode get_worker_mode() override { return work_executor_.get_worker_mode(); }
-    void set_worker_queue_mode(const WorkerQueueMode& mode) override { this->work_executor_.set_worker_queue_mode(mode); }
-    WorkerQueueMode get_worker_queue_mode() override { return this->work_executor_.get_worker_queue_mode(); }
-    bool is_worker_queue_empty() const override { return work_executor_.worker_queue.empty(); }
+    WorkExecutorMode get_worker_mode() override { return work_executor_->get_worker_mode(); }
+    bool is_worker_queue_empty() const override { return work_executor_->empty(); }
     bool can_use_passthrough_scheduling() const override;
 
     void push_work(std::function<void()> work, bool blocking) override;
@@ -295,7 +293,7 @@ private:
 
     // Work Executor for this device - can asynchronously process host side work for
     // all tasks scheduled on this device
-    WorkExecutor work_executor_;
+    std::unique_ptr<WorkExecutor> work_executor_;
     uint32_t worker_thread_core_ = 0;
     uint32_t completion_queue_reader_core_ = 0;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -185,8 +185,6 @@ public:
     void enable_async(bool enable) override;
     void synchronize() override;
     WorkExecutorMode get_worker_mode() override;
-    void set_worker_queue_mode(const WorkerQueueMode& mode) override;
-    WorkerQueueMode get_worker_queue_mode() override;
     bool is_worker_queue_empty() const override;
     bool can_use_passthrough_scheduling() const override;
     void push_work(std::function<void()> work, bool blocking) override;

--- a/tt_metal/api/tt-metalium/work_executor.hpp
+++ b/tt_metal/api/tt-metalium/work_executor.hpp
@@ -13,17 +13,8 @@
 #include <functional>
 #include <thread>
 
-#include "env_lib.hpp"
 #include "lock_free_queue.hpp"
 #include "tracy/Tracy.hpp"
-
-#if defined(TRACY_ENABLE)
-#define TracyTTThreadName(name, id)                     \
-    std::string tmp = fmt::format("{} : {}", name, id); \
-    tracy::SetThreadName(tmp.c_str());
-#else
-#define TracyTTThreadName(name, id)
-#endif
 
 namespace tt {
 
@@ -32,44 +23,17 @@ enum class WorkExecutorMode {
     ASYNCHRONOUS = 1,
 };
 
-enum class WorkerQueueMode {
-    LOCKFREE = 0,
-    LOCKBASED = 1,
-};
-
 enum class WorkerState {
     RUNNING = 0,
     TERMINATE = 1,
     IDLE = 2,
 };
 
-inline void set_device_thread_affinity(std::thread& thread_, int cpu_core_for_worker) {
-    // Bind a device worker/reader thread to a CPU core, determined using round-robin.
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    CPU_SET(cpu_core_for_worker, &cpuset);
-    int rc = pthread_setaffinity_np(thread_.native_handle(), sizeof(cpu_set_t), &cpuset);
-    if (rc) {
-        log_warning(
-            tt::LogMetal,
-            "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}",
-            rc);
-    }
-}
+// Binds a device thread to a CPU core, determined using round-robin.
+void set_device_thread_affinity(std::thread& worker_thread, int cpu_core_for_worker);
 
-inline void set_process_priority(int requested_priority) {
-    // Get priority for calling process
-    int process_priority = getpriority(PRIO_PROCESS, 0);
-    log_debug(tt::LogMetal, "Initial Process Priority: {}", process_priority);
-    if (process_priority == requested_priority) {
-        return;
-    }
-    // Set priority for calling process to user specified value
-    int rc = setpriority(PRIO_PROCESS, 0, requested_priority);
-    if (rc) {
-        log_warning(tt::LogMetal, "Unable to set process priority to {}, error code: {}", requested_priority, rc);
-    }
-}
+// Sets the process priority.
+void set_process_priority(int requested_priority);
 
 class WorkExecutor {
     // In asynchronous mode, each device has a worker thread that processes all host <--> cluster commands for this
@@ -77,86 +41,34 @@ class WorkExecutor {
     // that have access to the device handle can queue up tasks asynchronously. In synchronous/pass through mode, we
     // bypass the queue and tasks are executed immediately after being pushed.
 public:
-    LockFreeQueue<std::function<void()>> worker_queue;
+    WorkExecutor(int cpu_core, int device_id) : cpu_core_for_worker_(cpu_core), managed_device_id_(device_id) {}
+    ~WorkExecutor();
 
-    WorkExecutor(int cpu_core, int device_id) : cpu_core_for_worker(cpu_core), managed_device_id(device_id) {}
+    WorkExecutor(const WorkExecutor&) = delete;
+    WorkExecutor& operator=(const WorkExecutor&) = delete;
+    WorkExecutor(WorkExecutor&& other) = delete;
+    WorkExecutor& operator=(WorkExecutor&& other) = delete;
 
-    WorkExecutor(WorkExecutor&& other) {
-        worker_state = std::move(other.worker_state);
-        cpu_core_for_worker = std::move(other.managed_device_id);
-        managed_device_id = std::move(other.managed_device_id);
-    }
-
-    WorkExecutor& operator=(WorkExecutor&& other) {
-        if (this != &other) {
-            worker_state = std::move(other.worker_state);
-            managed_device_id = std::move(other.managed_device_id);
-            cpu_core_for_worker = std::move(other.cpu_core_for_worker);
-        }
-        return *this;
-    }
-
-    ~WorkExecutor() { reset(); }
-
-    inline void initialize() {
-        this->work_executor_mode = default_worker_executor_mode();
-        this->worker_queue_mode = default_worker_queue_mode();
-        this->worker_state = WorkerState::IDLE;
-        set_process_priority(0);
-        if (this->work_executor_mode == WorkExecutorMode::ASYNCHRONOUS) {
-            this->set_worker_queue_mode(this->worker_queue_mode);
-            this->start_worker();
-        }
-    }
-
-    inline void reset() {
-        if (this->work_executor_mode == WorkExecutorMode::ASYNCHRONOUS) {
-            stop_worker();
-        }
-        this->work_executor_mode = WorkExecutorMode::SYNCHRONOUS;
-    }
-
-    inline void run_worker() {
-        TracyTTThreadName("TT_WORKER_DEVICE_ID", this->managed_device_id);
-        while (true) {
-            {
-                // Worker stalls until queue is non-empty or terminate signal is set
-                std::unique_lock<std::mutex> lock(this->cv_mutex);
-                this->cv.wait(lock, [this] {
-                    return (not this->worker_queue.empty()) or this->worker_state == WorkerState::TERMINATE;
-                });
-            }
-            if (this->worker_state == WorkerState::TERMINATE) {
-                // Terminate signal set, and queue is empty - worker exits
-                if (this->worker_queue.empty()) {
-                    break;
-                }
-            }
-            ZoneScopedN("PopWork");
-            // Queue non-empty: run command
-            auto func = this->worker_queue.pop();
-            (*func)();
-        }
-    }
-
-    inline bool use_passthrough() const {
-        return std::this_thread::get_id() == this->worker_queue.worker_thread_id.load() ||
-               this->worker_state != WorkerState::RUNNING;
-    }
+    void initialize();
+    void reset();
+    bool use_passthrough() const;
+    void synchronize();
+    void set_worker_mode(WorkExecutorMode mode);
+    bool empty() const;
 
     template <typename F>
-    inline void push_work(F&& work_executor, bool blocking = false) {
+    void push_work(F&& work, bool blocking = false) {
         ZoneScopedN("PushWork");
         if (use_passthrough()) {
             // Worker is pushing to itself (nested work) or worker thread is not running. Execute work in current
             // thread.
-            work_executor();
+            work();
         } else {
             // Push to worker queue.
-            this->worker_queue.push(std::forward<F>(work_executor));
+            worker_queue_.push(std::forward<F>(work));
             {
-                std::lock_guard lock(this->cv_mutex);
-                cv.notify_one();
+                std::lock_guard lock(this->cv_mutex_);
+                cv_.notify_one();
             }
             if (blocking) {
                 this->synchronize();
@@ -164,96 +76,23 @@ public:
         }
     }
 
-    inline void synchronize() {
-        if (this->work_executor_mode == WorkExecutorMode::ASYNCHRONOUS and
-            not(std::this_thread::get_id() == worker_queue.worker_thread_id.load())) {
-            // Blocking = wait for queue flushed. Worker thread cannot explcitly insert a synchronize, otherwise we have
-            // a deadlock.
-            this->worker_queue.push([]() {});  // Send flush command (i.e. empty function)
-            {
-                std::lock_guard lock(this->cv_mutex);
-                cv.notify_one();
-            }
-            // Wait for queue empty, i.e. flush command picked up
-            while (not this->worker_queue.empty()) {
-                std::this_thread::sleep_for(std::chrono::microseconds(10));
-            };
-        }
-    }
-
-    inline void set_worker_mode(const WorkExecutorMode& mode) {
-        if (this->work_executor_mode == mode) {
-            return;
-        }
-        this->work_executor_mode = mode;
-        if (this->work_executor_mode == WorkExecutorMode::ASYNCHRONOUS) {
-            this->start_worker();
-        } else if (this->work_executor_mode == WorkExecutorMode::SYNCHRONOUS) {
-            this->synchronize();
-            this->stop_worker();
-        }
-    }
-
-    WorkExecutorMode get_worker_mode() { return work_executor_mode; }
-
-    inline void set_worker_queue_mode(const WorkerQueueMode& mode) {
-        if (mode == WorkerQueueMode::LOCKFREE) {
-            this->worker_queue.set_lock_free();
-        } else {
-            this->worker_queue.set_lock_based();
-        }
-        this->worker_queue_mode = mode;
-    }
-
-    WorkerQueueMode get_worker_queue_mode() const { return worker_queue_mode; }
-
-    inline std::thread::id get_parent_thread_id() const { return this->worker_queue.parent_thread_id; }
-
-    inline std::thread::id get_worker_thread_id() const { return this->worker_queue.worker_thread_id; }
+    WorkExecutorMode get_worker_mode() const { return work_executor_mode_; }
+    std::thread::id get_parent_thread_id() const { return worker_queue_.parent_thread_id; }
+    std::thread::id get_worker_thread_id() const { return worker_queue_.worker_thread_id; }
 
 private:
-    std::thread worker_thread;
-    WorkerState worker_state;
-    int cpu_core_for_worker;
-    int managed_device_id;
-    std::condition_variable cv;
-    std::mutex cv_mutex;
+    LockFreeQueue<std::function<void()>> worker_queue_;
+    std::thread worker_thread_;
+    WorkerState worker_state_;
+    WorkExecutorMode work_executor_mode_;
+    int cpu_core_for_worker_;
+    int managed_device_id_;
+    std::condition_variable cv_;
+    std::mutex cv_mutex_;
 
-    inline void start_worker() {
-        this->worker_queue.parent_thread_id = std::this_thread::get_id();
-        this->worker_state = WorkerState::RUNNING;
-        this->worker_thread = std::thread(&WorkExecutor::run_worker, this);
-        this->worker_queue.worker_thread_id = this->worker_thread.get_id();
-        // Bind a worker tied to a device to a specific CPU core in round robin fashion. Thread affinity == Better Perf.
-        set_device_thread_affinity(this->worker_thread, this->cpu_core_for_worker);
-    }
-
-    inline void stop_worker() {
-        if (this->worker_state == WorkerState::IDLE) {
-            return;
-        }
-        this->worker_state = WorkerState::TERMINATE;
-        {
-            std::lock_guard lock(this->cv_mutex);
-            cv.notify_one();
-        }
-        this->worker_thread.join();
-        this->worker_state = WorkerState::IDLE;
-    }
-
-    static WorkExecutorMode default_worker_executor_mode() {
-        static int value =
-            parse_env<int>("TT_METAL_ASYNC_DEVICE_QUEUE", static_cast<int>(WorkExecutorMode::SYNCHRONOUS));
-        return static_cast<WorkExecutorMode>(value);
-    }
-
-    static WorkerQueueMode default_worker_queue_mode() {
-        static int value = parse_env<int>("TT_METAL_LOCK_BASED_QUEUE", static_cast<int>(WorkerQueueMode::LOCKFREE));
-        return static_cast<WorkerQueueMode>(value);
-    }
-
-    WorkExecutorMode work_executor_mode;
-    WorkerQueueMode worker_queue_mode;
+    void run_worker();
+    void start_worker();
+    void stop_worker();
 };
 
 }  // namespace tt

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -523,14 +523,6 @@ WorkExecutorMode MeshDevice::get_worker_mode() {
     TT_THROW("get_worker_mode() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->get_worker_mode();
 }
-void MeshDevice::set_worker_queue_mode(const WorkerQueueMode& mode) {
-    TT_THROW("set_worker_queue_mode() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->set_worker_queue_mode(mode);
-}
-WorkerQueueMode MeshDevice::get_worker_queue_mode() {
-    TT_THROW("get_worker_queue_mode() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->get_worker_queue_mode();
-}
 bool MeshDevice::is_worker_queue_empty() const {
     TT_THROW("is_worker_queue_empty() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->is_worker_queue_empty();

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -11,6 +11,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/concurrency/work_executor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocator/algorithms/free_list.cpp

--- a/tt_metal/impl/concurrency/work_executor.cpp
+++ b/tt_metal/impl/concurrency/work_executor.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <work_executor.hpp>
+#include <pthread.h>
+#include <sched.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include "env_lib.hpp"
+#include <thread>
+
+#include "tracy/Tracy.hpp"
+
+#if defined(TRACY_ENABLE)
+#define TracyTTThreadName(name, id)                     \
+    std::string tmp = fmt::format("{} : {}", name, id); \
+    tracy::SetThreadName(tmp.c_str());
+#else
+#define TracyTTThreadName(name, id)
+#endif
+
+namespace tt {
+namespace {
+
+WorkExecutorMode default_worker_executor_mode() {
+    static int value = parse_env<int>("TT_METAL_ASYNC_DEVICE_QUEUE", static_cast<int>(WorkExecutorMode::SYNCHRONOUS));
+    return static_cast<WorkExecutorMode>(value);
+}
+
+}  // namespace
+
+void set_device_thread_affinity(std::thread& worker_thread, int cpu_core_for_worker) {
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(cpu_core_for_worker, &cpuset);
+    int rc = pthread_setaffinity_np(worker_thread.native_handle(), sizeof(cpu_set_t), &cpuset);
+    if (rc) {
+        log_warning(
+            tt::LogMetal,
+            "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}",
+            rc);
+    }
+}
+
+void set_process_priority(int requested_priority) {
+    // Get priority for calling process
+    int process_priority = getpriority(PRIO_PROCESS, 0);
+    log_debug(tt::LogMetal, "Initial Process Priority: {}", process_priority);
+    if (process_priority == requested_priority) {
+        return;
+    }
+    // Set priority for calling process to user specified value
+    int rc = setpriority(PRIO_PROCESS, 0, requested_priority);
+    if (rc) {
+        log_warning(tt::LogMetal, "Unable to set process priority to {}, error code: {}", requested_priority, rc);
+    }
+}
+
+WorkExecutor::~WorkExecutor() { reset(); }
+
+void WorkExecutor::initialize() {
+    work_executor_mode_ = default_worker_executor_mode();
+    worker_state_ = WorkerState::IDLE;
+    set_process_priority(0);
+    if (work_executor_mode_ == WorkExecutorMode::ASYNCHRONOUS) {
+        start_worker();
+    }
+}
+
+void WorkExecutor::reset() {
+    if (work_executor_mode_ == WorkExecutorMode::ASYNCHRONOUS) {
+        stop_worker();
+    }
+    work_executor_mode_ = WorkExecutorMode::SYNCHRONOUS;
+}
+
+bool WorkExecutor::use_passthrough() const {
+    return std::this_thread::get_id() == worker_queue_.worker_thread_id.load() || worker_state_ != WorkerState::RUNNING;
+}
+
+void WorkExecutor::synchronize() {
+    if (work_executor_mode_ == WorkExecutorMode::ASYNCHRONOUS and
+        not(std::this_thread::get_id() == worker_queue_.worker_thread_id.load())) {
+        // Blocking = wait for queue flushed. Worker thread cannot explcitly insert a synchronize, otherwise we have
+        // a deadlock.
+        worker_queue_.push([]() {});  // Send flush command (i.e. empty function)
+        {
+            std::lock_guard lock(cv_mutex_);
+            cv_.notify_one();
+        }
+        // Wait for queue empty, i.e. flush command picked up
+        while (not worker_queue_.empty()) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        };
+    }
+}
+
+void WorkExecutor::set_worker_mode(WorkExecutorMode mode) {
+    if (work_executor_mode_ == mode) {
+        return;
+    }
+    work_executor_mode_ = mode;
+    if (work_executor_mode_ == WorkExecutorMode::ASYNCHRONOUS) {
+        start_worker();
+    } else if (work_executor_mode_ == WorkExecutorMode::SYNCHRONOUS) {
+        synchronize();
+        stop_worker();
+    }
+}
+
+void WorkExecutor::run_worker() {
+    TracyTTThreadName("TT_WORKER_DEVICE_ID", managed_device_id_);
+    while (true) {
+        {
+            // Worker stalls until queue is non-empty or terminate signal is set
+            std::unique_lock<std::mutex> lock(cv_mutex_);
+            cv_.wait(lock, [this] { return (not worker_queue_.empty()) or worker_state_ == WorkerState::TERMINATE; });
+        }
+        // Terminate signal set, and queue is empty - worker exits
+        if (worker_state_ == WorkerState::TERMINATE and worker_queue_.empty()) {
+            break;
+        }
+        ZoneScopedN("PopWork");
+        // Queue non-empty: run command
+        auto func = worker_queue_.pop();
+        (*func)();
+    }
+}
+
+void WorkExecutor::start_worker() {
+    worker_queue_.parent_thread_id = std::this_thread::get_id();
+    worker_state_ = WorkerState::RUNNING;
+    worker_thread_ = std::thread(&WorkExecutor::run_worker, this);
+    worker_queue_.worker_thread_id = worker_thread_.get_id();
+    // Bind a worker tied to a device to a specific CPU core in round robin fashion. Thread affinity == Better Perf.
+    set_device_thread_affinity(worker_thread_, cpu_core_for_worker_);
+}
+
+void WorkExecutor::stop_worker() {
+    if (worker_state_ == WorkerState::IDLE) {
+        return;
+    }
+    worker_state_ = WorkerState::TERMINATE;
+    {
+        std::lock_guard lock(cv_mutex_);
+        cv_.notify_one();
+    }
+    worker_thread_.join();
+    worker_state_ = WorkerState::IDLE;
+}
+
+bool WorkExecutor::empty() const { return worker_queue_.empty(); }
+
+}  // namespace tt


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Fixes for several minor issues. See below for the details.

### What's changed
* Disable an ability to switch mode of the work queue. Remove the corresponding methods from `IDevice`.
* Hide `worker_queue_` as private member of `WorkExecutor`. Add `empty()` method to work executor to access the corresponding method of the work queue.
* Move implementation to `/tt_metal/impl/concurrency/work_executor.cpp`
* Disable move operation on work executor; they are broken because the state isn't fully moved. Use `std::unique_ptr` in `Device` instead.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
