### PR TITLE
#17203: Remove set_worker_queue_mode method from `IDevice`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn_multi_command_queue_fixture.hpp"
 #include <tt-metalium/tt_metal.hpp>
@@ -19,6 +20,7 @@ namespace {
 
 using ::testing::FloatEq;
 using ::testing::Pointwise;
+using ::tt::tt_metal::is_tensor_on_device;
 
 using MultiProducerCommandQueueTest = ttnn::MultiCommandQueueSingleDeviceFixture;
 
@@ -30,7 +32,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     // Enable async engine and set queue setting to lock_based
     device->enable_async(true);
 
-    const ttnn::SimpleShape tensor_shape{1, 1, 1024, 1024};
+    const ttnn::Shape tensor_shape{1, 1, 1024, 1024};
     const MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -81,7 +83,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
     // Enable async engine and set queue setting to lock_based
     device->enable_async(true);
 
-    const ttnn::SimpleShape tensor_shape{1, 1, 1024, 1024};
+    const ttnn::Shape tensor_shape{1, 1, 1024, 1024};
     const MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -2,91 +2,67 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <numeric>
+#include <thread>
+#include <gmock/gmock.h>
+
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn_multi_command_queue_fixture.hpp"
 #include <tt-metalium/tt_metal.hpp>
-#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include "ttnn/async_runtime.hpp"
-#include "ttnn/operations/functions.hpp"
 #include <tt-metalium/event.hpp>
-#include <cmath>
-#include <thread>
 
-using namespace tt;
-using namespace tt_metal;
-using MultiCommandQueueSingleDeviceFixture = ttnn::MultiCommandQueueSingleDeviceFixture;
-using namespace constants;
+namespace tt::tt_metal {
+namespace {
 
-TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiProducerLockBasedQueue) {
+using ::testing::FloatEq;
+using ::testing::Pointwise;
+
+using MultiProducerCommandQueueTest = ttnn::MultiCommandQueueSingleDeviceFixture;
+
+TEST_F(MultiProducerCommandQueueTest, Stress) {
     // Spawn 2 application level threads intefacing with the same device through the async engine.
     // This leads to shared access of the work_executor and host side worker queue.
     // Test thread safety.
     IDevice* device = this->device_;
     // Enable async engine and set queue setting to lock_based
     device->enable_async(true);
-    device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
 
-    MemoryConfig mem_cfg = MemoryConfig{
+    const ttnn::SimpleShape tensor_shape{1, 1, 1024, 1024};
+    const MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
         .shard_spec = std::nullopt};
+    const TensorLayout tensor_layout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), mem_cfg);
+    const TensorSpec tensor_spec(tensor_shape, tensor_layout);
+
     // Thread 0 uses cq_0, thread 1 uses cq_1
-    uint32_t t0_io_cq = 0;
-    uint32_t t1_io_cq = 1;
-    uint32_t tensor_buf_size = 1024 * 1024;
-    uint32_t datum_size_bytes = 2;
+    const uint32_t t0_io_cq = 0;
+    const uint32_t t1_io_cq = 1;
 
-    ttnn::Shape tensor_shape{1, 1, 1024, 1024};
-    auto t0_host_data = std::shared_ptr<bfloat16[]>(new bfloat16[tensor_buf_size]);
-    auto t0_readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[tensor_buf_size]);
-    auto t1_host_data = std::shared_ptr<bfloat16[]>(new bfloat16[tensor_buf_size]);
-    auto t1_readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[tensor_buf_size]);
+    std::vector<float> t0_host_data(tensor_shape.volume());
+    std::vector<float> t1_host_data(tensor_shape.volume());
+    std::iota(t0_host_data.begin(), t0_host_data.end(), 1024);
+    std::iota(t1_host_data.begin(), t1_host_data.end(), 2048);
 
