### PR TITLE
Do not run PR Gate on Draft PRs

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -13,6 +13,11 @@ name: PR Gate
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - "main"
 
@@ -29,6 +34,7 @@ concurrency:
 
 jobs:
   build-artifact:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     uses: ./.github/workflows/build-artifact.yaml
     with:
       os: "ubuntu-22.04-amd64"


### PR DESCRIPTION
### Ticket
None

### Problem description
We're running PR Gate automatically on Draft PRs.  By definition those aren't ready to be tested, so we shouldn't be wasting the compute.

### What's changed
Avoid running on Draft PRs.

