### PR TITLE
#15974: Create device tensors table in report database

### DIFF
--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -146,6 +146,7 @@ from ttnn.types import (
     TILE_LAYOUT,
     StorageType,
     DEVICE_STORAGE_TYPE,
+    MULTI_DEVICE_STORAGE_TYPE,
     CoreGrid,
     CoreRange,
     Shape,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15974

### Problem description

The report feature was not saving the `memory_config`, `device_id`, `address` and `buffer_type` fields in the `tensors` table for tensors with multi device storage type. These fields were saved to the database only for tensors with single device storage type, but the values were `null` for multi-device tensor records.

The ttnn-visualizer app is unable to display this information in its UI due to it being missing from the report database. The motivation for this change is to improve display of multi-device tensor metadata in ttnn-visualizer.

### What's changed

The `ttnn.database.insert_tensor` function had an explicit check for the tensor storage type, and only saved these fields to the report database if the storage type was `ttnn.DEVICE_STORAGE_TYPE`. Otherwise, it explicitly wrote nulls to the fields.

I have changed the `ttnn.database.insert_tensor` function to also handle `ttnn.MULTI_DEVICE_STORAGE_TYPE`. With multi device tensors though, there is more than one device id, and the buffer address could be different on each device. With multiple device ids and buffer addresses, the table has to be normalized. To handle the multiple device ids and buffer addresses, I have created a new table in the report db, called `device_tensors`.

The `device_tensors` table has three columns: `tensor_id`, `device_id` and `address`. I chose the table name to be consistent with the naming of the `ttnn.get_device_tensors` function that is used to get the device specific data. 

I have left the existing columns in place for now to ensure backwards compatibility with any tools using the current schema, including any existing installations of ttnn-visualizer. In the case of multi device storage type, the existing fields in the `tensors` table will get the device id and buffer address from the first item returned by `ttnn.get_device_tensors`.

This solution addresses the problem reported in issue #15974 of the fields showing null, while also putting the correct device ids and buffer addresses for multi-device tensors into the db for ttnn-visualizer to be updated to use going forward.

I have done most of my testing of this change using Llama3 tests. When I run `pytest models/demos/llama3/tests/test_llama_attention.py`, for example, I see the expected values being saved to the new table, and tensors with multi device storage type getting the previously null values in the `tensors` table filled in. However, this does not ensure that every record in the table has these values, as there are some tensors that have neither storage type (PyTorch ones).

### Checklist
- [X] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
