### PR TITLE
#0: Schedule runs for single card new models tests

### DIFF
--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -14,6 +14,7 @@ on:
   workflow_run:
     workflows:
       - "All post-commit tests"
+      - "(Single-card) Tests for new models"
     types:
       - completed
 

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -12,6 +12,8 @@ on:
           - Debug
           - RelWithDebInfo
           - CI
+  schedule:
+    - cron: "0 2,11 * * *"
 
 permissions:
   actions: read


### PR DESCRIPTION
### Ticket

Quick one off

### Problem description

The single-card new models pipeline does not have feedback that is iterative enough to enable devs to make decisions on the health of the pipeline. The constituent pipelines are run elsewhere, but more convenient feedback would be nice

### What's changed

Add schedule for:

- 2am GMT (6pm Pacific NA, 9pm Eastern NA, 3am Serbia, 7:30am India), when activity should be low across our offices
- 11am GMT (3am Pacific NA, 6am Eastern NA, 12pm Serbia, 4:30pm India), when activity in Europe should be higher, India should be wrapping up, so we people in NA get feedback whereas those in Europe/India have the 2am GMT run for feedback

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
