### PR TITLE
#17215: Add explicit dealloc for mesh buffer

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -128,6 +128,7 @@ TEST_F(MeshBufferTest, Deallocation) {
         return buffer->address();
     }();
 
+    // Test that creating and deallocating a MeshBuffer frees the address.
     auto buffer1 = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
     EXPECT_TRUE(buffer1->is_allocated());
     EXPECT_EQ(buffer1->address(), expected_address);
@@ -138,6 +139,14 @@ TEST_F(MeshBufferTest, Deallocation) {
     auto buffer2 = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
     EXPECT_TRUE(buffer2->is_allocated());
     EXPECT_EQ(buffer2->address(), expected_address);
+
+    // Test deallocation of the view also works.
+    auto buffer_view = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get(), buffer2->address());
+    EXPECT_TRUE(buffer_view->is_allocated());
+    EXPECT_EQ(buffer_view->address(), expected_address);
+
+    buffer_view->deallocate();
+    EXPECT_FALSE(buffer_view->is_allocated());
 }
 
 TEST_F(MeshBufferTest, GetDeviceBuffer) {

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -120,13 +120,24 @@ TEST_F(MeshBufferTest, Deallocation) {
         .bottom_up = false};
 
     const ReplicatedBufferConfig buffer_config{.size = 16 << 10};
-    uint32_t expected_address = 0;
-    {
-        auto replicated_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
-        expected_address = replicated_buffer->address();
-    }
-    auto replicated_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
-    EXPECT_EQ(replicated_buffer->address(), expected_address);
+
+    // Fetch an address that the allocator provides on first allocation.
+    const uint32_t expected_address = [&]() {
+        auto buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+        EXPECT_TRUE(buffer->is_allocated());
+        return buffer->address();
+    }();
+
+    auto buffer1 = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+    EXPECT_TRUE(buffer1->is_allocated());
+    EXPECT_EQ(buffer1->address(), expected_address);
+
+    buffer1->deallocate();
+    EXPECT_FALSE(buffer1->is_allocated());
+
+    auto buffer2 = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+    EXPECT_TRUE(buffer2->is_allocated());
+    EXPECT_EQ(buffer2->address(), expected_address);
 }
 
 TEST_F(MeshBufferTest, GetDeviceBuffer) {

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -133,13 +133,9 @@ void MeshBuffer::initialize_device_buffers() {
     }
 }
 
-bool MeshBuffer::is_allocated() const { return owns_data_ ? backing_buffer_ != nullptr : true; }
+bool MeshBuffer::is_allocated() const { return not std::holds_alternative<DeallocatedState>(state_); }
 
-void MeshBuffer::deallocate() {
-    if (owns_data_) {
-        backing_buffer_.reset();
-    }
-}
+void MeshBuffer::deallocate() { state_ = DeallocatedState{}; }
 
 std::shared_ptr<Buffer> MeshBuffer::get_device_buffer(const Coordinate& device_coord) const {
     TT_FATAL(

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -97,30 +97,23 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
             device_local_config.shard_parameters,
             device_local_config.bottom_up);
 
-        mesh_buffer = std::shared_ptr<MeshBuffer>(
-            new MeshBuffer(mesh_buffer_config, device_local_config, device_local_size, mesh_device, backing_buffer));
+        mesh_buffer = std::shared_ptr<MeshBuffer>(new MeshBuffer(
+            mesh_buffer_config, device_local_config, device_local_size, mesh_device, std::move(backing_buffer)));
     } else {
         mesh_buffer = std::shared_ptr<MeshBuffer>(
             new MeshBuffer(mesh_buffer_config, device_local_config, address.value(), device_local_size, mesh_device));
     }
 
-    mesh_buffer->allocate();
+    mesh_buffer->initialize_device_buffers();
 
     return mesh_buffer;
 }
 
-void MeshBuffer::allocate() {
-    if (backing_buffer_) {
-        TT_FATAL(
-            !address_, "The address for a MeshBuffer should not explicitly be initialized when it is being allocated");
-        address_ = backing_buffer_->address();
-    } else {
-        TT_FATAL(address_, "A MeshBuffer should be provided a valid address if its not being allocated");
-    }
+void MeshBuffer::initialize_device_buffers() {
     buffers_ = std::vector<std::vector<std::shared_ptr<Buffer>>>(
         mesh_device_->num_rows(), std::vector<std::shared_ptr<Buffer>>(mesh_device_->num_cols()));
 
-    auto allocate_device_buffer_at_address = [this](const Coordinate& coord) {
+    auto init_device_buffer_at_address = [this](const Coordinate& coord) {
         std::shared_ptr<Buffer> buffer = Buffer::create(
             mesh_device_->get_device(coord.row, coord.col),
             address_,
@@ -135,8 +128,16 @@ void MeshBuffer::allocate() {
 
     for (int row = 0; row < mesh_device_->num_rows(); row++) {
         for (int col = 0; col < mesh_device_->num_cols(); col++) {
-            buffers_[row][col] = allocate_device_buffer_at_address(Coordinate{row, col});
+            buffers_[row][col] = init_device_buffer_at_address(Coordinate{row, col});
         }
+    }
+}
+
+bool MeshBuffer::is_allocated() const { return owns_data_ ? backing_buffer_ != nullptr : true; }
+
+void MeshBuffer::deallocate() {
+    if (owns_data_) {
+        backing_buffer_.reset();
     }
 }
 


### PR DESCRIPTION
### Ticket
#17215

### Problem description
Explicit deallocation at the `MeshBuffer` is required because TTNN allows users to explicitly deallocate tensors that are not in use any more. Setting tensors to `None` or using `del` is one option forward, but this is a larger effort that requires refactoring hundreds of files.

### What's changed
Added `is_allocated` and `deallocate` methods, modified the corresponding test.

Minor changes to documentation and code style. No functional changes

### Checklist
- [ ] [All post commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13020708085) 
  - CI seems to be entirely broken. Ran `distributed_unit_tests` locally - these are the only ones that can potentially affect `MeshBuffer`.
- [X] New/Existing tests provide coverage for changes - ran the `MeshBuffer.Deallocation` test locally.
