### PR TITLE
#0: Add validation test for dispatched remote circular buffer config to device

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -57,7 +57,7 @@ TEST_F(DispatchFixture, TensixProgramGlobalCircularBuffers) {
     tt::DataFormat tile_format = tt::DataFormat::Float16_b;
     auto all_cores = sender_cores.merge(receiver_cores).merge(dummy_receiver_cores);
     auto device = devices_[0];
-    std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {{CoreCoord(0, 0), receiver_cores}};
+    std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {{sender_core, receiver_cores}};
     auto global_cb = tt::tt_metal::v1::experimental::CreateGlobalCircularBuffer(
         device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
     std::vector<std::pair<CoreCoord, CoreRangeSet>> dummy_sender_receiver_core_mapping = {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_DISPATCH_PROGRAM_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_stress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_EnqueueProgram.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_global_circular_buffers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sub_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_program_reuse.cpp
     PARENT_SCOPE

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "dispatch_fixture.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/global_circular_buffer_impl.hpp>
+#include <tt-metalium/global_circular_buffer.hpp>
+#include "tt_metal/include/tt_metal/program.hpp"
+
+TEST_F(DispatchFixture, TensixProgramGlobalCircularBuffers) {
+    CoreCoord sender_core = CoreCoord(0, 0);
+    CoreRangeSet sender_cores = CoreRangeSet(CoreRange(sender_core));
+    CoreRangeSet receiver_cores(CoreRange({1, 1}, {2, 2}));
+    uint32_t global_cb_size = 3200;
+    uint32_t cb_page_size = 32;
+    tt::DataFormat tile_format = tt::DataFormat::Float16_b;
+    auto all_cores = sender_cores.merge(receiver_cores);
+    auto device = devices_[0];
+    std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {{sender_core, receiver_cores}};
+    auto global_cb = tt::tt_metal::v1::experimental::CreateGlobalCircularBuffer(
+        device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
+
+    tt::tt_metal::Program program = CreateProgram();
+    uint32_t remote_cb_index = 31;
+    uint32_t local_cb_index = 0;
+    tt::tt_metal::CircularBufferConfig global_cb_config = tt::tt_metal::CircularBufferConfig(cb_page_size);
+    global_cb_config.remote_index(remote_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
+    global_cb_config.index(local_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
+    auto remote_cb =
+        tt::tt_metal::v1::experimental::CreateCircularBuffer(program, all_cores, global_cb_config, global_cb);
+
+    std::vector<uint32_t> compile_args = {remote_cb_index};
+    tt::tt_metal::KernelHandle dm0_sender_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp",
+        sender_cores,
+        tt::tt_metal::ReaderDataMovementConfig(compile_args));
+    tt::tt_metal::KernelHandle dm1_sender_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp",
+        sender_cores,
+        tt::tt_metal::WriterDataMovementConfig(compile_args));
+    tt::tt_metal::KernelHandle compute_sender_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp",
+        sender_cores,
+        tt::tt_metal::ComputeConfig{.compile_args = compile_args});
+    tt::tt_metal::KernelHandle dm0_receiver_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_receiver_config.cpp",
+        receiver_cores,
+        tt::tt_metal::ReaderDataMovementConfig(compile_args));
+    tt::tt_metal::KernelHandle dm1_receiver_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_receiver_config.cpp",
+        receiver_cores,
+        tt::tt_metal::WriterDataMovementConfig(compile_args));
+    tt::tt_metal::KernelHandle compute_receiver_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_receiver_config.cpp",
+        receiver_cores,
+        tt::tt_metal::ComputeConfig{.compile_args = compile_args});
+
+    for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping) {
+        auto sender_noc_coords = device->worker_core_from_logical_core(sender_core);
+        std::vector<CoreCoord> receiver_noc_coords;
+        for (const auto& receiver_core_range : receiver_cores.ranges()) {
+            const auto& receiver_cores_vec = corerange_to_cores(receiver_core_range);
+            for (const auto& receiver_core : receiver_cores_vec) {
+                receiver_noc_coords.push_back(device->worker_core_from_logical_core(receiver_core));
+            }
+        }
+        std::vector<uint32_t> sender_runtime_args(11 + receiver_noc_coords.size() * 2);
+        uint32_t sender_args_idx = 0;
+        sender_runtime_args[sender_args_idx++] = global_cb.config_address();  // config_addr
+        sender_runtime_args[sender_args_idx++] = 1;                           // is_sender
+        sender_runtime_args[sender_args_idx++] = receiver_noc_coords.size();  // num_receivers
+        sender_runtime_args[sender_args_idx++] = global_cb.buffer_address();  // fifo_start_addr
+        sender_runtime_args[sender_args_idx++] = global_cb.size();            // fifo_size
+        sender_runtime_args[sender_args_idx++] = global_cb.buffer_address();  // fifo_ptr
+        for (const auto& receiver_noc_coord : receiver_noc_coords) {
+            sender_runtime_args[sender_args_idx++] = receiver_noc_coord.x;  // remote_noc_x
+            sender_runtime_args[sender_args_idx++] = receiver_noc_coord.y;  // remote_noc_y
+        }
+        sender_runtime_args[sender_args_idx++] = 0;                           // aligned_pages_sent
+        sender_runtime_args[sender_args_idx++] = 0;                           // aligned_pages_acked
+        sender_runtime_args[sender_args_idx++] = global_cb.buffer_address();  // fifo_wr_ptr
+        sender_runtime_args[sender_args_idx++] =
+            global_cb.buffer_address() + global_cb.size();      // fifo_limit_page_aligned
+        sender_runtime_args[sender_args_idx++] = cb_page_size;  // fifo_page_size
+
+        std::vector<uint32_t> receiver_runtime_args = {
+            global_cb.config_address(),                     // config_addr
+            0,                                              // is_sender
+            global_cb.buffer_address(),                     // fifo_start_addr
+            global_cb.size(),                               // fifo_size
+            global_cb.buffer_address(),                     // fifo_ptr
+            sender_noc_coords.x,                            // sender_noc_x
+            sender_noc_coords.y,                            // sender_noc_y
+            0,                                              // aligned_pages_sent
+            0,                                              // aligned_pages_acked
+            global_cb.buffer_address(),                     // fifo_rd_ptr
+            global_cb.buffer_address() + global_cb.size(),  // fifo_limit_page_aligned
+            cb_page_size,                                   // fifo_page_size
+        };
+        tt::tt_metal::SetRuntimeArgs(program, dm0_sender_kernel, sender_cores, sender_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, dm1_sender_kernel, sender_cores, sender_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, compute_sender_kernel, sender_cores, sender_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, dm0_receiver_kernel, receiver_cores, receiver_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, dm1_receiver_kernel, receiver_cores, receiver_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, compute_receiver_kernel, receiver_cores, receiver_runtime_args);
+    }
+    this->RunProgram(device, program);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_receiver_config.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_receiver_config.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/assert.h"
+
+#if defined(COMPILE_FOR_TRISC)
+#include "compute_kernel_api/common.h"
+
+namespace NAMESPACE {
+void MAIN {
+#else
+#include "dataflow_api.h"
+
+void kernel_main() {
+#endif
+#if !defined(UCK_CHLKC_MATH)
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(0);
+
+    auto& remote_receiver_cb_interface = get_remote_receiver_cb_interface(remote_cb_id);
+
+    uint32_t arg_idx = 0;
+    uint32_t config_idx = 0;
+    bool pass = true;
+    // config_addr
+    uint32_t config_addr = get_arg_val<uint32_t>(arg_idx++);
+    pass &= remote_receiver_cb_interface.config_ptr == config_addr;
+    ASSERT(pass);
+    volatile tt_l1_ptr uint32_t* config_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_addr);
+    // is_sender
+    bool is_sender = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == is_sender;
+    ASSERT(pass);
+    // num_receivers
+    config_idx++;  // Skip num_receivers
+    // fifo_start_addr
+    uint32_t fifo_start_addr = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == fifo_start_addr;
+    ASSERT(pass);
+    pass &= remote_receiver_cb_interface.fifo_start_addr == fifo_start_addr;
+    ASSERT(pass);
+    // fifo_size
+    uint32_t fifo_size = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == fifo_size;
+    ASSERT(pass);
+    // fifo_ptr
+    uint32_t fifo_ptr = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == fifo_ptr;
+    ASSERT(pass);
+    // remote_noc_xy_addr
+    uint32_t remote_noc_xy_addr = config_ptr[config_idx++];
+    pass &= remote_receiver_cb_interface.sender_noc_x == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    pass &= remote_receiver_cb_interface.sender_noc_y == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+
+    // aligned_pages_acked_addr
+    uint32_t aligned_pages_sent_addr = config_ptr[config_idx++];
+    pass &= remote_receiver_cb_interface.aligned_pages_acked_ptr == aligned_pages_sent_addr + L1_ALIGNMENT;
+    ASSERT(pass);
+    volatile tt_l1_ptr uint32_t* pages_sent_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_sent_addr);
+    pass &= *pages_sent_ptr == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    volatile tt_l1_ptr uint32_t* pages_acked_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_receiver_cb_interface.aligned_pages_acked_ptr);
+    pass &= *pages_sent_ptr == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    // fifo_rd_ptr
+    pass &= remote_receiver_cb_interface.fifo_rd_ptr == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    // fifo_limit_page_aligned
+    pass &= remote_receiver_cb_interface.fifo_limit_page_aligned == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    // fifo_page_size
+    pass &= remote_receiver_cb_interface.fifo_page_size == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+
+    // Hang if watcher not enabled
+    while (!pass);
+#endif
+}
+#if defined(COMPILE_FOR_TRISC)
+}  // namespace NAMESPACE
+#endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/global_circular_buffer/validate_sender_config.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/assert.h"
+#include "debug/ring_buffer.h"
+
+#if defined(COMPILE_FOR_TRISC)
+#include "compute_kernel_api/common.h"
+
+namespace NAMESPACE {
+void MAIN {
+#else
+#include "dataflow_api.h"
+
+void kernel_main() {
+#endif
+#if !defined(UCK_CHLKC_MATH)
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(0);
+
+    auto& remote_sender_cb_interface = get_remote_sender_cb_interface(remote_cb_id);
+
+    uint32_t arg_idx = 0;
+    uint32_t config_idx = 0;
+    bool pass = true;
+    // config_addr
+    uint32_t config_addr = get_arg_val<uint32_t>(arg_idx++);
+    pass &= remote_sender_cb_interface.config_ptr == config_addr;
+    ASSERT(pass);
+    volatile tt_l1_ptr uint32_t* config_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_addr);
+    // is_sender
+    bool is_sender = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == is_sender;
+    ASSERT(pass);
+    // num_receivers
+    uint32_t num_receivers = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == num_receivers;
+    ASSERT(pass);
+    pass &= remote_sender_cb_interface.num_receivers == num_receivers;
+    ASSERT(pass);
+    // fifo_start_addr
+    uint32_t fifo_start_addr = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == fifo_start_addr;
+    ASSERT(pass);
+    pass &= remote_sender_cb_interface.fifo_start_addr == fifo_start_addr;
+    ASSERT(pass);
+    // fifo_size
+    uint32_t fifo_size = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == fifo_size;
+    ASSERT(pass);
+    // fifo_ptr
+    uint32_t fifo_ptr = get_arg_val<uint32_t>(arg_idx++);
+    pass &= config_ptr[config_idx++] == fifo_ptr;
+    ASSERT(pass);
+    // remote_noc_xy_addr
+    uint32_t remote_noc_xy_addr = config_ptr[config_idx++];
+    pass &= remote_sender_cb_interface.receiver_noc_xy_ptr == remote_noc_xy_addr;
+    ASSERT(pass);
+    volatile tt_l1_ptr uint32_t* remote_noc_xy_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_noc_xy_addr);
+    for (uint32_t i = 0; i < num_receivers * 2; ++i) {
+        pass &= remote_noc_xy_ptr[i] == get_arg_val<uint32_t>(arg_idx++);
+        ASSERT(pass);
+    }
+    // aligned_pages_sent_addr
+    uint32_t aligned_pages_sent_addr = config_ptr[config_idx++];
+    pass &= remote_sender_cb_interface.aligned_pages_sent_ptr == aligned_pages_sent_addr;
+    ASSERT(pass);
+    volatile tt_l1_ptr uint32_t* pages_sent_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_sender_cb_interface.aligned_pages_sent_ptr);
+    volatile tt_l1_ptr uint32_t* pages_acked_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        remote_sender_cb_interface.aligned_pages_sent_ptr + L1_ALIGNMENT);
+    for (uint32_t i = 0; i < num_receivers; ++i) {
+        pass &= *pages_sent_ptr == get_arg_val<uint32_t>(arg_idx);
+        ASSERT(pass);
+        pass &= *pages_acked_ptr == get_arg_val<uint32_t>(arg_idx + 1);
+        ASSERT(pass);
+        pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+        pages_acked_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+    }
+    arg_idx += 2;
+    // fifo_wr_ptr
+    pass &= remote_sender_cb_interface.fifo_wr_ptr == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    // fifo_limit_page_aligned
+    pass &= remote_sender_cb_interface.fifo_limit_page_aligned == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+    // fifo_page_size
+    pass &= remote_sender_cb_interface.fifo_page_size == get_arg_val<uint32_t>(arg_idx++);
+    ASSERT(pass);
+
+    // Hang if watcher not enabled
+    while (!pass);
+#endif
+}
+#if defined(COMPILE_FOR_TRISC)
+}  // namespace NAMESPACE
+#endif

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -133,10 +133,7 @@ FORCE_INLINE uint32_t get_bank_offset(uint32_t bank_index) {
  * | arg_idx        | Unique Runtime argument index                                           | uint32_t | 0 to 255    | True     |
  */
 // clang-format on
-static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) {
-    return (uint32_t)&rta_l1_base[arg_idx];
-    ;
-}
+static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) { return (uint32_t)&rta_l1_base[arg_idx]; }
 // clang-format off
 /**
  * Returns the address in L1 for a given runtime argument index for common (all cores) runtime arguments set via
@@ -188,7 +185,7 @@ template <typename T>
 FORCE_INLINE T get_common_arg_val(int arg_idx) {
     // only 4B args are supported (eg int32, uint32)
     static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
-    return *((volatile tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
+    return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }
 
 // clang-format off

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -30,7 +30,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     uint32_t size,
     BufferType buffer_type) :
     device_(device), sender_receiver_core_mapping_(sender_receiver_core_mapping), size_(size) {
-    TT_FATAL(this->device_ != nullptr, "Device cannot be null");
+    TT_FATAL(device_ != nullptr, "Device cannot be null");
     uint32_t num_sender_cores = sender_receiver_core_mapping.size();
     uint32_t num_receiver_cores = 0;
     uint32_t max_num_receivers_per_sender = 0;
@@ -39,14 +39,14 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping) {
         num_receiver_cores += receiver_cores.num_cores();
         sender_cores.emplace_back(sender_core);
-        this->receiver_cores_ = this->receiver_cores_.merge(receiver_cores);
+        receiver_cores_ = receiver_cores_.merge(receiver_cores);
         max_num_receivers_per_sender = std::max(max_num_receivers_per_sender, receiver_cores.num_cores());
     }
-    this->sender_cores_ = CoreRangeSet(sender_cores);
-    TT_FATAL(num_sender_cores == this->sender_cores_.num_cores(), "Duplicate sender cores found");
-    TT_FATAL(num_receiver_cores == this->receiver_cores_.num_cores(), "Duplicate receiver cores found");
-    this->all_cores_ = this->sender_cores_.merge(this->receiver_cores_);
-    TT_FATAL(this->all_cores_.num_cores() == num_sender_cores + num_receiver_cores, "Duplicate cores found");
+    sender_cores_ = CoreRangeSet(sender_cores);
+    TT_FATAL(num_sender_cores == sender_cores_.num_cores(), "Duplicate sender cores found");
+    TT_FATAL(num_receiver_cores == receiver_cores_.num_cores(), "Duplicate receiver cores found");
+    all_cores_ = sender_cores_.merge(receiver_cores_);
+    TT_FATAL(all_cores_.num_cores() == num_sender_cores + num_receiver_cores, "Duplicate cores found");
     this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
 }
 
@@ -54,20 +54,20 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     TT_FATAL(
         buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
         "Global circular buffer can only be created for L1 buffer types");
-    uint32_t num_cores = this->all_cores_.num_cores();
+    uint32_t num_cores = all_cores_.num_cores();
 
-    auto shard_parameters =
-        ShardSpecBuffer(this->all_cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
+    auto shard_parameters = ShardSpecBuffer(all_cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
 
-    uint32_t cb_buffer_size = this->size_ * num_cores;
-    this->cb_buffer_ = Buffer::create(
-        this->device_,
-        cb_buffer_size,
-        this->size_,
-        buffer_type,
-        TensorMemoryLayout::HEIGHT_SHARDED,
-        shard_parameters,
-        std::nullopt);
+    uint32_t cb_buffer_size = size_ * num_cores;
+    ShardedBufferConfig cb_buffer_shard_config = {
+        .device = device_,
+        .size = cb_buffer_size,
+        .page_size = size_,
+        .buffer_type = buffer_type,
+        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = shard_parameters,
+    };
+    cb_buffer_ = CreateBuffer(cb_buffer_shard_config);
 
     auto l1_alignment = hal.get_alignment(HalMemType::L1);
     // is_sender, receiver_val, fifo_start_addr, fifo_size, fifo_ptr, noc_xy coords, and pages_sent
@@ -76,27 +76,28 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     auto cb_config_page_size = tt::align((num_config_elements + num_noc_xy_words) * sizeof(uint32_t), l1_alignment) +
                                2 * max_num_receivers_per_sender * l1_alignment;
     uint32_t cb_config_size = cb_config_page_size * num_cores;
-    this->cb_config_buffer_ = Buffer::create(
-        this->device_,
-        cb_config_size,
-        cb_config_page_size,
-        buffer_type,
-        TensorMemoryLayout::HEIGHT_SHARDED,
-        shard_parameters,
-        std::nullopt);
+    ShardedBufferConfig cb_config_buffer_shard_config = {
+        .device = device_,
+        .size = cb_config_size,
+        .page_size = cb_config_page_size,
+        .buffer_type = buffer_type,
+        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(shard_parameters),
+    };
+    cb_config_buffer_ = CreateBuffer(cb_config_buffer_shard_config);
 
     // Write the config buffer to the device
     // Only block for the slow dispatch case
-    auto* device = this->device_;
+    auto* device = device_;
     device->push_work([device,
                        cb_config_size,
                        cb_config_page_size,
                        num_noc_xy_words,
                        l1_alignment,
-                       buffer_address = this->cb_buffer_->address(),
-                       cb_config_buffer = this->cb_config_buffer_,
-                       size = this->size_,
-                       sender_receiver_core_mapping = this->sender_receiver_core_mapping_] {
+                       buffer_address = cb_buffer_->address(),
+                       cb_config_buffer = cb_config_buffer_,
+                       size = size_,
+                       sender_receiver_core_mapping = sender_receiver_core_mapping_] {
         auto config_buffer_address = cb_config_buffer->address();
         const auto& core_to_core_id = cb_config_buffer->get_buffer_page_mapping()->core_to_core_id_;
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
@@ -144,22 +145,22 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     });
 }
 
-const Buffer& GlobalCircularBuffer::cb_buffer() const { return *this->cb_buffer_; }
+const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_; }
 
-const CoreRangeSet& GlobalCircularBuffer::sender_cores() const { return this->sender_cores_; }
+const CoreRangeSet& GlobalCircularBuffer::sender_cores() const { return sender_cores_; }
 
-const CoreRangeSet& GlobalCircularBuffer::receiver_cores() const { return this->receiver_cores_; }
+const CoreRangeSet& GlobalCircularBuffer::receiver_cores() const { return receiver_cores_; }
 
-const CoreRangeSet& GlobalCircularBuffer::all_cores() const { return this->all_cores_; }
+const CoreRangeSet& GlobalCircularBuffer::all_cores() const { return all_cores_; }
 
-DeviceAddr GlobalCircularBuffer::buffer_address() const { return this->cb_buffer_->address(); }
+DeviceAddr GlobalCircularBuffer::buffer_address() const { return cb_buffer_->address(); }
 
-DeviceAddr GlobalCircularBuffer::config_address() const { return this->cb_config_buffer_->address(); }
+DeviceAddr GlobalCircularBuffer::config_address() const { return cb_config_buffer_->address(); }
 
-uint32_t GlobalCircularBuffer::size() const { return this->size_; }
+uint32_t GlobalCircularBuffer::size() const { return size_; }
 
 const std::vector<std::pair<CoreCoord, CoreRangeSet>>& GlobalCircularBuffer::sender_receiver_core_mapping() const {
-    return this->sender_receiver_core_mapping_;
+    return sender_receiver_core_mapping_;
 }
 
 }  // namespace experimental

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -35,19 +35,19 @@ void GlobalSemaphore::setup_buffer(uint32_t initial_value, BufferType buffer_typ
     TT_FATAL(
         buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
         "Global semaphore can only be created for L1 buffer types");
-    TT_FATAL(this->device_ != nullptr, "Device cannot be null");
-    TT_FATAL(this->cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
-    uint32_t num_cores = this->cores_.num_cores();
-    auto shard_parameters = ShardSpecBuffer(this->cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
-
-    this->buffer_ = Buffer::create(
-        this->device_,
-        num_cores * sizeof(uint32_t),
-        sizeof(uint32_t),
-        buffer_type,
-        TensorMemoryLayout::HEIGHT_SHARDED,
-        shard_parameters,
-        std::nullopt);
+    TT_FATAL(device_ != nullptr, "Device cannot be null");
+    TT_FATAL(cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
+    uint32_t num_cores = cores_.num_cores();
+    auto shard_parameters = ShardSpecBuffer(cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
+    ShardedBufferConfig sem_shard_config = {
+        .device = device_,
+        .size = num_cores * sizeof(uint32_t),
+        .page_size = sizeof(uint32_t),
+        .buffer_type = buffer_type,
+        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(shard_parameters),
+    };
+    buffer_ = CreateBuffer(sem_shard_config);
 
     this->reset_semaphore_value(initial_value);
 }
@@ -59,8 +59,8 @@ DeviceAddr GlobalSemaphore::address() const { return buffer_->address(); }
 void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     // Write the initial value to the semaphore to the device
     // Only block for the slow dispatch case
-    auto* device = this->device_;
-    device->push_work([device, reset_value, num_cores = this->cores_.num_cores(), buffer = this->buffer_] {
+    auto* device = device_;
+    device->push_work([device, reset_value, num_cores = cores_.num_cores(), buffer = buffer_] {
         std::vector<uint32_t> host_buffer(num_cores, reset_value);
         if (device->using_slow_dispatch()) {
             detail::WriteToBuffer(*buffer, host_buffer);

--- a/tt_metal/include/compute_kernel_api/common.h
+++ b/tt_metal/include/compute_kernel_api/common.h
@@ -78,5 +78,5 @@ template <typename T>
 FORCE_INLINE T get_common_arg_val(int arg_idx) {
     // only 4B args are supported (eg int32, uint32)
     static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
-    return *((volatile tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
+    return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Global cbs has some functionality tests, but they aren't part of post commit.

### What's changed
Add initial test to post commit for validating dispatched params/configs. Will move/add some more functionality tests later on.

Also removed volatile from get_common_arg_val so it is now the same as with get_arg_val

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13016014831
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
