### PR TITLE
#0: Initial SubDevice support for TT-Mesh + tests

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_distributed.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_workload.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_sub_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_allocator.cpp
 )
 

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp"
+
+namespace tt::tt_metal::distributed::test {
+namespace {
+
+using MeshSubDeviceTest = T3000MultiDeviceFixture;
+
+TEST_F(MeshSubDeviceTest, SyncWorkloadsOnSubDevice) {
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+
+    uint32_t num_iters = 5;
+    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    mesh_device_->load_sub_device_manager(sub_device_manager);
+
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_sync_program(mesh_device_.get(), sub_device_1, sub_device_2);
+
+    LogicalDeviceRange devices =
+        LogicalDeviceRange({0, 0}, {mesh_device_->num_cols() - 1, mesh_device_->num_rows() - 1});
+    auto waiter_mesh_workload = CreateMeshWorkload();
+    auto syncer_mesh_workload = CreateMeshWorkload();
+    auto incrementer_mesh_workload = CreateMeshWorkload();
+    AddProgramToMeshWorkload(waiter_mesh_workload, waiter_program, devices);
+    AddProgramToMeshWorkload(syncer_mesh_workload, syncer_program, devices);
+    AddProgramToMeshWorkload(incrementer_mesh_workload, incrementer_program, devices);
+    for (uint32_t i = 0; i < num_iters; i++) {
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), waiter_mesh_workload, false);
+        mesh_device_->set_sub_device_stall_group({SubDeviceId{0}});
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), syncer_mesh_workload, true);
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), incrementer_mesh_workload, false);
+        mesh_device_->reset_sub_device_stall_group();
+    }
+    Finish(mesh_device_->mesh_command_queue());
+}
+
+TEST_F(MeshSubDeviceTest, DataCopyOnSubDevices) {
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {0, 0}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(CoreRange({1, 1}, {1, 1}))});
+    SubDevice sub_device_3(std::array{CoreRangeSet(CoreRange({2, 2}, {2, 2}))});
+
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+    uint32_t num_tiles = 32;
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size * num_tiles,
+        .buffer_type = tt_metal::BufferType::DRAM,
+        .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+        .bottom_up = true};
+
+    ReplicatedBufferConfig global_buffer_config{
+        .size = single_tile_size * num_tiles,
+    };
+    // Create IO Buffers
+    auto input_buf = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+    auto output_buf = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    // Create and Load SubDeviceConfig on the mesh
+    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2, sub_device_3}, 3200);
+    mesh_device_->load_sub_device_manager(sub_device_manager);
+
+    auto syncer_coord = sub_device_1.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
+    auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
+    auto syncer_core_phys = mesh_device_->worker_core_from_logical_core(syncer_coord);
+    auto datacopy_coord = sub_device_2.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
+    auto datacopy_core = CoreRangeSet(CoreRange(datacopy_coord, datacopy_coord));
+    auto datacopy_core_phys = mesh_device_->worker_core_from_logical_core(datacopy_coord);
+
+    auto all_cores = syncer_core.merge(datacopy_core);
+    auto global_sem = CreateGlobalSemaphore(mesh_device_.get(), all_cores, 0);
+
+    Program sync_and_incr_program = CreateProgram();
+    auto sync_kernel = CreateKernel(
+        sync_and_incr_program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/sync_and_increment.cpp",
+        syncer_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 3> sync_rt_args = {global_sem.address(), datacopy_core_phys.x, datacopy_core_phys.y};
+    SetRuntimeArgs(sync_and_incr_program, sync_kernel, syncer_core, sync_rt_args);
+
+    Program datacopy_program = CreateProgram();
+    auto datacopy_kernel = CreateKernel(
+        datacopy_program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/sync_and_datacopy.cpp",
+        datacopy_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 6> datacopy_rt_args = {
+        global_sem.address(), 0, 0, input_buf->address(), output_buf->address(), num_tiles};
+    SetRuntimeArgs(datacopy_program, datacopy_kernel, datacopy_core, datacopy_rt_args);
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(single_tile_size * num_tiles, {{src0_cb_index, DataFormat::UInt32}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    CBHandle cb_src0 = CreateCircularBuffer(datacopy_program, datacopy_core, cb_src0_config);
+
+    auto syncer_mesh_workload = CreateMeshWorkload();
+    auto datacopy_mesh_workload = CreateMeshWorkload();
+    LogicalDeviceRange devices =
+        LogicalDeviceRange({0, 0}, {mesh_device_->num_cols() - 1, mesh_device_->num_rows() - 1});
+
+    AddProgramToMeshWorkload(syncer_mesh_workload, sync_and_incr_program, devices);
+    AddProgramToMeshWorkload(datacopy_mesh_workload, datacopy_program, devices);
+
+    for (int i = 0; i < 50; i++) {
+        mesh_device_->set_sub_device_stall_group({SubDeviceId{2}});
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), syncer_mesh_workload, false);
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), datacopy_mesh_workload, false);
+
+        std::vector<uint32_t> src_vec(input_buf->size() / sizeof(uint32_t));
+        std::iota(src_vec.begin(), src_vec.end(), i);
+        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, false);
+        // Read Back global semaphore value across all cores to verify that it has been reset to 0
+        // before updating it through host
+        auto shard_parameters =
+            ShardSpecBuffer(all_cores, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {all_cores.size(), 1});
+        DeviceLocalBufferConfig global_sem_buf_local_config{
+            .page_size = sizeof(uint32_t),
+            .buffer_type = BufferType::L1,
+            .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+            .shard_parameters = shard_parameters,
+            .bottom_up = false};
+        ReplicatedBufferConfig global_sem_buf_global_config{
+            .size = all_cores.size() * sizeof(uint32_t),
+        };
+
+        auto global_sem_buf = MeshBuffer::create(
+            global_sem_buf_global_config, global_sem_buf_local_config, mesh_device_.get(), global_sem.address());
+
+        for (std::size_t logical_x = 0; logical_x < input_buf->device()->num_cols(); logical_x++) {
+            for (std::size_t logical_y = 0; logical_y < input_buf->device()->num_rows(); logical_y++) {
+                std::vector<uint32_t> dst_vec;
+                ReadShard(
+                    mesh_device_->mesh_command_queue(), dst_vec, global_sem_buf, Coordinate(logical_y, logical_x));
+                for (const auto& val : dst_vec) {
+                    EXPECT_EQ(val, 0);
+                }
+            }
+        }
+
+        for (auto device : mesh_device_->get_devices()) {
+            tt::llrt::write_hex_vec_to_core(
+                device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
+        }
+        mesh_device_->reset_sub_device_stall_group();
+        for (std::size_t logical_x = 0; logical_x < output_buf->device()->num_cols(); logical_x++) {
+            for (std::size_t logical_y = 0; logical_y < output_buf->device()->num_rows(); logical_y++) {
+                std::vector<uint32_t> dst_vec;
+                ReadShard(mesh_device_->mesh_command_queue(), dst_vec, output_buf, Coordinate(logical_y, logical_x));
+                EXPECT_EQ(dst_vec, src_vec);
+            }
+        }
+    }
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/global_semaphore.hpp>
 
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/sync_and_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/sync_and_datacopy.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t local_sem_addr = get_arg_val<uint32_t>(0);
+    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t dst_bank_id = get_arg_val<uint32_t>(2);
+    uint32_t src_dram_addr = get_arg_val<uint32_t>(3);
+    uint32_t dst_dram_addr = get_arg_val<uint32_t>(4);
+    uint32_t num_tiles = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;  // index=0
+    uint32_t tile_size_bytes = get_tile_size(cb_id_in0) * num_tiles;
+    uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+    uint64_t src_dram_noc_addr = get_noc_addr_from_bank_id<true>(src_bank_id, src_dram_addr);
+    uint64_t dst_dram_noc_addr = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_dram_addr);
+
+    volatile tt_l1_ptr uint32_t* local_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_sem_addr);
+    noc_semaphore_wait(local_sem, 1);
+    uint64_t noc_local_sem_addr = get_noc_addr(local_sem_addr);
+    noc_semaphore_inc(noc_local_sem_addr, -1);
+    noc_async_atomic_barrier();
+    noc_async_read(src_dram_noc_addr, l1_write_addr, tile_size_bytes);
+    noc_async_read_barrier();
+    noc_async_write(l1_write_addr, dst_dram_noc_addr, tile_size_bytes);
+    noc_async_write_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/sync_and_increment.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/sync_and_increment.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    DPRINT << "start syncer" << ENDL();
+    uint32_t sem_addr = get_arg_val<uint32_t>(0);
+    uint32_t remote_x = get_arg_val<uint32_t>(1);
+    uint32_t remote_y = get_arg_val<uint32_t>(2);
+
+    volatile tt_l1_ptr uint32_t* local_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+    noc_semaphore_wait(local_sem, 1);
+    uint64_t noc_local_sem_addr = get_noc_addr(sem_addr);
+    noc_semaphore_inc(noc_local_sem_addr, -1);
+    uint64_t noc_remote_sem_addr = get_noc_addr(remote_x, remote_y, sem_addr);
+    noc_semaphore_inc(noc_remote_sem_addr, 1);
+    noc_async_atomic_barrier();
+}

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -146,7 +146,6 @@ public:
 
     // Light Metal
     virtual void load_trace(uint8_t cq_id, uint32_t trace_id, const TraceDescriptor& trace_desc) = 0;