-    // Application level threads issue writes and readbacks.
+    const Tensor t0_host_tensor = Tensor::from_vector(t0_host_data, tensor_spec);
+    const Tensor t1_host_tensor = Tensor::from_vector(t1_host_data, tensor_spec);
+
     std::thread t0([&]() {
         for (int j = 0; j < 100; j++) {
-            // Initialize data
-            for (int i = 0; i < tensor_buf_size; i++) {
-                t0_host_data[i] = bfloat16(static_cast<float>(2 + j));
-            }
-            // Allocate and write buffer
-            tt_metal::TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
-            tt_metal::TensorSpec tensor_spec(tensor_shape, tensor_layout);
-            ASSERT_EQ(tensor_buf_size * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
-            auto t0_input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
-            auto t0_input_storage = tt::tt_metal::DeviceStorage{t0_input_buffer};
-            Tensor t0_input_tensor = Tensor(t0_input_storage, tensor_shape, DataType::BFLOAT16, Layout::TILE);
-            ttnn::write_buffer(t0_io_cq, t0_input_tensor, {t0_host_data});
-            // Readback and verify
-            ttnn::read_buffer(t0_io_cq, t0_input_tensor, {t0_readback_data});
-            t0_input_tensor.deallocate();
-            for (int i = 0; i < tensor_buf_size; i++) {
-                EXPECT_EQ(t0_readback_data[i], t0_host_data[i]);
-            }
+            Tensor t0_tensor = t0_host_tensor.to(device, mem_cfg, t0_io_cq);
+            EXPECT_TRUE(is_tensor_on_device(t0_tensor));
+            EXPECT_THAT(t0_tensor.to_vector<float>(), Pointwise(FloatEq(), t0_host_data));
         }
     });
 
     std::thread t1([&]() {
-        TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
-        TensorSpec tensor_spec(tensor_shape, tensor_layout);
-        ASSERT_EQ(tensor_buf_size * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
         for (int j = 0; j < 100; j++) {
-            for (int i = 0; i < tensor_buf_size; i++) {
-                t1_host_data[i] = bfloat16(static_cast<float>(4 + j));
-            }
-            auto t1_input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
-            auto t1_input_storage = tt::tt_metal::DeviceStorage{t1_input_buffer};
-            Tensor t1_input_tensor = Tensor(t1_input_storage, tensor_shape, DataType::BFLOAT16, Layout::TILE);
-
-            ttnn::write_buffer(t1_io_cq, t1_input_tensor, {t1_host_data});
-            ttnn::read_buffer(t1_io_cq, t1_input_tensor, {t1_readback_data});
-
-            t1_input_tensor.deallocate();
-            for (int i = 0; i < tensor_buf_size; i++) {
-                EXPECT_EQ(t1_readback_data[i], t1_host_data[i]);
-            }
+            Tensor t1_tensor = t1_host_tensor.to(device, mem_cfg, t1_io_cq);
+            EXPECT_TRUE(is_tensor_on_device(t1_tensor));
+            EXPECT_THAT(t1_tensor.to_vector<float>(), Pointwise(FloatEq(), t1_host_data));
         }
     });
 
@@ -94,7 +70,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiProducerLockBasedQueue) {
     t1.join();
 }
 
-TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
+TEST_F(MultiProducerCommandQueueTest, EventSync) {
     // Verify that the event_synchronize API stalls the calling thread until
     // the device records the event being polled.
     // Thread 0 = writer thread. Thread 1 = reader thread.
@@ -104,28 +80,24 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
     IDevice* device = this->device_;
     // Enable async engine and set queue setting to lock_based
     device->enable_async(true);
-    device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
 
-    MemoryConfig mem_cfg = MemoryConfig{
+    const ttnn::SimpleShape tensor_shape{1, 1, 1024, 1024};
+    const MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
         .shard_spec = std::nullopt};
-    uint32_t write_cq = 0;
-    uint32_t read_cq = 0;
-    uint32_t tensor_buf_size = 1024 * 1024;
-    uint32_t datum_size_bytes = 2;
+    const TensorLayout tensor_layout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), mem_cfg);
+    const TensorSpec tensor_spec(tensor_shape, tensor_layout);
+
+    const uint32_t write_cq = 0;
+    const uint32_t read_cq = 1;
 
     std::shared_ptr<Event> write_event = std::make_shared<Event>();
     std::shared_ptr<Event> read_event = std::make_shared<Event>();
 
