### PR TITLE
#0: Use MeshBuffer to store MeshWorkload kernel binaries

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -325,9 +325,9 @@ std::shared_ptr<Program> initialize_dummy_program(CoreCoord worker_grid_size) {
 
 std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
     std::shared_ptr<MeshDevice>& mesh_device,
-    std::vector<std::shared_ptr<Buffer>>& src0_bufs,
-    std::vector<std::shared_ptr<Buffer>>& src1_bufs,
-    std::vector<std::shared_ptr<Buffer>>& output_bufs) {
+    std::vector<std::shared_ptr<MeshBuffer>>& src0_bufs,
+    std::vector<std::shared_ptr<MeshBuffer>>& src1_bufs,
+    std::vector<std::shared_ptr<MeshBuffer>>& output_bufs) {
     const std::vector<std::string> op_id_to_op_define = {"add_tiles", "mul_tiles"};
     const std::vector<std::string> op_id_to_op_type_define = {"EltwiseBinaryType::ELWADD", "EltwiseBinaryType::ELWMUL"};
 
@@ -344,23 +344,26 @@ std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
             single_tile_size * num_tiles;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t page_size = single_tile_size;
 
-        for (auto device : mesh_device->get_devices()) {
-            tt_metal::InterleavedBufferConfig dram_config{
-                .device = device,
-                .size = dram_buffer_size,
-                .page_size = page_size,
-                .buffer_type = tt_metal::BufferType::DRAM};
-            for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
-                for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                    auto src0_dram_buffer = CreateBuffer(dram_config);
-                    src0_bufs.push_back(src0_dram_buffer);
+        ReplicatedBufferConfig global_buffer_config{.size = dram_buffer_size};
+        DeviceLocalBufferConfig per_device_buffer_config{
+            .page_size = page_size,
+            .buffer_type = tt_metal::BufferType::DRAM,
+            .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+            .bottom_up = true};
 
-                    auto src1_dram_buffer = CreateBuffer(dram_config);
-                    src1_bufs.push_back(src1_dram_buffer);
+        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+                auto src0_dram_buffer =
+                    MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device.get());
+                src0_bufs.push_back(src0_dram_buffer);
 
-                    auto dst_dram_buffer = CreateBuffer(dram_config);
-                    output_bufs.push_back(dst_dram_buffer);
-                }
+                auto src1_dram_buffer =
+                    MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device.get());
+                src1_bufs.push_back(src1_dram_buffer);
+
+                auto dst_dram_buffer =
+                    MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device.get());
+                output_bufs.push_back(dst_dram_buffer);
             }
         }
 
