### PR TITLE
Pull llrt.hpp out of public interface

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/rtoptions.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 class CommandQueueFixture : public DispatchFixture {
 protected:

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/device_pool.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 class DeviceFixture : public DispatchFixture {
 protected:

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/device_pool.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 // A dispatch-agnostic test fixture
 class DispatchFixture : public ::testing::Test {

--- a/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/test_tiles.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -8,7 +8,7 @@
 
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 #include <tt-metalium/mesh_device.hpp>
 
 #include "dispatch_fixture.hpp"

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 // Helper function to open a file as an fstream, and check that it was opened properly.
 inline bool OpenFile(string &file_name, std::fstream &file_stream, std::ios_base::openmode mode) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -4,7 +4,7 @@
 
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -5,7 +5,7 @@
 #include <tt-metalium/rtoptions.hpp>
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "hostdevcommon/dprint_common.h"
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, const tt::tt_metal::Program& program) {
 #if defined(TRACY_ENABLE)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -14,7 +14,7 @@
 #include "noc/noc_parameters.h"
 
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 #include <tt-metalium/tt_align.hpp>
 
 extern bool debug_g;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -18,7 +18,7 @@
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp"
 
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 #define CQ_PREFETCH_CMD_BARE_MIN_SIZE tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST)
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp
@@ -6,7 +6,7 @@
 
 #include <nlohmann/json.hpp>
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 static inline std::string to_string(pkt_dest_size_choices_t choice) {
     switch (choice) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/rtoptions.hpp>
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -9,7 +9,7 @@
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
 #include "utils.hpp"
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -9,7 +9,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tt_memory.h>
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 #include "tt_metal/detail/kernel_cache.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/kernel.hpp>

--- a/tests/tt_metal/tt_metal/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/test_flatten.cpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
 
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
 
-#include <tt-metalium/llrt.hpp>
+#include "llrt.hpp"
 
 #include <tt-metalium/dprint_server.hpp>
 

--- a/tt_metal/api/tt-metalium/profiler.hpp
+++ b/tt_metal/api/tt-metalium/profiler.hpp
@@ -12,7 +12,6 @@
 
 #include "buffer.hpp"
 #include "program_impl.hpp"
-#include "llrt.hpp"
 #include "profiler_state.hpp"
 #include "common.hpp"
 #include "tracy/TracyTTDevice.hpp"

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(
         Taskflow::Taskflow
         TT::Metalium::HostDevCommon
         Metalium::Metal::Hardware
+        Metalium::Metal::LLRT
 )
 
 target_include_directories(

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -5,7 +5,7 @@
 #include <circular_buffer.hpp>
 
 #include <host_api.hpp>
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <buffer.hpp>
 #include <global_circular_buffer_impl.hpp>
 #include <tt_metal.hpp>

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -16,7 +16,7 @@
 #include <set>
 #include <filesystem>
 #include <tuple>
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <logger.hpp>
 
 #include "dprint_server.hpp"

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -13,7 +13,7 @@
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include <device.hpp>
-#include <llrt.hpp>
+#include "llrt.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -17,7 +17,7 @@
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 #include <fmt/base.h>
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <tt_cluster.hpp>
 
 #include <core_coord.hpp>

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -16,7 +16,7 @@
 
 #include <hal.hpp>
 #include <dev_msgs.h>
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <rtoptions.hpp>
 #include "debug/ring_buffer.h"
 #include "watcher_device_reader.hpp"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -18,7 +18,7 @@
 #include "impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include <utils.hpp>
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <dev_msgs.h>
 #include <device_pool.hpp>
 #include <persistent_kernel_cache.hpp>

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -10,7 +10,7 @@
 #include <set>
 
 #include <build.hpp>
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <tt_metal.hpp>
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/kernel.hpp"

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -25,7 +25,7 @@
 #include <device_command.hpp>
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include "tt_metal/program.hpp"
 #include "tracy/Tracy.hpp"
 #include <tt_align.hpp>

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(
         Reflect::Reflect
         magic_enum
         span
-        Metalium::Metal::Impl
+        common
 )
+target_include_directories(llrt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -50,50 +50,52 @@ using WorkerCores = std::vector<WorkerCore>;
 
 // Return a reference to a potentially shared binary image.
 // The images are cached by path name.
-ll_api::memory const& get_risc_binary(
-    string const& path,
-    ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
+const ll_api::memory& get_risc_binary(
+    const string& path, ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
 
 // TODO: try using "stop" method from device instead, it's the proper way of asserting reset
 
 // CoreCoord core --> NOC coordinates ("functional workers" from the SOC descriptor)
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
-template<typename DType>
+template <typename DType>
 void write_hex_vec_to_core(
     chip_id_t chip,
-    const CoreCoord &core,
+    const CoreCoord& core,
     const std::vector<DType>& hex_vec,
     uint64_t addr,
     bool small_access = false) {
-    tt::Cluster::instance().write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
+    tt::Cluster::instance().write_core(
+        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
 }
-template<typename DType>
+template <typename DType>
 void write_hex_vec_to_core(
     chip_id_t chip,
-    const CoreCoord &core,
+    const CoreCoord& core,
     tt::stl::Span<const DType> hex_vec,
     uint64_t addr,
     bool small_access = false) {
-    tt::Cluster::instance().write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
+    tt::Cluster::instance().write_core(
+        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
 }
 
-std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t size);
+std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
 
-CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord &ethernet_core);
+CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord& ethernet_core);
 
-void write_launch_msg_to_core(chip_id_t chip, CoreCoord core, launch_msg_t *msg, go_msg_t * go_msg, uint64_t addr, bool send_go = true);
+void write_launch_msg_to_core(
+    chip_id_t chip, CoreCoord core, launch_msg_t* msg, go_msg_t* go_msg, uint64_t addr, bool send_go = true);
 
 void print_worker_cores(chip_id_t chip_id = 0);
 
 bool test_load_write_read_risc_binary(
-    ll_api::memory const& mem,
+    const ll_api::memory& mem,
     chip_id_t chip_id,
     const CoreCoord& core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
-void write_binary_to_address(ll_api::memory const& mem, chip_id_t chip_id, const CoreCoord& core, uint32_t address);
+void write_binary_to_address(const ll_api::memory& mem, chip_id_t chip_id, const CoreCoord& core, uint32_t address);
 
 // subchannel hard-coded to 0 for now
 CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id = 0);
@@ -101,7 +103,7 @@ CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id = 0);
 namespace internal_ {
 
 void wait_until_cores_done(
-    chip_id_t device_id, int run_state, std::unordered_set<CoreCoord> &not_done_phys_cores, int timeout_ms = 0);
+    chip_id_t device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms = 0);
 
 }  // namespace internal_
 

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -17,7 +17,9 @@ namespace tt {
 #define DEBUG_VALID_WORKER_ADDR(a, l) (DEBUG_VALID_L1_ADDR(a, l) || (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
 #define DEBUG_VALID_DRAM_ADDR(a, l, b, e) (((a) >= b) && ((a) + (l) <= e))
 
-#define DEBUG_VALID_ETH_ADDR(a, l) ((((a) >= HAL_MEM_ETH_BASE) && ((a) + (l) <= HAL_MEM_ETH_BASE + HAL_MEM_ETH_SIZE)) || (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
+#define DEBUG_VALID_ETH_ADDR(a, l)                                                        \
+    ((((a) >= HAL_MEM_ETH_BASE) && ((a) + (l) <= HAL_MEM_ETH_BASE + HAL_MEM_ETH_SIZE)) || \
+     (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
 
 static bool coord_found_p(std::vector<CoreCoord> coords, CoreCoord core) {
     for (CoreCoord item : coords) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -41,7 +41,7 @@
 #include "tracy/Tracy.hpp"
 #include "umd/device/tt_simulation_device.h"
 
-#include <debug/sanitize_noc_host.hpp>
+#include "sanitize_noc_host.hpp"
 #include <rtoptions.hpp>
 #include "tt_metal/llrt/tlb_config.hpp"
 #include <core_coord.hpp>

--- a/tt_metal/tools/CMakeLists.txt
+++ b/tt_metal/tools/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(
     tools
     PUBLIC
         profiler
-        llrt
+        Metalium::Metal::LLRT
     PRIVATE
         TT::Metalium::HostDevCommon
 )

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <llrt.hpp>
+#include "llrt.hpp"
 #include <tt_cluster.hpp>
 #include <span.hpp>
 

--- a/tt_metal/tools/profiler/CMakeLists.txt
+++ b/tt_metal/tools/profiler/CMakeLists.txt
@@ -12,4 +12,5 @@ target_link_libraries(
         Tracy::TracyClient
         Taskflow::Taskflow
         TT::Metalium::HostDevCommon
+        Metalium::Metal::LLRT
 )

--- a/tt_metal/tools/profiler/profiler.cpp
+++ b/tt_metal/tools/profiler/profiler.cpp
@@ -18,6 +18,8 @@
 #include "tracy/Tracy.hpp"
 #include <device.hpp>
 
+#include "llrt.hpp"
+
 namespace tt {
 
 namespace tt_metal {

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -19,6 +19,8 @@
 #include <device_pool.hpp>
 #include <tt_cluster.hpp>
 
+#include "llrt.hpp"
+
 namespace tt {
 
 namespace tt_metal {

--- a/tt_metal/tools/tt_gdb/tt_gdb.cpp
+++ b/tt_metal/tools/tt_gdb/tt_gdb.cpp
@@ -15,6 +15,8 @@
 
 #include "tt_gdb.hpp"
 
+#include "llrt.hpp"
+
 using json = nlohmann::json;
 
 namespace tt_gdb {

--- a/tt_metal/tools/tt_gdb/tt_gdb.hpp
+++ b/tt_metal/tools/tt_gdb/tt_gdb.hpp
@@ -4,7 +4,6 @@
 
 #include <string>
 #include <tt_cluster.hpp>
-#include <llrt.hpp>
 #include <device.hpp>
 
 namespace tt_gdb {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -35,6 +35,8 @@
 
 #include <graph_tracking.hpp>
 
+#include "llrt.hpp"
+
 namespace tt {
 
 namespace tt_metal {


### PR DESCRIPTION
### Problem description
llrt.hpp was in our public API folder, but is not intended to provide any such APIs externally.
It it "low level".

### What's changed
Move its inclusion to cpp files.
Move header file back to old location.
Break circular dependency caused by "sanitize_noc*"
impl object library depends on llrt object library now

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13000740492)
- [x] New/Existing tests provide coverage for changes