-    ttnn::Shape tensor_shape{1, 1, 1024, 1024};
-    auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[tensor_buf_size]);
-    TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
-    auto allocated_buffer =
-        tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, TensorSpec(tensor_shape, tensor_layout));
-    auto allocated_storage = tt::tt_metal::DeviceStorage{allocated_buffer};
-    auto allocated_tensor = Tensor(allocated_storage, tensor_shape, DataType::BFLOAT16, Layout::TILE);
-    auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[tensor_buf_size]);
+    std::vector<float> host_data(tensor_shape.volume());
+    std::iota(host_data.begin(), host_data.end(), 0);
+    Tensor device_tensor = create_device_tensor(tensor_spec, device);
 
     std::thread t0([&]() {
         for (int j = 0; j < 1000; j++) {
@@ -133,10 +105,12 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
                 ttnn::event_synchronize(read_event);
             }
             read_event = std::make_shared<Event>();
-            for (int i = 0; i < tensor_buf_size; i++) {
-                host_data[i] = bfloat16(static_cast<float>(2 + j));
-            }
-            ttnn::write_buffer(write_cq, allocated_tensor, {host_data});
+
+            // Create tensor and transfer to device
+            const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
+            memcpy(device->command_queue(write_cq), device_tensor, host_tensor);
+            EXPECT_TRUE(is_tensor_on_device(device_tensor));
+
             ttnn::record_event(device->command_queue(write_cq), write_event);
         }
     });
@@ -145,10 +119,12 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
         for (int j = 0; j < 1000; j++) {
             ttnn::event_synchronize(write_event);
             write_event = std::make_shared<Event>();
-            ttnn::read_buffer(read_cq, allocated_tensor, {readback_data});
-            for (int i = 0; i < tensor_buf_size; i++) {
-                EXPECT_EQ(readback_data[i], host_data[i]);
-            }
+
+            // Read back from device and verify
+            const Tensor readback_tensor = device_tensor.cpu(/*blocking=*/false, read_cq);
+            EXPECT_FALSE(is_tensor_on_device(readback_tensor));
+            EXPECT_THAT(readback_tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
+
             ttnn::record_event(device->command_queue(read_cq), read_event);
         }
     });
@@ -156,3 +132,6 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
     t0.join();
     t1.join();
 }
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -165,7 +165,6 @@ public:
     virtual void enable_async(bool enable) = 0;
     virtual void synchronize() = 0;
     virtual WorkExecutorMode get_worker_mode() = 0;
-    virtual void set_worker_queue_mode(const WorkerQueueMode& mode) = 0;
     virtual bool is_worker_queue_empty() const = 0;
 
     virtual void push_work(std::function<void()> work, bool blocking = false) = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -157,9 +157,6 @@ public:
     void enable_async(bool enable) override;
     void synchronize() override;
     WorkExecutorMode get_worker_mode() override { return work_executor_.get_worker_mode(); }
-    void set_worker_queue_mode(const WorkerQueueMode& mode) override {
-        this->work_executor_.set_worker_queue_mode(mode);
-    }
     bool is_worker_queue_empty() const override { return work_executor_.worker_queue.empty(); }
 
     void push_work(std::function<void()> work, bool blocking) override;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -161,7 +161,6 @@ public:
     void enable_async(bool enable) override;
     void synchronize() override;
     WorkExecutorMode get_worker_mode() override;
-    void set_worker_queue_mode(const WorkerQueueMode& mode) override;
     bool is_worker_queue_empty() const override;
     void push_work(std::function<void()> work, bool blocking) override;
     void enable_program_cache() override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -641,7 +641,6 @@ void MeshDevice::synchronize() {
     // Nothing to synchronize, as all work is executed by MeshDevice is synchronous.
 }
 WorkExecutorMode MeshDevice::get_worker_mode() { return WorkExecutorMode::SYNCHRONOUS; }
