### PR TITLE
De-duplicate build-docker-artifact in workflows

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -51,28 +51,14 @@ jobs:
     with:
       from-precompiled: true
     secrets: inherit
-  build-docker-image-2004:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
-    with:
-      os: ubuntu-20.04-amd64
-  build-docker-image-2204:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
-    with:
-      os: ubuntu-22.04-amd64
   build-artifact:
-    needs: build-docker-image-2004
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
-      build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
   build-artifact-profiler:
-    needs: build-docker-image-2004
     uses: ./.github/workflows/build-artifact.yaml
     with:
-      build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
       tracy: true
     secrets: inherit
@@ -158,12 +144,10 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
   code-analysis:
-    needs: build-docker-image-2204
     uses: ./.github/workflows/code-analysis.yaml
     secrets: inherit
     with:
       os: ubuntu-22.04-amd64
-      build-docker: false
   tt-train-cpp-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -188,7 +172,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
   build:
-    needs: [build-artifact, build-docker-image-2204]
+    needs: build-artifact
     uses: ./.github/workflows/build.yaml
     secrets: inherit
   # We used to use this for post-commit, but we didn't have enough runners

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -33,18 +33,11 @@ jobs:
   static-checks:
     uses: ./.github/workflows/all-static-checks.yaml
     secrets: inherit
-  build-docker-image:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
-    with:
-      os: "ubuntu-22.04-amd64"
   build-artifact:
-    needs: build-docker-image
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
       os: "ubuntu-22.04-amd64"
-      build-docker: false
   build-wheels:
     needs: build-artifact
     uses: ./.github/workflows/_build-wheels-impl.yaml

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -16,18 +16,28 @@ on:
         required: false
         type: string
         default: "ubuntu-20.04-amd64"
-      build-docker:
+      toolchain:
+        required: false
+        type: string
+        default: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+        description: "Toolchain file to use for build"
+      publish-artifact:
         required: false
         type: boolean
         default: true
-        description: "Build docker image"
+        # FIXME(afuller): We need to fix our artifact naming to avoid conflicts if we
+        #     wish to make builds of differing types available in a single workflow.
+        description: "Make resulting artifact available in the workflow"
+      skip-tt-train:
+        # FIXME: TT-Train needs to get fixed to not assume a specific toolchain.
+        #        Fow now enabling an opt-out. But this should get removed.
+        required: false
+        type: boolean
+        default: false
+
+
   workflow_dispatch:
     inputs:
-      build-docker:
-        required: false
-        type: boolean
-        default: true
-        description: "Build docker image"
       build-type:
         required: false
         type: string
@@ -45,15 +55,14 @@ on:
 
 jobs:
   build-docker-image:
-    if: ${{ inputs.build-docker == true }}
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
       os: ${{ inputs.os }}
 
   build-artifact:
+    name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.os }}"
     needs: build-docker-image
-    if: always()
     timeout-minutes: 30
     env:
       SILENT: 0
@@ -123,8 +132,10 @@ jobs:
             # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
             ccache -z
 
-            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache"
-            echo "${{ inputs.tracy }}"
+            args_fixme=$([ "${{ inputs.skip-tt-train }}" = "true" ] && echo "--build-metal-tests --build-ttnn-tests --build-programming-examples" || echo "--build-all")
+            echo "Args: ${args_fixme}"
+            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --toolchain-path ${{ inputs.toolchain }} ${args_fixme} --enable-ccache"
+            echo "Build tracy: ${{ inputs.tracy }}"
             if [ "${{ inputs.tracy }}" = "true" ]; then
               build_command="$build_command --enable-profiler"
             fi
@@ -137,8 +148,10 @@ jobs:
           cat build/ccache.stats >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: 'Tar files'
+        if: ${{ inputs.publish-artifact }}
         run: tar -cvhf ttm_any.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train data runtime
       - name: 'Upload Artifact'
