### PR TITLE
Eth API updates and fixes for BH 

### DIFF
--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -69,6 +69,9 @@ int main() {
     // put this into scratch space similar to idle erisc
     noc_bank_table_init(eth_l1_mem::address_map::ERISC_MEM_BANK_TO_NOC_SCRATCH);
 
+    mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
+    noc_index = 0;
+
     risc_init();
 
     mailboxes->slave_sync.all = RUN_SYNC_MSG_ALL_SLAVES_DONE;
@@ -79,7 +82,6 @@ int main() {
     }
 
     mailboxes->go_message.signal = RUN_MSG_DONE;
-    mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
 
     while (1) {
         // Wait...

--- a/tt_metal/hw/firmware/src/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/active_erisck.cc
@@ -21,12 +21,7 @@
 #include <kernel_includes.hpp>
 #include <stdint.h>
 
-extern uint32_t __kernel_init_local_l1_base[];
-extern uint32_t __fw_export_end_text[];
-
 void kernel_launch(uint32_t kernel_base_addr) {
-    DeviceZoneScopedMainChildN("ACTIVE-ERISC-KERNEL");
-
     extern uint32_t __kernel_init_local_l1_base[];
     extern uint32_t __fw_export_end_text[];
     do_crt1((uint32_t tt_l1_ptr*)(kernel_base_addr + (uint32_t)__kernel_init_local_l1_base -
@@ -34,5 +29,19 @@ void kernel_launch(uint32_t kernel_base_addr) {
 
     noc_local_state_init(NOC_INDEX);
 
-    kernel_main();
+    {
+        DeviceZoneScopedMainChildN("ACTIVE-ERISC-KERNEL");
+        kernel_main();
+        if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
+            WAYPOINT("NKFW");
+            // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the
+            // NOC interface is in a known idle state for the next kernel.
+            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+            WAYPOINT("NKFD");
+        }
+    }
 }

--- a/tt_metal/hw/firmware/src/tt_eth_api.cpp
+++ b/tt_metal/hw/firmware/src/tt_eth_api.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_eth_api.h"
+#include "ethernet/dataflow_api.h"
 
 void eth_txq_reg_write(uint32_t qnum, uint32_t offset, uint32_t val) {
     ETH_WRITE_REG(ETH_TXQ0_REGS_START + (qnum * ETH_TXQ_REGS_SIZE) + offset, val);
@@ -13,7 +14,7 @@ uint32_t eth_txq_reg_read(uint32_t qnum, uint32_t offset) {
 }
 
 void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
-    while (eth_txq_reg_read(q_num, ETH_TXQ_CMD) != 0) {
+    while (internal_::eth_txq_is_busy(q_num)) {
     }
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_START_ADDR, src_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_word_addr << 4);
@@ -22,7 +23,7 @@ void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_
 }
 
 void eth_write_remote_reg(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
-    while (eth_txq_reg_read(q_num, ETH_TXQ_CMD) != 0) {
+    while (internal_::eth_txq_is_busy(q_num)) {
     }
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, reg_addr);
     eth_txq_reg_write(q_num, ETH_TXQ_REMOTE_REG_DATA, val);

--- a/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
@@ -27,7 +27,7 @@ struct address_map {
     static constexpr std::int32_t MAX_L1_LOADING_SIZE = MAX_SIZE;
 
     static constexpr std::int32_t FABRIC_ROUTER_CONFIG_BASE = MAX_SIZE;
-    static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = FABRIC_ROUTER_CONFIG_BASE + FABRIC_ROUTER_CONFIG_BASE;
+    static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = FABRIC_ROUTER_CONFIG_BASE + FABRIC_ROUTER_CONFIG_SIZE;
     static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
     static constexpr std::uint32_t ERISC_BARRIER_BASE = ERISC_APP_ROUTING_INFO_BASE + ERISC_APP_ROUTING_INFO_SIZE;
 
@@ -56,8 +56,11 @@ struct address_map {
     static constexpr std::int32_t MEM_ERISC_STACK_BASE =
         RISC_LOCAL_MEM_BASE + MEM_ERISC_LOCAL_SIZE - MEM_ERISC_STACK_SIZE;
 
-    static constexpr std::int32_t ERISC_MEM_BANK_TO_NOC_SCRATCH =
-        MEM_ERISC_INIT_LOCAL_L1_BASE_SCRATCH + MEM_ERISC_LOCAL_SIZE;
+    static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0;  // don't need this - just to get things to compile
+    static constexpr std::int32_t ERISC_L1_UNRESERVED_BASE = (MEM_ERISC_MAP_END + (69 * 1024) + 63) & ~63;
+    static constexpr std::int32_t ERISC_L1_UNRESERVED_SIZE = MAX_SIZE - ERISC_L1_UNRESERVED_BASE;
+
+    static constexpr std::int32_t ERISC_MEM_BANK_TO_NOC_SCRATCH = ERISC_L1_UNRESERVED_BASE;
     // Memory for (dram/l1)_bank_to_noc_xy arrays, size needs to be atleast 2 * NUM_NOCS * (NUM_DRAM_BANKS +
     // NUM_L1_BANKS)
     static constexpr std::int32_t ERISC_MEM_BANK_TO_NOC_XY_SIZE = 1024;
@@ -65,10 +68,6 @@ struct address_map {
     // NUM_L1_BANKS)
     static constexpr std::int32_t ERISC_MEM_BANK_OFFSET_SIZE = 1024;
     static constexpr std::int32_t ERISC_MEM_BANK_TO_NOC_SIZE = ERISC_MEM_BANK_TO_NOC_XY_SIZE + ERISC_MEM_BANK_OFFSET_SIZE;
-
-    static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0;  // don't need this - just to get things to compile
-    static constexpr std::int32_t ERISC_L1_UNRESERVED_BASE = (MEM_ERISC_MAP_END + (69 * 1024) + 63) & ~63;
-    static constexpr std::int32_t ERISC_L1_UNRESERVED_SIZE = MAX_SIZE - ERISC_L1_UNRESERVED_BASE;
 
     static_assert((ERISC_L1_UNRESERVED_BASE % 64) == 0);
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1802,10 +1802,9 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
  */
 FORCE_INLINE
 void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
+    invalidate_l1_cache();
     WAYPOINT("NFBW");
-    do {
-        invalidate_l1_cache();
-    } while (!ncrisc_noc_reads_flushed(noc_idx));
+    while (!ncrisc_noc_reads_flushed(noc_idx));
     WAYPOINT("NFCW");
     while (!ncrisc_noc_nonposted_writes_sent(noc_idx));
     WAYPOINT("NFDW");

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -67,6 +67,7 @@ FORCE_INLINE
 void eth_noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val, uint32_t wait_min = 0) {
     uint32_t count = 0;
     while ((*sem_addr) != val) {
+        invalidate_l1_cache();
         if (count == wait_min) {
             run_routing();
             count = 0;
@@ -95,6 +96,7 @@ FORCE_INLINE
 void eth_noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val, uint32_t wait_min = 0) {
     uint32_t count = 0;
     while ((*sem_addr) < val) {
+        invalidate_l1_cache();
         if (count == wait_min) {
             run_routing();
             count = 0;
@@ -116,6 +118,7 @@ void eth_noc_async_read_barrier() {
     while (!ncrisc_noc_reads_flushed(noc_index)) {
         run_routing();
     }
+    invalidate_l1_cache();
 }
 
 /**
@@ -290,6 +293,7 @@ void eth_wait_for_receiver_done(uint32_t wait_min = 0) {
         1);
     uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != 0) {
+        invalidate_l1_cache();
         if (count == wait_min) {
             count = 0;
             run_routing();
@@ -352,6 +356,7 @@ void eth_wait_for_receiver_channel_done(uint32_t channel) {
     uint32_t max = 100000;
 
     while (!eth_is_receiver_channel_send_done(channel)) {
+        invalidate_l1_cache();
         count++;
         if (count > max) {
             count = 0;
@@ -378,6 +383,7 @@ FORCE_INLINE
 void eth_wait_receiver_done(uint32_t wait_min = 0) {
     uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != 0) {
+        invalidate_l1_cache();
         if (count == wait_min) {
             count = 0;
             run_routing();
@@ -406,6 +412,7 @@ FORCE_INLINE
 void eth_wait_for_bytes(uint32_t num_bytes, uint32_t wait_min = 0) {
     uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != num_bytes) {
+        invalidate_l1_cache();
         if (count == wait_min) {
             count = 0;
             run_routing();
@@ -454,6 +461,7 @@ void eth_wait_for_bytes_on_channel_sync_addr(
     uint32_t count = 0;
     uint32_t num_bytes_sent = eth_channel_syncs->bytes_sent;
     while (num_bytes_sent != num_bytes) {
+        invalidate_l1_cache();
         uint32_t received_this_iter = eth_channel_syncs->bytes_sent;
         if (received_this_iter != num_bytes_sent) {
             // We are currently in the process of receiving data on this channel, so we just just wait a
@@ -594,6 +602,7 @@ void eth_receiver_acknowledge(uint8_t channel = 0) {
 FORCE_INLINE
 void eth_wait_receiver_acknowledge(uint8_t channel = 0) {
     while (erisc_info->channels[channel].bytes_sent != 1) {
+        invalidate_l1_cache();
         run_routing();
     }
 }

--- a/tt_metal/hw/inc/ethernet/erisc.h
+++ b/tt_metal/hw/inc/ethernet/erisc.h
@@ -11,9 +11,11 @@ volatile inline uint32_t* flag_disable = (uint32_t*)(eth_l1_mem::address_map::LA
 
 namespace internal_ {
 inline __attribute__((always_inline)) void risc_context_switch() {
+#ifdef COOPERATIVE_ERISC
     ncrisc_noc_full_sync();
     rtos_context_switch_ptr();
     ncrisc_noc_counters_init();
+#endif
 }
 
 inline __attribute__((always_inline)) void disable_erisc_app() { flag_disable[0] = 0; }

--- a/tt_metal/hw/inc/ethernet/tt_eth_ss_regs.h
+++ b/tt_metal/hw/inc/ethernet/tt_eth_ss_regs.h
@@ -9,7 +9,11 @@
 // ETH Params
 
 #define NUM_ECC_SOURCES (5 + 4 * 3 + 2)
+#ifdef ARCH_BLACKHOLE
+#define NUM_ETH_QUEUES 3
+#else
 #define NUM_ETH_QUEUES 2
+#endif
 
 //////////////////
 // RISC debug regs
@@ -48,6 +52,9 @@
 #define ETH_TXQ_CMD_FLUSH (0x1 << 3)
 
 #define ETH_TXQ_STATUS 0x8              // IMPROVE: document (misc. internal bits for debug)
+#define ETH_TXQ_STATUS_CMD_ONGOING_BIT \
+    0x10  // On Blackhole bit 16 of the ETH_TXQ_STATUS register indicates whether a packer transfer (raw/data/reg write)
+          // is ongoing
 #define ETH_TXQ_MAX_PKT_SIZE_BYTES 0xC  // Max ethernet payload size (default = 1500 bytes)
 #define ETH_TXQ_BURST_LEN 0x10          // Value to drive on ati_q#_pbl output (default = 8)
 #define ETH_TXQ_TRANSFER_START_ADDR \

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -55,11 +55,20 @@ volatile uint32_t* RtosTable =
 
 namespace internal_ {
 
-FORCE_INLINE bool eth_txq_is_busy(uint32_t q_num) { return eth_txq_reg_read(q_num, ETH_TXQ_CMD) != 0; }
+FORCE_INLINE bool eth_txq_is_busy(uint32_t q_num) {
+#ifdef ARCH_WORMHOLE
+    return eth_txq_reg_read(q_num, ETH_TXQ_CMD) != 0;
+#else
+    // Due to https://tenstorrent.atlassian.net/browse/BH-55 we don't want to poll STATUS.cmd_ongoing bit too soon after
+    // a previous TX. Workaround is to perform any register operation on the same TX queue to slow down successive polls
+    eth_txq_reg_read(q_num, ETH_TXQ_CMD);
+    return ((eth_txq_reg_read(q_num, ETH_TXQ_STATUS) >> ETH_TXQ_STATUS_CMD_ONGOING_BIT) & 0x1) != 0;
+#endif
+}
 
 FORCE_INLINE
 void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
-    while (eth_txq_reg_read(q_num, ETH_TXQ_CMD) != 0) {
+    while (eth_txq_is_busy(q_num)) {
         // Note, this is overly eager... Kills perf on allgather
         risc_context_switch();
     }
@@ -71,7 +80,7 @@ void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_
 
 FORCE_INLINE
 void eth_send_packet_unsafe(uint32_t q_num, uint32_t src_word_addr, uint32_t dest_word_addr, uint32_t num_words) {
-    ASSERT(eth_txq_reg_read(q_num, ETH_TXQ_CMD) == 0);
+    ASSERT(!eth_txq_is_busy(q_num));
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_START_ADDR, src_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, dest_word_addr << 4);
     eth_txq_reg_write(q_num, ETH_TXQ_TRANSFER_SIZE_BYTES, num_words << 4);
@@ -89,7 +98,7 @@ void eth_send_packet_bytes_unsafe(uint32_t q_num, uint32_t src_addr, uint32_t de
 
 FORCE_INLINE
 void eth_write_remote_reg(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
-    while (eth_txq_reg_read(q_num, ETH_TXQ_CMD) != 0) {
+    while (eth_txq_is_busy(q_num)) {
         risc_context_switch();
     }
     eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, reg_addr);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -471,7 +471,8 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
             this->defines_ +=
                 "-DCOMPILE_FOR_ERISC "
                 "-DERISC "
-                "-DRISC_B0_HW ";
+                "-DRISC_B0_HW "
+                "-DCOOPERATIVE_ERISC ";
 
             this->includes_ += "-I " + env_.root_ + "tt_metal/hw/inc/ethernet ";
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -501,16 +501,16 @@ int Cluster::get_device_aiclk(const chip_id_t &chip_id) const {
     return 0;
 }
 
-void Cluster::deassert_risc_reset_at_core(const tt_cxy_pair &core) const {
+void Cluster::deassert_risc_reset_at_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets) const {
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(core.chip);
     tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
-    this->driver_->deassert_risc_reset_at_core(core.chip, core_coord);
+    this->driver_->deassert_risc_reset_at_core(core.chip, core_coord, soft_resets);
 }
 
-void Cluster::assert_risc_reset_at_core(const tt_cxy_pair &core) const {
+void Cluster::assert_risc_reset_at_core(const tt_cxy_pair& core, const TensixSoftResetOptions& soft_resets) const {
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(core.chip);
     tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
-    this->driver_->assert_risc_reset_at_core(core.chip, core_coord);
+    this->driver_->assert_risc_reset_at_core(core.chip, core_coord, soft_resets);
 }
 
 void Cluster::write_dram_vec(std::vector<uint32_t> &vec, tt_target_dram dram, uint64_t addr, bool small_access) const {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -95,8 +95,12 @@ public:
     //! device driver and misc apis
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
 
-    void deassert_risc_reset_at_core(const tt_cxy_pair& physical_chip_coord) const;
-    void assert_risc_reset_at_core(const tt_cxy_pair& physical_chip_coord) const;
+    void deassert_risc_reset_at_core(
+        const tt_cxy_pair& physical_chip_coord,
+        const TensixSoftResetOptions& soft_resets = TENSIX_DEASSERT_SOFT_RESET) const;
+    void assert_risc_reset_at_core(
+        const tt_cxy_pair& physical_chip_coord,
+        const TensixSoftResetOptions& soft_resets = TENSIX_ASSERT_SOFT_RESET) const;
 
     void write_dram_vec(
         std::vector<uint32_t>& vec, tt_target_dram dram, uint64_t addr, bool small_access = false) const;
@@ -172,6 +176,8 @@ public:
     // Returns set of logical active ethernet coordinates on chip
     // If skip_reserved_tunnel_cores is true, will return cores that dispatch is not using,
     // intended for users to grab available eth cores for testing
+    // `skip_reserved_tunnel_cores` is ignored on BH because there are no ethernet cores used for Fast Dispatch
+    // tunneling
     std::unordered_set<CoreCoord> get_active_ethernet_cores(
         chip_id_t chip_id, bool skip_reserved_tunnel_cores = false) const;
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/edm_handshake.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/edm_handshake.hpp
@@ -69,7 +69,7 @@ FORCE_INLINE void sender_side_start(
     std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     initialize_edm_common_datastructures(handshake_register_address);
     eth_wait_receiver_done(HS_CONTEXT_SWITCH_TIMEOUT);
-    while (eth_txq_reg_read(0, ETH_TXQ_CMD) != 0) {
+    while (eth_txq_is_busy()) {
         asm volatile("nop");
     }
     eth_send_bytes(handshake_register_address, handshake_register_address, 16);
@@ -101,7 +101,7 @@ FORCE_INLINE bool receiver_side_can_finish() { return eth_bytes_are_available_on
 FORCE_INLINE void receiver_side_finish(
     std::uint32_t handshake_register_address, size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     eth_wait_for_bytes(16, HS_CONTEXT_SWITCH_TIMEOUT);
-    while (eth_txq_reg_read(0, ETH_TXQ_CMD) != 0) {
+    while (eth_txq_is_busy()) {
         asm volatile("nop");
     }
     eth_receiver_channel_done(0);


### PR DESCRIPTION
### Ticket
N/A

### What's changed
Fixes for running kernels out of active eriscs on BH: 
- allow passing specified `TensixSoftResetOptions` when deasserting / asserting risc reset. This is done to enable init FW on active erisc to target erisc1 only
- update checking if txq is busy based on BH specification + apply workaround in https://tenstorrent.atlassian.net/browse/BH-55
- add some l1 cache invalidations in eth apis

Note: BH aerisc specific tests will be enabled when BH eth is enabled on CI. UMD changes for differentiating between active/idle eth is almost ready (on branch `abhullar/bh-multichip` this is done in Metal Runtime)

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13146530275)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12994962995)
- [x] [T3K nightly](https://github.com/tenstorrent/tt-metal/actions/runs/13146525044)
- [ ] [T3K frequent](https://github.com/tenstorrent/tt-metal/actions/runs/13146527985)
- [ ] [T3K unit](https://github.com/tenstorrent/tt-metal/actions/runs/13145965012)
