### PR TITLE
Prefer MOLD over LLD over LD

### DIFF
--- a/cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
@@ -6,3 +6,15 @@ set(CMAKE_CXX_COMPILER clang++-17 CACHE INTERNAL "C++ compiler")
 
 # Use for configure time
 set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix out code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-17)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()


### PR DESCRIPTION

### Ticket
[#17153](https://github.com/tenstorrent/tt-metal/issues/17153)

### Problem description
Our repo has crazy link times. Linking is repeated for absolutely every build -- any code change requires a re-link, and even a fully cached build will re-link as only the object files are cached.

The root cause should be addressed. But we should also use the best tools available to us. That's why we use Ninja and not Make.

Empirically I tested 5 linkers. Data [here](https://docs.google.com/spreadsheets/d/1Jomxy_0wLkzdjZeSYPKmJ75YeYxaRyQgfan0WtE-Vng/edit?gid=0#gid=0)
Results (in order of speed):
MOLD v1.0.3
LLD-17 v17.0.6
GOLD v0.198
LD v0.280
BFD (didn't check version)

#### Approach:

Serialized the entire build (-j1) so that total link time is more easily measured.
Cut out TT-Train. Even for a fully cached build there's a 20+s uncached build in there (Rust maybe?).
At least one build had some files that it got cache misses for. That's something orthogonal to hunt down; all 25 runs ought to have 100% cache hit rate. So turn a blind eye to the outlier.

### What's changed
Update the default toolchain to select MOLD, if found on the system, else select LDD-17, if found.  Otherwise stick with the system default.