-void MeshDevice::set_worker_queue_mode(const WorkerQueueMode& mode) {}
 bool MeshDevice::is_worker_queue_empty() const { return true; }
 void MeshDevice::push_work(std::function<void()> work, bool blocking) {
     // Execute inline synchronously.

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -12,7 +12,7 @@
 #include "command_queue.hpp"
 #include "host_runtime_commands.hpp"
 #include "command_queue_interface.hpp"
-#include "lock_free_queue.hpp"
+#include "multi_producer_single_consumer_queue.hpp"
 #include "worker_config_buffer.hpp"
 #include "program_impl.hpp"
 #include "trace_buffer.hpp"
@@ -116,7 +116,7 @@ private:
     volatile uint32_t num_completed_completion_q_reads;  // completion queue reader thread increments this after reading
                                                          // an entry out of the completion queue
 
-    LockFreeQueue<CompletionReaderVariant> issued_completion_q_reads;
+    MultiProducerSingleConsumerQueue<CompletionReaderVariant> issued_completion_q_reads;
     // These values are used to reset the host side launch message wptr after a trace is captured
     // Trace capture is a fully host side operation, but it modifies the state of the wptrs above
     // To ensure that host and device are not out of sync, we reset the wptrs to their original values

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -18,7 +18,7 @@
 #include "command_queue_interface.hpp"
 #include <tt-metalium/dispatch_settings.hpp>
 #include "device_command.hpp"
-#include "lock_free_queue.hpp"
+#include "multi_producer_single_consumer_queue.hpp"
 #include "program_command_sequence.hpp"
 #include "worker_config_buffer.hpp"
 #include "program_impl.hpp"


### PR DESCRIPTION
### Ticket
#17203

### Problem description
"Queue mode" of a device refers to whether the underlying executor queue acquires a lock in the `push` methods. This allows for multiple producers using the `push_work` method from multiple thread.

This is a low level implementation detail that should not be exposed to users - the default behavior should assume there could be multiple producer threads. Assuming the performance difference is negligible, the code can be simplified to disallow this customization.

### What's changed
1. Remove `IDevice:: set_worker_queue_mode` and further the concept of "queue mode" by forcing `LockFreeQueue` to always lock, assuming there could be multiple producers. Assume that the overhead of acquiring and releasing an uncontended mutex is negligible, if there is just a single producer thread.
2. Accordingly, rename `LockFreeQueue` to `MultiProducerSingleConsumerQueue`, to highlight the use case.
3. Re-wrote `test_multiprod_queue.cpp` using the new high-level `to_vector` / `from_vector` APIs.

Important context: there are 2 usages of `MultiProducerSingleConsumerQueue` in the codebase: `HWCommandQueue` and `WorkExecutor` inside of a device. Both use cases use conditional variables along with a mutex to signal the reader thread there is work in the queue. Practically speaking, every time we push to `MultiProducerSingleConsumerQueue` we already acquire a mutex. References:
1. https://github.com/tenstorrent/tt-metal/blob/1fe0579aeb2a52b038dedceb6115e25e82cbd5e5/tt_metal/impl/dispatch/hardware_command_queue.cpp#L272-L275
2. https://github.com/tenstorrent/tt-metal/blob/1fe0579aeb2a52b038dedceb6115e25e82cbd5e5/tt_metal/api/tt-metalium/work_executor.hpp#L157-L160

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13081100549) - one known failure fixed in https://github.com/tenstorrent/tt-metal/pull/17455
- [X] New/Existing tests provide coverage for changes
- [x] Model perf tests - [single card](https://github.com/tenstorrent/tt-metal/actions/runs/13093035066) [T3K](https://github.com/tenstorrent/tt-metal/actions/runs/13093036855)
- [X] [T3K model tests](https://github.com/tenstorrent/tt-metal/actions/runs/13122623363/job/36612104956) - failure in falcon 40b is the same as on main.
- [X] [TG perf](https://github.com/tenstorrent/tt-metal/actions/runs/13122575184) - the failing tests are broken on main.
