### PR TITLE
Afuller/fix clang tidy scan

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -190,6 +190,8 @@ jobs:
             # Symlink tomfoolery here so that Ninja believes the build command has not changed from the previous run
             ln -sf $(which clang-tidy-17) ./clang-tidy-shim
 
+            # Keep this line _exactly_ the same as the one in the "Create baseline" or it will not be incremental
+            cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
             nice -n 19 cmake --build --preset clang-tidy
             mkdir -p out
             ccache -s > out/ccache.stats


### PR DESCRIPTION
### Ticket
None

### Problem description
I broke the non-incremental build by trying to prevent future breakages of the incremental one.

### What's changed
Restore the 2nd CMake configure since the one in baseline is skipped for non-incremental.

