### PR TITLE
Add build option for code coverage instrumentation

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -79,16 +79,16 @@ runs:
           -v /etc/passwd:/etc/passwd:ro
           -v /etc/shadow:/etc/shadow:ro
           -v /etc/bashrc:/etc/bashrc:ro
-          -v ${{ github.workspace }}:${{ github.workspace }}
+          -v ${{ github.workspace }}:/work
           --net=host
           --log-driver local
           --log-opt max-size=50m
           ${{ inputs.docker_opts }}
           -e LOGURU_LEVEL=${{ env.LOGURU_LEVEL }}
-          -e PYTHONPATH=${{ github.workspace }}
-          -e HOME=${{ github.workspace }}
+          -e PYTHONPATH=/work
+          -e HOME=/work
           ${{ inputs.device }}
-          -w ${{ github.workspace }}
+          -w /work
         run: |
           set -eu
 

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -7,6 +7,10 @@ on:
         required: false
         default: Release
         type: string
+      coverage:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       build-type:
@@ -18,6 +22,10 @@ on:
           - Debug
           - RelWithDebInfo
           - CI
+      coverage:
+        required: false
+        type: boolean
+        default: false
   push:
     branches: ["main"]
 
@@ -75,6 +83,7 @@ jobs:
       build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
       tracy: true
+      coverage: ${{ inputs.coverage }}
     secrets: inherit
   # Slow Dispatch Unit Tests
   sd-unit-tests:
@@ -157,6 +166,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
+      upload_coverage: ${{ inputs.coverage }}
   code-analysis:
     needs: build-docker-image-2204
     uses: ./.github/workflows/code-analysis.yaml

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -10,7 +10,7 @@ on:
       coverage:
         required: false
         type: boolean
-        default: false
+        default: true
   workflow_dispatch:
     inputs:
       build-type:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -76,6 +76,7 @@ jobs:
     with:
       build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
+      coverage: ${{ inputs.coverage }}
   build-artifact-profiler:
     needs: build-docker-image-2004
     uses: ./.github/workflows/build-artifact.yaml

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -20,3 +20,4 @@ jobs:
     uses: ./.github/workflows/all-post-commit-workflows.yaml
     with:
       build-type: RelWithDebInfo
+      coverage: true

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   nightly-debug:
     uses: ./.github/workflows/all-post-commit-workflows.yaml
+    secrets: inherit
     with:
       build-type: RelWithDebInfo
       coverage: true

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -21,6 +21,11 @@ on:
         type: boolean
         default: true
         description: "Build docker image"
+      coverage:
+        required: false
+        type: boolean
+        default: false
+        description: "Build with coverage instrumentation"
   workflow_dispatch:
     inputs:
       build-docker:
@@ -124,9 +129,11 @@ jobs:
             ccache -z
 
             build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache"
-            echo "${{ inputs.tracy }}"
             if [ "${{ inputs.tracy }}" = "true" ]; then
               build_command="$build_command --enable-profiler"
+            fi
+            if [ "${{ inputs.coverage }}" = "true" ]; then
+              build_command="$build_command --coverage"
             fi
             nice -n 19 $build_command
             ccache -s > build/ccache.stats

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -128,7 +128,7 @@ jobs:
             # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
             ccache -z
 
-            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache"
+            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache --build-dir build"
             if [ "${{ inputs.tracy }}" = "true" ]; then
               build_command="$build_command --enable-profiler"
             fi

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -144,7 +144,7 @@ jobs:
           cat build/ccache.stats >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: 'Tar files'
