### PR TITLE
Add support for reading from / writing to partial buffer regions that are page size aligned for sharded buffers

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -10,6 +10,7 @@
 #include "command_queue_fixture.hpp"
 #include "core_coord.hpp"
 #include "math.hpp"
+#include "shape2d.hpp"
 #include "multi_command_queue_fixture.hpp"
 #include "dispatch_test_utils.hpp"
 #include "gtest/gtest.h"
@@ -83,9 +84,9 @@ struct ShardedSubBufferStressTestConfig {
     uint32_t region_offset = 0;
     uint32_t region_size = 0;
     CoreRangeSet cores;
-    std::array<uint32_t, 2> shard_shape;
-    std::array<uint32_t, 2> page_shape;
-    std::array<uint32_t, 2> tensor2d_shape;
+    Shape2D shard_shape;
+    Shape2D page_shape;
+    Shape2D tensor2d_shape;
     TensorMemoryLayout layout;
     ShardOrientation orientation;
 };
@@ -1066,12 +1067,12 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferForL1) 
                 config.page_size,
                 config.region_offset,
                 config.region_size,
-                tt::constants::TILE_HEIGHT,
-                tt::constants::TILE_WIDTH,
-                config.page_shape[0],
-                config.page_shape[1],
-                config.tensor2d_shape[0],
-                config.tensor2d_shape[1],
+                config.shard_shape.height(),
+                config.shard_shape.width(),
+                config.page_shape.height(),
+                config.page_shape.width(),
+                config.tensor2d_shape.height(),
+                config.tensor2d_shape.width(),
                 magic_enum::enum_name(config.layout).data(),
                 magic_enum::enum_name(config.orientation).data(),
                 config.cores.str());

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -1035,7 +1035,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferForL1) 
                                                         vector<uint32_t> result;
                                                         EnqueueReadSubBuffer(
                                                             device->command_queue(), *buffer, result, region, true);
-                                                        ASSERT_EQ(src, result);
+                                                        EXPECT_EQ(src, result);
                                                     }
                                                 }
                                                 tensor2d_shape_width += page_shape_width_div_factor;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -932,7 +932,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
             {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},  // needs to be multiple of page shape
             ShardOrientation::ROW_MAJOR,
             {tt::constants::TILE_HEIGHT / 2, tt::constants::TILE_WIDTH},
-            {(uint32_t)2, 1});  // <= num host pages, needs to be multiple of (shard shape / page shape); (2, 2) or (4,
+            {(uint32_t)4, 1});  // <= num host pages, needs to be multiple of (shard shape / page shape); (2, 2) or (4,
                                 // 1) are the only legit
         // auto buffer = CreateBuffer(ShardedBufferConfig{
         //     .device = device,
@@ -941,14 +941,14 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
         //     .buffer_layout = TensorMemoryLayout::BLOCK_SHARDED,
         //     .shard_parameters = shard_spec});
         auto buffer = Buffer::create(device, 1024, 256, BufferType::L1, TensorMemoryLayout::BLOCK_SHARDED, shard_spec);
-        auto src = local_test_functions::generate_arange_vector(512);
-        EnqueueWriteBuffer(device->command_queue(), *buffer, src, true);
+        auto src = local_test_functions::generate_arange_vector(buffer_region_size);
+        EnqueueWriteBuffer(device->command_queue(), *buffer, zeroes, true);
         const BufferRegion region(512, buffer_region_size);
-        // EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
         vector<uint32_t> result;
-        // EnqueueReadBuffer(device->command_queue(), *buffer, result, true);
+        EnqueueReadBuffer(device->command_queue(), *buffer, result, true);
         // EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
-        // EXPECT_EQ(src, result);
+        EXPECT_EQ(src, result);
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <sys/types.h>
 #include <cstdint>
 #include <memory>
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -589,6 +589,36 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpa
     }
 }
 
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
+    const uint32_t page_size = 256;
+    const uint32_t buffer_size = 64 * page_size;
+    const BufferRegion region(256, 512);
+    for (IDevice* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        CoreCoord start(0, 0);
+        CoreCoord end(5, 0);
+        CoreRange cores(start, end);
+        ShardSpecBuffer shard_spec = ShardSpecBuffer(
+            CoreRangeSet(cores),
+            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            ShardOrientation::ROW_MAJOR,
+            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {8, 8});
+        auto buffer = Buffer::create(
+            device, buffer_size, page_size, BufferType::DRAM, TensorMemoryLayout::BLOCK_SHARDED, shard_spec);
+
+        local_test_functions::clear_buffer(device->command_queue(), *buffer);
+
+        auto src = local_test_functions::generate_arange_vector(region.size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
+
+        vector<uint32_t> result;
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
+
+        EXPECT_EQ(src, result);
+    }
+}
+
 TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 64 * page_size;
