### PR TITLE
Restore clang-tidy scan to be incremental

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -137,10 +137,7 @@ jobs:
             # Suppress clang-tidy to first get an up-to-date build tree
             ln -sf /usr/bin/true ./clang-tidy-shim
 
-            # For Debug, check md5sum of a library
-            md5sum tt_metal/third_party/umd/device/libs/x86_64/libcreate_ethernet_map.a
-
-            cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY=$(pwd)/clang-tidy-shim -DCMAKE_C_CLANG_TIDY=$(pwd)/clang-tidy-shim
+            cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
             nice -n 19 cmake --build --preset clang-tidy
 
             mkdir -p out
@@ -193,10 +190,6 @@ jobs:
             # Symlink tomfoolery here so that Ninja believes the build command has not changed from the previous run
             ln -sf $(which clang-tidy-17) ./clang-tidy-shim
 
-            # For Debug, check md5sum of a library
-            md5sum tt_metal/third_party/umd/device/libs/x86_64/libcreate_ethernet_map.a
-
-            cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
             nice -n 19 cmake --build --preset clang-tidy
             mkdir -p out
             ccache -s > out/ccache.stats


### PR DESCRIPTION
### Ticket
None

### Problem description
When I fixed the warnings-as-errors I mistakenly only updated it for the scan. CMake (or Ninja) correctly noticed that the build command is different and thus all targets are invalidated. That results in a full scan instead of incremental.

### What's changed
Updated the baseline cmake configure to be the ultimately desired command.
Deleted the scan cmake configure to avoid having them diverge again in the future.

Deleted an old debug line that is no longer relevant now that we've nuked LFS.