@@ -505,7 +508,7 @@ void validate_sems(
 
 using MeshWorkloadTest = T3000MultiDeviceFixture;
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadOnActiveEth) {
+TEST_F(MeshWorkloadTest, MeshWorkloadOnActiveEth) {
     uint32_t num_workloads = 10;
     auto random_seed = 0;
     uint32_t num_iters = 500;
@@ -537,7 +540,7 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadOnActiveEth) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadMixedTensixEth) {
+TEST_F(MeshWorkloadTest, MeshWorkloadMixedTensixEth) {
     uint32_t num_workloads = 20;
     auto random_seed = 0;
     uint32_t num_iters = 30;
@@ -587,7 +590,7 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadMixedTensixEth) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadOnActiveEthRandomGridSize) {
+TEST_F(MeshWorkloadTest, MeshWorkloadOnActiveEthRandomGridSize) {
     uint32_t num_workloads = 30;
     auto random_seed = 0;
     uint32_t num_iters = 500;
@@ -624,7 +627,7 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadOnActiveEthRandomGridSize) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshWorkloadTest, TestSimultaneousMeshWorkloads) {
+TEST_F(MeshWorkloadTest, SimultaneousMeshWorkloads) {
     uint32_t num_programs = 100;
     uint32_t num_heterogeneous_programs = 64;
     uint32_t num_iterations = 1000;
@@ -704,7 +707,7 @@ TEST_F(MeshWorkloadTest, TestSimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshWorkloadTest, TestRandomizedMeshWorkload) {
+TEST_F(MeshWorkloadTest, RandomizedMeshWorkload) {
     uint32_t num_programs = 60;
     uint32_t num_iterations = 1500;
     auto random_seed = 10;
@@ -741,10 +744,10 @@ TEST_F(MeshWorkloadTest, TestRandomizedMeshWorkload) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshWorkloadTest, TestEltwiseBinaryMeshWorkload) {
-    std::vector<std::shared_ptr<Buffer>> src0_bufs = {};
-    std::vector<std::shared_ptr<Buffer>> src1_bufs = {};
-    std::vector<std::shared_ptr<Buffer>> output_bufs = {};
+TEST_F(MeshWorkloadTest, EltwiseBinaryMeshWorkload) {
+    std::vector<std::shared_ptr<MeshBuffer>> src0_bufs = {};
+    std::vector<std::shared_ptr<MeshBuffer>> src1_bufs = {};
+    std::vector<std::shared_ptr<MeshBuffer>> output_bufs = {};
 
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
 
@@ -755,66 +758,74 @@ TEST_F(MeshWorkloadTest, TestEltwiseBinaryMeshWorkload) {
     AddProgramToMeshWorkload(mesh_workload, *programs[0], devices_0);
     AddProgramToMeshWorkload(mesh_workload, *programs[1], devices_1);
     std::vector<uint32_t> src0_vec = create_constant_vector_of_bfloat16(src0_bufs[0]->size(), 2);
-    std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(src0_bufs[0]->size(), 3);
+    std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(src1_bufs[0]->size(), 3);
 
-    uint32_t buffer_idx = 0;
-    for (auto device : mesh_device_->get_devices()) {
-        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
-            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                EnqueueWriteBuffer(device->command_queue(), src0_bufs.at(buffer_idx), src0_vec, false);
-                EnqueueWriteBuffer(device->command_queue(), src1_bufs.at(buffer_idx), src1_vec, false);
-                buffer_idx++;
-            }
+    for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+        for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+            EnqueueWriteMeshBuffer(
+                mesh_device_->mesh_command_queue(), src0_bufs[col_idx * worker_grid_size.y + row_idx], src0_vec);
+            EnqueueWriteMeshBuffer(
+                mesh_device_->mesh_command_queue(), src1_bufs[col_idx * worker_grid_size.y + row_idx], src1_vec);
         }
     }
+
     // Run workload multiple times
     for (int i = 0; i < 1000; i++) {
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     }
 
-    buffer_idx = 0;
-    uint32_t dev_idx = 0;
-    for (auto device : mesh_device_->get_devices()) {
-        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
-            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                std::vector<bfloat16> dst_vec = {};
-                EnqueueReadBuffer(device->command_queue(), output_bufs.at(buffer_idx), dst_vec, true);
-                if (dev_idx < 4) {
-                    for (int i = 0; i < dst_vec.size(); i++) {
-                        EXPECT_EQ(dst_vec[i].to_float(), 5);
-                    }
-                } else {
-                    for (int i = 0; i < dst_vec.size(); i++) {
-                        EXPECT_EQ(dst_vec[i].to_float(), 6);
+    for (std::size_t logical_y = 0; logical_y < mesh_device_->num_rows(); logical_y++) {
+        for (std::size_t logical_x = 0; logical_x < mesh_device_->num_cols(); logical_x++) {
+            for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+                for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+                    std::vector<bfloat16> dst_vec = {};
+                    ReadShard(
+                        mesh_device_->mesh_command_queue(),
+                        dst_vec,
+                        output_bufs[col_idx * worker_grid_size.y + row_idx],
+                        Coordinate(logical_y, logical_x));
+                    if (logical_y == 0) {
+                        for (int i = 0; i < dst_vec.size(); i++) {
+                            EXPECT_EQ(dst_vec[i].to_float(), 5);
+                        }
+                    } else {
+                        for (int i = 0; i < dst_vec.size(); i++) {
+                            EXPECT_EQ(dst_vec[i].to_float(), 6);
+                        }
                     }
                 }
-                buffer_idx++;
             }
         }
-        dev_idx++;
     }
 }
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadSanity) {
+TEST_F(MeshWorkloadTest, MeshWorkloadSanity) {
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::Float16_b);
 
     uint32_t num_tiles = 1;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     // Create buffers
-    std::vector<std::shared_ptr<Buffer>> input_buffers = {};
-    std::vector<std::shared_ptr<Buffer>> output_buffers = {};
-    for (auto device : mesh_device_->get_devices()) {
-        InterleavedBufferConfig dram_config{
-            .device = device, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    std::vector<std::shared_ptr<MeshBuffer>> input_buffers = {};
+    std::vector<std::shared_ptr<MeshBuffer>> output_buffers = {};
 
-        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
-            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                input_buffers.push_back(CreateBuffer(dram_config));
-                output_buffers.push_back(CreateBuffer(dram_config));
-            }
+    ReplicatedBufferConfig global_buffer_config{.size = dram_buffer_size};
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = dram_buffer_size,
+        .buffer_type = tt_metal::BufferType::DRAM,
+        .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+        .bottom_up = true};
+
+    for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+        for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+            input_buffers.push_back(
+                MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get()));
+            output_buffers.push_back(
+                MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get()));
         }
     }
