### PR TITLE
#0: Fix dispatch core settings to use the actual remote device when accessing the core grid

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -145,13 +145,8 @@ void DispatchKernel::GenerateStaticConfigs() {
         dependent_config_.prefetch_h_local_downstream_sem_addr = 1;
         static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
 
-        // To match with previous implementation, need to use grid size from mmio device. TODO: that doesn't seem
-        // correct though?
-        auto mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id_);
-        const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(mmio_device_id);
-        CoreCoord remote_grid_size =
-            tt::get_compute_grid_size(mmio_device_id, device_->num_hw_cqs(), dispatch_core_config);
-        static_config_.packed_write_max_unicast_sub_cmds = remote_grid_size.x * remote_grid_size.y;
+        static_config_.packed_write_max_unicast_sub_cmds =
+            device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
         static_config_.dispatch_s_sync_sem_base_addr =
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
         static_config_.max_num_worker_sems = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
On galaxy, the dispatch cores were reporting the wrong unicast cmd size, resulting in watcher asserts. This was due to us calculating the size using the gateway/mmio device, instead of the actual remote device.

### What's changed
Use the remote device core grid instead of the mmio device.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
