### PR TITLE
Initialize work_executor_ and set WorkExecutorMode::SYNCHRONOUS in MeshDevice constructor

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -129,6 +129,8 @@ MeshDevice::MeshDevice(
     mesh_id_(generate_unique_mesh_id()),
     parent_mesh_(std::move(parent_mesh)) {
     work_executor_ = std::make_unique<WorkExecutor>(0 /* worker_core */, mesh_id_);
+    work_executor_->initialize();
+    work_executor_->set_worker_mode(WorkExecutorMode::SYNCHRONOUS);
 }
 
 std::shared_ptr<MeshDevice> MeshDevice::create(


### PR DESCRIPTION
 - Solves uninitialized work_executor from MeshDevice::create_submesh() calls leading to ND values at runtime and segfault at MeshDevice::close() in tt-forge-fe due to tt-metal/2c2110c778

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17119)

### Problem description

See ticket for more details, but non-deterministic/uninitialized work_executor created from `MeshDevice::create_submesh()` calls leads to garbage values for `work_executor_mode` which then leads to segfault at teardown after all tt-forge-fe tests finish/pass.

### What's changed

Just call the same 2 functions that would normally be done in MeshDevice::Initialize() which is skipped for sub MeshDevice creation.   An alternative might have been calling `MeshDevice::initialize()` for  sub `MeshDevice` created, but I wasn't sure how to do that.

Doesn't contain test change, and don't know if this is best/correct fix, will defer to @cfjchu, but it's the only simple fix that came to my mind and solves my failure. Since tt-metal uplifts blocked in tt-mlir/tt-forge-fe becuase of this , wanted to get some CI cycles on it sooner rather than later. 

### Checklist
- [x] Post commit CI passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/12978088120))
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