+
     // Create MeshWorkload
     Program program = CreateProgram();
     auto full_grid = CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -860,19 +871,11 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadSanity) {
 
     std::size_t buffer_idx = 0;
     std::vector<uint32_t> src_vec = create_constant_vector_of_bfloat16(dram_buffer_size, 1);
-    for (auto device : mesh_device_->get_devices()) {
-        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
-            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                EnqueueWriteBuffer(device->command_queue(), input_buffers.at(buffer_idx), src_vec, false);
-                buffer_idx++;
-            }
-        }
-    }
-    std::unordered_set<uint32_t> devices_with_output_populated = {};
 
-    for (std::size_t logical_x = devices_0.start_coord.x; logical_x < devices_0.end_coord.x; logical_x++) {
-        for (std::size_t logical_y = devices_0.start_coord.y; logical_y < devices_0.end_coord.y; logical_y++) {
-            devices_with_output_populated.insert(mesh_device_->get_device(logical_y, logical_x)->id());
+    for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+        for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+            EnqueueWriteMeshBuffer(
+                mesh_device_->mesh_command_queue(), input_buffers[col_idx * worker_grid_size.y + row_idx], src_vec);
         }
     }
 
@@ -887,13 +890,16 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadSanity) {
         }
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
         buffer_idx = 0;
