### PR TITLE
#17128 Advanced programming example vecadd_multi_core

### DIFF
--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PROGRAMMING_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/pad/pad_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sharding/shard_data_rm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vecadd_sharding/vecadd_sharding.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/vecadd_multi_core/vecadd_multi_core.cpp
 )
 
 include(${PROJECT_SOURCE_DIR}/cmake/helper_functions.cmake)

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
@@ -40,18 +40,23 @@ void MAIN {
 
     // Loop over the assigned tiles and perform the computation
     for (uint32_t i = start_tile_id; i < end_tile_id; i++) {
-        // Make sure there is a valid register we can use.
-        acquire_dst();
         // Wait until there is a tile in both input circular buffers
         cb_wait_front(cb_in0, 1);
         cb_wait_front(cb_in1, 1);
+        // Make sure there is a valid register we can use.
+        tile_regs_acquire();
         // Add the tiles from the input circular buffers and write the result to
         // the destination register
         add_tiles(cb_in0, cb_in1, 0, 0, dst_reg);
+        tile_regs_commit();
+
         // Make sure there is space in the output circular buffer
         cb_reserve_back(cb_out0, 1);
+        tile_regs_wait();
         // Copy the result from adding the tiles to the output circular buffer
         pack_tile(dst_reg, cb_out0);
+        tile_regs_release();
+
         // Mark the output tile as ready and pop the input tiles
         cb_push_back(cb_out0, 1);
         cb_pop_front(cb_in0, 1);

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
@@ -11,7 +11,7 @@
 namespace NAMESPACE {
 void MAIN {
     uint32_t n_tiles = get_arg_val<uint32_t>(0);
-    uint32_t core_id = get_arg_val<uint32_t>(1);  // Add core ID argument
+    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
 
     // We are going to read from these two circular buffers
     constexpr auto cb_in0 = get_compile_time_arg_val(0);
@@ -36,12 +36,10 @@ void MAIN {
     add_tiles_init(cb_in0, cb_in1);
 
     // Calculate the range of tiles this core should process
-    const uint32_t tiles_per_core = n_tiles;
-    const uint32_t start_tile = core_id * tiles_per_core;
-    const uint32_t end_tile = start_tile + tiles_per_core;
+    const uint32_t end_tile_id = start_tile_id + n_tiles;
 
     // Loop over the assigned tiles and perform the computation
-    for (uint32_t i = start_tile; i < end_tile; i++) {
+    for (uint32_t i = start_tile_id; i < end_tile_id; i++) {
         // Make sure there is a valid register we can use.
         acquire_dst();
         // Wait until there is a tile in both input circular buffers

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -11,7 +11,7 @@ void kernel_main() {
     uint32_t a_addr = get_arg_val<uint32_t>(0);
     uint32_t b_addr = get_arg_val<uint32_t>(1);
     uint32_t n_tiles = get_arg_val<uint32_t>(2);
-    uint32_t core_id = get_arg_val<uint32_t>(3);  // Add core ID argument
+    uint32_t start_tile_id = get_arg_val<uint32_t>(3);
 
     // The circular buffers to read the tiles into
     constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
@@ -39,13 +39,11 @@ void kernel_main() {
     };
 
     // Calculate the range of tiles this core should process
-    const uint32_t tiles_per_core = n_tiles;
-    const uint32_t start_tile = core_id * tiles_per_core;
-    const uint32_t end_tile = start_tile + tiles_per_core;
+    const uint32_t end_tile_id = start_tile_id + n_tiles;
 
     // Now we loop over the assigned tiles and read them into the circular
     // buffers
-    for (uint32_t i = start_tile; i < end_tile; i++) {
+    for (uint32_t i = start_tile_id; i < end_tile_id; i++) {
         // First we make sure there is space in the circular buffers
         cb_reserve_back(cb_in0, 1);
         cb_reserve_back(

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -7,7 +7,7 @@
 void kernel_main() {
     uint32_t c_addr = get_arg_val<uint32_t>(0);
     uint32_t n_tiles = get_arg_val<uint32_t>(1);
-    uint32_t core_id = get_arg_val<uint32_t>(2);  // Add core ID argument
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
 
     // The circular buffer that we are going to read from and write to DRAM
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
@@ -22,12 +22,10 @@ void kernel_main() {
     };
 
     // Calculate the range of tiles this core should process
-    const uint32_t tiles_per_core = n_tiles;
-    const uint32_t start_tile = core_id * tiles_per_core;
-    const uint32_t end_tile = start_tile + tiles_per_core;
+    const uint32_t end_tile_id = start_tile_id + n_tiles;
 
     // Loop over the assigned tiles and write them to the output buffer
-    for (uint32_t i = start_tile; i < end_tile; i++) {
+    for (uint32_t i = start_tile_id; i < end_tile_id; i++) {
         // Make sure there is a tile in the circular buffer
         cb_wait_front(cb_out0, 1);
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);


### PR DESCRIPTION
Advanced version of vecadd_multi_core compared to the old issue 16443

Changes:
old: hardcoded to 4 cores
new: no hardcode. Automatically split work to cores, like how a real program does.

old: kernels take core id as runtime arg.
new: core id is not good. Now it takes star tile_id and number_of_tiles_per core as runtime arg, like how a real kernel does.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17128)

### Problem description
Advanced version of vecadd_multi_core compared to the old issue 16443

Changes: 
Make the programming example closer to real world behavior

### What's changed
old: hardcoded to 4 cores 
new: no hardcode. Automatically split work to cores, like how a real program does.

old: kernels take core id as runtime arg. 
new: core id is not good. Now it takes star tile_id and number_of_tiles_per core as runtime arg, like how a real kernel does.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