@@ -931,143 +961,111 @@ TEST_F(MultiCommandQueueSingleDeviceBufferFixture, TestIssueMultipleReadWriteCom
 
 namespace l1_tests {
 
-TEST_F(CommandQueueSingleCardBufferFixture, TestReadWritesShardedSubBuffer) {
-    for (IDevice* device : devices_) {
-        for (const std::array<uint32_t, 2> cores :
-             {std::array<uint32_t, 2>{1, 1}, std::array<uint32_t, 2>{2, 3}, std::array<uint32_t, 2>{5, 5}}) {
-            for (const std::array<uint32_t, 2> num_pages : {
-                     std::array<uint32_t, 2>{1, 1},
-                     std::array<uint32_t, 2>{1, 2},
-                     std::array<uint32_t, 2>{2, 3},
-                 }) {
-                for (const std::array<uint32_t, 2> page_shape : {
-                         std::array<uint32_t, 2>{1, 65536},
-                         std::array<uint32_t, 2>{1, 65540},
-                         std::array<uint32_t, 2>{1, 65568},
-                         std::array<uint32_t, 2>{1, 65520},
-                         std::array<uint32_t, 2>{1, 132896},
-                         std::array<uint32_t, 2>{256, 256},
-                         std::array<uint32_t, 2>{336, 272},
-                     }) {
-                    for (const TensorMemoryLayout shard_strategy :
-                         {TensorMemoryLayout::HEIGHT_SHARDED,
-                          TensorMemoryLayout::WIDTH_SHARDED,
-                          TensorMemoryLayout::BLOCK_SHARDED}) {
-                        for (const uint32_t num_iterations : {
-                                 1,
-                             }) {
-                            BufferStressTestConfigSharded config(num_pages, cores);
-                            config.seed = 0;
-                            config.num_iterations = num_iterations;
-                            config.mem_config = shard_strategy;
-                            config.page_shape = page_shape;
-                            tt::log_info(
-                                tt::LogTest,
-                                "Device: {} cores: [{},{}] num_pages: [{},{}] page_shape: [{},{}], shard_strategy: {}, "
-                                "num_iterations: {}",
-                                device->id(),
-                                cores[0],
-                                cores[1],
-                                num_pages[0],
-                                num_pages[1],
-                                page_shape[0],
-                                page_shape[1],
-                                magic_enum::enum_name(shard_strategy).data(),
-                                num_iterations);
-                            local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
-                                device, device->command_queue(), config, BufferType::L1, true);
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferForL1) {
+    const uint32_t max_buffer_size = 192;
 
-TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
-    const uint32_t max_buffer_size = 2048;
-
-    uint32_t buffer_size = 16;
-    uint32_t page_size = 4;
-    uint32_t region_offset = 0;
-    uint32_t region_size = sizeof(uint32_t);
     for (IDevice* device : devices_) {
-        while (buffer_size < max_buffer_size) {
-            while (page_size < buffer_size) {
+        tt::log_info("Running on Device {}", device->id());
+        uint32_t buffer_size = 0;
+        while (buffer_size <= max_buffer_size) {
+            uint32_t page_size = 4;
+            while (page_size <= buffer_size) {
+                uint32_t region_offset = 0;
                 while (buffer_size % page_size == 0 && region_offset < buffer_size) {
-                    while (region_offset + region_size < buffer_size) {
+                    uint32_t region_size = page_size;
+                    while (region_offset + region_size <= buffer_size) {
                         CoreCoord start(0, 0);
-                        CoreCoord end(5, 5);
-                        CoreRange cores(start, end);
-                        const uint32_t num_pages = buffer_size / page_size;
-                        const uint32_t num_shards = cores.size();
-                        const uint32_t num_pages_per_shard = tt::div_up(num_pages, num_shards);
-                        uint32_t page_shape_height_div_factor = 1;
-                        while (page_shape_height_div_factor <= num_pages_per_shard) {
-                            uint32_t page_shape_width_div_factor = 1;
-                            while (page_shape_width_div_factor <= num_pages_per_shard) {
-                                if (page_shape_width_div_factor * page_shape_height_div_factor == num_pages_per_shard) {
-                                    uint32_t tensor2d_shape_height = page_shape_height_div_factor;
-                                    while (tensor2d_shape_height <= num_pages) {
-                                        uint32_t tensor2d_shape_width = page_shape_width_div_factor;
-                                        while (tensor2d_shape_width <= num_pages) {
-                                            if (tensor2d_shape_height * tensor2d_shape_width == num_pages) {
-                                                for (TensorMemoryLayout layout :
-                                                     {TensorMemoryLayout::HEIGHT_SHARDED,
-                                                      TensorMemoryLayout::BLOCK_SHARDED,
-                                                      TensorMemoryLayout::WIDTH_SHARDED}) {
-                                                    ShardSpecBuffer shard_spec = ShardSpecBuffer(
-                                                        CoreRangeSet(cores),
-                                                        {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
-                                                        ShardOrientation::ROW_MAJOR,
-                                                        {tt::constants::TILE_HEIGHT / page_shape_height_div_factor,
-                                                         tt::constants::TILE_WIDTH / page_shape_width_div_factor},
-                                                        {tensor2d_shape_height, tensor2d_shape_width});
-                                                    auto buffer = Buffer::create(
-                                                        device,
-                                                        buffer_size,
-                                                        page_size,
-                                                        BufferType::L1,
-                                                        layout,
-                                                        shard_spec);
-                                                    local_test_functions::clear_buffer(
-                                                        device->command_queue(), *buffer);
-                                                    const BufferRegion region(region_offset, region_size);
-                                                    vector<uint32_t> src =
-                                                        local_test_functions::generate_arange_vector(region_size);
-                                                    EnqueueWriteSubBuffer(
-                                                        device->command_queue(), *buffer, src, region, false);
-                                                    vector<uint32_t> result;
-                                                    EnqueueReadSubBuffer(
-                                                        device->command_queue(), *buffer, result, region, true);
-                                                    EXPECT_EQ(src, result);
+                        for (uint32_t end_core_idx = 3; end_core_idx <= 4; end_core_idx++) {
+                            CoreCoord end(end_core_idx, end_core_idx);
+                            CoreRange cores(start, end);
+                            const uint32_t num_pages = buffer_size / page_size;
+                            const uint32_t num_shards = cores.size();
+                            const uint32_t num_pages_per_shard = tt::div_up(num_pages, num_shards);
+                            uint32_t page_shape_height_div_factor = 1;
+                            while (page_shape_height_div_factor <= num_pages_per_shard) {
+                                uint32_t page_shape_width_div_factor = 1;
+                                while (page_shape_width_div_factor <= num_pages_per_shard) {
+                                    if (page_shape_width_div_factor * page_shape_height_div_factor ==
+                                        num_pages_per_shard) {
+                                        uint32_t tensor2d_shape_height = page_shape_height_div_factor;
+                                        while (tensor2d_shape_height <= num_pages) {
+                                            uint32_t tensor2d_shape_width = page_shape_width_div_factor;
+                                            while (tensor2d_shape_width <= num_pages) {
+                                                if (tensor2d_shape_height * tensor2d_shape_width == num_pages) {
+                                                    for (TensorMemoryLayout layout :
+                                                         {TensorMemoryLayout::HEIGHT_SHARDED,
+                                                          TensorMemoryLayout::BLOCK_SHARDED,
+                                                          TensorMemoryLayout::WIDTH_SHARDED}) {
+                                                        tt::log_info(
+                                                            tt::LogTest,
+                                                            "Device: {} buffer_size: {} page_size: {}"
+                                                            " region_offset: {} region_size: {} page_shape: [{}, {}]"
+                                                            " tensor2d_shape: [{}, {}] layout: {} cores: {}",
+                                                            device->id(),
+                                                            buffer_size,
+                                                            page_size,
+                                                            region_offset,
+                                                            region_size,
+                                                            tt::constants::TILE_HEIGHT / page_shape_height_div_factor,
+                                                            tt::constants::TILE_WIDTH / page_shape_width_div_factor,
+                                                            tensor2d_shape_height,
+                                                            tensor2d_shape_width,
+                                                            magic_enum::enum_name(layout).data(),
+                                                            cores.str());
+                                                        ShardSpecBuffer shard_spec = ShardSpecBuffer(
+                                                            CoreRangeSet(cores),
+                                                            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+                                                            ShardOrientation::ROW_MAJOR,
+                                                            {tt::constants::TILE_HEIGHT / page_shape_height_div_factor,
+                                                             tt::constants::TILE_WIDTH / page_shape_width_div_factor},
+                                                            {tensor2d_shape_height, tensor2d_shape_width});
+                                                        auto buffer = Buffer::create(
+                                                            device,
+                                                            buffer_size,
+                                                            page_size,
+                                                            BufferType::L1,
+                                                            layout,
+                                                            shard_spec);
+                                                        local_test_functions::clear_buffer(
+                                                            device->command_queue(), *buffer);
+                                                        const BufferRegion region(region_offset, region_size);
+                                                        vector<uint32_t> src =
+                                                            local_test_functions::generate_arange_vector(region_size);
+                                                        EnqueueWriteSubBuffer(
+                                                            device->command_queue(), *buffer, src, region, false);
+                                                        vector<uint32_t> result;
+                                                        EnqueueReadSubBuffer(
+                                                            device->command_queue(), *buffer, result, region, true);
+                                                        ASSERT_EQ(src, result);
+                                                    }
                                                 }
+                                                tensor2d_shape_width += page_shape_width_div_factor;
                                             }
-                                            tensor2d_shape_width += page_shape_width_div_factor;
+                                            tensor2d_shape_height += page_shape_height_div_factor;
                                         }
-                                        tensor2d_shape_height += page_shape_height_div_factor;
                                     }
+                                    page_shape_width_div_factor += 1;
                                 }
-                                page_shape_width_div_factor += 1;
+                                page_shape_height_div_factor += 1;
                             }
-                            page_shape_height_div_factor += 1;
                         }
-                        region_size += page_size;
+                        region_size += 2 * page_size;
                     }
                     region_offset += page_size;
                 }
                 page_size += sizeof(uint32_t);
             }
-            buffer_size += sizeof(uint32_t);
+            buffer_size += 2 * sizeof(uint32_t);
         }
     }
 }
 
-TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingWritesShardedSubBuffer) {
-    const uint32_t buffer_size = 1024;
-    const uint32_t buffer_region_size = 256;
+TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingWritesShardedSubBufferForL1) {
     const uint32_t page_size = 64;
+    const uint32_t buffer_size = 16 * page_size;
+    const uint32_t buffer_region_size = 4 * page_size;
     for (IDevice* device : devices_) {
+        tt::log_info("Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
         CoreRange cores(start_coord, end_coord);
@@ -1076,12 +1074,11 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingWritesShar
             {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
             ShardOrientation::ROW_MAJOR,
             {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
-            {(uint32_t)cores.size(), 1});
+            {16, 1});
         auto buffer = Buffer::create(
             device, buffer_size, page_size, BufferType::L1, TensorMemoryLayout::WIDTH_SHARDED, shard_spec);
 
-        vector<uint32_t> zeroes(buffer_size / sizeof(uint32_t), 0);
-        EnqueueWriteBuffer(device->command_queue(), *buffer, zeroes, true);
+        local_test_functions::clear_buffer(device->command_queue(), *buffer);
 
         vector<uint32_t> ones(buffer_region_size / sizeof(uint32_t), 1);
         BufferRegion region(0, buffer_region_size);
@@ -1114,23 +1111,78 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingWritesShar
     }
 }
 
-TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferMultiplePagesPerShard) {
-    const uint32_t buffer_region_size = 256;
-    vector<uint32_t> zeroes(128, 0);
+TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingReadsShardedSubBufferForL1) {
+    const uint32_t page_size = 64;
+    const uint32_t buffer_size = 16 * page_size;
+    const uint32_t buffer_region_size = buffer_size / 4;
+    for (IDevice* device : devices_) {
+        tt::log_info("Running on Device {}", device->id());
+        CoreCoord start_coord = {0, 0};
+        CoreCoord end_coord = {5, 5};
+        CoreRange cores(start_coord, end_coord);
+        ShardSpecBuffer shard_spec = ShardSpecBuffer(
+            CoreRangeSet(cores),
+            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            ShardOrientation::ROW_MAJOR,
+            {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
+            {8, 2});
+        auto buffer = Buffer::create(
+            device, buffer_size, page_size, BufferType::L1, TensorMemoryLayout::BLOCK_SHARDED, shard_spec);
+
+        vector<uint32_t> expected = local_test_functions::generate_arange_vector(buffer_size);
+        EnqueueWriteBuffer(device->command_queue(), *buffer, expected, true);
+
+        vector<uint32_t> first_read;
+        BufferRegion region(0, buffer_region_size);
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, first_read, region, false);
+
+        vector<uint32_t> second_read;
+        region = BufferRegion(buffer_region_size, buffer_region_size);
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, second_read, region, false);
+
+        vector<uint32_t> third_read;
+        region = BufferRegion(buffer_region_size * 2, buffer_region_size);
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, third_read, region, false);
+
+        vector<uint32_t> fourth_read;
+        region = BufferRegion(buffer_region_size * 3, buffer_region_size);
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, fourth_read, region, false);
+
+        Finish(device->command_queue());
+
+        vector<uint32_t> result;
+        result.reserve(buffer_size / sizeof(uint32_t));
+
+        result.insert(result.end(), first_read.begin(), first_read.end());
+        result.insert(result.end(), second_read.begin(), second_read.end());
+        result.insert(result.end(), third_read.begin(), third_read.end());
+        result.insert(result.end(), fourth_read.begin(), fourth_read.end());
+
+        EXPECT_EQ(expected, result);
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferMultiplePagesPerShardForL1) {
+    const uint32_t page_size = 64;
+    const uint32_t buffer_size = page_size * 16;
+    const uint32_t buffer_region_offset = page_size * 3;
+    const uint32_t buffer_region_size = page_size * 7;
     vector<uint32_t> src = local_test_functions::generate_arange_vector(buffer_region_size);
     for (IDevice* device : devices_) {
+        tt::log_info("Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {3, 3};
         CoreRange cores(start_coord, end_coord);
         ShardSpecBuffer shard_spec = ShardSpecBuffer(
             CoreRangeSet(cores),
             {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
-            ShardOrientation::ROW_MAJOR,
-            {tt::constants::TILE_HEIGHT / 2, tt::constants::TILE_WIDTH / 2},
-            {4, 2});  // (1, 16), (4, 4), (8, 2), (2, 8)
-        auto buffer = Buffer::create(device, 64 * 8, 64, BufferType::L1, TensorMemoryLayout::BLOCK_SHARDED, shard_spec);
-        EnqueueWriteBuffer(device->command_queue(), *buffer, zeroes, true);
-        const BufferRegion region(192, buffer_region_size);
+            ShardOrientation::COL_MAJOR,
+            {tt::constants::TILE_HEIGHT / 4, tt::constants::TILE_WIDTH / 2},
+            {8, 2});
+        auto buffer = Buffer::create(
+            device, buffer_size, page_size, BufferType::L1, TensorMemoryLayout::BLOCK_SHARDED, shard_spec);
+        local_test_functions::clear_buffer(device->command_queue(), *buffer);
+        const BufferRegion region(buffer_region_offset, buffer_region_size);
         EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
         vector<uint32_t> result;
         EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -152,7 +152,7 @@ struct BufferPageMapping {
     std::vector<std::optional<uint32_t>> dev_page_to_host_page_mapping_;
     std::vector<uint32_t> host_page_to_dev_page_mapping_;
     std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
-    std::vector<uint32_t> host_page_to_local_shard_page_mapping_;
+    std::vector<uint32_t> host_page_to_local_shard_page_mapping_;  // use this
     std::vector<std::array<uint32_t, 2>> core_shard_shape_;
 };
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -152,7 +152,7 @@ struct BufferPageMapping {
     std::vector<std::optional<uint32_t>> dev_page_to_host_page_mapping_;
     std::vector<uint32_t> host_page_to_dev_page_mapping_;
     std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
-    std::vector<uint32_t> host_page_to_local_shard_page_mapping_;  // use this
+    std::vector<uint32_t> host_page_to_local_shard_page_mapping_;
     std::vector<std::array<uint32_t, 2>> core_shard_shape_;
 };
 

--- a/tt_metal/api/tt-metalium/hardware_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/hardware_command_queue.hpp
@@ -35,6 +35,7 @@ struct ReadBufferDescriptor {
     uint32_t dst_offset;
     uint32_t num_pages_read;
     uint32_t cur_dev_page_id;
+    uint32_t starting_host_page_id;
 
     ReadBufferDescriptor(
         TensorMemoryLayout buffer_layout,
@@ -44,6 +45,7 @@ struct ReadBufferDescriptor {
         uint32_t dst_offset,
         uint32_t num_pages_read,
         uint32_t cur_dev_page_id,
+        uint32_t starting_host_page_id = 0,
         const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping = nullptr) :
         buffer_layout(buffer_layout),
         page_size(page_size),
@@ -52,7 +54,8 @@ struct ReadBufferDescriptor {
         dst(dst),
         dst_offset(dst_offset),
         num_pages_read(num_pages_read),
-        cur_dev_page_id(cur_dev_page_id) {}
+        cur_dev_page_id(cur_dev_page_id),
+        starting_host_page_id(starting_host_page_id) {}
 };
 
 // Used so host knows data in completion queue is just an event ID

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -203,7 +203,7 @@ void MeshCommandQueue::read_shard_from_device(
 
     if (is_sharded(shard_view->buffer_layout())) {
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
-            *shard_view, id_, expected_num_workers_completed);
+            *shard_view, id_, expected_num_workers_completed, region);
         auto cores = buffer_dispatch::get_cores_for_sharded_buffer(
             dispatch_params.width_split, dispatch_params.buffer_page_mapping, *shard_view);
         for (uint32_t core_id = 0; core_id < shard_view->num_cores(); ++core_id) {

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -13,9 +13,9 @@ namespace buffer_dispatch {
 
 // Dispatch constants required for writing buffer data
 struct BufferDispatchConstants {
-    uint32_t issue_queue_cmd_limit;
-    uint32_t max_prefetch_cmd_size;
-    uint32_t max_data_sizeB;
+    uint32_t issue_queue_cmd_limit = 0;
+    uint32_t max_prefetch_cmd_size = 0;
+    uint32_t max_data_sizeB = 0;
 };
 
 // Dispatch parameters computed during runtime. These are used
@@ -23,31 +23,31 @@ struct BufferDispatchConstants {
 // required to write buffer data.
 struct BufferWriteDispatchParams {
     tt::stl::Span<const uint32_t> expected_num_workers_completed;
-    uint32_t address;
-    uint32_t dst_page_index;
-    uint32_t page_size_to_write;
-    uint32_t total_pages_to_write;
-    uint32_t total_pages_written;
-    uint32_t pages_per_txn;
-    bool issue_wait;
-    IDevice* device;
-    uint32_t cq_id;
+    uint32_t address = 0;
+    uint32_t dst_page_index = 0;
+    uint32_t page_size_to_write = 0;
+    uint32_t total_pages_to_write = 0;
+    uint32_t total_pages_written = 0;
+    uint32_t pages_per_txn = 0;
+    bool issue_wait = false;
+    IDevice* device = nullptr;
+    uint32_t cq_id = 0;
 };
 
 // Parameters specific to interleaved buffers
 struct InterleavedBufferWriteDispatchParams : BufferWriteDispatchParams {
-    uint32_t write_partial_pages;
-    uint32_t padded_buffer_size;
-    uint32_t max_num_pages_to_write;
+    uint32_t write_partial_pages = 0;
+    uint32_t padded_buffer_size = 0;
+    uint32_t max_num_pages_to_write = 0;
 };
 
 // Parameters specific to sharded buffers
 struct ShardedBufferWriteDispatchParams : BufferWriteDispatchParams {
-    bool width_split;
-    uint32_t starting_dst_host_page_index;
-    uint32_t initial_pages_skipped;
-    std::shared_ptr<const BufferPageMapping> buffer_page_mapping;
-    uint32_t max_pages_per_shard;
+    bool width_split = false;
+    uint32_t starting_dst_host_page_index = 0;
+    uint32_t initial_pages_skipped = 0;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping = nullptr;
+    uint32_t max_pages_per_shard = 0;
     CoreCoord core;
 };
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -4,6 +4,7 @@
 
 #include <device_command.hpp>
 #include <device.hpp>
+#include "assert.hpp"
 #include "dispatch.hpp"
 
 namespace tt::tt_metal {
@@ -499,6 +500,11 @@ void write_sharded_buffer_to_core(
 }
 
 void validate_buffer_region_conditions(const Buffer& buffer, const BufferRegion& region) {
+    TT_FATAL(
+        buffer.is_valid_region(region),
+        "Buffer region with offset {} and size {} is invalid.",
+        region.offset,
+        region.size);
     if (buffer.is_valid_partial_region(region)) {
         TT_FATAL(
             region.offset % buffer.page_size() == 0,

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -755,7 +755,7 @@ void copy_sharded_buffer_from_core_to_completion_queue(
                 dispatch_params.buffer_page_mapping->host_page_to_dev_page_mapping_[host_page];
             bank_base_address +=
                 (dispatch_params.buffer_page_mapping->host_page_to_local_shard_page_mapping_[host_page] *
-                 buffer.page_size());
+                 buffer.aligned_page_size());
         }
     } else {
         host_page = dispatch_params.src_page_index;
@@ -772,7 +772,7 @@ void copy_sharded_buffer_from_core_to_completion_queue(
                 ((core_id + 1) * dispatch_params.max_pages_per_shard) - dispatch_params.initial_pages_skipped;
             const uint32_t curr_page_idx_in_shard = dispatch_params.max_pages_per_shard - remaining_pages_in_shard;
             pages_per_txn = std::min(pages_per_txn, remaining_pages_in_shard);
-            bank_base_address += curr_page_idx_in_shard * buffer.page_size();
+            bank_base_address += curr_page_idx_in_shard * buffer.aligned_page_size();
         }
     }
 

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -27,8 +27,11 @@ struct BufferReadDispatchParams {
 
 struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
     bool width_split;
+    uint32_t initial_pages_skipped;
+    uint32_t starting_src_host_page_index;
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping;
-    uint32_t num_total_pages;
+    uint32_t total_pages_to_read;
+    uint32_t total_pages_read;
     uint32_t max_pages_per_shard;
     CoreCoord core;
 };
@@ -43,7 +46,10 @@ void write_to_device_buffer(
     tt::stl::Span<const SubDeviceId> sub_device_ids);
 
 ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
-    Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed);
+    Buffer& buffer,
+    uint32_t cq_id,
+    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    const BufferRegion& region);
 
 BufferReadDispatchParams initialize_interleaved_buf_read_dispatch_params(
     Buffer& buffer,

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -16,23 +16,23 @@ namespace buffer_dispatch {
 
 struct BufferReadDispatchParams {
     tt::stl::Span<const uint32_t> expected_num_workers_completed;
-    uint32_t cq_id;
-    IDevice* device;
-    uint32_t padded_page_size;
-    uint32_t src_page_index;
-    uint32_t unpadded_dst_offset;
-    uint32_t pages_per_txn;
-    uint32_t address;
+    uint32_t cq_id = 0;
+    IDevice* device = nullptr;
+    uint32_t padded_page_size = 0;
+    uint32_t src_page_index = 0;
+    uint32_t unpadded_dst_offset = 0;
+    uint32_t pages_per_txn = 0;
+    uint32_t address = 0;
 };
 
 struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
-    bool width_split;
-    uint32_t initial_pages_skipped;
-    uint32_t starting_src_host_page_index;
-    std::shared_ptr<const BufferPageMapping> buffer_page_mapping;
-    uint32_t total_pages_to_read;
-    uint32_t total_pages_read;
-    uint32_t max_pages_per_shard;
+    bool width_split = false;
+    uint32_t initial_pages_skipped = 0;
+    uint32_t starting_src_host_page_index = 0;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping = nullptr;
+    uint32_t total_pages_to_read = 0;
+    uint32_t total_pages_read = 0;
+    uint32_t max_pages_per_shard = 0;
     CoreCoord core;
 };
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -76,12 +76,6 @@ void ValidateBufferRegion(
         "Buffer region with offset {} and size {} is invalid.",
         region.offset,
         region.size);
-
-    if (buffer_obj.is_valid_partial_region(region)) {
-        TT_FATAL(
-            !is_sharded(buffer_obj.buffer_layout()),
-            "Reading from and writing to partial buffer regions is only supported for non-sharded buffers.");
-    }
 }
 }  // namespace detail
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -307,7 +307,7 @@ void HWCommandQueue::enqueue_read_buffer(
         // Forward data from each core to the completion queue.
         // Then have the completion queue reader thread copy this data to user space.
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
-            buffer, this->id, this->expected_num_workers_completed);
+            buffer, this->id, this->expected_num_workers_completed, region);
         auto cores = buffer_dispatch::get_cores_for_sharded_buffer(
             dispatch_params.width_split, dispatch_params.buffer_page_mapping, buffer);
         for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {


### PR DESCRIPTION
This PR adds support for reading from and writing to partial buffer regions that are page size aligned for sharded buffers.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