-        for (auto device : mesh_device_->get_devices()) {
-            for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
-                for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                    std::vector<bfloat16> dst_vec = {};
-                    EnqueueReadBuffer(device->command_queue(), output_buffers.at(buffer_idx), dst_vec, true);
-                    buffer_idx++;
-                    if (devices_with_output_populated.find(device->id()) != devices_with_output_populated.end()) {
+        for (std::size_t logical_x = devices_0.start_coord.x; logical_x < devices_0.end_coord.x; logical_x++) {
+            for (std::size_t logical_y = devices_0.start_coord.y; logical_y < devices_0.end_coord.y; logical_y++) {
+                for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+                    for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+                        std::vector<bfloat16> dst_vec = {};
+                        ReadShard(
+                            mesh_device_->mesh_command_queue(),
+                            dst_vec,
+                            output_buffers[col_idx * worker_grid_size.y + row_idx],
+                            Coordinate(logical_y, logical_x));
                         for (int i = 0; i < dst_vec.size(); i++) {
                             float ref_val = std::pow(2, (iter % 2) + 1);
                             if (i >= 512) {
@@ -908,7 +914,7 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadSanity) {
     }
 }
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadCBUpdate) {
+TEST_F(MeshWorkloadTest, MeshWorkloadCBUpdate) {
     std::shared_ptr<Program> program = std::make_shared<Program>();
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     CoreRange cr = CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
@@ -943,7 +949,7 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadCBUpdate) {
     verify_cb_config(mesh_device_, mesh_workload, updated_cb_config_vector, cr_set);
 }
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadSemaphoreSanity) {
+TEST_F(MeshWorkloadTest, MeshWorkloadSemaphoreSanity) {
     auto worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     auto full_grid = CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     Program program;
@@ -964,7 +970,7 @@ TEST_F(MeshWorkloadTest, TestMeshWorkloadSemaphoreSanity) {
     }
 }
 
-TEST_F(MeshWorkloadTest, TestMeshWorkloadSemaphoreDifferentPrograms) {
+TEST_F(MeshWorkloadTest, MeshWorkloadSemaphoreDifferentPrograms) {
     auto worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     auto full_grid = CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     Program program0;

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -52,17 +52,11 @@ struct ShardedBufferConfig {
     ShardOrientation shard_orientation = ShardOrientation::ROW_MAJOR;
 
     // Computes the number of bytes per datum in the sharded buffer.
-    uint32_t compute_datum_size_bytes() const {
-        return global_size / (global_buffer_shape.height() * global_buffer_shape.width());
-    }
+    uint32_t compute_datum_size_bytes() const;
 
-    std::pair<bool, bool> replicated_dims() const { return {shard_shape.height() == 0, shard_shape.width() == 0}; }
+    std::pair<bool, bool> replicated_dims() const;
 
-    Shape2D physical_shard_shape() const {
-        const auto [shard_height, shard_width] = shard_shape;
-        const auto [global_height, global_width] = global_buffer_shape;
-        return Shape2D(shard_height == 0 ? global_height : shard_height, shard_width == 0 ? global_width : shard_width);
-    }
+    Shape2D physical_shard_shape() const;
 };
 
 enum class MeshBufferLayout : uint8_t { REPLICATED, SHARDED };
@@ -91,7 +85,7 @@ public:
     const ShardedBufferConfig& global_shard_spec() const;
     const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
 
-    std::shared_ptr<Buffer> get_device_buffer(const Coordinate& device_coord);
+    std::shared_ptr<Buffer> get_device_buffer(const Coordinate& device_coord) const;
     uint32_t datum_size_bytes() const;
     Shape2D physical_shard_shape() const;
     std::pair<bool, bool> replicated_dims() const;

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -35,7 +35,7 @@ private:
         tt::stl::Span<const SubDeviceId> sub_device_ids);
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(
-        MeshBuffer& buffer,
+        const MeshBuffer& buffer,
         const void* src,
         std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids);
@@ -60,10 +60,10 @@ public:
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking);
     // MeshBuffer Write APIs
     void enqueue_write_shard(
-        std::shared_ptr<MeshBuffer>& mesh_buffer, void* host_data, const Coordinate& coord, bool blocking);
+        std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking);
     void enqueue_write_shard_to_sub_grid(
-        MeshBuffer& buffer, void* host_data, const LogicalDeviceRange& device_range, bool blocking);
-    void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, void* host_data, bool blocking);
+        const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking);
+    void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking);
     // MeshBuffer Read APIs
     void enqueue_read_shard(
         void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -45,7 +45,7 @@ private:
     ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program);
 
     std::unordered_map<std::size_t, ProgramBinaryStatus> program_binary_status_;
-    std::unordered_set<std::shared_ptr<Buffer>> kernel_bin_buffers_;
+    std::shared_ptr<MeshBuffer> kernel_bin_buf_;
     std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>> kernels_;
     std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
     std::vector<Semaphore> semaphores_;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -54,6 +54,20 @@ void validate_mesh_buffer_config(const MeshBufferConfig& config, const MeshDevic
 
 }  // namespace
 
