### PR TITLE
Remove `get_completion_queue_reader_core()` API from Device

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -255,8 +255,6 @@ public:
     virtual std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) = 0;
 
-    virtual uint32_t get_completion_queue_reader_core() const = 0;
-
     virtual bool is_mmio_capable() const = 0;
     virtual std::vector<std::vector<chip_id_t>> get_tunnels_from_mmio() const = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -294,8 +294,8 @@ private:
     // Work Executor for this device - can asynchronously process host side work for
     // all tasks scheduled on this device
     WorkExecutor work_executor_;
-    uint32_t worker_thread_core_;
-    uint32_t completion_queue_reader_core_;
+    uint32_t worker_thread_core_ = 0;
+    uint32_t completion_queue_reader_core_ = 0;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
     uint8_t num_hw_cqs_ = 1;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -41,8 +41,7 @@ public:
         std::size_t trace_region_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false,
-        uint32_t worker_core = 0,
-        uint32_t completion_queue_reader_core = 0);
+        uint32_t worker_core = 0);
 
     ~Device() override;
 
@@ -244,8 +243,6 @@ public:
     std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
 
-    uint32_t get_completion_queue_reader_core() const override { return completion_queue_reader_core_; }
-
     bool is_mmio_capable() const override;
     std::vector<std::vector<chip_id_t>> get_tunnels_from_mmio() const override { return tunnels_from_mmio_; }
 
@@ -297,7 +294,6 @@ private:
     // all tasks scheduled on this device
     WorkExecutor work_executor_;
     uint32_t worker_thread_core_ = 0;
-    uint32_t completion_queue_reader_core_ = 0;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
     uint8_t num_hw_cqs_ = 1;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -41,7 +41,8 @@ public:
         std::size_t trace_region_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false,
-        uint32_t worker_core = 0);
+        uint32_t worker_thread_core = 0,
+        uint32_t completion_queue_reader_core = 0);
 
     ~Device() override;
 
@@ -293,7 +294,8 @@ private:
     // Work Executor for this device - can asynchronously process host side work for
     // all tasks scheduled on this device
     WorkExecutor work_executor_;
-    uint32_t worker_thread_core_ = 0;
+    uint32_t worker_thread_core_;
+    uint32_t completion_queue_reader_core_;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
     uint8_t num_hw_cqs_ = 1;
 

--- a/tt_metal/api/tt-metalium/hardware_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/hardware_command_queue.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <cstdint>
 #include <memory>
 #include <thread>
 
