### PR TITLE
#0: Fix ttnn shared libs build

### DIFF
--- a/ttnn/cpp/ttnn/tensor/shape/shape.cpp
+++ b/ttnn/cpp/ttnn/tensor/shape/shape.cpp
@@ -54,34 +54,3 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::SimpleShape& shap
 }
 
 }  // namespace tt::tt_metal
-
-#if TTNN_WITH_PYTHON_BINDINGS
-namespace PYBIND11_NAMESPACE {
-namespace detail {
-namespace py = pybind11;
-bool type_caster<ttnn::SimpleShape>::load(handle src, bool) {
-    if (!py::isinstance<py::iterable>(src)) {
-        return false;
-    }
-    ttnn::SmallVector<uint32_t> vec;
-    for (auto item : src.cast<py::iterable>()) {
-        if (!py::isinstance<py::int_>(item)) {
-            return false;
-        }
-        vec.push_back(item.cast<uint32_t>());
-    }
-    value = ttnn::SimpleShape(std::move(vec));
-    return true;
-}
-
-handle type_caster<ttnn::SimpleShape>::cast(
-    const ttnn::SimpleShape& src, return_value_policy /* policy */, handle /* parent */) {
-    py::list py_list;
-    for (size_t i = 0; i < src.rank(); i++) {
-        py_list.append(src[i]);
-    }
-    return py_list.release();
-}
-}  // namespace detail
-}  // namespace PYBIND11_NAMESPACE
-#endif

--- a/ttnn/cpp/ttnn/tensor/shape/shape.cpp
+++ b/ttnn/cpp/ttnn/tensor/shape/shape.cpp
@@ -54,3 +54,34 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::SimpleShape& shap
 }
 
 }  // namespace tt::tt_metal
+
+#if TTNN_WITH_PYTHON_BINDINGS
+namespace PYBIND11_NAMESPACE {
+namespace detail {
+namespace py = pybind11;
+bool type_caster<ttnn::SimpleShape>::load(handle src, bool) {
+    if (!py::isinstance<py::iterable>(src)) {
+        return false;
+    }
+    ttnn::SmallVector<uint32_t> vec;
+    for (auto item : src.cast<py::iterable>()) {
+        if (!py::isinstance<py::int_>(item)) {
+            return false;
+        }
+        vec.push_back(item.cast<uint32_t>());
+    }
+    value = ttnn::SimpleShape(std::move(vec));
+    return true;
+}
+
+handle type_caster<ttnn::SimpleShape>::cast(
+    const ttnn::SimpleShape& src, return_value_policy /* policy */, handle /* parent */) {
+    py::list py_list;
+    for (size_t i = 0; i < src.rank(); i++) {
+        py_list.append(src[i]);
+    }
+    return py_list.release();
+}
+}  // namespace detail
+}  // namespace PYBIND11_NAMESPACE
+#endif

--- a/ttnn/cpp/ttnn/tensor/shape/shape.hpp
+++ b/ttnn/cpp/ttnn/tensor/shape/shape.hpp
@@ -57,9 +57,6 @@ using tt::tt_metal::SimpleShape;
 #if TTNN_WITH_PYTHON_BINDINGS
 namespace PYBIND11_NAMESPACE {
 namespace detail {
-
-namespace py = pybind11;
-
 template <>
 class type_caster<ttnn::SimpleShape> {
 public:

--- a/ttnn/cpp/ttnn/tensor/shape/shape.hpp
+++ b/ttnn/cpp/ttnn/tensor/shape/shape.hpp
@@ -65,28 +65,9 @@ class type_caster<ttnn::SimpleShape> {
 public:
     PYBIND11_TYPE_CASTER(ttnn::SimpleShape, _("SimpleShape"));
 
-    bool load(handle src, bool) {
-        if (!py::isinstance<py::iterable>(src)) {
-            return false;
-        }
-        ttnn::SmallVector<uint32_t> vec;
-        for (auto item : src.cast<py::iterable>()) {
-            if (!py::isinstance<py::int_>(item)) {
-                return false;
-            }
-            vec.push_back(item.cast<uint32_t>());
-        }
-        value = ttnn::SimpleShape(std::move(vec));
-        return true;
-    }
-
-    static handle cast(const ttnn::SimpleShape& src, return_value_policy /* policy */, handle /* parent */) {
-        py::list py_list;
-        for (size_t i = 0; i < src.rank(); i++) {
-            py_list.append(src[i]);
-        }
-        return py_list.release();
-    }
+    PYBIND11_EXPORT bool load(handle src, bool);
+    PYBIND11_EXPORT static handle cast(
+        const ttnn::SimpleShape& src, return_value_policy /* policy */, handle /* parent */);
 };
 }  // namespace detail
 }  // namespace PYBIND11_NAMESPACE


### PR DESCRIPTION
### Problem description
Build using `--ttnn-shared-sublibs` was broken

### What's changed
Pybind uses hidden visibility, which causes a linker error for functions defined in *.cpp files. 
Defintions moved to header file. 

### Checklist
- [ ] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13003713246)
