### PR TITLE
Increase rms_norm and layernorm coverage for Llama shapes

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
@@ -221,3 +221,33 @@ def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config,
     if is_grayskull() and in_dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull")
     run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device)
+
+
+@pytest.mark.parametrize("h", [1632, 8192, 16384])
+@pytest.mark.parametrize("w", [1280])
+@pytest.mark.parametrize("num_chunks", [1, 4])
+def test_layer_norm_4D_llama(device, h, w, num_chunks):
+    """
+    Test specific shapes for LLama and other LLMs
+    """
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((1, num_chunks, h, w), dtype=torch.bfloat16)
+    torch_weight = torch.rand((w,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((w,), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch.nn.functional.layer_norm(
+        torch_input_tensor, normalized_shape=[w], weight=torch_weight, bias=torch_bias
+    )
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch_bias, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    passing, output = comp_pcc(torch_output_tensor, output_tensor, 0.9998)
+    assert passing, output

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
@@ -249,5 +249,5 @@ def test_layer_norm_4D_llama(device, h, w, num_chunks):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    passing, output = comp_pcc(torch_output_tensor, output_tensor, 0.9998)
+    passing, output = comp_pcc(torch_output_tensor, output_tensor)
     assert passing, output


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16013

### Problem description
Part of the Blackhole LLama bringup. This makes sure that the shapes we care about in LLama are being covered by the sweep so BH functionality is guaranteed.

### Checklist
The changes are in post-commit unit tests groups 1 and 5
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13011642551)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13008589556)
