### PR TITLE
Fix shard and physical height mismatch in `ttnn.convert_to_chw` tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -36,7 +36,7 @@ def test_convert_to_chw(device, C, HW, core_grid):
     input_tensor = ttnn.to_device(input_tensor, device, input_memory_config)
 
     output_memory_config = ttnn.create_sharded_memory_config(
-        [1, 1, 32, HW], core_grid, ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.ROW_MAJOR
+        [1, 1, C, HW], core_grid, ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.ROW_MAJOR
     )
     actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_memory_config)
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -58,19 +58,19 @@ operation::ProgramWithCallbacks multi_core_convert_to_chw(
     const tt::DataFormat intermediary_format = tt::DataFormat::Float16_b;
     const uint32_t intermediary_tile_size = tt::tt_metal::detail::TileSize(intermediary_format);
 
-    const uint32_t cb_in_id = tt::CB::c_in0;
+    const uint32_t cb_in_id = tt::CBIndex::c_0;
     const uint32_t cb_in_total_size = total_tiles_per_core * input_tile_size;
     const uint32_t cb_in_page_size = input_tile_size;
     const auto cb_in = create_circular_buffer(cb_in_id, cb_in_total_size, cb_in_page_size, input_format, a.buffer());
 
-    const uint32_t cb_out_id = tt::CB::c_out0;
+    const uint32_t cb_out_id = tt::CBIndex::c_1;
     const uint32_t element_size = tt::datum_size(input_format);
     const uint32_t cb_out_total_size = tt::div_up(C * HW * element_size, input_cores.size());
     const uint32_t cb_out_page_size = tt::div_up(HW * element_size, input_cores.size());
     const auto cb_out =
         create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, input_format, output.buffer());
 
-    const uint32_t cb_in_transpose_id = tt::CB::c_intermed0;
+    const uint32_t cb_in_transpose_id = tt::CBIndex::c_2;
     const uint32_t cb_in_transpose_total_size = intermediary_tile_size;
     const uint32_t cb_in_transpose_page_size = intermediary_tile_size;
     const auto cb_in_transpose = create_circular_buffer(


### PR DESCRIPTION
### Ticket
- #17247

### What's changed
- Fix validation in `pytest tests/ttnn/unit_tests/operations/test_convert_to_chw.py::test_convert_to_chw`
- Consolidate CB indices in `ttnn.convert_to_chw`

### Checklist

 - [x] Commit that flips the check to TT_FATAL + whatever fix ops/tests/models need
 - [x] Post-commit all passes (UNet Shallow only, with TT_FATAL): https://github.com/tenstorrent/tt-metal/actions/runs/13019539000
 - [x] Nightly fast dispatch passes (UNet Shallow only, with TT_FATAL): https://github.com/tenstorrent/tt-metal/actions/runs/13019542734
 - [x] Post-commit all passes (with TT_ASSERT):  https://github.com/tenstorrent/tt-metal/actions/runs/13037856394
 - [x] Nightly fast dispatch passes (with TT_ASSERT): https://github.com/tenstorrent/tt-metal/actions/runs/13037864680

Note: The failure was only in a single test, and this test is confirmed to be now passing. The only model using this op is UNet Shallow, its tests are passing.
