### PR TITLE
#0: Fix incorrect assertion for page size for prefetch relay inline to dispatch s

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue_interface.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_interface.hpp
@@ -88,9 +88,9 @@ public:
 
     static constexpr uint32_t DISPATCH_BUFFER_LOG_PAGE_SIZE = 12;
     static constexpr uint32_t DISPATCH_BUFFER_SIZE_BLOCKS = 4;
-    // dispatch_s CB page size is 128 bytes. This should currently be enough to accomodate all commands that
-    // are sent to it. Change as needed, once this endpoint is required to handle more than go signal mcasts.
-    static constexpr uint32_t DISPATCH_S_BUFFER_LOG_PAGE_SIZE = 7;
+    // dispatch_s CB page size is 256 bytes. This should currently be enough to accomodate all commands that
+    // are sent to it or change as needed.
+    static constexpr uint32_t DISPATCH_S_BUFFER_LOG_PAGE_SIZE = 8;
 
     static constexpr uint32_t PREFETCH_D_BUFFER_LOG_PAGE_SIZE = 12;
     static constexpr uint32_t PREFETCH_D_BUFFER_BLOCKS = 4;

--- a/tt_metal/api/tt-metalium/device_command.hpp
+++ b/tt_metal/api/tt-metalium/device_command.hpp
@@ -453,9 +453,6 @@ public:
             dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES);
         auto data_sizeB = noc_mcast_unicast_data.size() * sizeof(uint32_t);
         uint32_t lengthB = sizeof(CQDispatchCmd) + data_sizeB;
-        TT_ASSERT(
-            lengthB <= (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE),
-            "Data for go signal mcast must fit within one page");
         this->add_prefetch_relay_inline(true, lengthB, dispatcher_type);
         auto initialize_set_go_signal_noc_data_cmd = [&](CQDispatchCmd* set_go_signal_noc_data_cmd) {
             set_go_signal_noc_data_cmd->base.cmd_id = CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA;
@@ -777,7 +774,9 @@ private:
         bool flush, uint32_t lengthB, DispatcherSelect dispatcher_type = DispatcherSelect::DISPATCH_MASTER) {
         if (!flush) {
             TT_ASSERT(
-                lengthB <= (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE),
+                lengthB <= (1 << dispatcher_type == DispatcherSelect::DISPATCH_MASTER
+                                ? dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE
+                                : dispatch_constants::DISPATCH_S_BUFFER_LOG_PAGE_SIZE),
                 "Data to relay for inline no flush must fit within one page");
         }
         auto initialize_relay_write = [&](CQPrefetchCmd* relay_write) {


### PR DESCRIPTION
and increase the dispatch s page size to avoid having to split some commands when having multiple sub-devices instead

### Ticket
Link to Github Issue

### Problem description
Llama integration with 3 sub-devices was running into a hang/watcher assert. We were sending more than 1 page of data to dispatch s in one command, which is not supported. Our host side assert was incorrectly validating against the page size of regular/master dispatch, which is larger than dispatch s page size.


### What's changed
Fix the assert to correctly compare against dispatch s page size.
Bump up the dispatch s page size to support the llama use case without having to split commands.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
