### PR TITLE
#16847: update to address the unaligned noc_async_copy from DRAM to L1

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -852,7 +852,8 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(
             .set_page_size(src1_cb_index, stick_size_padded_aligned);
     auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
 
-    if (stick_size_padded_front != 0) {
+    bool unaligned = stick_size_padded_aligned % hal.get_alignment(HalMemType::DRAM) != 0;
+    if (stick_size_padded_front != 0 || unaligned) {
         uint32_t src2_cb_index = tt::CBIndex::c_2;
         tt::tt_metal::CircularBufferConfig cb_src2_config =
             tt::tt_metal::CircularBufferConfig(stick_size_padded_aligned, {{src2_cb_index, cb_data_format}})
@@ -895,7 +896,8 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(
         (std::uint32_t)(stick_size_padded / row_major_min_bytes),
         (std::uint32_t)src_stick_size_is_power_of_two,
         (std::uint32_t)src_stick_size_is_power_of_two ? src_log2_stick_size : stick_size,
-        (std::uint32_t)stick_size_padded_aligned};
+        (std::uint32_t)stick_size_padded_aligned,
+        (std::uint32_t)unaligned};
     std::vector<uint32_t> writer_ct_args = {
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)dst_is_dram,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16847)

### Problem description
The DRAM to L1 data copy hits unaligned address and need scratchpad copy.

### What's changed
Enable unaligned copy from DRAM to L1 using scratch pad.


### Checklist
- [x] Post commit CI passes(https://github.com/tenstorrent/tt-metal/actions/runs/12982484257)
- [x] Blackhole Post commit (https://github.com/tenstorrent/tt-metal/actions/runs/12982487520) 
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
