### PR TITLE
#16871: Unify conditional typecasting in BinaryNg

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -725,6 +725,9 @@ def test_inplace_bf4b_bf8b(a_shape, b_shape, input_dtype, ttnn_fn, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
@@ -804,7 +807,7 @@ def test_inplace_binary_ops_fp32(input_shapes, ttnn_fn, device):
     "ttnn_fn",
     binary_inplace_fns,
 )
-def test_inplace_binary_scalar_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
+def test_inplace_binary_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
     torch.manual_seed(0)
     ttnn_op = getattr(ttnn.experimental, ttnn_fn)
 
@@ -872,37 +875,26 @@ def test_inplace_binary_with_scalar(a_shape, scalar, ttnn_fn, device):
 
 @pytest.mark.parametrize(
     "a_shape, b_shape, out_shape",
-    ((torch.Size([1, 1]), torch.Size([5, 3, 128, 64]), torch.Size([5, 3, 128, 64])),),
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 1, 32])),
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 128, 64]), torch.Size([5, 3, 1, 64])),
+        (torch.Size([5, 2, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+    ),
 )
-def test_inplace_add_opt_output(a_shape, b_shape, out_shape, device):
+@pytest.mark.parametrize(
+    "ttnn_fn",
+    binary_fns,
+)
+def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, device):
     torch.manual_seed(0)
+    ttnn_op = getattr(ttnn.experimental, ttnn_fn)
 
-    min, max = (1, 0)
-    torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
-    torch_input_tensor_b, input_tensor_b = rand_bf16_gen(b_shape, device, min=min, max=max)
-    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), ttnn.bfloat8_b)(out_shape)
+    _, input_tensor_a = rand_bf16_gen(a_shape, device)
+    _, input_tensor_b = rand_bf16_gen(b_shape, device)
+    _, out_tt = rand_bf16_gen(out_shape, device)
 
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=ttnn.bfloat8_b,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=ttnn.bfloat8_b,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    out_tt = ttnn.from_torch(
-        out, dtype=ttnn.bfloat8_b, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-    golden_function = ttnn.get_golden_function(ttnn.experimental.add)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
-
-    ttnn.experimental.add(input_tensor_a, input_tensor_b, output_tensor=out_tt)
-    output_tensor = ttnn.to_torch(out_tt)
-    assert output_tensor.shape == torch_output_tensor.shape
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
+    with pytest.raises(
+        RuntimeError, match=r"Shape of Output tensor.+ provided does not match the broadcasted output shape .+"
+    ):
+        cq_id = 0
+        ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 import ttnn
-import random
 
 from functools import partial
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_pcc
@@ -28,6 +27,7 @@ from models.utility_functions import torch_random, skip_for_grayskull
     ([ttnn.int32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32, ttnn.bfloat4_b]),
 )
 def test_binary_scalar_ops(input_shapes, dtype, device):
+    torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.float32), dtype)(a_shape)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -53,6 +53,7 @@ binary_fns = {
 )
 # No typecast on inputs and optional output
 def test_opt_output_no_typecast(input_shapes, dtype, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn.experimental, ttnn_fn)
 
@@ -80,7 +81,7 @@ def test_opt_output_no_typecast(input_shapes, dtype, ttnn_fn, device):
     golden_fn = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
     status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
-    assert status >= 0.99
+    assert status >= 0.999
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
@@ -103,6 +104,7 @@ def test_opt_output_no_typecast(input_shapes, dtype, ttnn_fn, device):
 )
 # Typecast on both inputs and optional output
 def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
+    torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn.experimental, ttnn_fn)
 
@@ -629,6 +631,7 @@ def test_inplace_sub_typecast_b(input_shapes, device):
 @pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
 # Typecast on both input and optional tensor
 def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
+    torch.manual_seed(0)
     a_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn.experimental, ttnn_fn)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -1,0 +1,659 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+
