### PR TITLE
LightMetal - New APIs LightMetalBeginCapture() and LightMetalEndCapture() and docs (#17039)

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/LightMetalBeginCapture.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/LightMetalBeginCapture.rst
@@ -1,0 +1,4 @@
+LightMetalBeginCapture
+======================
+
+.. doxygenfunction:: tt::tt_metal::v0::LightMetalBeginCapture

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/LightMetalEndCapture.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/LightMetalEndCapture.rst
@@ -1,0 +1,4 @@
+LightMetalEndCapture
+====================
+
+.. doxygenfunction:: tt::tt_metal::v0::LightMetalEndCapture

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -16,5 +16,7 @@ CommandQueue
   ReplayTrace
   ReleaseTrace
   EnqueueTrace
+  LightMetalBeginCapture
+  LightMetalEndCapture
   Finish
   Synchronize

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -12,6 +12,7 @@
 #include "device.hpp"
 #include "sub_device_types.hpp"
 #include "span.hpp"
+#include "lightmetal_binary.hpp"
 
 /** @file */
 
@@ -882,6 +883,27 @@ void ReleaseTrace(IDevice* device, const uint32_t tid);
  */
 // clang-format on
 void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking);
+
+// clang-format off
+/**
+ * Begin Light Metal Binary capturing on host and all devices. This will trace host API calls and device (metal trace) workloads to a
+ * binary blob returned to caller when tracing is finished, which can later be rerun directly from binary.
+ * Note: This LightMetalBinary Trace/Replay feature is currently under active development and is not fully supported, use at own risk.
+ *
+ * Return value: void
+ */
+// clang-format on
+void LightMetalBeginCapture();
+
+// clang-format off
+/**
+ * Ends Light Metal Binary capturing on host and all devices returns the binary blob to the user.
+ * Note: This LightMetalBinary Trace/Replay feature is currently under active development and is not fully supported, use at own risk.
+ *
+ * Return value: LightMetalBinary
+ */
+// clang-format on
+LightMetalBinary LightMetalEndCapture();
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/lightmetal_binary.hpp
+++ b/tt_metal/api/tt-metalium/lightmetal_binary.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <cstdint>
+#include <string>
+#include <fstream>
+#include <stdexcept>
+#include <iostream>
+
+namespace tt::tt_metal {
+
+// Public interface wrapper for serialized LightMetalBinary data
+class LightMetalBinary {
+private:
+    std::vector<uint8_t> data_;
+
+public:
+    // Defalt constructor, and constructor from raw data vector.
+    LightMetalBinary() = default;
+    explicit LightMetalBinary(std::vector<uint8_t> data) : data_(std::move(data)) {}
+
+    // Public accesors for the binary data
+    const std::vector<uint8_t>& get_data() const { return data_; }
+    void set_data(std::vector<uint8_t> data) { data_ = std::move(data); }
+    size_t size() const { return data_.size(); }
+    bool is_empty() const { return data_.empty(); }
+
+    // Save binary data to a file
+    void save_to_file(const std::string& filename) const {
+        std::ofstream outFile(filename, std::ios::binary);
+        if (!outFile.is_open()) {
+            throw std::ios_base::failure("Failed to open file: " + filename);
+        }
+        outFile.write(reinterpret_cast<const char*>(data_.data()), data_.size());
+        if (!outFile.good()) {
+            throw std::ios_base::failure("Failed to write to file: " + filename);
+        }
+    }
+
+    // Load binary data from a file
+    static LightMetalBinary load_from_file(const std::string& filename) {
+        std::ifstream in_file(filename, std::ios::binary | std::ios::ate);
+        if (!in_file.is_open()) {
+            throw std::ios_base::failure("Failed to open file: " + filename);
+        }
+        auto file_size = in_file.tellg();
+        if (file_size <= 0) {
+            throw std::runtime_error("File is empty or error occurred while reading: " + filename);
+        }
+        std::vector<uint8_t> buffer(file_size);
+        in_file.seekg(0, std::ios::beg);
+        in_file.read(reinterpret_cast<char*>(buffer.data()), file_size);
+        if (!in_file.good()) {
+            throw std::ios_base::failure("Failed to read file: " + filename);
+        }
+        return LightMetalBinary(std::move(buffer));
+    }
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1364,6 +1364,16 @@ void ReplayTrace(IDevice* device, const uint8_t cq_id, const uint32_t tid, const
 
 void ReleaseTrace(IDevice* device, const uint32_t tid) { device->release_trace(tid); }
 
+// Light Metal Begin/End Capture APIs are stubs for now, filled in soon.
+void LightMetalBeginCapture() {
+    log_warning(tt::LogMetalTrace, "Begin LightMetalBinary Capture - not yet implemented.");
+}
+
+LightMetalBinary LightMetalEndCapture() {
+    log_warning(tt::LogMetalTrace, "End LightMetalBinary Capture - not yet implemented.");
+    return {};
+}
+
 void Synchronize(IDevice* device, const std::optional<uint8_t> cq_id, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
         if (cq_id.has_value()) {


### PR DESCRIPTION
### Ticket

I am breaking up original PR I put up recently into smaller bite-sized chunks as @omilyutin-tt suggested.

> [Feature Request] Add Light Metal capture/replay initial changes to tt-metal for some workloads https://github.com/tenstorrent/tt-metal/issues/17039


### Problem description

This is initial/bootstrapping changes for "Light Metal" capture/replay feature that uses Flatbufers as serialization/deserialization library. See my previous bigger PR (https://github.com/tenstorrent/tt-metal/pull/16573) if you want to see how this will be used by followup merge, or context.

### What's changed

 - Add the new APIs, under experimental namespace as suggested by @aliuTT in original PR
 - Unused for now, empty stubs, will be filled in by subsequent PR (baby steps) to denote start and end of capturing host+device workload
 - Also add a new `LightMetalBinary` class (was a struct, improved to be a class after some discussion in prev PR) returned by `LightMetalEndCapture()` API.  It's basically just a wrapper of `std::vector<uint8_t>` data which was suggested not to return raw vector but give it more meaningful name by @omilyutin-tt 

### Checklist
- [ ] Post commit CI passes
- [x] Build docs job, Build x All Configs Jobs
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
