### PR TITLE
#16149: Add DeviceCommandCalculator to calculate command size

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/CMakeLists.txt
@@ -1,1 +1,5 @@
-set(UNIT_TESTS_DISPATCH_UTIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_settings.cpp PARENT_SCOPE)
+set(UNIT_TESTS_DISPATCH_UTIL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_settings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_device_command.cpp
+    PARENT_SCOPE
+)

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/device_command.hpp>
+#include "cq_commands.hpp"
+#include "memcpy.hpp"
+#include <gtest/gtest.h>
+#include "tt_metal/impl/dispatch/device_command_calculator.hpp"
+
+TEST(DeviceCommandTest, AddDispatchWait) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_wait();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_dispatch_wait(0, 0, 0);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchWaitWithPrefetchStall) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_wait_with_prefetch_stall();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_dispatch_wait_with_prefetch_stall(0, 0, 0);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddPrefetchRelayLinear) {
+    DeviceCommandCalculator calculator;
+    calculator.add_prefetch_relay_linear();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_prefetch_relay_linear(0, 0, 0);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddData) {
+    DeviceCommandCalculator calculator;
+    calculator.add_data(32);
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    uint32_t data[1] = {};
+    command.add_data(data, 4, 32);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchWriteLinear) {
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_linear<false, false>(5);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        command.add_dispatch_write_linear<false, false>(0, 0, 0, 5);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_linear<true, true>(5);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        uint32_t data[2] = {};
+        command.add_dispatch_write_linear<true, true>(0, 0, 0, 5, data);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_linear<true, false>(5);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        command.add_dispatch_write_linear<true, false>(0, 0, 0, 5);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_linear<false, true>(5);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        uint32_t data[2] = {};
+        command.add_dispatch_write_linear<false, true>(0, 0, 0, 5, data);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+}
+
+TEST(DeviceCommandTest, AddDispatchGoSignalMcast) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_go_signal_mcast();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_dispatch_go_signal_mcast(0, 0, 0, 0, 0, 0, DispatcherSelect::DISPATCH_MASTER);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddNotifyDispatchSGoSignalCmd) {
+    DeviceCommandCalculator calculator;
+    calculator.add_notify_dispatch_s_go_signal_cmd();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_notify_dispatch_s_go_signal_cmd(0, 0);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchSetNumWorkerSems) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_set_num_worker_sems();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_dispatch_set_num_worker_sems(0, DispatcherSelect::DISPATCH_MASTER);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchSetGoSignalNocData) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_set_go_signal_noc_data(5);
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    vector_memcpy_aligned<uint32_t> data(5);
+    command.add_dispatch_set_go_signal_noc_data(data, DispatcherSelect::DISPATCH_MASTER);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchSetWriteOffsets) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_set_write_offsets();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_dispatch_set_write_offsets(0, 0, 0);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchTerminate) {
+    DeviceCommandCalculator calculator;
+    calculator.add_dispatch_terminate();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_dispatch_terminate();
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchWritePaged) {
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_paged<false>(1, 5);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        command.add_dispatch_write_paged<false>(0, 0, 0, 0, 1, 5);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_paged<true>(1, 5);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        uint32_t data[2] = {};
+        command.add_dispatch_write_paged<true>(0, 0, 0, 0, 1, 5, data);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+}
+
+TEST(DeviceCommandTest, AddPrefetchRelayPaged) {
+    DeviceCommandCalculator calculator;
+    calculator.add_prefetch_relay_paged();
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    command.add_prefetch_relay_paged(0, 0, 0, 0, 0, 0);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddPrefetchRelayPagedPacked) {
+    DeviceCommandCalculator calculator;
+    calculator.add_prefetch_relay_paged_packed(1);
+
+    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds(1);
+    command.add_prefetch_relay_paged_packed(0, sub_cmds, 1);
+    EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+}
+
+TEST(DeviceCommandTest, AddDispatchWritePacked) {
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(2, 5, 100, /*no_stride*/ false);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds(2);
+        uint32_t data[1] = {};
+        std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}, {data, 4}};
+        command.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
+            2, 0, 5, 0, sub_cmds, data_collection, 100, 0, false);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(2, 5, 100, /*no_stride*/ true);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds(2);
+        uint32_t data[1] = {};
+        std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}};
+        command.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
+            2, 0, 5, 0, sub_cmds, data_collection, 100, 0, true);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+}
+
+TEST(DeviceCommandTest, AddDispatchWritePackedLarge) {
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed_large(1);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds(1);
+        command.add_dispatch_write_packed_large(0, 1, sub_cmds);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+    {
+        DeviceCommandCalculator calculator;
+        calculator.add_dispatch_write_packed_large(1, 4);
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds(1);
+
+        uint8_t data[4] = {};
+        std::vector<tt::stl::Span<const uint8_t>> data_collection{{data, 4}};
+        command.add_dispatch_write_packed_large(0, 1, sub_cmds, data_collection, nullptr);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+}

--- a/tt_metal/api/tt-metalium/device_command.hpp
+++ b/tt_metal/api/tt-metalium/device_command.hpp
@@ -17,6 +17,7 @@
 #include "tt_align.hpp"
 
 namespace tt::tt_metal {
+
 template <bool hugepage_write = false>
 class DeviceCommand {
 public:

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hal.hpp"
+#include "tt_align.hpp"
+
+namespace tt::tt_metal {
+class DeviceCommandCalculator {
+public:
+    uint32_t write_offset_bytes() const { return this->cmd_write_offsetB; }
+
+    void add_dispatch_wait() {
+        this->cmd_write_offsetB += sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_wait_with_prefetch_stall() {
+        this->add_dispatch_wait();
+        this->cmd_write_offsetB += sizeof(CQPrefetchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+    void add_prefetch_relay_linear() {
+        this->cmd_write_offsetB += sizeof(CQPrefetchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_data(uint32_t cmd_write_offset_incrementB) { this->cmd_write_offsetB += cmd_write_offset_incrementB; }
+
+    template <bool flush_prefetch = true, bool inline_data = false>
+    void add_dispatch_write_linear(uint32_t data_sizeB) {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+
+        if constexpr (flush_prefetch) {
+            if constexpr (inline_data) {
+                this->add_data(data_sizeB);
+                // this->cmd_write_offsetB has been incremented by sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) +
+                // data_sizeB need to ensure this is aligned for next cmds to be written at the correct location
+                this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+            }
+        } else {
+            // Need to make sure next command that flushes prefetch is written to correctly aligned location
+            this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+        }
+    }
+
+    void add_dispatch_go_signal_mcast() {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_notify_dispatch_s_go_signal_cmd() {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_set_num_worker_sems() {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_set_go_signal_noc_data(uint32_t num_words) {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd) + num_words * sizeof(uint32_t);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_set_write_offsets() {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_terminate() {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    template <bool inline_data = false>
+    void add_dispatch_write_paged(uint32_t page_size, uint32_t pages) {
+        uint32_t data_sizeB = page_size * pages;
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        if constexpr (inline_data) {
+            this->add_data(tt::align(data_sizeB, this->pcie_alignment));
+        }
+    }
+
+    void add_prefetch_relay_paged() {
+        this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
+    }
+
+    void add_prefetch_relay_paged_packed(uint16_t num_sub_cmds) {
+        static_assert(sizeof(CQPrefetchRelayPagedPackedSubCmd) % sizeof(uint32_t) == 0);
+
+        uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(CQPrefetchRelayPagedPackedSubCmd);
+        uint32_t increment_sizeB = tt::align(sub_cmds_sizeB + sizeof(CQPrefetchCmd), this->pcie_alignment);
+        this->cmd_write_offsetB += increment_sizeB;
+    }
+
+    template <typename PackedSubCmd>
+    void add_dispatch_write_packed(
+        uint16_t num_sub_cmds,
+        uint16_t packed_data_sizeB,
+        uint32_t packed_write_max_unicast_sub_cmds,
+        const bool no_stride = false) {
+        static_assert(
+            std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
+            std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
+        bool multicast = std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value;
+
+        uint32_t packed_write_max_multicast_sub_cmds =
+            get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
+        uint32_t max_num_packed_sub_cmds = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value
+                                               ? packed_write_max_unicast_sub_cmds
+                                               : packed_write_max_multicast_sub_cmds;
+        TT_FATAL(
+            num_sub_cmds <= max_num_packed_sub_cmds,
+            "Max number of packed sub commands are {} but requesting {}",
+            max_num_packed_sub_cmds,
+            num_sub_cmds);
+
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+
+        static_assert(sizeof(PackedSubCmd) % sizeof(uint32_t) == 0);
+        uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(PackedSubCmd);
+
+        uint32_t increment_sizeB =
+            tt::align(sub_cmds_sizeB, this->l1_alignment);  // this assumes CQDispatchCmd is L1 aligned
+        this->cmd_write_offsetB += increment_sizeB;
+
+        // copy the actual data
+        increment_sizeB = tt::align(packed_data_sizeB, this->l1_alignment);
+        uint32_t num_data_copies = no_stride ? 1 : num_sub_cmds;
+        this->cmd_write_offsetB += num_data_copies * increment_sizeB;
+
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_write_packed_large(uint16_t num_sub_cmds) {
+        TT_ASSERT(
+            num_sub_cmds <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS,
+            "Cannot fit {} sub cmds in one CQDispatchWritePackedLargeCmd",
+            num_sub_cmds);
+        static_assert(sizeof(CQDispatchWritePackedLargeSubCmd) % sizeof(uint32_t) == 0);
+        uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(CQDispatchWritePackedLargeSubCmd);
+        uint32_t payload_size = tt::align(sizeof(CQDispatchCmd) + sub_cmds_sizeB, this->l1_alignment);
+        this->add_prefetch_relay_inline();
+        uint32_t payload_dst_size =
+            tt::align(sizeof(CQPrefetchCmd) + payload_size, this->pcie_alignment) - sizeof(CQPrefetchCmd);
+        this->cmd_write_offsetB += payload_dst_size;
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+    void add_dispatch_write_packed_large(uint16_t num_sub_cmds, uint32_t payload_sizeB) {
+        TT_ASSERT(
+            num_sub_cmds <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS,
+            "Cannot fit {} sub cmds in one CQDispatchWritePackedLargeCmd",
+            num_sub_cmds);
+        static_assert(sizeof(CQDispatchWritePackedLargeSubCmd) % sizeof(uint32_t) == 0);
+        uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(CQDispatchWritePackedLargeSubCmd);
+        uint32_t payload_size = tt::align(sizeof(CQDispatchCmd) + sub_cmds_sizeB, this->l1_alignment);
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += payload_size;
+        this->cmd_write_offsetB += tt::align(payload_sizeB, this->l1_alignment);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+    }
+
+private:
+    void add_prefetch_relay_inline() { this->cmd_write_offsetB += sizeof(CQPrefetchCmd); }
+    uint32_t cmd_write_offsetB = 0;
+    uint32_t pcie_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
+    uint32_t l1_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1);
+};
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#16149

### Problem description
Currently the size of device commands is calculated in multiple places, so it's liable to be broken in anything changes.

### What's changed
DeviceCommandCalculator has a similar structure to DeviceCommand, and can be used to calculate the size of a sequence of commands. program/dispatch.cpp has been converted to use the calculator, rather than doing all the calculations manually.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
