### PR TITLE
#15931: Disable SD tests failing on the CI

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -70,6 +70,7 @@ def unsqueeze_all_params_to_4d(params):
         (2, 4, 64, 64),
     ],
 )
+@pytest.mark.skip(reason="#15931: Failing, skip for now")
 def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_height, input_width):
     device.enable_program_cache()
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -29,6 +29,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
 @pytest.mark.parametrize("res_hidden_states_tuple", [([2, 1280, 8, 8], [2, 1280, 8, 8], [2, 1280, 8, 8])])
 @pytest.mark.parametrize("hidden_states", [[2, 1280, 8, 8]])
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
+@pytest.mark.skip(reason="#15931: Failing, skip for now")
 def test_upblock_512x512(reset_seeds, device, res_hidden_states_tuple, hidden_states, temb):
     os.environ["SLOW_MATMULS"] = "1"
 


### PR DESCRIPTION
### Ticket
#15931

### Problem description
Nightly model tests failing on the CI: https://github.com/tenstorrent/tt-metal/actions/runs/12978701768/job/36193654440

The test was reenabled last week after setting matmul subblock h/w to 1 and local testing, but started failing again, so disabling again until investigated.

### Checklist
Nightly model pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/12984006511