### PR TITLE
fix sub-height height sharded WH transpose by setting output memory config to width sharded

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -33,7 +33,6 @@ struct PermuteDeviceOperation {
 
     // Implementation for a row major tensor where the row dimension is not moved in the permutation
     struct MultiCoreRowInvariant {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
         struct shared_variables_t {
             tt::tt_metal::KernelHandle unary_reader_kernel_id;
             tt::tt_metal::KernelHandle unary_writer_kernel_id;
@@ -55,7 +54,6 @@ struct PermuteDeviceOperation {
 
     // Implementation for a row major tensor where the row dimension is moved in the permutation
     struct MultiCoreBlockedGeneric {
-        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
         struct shared_variables_t {
             tt::tt_metal::KernelHandle unary_reader_kernel_id;
             tt::tt_metal::KernelHandle unary_writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -81,6 +81,8 @@ ttnn::Tensor permute_impl(
             output = transpose_hc(transpose_wh(formatted_input_tensor));
         } else if (N == 0 && C == 3 && H == 2 && W == 1) {
             output = transpose_wh(transpose_hc(transpose_wh(formatted_input_tensor)));
+        } else {
+            TT_FATAL(false, "Sharded permute not supported for this permutation");
         }
     } else {
         if (N == 0 && C == 1 && H == 2 && W == 3) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -68,10 +68,24 @@ void Transpose::validate(const std::vector<Tensor>& input_tensors) const {
                 H,
                 shard_spec.shape[0]);
             TT_FATAL(shard_spec.shape[1] == W, "Only height sharding is supported");
+            if (H > shard_spec.shape[0]) {
+                TT_FATAL(
+                    N == 1,
+                    "Transpose WH does not support sharded inputs when shard height {} is less than H {} and N {} > 1",
+                    shard_spec.shape[0],
+                    H,
+                    N);
+                TT_FATAL(
+                    C == 1,
+                    "Transpose WH does not support sharded inputs when  shard height {} is less than H {} and C {} > 1",
+                    shard_spec.shape[0],
+                    H,
+                    N);
+            }
             TT_FATAL(this->output_mem_config.is_sharded(), "Output must be sharded for transpose WH");
             TT_FATAL(
-                this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED,
-                "Only height and block sharding is supported for transpose wh");
+                this->output_mem_config.memory_layout != TensorMemoryLayout::BLOCK_SHARDED,
+                "Only height and width sharding output is supported for transpose wh");
         } else {
             TT_FATAL(!this->output_mem_config.is_sharded(), "Interleaved input tensors cannot output sharded outputs");
         }
@@ -174,7 +188,7 @@ std::vector<ttnn::TensorSpec> Transpose::compute_output_specs(const std::vector<
             } else {
                 std::swap(shard_spec.shape[0], shard_spec.shape[1]);
                 output_mem_config.shard_spec = shard_spec;
-                output_mem_config.memory_layout = TensorMemoryLayout::BLOCK_SHARDED;
+                output_mem_config.memory_layout = TensorMemoryLayout::WIDTH_SHARDED;
             }
         } else if (this->dim == TransposeOpDim::HC) {
             output_mem_config.shard_spec = input_tensor.shard_spec().value();


### PR DESCRIPTION
### Ticket
#17031

### Problem description
The following test was invalidly set to output a block sharding config.

pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py::test_transpose_hw_sharded_tiled_8_cores[32-256-1-1]

It is not block sharded as the sharding grid does not match the core grid. 

### What's changed
It can be correctly labelled width sharding. Tested with bliu/main before the FATALs were changed to ASSERTs. Add some extra FATAL checks in transpose to ensure it's correctly width sharded.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12957705353
- [ ] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13041786814
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/12956270912