+        if: ${{ inputs.publish-artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: TTMetal_build_any${{ (inputs.tracy && '_profiler') || '' }}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -18,6 +18,7 @@ on:
             - "ubuntu-22.04-amd64"
 jobs:
   build-docker-image:
+    name: "🐳️ Build ${{ inputs.os }} image"
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       CONFIG: ci

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -1,4 +1,4 @@
-name: "[post-commit] Build C++ binaries with all configs"
+name: "[deprecated] Build TT-Metalium across all configs"
 
 on:
   workflow_call:
@@ -13,20 +13,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  static-checks:
-    uses: ./.github/workflows/all-static-checks.yaml
-    secrets: inherit
-  build-docker-image-2004:
-    uses:  ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
-    with:
-      os: ubuntu-20.04-amd64
-  build-docker-image-2204:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
-    with:
-      os: ubuntu-22.04-amd64
   build:
-    needs: [build-docker-image-2004, build-docker-image-2204]
     uses: ./.github/workflows/build.yaml
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,91 +1,53 @@
-name: "[internal] Build C++ binaries with all configs impl"
+name: "Build TT-Metalium across all configs"
 
 on:
-  #TODO: If we want to run this via dispatch, will need to include build docker image workflow
-  #workflow_dispatch:
+  workflow_dispatch:
   workflow_call:
 
 jobs:
-  build-lib:
-    strategy:
-      fail-fast: false
-      matrix:
-        build: [
-          {type: Debug, toolchain: cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake, runs-on: ["build", "in-service"], os: ubuntu-20.04},
-          {type: RelWithDebInfo, toolchain: cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake, runs-on: ["build", "in-service"], os: ubuntu-20.04},
-          {type: Release, toolchain: cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake, runs-on: ["build", "in-service"], os: ubuntu-22.04},
-          {type: Release, toolchain: cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake, runs-on: ["build", "in-service"], os: ubuntu-22.04},
-          {type: Release, toolchain: cmake/x86_64-linux-gcc-12-toolchain.cmake, runs-on: ["build", "in-service"], os: ubuntu-22.04},
-        ]
-    env:
-      # So we can get all the makefile output we want
-      VERBOSE: 1
-    runs-on: ${{ matrix.build.runs-on }}
-    name: ${{ matrix.build.type }} ${{ matrix.build.toolchain }} any ${{ matrix.build.os }}
-    steps:
-      - name: Verify ccache availability
-        shell: bash
-        run: |
-          if [ ! -d "/mnt/MLPerf/ccache" ]; then
-            echo "::error title=ccache-mlperf-not-mounted::NFS drive is not mounted; build machine not properly provisioned."
-            exit 1
-          fi
-          if [ ! -d "$HOME/.ccache-ci" ]; then
-            echo "::error title=ccache-not-provisioned::Ccache is not properly provisioned."
-            exit 1
-          fi
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-          echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
-          echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
-      - name: Build C++ libraries and tests
-        uses: ./.github/actions/docker-run
-        with:
-          docker_username: ${{ github.actor }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            --group-add 1457
-            -v /home/ubuntu/.ccache-ci:/home/ubuntu/.ccache
-            -e CCACHE_DIR=/home/ubuntu/.ccache
-            -v /mnt/MLPerf/ccache:/mnt/MLPerf/ccache
-          docker_os_arch: tt-metalium/${{ matrix.build.os }}-amd64
-          run_args: |
-            set -eu # basic shell hygiene
-            set -x
+  ubuntu-2004-debug:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      os: "ubuntu-20.04-amd64"
+      toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+      build-type: "Debug"
+      publish-artifact: false
 
-            # /tmp is a tmpfs; more efficient than persisted storage
-            mkdir -p /tmp/ccache
-            export CCACHE_TEMPDIR=/tmp/ccache
+  ubuntu-2004-relwithdebinfo:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      os: "ubuntu-20.04-amd64"
+      toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+      build-type: "RelWithDebInfo"
+      publish-artifact: false
 
-            ccache --version
-            ccache --show-config
-            ccache --show-stats
+  ubuntu-2204-release:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      os: "ubuntu-22.04-amd64"
+      toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+      build-type: "Release"
+      publish-artifact: false
 
-            # Zero out the stats so we can see how we did this build
-            # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
-            ccache -z
+  ubuntu-2204-libstdcpp:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      os: "ubuntu-22.04-amd64"
+      toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+      build-type: "Release"
+      publish-artifact: false
+      skip-tt-train: true
 
-            build_command="./build_metal.sh --build-type ${{ matrix.build.type }} --toolchain-path ${{ matrix.build.toolchain }} --build-tests --build-programming-examples --disable-unity-builds --enable-ccache"
-            nice -n 19 $build_command
-
-            ccache --show-stats
-            mkdir out
-            ccache -s > out/ccache.stats
-            cat out/ccache.stats
-      - name: Publish Ccache summary
-        run: |
-          cat out/ccache.stats
-          echo '## CCache Summary' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat out/ccache.stats >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-      - name: Check disk space
-        run: |
-          df -h
-      - uses: ./.github/actions/slack-report
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U06CXU895AP # Michael Chiou
+  ubuntu-2204-gcc12:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      os: "ubuntu-22.04-amd64"
+      toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
+      build-type: "Release"
+      publish-artifact: false
+      skip-tt-train: true # FIXME

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -11,11 +11,6 @@ on:
         required: false
         type: boolean
         default: false
-      build-docker:
-        required: false
-        type: boolean
-        default: true
-        description: "Build docker image"
   workflow_dispatch:
     inputs:
       os:
@@ -26,24 +21,16 @@ on:
         required: false
         type: boolean
         default: false
-      build-docker:
-        required: false
-        type: boolean
-        default: true
-        description: "Build docker image"
 
 jobs:
   build-docker-image:
-    if: ${{ inputs.build-docker == true }}
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
       os: ${{ inputs.os }}
 
-
   clang-tidy:
     needs: build-docker-image
-    if: always()
     env:
       ARCH_NAME: wormhole_b0
     runs-on:

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -22,24 +22,15 @@ permissions:
   packages: write
 
 jobs:
-  build-docker-image-2004:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
-    with:
-      os: ubuntu-20.04-amd64
   build-artifact:
-    needs: build-docker-image-2004
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
-      build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
   build-artifact-profiler:
-    needs: build-docker-image-2004
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
-      build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
     secrets: inherit
   device-perf-single-card:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -11,21 +11,13 @@ permissions:
   packages: write
 
 jobs:
-  build-docker-image:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
   build-artifact:
-    needs: build-docker-image
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-    with:
-      build-docker: false
   build-artifact-profiler:
-    needs: build-docker-image
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
-      build-docker: false
   single-card-demos:
     needs: build-artifact
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml


### PR DESCRIPTION
### Ticket
Fixes #17110

### Problem description
The build is non-cancellable in the workflows because of `if: always()`.
That is present because of duplication of `build-docker-image`.
That was there probably to be more efficient when we had `ARCH_NAME`.  No longer relevant.

### What's changed
* Removed `if: always()` from build-artifact
* Removed the option to skip the docker build in build-artifact
* Deleted all the docker builds in workflows that invoke build-artifact
* Improved some names to make the GHA UI slightly less bad
* TECH-DEBT: TT-Train doesn't handle libstdc++, avoided touching that combination for now

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12961060155)
- [x] [Blackhole Post commit (if applicable)](https://github.com/tenstorrent/tt-metal/actions/runs/12961156117)
- [x] [Full new models tests passes](https://github.com/tenstorrent/tt-metal/actions/runs/12961160001)
- [ ] Package And Release workflow works
