### PR TITLE
1D support for tilize/reshape ops

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -244,3 +244,16 @@ def test_int_untilize(device, batch_size, sentence_size):
     output_torch = ttnn.to_torch(output_tt)
 
     assert_with_pcc(torch_input_tensor, output_torch)
+
+
+@pytest.mark.parametrize("shape", [[143], [64], [380]])
+@pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_to_layout_for_1D(shape, dtype, input_layout, output_layout, device):
+    torch.manual_seed(2005)
+    input_a = torch.randn(shape, dtype=dtype)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout)
+    output_tensor = ttnn.to_layout(input_tensor, output_layout)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(input_a, output_tensor)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -257,3 +257,14 @@ def test_to_layout_for_1D(shape, dtype, input_layout, output_layout, device):
     output_tensor = ttnn.to_layout(input_tensor, output_layout)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(input_a, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[30], [64], [2040]])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_tilize_with_padding_for_1D(shape, dtype, device):
+    torch.manual_seed(2005)
+    input_a = torch.randn(shape, dtype=dtype)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.tilize_with_zero_padding(input_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(input_a, output_tensor)

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -92,8 +92,7 @@ Tensor to_layout_impl(
 
     auto tensor = tensor_arg;
     const auto tile = tensor.get_tensor_spec().tile();
-    auto output_shape =
-        tensor_arg.get_logical_shape().rank() == 0 ? tensor_arg.get_padded_shape() : tensor_arg.get_logical_shape();
+    auto output_shape = tensor_arg.get_logical_shape();
     auto output_memory_config =
         memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
 

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -195,11 +195,6 @@ inline std::vector<std::vector<BlockRep>> distribute_work(
     bool has_cliff,
     uint32_t nblocks_per_core_cliff,
     uint32_t tile_height) {
-    TT_FATAL(
-        logical_shape.rank() >= 2,
-        "Only tensors >=2D, tensors are supported. Shape: {}",
-        logical_shape);
-
     auto input_w = logical_shape[-4];
     auto input_z = logical_shape[-3];
     auto input_y = logical_shape[-2];

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -259,9 +259,11 @@ ttnn::Tensor PerformView(const ttnn::Tensor& tensor, const ttnn::Shape& shape, c
     if (tensor.get_shape() == shape) {
         return tensor;
     }
-    if (tensor.get_layout() == ttnn::TILE_LAYOUT &&
-        (shape[-1]%tile_first_dim!=0 || shape.rank()==1 || shape[-2]%tile_second_dim!=0 ))
-    {
+    if (shape.rank() == 1) {
+        return ttnn::experimental::view(tensor, ttnn::SimpleShape(shape.logical_shape()));
+    } else if (
+        tensor.get_layout() == ttnn::TILE_LAYOUT &&
+        (shape[-1] % tile_first_dim != 0 || shape[-2] % tile_second_dim != 0)) {
         //Correct the output shape to add padding metadata before reshape (view)
         return ttnn::experimental::view(tensor, tiling_reshape_corrector(shape, tile_first_dim, tile_second_dim));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -23,6 +23,8 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
             input_tensor_a.get_dtype() == DataType::FLOAT32,
         "Can only tilize bfloat16/float32 or uint32 tensors");
 
+    TT_FATAL(input_shape.rank() >= 1, "Input tensor must be of rank >= 1, but its shape is {}", input_shape);
+
     for (auto i = 0; i < input_shape.rank(); i++) {
         TT_FATAL(
             input_shape[i] <= this->output_padded_shape[i],

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -22,7 +22,6 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
         input_tensor_a.get_dtype() == DataType::BFLOAT16 or input_tensor_a.get_dtype() == DataType::UINT32 or
             input_tensor_a.get_dtype() == DataType::FLOAT32,
         "Can only tilize bfloat16/float32 or uint32 tensors");
-    TT_FATAL(input_shape.rank() >= 2, "Input tensor must be of rank >2, but its shape is {}", input_shape);
 
     for (auto i = 0; i < input_shape.rank(); i++) {
         TT_FATAL(


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/17071#event-16052216677

### Problem description
Tilize/Reshape operations don't support 1D tensors

### What's changed
Given that APIs support now 1D tiles, this PR adds the 1D support for the reshape and the tilize operations.
The reshape corrector is still used in the view operation because of the tests that still use ttnn::Shape

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12994541727
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