+uint32_t ShardedBufferConfig::compute_datum_size_bytes() const {
+    return global_size / (global_buffer_shape.height() * global_buffer_shape.width());
+}
+
+std::pair<bool, bool> ShardedBufferConfig::replicated_dims() const {
+    return {shard_shape.height() == 0, shard_shape.width() == 0};
+}
+
+Shape2D ShardedBufferConfig::physical_shard_shape() const {
+    const auto [shard_height, shard_width] = shard_shape;
+    const auto [global_height, global_width] = global_buffer_shape;
+    return Shape2D(shard_height == 0 ? global_height : shard_height, shard_width == 0 ? global_width : shard_width);
+}
+
 std::shared_ptr<MeshBuffer> MeshBuffer::create(
     const MeshBufferConfig& mesh_buffer_config,
     const DeviceLocalBufferConfig& device_local_config,
@@ -126,7 +140,7 @@ void MeshBuffer::allocate() {
     }
 }
 
-std::shared_ptr<Buffer> MeshBuffer::get_device_buffer(const Coordinate& device_coord) {
+std::shared_ptr<Buffer> MeshBuffer::get_device_buffer(const Coordinate& device_coord) const {
     TT_FATAL(
         device_coord.row < mesh_device_->num_rows() and device_coord.col < mesh_device_->num_cols(),
         "Logical coordinates must be within the bounds of the mesh: {}, {}, mesh shape: {}, {}",

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -231,7 +231,7 @@ void MeshCommandQueue::read_shard_from_device(
 }
 
 void MeshCommandQueue::enqueue_write_shard(
-    std::shared_ptr<MeshBuffer>& mesh_buffer, void* host_data, const Coordinate& coord, bool blocking) {
+    std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking) {
     // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
     // We should not be querying SubDevices from device 0.
     auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device(0)->get_sub_device_ids());
@@ -258,7 +258,7 @@ void MeshCommandQueue::enqueue_read_shard(
 }
 
 void MeshCommandQueue::write_sharded_buffer(
-    MeshBuffer& buffer,
+    const MeshBuffer& buffer,
     const void* src,
     std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
@@ -398,7 +398,7 @@ void MeshCommandQueue::read_sharded_buffer(
 }
 
 void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
-    MeshBuffer& buffer, void* host_data, const LogicalDeviceRange& device_range, bool blocking) {
+    const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking) {
     // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
     // We should not be querying SubDevices from device 0.
     auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device(0)->get_sub_device_ids());
@@ -423,7 +423,7 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
 }
 
 void MeshCommandQueue::enqueue_write_mesh_buffer(
-    const std::shared_ptr<MeshBuffer>& buffer, void* host_data, bool blocking) {
+    const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
     LogicalDeviceRange mesh_device_extent({0, 0}, {buffer->device()->num_cols(), buffer->device()->num_rows()});
     this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
 }

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -56,49 +56,45 @@ void MeshWorkload::load_binaries(MeshCommandQueue& mesh_cq) {
             uint32_t curr_kernel_bin_size = program.get_program_transfer_info().binary_data.size() * sizeof(uint32_t);
             max_kernel_bin_buf_size = std::max(max_kernel_bin_buf_size, curr_kernel_bin_size);
         }
-        // Allocate a buffer for kernel binaries on each device.
-        // Once MeshBuffer is available, allocate kernel bin MeshBuffer directly here
-        for (auto device : mesh_device->get_devices()) {
-            std::shared_ptr<Buffer> kernel_bin_buf = Buffer::create(
-                device,
-                max_kernel_bin_buf_size,
-                HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
-                BufferType::DRAM,
-                TensorMemoryLayout::INTERLEAVED,
-                std::nullopt,
-                false);
-            kernel_bin_buffers_.insert(
-                kernel_bin_buf);  // Tie the lifetime of kernel binary buffers to the MeshWorkload
-        }
-        // Iterate over the sub-grids and EnqueueWriteMeshBuffer to each sub-grid that runs the program
-        for (auto& [device_range, program] : programs_) {
-            std::size_t kernel_bin_size = program.get_program_transfer_info().binary_data.size() * sizeof(uint32_t);
-            for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x;
-                 logical_x++) {
-                for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y;
-                     logical_y++) {
-                    IDevice* device = mesh_device->get_device(logical_y, logical_x);
-                    // Get a view of the allocated buffer that matches the size of the kernel binary
-                    // for the sub grid
-                    std::shared_ptr<Buffer> buffer_view = Buffer::create(
-                        device,
-                        (*(kernel_bin_buffers_.begin()))->address(),
-                        kernel_bin_size,
-                        HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
-                        BufferType::DRAM,
-                        TensorMemoryLayout::INTERLEAVED,
-                        std::nullopt,
-                        false);
-                    EnqueueWriteBuffer(
-                        device->command_queue(mesh_cq.id()),
-                        buffer_view,
-                        program.get_program_transfer_info().binary_data.data(),
-                        false);
-                    // Assign this memory region to the program. Required when the program
-                    // object is used to generate dispatch commands
-                    program.set_kernels_bin_buffer(buffer_view);
-                    program.set_program_binary_status(device->id(), ProgramBinaryStatus::InFlight);
-                }
+        // In production cases, max_kernel_bin_buf_size will always be non-zero (programs have kernels). This check is
+        // primarily for test workloads, where a program may not have an attached kernel.
+        if (max_kernel_bin_buf_size) {
+            // Allocate a MeshBuffer for kernel binaries on each device. This buffer is replicated along the MeshDevice
+            // and matches the max kernel binary size across programs.
+            DeviceLocalBufferConfig device_local_kernel_bin_buf_config = {
+                .page_size = HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
+                .buffer_type = BufferType::DRAM,
+                .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+            };
+            ReplicatedBufferConfig global_kernel_bin_buf_config = {
+                .size = max_kernel_bin_buf_size,
+            };
+            kernel_bin_buf_ =
+                MeshBuffer::create(global_kernel_bin_buf_config, device_local_kernel_bin_buf_config, mesh_device);
+            // Iterate over the sub-grids and EnqueueWriteMeshBuffer to each sub-grid that runs an individual program
+            for (auto& [device_range, program] : this->programs_) {
+                const auto& grid_start = device_range.start_coord;
+                std::size_t kernel_bin_size = program.get_program_transfer_info().binary_data.size() * sizeof(uint32_t);
+                global_kernel_bin_buf_config.size = kernel_bin_size;
+                auto kernel_bin_buf_view = MeshBuffer::create(
+                    global_kernel_bin_buf_config,
+                    device_local_kernel_bin_buf_config,
+                    mesh_device,
+                    kernel_bin_buf_->address());
+
+                mesh_device->mesh_command_queue().enqueue_write_shard_to_sub_grid(
+                    *kernel_bin_buf_view, program.get_program_transfer_info().binary_data.data(), device_range, false);
+
+                std::shared_ptr<Buffer> buffer_view = Buffer::create(
+                    mesh_device->get_device(grid_start.y, grid_start.x),
+                    kernel_bin_buf_->address(),
+                    kernel_bin_size,
+                    HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
+                    BufferType::DRAM,
+                    TensorMemoryLayout::INTERLEAVED,
+                    std::nullopt,
+                    false);
+                program.set_kernels_bin_buffer(buffer_view);
             }
         }
         program_binary_status_[mesh_device->id()] = ProgramBinaryStatus::InFlight;


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
With `MeshBuffer` reads and writes enabled, we can use a `MeshBuffer` to store kernel binaries on a `MeshDevice`.

### What's changed
Update calls to `Buffer::create` per device with a blanket call to `MeshBuffer::create` and use `enqueue_write_shard_to_sub_grid ` to get kernel binaries on a `MeshDevice`.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