+from models.utility_functions import skip_for_grayskull, torch_random
+from functools import partial
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+
+binary_fns = {
+    "gte",
+    "gt",
+    "lte",
+    "lt",
+    "eq",
+    "ne",
+    "logical_and",
+    "logical_or",
+    "logical_xor",
+    "ldexp",
+    "logaddexp",
+    "logaddexp2",
+    "squared_difference",
+    "add",
+    "sub",
+    "rsub",
+    "mul",
+    "bias_gelu",
+}
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_fn",
+    binary_fns,
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.bfloat16]),
+)
+# No typecast on inputs and optional output
+def test_opt_output_no_typecast(input_shapes, dtype, ttnn_fn, device):
+    a_shape, b_shape, out_shape = input_shapes
+    ttnn_op = getattr(ttnn.experimental, ttnn_fn)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), dtype)(
+        a_shape
+    )
+    torch_input_tensor_b = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), dtype)(
+        b_shape
+    )
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), dtype)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cq_id = 0
+    ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.99
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_fn",
+    binary_fns,
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.bfloat8_b]),
+)
+# Typecast on both inputs and optional output
+def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
+    a_shape, b_shape, out_shape = input_shapes
+    ttnn_op = getattr(ttnn.experimental, ttnn_fn)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), dtype)(
+        a_shape
+    )
+    torch_input_tensor_b = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), dtype)(
+        b_shape
+    )
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), dtype)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cq_id = 0
+    ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128])),
+    ),
+)
+# Typecast on both inputs
+def test_sub_typecast(input_shapes, device):
+    a_shape, b_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(b_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    output_tensor = ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128])),
+    ),
+)
+# Typecast on input tensor a
+def test_sub_typecast_a(input_shapes, device):
+    a_shape, b_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(b_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    output_tensor = ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128])),
+    ),
+)
+# Typecast on input tensor b
+def test_sub_typecast_b(input_shapes, device):
+    a_shape, b_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(b_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    output_tensor = ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+    ),
+)
+# Typecast on both inputs
+def test_sub_opt_output_typecast_inputs(input_shapes, device):
+    a_shape, b_shape, out_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(b_shape)
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), ttnn.bfloat16)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cq_id = 0
+    ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+    ),
+)
+# Typecast on output
+def test_sub_opt_output_typecast_out(input_shapes, device):
+    a_shape, b_shape, out_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(b_shape)
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), ttnn.bfloat8_b)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=ttnn.bfloat8_b, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cq_id = 0
+    ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+    ),
+)
+# Typecast on input tensor a
+def test_sub_opt_output_typecast_a(input_shapes, device):
+    a_shape, b_shape, out_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(b_shape)
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), ttnn.bfloat16)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cq_id = 0
+    ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1]), torch.Size([5, 3, 128, 64])),
+        (torch.Size([5, 1, 1]), torch.Size([1, 32, 128]), torch.Size([5, 32, 128])),
+    ),
+)
+# Typecast on input tensor b
+def test_sub_opt_output_typecast_b(input_shapes, device):
+    a_shape, b_shape, out_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(b_shape)
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), ttnn.bfloat16)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    cq_id = 0
+    ttnn.experimental.sub(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([5, 3, 32, 32]), torch.Size([1, 1, 1, 1])),
+        (torch.Size([5, 3, 64, 128]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 3, 128, 64]), torch.Size([1, 1, 128, 1])),
+        (torch.Size([5, 32, 128]), torch.Size([5, 1, 1])),
+    ),
+)
+# Typecast on both inputs
+def test_inplace_sub_typecast(input_shapes, device):
+    a_shape, b_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(b_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    ttnn.experimental.sub_(input_tensor_a, input_tensor_b, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(input_tensor_a)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub_)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([5, 3, 32, 32]), torch.Size([1, 1, 1, 1])),
+        (torch.Size([5, 3, 64, 128]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 3, 128, 64]), torch.Size([1, 1, 128, 1])),
+        (torch.Size([5, 32, 128]), torch.Size([5, 1, 1])),
+    ),
+)
+# Typecast on input tensor a
+def test_inplace_sub_typecast_a(input_shapes, device):
+    a_shape, b_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(b_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    ttnn.experimental.sub_(input_tensor_a, input_tensor_b, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(input_tensor_a)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub_)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([5, 3, 32, 32]), torch.Size([1, 1, 1, 1])),
+        (torch.Size([5, 3, 64, 128]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 3, 128, 64]), torch.Size([1, 1, 128, 1])),
+        (torch.Size([5, 32, 128]), torch.Size([5, 1, 1])),
+    ),
+)
+# Typecast on input tensor b
+def test_inplace_sub_typecast_b(input_shapes, device):
+    a_shape, b_shape = input_shapes
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16
+    )(a_shape)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(b_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    ttnn.experimental.sub_(input_tensor_a, input_tensor_b, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(input_tensor_a)
+
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub_)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, torch_input_tensor_b)
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999
+
+
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([1, 1, 1, 1])),
+        (torch.Size([5, 3, 64, 128]), torch.Size([5, 3, 64, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([5, 1, 1, 64])),
+        (torch.Size([5, 32, 32]), torch.Size([5, 32, 32])),
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_fn",
+    [
+        "add",
+        "sub",
+        "mul",
+        "div",
+        "rsub",
+        "gt",
+        "lt",
+        "lte",
+        "gte",
+        "eq",
+        "ne",
+        "squared_difference",
+    ],
+)
+@pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
+# Typecast on both input and optional tensor
+def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
+    a_shape, out_shape = input_shapes
+    ttnn_op = getattr(ttnn.experimental, ttnn_fn)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat8_b
+    )(a_shape)
+    out = gen_func_with_cast_tt(partial(torch_random, low=0, high=1, dtype=torch.bfloat16), ttnn.bfloat8_b)(out_shape)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out_tt = ttnn.from_torch(
+        out, dtype=ttnn.bfloat8_b, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    cq_id = 0
+    ttnn_op(input_tensor_a, scalar, queue_id=cq_id, output_tensor=out_tt)
+    output_tensor = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_fn(torch_input_tensor_a, scalar)
+
+    status = ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor)
+    assert status >= 0.999

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -5,13 +5,14 @@
 
 #include "binary_ng.hpp"
 #include "device/binary_ng_device_operation.hpp"
