### PR TITLE
#0: Clean up some include paths around RTOptions and remove direct checks on TT_METAL_SIMULATOR env var

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -41,8 +41,8 @@ inline std::string get_env_arch_name() {
 
 inline std::string get_umd_arch_name() {
 
-    if(std::getenv("TT_METAL_SIMULATOR")) {
-        tt_SimulationDeviceInit init(std::getenv("TT_METAL_SIMULATOR"));
+    if(llrt::RunTimeOptions::get_instance().get_simulator_enabled()) {
+        tt_SimulationDeviceInit init(llrt::RunTimeOptions::get_instance().get_simulator_path());
         return tt::arch_to_str(init.get_arch_name());
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
+#include "get_platform_architecture.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <yaml-cpp/yaml.h>
 

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -22,51 +22,6 @@ struct core_descriptor_t {
     std::vector<CoreCoord> logical_dispatch_cores;
 };
 
-inline std::string get_core_descriptor_file(
-    const tt::ARCH& arch, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
-    string core_desc_dir;
-    if (getenv("TT_METAL_HOME")) {
-        core_desc_dir = getenv("TT_METAL_HOME");
-    } else {
-        core_desc_dir = "./";
-    }
-    if (core_desc_dir.back() != '/') {
-        core_desc_dir += "/";
-    }
-    core_desc_dir += "tt_metal/core_descriptors/";
-
-    bool targeting_sim = std::getenv("TT_METAL_SIMULATOR") != nullptr;
-    if (targeting_sim) {
-        switch (arch) {
-            case tt::ARCH::Invalid:
-                throw std::runtime_error(
-                    "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
-            case tt::ARCH::GRAYSKULL: return core_desc_dir + "grayskull_versim_1x1_arch.yaml";
-            case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
-            case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
-            default: throw std::runtime_error("Unsupported device arch");
-        };
-    } else {
-        switch (arch) {
-            case tt::ARCH::Invalid:
-                throw std::runtime_error(
-                    "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
-            case tt::ARCH::GRAYSKULL: return core_desc_dir + "grayskull_120_arch.yaml";
-            case tt::ARCH::WORMHOLE_B0:
-                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH
-                                            ? "wormhole_b0_80_arch_eth_dispatch.yaml"
-                                            : "wormhole_b0_80_arch.yaml");
-            case tt::ARCH::BLACKHOLE:
-                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH
-                                            ? "blackhole_140_arch_eth_dispatch.yaml"
-                                            : "blackhole_140_arch.yaml");
-            default: throw std::runtime_error("Unsupported device arch");
-        };
-    }
-    return "";
-}
-
 inline const std::string& get_product_name(tt::ARCH arch, uint32_t num_harvested_rows) {
     const static std::map<tt::ARCH, std::map<uint32_t, std::string>> product_name = {
         {tt::ARCH::GRAYSKULL, {{0, "E150"}, {2, "E75"}}},

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -7,7 +7,6 @@
 #include "core_descriptor.hpp"
 #include "core_coord.hpp"
 #include "data_types.hpp"
-#include "get_platform_architecture.hpp"
 #include "reflection.hpp"
 
 namespace tt::tt_metal {
@@ -46,10 +45,7 @@ private:
     DispatchCoreType type_;
     DispatchCoreAxis axis_;
 
-    static DispatchCoreAxis get_default_axis() {
-        return (tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE) ? DispatchCoreAxis::COL
-                                                                                  : DispatchCoreAxis::ROW;
-    }
+    static DispatchCoreAxis get_default_axis();
 
 public:
     DispatchCoreConfig() : type_(DispatchCoreType::WORKER), axis_(get_default_axis()) {}

--- a/tt_metal/api/tt-metalium/get_platform_architecture.hpp
+++ b/tt_metal/api/tt-metalium/get_platform_architecture.hpp
@@ -8,6 +8,7 @@
 
 #include "tt_backend_api_types.hpp"
 #include "assert.hpp"
+#include "rtoptions.hpp"
 #include "umd/device/pci_device.hpp"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/tt_simulation_device.h"
@@ -50,7 +51,7 @@ namespace tt::tt_metal {
 inline tt::ARCH get_platform_architecture() {
     auto arch = tt::ARCH::Invalid;
     if (std::getenv("TT_METAL_SIMULATOR")) {
-        tt_SimulationDeviceInit init(std::getenv("TT_METAL_SIMULATOR"));
+        tt_SimulationDeviceInit init(llrt::RunTimeOptions::get_instance().get_simulator_path());
         arch = init.get_arch_name();
     } else {
         // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.

--- a/tt_metal/api/tt-metalium/get_platform_architecture.hpp
+++ b/tt_metal/api/tt-metalium/get_platform_architecture.hpp
@@ -50,7 +50,7 @@ namespace tt::tt_metal {
  */
 inline tt::ARCH get_platform_architecture() {
     auto arch = tt::ARCH::Invalid;
-    if (std::getenv("TT_METAL_SIMULATOR")) {
+    if (llrt::RunTimeOptions::get_instance().get_simulator_enabled()) {
         tt_SimulationDeviceInit init(llrt::RunTimeOptions::get_instance().get_simulator_path());
         arch = init.get_arch_name();
     } else {

--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -130,7 +130,7 @@ class RunTimeOptions {
     // This option will enable this feature to help flush out whether there is a missing cache invalidation
     bool enable_hw_cache_invalidation = false;
 
-    tt_metal::DispatchCoreConfig dispatch_core_config = tt_metal::DispatchCoreConfig{};
+    tt_metal::DispatchCoreType dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
 
     bool skip_deleting_built_cache = false;
 
@@ -309,7 +309,7 @@ public:
 
     inline bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
 
-    inline tt_metal::DispatchCoreConfig get_dispatch_core_config() { return dispatch_core_config; }
+    tt_metal::DispatchCoreConfig get_dispatch_core_config();
 
     inline bool get_skip_deleting_built_cache() { return skip_deleting_built_cache; }
 

--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 #include "core_coord.hpp"
-#include "dispatch_core_manager.hpp"
+#include "dispatch_core_manager.hpp"       // For DispatchCoreConfig
 #include "umd/device/tt_soc_descriptor.h"  // For CoreType
 
 namespace tt {
@@ -133,6 +133,9 @@ class RunTimeOptions {
     tt_metal::DispatchCoreConfig dispatch_core_config = tt_metal::DispatchCoreConfig{};
 
     bool skip_deleting_built_cache = false;
+
+    bool simulator_enabled = false;
+    std::filesystem::path simulator_path = "";
 
     RunTimeOptions();
 
@@ -309,6 +312,9 @@ public:
     inline tt_metal::DispatchCoreConfig get_dispatch_core_config() { return dispatch_core_config; }
 
     inline bool get_skip_deleting_built_cache() { return skip_deleting_built_cache; }
+
+    inline bool get_simulator_enabled() { return simulator_enabled; }
+    inline const std::filesystem::path& get_simulator_path() { return simulator_path; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -24,6 +24,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/host_runtime_commands.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_query_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_core_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/hardware_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/launch_message_ring_buffer_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dispatch_core_manager.hpp"
+#include "dispatch_core_common.hpp"
+#include "get_platform_architecture.hpp"
+
+namespace tt::tt_metal {
+
+DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
+    return (tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE) ? DispatchCoreAxis::COL
+                                                                              : DispatchCoreAxis::ROW;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -219,7 +219,7 @@ void wait_until_cores_done(
     // poll the cores until the set of not done cores is empty
     int loop_count = 1;
     auto start = std::chrono::high_resolution_clock::now();
-    bool is_simulator = std::getenv("TT_METAL_SIMULATOR") != nullptr;
+    bool is_simulator = llrt::RunTimeOptions::get_instance().get_simulator_enabled();
 
     if (is_simulator) timeout_ms = 0;
     while (!not_done_phys_cores.empty()) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -115,7 +115,7 @@ RunTimeOptions::RunTimeOptions() {
     }
 
     if (getenv("TT_METAL_GTEST_ETH_DISPATCH")) {
-        this->dispatch_core_config.set_dispatch_core_type(tt_metal::DispatchCoreType::ETH);
+        this->dispatch_core_type = tt_metal::DispatchCoreType::ETH;
     }
 
     if (getenv("TT_METAL_SKIP_LOADING_FW")) {
@@ -379,6 +379,14 @@ void RunTimeOptions::ParseFeaturePrependDeviceCoreRisc(RunTimeDebugFeatures feat
     char *env_var_str = std::getenv(env_var.c_str());
     feature_targets[feature].prepend_device_core_risc =
         (env_var_str != nullptr) ? (strcmp(env_var_str, "1") == 0) : true;
+}
+
+// Can't create a DispatchCoreConfig as part of the RTOptions constructor because the DispatchCoreConfig constructor
+// depends on RTOptions settings.
+tt_metal::DispatchCoreConfig RunTimeOptions::get_dispatch_core_config() {
+    tt_metal::DispatchCoreConfig dispatch_core_config = tt_metal::DispatchCoreConfig{};
+    dispatch_core_config.set_dispatch_core_type(this->dispatch_core_type);
+    return dispatch_core_config;
 }
 
 }  // namespace llrt

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -127,6 +127,11 @@ RunTimeOptions::RunTimeOptions() {
     }
 
     this->enable_hw_cache_invalidation = (std::getenv("TT_METAL_ENABLE_HW_CACHE_INVALIDATION") != nullptr);
+
+    if (std::getenv("TT_METAL_SIMULATOR")) {
+        this->simulator_enabled = true;
+        this->simulator_path = std::getenv("TT_METAL_SIMULATOR");
+    }
 }
 
 const std::string& RunTimeOptions::get_root_dir() {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -119,8 +119,8 @@ Cluster::Cluster() {
 }
 
 void Cluster::detect_arch_and_target() {
-
-    this->target_type_ = (std::getenv("TT_METAL_SIMULATOR")) ? TargetDevice::Simulator : TargetDevice::Silicon;
+    this->target_type_ = (llrt::RunTimeOptions::get_instance().get_simulator_enabled()) ? TargetDevice::Simulator
+                                                                                        : TargetDevice::Silicon;
 
     this->arch_ = tt_metal::get_platform_architecture();
 
@@ -267,7 +267,7 @@ void Cluster::open_driver(const bool &skip_driver_allocs) {
         // that is later expected to be populated by unrelated APIs
         // TT_FATAL(device_driver->get_target_mmio_device_ids().size() == 1, "Only one target mmio device id allowed.");
     } else if (this->target_type_ == TargetDevice::Simulator) {
-        auto simulator_directory = std::getenv("TT_METAL_SIMULATOR");
+        auto simulator_directory = llrt::RunTimeOptions::get_instance().get_simulator_path();
         device_driver = std::make_unique<tt_SimulationDevice>(simulator_directory);
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/tenstorrent/tt-metal/pull/16375, cleans up the uses of TT_METAL_SIMULATOR and moves that setting into RTOptions. Required a bit of header file cleanup.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/13107473655
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
