### PR TITLE
Prevent UNet Shallow perf report entry from being overwritten

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -123,7 +123,7 @@ def test_unet_trace_perf_multi_device(
     total_num_samples = result.batch * result.groups * result.num_devices
     expected_inference_time = total_num_samples / expected_throughput
     prep_perf_report(
-        model_name="unet_shallow-trace_2cq_same_io-multi_device",
+        model_name=model_name,
         batch_size=total_num_samples,
         inference_and_compile_time=result.inference_and_compile_time,
         inference_time=result.inference_time,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -169,7 +169,9 @@ class UNetConv2D:
 
         self.weight = ttnn.from_torch(weight, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
         self.bias = ttnn.from_torch(bias, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
-        self.conv_kwargs = {
+
+    def get_conv2d_kwargs(self):
+        return {
             "in_channels": self.in_channels,
             "out_channels": self.out_channels,
             "batch_size": self.batch_size,
@@ -183,37 +185,17 @@ class UNetConv2D:
             "device": self.device,
             "conv_config": self.conv_config,
         }
-        # if not ttnn.is_tensor_storage_on_device(self.weight):
-        #     self.weight = ttnn.prepare_conv_weights(
-        #         weight_tensor=self.weight,
-        #         weights_format="OIHW",
-        #         input_memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
-        #         if self.use_1d_systolic_array
-        #         else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
-        #         input_layout=ttnn.TILE_LAYOUT,  # not used for sharded tensor
-        #         **self.conv_kwargs,
-        #     )
-        #     self.bias = ttnn.prepare_conv_bias(
-        #         bias_tensor=self.bias,
-        #         input_memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
-        #         if self.use_1d_systolic_array
-        #         else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
-        #         input_layout=ttnn.TILE_LAYOUT,  # not used for sharded tensor
-        #         **self.conv_kwargs,
-        #     )
-        #     self.weight = ttnn.to_device(self.weight, self.device)
-        #     self.bias = ttnn.to_device(self.bias, self.device)
 
     def __call__(self, x):
         x, [self.weight, self.bias] = ttnn.conv2d(
             input_tensor=x,
             weight_tensor=self.weight,
             bias_tensor=self.bias,
-            **self.conv_kwargs,
             compute_config=self.compute_config,
             conv_op_cache=self.cache,
             return_output_dim=False,
             return_weights_and_bias=True,
+            **self.get_conv2d_kwargs(),
         )
         return x
 


### PR DESCRIPTION
### Summary

Small fix to prevent async perf report entry from being overwritten by the async one because of incorrect model name

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13014685212
- [x] E2E performance regression CI testing passes: https://github.com/tenstorrent/tt-metal/actions/runs/13014673328