-
     virtual bool using_slow_dispatch() const = 0;
     virtual bool using_fast_dispatch() const = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -135,7 +135,6 @@ public:
     std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override { return trace_buffers_size_; }
     void set_trace_buffers_size(uint32_t size) override { trace_buffers_size_ = size; }
-
     // Light Metal
     void load_trace(uint8_t cq_id, uint32_t trace_id, const TraceDescriptor& trace_desc) override;
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -17,36 +17,20 @@ class MeshCommandQueue {
     // tt::tt_metal::CommandQueue.
     // Additional support for Reads and Writes to be added
 private:
-    uint32_t num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id);
     void populate_virtual_program_dispatch_core();
     void populate_dispatch_core_type();
     CoreCoord virtual_program_dispatch_core() const;
     CoreType dispatch_core_type() const;
     // Helper functions for reading and writing individual shards
     void write_shard_to_device(
-        std::shared_ptr<Buffer>& shard_view,
-        const void* src,
-        std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
+        std::shared_ptr<Buffer>& shard_view, const void* src, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void read_shard_from_device(
-        std::shared_ptr<Buffer>& shard_view,
-        void* dst,
-        std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
+        std::shared_ptr<Buffer>& shard_view, void* dst, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     // Helper functions for read and write entire Sharded-MeshBuffers
-    void write_sharded_buffer(
-        const MeshBuffer& buffer,
-        const void* src,
-        std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
-    void read_sharded_buffer(
-        MeshBuffer& buffer,
-        void* dst,
-        std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
-    tt::tt_metal::WorkerConfigBufferMgr config_buffer_mgr_;
-    LaunchMessageRingBufferState worker_launch_message_buffer_state_;
-    uint32_t expected_num_workers_completed_ = 0;
+    void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
+    void read_sharded_buffer(MeshBuffer& buffer, void* dst);
+    std::array<tt::tt_metal::WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> config_buffer_mgr_;
+    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed_;
     MeshDevice* mesh_device_;
     uint32_t id_;
     CoreCoord dispatch_core_;
@@ -56,7 +40,7 @@ public:
     MeshCommandQueue(MeshDevice* mesh_device, uint32_t id);
     MeshDevice* device() const { return mesh_device_; }
     uint32_t id() const { return id_; }
-    WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_; };
+    WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_[index]; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking);
     // MeshBuffer Write APIs
     void enqueue_write_shard(
@@ -69,6 +53,10 @@ public:
         void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking);
     void finish();
+    void reset_worker_state(
+        bool reset_launch_msg_state,
+        uint32_t num_sub_devices,
+        const vector_memcpy_aligned<uint32_t>& go_signal_noc_data);
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -143,7 +143,6 @@ public:
     std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override;
     void set_trace_buffers_size(uint32_t size) override;
-
     // Light Metal
     void load_trace(uint8_t cq_id, uint32_t trace_id, const TraceDescriptor& trace_desc) override;
 

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -15,33 +15,13 @@ namespace tt::tt_metal::distributed {
 MeshCommandQueue::MeshCommandQueue(MeshDevice* mesh_device, uint32_t id) {
     this->mesh_device_ = mesh_device;
     this->id_ = id;
-
-    this->config_buffer_mgr_ = tt::tt_metal::WorkerConfigBufferMgr();
-    program_dispatch::initialize_worker_config_buf_mgr(this->config_buffer_mgr_);
+    for (int i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {
+        config_buffer_mgr_[i] = tt::tt_metal::WorkerConfigBufferMgr();
+        program_dispatch::initialize_worker_config_buf_mgr(config_buffer_mgr_[i]);
+        expected_num_workers_completed_[i] = 0;
+    }
     this->populate_virtual_program_dispatch_core();
     this->populate_dispatch_core_type();
-}
-
-uint32_t MeshCommandQueue::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) {
-    if (core_type == HalProgrammableCoreType::TENSIX) {
-        uint32_t num_workers = 0;
-        for (auto& device : this->mesh_device_->get_devices()) {
-            if (num_workers) {
-                TT_FATAL(
-                    num_workers == device->num_worker_cores(core_type, sub_device_id),
-                    "Worker grid size must be consistent across all devices in a Mesh.");
-            } else {
-                num_workers = device->num_worker_cores(core_type, sub_device_id);
-            }
-        }
-        return num_workers;
-    } else {
-        uint32_t min_num_worker_cores = std::numeric_limits<uint32_t>::max();
-        for (auto& device : this->mesh_device_->get_devices()) {
-            min_num_worker_cores = std::min(min_num_worker_cores, device->num_worker_cores(core_type, sub_device_id));
-        }
-        return min_num_worker_cores;
-    }
 }
 
 void MeshCommandQueue::populate_virtual_program_dispatch_core() {
@@ -80,7 +60,10 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
     std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.determine_sub_device_ids(mesh_device_);
     TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
     auto sub_device_id = *(sub_device_ids.begin());
+    auto sub_device_index = sub_device_id.to_index();
     auto mesh_device_id = this->mesh_device_->id();
+    auto& sysmem_manager = mesh_device_->get_device(0, 0)->sysmem_manager();
+
     TT_FATAL(
         mesh_workload.get_program_binary_status(mesh_device_id) != ProgramBinaryStatus::NotSent,
         "Expected program binaries to be written to the MeshDevice.");
@@ -89,21 +72,23 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
     uint32_t num_workers = 0;
     bool unicast_go_signals = mesh_workload.runs_on_noc_unicast_only_cores();
     bool mcast_go_signals = mesh_workload.runs_on_noc_multicast_only_cores();
+    TT_FATAL(!unicast_go_signals, "Running a MeshWorkload on Ethernet Cores is not supported!");
+    TT_ASSERT(
+        mesh_device_->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id) == 0,
+        "MeshDevice should not report Ethernet Cores.");
+
     if (mcast_go_signals) {
-        num_workers += this->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
-    }
-    if (unicast_go_signals) {
-        num_workers += this->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
+        num_workers += mesh_device_->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
     }
 
     program_dispatch::ProgramDispatchMetadata dispatch_metadata;
     // Reserve space in the L1 Kernel Config Ring Buffer for this workload.
     program_dispatch::reserve_space_in_kernel_config_buffer(
-        this->config_buffer_mgr_,
+        this->get_config_buffer_mgr(sub_device_index),
         mesh_workload.get_program_config_sizes(),
         mesh_workload.get_program_binary_status(mesh_device_id),
         num_workers,
-        this->expected_num_workers_completed_,
+        expected_num_workers_completed_[sub_device_index],
         dispatch_metadata);
 
     std::unordered_set<uint32_t> chip_ids_in_workload = {};
@@ -117,15 +102,17 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
         program_dispatch::update_program_dispatch_commands(
             program,
             program_cmd_seq,
-            this->worker_launch_message_buffer_state_.get_mcast_wptr(),
-            this->worker_launch_message_buffer_state_.get_unicast_wptr(),
-            this->expected_num_workers_completed_,
+            sysmem_manager.get_worker_launch_message_buffer_state()[sub_device_index].get_mcast_wptr(),
+            sysmem_manager.get_worker_launch_message_buffer_state()[sub_device_index].get_unicast_wptr(),
+            expected_num_workers_completed_[sub_device_index],
             this->virtual_program_dispatch_core(),
             this->dispatch_core_type(),
             sub_device_id,
             dispatch_metadata,
             mesh_workload.get_program_binary_status(mesh_device_id),
-            std::pair<bool, int>(unicast_go_signals, this->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id)));
+            std::pair<bool, int>(
+                unicast_go_signals,
+                mesh_device_->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id)));
 
         for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x + 1;
              logical_x++) {
@@ -148,22 +135,22 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
         if (chip_ids_in_workload.find(device->id()) == chip_ids_in_workload.end()) {
             experimental::write_go_signal(
                 device->command_queue(this->id_),
-                this->expected_num_workers_completed_,
+                expected_num_workers_completed_[sub_device_index],
                 this->virtual_program_dispatch_core(),
                 mcast_go_signals,
                 unicast_go_signals,
-                this->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id));
+                mesh_device_->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id));
         }
     }
     // Increment Launch Message Buffer Write Pointers
     if (mcast_go_signals) {
-        this->worker_launch_message_buffer_state_.inc_mcast_wptr(1);
+        sysmem_manager.get_worker_launch_message_buffer_state()[sub_device_index].inc_mcast_wptr(1);
     }
     if (unicast_go_signals) {
-        this->worker_launch_message_buffer_state_.inc_unicast_wptr(1);
+        sysmem_manager.get_worker_launch_message_buffer_state()[sub_device_index].inc_unicast_wptr(1);
     }
     // Update the expected number of workers dispatch must wait on
