### PR TITLE
LightMetal - Add Flatbuffers into cmake infra/build as cpm package (#17039)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include(clang-tidy)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 if(NOT ENABLE_LIBCXX)
     # required when linking with libstdc++ with clang and gcc

--- a/cmake/flatbuffers.cmake
+++ b/cmake/flatbuffers.cmake
@@ -1,0 +1,17 @@
+# Function to generate FlatBuffers C++ headers from schema files
+function(GENERATE_FBS_HEADER FBS_FILE)
+    get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WE)
+    set(FBS_GENERATED_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers")
+    set(FBS_GENERATED_HEADER_FILE "${FBS_GENERATED_HEADER_DIR}/${FBS_FILE_NAME}_generated.h")
+    add_custom_command(
+        OUTPUT
+            ${FBS_GENERATED_HEADER_FILE}
+        COMMAND
+            flatc --cpp --scoped-enums -I ${CMAKE_CURRENT_SOURCE_DIR} -o "${FBS_GENERATED_HEADER_DIR}" ${FBS_FILE}
+        DEPENDS
+            flatc
+            ${FBS_FILE}
+        COMMENT "Building C++ header for ${FBS_FILE}"
+    )
+    set(FBS_GENERATED_HEADER_FILE ${FBS_GENERATED_HEADER_FILE} PARENT_SCOPE)
+endfunction()

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -20,8 +20,6 @@ set_target_properties(
             "${PROJECT_BINARY_DIR}/lib"
         ARCHIVE_OUTPUT_DIRECTORY
             "${PROJECT_BINARY_DIR}/lib"
-        POSITION_INDEPENDENT_CODE
-            ON # this is equivalent to adding -fPIC
         OUTPUT_NAME
             "tracy"
 )

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -173,3 +173,24 @@ CPMAddPackage(
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE" # Taskflow's CMakeLists.txt is super noisy
 )
 add_library(Taskflow::Taskflow ALIAS Taskflow)
+
+############################################################################################################################
+# flatbuffers : https://github.com/google/flatbuffers
+############################################################################################################################
+
+CPMAddPackage(
+    NAME flatbuffers
+    GITHUB_REPOSITORY google/flatbuffers
+    GIT_TAG v24.3.25
+    OPTIONS
+        "FLATBUFFERS_BUILD_FLATC ON"
+        "FLATBUFFERS_BUILD_TESTS OFF"
+        "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
+        "FLATBUFFERS_STRICT_MODE ON"
+)
+
+if(flatbuffers_ADDED)
+    # Few files including idl_gen_dart.cpp:175:18, Possibly related: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+    target_compile_options(flatc PRIVATE -Wno-restrict)
+    target_compile_options(flatbuffers PRIVATE -Wno-restrict)
+endif()

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -45,6 +45,16 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/event/event.cpp
 )
 
+# Include helper functions and generate headers from flatbuffer schemas
+include(flatbuffers)
+
+set(FLATBUFFER_SCHEMAS) # Empty to start, coming soon.
+
+foreach(FBS_FILE ${FLATBUFFER_SCHEMAS})
+    GENERATE_FBS_HEADER(${FBS_FILE})
+    list(APPEND IMPL_SRC ${FBS_GENERATED_HEADER_FILE})
+endforeach()
+
 add_library(impl OBJECT ${IMPL_SRC})
 add_library(Metalium::Metal::Impl ALIAS impl)
 
@@ -60,6 +70,7 @@ target_link_libraries(
         Taskflow::Taskflow
         TT::Metalium::HostDevCommon
         Metalium::Metal::Hardware
+        FlatBuffers::FlatBuffers
 )
 
 target_include_directories(
@@ -68,6 +79,8 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/tt_metal
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal/include
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers
 )
 
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast)


### PR DESCRIPTION
### Ticket

I am breaking up original PR I put up recently into smaller bite-sized chunks as @omilyutin-tt suggested.

[Feature Request] Add Light Metal capture/replay initial changes to tt-metal for some workloads https://github.com/tenstorrent/tt-metal/issues/17039

### Problem description

This is initial/bootstrapping changes for "Light Metal" capture/replay feature that uses Flatbufers as serialization/deserialization library.  See my previous bigger PR ([link](https://github.com/tenstorrent/tt-metal/pull/16573)) if you want to see how this will be used by followup merge, or context.
 
### What's changed

 - Mostly unused here, used by light metal capture/replay coming in follow up PR
 - Add CMAKE_POSITION_INDEPENDENT_CODE=ON (-fPIC) for flatbuffer to avoid linking errors when lifting to tt-mlir project.
 - Use -Wno-restrict for flatbuffers compile to supress warning in g++12 build

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12995754952)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
