### PR TITLE
[FABRIC] ASYNC_WR_ATOMIC_INC

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -40,6 +40,7 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*T3k*
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -98,6 +98,7 @@ run_tg_tests() {
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
 
   elif [[ "$1" == "llama3-70b" ]]; then
     run_tg_llama3.1-70b_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx.cpp
@@ -9,6 +9,7 @@
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_test.hpp"
 #include "tt_fabric/hw/inc/tt_fabric_interface.h"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/common/kernel_utils.hpp"
 // clang-format on
 
 // seed to re-generate the data and validate against incoming data
@@ -40,6 +41,8 @@ constexpr pkt_dest_size_choices_t pkt_dest_size_choice =
 
 constexpr bool skip_pkt_content_gen = get_compile_time_arg_val(9);
 
+constexpr bool fixed_async_wr_notif_addr = get_compile_time_arg_val(10);
+
 #define PAYLOAD_MASK (0xFFFF0000)
 
 void kernel_main() {
@@ -49,16 +52,19 @@ void kernel_main() {
     bool async_wr_check_failed = false;
     uint32_t num_producers = 0;
     uint32_t rx_buf_size;
+    uint32_t time_seed;
 
     // parse runtime args
-    num_producers = get_arg_val<uint32_t>(0);
-    rx_buf_size = get_arg_val<uint32_t>(1);
+    uint32_t rt_args_idx = 0;
+    time_seed = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    num_producers = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    rx_buf_size = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
     test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
 
-    if constexpr (ASYNC_WR == test_command) {
+    if constexpr (ASYNC_WR & test_command) {
         uint32_t packet_rnd_seed;
         uint64_t curr_packet_words, curr_payload_words, processed_packet_words_src;
         uint32_t max_packet_size_mask, temp;
@@ -72,8 +78,10 @@ void kernel_main() {
         tt_l1_ptr uint32_t* target_addresses;
 
         // parse runtime args relevant to the command
-        src_endpoint_ids = reinterpret_cast<tt_l1_ptr uint32_t*>(get_arg_addr(2));
-        target_addresses = reinterpret_cast<tt_l1_ptr uint32_t*>(get_arg_addr(2 + num_producers));
+        src_endpoint_ids =
+            reinterpret_cast<tt_l1_ptr uint32_t*>(get_arg_addr(increment_arg_idx(rt_args_idx, num_producers)));
+        target_addresses =
+            reinterpret_cast<tt_l1_ptr uint32_t*>(get_arg_addr(increment_arg_idx(rt_args_idx, num_producers)));
 
         // compute max_packet_size_mask (borrowed from tx kernel)
         if constexpr (pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM) {
@@ -97,6 +105,27 @@ void kernel_main() {
             rx_addr_hi = target_addresses[i] + rx_buf_size;
             read_addr = base_target_addr;
             processed_packet_words_src = 0;
+            uint32_t packet_index = 1;
+
+            // if fixed notification address, wait for all the packets
+            if constexpr ((test_command & ATOMIC_INC) && fixed_async_wr_notif_addr) {
+                uint64_t temp_words = 0, temp_packets = 0;
+                uint32_t temp_seed = packet_rnd_seed, temp_poll_val;
+                while (temp_words < total_data_words) {
+                    if constexpr (pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM) {
+                        temp_seed = prng_next(temp_seed);
+                        temp_words += packet_rnd_seed_to_size(temp_seed, max_packet_size_words, max_packet_size_mask);
+                    } else if constexpr (
+                        pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE) {
+                        temp_words += max_packet_size_words;
+                    }
+                    temp_packets++;
+                }
+
+                temp_poll_val = time_seed + packet_index + (temp_packets * atomic_increment);
+                poll_addr = base_target_addr;
+                while (temp_poll_val != *poll_addr);
+            }
 
             // read out the data
             while (processed_packet_words_src < total_data_words) {
@@ -122,10 +151,22 @@ void kernel_main() {
                     start_val = packet_rnd_seed & PAYLOAD_MASK;
 
                     // get the value and addr to poll on
-                    poll_val = start_val + curr_payload_words - 1;
-                    poll_addr = read_addr + (curr_payload_words * PACKET_WORD_SIZE_BYTES / 4) - 1;
+                    if constexpr (test_command & ATOMIC_INC) {
+                        // poll on the first word in the payload
+                        poll_addr = read_addr;
+                        if constexpr (fixed_async_wr_notif_addr) {
+                            // no need to poll further in this case
+                            poll_val = *poll_addr;
+                        } else {
+                            poll_val = time_seed + packet_index + atomic_increment;
+                            packet_index++;
+                        }
+                    } else {
+                        // poll on the last word in the payload
+                        poll_val = start_val + curr_payload_words - 1;
+                        poll_addr = read_addr + (curr_payload_words * PACKET_WORD_SIZE_BYTES / 4) - 1;
+                    }
 
-                    // poll on the last word in the payload
                     while (poll_val != *poll_addr);
 
                     // check correctness
@@ -157,9 +198,6 @@ void kernel_main() {
 
         processed_packet_words = num_packets * PACKET_HEADER_SIZE_WORDS;
     }
-
-    // auto start = std::chrono::system_clock::now();
-    /// DPRINT << "time: " << (uint32_t)start << ENDL();
 
     // write out results
     set_64b_result(test_results, processed_packet_words, PQ_TEST_WORD_CNT_INDEX);

--- a/tt_fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_fabric/hw/inc/tt_fabric_interface.h
@@ -22,19 +22,17 @@ constexpr uint32_t DEFAULT_MAX_NOC_SEND_WORDS = (NOC_MAX_BURST_WORDS * NOC_WORD_
 constexpr uint32_t DEFAULT_MAX_ETH_SEND_WORDS = 2 * 1024;
 constexpr uint32_t FVC_SYNC_THRESHOLD = 256;
 
-enum SessionCommand : uint32_t {
-    ASYNC_WR = (0x1 << 0),
-    ASYNC_WR_RESP = (0x1 << 1),
-    ASYNC_RD = (0x1 << 2),
-    ASYNC_RD_RESP = (0x1 << 3),
-    DSOCKET_WR = (0x1 << 4),
-    SSOCKET_WR = (0x1 << 5),
-    ATOMIC_INC = (0x1 << 6),
-    ATOMIC_READ_INC = (0x1 << 7),
-    SOCKET_OPEN = (0x1 << 8),
-    SOCKET_CLOSE = (0x1 << 9),
-    SOCKET_CONNECT = (0x1 << 10),
-};
+#define ASYNC_WR (0x1 << 0)
+#define ASYNC_WR_RESP (0x1 << 1)
+#define ASYNC_RD (0x1 << 2)
+#define ASYNC_RD_RESP (0x1 << 3)
+#define DSOCKET_WR (0x1 << 4)
+#define SSOCKET_WR (0x1 << 5)
+#define ATOMIC_INC (0x1 << 6)
+#define ATOMIC_READ_INC (0x1 << 7)
+#define SOCKET_OPEN (0x1 << 8)
+#define SOCKET_CLOSE (0x1 << 9)
+#define SOCKET_CONNECT (0x1 << 10)
 
 #define INVALID 0x0
 #define DATA 0x1
@@ -60,7 +58,7 @@ typedef struct _tt_routing {
 static_assert(sizeof(tt_routing) == 16);
 
 typedef struct _tt_session {
-    SessionCommand command;
+    uint32_t command;
     uint32_t target_offset_l;  // RDMA address
     uint32_t target_offset_h;
     uint32_t ack_offset_l;  // fabric client local address for session command acknowledgement.
@@ -97,6 +95,13 @@ typedef struct _atomic_params {
     uint32_t wrap_boundary : 8;
 } atomic_params;
 
+typedef struct _async_wr_atomic_params {
+    uint32_t padding;
+    uint32_t l1_offset;
+    uint32_t noc_xy : 24;
+    uint32_t increment : 8;
+} async_wr_atomic_params;
+
 typedef struct _read_params {
     uint32_t return_offset_l;  // address where read data should be copied
     uint32_t return_offset_h;
@@ -111,6 +116,7 @@ typedef union _packet_params {
     mcast_params mcast_parameters;
     socket_params socket_parameters;
     atomic_params atomic_parameters;
+    async_wr_atomic_params async_wr_atomic_parameters;
     read_params read_parameters;
     misc_params misc_parameters;
     uint8_t bytes[12];


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16912)

### Problem description
Currently tt-fabric supports two individual commands, AsyncWrite and AtomicIncrements.

We need to implement a compound command that combines the two in one packet.

### What's changed
Added support for new command, updated tests, added tests to CI

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