+#include <optional>
 
 inline Tensor typecast_to(DataType dtype, const Tensor& input) {
     return input.get_dtype() == dtype ? input : ttnn::typecast(input, dtype);
 }
 
-inline bool needs_typecast_to_bfloat16(const Tensor& input) {
-    return (input.get_dtype() == DataType::BFLOAT8_B || input.get_dtype() == DataType::BFLOAT4_B);
+inline bool needs_typecast_to_bfloat16(const ttnn::DataType input) {
+    return (input == ttnn::DataType::BFLOAT8_B || input == ttnn::DataType::BFLOAT4_B);
 }
 
 namespace ttnn::operations::binary_ng {
@@ -27,22 +28,65 @@ Tensor BinaryNg<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
-    bool typecast_a = needs_typecast_to_bfloat16(input_tensor_a);
-    bool typecast_b = needs_typecast_to_bfloat16(input_tensor_b);
-    Tensor input_a = typecast_a ? typecast_to(DataType::BFLOAT16, input_tensor_a) : input_tensor_a;
-    Tensor input_b = typecast_b ? typecast_to(DataType::BFLOAT16, input_tensor_b) : input_tensor_b;
+    const ttnn::DataType a_dtype = input_tensor_a.get_dtype();
+    const ttnn::DataType b_dtype = input_tensor_b.get_dtype();
+    ttnn::DataType out_dtype = a_dtype;
+    const bool output_preallocated = optional_output_tensor.has_value();
 
-    return ttnn::prim::binary_ng(
-        queue_id,
-        input_a,
-        input_b,
-        binary_op_type,
-        output_dtype,
-        memory_config,
-        optional_output_tensor,
-        lhs_activations,
-        rhs_activations,
-        post_activations);
+    if (output_preallocated) {
+        out_dtype = optional_output_tensor.value().get_dtype();
+        TT_FATAL(out_dtype == a_dtype, "Output tensor datatype does not match input tensor datatype");
+    }
+
+    bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
+    bool typecast_b = needs_typecast_to_bfloat16(b_dtype);
+
+    if (!typecast_a && !typecast_b) {
+        return ttnn::prim::binary_ng(
+            queue_id,
+            input_tensor_a,
+            input_tensor_b,
+            binary_op_type,
+            input_tensor_a.get_dtype(),
+            optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
+                                               : memory_config.value_or(input_tensor_a.memory_config()),
+            optional_output_tensor,
+            lhs_activations,
+            rhs_activations,
+            post_activations);
+
+    } else {
+        Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
+        Tensor input_b = typecast_to(DataType::BFLOAT16, input_tensor_b);
+
+        Tensor result = ttnn::prim::binary_ng(
+            queue_id,
+            input_a,
+            input_b,
+            binary_op_type,
+            input_a.get_dtype(),
+            input_a.memory_config(),
+            (output_preallocated && !typecast_a) ? optional_output_tensor.value() : input_a,
+            lhs_activations,
+            rhs_activations,
+            post_activations);
+
+        if (output_preallocated && typecast_a) {
+            copy::detail::copy_impl(
+                queue_id,
+                input_a,
+                {ttnn::operations::unary::UnaryWithParam(
+                    ttnn::operations::unary::UnaryOpType::TYPECAST,
+                    {static_cast<float>(input_a.get_dtype()), static_cast<float>(a_dtype)})},
+                std::nullopt,
+                optional_output_tensor);
+
+            return optional_output_tensor.value();
+        } else if (typecast_a) {
+            return ttnn::typecast(result, a_dtype);
+        }
+        return (output_preallocated && !typecast_a) ? optional_output_tensor.value() : result;
+    }
 }
 
 template <BinaryOpType binary_op_type>
@@ -68,6 +112,45 @@ Tensor BinaryNg<binary_op_type>::invoke(
 }
 
 template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryNg<binary_op_type>::invoke(
+    uint8_t queue_id,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
+    return BinaryNg<binary_op_type>::invoke(
+        queue_id,
+        input_tensor_a,
+        input_tensor_b,
+        input_tensor_a.get_dtype(),
+        input_tensor_a.memory_config(),
+        input_tensor_a,
+        lhs_activations,
+        rhs_activations,
+        post_activations);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryNg<binary_op_type>::invoke(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
+    return BinaryNg<binary_op_type>::invoke(
+        DefaultQueueId,
+        input_tensor_a,
+        input_tensor_b,
+        input_tensor_a.get_dtype(),
+        input_tensor_a.memory_config(),
+        input_tensor_a,
+        lhs_activations,
+        rhs_activations,
+        post_activations);
+}
+
+template <BinaryOpType binary_op_type>
 Tensor BinaryNg<binary_op_type>::invoke(
     uint8_t queue_id,
     const Tensor& input_tensor_a,
@@ -78,7 +161,9 @@ Tensor BinaryNg<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
-    bool typecast_a = needs_typecast_to_bfloat16(input_tensor_a);
+    const ttnn::DataType a_dtype = input_tensor_a.get_dtype();
+    bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
+    // bool typecast_a = needs_typecast_to_bfloat16(input_tensor_a);
     Tensor input_a = typecast_a ? typecast_to(DataType::BFLOAT16, input_tensor_a) : input_tensor_a;
 
     return ttnn::prim::binary_ng(
@@ -189,132 +274,6 @@ Tensor BinaryNgBitwise<binary_op_type>::invoke(
     std::optional<Tensor> optional_output_tensor) {
     return BinaryNgBitwise<binary_op_type>::invoke(
         DefaultQueueId, input_tensor_a, scalar, memory_config, optional_output_tensor);
-}
-
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryNg<binary_op_type>::invoke(
-    uint8_t queue_id,
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
-    bool typecast_a = needs_typecast_to_bfloat16(input_tensor_a);
-    bool typecast_b = needs_typecast_to_bfloat16(input_tensor_b);
-
-    if (!typecast_a && !typecast_b) {
-        return ttnn::prim::binary_ng(
-            queue_id,
-            input_tensor_a,
-            input_tensor_b,
-            binary_op_type,
-            input_tensor_a.get_dtype(),
-            input_tensor_a.memory_config(),
-            input_tensor_a,
-            lhs_activations,
-            rhs_activations,
-            post_activations);
-    } else {
-        Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
-        Tensor input_b = typecast_to(DataType::BFLOAT16, input_tensor_b);
-
-        ttnn::prim::binary_ng(
-            queue_id,
-            input_a,
-            input_b,
-            binary_op_type,
-            input_a.get_dtype(),
-            input_a.memory_config(),
-            input_a,
-            lhs_activations,
-            rhs_activations,
-            post_activations);
-
-        if (typecast_a) {
-            copy::detail::copy_impl(
-                queue_id,
-                input_a,
-                {ttnn::operations::unary::UnaryWithParam(
-                    ttnn::operations::unary::UnaryOpType::TYPECAST,
-                    {static_cast<float>(input_a.get_dtype()), static_cast<float>(input_tensor_a.get_dtype())})},
-                input_tensor_a.memory_config(),
-                input_tensor_a);
-
-            return input_tensor_a;
-        }
-        return input_tensor_a;
-    }
-}
-
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryNg<binary_op_type>::invoke(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
-    return InplaceBinaryNg<binary_op_type>::invoke(
-        DefaultQueueId, input_tensor_a, input_tensor_b, lhs_activations, rhs_activations, post_activations);
-}
-
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryNg<binary_op_type>::invoke(
-    uint8_t queue_id,
-    const Tensor& input_tensor_a,
-    float scalar,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
-    bool typecast_a = needs_typecast_to_bfloat16(input_tensor_a);
-
-    if (!typecast_a) {
-        return ttnn::prim::binary_ng(
-            queue_id,
-            input_tensor_a,
-            scalar,
-            binary_op_type,
-            input_tensor_a.get_dtype(),
-            input_tensor_a.memory_config(),
-            input_tensor_a,
-            lhs_activations,
-            rhs_activations,
-            post_activations);
-    } else {
-        Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
-        ttnn::prim::binary_ng(
-            queue_id,
-            input_a,
-            scalar,
-            binary_op_type,
-            input_a.get_dtype(),
-            input_a.memory_config(),
-            input_a,
-            lhs_activations,
-            rhs_activations,
-            post_activations);
-
-        copy::detail::copy_impl(
-            queue_id,
-            input_a,
-            {ttnn::operations::unary::UnaryWithParam(
-                ttnn::operations::unary::UnaryOpType::TYPECAST,
-                {static_cast<float>(input_a.get_dtype()), static_cast<float>(input_tensor_a.get_dtype())})},
-            input_tensor_a.memory_config(),
-            input_tensor_a);
-
-        return input_tensor_a;
-    }
-}
-
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryNg<binary_op_type>::invoke(
-    const Tensor& input_tensor_a,
-    float scalar,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> post_activations) {
-    return InplaceBinaryNg<binary_op_type>::invoke(
-        DefaultQueueId, input_tensor_a, scalar, lhs_activations, rhs_activations, post_activations);
 }
 
 template struct BinaryNg<BinaryOpType::ADD>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -31,11 +31,11 @@ Tensor BinaryNg<binary_op_type>::invoke(
     const ttnn::DataType b_dtype = input_tensor_b.get_dtype();
     const bool output_preallocated = optional_output_tensor.has_value();
     const ttnn::DataType out_dtype =
-        output_preallocated ? optional_output_tensor.value().get_dtype() : output_dtype.value_or(a_dtype);
+        output_preallocated ? optional_output_tensor->get_dtype() : output_dtype.value_or(a_dtype);
 
     if (output_dtype.has_value() && output_preallocated) {
         TT_FATAL(
-            output_dtype.value() == out_dtype,
+            *output_dtype == out_dtype,
             "If both output dtype and output tensor are provided, their dtypes should match");
     }
 
@@ -50,7 +50,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
             input_tensor_b,
             binary_op_type,
             out_dtype,
-            output_preallocated ? optional_output_tensor.value().memory_config()
+            output_preallocated ? optional_output_tensor->memory_config()
                                 : memory_config.value_or(input_tensor_a.memory_config()),
             optional_output_tensor,
             lhs_activations,
@@ -59,11 +59,9 @@ Tensor BinaryNg<binary_op_type>::invoke(
     } else {
         Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
         Tensor input_b = typecast_to(DataType::BFLOAT16, input_tensor_b);
-        std::optional<Tensor> output_tensor =
-            (output_preallocated && !typecast_out) ? optional_output_tensor
-            : (output_preallocated && typecast_out)
-                ? std::make_optional(ttnn::typecast(optional_output_tensor.value(), DataType::BFLOAT16))
-                : std::nullopt;
+        const auto output_tensor = output_preallocated and typecast_out
+                                       ? ttnn::typecast(*optional_output_tensor, DataType::BFLOAT16)
+                                       : optional_output_tensor;
 
         Tensor result = ttnn::prim::binary_ng(
             queue_id,
@@ -77,12 +75,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
             rhs_activations,
             post_activations);
 
-        if (output_preallocated && typecast_out) {
-            return ttnn::typecast(result, out_dtype, std::nullopt, optional_output_tensor);
-        } else if (typecast_out) {
-            return ttnn::typecast(result, out_dtype);
-        }
-        return (output_preallocated && !typecast_out) ? optional_output_tensor.value() : result;
+        return typecast_out ? ttnn::typecast(result, out_dtype, std::nullopt, optional_output_tensor) : result;
     }
 }
 
@@ -122,11 +115,11 @@ Tensor BinaryNg<binary_op_type>::invoke(
     const ttnn::DataType a_dtype = input_tensor_a.get_dtype();
     const bool output_preallocated = optional_output_tensor.has_value();
     const ttnn::DataType out_dtype =
-        output_preallocated ? optional_output_tensor.value().get_dtype() : output_dtype.value_or(a_dtype);
+        output_preallocated ? optional_output_tensor->get_dtype() : output_dtype.value_or(a_dtype);
 
     if (output_dtype.has_value() && output_preallocated) {
         TT_FATAL(
-            output_dtype.value() == out_dtype,
+            *output_dtype == out_dtype,
             "If both output dtype and output tensor are provided, their dtypes should match");
     }
 
@@ -140,7 +133,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
             scalar,
             binary_op_type,
             out_dtype,
-            output_preallocated ? optional_output_tensor.value().memory_config()
+            output_preallocated ? optional_output_tensor->memory_config()
                                 : memory_config.value_or(input_tensor_a.memory_config()),
             optional_output_tensor,
             lhs_activations,
@@ -148,11 +141,9 @@ Tensor BinaryNg<binary_op_type>::invoke(
             post_activations);
     } else {
         Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
-        std::optional<Tensor> output_tensor =
-            (output_preallocated && !typecast_out) ? optional_output_tensor
-            : (output_preallocated && typecast_out)
-                ? std::make_optional(ttnn::typecast(optional_output_tensor.value(), DataType::BFLOAT16))
-                : std::nullopt;
+        const auto output_tensor = output_preallocated and typecast_out
+                                       ? ttnn::typecast(*optional_output_tensor, DataType::BFLOAT16)
+                                       : optional_output_tensor;
 
         Tensor result = ttnn::prim::binary_ng(
             queue_id,
@@ -166,12 +157,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
             rhs_activations,
             post_activations);
 
-        if (output_preallocated && typecast_out) {
-            return ttnn::typecast(result, out_dtype, std::nullopt, optional_output_tensor);
-        } else if (typecast_out) {
-            return ttnn::typecast(result, out_dtype);
-        }
-        return (output_preallocated && !typecast_out) ? optional_output_tensor.value() : result;
+        return typecast_out ? ttnn::typecast(result, out_dtype, std::nullopt, optional_output_tensor) : result;
     }
 }
 


### PR DESCRIPTION
### Ticket
#16871

### Problem description
Move conditional logic that exists in inplace binary_ng to binary_ng and delegate inplace binary_ng to binary_ng struct.

### What's changed
Unified the logic for binary_ng and inplace binary_ng.


### Explanation
bfloat8_b and bfloat4_b tensors need to be typecasted to bfloat16 for binary_ng. 
In this unified logic, inplace operation is delegated to BinaryNg by passing `input_tensor_a` as the `optional_output_tensor`. This combined logic takes care of the following:
**1. Operation with no optional output provided:**
    Eg: output_tensor = ttnn.experimental.sub(input_tensor_a, input_tensor_b). In this case, if none of the inputs require typecasting, the program will return the result. The resulting tensor will have the dtype of `input_tensor_a`. If `input_tensor_a` alone or both input tensors require typecasting, we typecast the output_tensor back to the original dtype and return result. 
 
  <img width="344" alt="Screenshot 2025-01-28 at 19 37 57" src="https://github.com/user-attachments/assets/de301b9f-e8fc-435f-8032-223297ac9d12" />

**2. Operation with optional output tensor provided:**
     Eg: ttnn.experimental.sub(input_tensor_a, input_tensor_b, output_tensor = out_tt) where out_tt is a tensor of provided output shape. In this case, if none of the inputs require typecasting, the program will return the result. The resulting tensor will have the dtype of `out_tt`. If `out_tt` is of dtype bfloat8_b or bfloat4_b, we typecast it to bfloat16 before passing it to the invoke function. We then typecast the result back to the original dtype and copy it back to `out_tt`, which is then returned. 
      <img width="338" alt="Screenshot 2025-01-29 at 17 57 38" src="https://github.com/user-attachments/assets/4e4ddda5-e0ea-48f5-8e91-73154efcf4b6" />


**3. Inplace operation:**
    Eg: ttnn.experimental.sub_(input_tensor_a, input_tensor_b). In this case, the optional output tensor is `input_tensor_a`. if none of the inputs require typecasting, the program will return the result with the dtype of `input_tensor_a`. If `input_tensor_a` alone or both input tensors require typecasting, we typecast result from bfloat16 back to to `input_tensor_a`'s dtype.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13072107561
- [x] Blackhole Post commit tests https://github.com/tenstorrent/tt-metal/actions/runs/13072118352
- [x] (Single-card) Tests for new models https://github.com/tenstorrent/tt-metal/actions/runs/13072147663
- [x] New/Existing tests provide coverage for changes