-        run: tar -cvhf ttm_any.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train data runtime
+        run: tar -cvhf ttm_any.tar build ttnn/ttnn/*.so ttnn/ttnn/*.so data runtime
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -109,14 +109,14 @@ jobs:
             --tmpfs /tmp
             -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
             --group-add 1457
-            -v ${{ github.workspace }}:${{ github.workspace }}
+            -v ${{ github.workspace }}:/work
             -v /etc/passwd:/etc/passwd:ro
             -v /etc/shadow:/etc/shadow:ro
             -v /etc/bashrc:/etc/bashrc:ro
             -v /home/ubuntu/.ccache-ci:/home/ubuntu/.ccache
             -v /mnt/MLPerf/ccache:/mnt/MLPerf/ccache
-            -e CARGO_HOME=${{ github.workspace }}/.cargo
-            -w ${{ github.workspace }}
+            -e CARGO_HOME=/work/.cargo
+            -w /work
           run: |
             set -eu # basic shell hygiene
 

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -109,9 +109,10 @@ jobs:
             ${{ matrix.test-group.cmd }}
             lcov --directory . --capture --gcov-tool /work/scripts/llvm-gcov-wrapper --output-file coverage.info
       - uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: ${{ inputs.upload_coverage }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -106,6 +106,10 @@ jobs:
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             ${{ matrix.test-group.cmd }}
+            echo "Checking for gcno files"
+            find . -name "*.gcno"
+            echo "Checking for gcda files"
+            find . -name "*.gcda"
             lcov --directory . --capture --output-file coverage.info
       - uses: codecov/codecov-action@v5
         if: ${{ inputs.upload_coverage }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -107,8 +107,7 @@ jobs:
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             ${{ matrix.test-group.cmd }}
-            sleep 600
-            lcov --directory . --capture --gcov-tool /work/llvm-gcov-wrapper --output-file coverage.info
+            lcov --directory . --capture --gcov-tool /work/scripts/llvm-gcov-wrapper --output-file coverage.info
       - uses: codecov/codecov-action@v5
         if: ${{ inputs.upload_coverage }}
         with:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -107,6 +107,7 @@ jobs:
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             ${{ matrix.test-group.cmd }}
+            sleep 600
             lcov --directory . --capture --gcov-tool /work/llvm-gcov-wrapper --output-file coverage.info
       - uses: codecov/codecov-action@v5
         if: ${{ inputs.upload_coverage }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -111,7 +111,7 @@ jobs:
             find . -name "*.gcno"
             echo "Checking for gcda files"
             find . -name "*.gcda"
-            lcov --directory . --capture --output-file coverage.info
+            lcov --gcov-tool=$(which llvm-cov-17) --directory . --capture --output-file coverage.info
       - uses: codecov/codecov-action@v5
         if: ${{ inputs.upload_coverage }}
         with:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -98,9 +98,10 @@ jobs:
           docker_os_arch: tt-metalium/${{ inputs.os }}-amd64
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
-            -e TT_METAL_HOME=${{ github.workspace }}
+            -e TT_METAL_HOME=/work
             -e ARCH_NAME=${{ inputs.arch }}
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e LD_LIBRARY_PATH=/work/build/lib
+            -w /work
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: "ubuntu-20.04"
+      upload_coverage:
+        required: false
+        type: boolean
+        default: 'false'
   workflow_dispatch:
     inputs:
       arch:
@@ -42,6 +46,10 @@ on:
         required: false
         type: string
         default: "ubuntu-20.04"
+      upload_coverage:
+        required: false
+        type: boolean
+        default: 'false'
 
 jobs:
   cpp-unit-tests:
@@ -98,6 +106,14 @@ jobs:
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             ${{ matrix.test-group.cmd }}
+            lcov --directory . --capture --output-file coverage.info
+      - uses: codecov/codecov-action@v5
+        if: ${{ (inputs.upload_coverage == 'true') }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.info
+          fail_ci_if_error: true
+          verbose: true
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -20,7 +20,7 @@ on:
       upload_coverage:
         required: false
         type: boolean
-        default: 'false'
+        default: false
   workflow_dispatch:
     inputs:
       arch:
@@ -49,7 +49,7 @@ on:
       upload_coverage:
         required: false
         type: boolean
-        default: 'false'
+        default: false
 
 jobs:
   cpp-unit-tests:
@@ -108,7 +108,7 @@ jobs:
             ${{ matrix.test-group.cmd }}
             lcov --directory . --capture --output-file coverage.info
       - uses: codecov/codecov-action@v5
-        if: ${{ (inputs.upload_coverage == 'true') }}
+        if: ${{ inputs.upload_coverage }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -107,8 +107,7 @@ jobs:
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             ${{ matrix.test-group.cmd }}
-            echo -e '#!/bin/bash\nexec llvm-cov-17 gcov "$@"' > llvm-gcov-wrapper && chmod +x llvm-gcov-wrapper
-            lcov --directory . --capture --gcov-tool $(pwd)/llvm-gcov-wrapper --output-file coverage.info
+            lcov --directory . --capture --gcov-tool /work/llvm-gcov-wrapper --output-file coverage.info
       - uses: codecov/codecov-action@v5
         if: ${{ inputs.upload_coverage }}
         with:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -107,11 +107,8 @@ jobs:
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             ${{ matrix.test-group.cmd }}
-            echo "Checking for gcno files"
-            find . -name "*.gcno"
-            echo "Checking for gcda files"
-            find . -name "*.gcda"
-            lcov --gcov-tool=$(which llvm-cov-17) --directory . --capture --output-file coverage.info
+            echo -e '#!/bin/bash\nexec llvm-cov-17 gcov "$@"' > llvm-gcov-wrapper && chmod +x llvm-gcov-wrapper
+            lcov --directory . --capture --gcov-tool $(pwd)/llvm-gcov-wrapper --output-file coverage.info
       - uses: codecov/codecov-action@v5
         if: ${{ inputs.upload_coverage }}
         with:

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -33,6 +33,7 @@ show_help() {
     echo "  --c-compiler-path                Set path to C++ compiler."
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
+    echo "  --coverage                       Instrument the build for code coverage."
 }
 
 clean() {
@@ -63,6 +64,7 @@ cxx_compiler_path=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+coverage="OFF"
 
 declare -a cmake_args
 
@@ -96,6 +98,7 @@ cxx-compiler-path:
 c-compiler-path:
 ttnn-shared-sub-libs
 toolchain-path:
+coverage
 "
 
 # Flatten LONGOPTIONS into a comma-separated string for getopt
@@ -169,6 +172,8 @@ while true; do
             build_type="Debug";;
         --clean)
 	    clean; exit 0;;
+        --coverage)
+            coverage="ON";unity_builds="OFF";;
         --)
             shift;break;;
     esac
@@ -180,6 +185,11 @@ if [[ $# -gt 0 ]]; then
     echo "ERROR: Unrecognized positional argument(s): $@"
     show_help
     exit 1
+fi
+
+# For code coverage we are going to froce build type to be Debug
+if [ "$coverage" = "ON" ]; then
+    build_type="Debug"
 fi
 
 # Validate the build_type
@@ -313,6 +323,10 @@ if [ "$build_all" = "ON" ]; then
     cmake_args+=("-DTTNN_BUILD_TESTS=ON")
     cmake_args+=("-DBUILD_PROGRAMMING_EXAMPLES=ON")
     cmake_args+=("-DBUILD_TT_TRAIN=ON")
+fi
+
+if [ "$coverage" = "ON" ]; then
+    cmake_args+=("-DCOVERAGE=ON")
 fi
 
 # toolchain and cxx_compiler settings would conflict with eachother

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -207,7 +207,7 @@ fi
 
 # If build-dir is not specified
 # Use build_type and enable_profiler setting to choose a default path
-if [ "build_dir" == "" ]; then
+if [ "$build_dir" = "" ]; then
     build_dir="build_$build_type"
     if [ "$enable_profiler" = "ON" ]; then
         build_dir="${build_dir}_tracy"

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -19,6 +19,7 @@ option(ENABLE_CCACHE "Build with compiler cache" FALSE)
 option(TT_UNITY_BUILDS "Build with Unity builds" ON)
 option(BUILD_TT_TRAIN "Enables build of tt-train" OFF)
 option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up incremental builds" OFF)
+option(COVERAGE "Instrument the build for generating code coverage" OFF)
 
 ###########################################################################################
 

--- a/scripts/docker/requirements-20.04.txt
+++ b/scripts/docker/requirements-20.04.txt
@@ -22,3 +22,4 @@ ninja-build
 patchelf
 graphviz
 bc
+lcov

--- a/scripts/docker/requirements-22.04.txt
+++ b/scripts/docker/requirements-22.04.txt
@@ -20,3 +20,4 @@ ninja-build
 libxml2-dev
 libxslt-dev
 bc
+lcov

--- a/scripts/llvm-gcov-wrapper
+++ b/scripts/llvm-gcov-wrapper
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec llvm-cov-17 gcov "$@"

--- a/tt_fabric/CMakeLists.txt
+++ b/tt_fabric/CMakeLists.txt
@@ -41,3 +41,8 @@ set_target_properties(
         INSTALL_RPATH
             "${PROJECT_BINARY_DIR}/lib"
 )
+
+if(COVERAGE)
+    target_compile_options(tt_fabric PRIVATE --coverage)
+    target_link_options(tt_fabric PRIVATE --coverage)
+endif()

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -77,6 +77,11 @@ include_directories(
     api/tt-metalium
 )
 
+if(COVERAGE)
+    target_compile_options(tt_metal PRIVATE --coverage)
+    target_link_options(tt_metal PRIVATE --coverage)
+endif()
+
 add_subdirectory(hw)
 add_subdirectory(hostdevcommon)
 add_subdirectory(common)

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -34,3 +34,7 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal
 )
+
+if(COVERAGE)
+    target_compile_options(common PRIVATE --coverage)
+endif()

--- a/tt_metal/detail/CMakeLists.txt
+++ b/tt_metal/detail/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(
         Metalium::Metal::Impl
         TT::Metalium::HostDevCommon
 )
+
 if(COVERAGE)
     target_compile_options(detail PRIVATE --coverage)
 endif()

--- a/tt_metal/detail/CMakeLists.txt
+++ b/tt_metal/detail/CMakeLists.txt
@@ -12,3 +12,6 @@ target_link_libraries(
         Metalium::Metal::Impl
         TT::Metalium::HostDevCommon
 )
+if(COVERAGE)
+    target_compile_options(detail PRIVATE --coverage)
+endif()

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -19,3 +19,6 @@ target_link_libraries(
         Metalium::Metal::Impl
         TT::Metalium::HostDevCommon
 )
+if(COVERAGE)
+    target_compile_options(distributed PRIVATE --coverage)
+endif()

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
         Metalium::Metal::Impl
         TT::Metalium::HostDevCommon
 )
+
 if(COVERAGE)
     target_compile_options(distributed PRIVATE --coverage)
 endif()

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -71,6 +71,7 @@ target_include_directories(
 )
 
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast)
+
 if(COVERAGE)
     target_compile_options(impl PRIVATE --coverage)
 endif()

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -71,3 +71,6 @@ target_include_directories(
 )
 
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast)
+if(COVERAGE)
+    target_compile_options(impl PRIVATE --coverage)
+endif()

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -21,3 +21,7 @@ target_link_libraries(
 if(DEFINED VERSION_HASH)
     target_compile_definitions(jit_build PRIVATE "-DGIT_COMMIT_HASH=\"${VERSION_HASH}\"")
 endif()
+
+if(COVERAGE)
+    target_compile_options(jit_build PRIVATE --coverage)
+endif()

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -110,6 +110,7 @@ target_link_libraries(
         Metalium::Metal::Impl
 )
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)
+
 if(COVERAGE)
     target_compile_options(llrt PRIVATE --coverage)
 endif()

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -110,3 +110,6 @@ target_link_libraries(
         Metalium::Metal::Impl
 )
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)
+if(COVERAGE)
+    target_compile_options(llrt PRIVATE --coverage)
+endif()

--- a/tt_metal/tools/CMakeLists.txt
+++ b/tt_metal/tools/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(
     PRIVATE
         TT::Metalium::HostDevCommon
 )
+
 if(COVERAGE)
     target_compile_options(tools PRIVATE --coverage)
 endif()

--- a/tt_metal/tools/CMakeLists.txt
+++ b/tt_metal/tools/CMakeLists.txt
@@ -12,3 +12,6 @@ target_link_libraries(
     PRIVATE
         TT::Metalium::HostDevCommon
 )
+if(COVERAGE)
+    target_compile_options(tools PRIVATE --coverage)
+endif()

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -848,6 +848,11 @@ set_target_properties(
             ""
 )
 
+if(COVERAGE)
+    target_compile_options(ttnn PRIVATE --coverage)
+    target_link_options(ttnn PRIVATE --coverage)
+endif()
+
 TT_ENABLE_UNITY_BUILD(ttnn)
 
 #We move the library binaries to a different path rather than PROJECT_BINARY_DIR


### PR DESCRIPTION
### Problem description
It would be nice to have code coverage data from our workflows.
As a start we need to instrument the code.

### What's changed
Use CMake to automatically instrument targets of interest

- At the moment there is no CI mechanism to test this. Just have to make sure this PR doesn't break existing stuff.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12941150803)
- [ ] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/13006477113