@@ -75,7 +76,7 @@ using CompletionReaderVariant = std::variant<std::monostate, ReadBufferDescripto
 
 class HWCommandQueue {
 public:
-    HWCommandQueue(IDevice* device, uint32_t id, NOC noc_index);
+    HWCommandQueue(IDevice* device, uint32_t id, NOC noc_index, uint32_t completion_queue_reader_core = 0);
 
     ~HWCommandQueue();
 
@@ -110,6 +111,7 @@ public:
 private:
     uint32_t id;
     uint32_t size_B;
+    uint32_t completion_queue_reader_core = 0;
     std::optional<uint32_t> tid;
     std::shared_ptr<detail::TraceDescriptor> trace_ctx;
     std::thread completion_queue_thread;

--- a/tt_metal/api/tt-metalium/hardware_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/hardware_command_queue.hpp
@@ -111,7 +111,7 @@ public:
 private:
     uint32_t id;
     uint32_t size_B;
-    uint32_t completion_queue_reader_core;
+    uint32_t completion_queue_reader_core = 0;
     std::optional<uint32_t> tid;
     std::shared_ptr<detail::TraceDescriptor> trace_ctx;
     std::thread completion_queue_thread;

--- a/tt_metal/api/tt-metalium/hardware_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/hardware_command_queue.hpp
@@ -111,7 +111,7 @@ public:
 private:
     uint32_t id;
     uint32_t size_B;
-    uint32_t completion_queue_reader_core = 0;
+    uint32_t completion_queue_reader_core;
     std::optional<uint32_t> tid;
     std::shared_ptr<detail::TraceDescriptor> trace_ctx;
     std::thread completion_queue_thread;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -223,7 +223,6 @@ public:
     // TODO #16526: Temporary api until migration to actual fabric is complete
     std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
-    uint32_t get_completion_queue_reader_core() const override;
     bool is_mmio_capable() const override;
     std::vector<std::vector<chip_id_t>> get_tunnels_from_mmio() const override;
     MemoryBlockTable get_memory_block_table(const BufferType& buffer_type) const override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -118,6 +118,7 @@ uint32_t MeshDevice::dram_size_per_channel() const {
 
 IDevice* MeshDevice::reference_device() const { return this->get_devices().at(0); }
 
+// clang-format off
 MeshDevice::MeshDevice(
     std::shared_ptr<ScopedDevices> mesh_handle,
     const MeshShape& mesh_shape,
@@ -127,11 +128,13 @@ MeshDevice::MeshDevice(
     mesh_shape_(mesh_shape),
     type_(type),
     mesh_id_(generate_unique_mesh_id()),
-    parent_mesh_(std::move(parent_mesh)) {
+    parent_mesh_(std::move(parent_mesh))
+{
     work_executor_ = std::make_unique<WorkExecutor>(0 /* worker_core */, mesh_id_);
     work_executor_->initialize();
     work_executor_->set_worker_mode(WorkExecutorMode::SYNCHRONOUS);
 }
+// clang-format on
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,
@@ -787,10 +790,7 @@ void MeshDevice::reset_sub_device_stall_group() {
 uint32_t MeshDevice::num_sub_devices() const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices();
 }
-uint32_t MeshDevice::get_completion_queue_reader_core() const {
-    TT_THROW("get_completion_queue_reader_core() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->get_completion_queue_reader_core();
-}
+
 bool MeshDevice::is_mmio_capable() const {
     TT_THROW("is_mmio_capable() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->is_mmio_capable();

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -118,7 +118,6 @@ uint32_t MeshDevice::dram_size_per_channel() const {
 
 IDevice* MeshDevice::reference_device() const { return this->get_devices().at(0); }
 
-// clang-format off
 MeshDevice::MeshDevice(
     std::shared_ptr<ScopedDevices> mesh_handle,
     const MeshShape& mesh_shape,
@@ -134,7 +133,6 @@ MeshDevice::MeshDevice(
     work_executor_->initialize();
     work_executor_->set_worker_mode(WorkExecutorMode::SYNCHRONOUS);
 }
-// clang-format on
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -45,8 +45,9 @@ Device::Device(
     size_t trace_region_size,
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal,
-    uint32_t worker_core) :
-    id_(device_id), worker_thread_core_(worker_core), work_executor_(worker_core, device_id)
+    uint32_t worker_thread_core,
+    uint32_t completion_queue_reader_core) :
+    id_(device_id), worker_thread_core_(worker_thread_core), completion_queue_reader_core_(completion_queue_reader_core), work_executor_(worker_thread_core, device_id)
 {
     ZoneScoped;
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, minimal);
@@ -972,7 +973,8 @@ void Device::init_command_queue_host() {
     hw_command_queues_.reserve(num_hw_cqs());
     sw_command_queues_.reserve(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
-        hw_command_queues_.push_back(std::make_unique<HWCommandQueue>(this, cq_id, dispatch_downstream_noc));
+        hw_command_queues_.push_back(
+            std::make_unique<HWCommandQueue>(this, cq_id, dispatch_downstream_noc, completion_queue_reader_core_));
         sw_command_queues_.push_back(std::make_unique<CommandQueue>(this, cq_id));
     }
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -37,7 +37,6 @@ namespace tt {
 
 namespace tt_metal {
 
-// clang-format off
 Device::Device(
     chip_id_t device_id,
     const uint8_t num_hw_cqs,
@@ -52,7 +51,6 @@ Device::Device(
     ZoneScoped;
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, minimal);
 }
-// clang-format on
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
     return tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -37,12 +37,21 @@ namespace tt {
 
 namespace tt_metal {
 
+// clang-format off
 Device::Device(
-    chip_id_t device_id, const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap, bool minimal, uint32_t worker_core, uint32_t completion_queue_reader_core) :
-    id_(device_id), worker_thread_core_(worker_core), completion_queue_reader_core_(completion_queue_reader_core), work_executor_(worker_core, device_id) {
+    chip_id_t device_id,
+    const uint8_t num_hw_cqs,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    bool minimal,
+    uint32_t worker_core) :
+    id_(device_id), worker_thread_core_(worker_core), work_executor_(worker_core, device_id)
+{
     ZoneScoped;
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, minimal);
 }
+// clang-format on
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
     return tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -290,8 +290,8 @@ void DevicePool::activate_device(chip_id_t id) {
             this->trace_region_size,
             this->l1_bank_remap,
             false,
-            worker_core_thread_core);
-        // completion_queue_reader_core); BLOZANO: NEED TO RESOLVE HOW TO PASS THIS TO HWCMDQUEUE
+            worker_core_thread_core,
+            completion_queue_reader_core);
         device->update_dispatch_cores_for_multi_cq_eth_dispatch();
         if (!this->firmware_built_keys.contains(device->build_key())) {
             device->build_firmware();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -290,8 +290,8 @@ void DevicePool::activate_device(chip_id_t id) {
             this->trace_region_size,
             this->l1_bank_remap,
             false,
-            worker_core_thread_core,
-            completion_queue_reader_core);
+            worker_core_thread_core);
+        // completion_queue_reader_core); BLOZANO: NEED TO RESOLVE HOW TO PASS THIS TO HWCMDQUEUE
         device->update_dispatch_cores_for_multi_cq_eth_dispatch();
         if (!this->firmware_built_keys.contains(device->build_key())) {
             device->build_firmware();

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -43,8 +43,10 @@ Buffer& get_buffer_object(const std::variant<std::reference_wrapper<Buffer>, std
 
 }  // namespace
 
-HWCommandQueue::HWCommandQueue(IDevice* device, uint32_t id, NOC noc_index) :
-    manager(device->sysmem_manager()), completion_queue_thread{} {
+HWCommandQueue::HWCommandQueue(IDevice* device, uint32_t id, NOC noc_index, uint32_t completion_queue_reader_core) :
+    manager(device->sysmem_manager()),
+    completion_queue_thread{},
+    completion_queue_reader_core(completion_queue_reader_core) {
     ZoneScopedN("CommandQueue_constructor");
     this->device = device;
     this->id = id;
@@ -86,7 +88,7 @@ HWCommandQueue::HWCommandQueue(IDevice* device, uint32_t id, NOC noc_index) :
     std::thread completion_queue_thread = std::thread(&HWCommandQueue::read_completion_queue, this);
     this->completion_queue_thread = std::move(completion_queue_thread);
     // Set the affinity of the completion queue reader.
-    set_device_thread_affinity(this->completion_queue_thread, device->get_completion_queue_reader_core());
+    set_device_thread_affinity(this->completion_queue_thread, this->completion_queue_reader_core);
 
     for (uint32_t i = 0; i < dispatch_constants::DISPATCH_MESSAGE_ENTRIES; i++) {
         this->expected_num_workers_completed[i] = 0;


### PR DESCRIPTION
### Ticket
Closes #17204

### Problem description
This is a device API that exists, merely for HWCommandQueue to query a parameter.
The value is not at all used by Device for any other purpose.

### What's changed
Remove API.
Inject the parameter into HWCommandQueue via HWCommandQueue's constructor.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13022293313)
- [x] New/Existing tests provide coverage for changes
