### PR TITLE
#17083: Add support for watcher printing phys coords

### DIFF
--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -99,6 +99,7 @@ class RunTimeOptions {
     bool watcher_append = false;
     bool watcher_auto_unpause = false;
     bool watcher_noinline = false;
+    bool watcher_phys_coords = false;
     bool record_noc_transfer_data = false;
 
     TargetSelection feature_targets[RunTimeDebugFeatureCount];
@@ -166,6 +167,8 @@ public:
     inline void set_watcher_auto_unpause(bool auto_unpause) { watcher_auto_unpause = auto_unpause; }
     inline int get_watcher_noinline() { return watcher_noinline; }
     inline void set_watcher_noinline(bool noinline) { watcher_noinline = noinline; }
+    inline int get_watcher_phys_coords() { return watcher_phys_coords; }
+    inline void set_watcher_phys_coords(bool phys_coords) { watcher_phys_coords = phys_coords; }
     inline std::set<std::string>& get_watcher_disabled_features() { return watcher_disabled_features; }
     inline bool watcher_status_disabled() { return watcher_feature_disabled(watcher_waypoint_str); }
     inline bool watcher_noc_sanitize_disabled() { return watcher_feature_disabled(watcher_noc_sanitize_str); }

--- a/tt_metal/api/tt-metalium/tt_cluster.hpp
+++ b/tt_metal/api/tt-metalium/tt_cluster.hpp
@@ -72,6 +72,8 @@ class Cluster {
     CoreCoord get_virtual_coordinate_from_logical_coordinates(chip_id_t chip_id, CoreCoord logical_coord, const CoreType& core_type) const;
     CoreCoord get_virtual_coordinate_from_physical_coordinates(chip_id_t chip_id, CoreCoord physical_coord) const;
     tt_cxy_pair get_virtual_coordinate_from_logical_coordinates(tt_cxy_pair logical_coordinate, const CoreType& core_type) const;
+    CoreCoord get_physical_coordinate_from_logical_coordinates(
+        chip_id_t chip_id, CoreCoord logical_coord, const CoreType& core_type, bool no_warn = false) const;
     const std::unordered_set<CoreCoord>& get_virtual_worker_cores(chip_id_t chip_id) const;
     const std::unordered_set<CoreCoord>& get_virtual_eth_cores(chip_id_t chip_id) const;
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -306,20 +306,24 @@ void WatcherDeviceReader::Dump(FILE* file) {
 void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_eth_core) {
     // Watcher only treats ethernet + worker cores.
     bool is_eth_core = (logical_core.type == CoreType::ETH);
-    CoreDescriptor core;
-    core.coord = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-    core.type = logical_core.type;
+    CoreDescriptor virtual_core;
+    virtual_core.coord = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+    virtual_core.type = logical_core.type;
 
     // Print device id, core coords (logical)
     string core_type = is_eth_core ? "ethnet" : "worker";
-    string core_str = fmt::format(
-        "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2})",
-        device->id(),
-        core_type,
+    string core_coord_str = fmt::format(
+        "core(x={:2},y={:2}) virtual(x={:2},y={:2})",
         logical_core.coord.x,
         logical_core.coord.y,
-        core.coord.x,
-        core.coord.y);
+        virtual_core.coord.x,
+        virtual_core.coord.y);
+    if (tt::llrt::RunTimeOptions::get_instance().get_watcher_phys_coords()) {
+        CoreCoord phys_core = tt::Cluster::instance().get_physical_coordinate_from_logical_coordinates(
+            device->id(), logical_core.coord, logical_core.type, true);
+        core_coord_str += fmt::format(" phys(x={:2},y={:2})", phys_core.x, phys_core.y);
+    }
+    string core_str = fmt::format("Device {} {} {}", device->id(), core_type, core_coord_str);
     fprintf(f, "%s: ", core_str.c_str());
 
     // Ethernet cores have a different mailbox base addr
@@ -333,7 +337,7 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     }
 
     std::vector<uint32_t> data;
-    data = tt::llrt::read_hex_vec_from_core(device->id(), core.coord, mailbox_addr, sizeof(mailboxes_t));
+    data = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core.coord, mailbox_addr, sizeof(mailboxes_t));
     mailboxes_t* mbox_data = (mailboxes_t*)(&data[0]);
     // Get the launch message buffer read pointer.
     // For more accurate reporting of launch messages and running kernel ids, dump data from the previous valid
@@ -343,7 +347,7 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
         launch_msg_read_ptr = (launch_msg_read_ptr - 1 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
     }
     // Validate these first since they are used in diagnostic messages below.
-    ValidateKernelIDs(core, &(mbox_data->launch[launch_msg_read_ptr]));
+    ValidateKernelIDs(virtual_core, &(mbox_data->launch[launch_msg_read_ptr]));
 
     // Whether or not watcher data is available depends on a flag set on the device.
     bool enabled = (mbox_data->watcher.enable == WatcherEnabled);
@@ -351,39 +355,39 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     if (enabled) {
         // Dump state only gathered if device is compiled w/ watcher
         if (!tt::llrt::RunTimeOptions::get_instance().watcher_status_disabled()) {
-            DumpWaypoints(core, mbox_data, false);
+            DumpWaypoints(virtual_core, mbox_data, false);
         }
         // Ethernet cores have firmware that starts at address 0, so no need to check it for a
         // magic value.
         if (!is_eth_core) {
-            DumpL1Status(core, &mbox_data->launch[launch_msg_read_ptr]);
+            DumpL1Status(virtual_core, &mbox_data->launch[launch_msg_read_ptr]);
         }
         if (!tt::llrt::RunTimeOptions::get_instance().watcher_noc_sanitize_disabled()) {
             const auto NUM_NOCS_ = tt::tt_metal::hal.get_num_nocs();
             for (uint32_t noc = 0; noc < NUM_NOCS_; noc++) {
-                DumpNocSanitizeStatus(core, core_str, mbox_data, noc);
+                DumpNocSanitizeStatus(virtual_core, core_str, mbox_data, noc);
             }
         }
         if (!tt::llrt::RunTimeOptions::get_instance().watcher_assert_disabled()) {
-            DumpAssertStatus(core, core_str, mbox_data);
+            DumpAssertStatus(virtual_core, core_str, mbox_data);
         }
         if (!tt::llrt::RunTimeOptions::get_instance().watcher_pause_disabled()) {
-            DumpPauseStatus(core, core_str, mbox_data);
+            DumpPauseStatus(virtual_core, core_str, mbox_data);
         }
     }
 
     // Ethernet cores don't use the launch message/sync reg
     if (!is_eth_core) {
         // Dump state always available
-        DumpLaunchMessage(core, mbox_data);
+        DumpLaunchMessage(virtual_core, mbox_data);
         if (tt::llrt::RunTimeOptions::get_instance().get_watcher_dump_all()) {
             // Reading registers while running can cause hangs, only read if
             // requested explicitly
-            DumpSyncRegs(core);
+            DumpSyncRegs(virtual_core);
         }
     } else {
         fprintf(f, "rmsg:");
-        DumpRunState(core, &mbox_data->launch[launch_msg_read_ptr], mbox_data->go_message.signal);
+        DumpRunState(virtual_core, &mbox_data->launch[launch_msg_read_ptr], mbox_data->go_message.signal);
         fprintf(f, " h_id:%d ", mbox_data->launch[launch_msg_read_ptr].kernel_config.host_assigned_id);
     }
 
@@ -405,10 +409,10 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     // Ring buffer at the end because it can print a bunch of data, same for stack usage
     if (enabled) {
         if (!tt::llrt::RunTimeOptions::get_instance().watcher_stack_usage_disabled()) {
-            DumpStackUsage(core, mbox_data);
+            DumpStackUsage(virtual_core, mbox_data);
         }
         if (!tt::llrt::RunTimeOptions::get_instance().watcher_ring_buffer_disabled()) {
-            DumpRingBuffer(core, mbox_data, false);
+            DumpRingBuffer(virtual_core, mbox_data, false);
         }
     }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -168,6 +168,9 @@ void RunTimeOptions::ParseWatcherEnv() {
     const char* watcher_noinline_str = getenv("TT_METAL_WATCHER_NOINLINE");
     watcher_noinline = (watcher_noinline_str != nullptr);
 
+    const char* watcher_phys_str = getenv("TT_METAL_WATCHER_PHYS_COORDS");
+    watcher_phys_coords = (watcher_phys_str != nullptr);
+
     // Auto unpause is for testing only, no env var.
     watcher_auto_unpause = false;
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -449,6 +449,18 @@ CoreCoord Cluster::get_virtual_coordinate_from_physical_coordinates(chip_id_t ch
     return {translated_coord.x, translated_coord.y};
 }
 
+CoreCoord Cluster::get_physical_coordinate_from_logical_coordinates(
+    chip_id_t chip_id, CoreCoord logical_coord, const CoreType& core_type, bool no_warn) const {
+    if (!no_warn) {
+        log_warning(
+            tt::LogDevice,
+            "Conversion requested to Physical Coordinates. Please note that Physical Coordinates are not expected to "
+            "be used in tt-metal APIs.");
+    }
+    auto& soc_desc = this->get_soc_desc(chip_id);
+    return soc_desc.get_physical_core_from_logical_core(logical_coord, core_type);
+}
+
 CoreCoord Cluster::get_logical_ethernet_core_from_virtual(chip_id_t chip, CoreCoord core) const {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(chip);
     auto phys_eth_core = this->virtual_to_umd_coord_mapping_.at(tt_cxy_pair(chip, core.x, core.y));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17083

### Problem description
Watcher dump includes logical/virtual coords, but some of our debug requires phys coords.

### What's changed
Add option for watcher output to contain logical+virtual+physical coords. Hide behind env var `TT_METAL_WATCHER_PHYS_COORDS` since we don't want to expose phys cores to users.

Before:
```
...
Device 0 worker core(x= 0,y= 1) virtual(x=18,y=19):   GW,   W,   W,   W,   W  rmsg:D0D|bnt h_id:0 smsg:DDDD k_ids:15|16|17
...
```
After (with `TT_METAL_WATCHER_PHYS_COORDS=1`):
```
...
Device 0 worker core(x= 0,y= 1) virtual(x=18,y=19) phys(x= 1,y= 2):   GW,   W,   W,   W,   W  rmsg:D0D|bnt h_id:0 smsg:DDDD k_ids:15|16|17
...
```

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/13016508029
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
