### PR TITLE
#15174: Re-enable mistral7b demo test after fw upgrade

### DIFF
--- a/models/demos/wormhole/mistral7b/README.md
+++ b/models/demos/wormhole/mistral7b/README.md
@@ -4,11 +4,9 @@ Demo showcasing Mistral-7B running on Wormhole, using ttnn.
 
 ## How to Run
 
-⚠️ **WARNING: DO NOT RUN THIS DEMO FOR NOW** ⚠️
+⚠️ **WARNING: DO NOT RUN THIS DEMO ON WORMHOLE FIRMWARE OLDER THAN 80.13.0.0** ⚠️
 
-This demo is currently disabled as it has been linked to hardware failures that can permanently damage cards. Please do not attempt to run it until further notice.
-
-[The issue](https://github.com/tenstorrent/cloud/issues/3323) appears to be connected to blown FETs (Field Effect Transistors) that can disable cards. We are investigating the root cause and will update this notice once the demo is confirmed to be safe to run.
+This demo has been linked to hardware failures that can permanently damage cards. A patch was released for firmware 80.13.0.0. Please do not attempt to run it on anything older.
 
 ### Download the weights
 

--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -330,8 +330,6 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
     ],
 )
 def test_mistral7B_demo(device, use_program_cache, input_prompts, instruct_weights, is_ci_env, num_batches):
-    pytest.skip("https://github.com/tenstorrent/cloud/issues/3323: May kill WH cards (internal issue 14440)")
-
     if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1 or num_batches == 3)):
         pytest.skip(
             "CI demo test only runs instruct weights (1 and 3 batches) to reduce CI pipeline load (both are supported)"

--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -330,10 +330,8 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
     ],
 )
 def test_mistral7B_demo(device, use_program_cache, input_prompts, instruct_weights, is_ci_env, num_batches):
-    if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1 or num_batches == 3)):
-        pytest.skip(
-            "CI demo test only runs instruct weights (1 and 3 batches) to reduce CI pipeline load (both are supported)"
-        )
+    if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1)):
+        pytest.skip("CI demo test only runs instruct weights (1 repeat batch) to reduce CI pipeline load")
 
     return run_mistral_demo(
         user_input=input_prompts,

--- a/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
@@ -577,9 +577,6 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
 def test_mistral7B_demo(
     device, use_program_cache, input_prompts, instruct_weights, is_ci_env, is_single_card_n300, num_batches
 ):
-    if is_ci_env:
-        pytest.skip("Issue #14440: May kill WH cards")
-
     if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1 or num_batches == 3)):
         pytest.skip(
             "CI demo test only runs instruct weights (1 and 3 batches) to reduce CI pipeline load (both are supported)"

--- a/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
@@ -577,10 +577,8 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
 def test_mistral7B_demo(
     device, use_program_cache, input_prompts, instruct_weights, is_ci_env, is_single_card_n300, num_batches
 ):
-    if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1 or num_batches == 3)):
-        pytest.skip(
-            "CI demo test only runs instruct weights (1 and 3 batches) to reduce CI pipeline load (both are supported)"
-        )
+    if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1)):
+        pytest.skip("CI demo test only runs instruct weights (1 repeat batch) to reduce CI pipeline load")
 
     return run_mistral_demo(
         user_input=input_prompts,

--- a/models/demos/wormhole/mistral7b/tt/mistral_model.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_model.py
@@ -29,6 +29,7 @@ class TtTransformer(nn.Module):
         self.n_layers = args.n_layers
         self.start_pos = start_pos
         self.device = device
+        self.model_config = args.get_model_config()
         assert self.vocab_size > 0
 
         self.layers = torch.nn.ModuleList(
@@ -79,10 +80,13 @@ class TtTransformer(nn.Module):
         if mode == "prefill":
             return x
         x = self.norm(x, mode=mode)
+
         output = ttnn.linear(
             x,
             self.output_weight,
             compute_kernel_config=self.args.get_compute_kernel_config(),
-            core_grid=self.args.max_grid_size,
+            program_config=self.model_config["OUTPUT_MM_PROGCFG"],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=ttnn.bfloat8_b,
         )
         return output

--- a/models/demos/wormhole/mistral7b/tt/model_config.py
+++ b/models/demos/wormhole/mistral7b/tt/model_config.py
@@ -215,6 +215,18 @@ class TtModelArgs:
                 fuse_batch=seq_len <= 2048,
             )
 
+            self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(7, 8),
+                in0_block_w=1,
+                per_core_M=1,
+                per_core_N=18,  # vocab size: 32000 = 1000 tiles. 1000/56cores = 18
+                out_subblock_h=1,
+                out_subblock_w=1,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            )
+
             self.model_config["XQKV_PREFILL_PROGCFG"] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(8, 8),
                 in0_block_w=1,  # how much inner dim you take each time

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -9,7 +9,7 @@ run_common_func_tests() {
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-default_mode_1024_stochastic]; fail+=$?
 
   # Mistral7B
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/demo/demo.py --timeout 420; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/demo/demo.py; fail+=$?
 
   # Qwen7B
   QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/demo/demo.py -k instruct --timeout 420; fail+=$?
@@ -69,7 +69,7 @@ run_common_perf_tests(){
   fail=0
 
   # Mistral7B
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/demo/demo_with_prefill.py --timeout 420; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/demo/demo_with_prefill.py; fail+=$?
 
   # Mamba
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420; fail+=$?

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -9,8 +9,7 @@ run_common_func_tests() {
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-default_mode_1024_stochastic]; fail+=$?
 
   # Mistral7B
-  # Skipping: kills WH cards, check issue #14440
-  # WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/demo/demo.py --timeout 420; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/demo/demo.py --timeout 420; fail+=$?
 
   # Qwen7B
   QWEN_DIR=/mnt/MLPerf/tt_dnn-models/qwen/Qwen2-7B-Instruct WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml FAKE_DEVICE=N150 pytest -n auto models/demos/qwen/demo/demo.py -k instruct --timeout 420; fail+=$?
@@ -70,8 +69,7 @@ run_common_perf_tests(){
   fail=0
 
   # Mistral7B
-  # Skipping: kills WH cards, check issue #14440
-  # WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/demo/demo_with_prefill.py --timeout 420; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/demo/demo_with_prefill.py --timeout 420; fail+=$?
 
   # Mamba
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420; fail+=$?


### PR DESCRIPTION
### Tickets
#15174
https://github.com/tenstorrent/tt-metal/issues/17106

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] All-post commit: https://github.com/tenstorrent/tt-metal/actions/runs/13034220799
- [x] Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/13031292701
- [x] Single-device perf: https://github.com/tenstorrent/tt-metal/actions/runs/13034175893
- [x] Single-device nightly: https://github.com/tenstorrent/tt-metal/actions/runs/13034188412
