### PR TITLE
#17215: Initial MeshBuffer integration with TTNN

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TTNN_TENSOR_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_create_tensor_multi_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_create_tensor_with_layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_distributed_tensor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_mesh_tensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_partition.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_shape_base.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_tensor_sharding.cpp

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn_test_fixtures.hpp"
+#include <ttnn/distributed/types.hpp>
+#include <ttnn/distributed/distributed_tensor.hpp>
+
+namespace ttnn::distributed::test {
+namespace {
+
+using ::testing::IsNull;
+using ::testing::Not;
+
+using MeshTensorTest = T3kMultiDeviceFixture;
+
+TensorSpec get_tensor_spec(const ttnn::SimpleShape& shape, DataType dtype) {
+    return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
+}
+
+TEST_F(MeshTensorTest, Lifecycle) {
+    const TensorSpec tensor_spec =
+        TensorSpec(ttnn::SimpleShape{1, 1, 32, 32}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    Tensor input_tensor = allocate_tensor_on_mesh(tensor_spec, mesh_device_.get());
+
+    EXPECT_EQ(input_tensor.workers.size(), mesh_device_->num_devices());
+    EXPECT_TRUE(input_tensor.is_allocated());
+
+    const auto& storage = input_tensor.get_storage();
+    auto* multi_device_storage = std::get_if<tt::tt_metal::MultiDeviceStorage>(&storage);
+
+    ASSERT_NE(multi_device_storage, nullptr);
+    EXPECT_THAT(multi_device_storage->mesh_buffer, Not(IsNull()));
+
+    // Buffer address stays the same across all device buffers.
+    const auto buffer_address = multi_device_storage->mesh_buffer->address();
+    for (auto* device : mesh_device_->get_devices()) {
+        auto buffer = multi_device_storage->get_buffer_for_device(device);
+        ASSERT_NE(buffer, nullptr);
+        EXPECT_TRUE(buffer->is_allocated());
+        EXPECT_EQ(buffer->address(), buffer_address);
+    }
+}
+
+}  // namespace
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -15,10 +15,6 @@ namespace {
 
 using MeshTensorTest = T3kMultiDeviceFixture;
 
-TensorSpec get_tensor_spec(const ttnn::SimpleShape& shape, DataType dtype) {
-    return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
-}
-
 TEST_F(MeshTensorTest, Lifecycle) {
     const TensorSpec tensor_spec =
         TensorSpec(ttnn::SimpleShape{1, 1, 32, 32}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -13,9 +13,6 @@
 namespace ttnn::distributed::test {
 namespace {
 
-using ::testing::IsNull;
-using ::testing::Not;
-
 using MeshTensorTest = T3kMultiDeviceFixture;
 
 TensorSpec get_tensor_spec(const ttnn::SimpleShape& shape, DataType dtype) {
@@ -35,9 +32,9 @@ TEST_F(MeshTensorTest, Lifecycle) {
     auto* multi_device_storage = std::get_if<tt::tt_metal::MultiDeviceStorage>(&storage);
 
     ASSERT_NE(multi_device_storage, nullptr);
-    EXPECT_THAT(multi_device_storage->mesh_buffer, Not(IsNull()));
+    EXPECT_NE(multi_device_storage->mesh_buffer, nullptr);
 
-    // Buffer address stays the same across all device buffers.
+    // Buffer address is the same across all device buffers.
     const auto buffer_address = multi_device_storage->mesh_buffer->address();
     for (auto* device : mesh_device_->get_devices()) {
         auto buffer = multi_device_storage->get_buffer_for_device(device);
@@ -45,6 +42,9 @@ TEST_F(MeshTensorTest, Lifecycle) {
         EXPECT_TRUE(buffer->is_allocated());
         EXPECT_EQ(buffer->address(), buffer_address);
     }
+
+    input_tensor.deallocate();
+    EXPECT_FALSE(input_tensor.is_allocated());
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -26,6 +26,7 @@ namespace detail {
 bool DispatchStateCheck(bool isFastDispatch);
 
 bool InWorkerThread();
+inline bool InMainThread() { return not InWorkerThread(); }
 
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -261,7 +261,7 @@ Tensor create_multi_device_tensor(
             specs.insert({device_id, tensor.get_tensor_spec()});
         }
         return Tensor{
-            MultiDeviceStorage{strategy, ordered_device_ids, device_buffers, specs},
+            MultiDeviceStorage{strategy, ordered_device_ids, device_buffers, specs, /*mesh_buffer_=*/nullptr},
             TensorSpec(
                 tensors.at(0).get_logical_shape(),
                 TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -96,7 +96,7 @@ Tensor aggregate_as_tensor(
     } else {
         std::vector<int> ordered_device_ids;
         std::unordered_map<int, ttnn::TensorSpec> specs;
-        std::unordered_map<int, DeviceBuffer> device_buffers;
+        std::unordered_map<int, std::shared_ptr<Buffer>> device_buffers;
         for (const auto& shard : tensor_shards) {
             IDevice* device = std::get<DeviceStorage>(shard.get_storage()).buffer->device();
             auto device_id = device->id();
@@ -116,7 +116,8 @@ Tensor aggregate_as_tensor(
                     shard_tile.get_width());
             }
         }
-        auto storage = MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), specs};
+        auto storage =
+            MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), specs, /*mesh_buffer_=*/nullptr};
         return Tensor(std::move(storage), reference_shard.get_tensor_spec());
     }
 }
@@ -247,7 +248,7 @@ Tensor create_multi_device_tensor(
     if (storage_type == StorageType::MULTI_DEVICE) {
         std::vector<int> ordered_device_ids;
         std::unordered_map<int, ttnn::TensorSpec> specs;
-        std::unordered_map<int, DeviceBuffer> device_buffers;
+        std::unordered_map<int, std::shared_ptr<Buffer>> device_buffers;
         for (const auto& tensor : tensors) {
             TT_ASSERT(
                 std::holds_alternative<DeviceStorage>(tensor.get_storage()),

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -81,7 +81,7 @@ Tensor tensor_reshape(
                 if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
                     if (tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
                         DeviceStorage device_storage = std::get<T>(tensor.get_storage());
-                        DeviceBuffer device_buffer = device_storage.get_buffer();
+                        auto device_buffer = device_storage.get_buffer();
                         const auto& tensor_spec = tensor.tensor_spec();
                         auto page_size_bytes = tensor_spec.compute_page_size_bytes();
                         device_buffer->set_page_size(page_size_bytes);
@@ -89,7 +89,7 @@ Tensor tensor_reshape(
                         return Tensor(device_storage, new_spec);
                     } else {
                         DeviceStorage device_storage = std::get<T>(tensor.get_storage());
-                        DeviceBuffer device_buffer = device_storage.get_buffer();
+                        auto device_buffer = device_storage.get_buffer();
                         ShardSpecBuffer shard_spec_buffer = device_buffer->shard_spec();
 
                         auto shard_spec = shard_spec_buffer.tensor_shard_spec;

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -6,9 +6,9 @@
 
 namespace tt::tt_metal {
 
-std::vector<DeviceBuffer> MultiDeviceStorage::get_buffers() const {
+std::vector<std::shared_ptr<Buffer>> MultiDeviceStorage::get_buffers() const {
     std::lock_guard<std::mutex> lock(buffer_mtx);
-    std::vector<DeviceBuffer> buf_vec;
+    std::vector<std::shared_ptr<Buffer>> buf_vec;
     buf_vec.reserve(buffers.size());
     for (const auto& pair : buffers) {
         buf_vec.push_back(pair.second);

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -38,12 +38,13 @@ struct OwnedStorage {
     }
 };
 
+// TODO: #17215 - Replace `DeviceStorage` with "mesh storage".
 struct DeviceStorage {
     std::shared_ptr<Buffer> buffer;
     DeviceStorage() = default;
     DeviceStorage(std::shared_ptr<Buffer> buffer_) : buffer(std::move(buffer_)) {}
 
-    const MemoryConfig memory_config() const {
+    MemoryConfig memory_config() const {
         if (this->buffer.get() == nullptr) {
             TT_THROW("MemoryConfig can only be obtained if the buffer is not null");
         }
@@ -307,8 +308,9 @@ struct MultiDeviceStorage {
     std::vector<std::shared_ptr<Buffer>> get_buffers() const;
 
     inline void insert_buffer_and_spec_for_device(
-        IDevice* device, const std::shared_ptr<Buffer> buffer, TensorSpec spec) {
+        IDevice* device, const std::shared_ptr<Buffer>& buffer, TensorSpec spec) {
         std::scoped_lock lock(buffer_mtx, shape_mtx);
+        TT_FATAL(mesh_buffer == nullptr, "MeshBuffer backed storage does not support inserting individual buffers");
         TT_ASSERT(
             device == buffer->device(),
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -226,6 +226,7 @@ struct MultiDeviceStorage {
 
     // TODO: #17215 - This isn't populated by default. Switch to creating MeshBuffer backed storage, when TTNN is ready
     // to consume it.
+    // Eventually, `MultiDeviceStorage` will be renamed to `MeshDeviceStorage`, and unified with `DeviceStorage`.
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
     mutable std::mutex buffer_mtx;
     mutable std::mutex shape_mtx;
@@ -238,6 +239,7 @@ struct MultiDeviceStorage {
         swap(first.ordered_device_ids, second.ordered_device_ids);
         swap(first.buffers, second.buffers);
         swap(first.specs, second.specs);
+        swap(first.mesh_buffer, second.mesh_buffer);
     }
 
     MultiDeviceStorage(
@@ -260,6 +262,7 @@ struct MultiDeviceStorage {
         strategy = other.strategy;
         buffers = other.buffers;
         specs = other.specs;
+        mesh_buffer = other.mesh_buffer;
     }
 
     MultiDeviceStorage& operator=(const MultiDeviceStorage& other) {
@@ -275,7 +278,7 @@ struct MultiDeviceStorage {
 
     bool operator==(const MultiDeviceStorage& other) {
         return this->ordered_device_ids == other.ordered_device_ids and this->strategy == other.strategy and
-               this->buffers == other.buffers and this->specs == other.specs;
+               this->buffers == other.buffers and this->specs == other.specs and this->mesh_buffer == other.mesh_buffer;
     }
 
     MemoryConfig memory_config() const {

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -364,12 +364,15 @@ struct MultiDeviceStorage {
 
     inline bool is_allocated() const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-
-        return std::all_of(
-            ordered_device_ids.begin(), ordered_device_ids.end(), [&buffers = this->buffers](auto&& device_id) {
-                const auto& buffer = buffers.at(device_id);
-                return buffer && buffer->is_allocated();
-            });
+        if (mesh_buffer != nullptr) {
+            return mesh_buffer->is_allocated();
+        } else {
+            return std::all_of(
+                ordered_device_ids.begin(), ordered_device_ids.end(), [&buffers = this->buffers](auto&& device_id) {
+                    const auto& buffer = buffers.at(device_id);
+                    return buffer && buffer->is_allocated();
+                });
+        }
     }
 };
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -363,10 +363,10 @@ struct MultiDeviceStorage {
     }
 
     inline bool is_allocated() const {
-        std::lock_guard<std::mutex> lock(buffer_mtx);
         if (mesh_buffer != nullptr) {
             return mesh_buffer->is_allocated();
         } else {
+            std::lock_guard<std::mutex> lock(buffer_mtx);
             return std::all_of(
                 ordered_device_ids.begin(), ordered_device_ids.end(), [&buffers = this->buffers](auto&& device_id) {
                     const auto& buffer = buffers.at(device_id);

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -59,7 +59,7 @@ struct DeviceStorage {
             .shard_spec = shard_spec};
     }
 
-    inline void insert_buffer(std::shared_ptr<Buffer> buffer_) { this->buffer = buffer_; }
+    inline void insert_buffer(const std::shared_ptr<Buffer>& buffer_) { this->buffer = buffer_; }
 
     inline std::shared_ptr<Buffer> get_buffer() const { return this->buffer; }
     static constexpr auto attribute_names = std::forward_as_tuple("memory_config");
@@ -149,7 +149,7 @@ struct MultiDeviceHostStorage {
     MultiDeviceHostStorage() = default;
     MultiDeviceHostStorage(
         DistributedTensorConfig strategy_, std::vector<OwnedBuffer> buffers_, std::vector<TensorSpec> specs_) :
-        strategy(strategy_), buffers(buffers_), specs(specs_) {}
+        strategy(strategy_), buffers(std::move(buffers_)), specs(std::move(specs_)) {}
     MultiDeviceHostStorage(MultiDeviceHostStorage&& other) { swap(*this, other); }
     // unfotunately we need to have this code written manually.
     MultiDeviceHostStorage(const MultiDeviceHostStorage& other) {

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -442,7 +442,7 @@ void Tensor::deallocate_impl(bool force, bool deallocation_through_destructor) {
                     if (storage.mesh_buffer != nullptr) {
                         // TODO: #17215 - Consider if it is possible to retain references to individual device buffers
                         // after mesh buffer was deallocated.
-                        storage.mesh_buffer.reset();
+                        storage.mesh_buffer->deallocate();
                     } else {
                         auto dealloc_lambda = std::make_shared<std::function<void(IDevice*)>>(
                             [force, attr = this->tensor_attributes](IDevice* worker) mutable {

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -399,6 +399,10 @@ void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& reg
 void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 Tensor allocate_tensor_on_devices(const TensorSpec& spec, const std::vector<IDevice*>& devices);
+
+// Allocates a tensor on a mesh device through mesh buffer.
+Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
+
 void write_tensor(const Tensor& host_tensor, Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
 
 Tensor set_tensor_id(const Tensor& tensor);

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -36,7 +36,8 @@ namespace distributed {
 class MeshDevice;
 }
 
-struct Tensor {
+class Tensor {
+public:
     struct TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
         Storage storage;
         TensorSpec tensor_spec;
@@ -81,7 +82,6 @@ struct Tensor {
 
     // Tensor gets worker queue handle through the device
     std::vector<IDevice*> workers = {};
-    bool deallocate_through_destructor = false;
 
     // ======================================================================================
     //                                  Hi Level APIs
@@ -123,7 +123,6 @@ struct Tensor {
             perform_cleanup_for_async_mode();
             this->workers = std::move(other.workers);
             this->tensor_attributes = std::move(other.tensor_attributes);
-            this->deallocate_through_destructor = std::move(other.deallocate_through_destructor);
         }
         return *this;
     }
@@ -351,6 +350,7 @@ struct Tensor {
 
 private:
     void init(Storage storage, TensorSpec tensor_spec);
+    void deallocate_impl(bool force, bool deallocation_through_destructor);
 };
 
 Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device);

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -302,7 +302,7 @@ struct Tensor {
             storage_type);
         return std::get<DeviceStorage>(this->get_storage()).get_buffer().get();
     }
-    DeviceBuffer device_buffer() const { return std::get<DeviceStorage>(this->get_storage()).get_buffer(); }
+    std::shared_ptr<Buffer> device_buffer() const { return std::get<DeviceStorage>(this->get_storage()).get_buffer(); }
 
     IDevice* device() const {
         if (this->storage_type() == tt::tt_metal::StorageType::DEVICE) {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -185,16 +185,16 @@ void validate_on_device_dtype_and_layout(
 //                           Data reader, writer, and initializers
 // ======================================================================================
 
-DeviceBuffer allocate_buffer_on_device(IDevice* device, const TensorSpec& tensor_spec);
+std::shared_ptr<Buffer> allocate_buffer_on_device(IDevice* device, const TensorSpec& tensor_spec);
 
 template <typename T>
 inline void read_data_from_device_buffer(
-    CommandQueue& cq, DeviceBuffer device_buffer, void* host_buffer_data, bool blocking) {
+    CommandQueue& cq, std::shared_ptr<Buffer> device_buffer, void* host_buffer_data, bool blocking) {
     EnqueueReadBuffer(cq, device_buffer, host_buffer_data, blocking);
 }
 
 template <typename T>
-inline void read_data_from_device_buffer(DeviceBuffer device_buffer, std::vector<T>& host_buffer) {
+inline void read_data_from_device_buffer(std::shared_ptr<Buffer> device_buffer, std::vector<T>& host_buffer) {
     ::tt::tt_metal::detail::ReadFromBuffer(device_buffer, host_buffer);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -187,6 +187,9 @@ void validate_on_device_dtype_and_layout(
 
 std::shared_ptr<Buffer> allocate_buffer_on_device(IDevice* device, const TensorSpec& tensor_spec);
 
+std::shared_ptr<distributed::MeshBuffer> allocate_mesh_buffer_on_device(
+    distributed::MeshDevice* mesh_device, const TensorSpec& tensor_spec);
+
 template <typename T>
 inline void read_data_from_device_buffer(
     CommandQueue& cq, std::shared_ptr<Buffer> device_buffer, void* host_buffer_data, bool blocking) {

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -120,30 +120,29 @@ uint32_t num_buffers_in_tensor(const Tensor& tensor) {
 
 Tensor get_shard_for_device(const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index) {
     ZoneScopedN("GetShardForDevice");
-    Tensor shard = Tensor();
     auto& storage = tensor.tensor_attributes->storage;
-    std::visit(
-        [target_device, buffer_index, &tensor, &shard](auto&& s) {
+    return std::visit(
+        [target_device, buffer_index, &tensor](auto&& s) {
             using T = std::decay_t<decltype(s)>;
             // Stalling reads for tensor data-type and layout are needed here
             // since some worker might have raced ahead to these lookups, while
             // another worker is populating this metadata.
             if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
-                shard = Tensor{
+                return Tensor{
                     DeviceStorage{s.get_buffer_for_device(target_device)}, s.get_tensor_spec_for_device(target_device)};
             } else if constexpr (std::is_same_v<T, MultiDeviceHostStorage>) {
-                shard =
-                    Tensor{OwnedStorage{s.get_buffer(buffer_index.value())}, s.get_tensor_spec(buffer_index.value())};
+                return Tensor{
+                    OwnedStorage{s.get_buffer(buffer_index.value())}, s.get_tensor_spec(buffer_index.value())};
             } else if constexpr (
                 std::is_same_v<T, OwnedStorage> || std::is_same_v<T, BorrowedStorage> ||
                 std::is_same_v<T, DeviceStorage>) {
-                shard = tensor;
+                return tensor;
             } else {
                 TT_THROW("get_shard_for_device only supports multi-device or device tensors");
+                return Tensor();
             }
         },
         storage);
-    return shard;
 }
 
 void insert_buffer_and_shape_for_device(

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/device_impl.hpp>
 #include <tt-metalium/reflection.hpp>


### PR DESCRIPTION
### Ticket
#17215 

### Problem description
See #17215

### What's changed
Extend `MultiDeviceStorage` with `MeshBuffer`, which is optionally created to back the individual per-device shards. This allows to incrementally switch over to `MeshBuffer` backed variant, while not breaking any of the existing ops.

Long term plan for tensor storage:
* `MeshBuffer` backed `MultiDeviceStorage` will become the default in TTNN. It will eventually be renamed to `MeshDeviceStorage`, with the `DeviceStorage` being removed.
* Interactions with `MeshBuffer` will be entirely synchronous and will be done on the main thread. This allows to get rid of any of the async code in `Tensor`.

Next steps in terms of integrating with `MeshBuffer`:
- [X] Implement explicit dealloc routine for `MeshBuffer` (done in https://github.com/tenstorrent/tt-metal/pull/17265 and integrated here).
- [ ] Implement read / write shards APIs for `MeshBuffer`. From the TTNN perspective, interacting with these APIs will be entirely synchronous.
- [ ] Use read / write shards APIs when writing data to `MeshBuffer` backed `MultiDeviceStorage`.
- [ ] When launching multi-device operations, create a `MeshBuffer` backed `MultiDeviceStorage` first, then supply the individual shards into ops. This way allows to perform allocation in lock-step across mesh, while maintaining compatibility with the existing ops infra. Note this will change with the introduction of `MeshWorkload`, and this will require further exploration.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13036677827)
- [X] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13036686228)
- [X] New/Existing tests provide coverage for changes
