### PR TITLE
#0: Add native 2D sharding and replication functionality to MeshBuffer

### DIFF
--- a/tt_metal/distributed/distributed.hpp
+++ b/tt_metal/distributed/distributed.hpp
@@ -46,6 +46,28 @@ void ReadShard(
     mesh_cq.enqueue_read_shard(dst.data(), mesh_buffer, coord, blocking);
 }
 
+template <typename DType>
+void EnqueueWriteMeshBuffer(
+    MeshCommandQueue& mesh_cq,
+    std::shared_ptr<MeshBuffer>& mesh_buffer,
+    std::vector<DType>& src,
+    bool blocking = false) {
+    mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
+}
+
+template <typename DType>
+void EnqueueReadMeshBuffer(
+    MeshCommandQueue& mesh_cq,
+    std::vector<DType>& dst,
+    std::shared_ptr<MeshBuffer>& mesh_buffer,
+    bool blocking = true) {
+    TT_FATAL(
+        mesh_buffer->global_layout() == MeshBufferLayout::SHARDED,
+        "Can only read a Sharded MeshBuffer from a MeshDevice.");
+    dst.resize(mesh_buffer->global_shard_spec().global_size / sizeof(DType));
+    mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
+}
+
 void Finish(MeshCommandQueue& mesh_cq);
 
 }  // namespace distributed

--- a/tt_metal/distributed/mesh_command_queue.hpp
+++ b/tt_metal/distributed/mesh_command_queue.hpp
@@ -23,6 +23,7 @@ private:
     void populate_dispatch_core_type();
     CoreCoord virtual_program_dispatch_core() const;
     CoreType dispatch_core_type() const;
+    // Helper functions for reading and writing individual shards
     void write_shard_to_device(
         std::shared_ptr<Buffer>& shard_view,
         const void* src,
@@ -30,6 +31,17 @@ private:
         tt::stl::Span<const SubDeviceId> sub_device_ids);
     void read_shard_from_device(
         std::shared_ptr<Buffer>& shard_view,
+        void* dst,
+        std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
+    // Helper functions for read and write entire Sharded-MeshBuffers
+    void write_sharded_buffer(
+        MeshBuffer& buffer,
+        const void* src,
+        std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void read_sharded_buffer(
+        MeshBuffer& buffer,
         void* dst,
         std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids);
@@ -47,10 +59,16 @@ public:
     uint32_t id() const { return id_; }
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking);
+    // MeshBuffer Write APIs
     void enqueue_write_shard(
         std::shared_ptr<MeshBuffer>& mesh_buffer, void* host_data, const Coordinate& coord, bool blocking);
+    void enqueue_write_shard_to_sub_grid(
+        MeshBuffer& buffer, void* host_data, const LogicalDeviceRange& device_range, bool blocking);
+    void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, void* host_data, bool blocking);
+    // MeshBuffer Read APIs
     void enqueue_read_shard(
-        void* host_data, std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);
+        void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);
+    void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking);
     void finish();
 };
 


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
As per the `MeshBuffer` spec outlined [here](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md#33-memory-management-meshbuffer-and-meshallocator-), TT-Mesh needs to implement native multi-device sharding and replication.

This is a requirement to bring-up the following APIs:
```
void EnqueueWriteMeshBuffer(
    MeshCommandQueue& mesh_cq,
    std::shared_ptr<MeshBuffer>& mesh_buffer,
    std::vector<DType>& src,
    bool blocking = false);
    
void EnqueueReadMeshBuffer(
    MeshCommandQueue& mesh_cq,
    std::vector<DType>& dst,
    std::shared_ptr<MeshBuffer>& mesh_buffer,
    bool blocking = true);
```

### What's changed
- Add the 2D `MeshBuffer` sharding and replication support to `MeshCommandQueue::enqueue_write_mesh_buffer`
- Add 2D  `MeshBuffer` concatenation support to `MeshCommandQueue::enqueue_read_mesh_buffer` (can only concatenate pure sharded `MeshBuffers`, assert triggered if a user tries to read a replicated `MeshBuffer`).
- Limitations: 
    - **Performance:** More memcpy's and loops than what we would like longer term. Performance profiling and improvements will be in a follow-up PR
    - Current support is only for 2D data-distribution -> Generic ND sharding is not supported (an N-Dimensional Tensor can only be sharded along the inner or outermost dimensions). This support will be brought up in future, based on requirements and the status of single device sharding
 - Add sanity tests sweeping over different shapes and shard layouts.
 - Integrating this feature in TTNN requires the ability to generate a `MeshBuffer` data distribution spec given a TTNN tensor sharding strategy

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
