### PR TITLE
Remove ARCH_NAME references in prog_examples

### DIFF
--- a/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
@@ -1,15 +1,6 @@
 # Tutorial - Add Two Integers in a Compute Kernel 🚧
 
-1. To build and execute:
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+1. To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -5,17 +5,7 @@ In this example, we will build a TT-Metal program that will add two vectors cont
 This program can be found in
 [add_2_integers_in_compute.cpp](../../../tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp).
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/Tutorial_Add_Two_Integers_in_a_Baby_RISC-V.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/Tutorial_Add_Two_Integers_in_a_Baby_RISC-V.md
@@ -1,14 +1,5 @@
 # Tutorial - Add Two Integers in a Baby RISC-V 🚧
-1. To build and execute:
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+1. To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
@@ -6,17 +6,7 @@ We'll go through this code section by section. Note that we have this exact, ful
 [add_2_integers_in_riscv.cpp](../../../tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp),
 so you can follow along.
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/dram_loopback/dram_loopback.md
+++ b/tech_reports/prog_examples/dram_loopback/dram_loopback.md
@@ -6,17 +6,7 @@ buffer to do so. We call this concept \"loopback\".
 
 We\'ll go through this code section by section. Note that we have this exact, full example program in [loopback.cpp](../../../tt_metal/programming_examples/loopback/loopback.cpp), so you can follow along.
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/eltwise_binary/eltwise_binary.md
+++ b/tech_reports/prog_examples/eltwise_binary/eltwise_binary.md
@@ -5,17 +5,7 @@ We now build a program that will perform eltwise binary operations on a some equ
 
 We'll go through any new code section by section. This builds on top of previous examples. Note that we have this exact, full example program in [eltwise_binary.cpp](../../../tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp), so you can follow along.
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
+++ b/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
@@ -4,17 +4,7 @@ We will build a simple program in TT-Metal that will set up a void compute kerne
 
 We'll go through this code section by section. The full example program is at [hello_world_compute_kernel.cpp](../../../tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp)
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/hello_world_data_movement/hello_world_data_movement.md
+++ b/tech_reports/prog_examples/hello_world_data_movement/hello_world_data_movement.md
@@ -6,16 +6,7 @@ We'll go through this code section by section. Note that we have this exact, ful
 [hello_world_datamovement_kernel.cpp](../../../tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp),
 so you can follow along.
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
+To build and execute, you may use the following commands:
 Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)

--- a/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
+++ b/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
@@ -11,16 +11,7 @@ All important ways we use the API different are in the new `matmul_multi_core` f
 
 The full example program is in [matmul_multi_core.cpp](../../../tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp)
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
+To build and execute, you may use the following commands:
 Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)

--- a/tech_reports/prog_examples/matmul_multi_core_optimized/matmul_multi_core_optimized.md
+++ b/tech_reports/prog_examples/matmul_multi_core_optimized/matmul_multi_core_optimized.md
@@ -2,15 +2,7 @@
 
 The Tensix core architecture's secret weapon is its full user control over memory workload spread, core communication style, novel block matmul kernels, and compute patterns. In this section, we will harness real power through 3 shiny optimizations, each building off one another: data reuse, data multicast, and multidimensional systolic arrays (coming soon).
 
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples

--- a/tech_reports/prog_examples/matmul_single_core/matmul_single_core.md
+++ b/tech_reports/prog_examples/matmul_single_core/matmul_single_core.md
@@ -5,16 +5,7 @@ We'll build a program that will perform matmul operations on two tensors with eq
 The full example program is in
 [matmul_single_core.cpp](../../../tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp)
 
-To build and execute, you may use the following commands. Note that we include the necessary environment variables here, but you may possibly need more depending on the most up-to-date installation methods.
-
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
+To build and execute, you may use the following commands:
 Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -13,15 +13,7 @@ In this example, we will implement a basic TT-Metalium program for padding an in
 
 The code for this program can be found in [pad_multi_core.cpp](../../../tt_metal/programming_examples/pad/pad_multi_core.cpp).
 
-The following commands will build and execute the code for this example. Environment variables may be modified based on the latest specifications.
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
+To build and execute, you may use the following commands:
 Then run the following:
 ```bash
     export TT_METAL_HOME=$(pwd)

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -3,18 +3,7 @@
 In this example, we will implement a simple TT-Metalium program to demonstrate how sharding works for untilized data. The code for this program can be found in
 [shard_data_rm.cpp](../../../tt_metal/programming_examples/sharding/shard_data_rm.cpp).
 
-The following commands will build and execute the code for this example.
-Environment variables may be modified based on the latest
-specifications.
-Run the appropriate command for the Tenstorrent card you have installed:
-
-| Card             | Command                              |
-|------------------|--------------------------------------|
-| Grayskull        | ```export ARCH_NAME=grayskull```     |
-| Wormhole         | ```export ARCH_NAME=wormhole_b0```   |
-| Blackhole        | ```export ARCH_NAME=blackhole```     |
-
-Then run the following:
+To build and execute, you may use the following commands:
 ```bash
     export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples


### PR DESCRIPTION
### Ticket
[#17183](https://github.com/tenstorrent/tt-metal/issues/17183)

### Problem description
Unnecessary references to ARCH_NAME in prog_examples

### What's changed
Removed all references to ARCH_NAME in prog_examples
