### PR TITLE
Add a timeout for docker image building

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -19,6 +19,7 @@ on:
 jobs:
   build-docker-image:
     name: "🐳️ Build ${{ inputs.os }} image"
+    timeout-minutes: 30
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       CONFIG: ci


### PR DESCRIPTION
### Problem description
Docker image build can take infinite time in the event of networking issue.

### What's changed
Add timeout

### Checklist
