### PR TITLE
Bump CMake in the Docker image

### DIFF
--- a/dockerfile/ubuntu-20.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-20.04-amd64.Dockerfile
@@ -8,7 +8,7 @@ ENV CCACHE_TEMPDIR=/tmp/ccache
 
 # Use a newer version of CMake than what is available from Canonical for 20.04
 RUN apt -y update \
-    && apt install -y --no-install-recommends ca-certificates gpg wget \
+    && apt install -y --no-install-recommends ca-certificates gpg wget  \
     && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
     && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfile/ubuntu-22.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-22.04-amd64.Dockerfile
@@ -6,6 +6,13 @@ ARG UBUNTU_VERSION=22.04
 ENV DOXYGEN_VERSION=1.9.6
 ENV CCACHE_TEMPDIR=/tmp/ccache
 
+# Use a newer version of CMake than what is available from Canonical for 22.04
+RUN apt -y update \
+    && apt install -y --no-install-recommends ca-certificates gpg wget \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt update -y && apt install software-properties-common gpg-agent -y
 
 # add custom repo

--- a/scripts/docker/requirements-20.04.txt
+++ b/scripts/docker/requirements-20.04.txt
@@ -7,8 +7,7 @@ pandoc
 libtbb-dev
 libcapstone-dev
 pkg-config
-cmake=3.22.2-0kitware1ubuntu20.04.1
-cmake-data=3.22.2-0kitware1ubuntu20.04.1
+cmake
 curl
 wget
 python3-pip


### PR DESCRIPTION
### Ticket
None

### Problem description
The version of CMake currently in our Docker images pre-dates support for alternative linkers and the `FILE_SET` feature.  We wish to use both.

### What's changed
Bumped the version of CMake installed into the Docker image.
NOTE: We still have the workflow to ensure we are compatible with the stated minimum CMake version.  Users of the old version will miss out on the optional features, but they can still build correctly.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