-    this->expected_num_workers_completed_ += num_workers;
+    expected_num_workers_completed_[sub_device_index] += num_workers;
     // From the dispatcher's perspective, binaries are now committed to DRAM
     mesh_workload.set_program_binary_status(mesh_device_id, ProgramBinaryStatus::Committed);
     mesh_workload.set_last_used_command_queue_for_testing(this);
@@ -180,32 +167,27 @@ void MeshCommandQueue::finish() {
 }
 
 void MeshCommandQueue::write_shard_to_device(
-    std::shared_ptr<Buffer>& shard_view,
-    const void* src,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    std::shared_ptr<Buffer>& shard_view, const void* src, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto device = shard_view->device();
     BufferRegion region(0, shard_view->size());
+    sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     buffer_dispatch::write_to_device_buffer(
-        src, *shard_view, region, id_, expected_num_workers_completed, this->dispatch_core_type(), sub_device_ids);
+        src, *shard_view, region, id_, expected_num_workers_completed_, this->dispatch_core_type(), sub_device_ids);
 }
 
 void MeshCommandQueue::read_shard_from_device(
-    std::shared_ptr<Buffer>& shard_view,
-    void* dst,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    std::shared_ptr<Buffer>& shard_view, void* dst, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto device = shard_view->device();
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+    sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
 
     bool exit_condition = false;
 
     BufferRegion region(0, shard_view->size());
-
     if (is_sharded(shard_view->buffer_layout())) {
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
-            *shard_view, id_, expected_num_workers_completed, region);
+            *shard_view, id_, expected_num_workers_completed_, region);
         auto cores = buffer_dispatch::get_cores_for_sharded_buffer(
             dispatch_params.width_split, dispatch_params.buffer_page_mapping, *shard_view);
         for (uint32_t core_id = 0; core_id < shard_view->num_cores(); ++core_id) {
@@ -220,7 +202,7 @@ void MeshCommandQueue::read_shard_from_device(
         }
     } else {
         auto dispatch_params = buffer_dispatch::initialize_interleaved_buf_read_dispatch_params(
-            *shard_view, id_, expected_num_workers_completed, region);
+            *shard_view, id_, expected_num_workers_completed_, region);
         buffer_dispatch::copy_interleaved_buffer_to_completion_queue(
             dispatch_params, *shard_view, sub_device_ids, this->dispatch_core_type());
         if (dispatch_params.pages_per_txn > 0) {
@@ -234,13 +216,8 @@ void MeshCommandQueue::read_shard_from_device(
 
 void MeshCommandQueue::enqueue_write_shard(
     std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking) {
-    // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
-    // We should not be querying SubDevices from device 0.
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
-    expected_num_workers_completed[0] = expected_num_workers_completed_;
     auto shard = mesh_buffer->get_device_buffer(coord);
-    this->write_shard_to_device(shard, host_data, expected_num_workers_completed, sub_device_ids);
+    this->write_shard_to_device(shard, host_data);
 
     if (blocking) {
         this->finish();
@@ -250,20 +227,11 @@ void MeshCommandQueue::enqueue_write_shard(
 void MeshCommandQueue::enqueue_read_shard(
     void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking) {
     TT_FATAL(blocking, "Only blocking reads are currently supported from MeshBuffer shards.");
-    // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
-    // We should not be querying SubDevices from device 0.
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
-    expected_num_workers_completed[0] = expected_num_workers_completed_;
     auto shard = mesh_buffer->get_device_buffer(coord);
-    this->read_shard_from_device(shard, host_data, expected_num_workers_completed, sub_device_ids);
+    this->read_shard_from_device(shard, host_data);
 }
 
-void MeshCommandQueue::write_sharded_buffer(
-    const MeshBuffer& buffer,
-    const void* src,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+void MeshCommandQueue::write_sharded_buffer(const MeshBuffer& buffer, const void* src) {
     auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;
     auto global_buffer_size = buffer.global_shard_spec().global_size;
 
@@ -304,30 +272,26 @@ void MeshCommandQueue::write_sharded_buffer(
                          replicated_device_y++) {
                         auto device_shard_view =
                             buffer.get_device_buffer(Coordinate(replicated_device_y, replicated_device_x));
-                        this->write_shard_to_device(
-                            device_shard_view, shard_data.data(), expected_num_workers_completed, sub_device_ids);
+                        this->write_shard_to_device(device_shard_view, shard_data.data());
                     }
                 }
             } else if (height_replicated or width_replicated) {
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     for (auto replicated_device_y = 0; replicated_device_y < num_devices_y; replicated_device_y++) {
                         auto device_shard_view = buffer.get_device_buffer(Coordinate(replicated_device_y, device_x));
-                        this->write_shard_to_device(
-                            device_shard_view, shard_data.data(), expected_num_workers_completed, sub_device_ids);
+                        this->write_shard_to_device(device_shard_view, shard_data.data());
                     }
                     device_x++;
                 } else {
                     for (auto replicated_device_x = 0; replicated_device_x < num_devices_x; replicated_device_x++) {
                         auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, replicated_device_x));
-                        this->write_shard_to_device(
-                            device_shard_view, shard_data.data(), expected_num_workers_completed, sub_device_ids);
+                        this->write_shard_to_device(device_shard_view, shard_data.data());
                     }
                     device_y++;
                 }
             } else {
                 auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, device_x));
-                this->write_shard_to_device(
-                    device_shard_view, shard_data.data(), expected_num_workers_completed, sub_device_ids);
+                this->write_shard_to_device(device_shard_view, shard_data.data());
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     if (++device_x == num_devices_x) {
                         device_x = 0;
@@ -344,11 +308,7 @@ void MeshCommandQueue::write_sharded_buffer(
     }
 }
 
-void MeshCommandQueue::read_sharded_buffer(
-    MeshBuffer& buffer,
-    void* dst,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+void MeshCommandQueue::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
     const auto& [height_replicated, width_replicated] = buffer.replicated_dims();
     TT_FATAL(
         not(height_replicated or width_replicated), "Cannot read a MeshBuffer that is replicated along any dimension.");
@@ -371,8 +331,7 @@ void MeshCommandQueue::read_sharded_buffer(
     for (std::size_t shard_y = 0; shard_y < num_shards_y; shard_y++) {
         for (std::size_t shard_x = 0; shard_x < num_shards_x; shard_x++) {
             auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, device_x));
-            this->read_shard_from_device(
-                device_shard_view, shard_data.data(), expected_num_workers_completed, sub_device_ids);
+            this->read_shard_from_device(device_shard_view, shard_data.data());
             uint32_t write_offset = shard_x * single_write_size + shard_y * stride_size_bytes * shard_shape.height();
             uint32_t size_to_write = total_write_size_per_shard;
             uint32_t local_offset = 0;
@@ -401,24 +360,17 @@ void MeshCommandQueue::read_sharded_buffer(
 
 void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
     const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking) {
-    // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
-    // We should not be querying SubDevices from device 0.
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
-    expected_num_workers_completed[0] = expected_num_workers_completed_;
-
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
         for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x + 1;
              logical_x++) {
             for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y + 1;
                  logical_y++) {
                 auto device_shard_view = buffer.get_device_buffer(Coordinate(logical_y, logical_x));
-                this->write_shard_to_device(
-                    device_shard_view, host_data, expected_num_workers_completed, sub_device_ids);
+                this->write_shard_to_device(device_shard_view, host_data);
             }
         }
     } else {
-        this->write_sharded_buffer(buffer, host_data, expected_num_workers_completed, sub_device_ids);
+        this->write_sharded_buffer(buffer, host_data);
     }
     if (blocking) {
         this->finish();
@@ -435,10 +387,15 @@ void MeshCommandQueue::enqueue_read_mesh_buffer(
     void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
     TT_FATAL(
         buffer->global_layout() == MeshBufferLayout::SHARDED, "Can only read a Sharded MeshBuffer from a MeshDevice.");
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
-    expected_num_workers_completed[0] = expected_num_workers_completed_;
-    this->read_sharded_buffer(*buffer, host_data, expected_num_workers_completed, sub_device_ids);
+    this->read_sharded_buffer(*buffer, host_data);
+}
+
+void MeshCommandQueue::reset_worker_state(
+    bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_memcpy_aligned<uint32_t>& go_signal_noc_data) {
+    for (auto device : mesh_device_->get_devices()) {
+        auto& hw_cq = device->command_queue(id_);
+        hw_cq.reset_worker_state(reset_launch_msg_state, num_sub_devices, go_signal_noc_data);
+    }
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -518,30 +518,24 @@ uint32_t MeshDevice::get_noc_multicast_encoding(uint8_t noc_index, const CoreRan
 }
 
 // Floating point and build environment
-const JitBuildEnv& MeshDevice::build_env() const {
-    TT_THROW("build_env() is not supported on MeshDevice - use individual devices instead");
-    return reference_device()->build_env();
-}
+const JitBuildEnv& MeshDevice::build_env() const { return reference_device()->build_env(); }
 
 // Build and firmware paths
 const string MeshDevice::build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    TT_THROW("build_firmware_target_path() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->build_firmware_target_path(programmable_core, processor_class, i);
 }
-const string MeshDevice::build_kernel_target_path(uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const {
-    TT_THROW("build_kernel_target_path() is not supported on MeshDevice - use individual devices instead");
+const string MeshDevice::build_kernel_target_path(
+    uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const {
     return reference_device()->build_kernel_target_path(programmable_core, processor_class, i, kernel_name);
 }
-const JitBuildState& MeshDevice::build_firmware_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    TT_THROW("build_firmware_state() is not supported on MeshDevice - use individual devices instead");
+const JitBuildState& MeshDevice::build_firmware_state(
+    uint32_t programmable_core, uint32_t processor_class, int i) const {
     return reference_device()->build_firmware_state(programmable_core, processor_class, i);
 }
 const JitBuildState& MeshDevice::build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    TT_THROW("build_kernel_state() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->build_kernel_state(programmable_core, processor_class, i);
 }
 const JitBuildStateSubset MeshDevice::build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const {
-    TT_THROW("build_kernel_states() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->build_kernel_states(programmable_core, processor_class);
 }
 
@@ -655,13 +649,12 @@ void MeshDevice::push_work(std::function<void()> work, bool blocking) {
 }
 program_cache::detail::ProgramCache& MeshDevice::get_program_cache() { return reference_device()->get_program_cache(); }
 HalProgrammableCoreType MeshDevice::get_programmable_core_type(CoreCoord virtual_core) const { return reference_device()->get_programmable_core_type(virtual_core); }
-std::vector<std::pair<transfer_info_cores, uint32_t>> MeshDevice::extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) {
-    TT_THROW("extract_dst_noc_multicast_info() is not supported on MeshDevice - use individual devices instead");
+std::vector<std::pair<transfer_info_cores, uint32_t>> MeshDevice::extract_dst_noc_multicast_info(
+    const std::vector<CoreRange>& ranges, const CoreType core_type) {
     return reference_device()->extract_dst_noc_multicast_info(ranges, core_type);
 }
 
 size_t MeshDevice::get_device_kernel_defines_hash() {
-    TT_THROW("get_device_kernel_defines_hash() is not supported on MeshDevice - use individual devices instead");
     return validate_and_get_reference_value(
         scoped_devices_->get_devices(), [](const auto& device) { return device->get_device_kernel_defines_hash(); });
 }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -987,6 +987,21 @@ void copy_completion_queue_data_into_user_space(
     }
 }
 
+tt::stl::Span<const SubDeviceId> select_sub_device_ids(
+    IDevice* device, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    if (sub_device_ids.empty()) {
+        return device->get_sub_device_stall_group();
+    } else {
+        for (const auto& sub_device_id : sub_device_ids) {
+            TT_FATAL(
+                sub_device_id.to_index() < device->num_sub_devices(),
+                "Invalid sub-device id specified {}",
+                sub_device_id.to_index());
+        }
+        return sub_device_ids;
+    }
+}
+
 template void issue_buffer_dispatch_command_sequence<InterleavedBufferWriteDispatchParams>(
     const void*, Buffer&, InterleavedBufferWriteDispatchParams&, tt::stl::Span<const SubDeviceId>, CoreType);
 template void issue_buffer_dispatch_command_sequence<ShardedBufferWriteDispatchParams>(

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -128,6 +128,10 @@ void copy_completion_queue_data_into_user_space(
 std::vector<CoreCoord> get_cores_for_sharded_buffer(
     bool width_split, const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping, Buffer& buffer);
 
+// Selects all sub-devices in the sub device stall group if none are specified
+tt::stl::Span<const SubDeviceId> select_sub_device_ids(
+    IDevice* device, tt::stl::Span<const SubDeviceId> sub_device_ids);
+
 std::shared_ptr<::tt::tt_metal::CompletionReaderVariant> generate_sharded_buffer_read_descriptor(
     void* dst, ShardedBufferReadDispatchParams& dispatch_params, Buffer& buffer);
 std::shared_ptr<::tt::tt_metal::CompletionReaderVariant> generate_interleaved_buffer_read_descriptor(

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -7,9 +7,9 @@
 
 namespace tt::tt_metal {
 
-// Interface through which device-dispatch characteristics can be queried.
-// This layer builds on top of the dispatch core manager (responsible for assigning
-// cores to specific dispatch tasks) and the Cluster (tracks multi-chip topology)
+// Cluster level interface through which device-dispatch characteristics can be
+// queried. This layer builds on top of the dispatch core manager (responsible for
+// assigning cores to specific dispatch tasks) and the Cluster (tracks multi-chip topology)
 // to provide users with higher level queries about the dispatch topology.
 
 // Any new functions querying dispatch state should be placed in this interface (along
@@ -28,6 +28,10 @@ public:
     bool dispatch_s_enabled() const;
     bool distributed_dispatcher() const;
     NOC go_signal_noc() const;
+    // General Dispatch related queries - configs and core placement
+    const DispatchCoreConfig& get_dispatch_core_config() const;
+    const std::vector<CoreCoord>& get_logical_storage_cores(uint32_t device_id) const;
+    const std::vector<CoreCoord>& get_logical_dispatch_cores(uint32_t device_id) const;
 
 private:
     void reset(uint8_t num_hw_cqs);
@@ -37,7 +41,7 @@ private:
     bool distributed_dispatcher_ = false;
     NOC go_signal_noc_ = NOC::NOC_0;
     uint8_t num_hw_cqs_ = 0;
-    CoreType dispatch_core_type_ = CoreType::WORKER;
+    DispatchCoreConfig dispatch_core_config_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -22,6 +22,7 @@
 #include <device.hpp>
 #include <command_queue.hpp>
 #include <device_command.hpp>
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
 #include "llrt.hpp"
@@ -1332,7 +1333,7 @@ void Program::generate_dispatch_commands(IDevice* device) {
 
 void Program::allocate_kernel_bin_buf_on_device(IDevice* device) { pimpl_->allocate_kernel_bin_buf_on_device(device); }
 
-void detail::Program_::compile(IDevice*device, bool fd_bootloader_mode) {
+void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
     //ZoneScoped;
     if (compiled_.contains(device->build_key())) {
         return;
@@ -1365,9 +1366,11 @@ void detail::Program_::compile(IDevice*device, bool fd_bootloader_mode) {
         //      - eth kernels cannot be on idle eth cores
         bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
 
-        const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+        const auto& dispatch_core_config = DispatchQueryManager::instance().get_dispatch_core_config();
         CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-        const std::vector<CoreCoord> &storage_cores = tt::get_logical_storage_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
+        auto physical_device_id = device->id() % tt::Cluster::instance().number_of_devices();
+        const std::vector<CoreCoord>& storage_cores =
+            DispatchQueryManager::instance().get_logical_storage_cores(physical_device_id);
         bool on_storage_only_core =  std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
             return kernel->is_on_logical_core(storage_core);
         });
@@ -1375,8 +1378,8 @@ void detail::Program_::compile(IDevice*device, bool fd_bootloader_mode) {
 
         // Kernels used to implement fast dispatch can be placed on dispatch cores
         if (not slow_dispatch and not fd_bootloader_mode) {
-            const std::vector<CoreCoord> &dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
-
+            const std::vector<CoreCoord>& dispatch_cores =
+                DispatchQueryManager::instance().get_logical_dispatch_cores(physical_device_id);
             bool on_dispatch_core = std::any_of(dispatch_cores.begin(), dispatch_cores.end(), [&kernel, &dispatch_core_type](const CoreCoord &dispatch_core) {
                 if (kernel->get_kernel_core_type() != dispatch_core_type) {
                     return false;


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
`SubDevice` is a core TT-Metal concept. The goal of this PR is to add initial support for running `MeshWorkloads` on a `SubDevice` config stamped out across a mesh + performing `SubDevice` aware data-movement and synchronization with `MeshBuffers`.

### What's changed
- Use the `MeshDevice` native `SubDeviceManagerTracker` to create and load `SubDevice` configs on the Virtual Mesh
- Given that `SubDevice` tracking is done at the `MeshDevice` level, the following steps for enqueuing a `MeshWorkload` need to be uplifted to use `MeshDevice` components:
  - Compilation: Use the build system exposed by the `MeshDevice`
  - CB Allocation: Use the allocator exposed by the `MeshDevice` to do this (**Previous behaviour where we relied on the single device allocator for CB allocation is incorrect**)
  -  Lowering: Dispatch Command Assembly needs to rely on the `MeshDevice` instead of the underlying devices
- Add support for Global Semaphores at the Mesh level: This requires the Global Semaphore initialization step to write to a `MeshBuffer`, which under the hood requires dynamic resolution of the device type. **This is not ideal behaviour and will be cleaned up by unifying Buffer with MeshBuffer and CQ with MeshCQ**
- Allow the resetting `SubDevice` configs at the Mesh level (`SubDeviceManagerTracker::reset_sub_device_state`): **Requires dynamic resolution of the device type to infer whether a reset should be issued through a CQ or a MeshCQ. Will be cleaned up after unification**
- Expose `select_sub_device_ids` as a general API so that it can be used by `MeshCommandQueue` functions
- Add basic `SubDevice` tests running `MeshWorkloads`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
