### PR TITLE
Move definitions to implementation for core.hpp

### DIFF
--- a/ttnn/cpp/ttnn/core.cpp
+++ b/ttnn/cpp/ttnn/core.cpp
@@ -8,10 +8,6 @@
 
 namespace ttnn::core {
 
-std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {
-    return (value + (tile_size - 1)) / tile_size * tile_size;
-}
-
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {
     return tensor.storage_type() == storage_type;
 }

--- a/ttnn/cpp/ttnn/core.cpp
+++ b/ttnn/cpp/ttnn/core.cpp
@@ -4,7 +4,49 @@
 
 #include "ttnn/core.hpp"
 
+namespace ttnn::core {
+
+std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {
+    return (value + (tile_size - 1)) / tile_size * tile_size;
+}
+
+bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {
+    return tensor.storage_type() == storage_type;
+}
+
+std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor) {
+    if (not tensor.is_allocated() or not is_tensor_on_device_or_multidevice(tensor)) {
+        return std::nullopt;
+    }
+    return tensor.memory_config();
+}
+
+void set_printoptions(const std::string& profile) {
+    tt::tt_metal::tensor_impl::TTNN_TENSOR_PRINT_PROFILE =
+        magic_enum::enum_cast<tt::tt_metal::tensor_impl::TensorPrintProfile>(profile, [](char lhs, char rhs) {
+            return std::tolower(lhs) == std::tolower(rhs);
+        }).value();
+}
+
+void segfault_handler(int sig) {
+    std::cerr << tt::assert::backtrace_to_string() << std::endl;
+    exit(EXIT_FAILURE);
+}
+
+void dump_stack_trace_on_segfault() {
+    if (std::signal(SIGSEGV, segfault_handler) == SIG_ERR) {
+        std::cerr << "Error: cannot handle SIGSEGV" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+}  // namespace ttnn::core
+
 namespace ttnn {
+
+CoreIDs& CoreIDs::instance() {
+    static CoreIDs instance;
+    return instance;
+}
 
 std::int64_t CoreIDs::get_python_operation_id() { return python_operation_id.load(); }
 void CoreIDs::set_python_operation_id(std::int64_t python_operation_id_) { python_operation_id = python_operation_id_; }

--- a/ttnn/cpp/ttnn/core.cpp
+++ b/ttnn/cpp/ttnn/core.cpp
@@ -8,6 +8,10 @@
 
 namespace ttnn::core {
 
+std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {
+    return (value + (tile_size - 1)) / tile_size * tile_size;
+}
+
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {
     return tensor.storage_type() == storage_type;
 }
@@ -24,6 +28,11 @@ void set_printoptions(const std::string& profile) {
         magic_enum::enum_cast<tt::tt_metal::tensor_impl::TensorPrintProfile>(profile, [](char lhs, char rhs) {
             return std::tolower(lhs) == std::tolower(rhs);
         }).value();
+}
+
+void segfault_handler(int sig) {
+    std::cerr << tt::assert::backtrace_to_string() << std::endl;
+    exit(EXIT_FAILURE);
 }
 
 void dump_stack_trace_on_segfault() {

--- a/ttnn/cpp/ttnn/core.cpp
+++ b/ttnn/cpp/ttnn/core.cpp
@@ -8,10 +8,6 @@
 
 namespace ttnn::core {
 
-std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {
-    return (value + (tile_size - 1)) / tile_size * tile_size;
-}
-
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {
     return tensor.storage_type() == storage_type;
 }
@@ -28,11 +24,6 @@ void set_printoptions(const std::string& profile) {
         magic_enum::enum_cast<tt::tt_metal::tensor_impl::TensorPrintProfile>(profile, [](char lhs, char rhs) {
             return std::tolower(lhs) == std::tolower(rhs);
         }).value();
-}
-
-void segfault_handler(int sig) {
-    std::cerr << tt::assert::backtrace_to_string() << std::endl;
-    exit(EXIT_FAILURE);
 }
 
 void dump_stack_trace_on_segfault() {

--- a/ttnn/cpp/ttnn/core.cpp
+++ b/ttnn/cpp/ttnn/core.cpp
@@ -4,6 +4,8 @@
 
 #include "ttnn/core.hpp"
 
+#include <magic_enum/magic_enum.hpp>
+
 namespace ttnn::core {
 
 std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -41,6 +41,7 @@ void dump_stack_trace_on_segfault();
 
 using core::get_memory_config;
 using core::has_storage_type_of;
+using core::pad_to_multiple_of_tile_size;
 using core::set_printoptions;
 
 class CoreIDs {

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -29,15 +29,11 @@ namespace ttnn {
 
 namespace core {
 
-std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size);
-
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type);
 
 std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor);
 
 void set_printoptions(const std::string& profile);
-
-void segfault_handler(int sig);
 
 void dump_stack_trace_on_segfault();
 

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -29,11 +29,15 @@ namespace ttnn {
 
 namespace core {
 
+std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size);
+
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type);
 
 std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor);
 
 void set_printoptions(const std::string& profile);
+
+void segfault_handler(int sig);
 
 void dump_stack_trace_on_segfault();
 

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -29,8 +29,6 @@ namespace ttnn {
 
 namespace core {
 
-std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size);
-
 bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type);
 
 std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor);
@@ -45,7 +43,6 @@ void dump_stack_trace_on_segfault();
 
 using core::get_memory_config;
 using core::has_storage_type_of;
-using core::pad_to_multiple_of_tile_size;
 using core::set_printoptions;
 
 class CoreIDs {

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 #include <csignal>
+#include <cstdint>
 #include <optional>
+#include <string>
 
 #include <magic_enum/magic_enum.hpp>
 #include "ttnn/tensor/tensor.hpp"
@@ -28,39 +30,17 @@ namespace ttnn {
 
 namespace core {
 
-inline std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {
-    return (value + (tile_size - 1)) / tile_size * tile_size;
-}
+std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size);
 
-inline bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {
-    return tensor.storage_type() == storage_type;
-}
+bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type);
 
-inline std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor) {
-    if (not tensor.is_allocated() or not is_tensor_on_device_or_multidevice(tensor)) {
-        return std::nullopt;
-    }
-    return tensor.memory_config();
-}
+std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor);
 
-inline void set_printoptions(const std::string& profile) {
-    tt::tt_metal::tensor_impl::TTNN_TENSOR_PRINT_PROFILE =
-        magic_enum::enum_cast<tt::tt_metal::tensor_impl::TensorPrintProfile>(profile, [](char lhs, char rhs) {
-            return std::tolower(lhs) == std::tolower(rhs);
-        }).value();
-}
+void set_printoptions(const std::string& profile);
 
-inline void segfault_handler(int sig) {
-    std::cerr << tt::assert::backtrace_to_string() << std::endl;
-    exit(EXIT_FAILURE);
-}
+void segfault_handler(int sig);
 
-inline void dump_stack_trace_on_segfault() {
-    if (std::signal(SIGSEGV, segfault_handler) == SIG_ERR) {
-        std::cerr << "Error: cannot handle SIGSEGV" << std::endl;
-        exit(EXIT_FAILURE);
-    }
-}
+void dump_stack_trace_on_segfault();
 
 }  // namespace core
 
@@ -71,10 +51,7 @@ using core::set_printoptions;
 
 class CoreIDs {
 public:
-    static CoreIDs& instance() {
-        static CoreIDs instance;
-        return instance;
-    }
+    static CoreIDs& instance();
 
     std::int64_t get_python_operation_id();
     void set_python_operation_id(std::int64_t operation_id);

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -41,7 +41,6 @@ void dump_stack_trace_on_segfault();
 
 using core::get_memory_config;
 using core::has_storage_type_of;
-using core::pad_to_multiple_of_tile_size;
 using core::set_printoptions;
 
 class CoreIDs {

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -8,7 +8,6 @@
 #include <optional>
 #include <string>
 
-#include <magic_enum/magic_enum.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"  // TTNN_TENSOR_PRINT_PROFILE
 #include "ttnn/tensor/types.hpp"


### PR DESCRIPTION
### Problem description
Build time on single core machine is 2.5 hours.

core.hpp is a header file that is included 462 times, and it consumes 745s of compile time.
There are inline functions in this file, and its not clear to me why.
Defining the definition in every translation unit will have a compile time cost.
If these functions need to be inlined in the binary, the compiler should make that decision automatically (I believe).
Additionally, magic_enum is a very expensive template library, and it is included 462 times transitively.
Move it to Cpp file.

I would like to see if I can start using forward declarations as well in a follow up PR.

### What's changed
Remove usage of inline for free functions in ttnn::core namespace.
Add missing includes.
Move singleton instance() method definition to cpp file, along with all other methods.
Move magic_enum inclusion to implementation.

### How does compile time change?
This PR fixes this problem (gone)
<img width="943" alt="image" src="https://github.com/user-attachments/assets/fc259b71-e674-4199-bc9b-ca648dbebd70" />

And decreases the compile time cost of core.hpp by 40%.
<img width="1375" alt="image" src="https://github.com/user-attachments/assets/850f61b4-30b5-47ee-b835-95ffdfe4d0d3" />


### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12978097498)
- [ ] [Rerun Post-Commit after dead code removal](https://github.com/tenstorrent/tt-metal/actions/runs/12980073310)
- [x] New/Existing tests provide coverage for changes
