### PR TITLE
remove ND failing big shape in transpose failures that is already tracked and disabled in test_transpose_2d

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -800,7 +800,6 @@ def test_transpose_failures(config, memory_config, device):
         ],
         [[1, 9, 8, 40], [1, 2], ttnn.ROW_MAJOR_LAYOUT],
         [[1, 8, 8, 8], [1, 2], ttnn.ROW_MAJOR_LAYOUT],
-        [[21843, 768], [0, 1], ttnn.ROW_MAJOR_LAYOUT],
     ],
 )
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])


### PR DESCRIPTION
### Ticket
#17144

### Problem description
This shape fails N-D on main, starting about a month and a half ago

### What's changed
Since this shape is tested earlier in the suite, I'm removing it.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12993059516
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
