### PR TITLE
Remove references to ARCH_NAME in programming example

### DIFF
--- a/tech_reports/prog_examples/eltwise_sfpu/eltwise_sfpu.md
+++ b/tech_reports/prog_examples/eltwise_sfpu/eltwise_sfpu.md
@@ -4,22 +4,13 @@ We now build a program that will perform an eltwise SFPU unary operation on a si
 
 We'll go through any new code section by section. This builds on top of previous examples. Note that we have this exact, full example program in [eltwise_sfpu.cpp](../../../tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp), so you can follow along.
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/eltwise_sfpu
 ```
+
 ## Circular buffers for data movement to/from compute engine
 
 The number of buffers we're using in DRAM will stay the same. However, we need to declare some circular buffers to enable data transfer between the reader, compute, and writer engines.


### PR DESCRIPTION
### Ticket
None

### Problem description
Programming example still references `ARCH_NAME`

### What's changed
`ARCH_NAME` isn't needed to build metal anymore

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
