### PR TITLE
#0: Update distributed tests build to account for arch

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -62,7 +62,7 @@ jobs:
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth_${{ inputs.arch }}"},
           {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
-          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=MeshDeviceSuite.*"},
+          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }} --gtest_filter=MeshDeviceSuite.*"},
           {name: FD2, cmd: ./tests/scripts/run_cpp_fd2_tests.sh},
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -62,7 +62,7 @@ jobs:
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth_${{ inputs.arch }}"},
           {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
-          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=MeshDeviceSuite.*"},
+          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }} --gtest_filter=MeshDeviceSuite.*"},
 
           {name: dispatch multicmd queue, cmd: "TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch_${{ inputs.arch }} --gtest_filter=MultiCommandQueue*Fixture.*"},
 

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -13,7 +13,7 @@ run_t3000_ttmetal_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttmetal_tests"
-  ./build/test/tt_metal/distributed/distributed_unit_tests
+  ./build/test/tt_metal/distributed/distributed_unit_tests_${ARCH_NAME}
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth_${ARCH_NAME} --gtest_filter="DeviceFixture.ActiveEthKernelsDirectSendAllConnectedChips" ; fail+=$?
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth_${ARCH_NAME} --gtest_filter="DeviceFixture.ActiveEthKernelsSendInterleavedBufferAllConnectedChips" ; fail+=$?
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_eth_${ARCH_NAME} --gtest_filter="DeviceFixture.ActiveEthKernelsDirectRingGatherAllChips" ; fail+=$?

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -5,27 +5,48 @@ set(UNIT_TESTS_DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_allocator.cpp
 )
 
-add_executable(distributed_unit_tests ${UNIT_TESTS_DISTRIBUTED_SRC})
-target_link_libraries(
-    distributed_unit_tests
-    PRIVATE
-        tt_metal
-        test_common_libs
+# Define the function to create test executables for each architecture
+function(create_unit_test_executable arch_name)
+    # Define the test executable name using the architecture name
+    set(exec_name distributed_unit_tests_${arch_name})
+    string(REPLACE "wormhole" "wormhole_b0" exec_name "${exec_name}")
+
+    add_executable(${exec_name} ${UNIT_TESTS_DISTRIBUTED_SRC})
+
+    target_link_libraries(
+        ${exec_name}
+        PRIVATE
+            tt_metal
+            test_common_libs
+    )
+
+    target_include_directories(
+        ${exec_name}
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${arch_name}
+            "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+            ${PROJECT_SOURCE_DIR}/tests
+    )
+
+    set_target_properties(
+        ${exec_name}
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY
+                ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
+    )
+endfunction()
+
+# Define the architectures for which to create test executables
+set(ARCHITECTURES
+    "grayskull"
+    "wormhole"
+    "blackhole"
 )
 
-target_include_directories(
-    distributed_unit_tests
-    PRIVATE
-        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
-        ${PROJECT_SOURCE_DIR}/tests
-)
-
-set_target_properties(
-    distributed_unit_tests
-    PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY
-            ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
-)
+# Create a test executable for each architecture
+foreach(arch IN LISTS ARCHITECTURES)
+    create_unit_test_executable(${arch})
+endforeach()
 
 # Dont do this for now
 # When the test is probed something is constructed that tries to access a device


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
The existing distributed test build flow does not account for architecture names. This makes it impossible to include architecture specific files, required for testing (for example address maps).

### What's changed
Make `tests/tt_metal/distributed/CMakeLists.txt` arch aware. This is similar to what's done in all our tt-metal cpp tests.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
