### PR TITLE
[UMD] Dram view in soc descriptor

### DIFF
--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -15,8 +15,8 @@
 */
 struct metal_SocDescriptor : public tt_SocDescriptor {
 public:
-    std::vector<CoreCoord> view_worker_dram_core;   // per channel preferred worker endpoint
-    std::vector<CoreCoord> view_eth_dram_core;      // per dram view preferred eth endpoint
+    std::vector<CoreCoord> view_worker_dram_cores;  // per channel preferred worker endpoint
+    std::vector<CoreCoord> view_eth_dram_cores;     // per dram view preferred eth endpoint
     std::vector<size_t> dram_view_address_offsets;  // starting address offset
     std::vector<CoreCoord> logical_ethernet_cores;
     uint64_t dram_core_size;

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -15,9 +15,11 @@
 */
 struct metal_SocDescriptor : public tt_SocDescriptor {
 public:
-    std::vector<CoreCoord> view_worker_dram_cores;  // per channel preferred worker endpoint
-    std::vector<CoreCoord> view_eth_dram_cores;     // per dram view preferred eth endpoint
+    std::vector<size_t> dram_view_channels;
+    std::vector<CoreCoord> dram_view_worker_cores;  // per channel preferred worker endpoint
+    std::vector<CoreCoord> dram_view_eth_cores;     // per dram view preferred eth endpoint
     std::vector<size_t> dram_view_address_offsets;  // starting address offset
+
     std::vector<CoreCoord> logical_ethernet_cores;
     uint64_t dram_core_size;
     uint64_t dram_view_size;
@@ -36,10 +38,11 @@ public:
     metal_SocDescriptor(const tt_SocDescriptor& other, uint32_t harvesting_mask, const BoardType& board_type);
     metal_SocDescriptor() = default;
 
-    CoreCoord get_preferred_worker_core_for_dram_channel(int dram_chan) const;
-    CoreCoord get_preferred_eth_core_for_dram_channel(int dram_chan) const;
-    CoreCoord get_logical_core_for_dram_channel(int dram_chan) const;
-    size_t get_address_offset(int dram_chan) const;
+    CoreCoord get_preferred_worker_core_for_dram_view(int dram_view) const;
+    CoreCoord get_preferred_eth_core_for_dram_view(int dram_view) const;
+    CoreCoord get_logical_core_for_dram_view(int dram_view) const;
+    size_t get_address_offset(int dram_view) const;
+    size_t get_channel_for_dram_view(int dram_view) const;
     size_t get_num_dram_views() const;
 
     bool is_harvested_core(const CoreCoord& core) const;

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -15,11 +15,12 @@
 */
 struct metal_SocDescriptor : public tt_SocDescriptor {
 public:
-    std::vector<CoreCoord> preferred_worker_dram_core;  // per channel preferred worker endpoint
-    std::vector<CoreCoord> preferred_eth_dram_core;     // per channel preferred eth endpoint
-    std::vector<size_t> dram_address_offsets;           // starting address offset
+    std::vector<CoreCoord> view_worker_dram_core;   // per channel preferred worker endpoint
+    std::vector<CoreCoord> view_eth_dram_core;      // per dram view preferred eth endpoint
+    std::vector<size_t> dram_view_address_offsets;  // starting address offset
     std::vector<CoreCoord> logical_ethernet_cores;
     uint64_t dram_core_size;
+    uint64_t dram_view_size;
 
     // in tt_SocDescriptor worker_log_to_routing_x and worker_log_to_routing_y map logical coordinates to NOC virtual
     // coordinates UMD accepts NOC virtual coordinates but Metal needs NOC physical coordinates to ensure a harvested
@@ -39,6 +40,7 @@ public:
     CoreCoord get_preferred_eth_core_for_dram_channel(int dram_chan) const;
     CoreCoord get_logical_core_for_dram_channel(int dram_chan) const;
     size_t get_address_offset(int dram_chan) const;
+    size_t get_num_dram_views() const;
 
     bool is_harvested_core(const CoreCoord& core) const;
     const std::vector<CoreCoord>& get_pcie_cores() const;

--- a/tt_metal/api/tt-metalium/tt_cluster.hpp
+++ b/tt_metal/api/tt-metalium/tt_cluster.hpp
@@ -20,7 +20,7 @@
 
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 
-using tt_target_dram = std::tuple<int, int>;
+using tt_target_dram = std::tuple<int, int, int>;
 
 enum EthRouterMode : uint32_t {
     IDLE = 0,

--- a/tt_metal/api/tt-metalium/tt_cluster.hpp
+++ b/tt_metal/api/tt-metalium/tt_cluster.hpp
@@ -20,7 +20,7 @@
 
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 
-using tt_target_dram = std::tuple<int, int, int>;
+using tt_target_dram = std::tuple<int, int>;
 
 enum EthRouterMode : uint32_t {
     IDLE = 0,

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -12,44 +12,53 @@
 #include "umd/device/cluster.h"
 #include "yaml-cpp/yaml.h"
 
-CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_channel(int dram_chan) const {
+CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view) const {
     TT_ASSERT(
-        dram_chan < this->view_worker_dram_cores.size(),
-        "dram_chan={} must be within range of view_worker_dram_cores.size={}",
-        dram_chan,
-        this->view_worker_dram_cores.size());
-    return this->view_worker_dram_cores.at(dram_chan);
+        dram_view < this->dram_view_worker_cores.size(),
+        "dram_view={} must be within range of dram_view_worker_cores.size={}",
+        dram_view,
+        this->dram_view_worker_cores.size());
+    return this->dram_view_worker_cores.at(dram_view);
 };
 
-CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_channel(int dram_chan) const {
+CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view) const {
     TT_ASSERT(
-        dram_chan < this->view_eth_dram_cores.size(),
-        "dram_chan={} must be within range of view_eth_dram_cores.size={}",
-        dram_chan,
-        this->view_eth_dram_cores.size());
-    return this->view_eth_dram_cores.at(dram_chan);
+        dram_view < this->dram_view_eth_cores.size(),
+        "dram_view={} must be within range of dram_view_eth_cores.size={}",
+        dram_view,
+        this->dram_view_eth_cores.size());
+    return this->dram_view_eth_cores.at(dram_view);
 };
 
-CoreCoord metal_SocDescriptor::get_logical_core_for_dram_channel(int dram_chan) const {
+CoreCoord metal_SocDescriptor::get_logical_core_for_dram_view(int dram_view) const {
     const uint32_t num_dram_views = this->get_num_dram_views();
     TT_FATAL(
-        dram_chan < num_dram_views,
-        "dram_chan={} must be within range of num_dram_views={}",
-        dram_chan,
+        dram_view < num_dram_views,
+        "dram_view={} must be within range of num_dram_views={}",
+        dram_view,
         num_dram_views);
-    return CoreCoord(dram_chan, 0);
+    return CoreCoord(dram_view, 0);
 }
 
-size_t metal_SocDescriptor::get_address_offset(int dram_chan) const {
+size_t metal_SocDescriptor::get_address_offset(int dram_view) const {
     TT_ASSERT(
-        dram_chan < this->dram_view_address_offsets.size(),
-        "dram_chan={} must be within range of dram_view_address_offsets.size={}",
-        dram_chan,
+        dram_view < this->dram_view_address_offsets.size(),
+        "dram_view={} must be within range of dram_view_address_offsets.size={}",
+        dram_view,
         this->dram_view_address_offsets.size());
-    return this->dram_view_address_offsets.at(dram_chan);
+    return this->dram_view_address_offsets.at(dram_view);
 }
 
-size_t metal_SocDescriptor::get_num_dram_views() const { return this->view_eth_dram_cores.size(); }
+size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
+    TT_ASSERT(
+        dram_view < this->dram_view_channels.size(),
+        "dram_view={} must be within range of dram_view_channels.size={}",
+        dram_view,
+        this->dram_view_channels.size());
+    return this->dram_view_channels.at(dram_view);
+}
+
+size_t metal_SocDescriptor::get_num_dram_views() const { return this->dram_view_eth_cores.size(); }
 
 bool metal_SocDescriptor::is_harvested_core(const CoreCoord& core) const {
     for (const auto& core_it : this->physical_harvested_workers) {
@@ -122,7 +131,7 @@ CoreCoord metal_SocDescriptor::get_physical_tensix_core_from_logical(const CoreC
 }
 
 CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const CoreCoord& logical_coord) const {
-    return this->get_preferred_worker_core_for_dram_channel(this->get_dram_channel_from_logical_core(logical_coord));
+    return this->get_preferred_worker_core_for_dram_view(this->get_dram_channel_from_logical_core(logical_coord));
 }
 
 CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core(
@@ -140,67 +149,41 @@ CoreCoord metal_SocDescriptor::get_dram_grid_size() const { return CoreCoord(thi
 void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     YAML::Node device_descriptor_yaml = YAML::LoadFile(this->device_descriptor_file_path);
     this->dram_view_size = device_descriptor_yaml["dram_view_size"].as<uint64_t>();
-    this->view_eth_dram_cores.clear();
-    for (const auto& core_node : device_descriptor_yaml["dram_view_eth_endpoint"]) {
-        if (core_node.IsScalar()) {
-            tt_xy_pair dram_logical_coords = format_node(core_node.as<std::string>());
-            if (dram_logical_coords.x >= dram_cores.size()) {
-                TT_THROW(
-                    "DRAM channel {} does not exist in the device descriptor, but is specified in "
-                    "dram_view_eth_endpoint",
-                    dram_logical_coords.x);
-            }
-            if (dram_logical_coords.y >= dram_cores[dram_logical_coords.x].size()) {
-                TT_THROW(
-                    "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
-                    "dram_view_eth_endpoint",
-                    dram_logical_coords.y);
-            }
-            this->view_eth_dram_cores.push_back(dram_cores[dram_logical_coords.x][dram_logical_coords.y]);
-        } else {
-            TT_THROW("Only NOC coords supported for dram_view_eth_endpoint cores");
+    this->dram_core_size = device_descriptor_yaml["dram_views"].size() * this->dram_view_size;
+    this->dram_view_channels.clear();
+    this->dram_view_eth_cores.clear();
+    this->dram_view_worker_cores.clear();
+    this->dram_view_address_offsets.clear();
+
+    for (const auto& dram_view : device_descriptor_yaml["dram_views"]) {
+        size_t channel = dram_view["channel"].as<size_t>();
+        int eth_endpoint = dram_view["eth_endpoint"].as<int>();
+        int worker_endpoint = dram_view["worker_endpoint"].as<int>();
+        size_t address_offset = dram_view["address_offset"].as<size_t>();
+
+        if (channel >= dram_cores.size()) {
+            TT_THROW(
+                "DRAM channel {} does not exist in the device descriptor, but is specified in dram_view.channel",
+                channel);
         }
-    }
-    int num_dram_views = this->view_eth_dram_cores.size();
-
-    this->view_worker_dram_cores.clear();
-    for (const auto& core_node : device_descriptor_yaml["dram_view_worker_endpoint"]) {
-        if (core_node.IsScalar()) {
-            tt_xy_pair dram_logical_coords = format_node(core_node.as<std::string>());
-            if (dram_logical_coords.x >= dram_cores.size()) {
-                TT_THROW(
-                    "DRAM channel {} does not exist in the device descriptor, but is specified in "
-                    "dram_view_worker_endpoint",
-                    dram_logical_coords.x);
-            }
-            if (dram_logical_coords.y >= dram_cores[dram_logical_coords.x].size()) {
-                TT_THROW(
-                    "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
-                    "dram_view_worker_endpoint",
-                    dram_logical_coords.y);
-            }
-            this->view_worker_dram_cores.push_back(dram_cores[dram_logical_coords.x][dram_logical_coords.y]);
-        } else {
-            TT_THROW("Only NOC coords supported for dram_view_worker_endpoint");
+        if (eth_endpoint >= dram_cores[channel].size()) {
+            TT_THROW(
+                "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
+                "dram_view.eth_endpoint",
+                eth_endpoint);
         }
-    }
-    if (this->view_worker_dram_cores.size() != num_dram_views) {
-        TT_THROW(
-            "Expected to specify preferred DRAM endpoint for worker core for {} views but yaml specifies {} "
-            "views through dram_view_eth_endpoint",
-            num_dram_views,
-            this->view_worker_dram_cores.size());
-    }
+        if (worker_endpoint >= dram_cores[channel].size()) {
+            TT_THROW(
+                "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
+                "dram_view.worker_endpoint",
+                worker_endpoint);
+        }
 
-    this->dram_view_address_offsets = device_descriptor_yaml["dram_view_address_offsets"].as<std::vector<size_t>>();
-    if (this->dram_view_address_offsets.size() != num_dram_views) {
-        TT_THROW(
-            "Expected DRAM offsets for {} views but yaml specified {} views through dram_view_eth_endpoint",
-            num_dram_views,
-            this->dram_view_address_offsets.size());
+        this->dram_view_channels.push_back(channel);
+        this->dram_view_eth_cores.push_back(dram_cores[channel][eth_endpoint]);
+        this->dram_view_worker_cores.push_back(dram_cores[channel][worker_endpoint]);
+        this->dram_view_address_offsets.push_back(address_offset);
     }
-
-    this->dram_core_size = num_dram_views * this->dram_view_size;
 }
 
 // UMD expects virtual NOC coordinates for worker cores

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -143,7 +143,20 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     this->view_eth_dram_core.clear();
     for (const auto& core_node : device_descriptor_yaml["dram_view_eth_endpoint"]) {
         if (core_node.IsScalar()) {
-            this->view_eth_dram_core.push_back(format_node(core_node.as<std::string>()));
+            tt_xy_pair dram_logical_coords = format_node(core_node.as<std::string>());
+            if (dram_logical_coords.x >= dram_cores.size()) {
+                TT_THROW(
+                    "DRAM channel {} does not exist in the device descriptor, but is specified in "
+                    "dram_view_eth_endpoint",
+                    dram_logical_coords.x);
+            }
+            if (dram_logical_coords.y >= dram_cores[dram_logical_coords.x].size()) {
+                TT_THROW(
+                    "DRAM subchannel {} does not exist in the device descriptor, but is specified in "
+                    "dram_view_eth_endpoint",
+                    dram_logical_coords.y);
+            }
+            this->view_eth_dram_core.push_back(dram_cores[dram_logical_coords.x][dram_logical_coords.y]);
         } else {
             TT_THROW("Only NOC coords supported for dram_view_eth_endpoint cores");
         }

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -139,7 +139,6 @@ CoreCoord metal_SocDescriptor::get_dram_grid_size() const { return CoreCoord(thi
 
 void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     YAML::Node device_descriptor_yaml = YAML::LoadFile(this->device_descriptor_file_path);
-    int num_dram_channels = this->get_num_dram_channels();
     this->dram_view_size = device_descriptor_yaml["dram_view_size"].as<uint64_t>();
     this->view_eth_dram_core.clear();
     for (const auto& core_node : device_descriptor_yaml["dram_view_eth_endpoint"]) {
@@ -312,8 +311,8 @@ void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
     }
 
     int coreCount = this->physical_routing_to_profiler_flat_id.size();
-    this->profiler_ceiled_core_count_perf_dram_bank = coreCount / this->get_num_dram_channels();
-    if ((coreCount % this->get_num_dram_channels()) > 0) {
+    this->profiler_ceiled_core_count_perf_dram_bank = coreCount / this->get_num_dram_views();
+    if ((coreCount % this->get_num_dram_views()) > 0) {
         this->profiler_ceiled_core_count_perf_dram_bank++;
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1160,9 +1160,7 @@ tt::ARCH Device::arch() const {
     return tt::Cluster::instance().arch();
 }
 
-int Device::num_dram_channels() const {
-    return tt::Cluster::instance().get_soc_desc(id_).get_num_dram_channels();
-}
+int Device::num_dram_channels() const { return tt::Cluster::instance().get_soc_desc(id_).get_num_dram_views(); }
 
 uint32_t Device::l1_size_per_core() const {
     return tt::Cluster::instance().get_soc_desc(id_).worker_l1_size;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -265,7 +265,7 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
     const auto &logical_size = this->logical_grid_size();
     const auto &compute_size = this->compute_with_storage_grid_size();
     AllocatorConfig config(
-        {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_channels()),
+        {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_views()),
          .dram_bank_size = soc_desc.dram_view_size,
          .dram_bank_offsets = {},
          .dram_unreserved_base =
@@ -290,7 +290,7 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
         "Reserved size must be aligned to allocator alignment {}",
         config.alignment);
     // Initialize dram_offsets from soc_descriptor
-    for (auto channel = 0; channel < soc_desc.get_num_dram_channels(); channel++) {
+    for (auto channel = 0; channel < soc_desc.get_num_dram_views(); channel++) {
         config.dram_bank_offsets.push_back(soc_desc.get_address_offset(channel));
     }
     // Initialize core_type_from_noc_coord_table table

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -266,7 +266,7 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
     const auto &compute_size = this->compute_with_storage_grid_size();
     AllocatorConfig config(
         {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_channels()),
-         .dram_bank_size = soc_desc.dram_bank_size,
+         .dram_bank_size = soc_desc.dram_view_size,
          .dram_bank_offsets = {},
          .dram_unreserved_base =
              hal.get_dev_addr(HalDramMemAddrType::DRAM_BARRIER) + hal.get_dev_size(HalDramMemAddrType::DRAM_BARRIER),
@@ -1167,9 +1167,7 @@ int Device::num_dram_channels() const {
 uint32_t Device::l1_size_per_core() const {
     return tt::Cluster::instance().get_soc_desc(id_).worker_l1_size;
 }
-uint32_t Device::dram_size_per_channel() const {
-    return tt::Cluster::instance().get_soc_desc(id_).dram_bank_size;
-}
+uint32_t Device::dram_size_per_channel() const { return tt::Cluster::instance().get_soc_desc(id_).dram_view_size; }
 
 CoreCoord Device::grid_size() const {
     return tt::Cluster::instance().get_soc_desc(id_).grid_size;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1350,12 +1350,12 @@ uint32_t Device::dram_channel_from_bank_id(uint32_t bank_id, SubDeviceId sub_dev
 }
 
 CoreCoord Device::dram_core_from_dram_channel(uint32_t dram_channel) const {
-    return tt::Cluster::instance().get_soc_desc(id_).get_preferred_worker_core_for_dram_channel(dram_channel);
+    return tt::Cluster::instance().get_soc_desc(id_).get_preferred_worker_core_for_dram_view(dram_channel);
 }
 
 CoreCoord Device::logical_core_from_dram_channel(uint32_t dram_channel) const {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    return tt::Cluster::instance().get_soc_desc(id_).get_logical_core_for_dram_channel(dram_channel);
+    return tt::Cluster::instance().get_soc_desc(id_).get_logical_core_for_dram_view(dram_channel);
 }
 
 uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -167,7 +167,7 @@ void write_binary_to_address(ll_api::memory const& mem, chip_id_t chip_id, const
 }
 
 CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id) {
-    return tt::Cluster::instance().get_soc_desc(chip_id).get_preferred_worker_core_for_dram_channel(dram_channel_id);
+    return tt::Cluster::instance().get_soc_desc(chip_id).get_preferred_worker_core_for_dram_view(dram_channel_id);
 }
 
 namespace internal_ {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -500,10 +500,10 @@ void Cluster::write_dram_vec(std::vector<uint32_t> &vec, tt_target_dram dram, ui
         "Bounds-Error -- dram_view={} is outside of num_dram_views={}",
         d_view,
         desc_to_use.get_num_dram_views());
+    int d_chan = desc_to_use.get_channel_for_dram_view(d_view);
     TT_ASSERT(
         d_subchannel < desc_to_use.dram_cores.at(d_chan).size(),
         "Trying to address dram sub channel that doesnt exist in the device descriptor");
-    int d_chan = desc_to_use.get_channel_for_dram_view(d_view);
     tt_cxy_pair dram_core = tt_cxy_pair(chip_id, desc_to_use.get_core_for_dram_channel(d_chan, d_subchannel));
     size_t offset = desc_to_use.get_address_offset(d_view);
     write_core(vec.data(), vec.size() * sizeof(uint32_t), dram_core, addr + offset, small_access);
@@ -519,10 +519,10 @@ void Cluster::read_dram_vec(
         "Bounds-Error -- dram_view={} is outside of num_dram_views={}",
         d_view,
         desc_to_use.get_num_dram_views());
+    int d_chan = desc_to_use.get_channel_for_dram_view(d_view);
     TT_ASSERT(
         d_subchannel < desc_to_use.dram_cores.at(d_chan).size(),
         "Trying to address dram sub channel that doesnt exist in the device descriptor");
-    int d_chan = desc_to_use.get_channel_for_dram_view(d_view);
     tt_cxy_pair dram_core = tt_cxy_pair(chip_id, desc_to_use.get_core_for_dram_channel(d_chan, d_subchannel));
     size_t offset = desc_to_use.get_address_offset(d_view);
     read_core(vec, sz_in_bytes, dram_core, addr + offset, small_access);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -492,37 +492,31 @@ void Cluster::assert_risc_reset_at_core(const tt_cxy_pair &core) const {
 }
 
 void Cluster::write_dram_vec(std::vector<uint32_t> &vec, tt_target_dram dram, uint64_t addr, bool small_access) const {
-    int chip_id, d_chan, d_subchannel;
-    std::tie(chip_id, d_chan, d_subchannel) = dram;
+    int chip_id, dram_view;
+    std::tie(chip_id, dram_view) = dram;
     const metal_SocDescriptor &desc_to_use = get_soc_desc(chip_id);
     TT_FATAL(
-        d_chan < desc_to_use.dram_cores.size(),
-        "Bounds-Error -- dram_channel={} is outside of num_dram_channels={}",
-        d_chan,
-        desc_to_use.dram_cores.size());
-    TT_ASSERT(
-        d_subchannel < desc_to_use.dram_cores.at(d_chan).size(),
-        "Trying to address dram sub channel that doesnt exist in the device descriptor");
-    tt_cxy_pair dram_core = tt_cxy_pair(chip_id, desc_to_use.get_core_for_dram_channel(d_chan, d_subchannel));
-    size_t offset = desc_to_use.get_address_offset(d_chan);
+        dram_view < desc_to_use.get_num_dram_views(),
+        "Bounds-Error -- dram_view={} is outside of num_dram_views={}",
+        dram_view,
+        desc_to_use.get_num_dram_views());
+    tt_cxy_pair dram_core = tt_cxy_pair(chip_id, desc_to_use.get_preferred_worker_core_for_dram_channel(dram_view));
+    size_t offset = desc_to_use.get_address_offset(dram_view);
     write_core(vec.data(), vec.size() * sizeof(uint32_t), dram_core, addr + offset, small_access);
 }
 
 void Cluster::read_dram_vec(
     std::vector<uint32_t> &vec, uint32_t sz_in_bytes, tt_target_dram dram, uint64_t addr, bool small_access) const {
-    int chip_id, d_chan, d_subchannel;
-    std::tie(chip_id, d_chan, d_subchannel) = dram;
+    int chip_id, dram_view;
+    std::tie(chip_id, dram_view) = dram;
     const metal_SocDescriptor &desc_to_use = get_soc_desc(chip_id);
     TT_FATAL(
-        d_chan < desc_to_use.dram_cores.size(),
-        "Bounds-Error -- dram_channel={} is outside of num_dram_channels={}",
-        d_chan,
-        desc_to_use.dram_cores.size());
-    TT_ASSERT(
-        d_subchannel < desc_to_use.dram_cores.at(d_chan).size(),
-        "Trying to address dram sub channel that doesnt exist in the device descriptor");
-    tt_cxy_pair dram_core = tt_cxy_pair(chip_id, desc_to_use.get_core_for_dram_channel(d_chan, d_subchannel));
-    size_t offset = desc_to_use.get_address_offset(d_chan);
+        dram_view < desc_to_use.get_num_dram_views(),
+        "Bounds-Error -- dram_view={} is outside of num_dram_views={}",
+        dram_view,
+        desc_to_use.get_num_dram_views());
+    tt_cxy_pair dram_core = tt_cxy_pair(chip_id, desc_to_use.get_preferred_worker_core_for_dram_channel(dram_view));
+    size_t offset = desc_to_use.get_address_offset(dram_view);
     read_core(vec, sz_in_bytes, dram_core, addr + offset, small_access);
 }
 
@@ -1100,7 +1094,6 @@ uint32_t Cluster::get_device_tunnel_depth(chip_id_t chip_id) const {
 }  // namespace tt
 
 std::ostream &operator<<(std::ostream &os, tt_target_dram const &dram) {
-    os << "Target DRAM chip = " << std::get<0>(dram) << ", chan = " << std::get<1>(dram)
-       << ", subchan = " << std::get<2>(dram);
+    os << "Target DRAM chip = " << std::get<0>(dram) << ", chan = " << std::get<1>(dram);
     return os;
 }

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -20,11 +20,11 @@ dram:
       [9-5, 9-7, 9-6],
   ]
 
+# Coords for eth and worker dram endpoints are given in dram coordinates.
+# For example 0-2 means third core in the first dram cores array which would resolve to 0-11.
 dram_view_eth_endpoint:
-  [ 0-1, 0-2, 0-4, 0-5, 9-1, 9-2, 9-4, 9-5 ]
+  [ 0-1, 1-0, 2-1, 3-0, 4-1, 5-0, 6-1, 7-0 ]
 
-# These are given in dram coordinates, for example 0-2 means first dram bank array,
-# third noc port core which would resolve to 0-11 in noc coordinates.
 dram_view_worker_endpoint:
   [ 0-2, 1-2, 2-2, 3-2, 4-2, 5-2, 6-2, 7-2 ]
 

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -1,7 +1,3 @@
-# soc-descriptor yaml
-# Anything using [#-#] is noc coordinates
-# Anything using [[#, #]] is logical coordinates (Can be relative)
-# relative index: 0 means first row, -1 means last row of functional grid...
 grid:
   x_size: 17
   y_size: 12
@@ -24,14 +20,19 @@ dram:
       [9-5, 9-7, 9-6],
   ]
 
-dram_preferred_eth_endpoint:
+dram_view_eth_endpoint:
   [ 0-1, 0-2, 0-4, 0-5, 9-1, 9-2, 9-4, 9-5 ]
 
-dram_preferred_worker_endpoint:
-  [ 0-11, 0-3, 0-8, 0-6, 9-11, 9-3, 9-8, 9-6 ]
+# These are given in dram coordinates, for example 0-2 means first dram bank array,
+# third noc port core which would resolve to 0-11 in noc coordinates.
+dram_view_worker_endpoint:
+  [ 0-2, 1-2, 2-2, 3-2, 4-2, 5-2, 6-2, 7-2 ]
 
-dram_address_offsets:
+dram_view_address_offsets:
   [ 0, 0, 0, 0, 0, 0, 0, 0 ]
+
+dram_view_size:
+  4278190080
 
 eth:
   [

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -20,16 +20,60 @@ dram:
       [9-5, 9-7, 9-6],
   ]
 
-# Coords for eth and worker dram endpoints are given in dram coordinates.
-# For example 0-2 means third core in the first dram cores array which would resolve to 0-11.
-dram_view_eth_endpoint:
-  [ 0-1, 1-0, 2-1, 3-0, 4-1, 5-0, 6-1, 7-0 ]
-
-dram_view_worker_endpoint:
-  [ 0-2, 1-2, 2-2, 3-2, 4-2, 5-2, 6-2, 7-2 ]
-
-dram_view_address_offsets:
-  [ 0, 0, 0, 0, 0, 0, 0, 0 ]
+# Dram view parameters are used by tt-metal and are not recognized by UMD.
+# Eth and worker dram endpoints represent subchannel id from dram array.
+# For example, a dram view where channel is 0 and worker_endpoint is 2 would resolve to dram core at position [0,2] which is 0-11.
+dram_views:
+  [
+    {
+      channel: 0,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 1,
+      eth_endpoint: 0,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 2,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 3,
+      eth_endpoint: 0,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 4,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 5,
+      eth_endpoint: 0,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 6,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 7,
+      eth_endpoint: 0,
+      worker_endpoint: 2,
+      address_offset: 0
+    }
+  ]
 
 dram_view_size:
   4278190080

--- a/tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml
@@ -11,14 +11,17 @@ pcie:
 dram:
   [[1-0]]
 
-dram_preferred_eth_endpoint:
+dram_view_eth_endpoint:
   [ 1-0 ]
 
-dram_preferred_worker_endpoint:
-  [ 1-0 ]
+dram_view_worker_endpoint:
+  [ 0-0 ]
 
-dram_address_offsets:
+dram_view_address_offsets:
   [ 0 ]
+
+dram_view_size:
+  1073741824
 
 eth:
   []

--- a/tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml
@@ -11,14 +11,15 @@ pcie:
 dram:
   [[1-0]]
 
-dram_view_eth_endpoint:
-  [ 0-0 ]
-
-dram_view_worker_endpoint:
-  [ 0-0 ]
-
-dram_view_address_offsets:
-  [ 0 ]
+dram_views:
+  [
+    {
+      channel: 0,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    }
+  ]
 
 dram_view_size:
   1073741824

--- a/tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml
@@ -12,7 +12,7 @@ dram:
   [[1-0]]
 
 dram_view_eth_endpoint:
-  [ 1-0 ]
+  [ 0-0 ]
 
 dram_view_worker_endpoint:
   [ 0-0 ]

--- a/tt_metal/soc_descriptors/grayskull_120_arch.yaml
+++ b/tt_metal/soc_descriptors/grayskull_120_arch.yaml
@@ -11,16 +11,60 @@ pcie:
 dram:
   [[1-0], [1-6], [4-0], [4-6], [7-0], [7-6], [10-0], [10-6]]
 
-# Coords for eth and worker dram endpoints are given in dram coordinates.
-# These are only simple dram arrays, so each coord references the only core in corresponding dram array.
-dram_view_eth_endpoint:
-  [ 0-0, 1-0, 2-0, 3-0, 4-0, 5-0, 6-0, 7-0 ]
-
-dram_view_worker_endpoint:
-  [ 0-0, 1-0, 2-0, 3-0, 4-0, 5-0, 6-0, 7-0 ]
-
-dram_view_address_offsets:
-  [ 0, 0, 0, 0, 0, 0, 0, 0 ]
+# Dram view parameters are used by tt-metal and are not recognized by UMD.
+# Eth and worker dram endpoints represent subchannel id from dram array.
+# These are simple dram views, so each endpoint references the only core in the corresponding dram channel.
+dram_views:
+  [
+    {
+      channel: 0,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 1,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 2,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 3,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 4,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 5,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 6,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 7,
+      eth_endpoint: 0,
+      worker_endpoint: 0,
+      address_offset: 0
+    }
+  ]
 
 dram_view_size:
   1073741824

--- a/tt_metal/soc_descriptors/grayskull_120_arch.yaml
+++ b/tt_metal/soc_descriptors/grayskull_120_arch.yaml
@@ -11,8 +11,10 @@ pcie:
 dram:
   [[1-0], [1-6], [4-0], [4-6], [7-0], [7-6], [10-0], [10-6]]
 
+# Coords for eth and worker dram endpoints are given in dram coordinates.
+# These are only simple dram arrays, so each coord references the only core in corresponding dram array.
 dram_view_eth_endpoint:
-  [ 1-0, 1-6, 4-0, 4-6, 7-0, 7-6, 10-0, 10-6 ]
+  [ 0-0, 1-0, 2-0, 3-0, 4-0, 5-0, 6-0, 7-0 ]
 
 dram_view_worker_endpoint:
   [ 0-0, 1-0, 2-0, 3-0, 4-0, 5-0, 6-0, 7-0 ]

--- a/tt_metal/soc_descriptors/grayskull_120_arch.yaml
+++ b/tt_metal/soc_descriptors/grayskull_120_arch.yaml
@@ -1,8 +1,3 @@
-# soc-descriptor yaml
-# Anything using [#-#] is noc coordinates
-# Anything using [[#, #]] is logical coordinates (Can be relative)
-# relative index: 0 means first row, -1 means last row of functional grid...
-
 grid:
   x_size: 13
   y_size: 12
@@ -16,14 +11,17 @@ pcie:
 dram:
   [[1-0], [1-6], [4-0], [4-6], [7-0], [7-6], [10-0], [10-6]]
 
-dram_preferred_eth_endpoint:
+dram_view_eth_endpoint:
   [ 1-0, 1-6, 4-0, 4-6, 7-0, 7-6, 10-0, 10-6 ]
 
-dram_preferred_worker_endpoint:
-  [ 1-0, 1-6, 4-0, 4-6, 7-0, 7-6, 10-0, 10-6 ]
+dram_view_worker_endpoint:
+  [ 0-0, 1-0, 2-0, 3-0, 4-0, 5-0, 6-0, 7-0 ]
 
-dram_address_offsets:
+dram_view_address_offsets:
   [ 0, 0, 0, 0, 0, 0, 0, 0 ]
+
+dram_view_size:
+  1073741824
 
 eth:
   []

--- a/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
@@ -11,16 +11,10 @@ pcie:
 dram:
   [
     [0-0, 0-1, 0-11],
-    [0-0, 0-1, 0-11],
-    [0-5, 0-6, 0-7],
     [0-5, 0-6, 0-7],
     [5-0, 5-1, 5-11],
-    [5-0, 5-1, 5-11],
-    [5-2, 5-9, 5-10],
     [5-2, 5-9, 5-10],
     [5-3, 5-4, 5-8],
-    [5-3, 5-4, 5-8],
-    [5-5, 5-6, 5-7],
     [5-5, 5-6, 5-7]
   ]
 
@@ -31,7 +25,7 @@ dram_view_eth_endpoint:
 # These are given in dram coordinates, for example 0-2 means first dram bank array,
 # third noc port core which would resolve to 0-11 in noc coordinates.
 dram_view_worker_endpoint:
-  [ 0-2, 0-1, 2-0, 2-2, 4-1, 4-2, 6-0, 6-1, 8-2, 8-0, 10-0, 10-2 ]
+  [ 0-2, 0-1, 1-0, 1-2, 2-1, 2-2, 3-0, 3-1, 4-2, 4-0, 5-0, 5-2 ]
 
 dram_view_address_offsets:
   [ 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824 ]

--- a/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
@@ -18,17 +18,84 @@ dram:
     [5-5, 5-6, 5-7]
   ]
 
-# Dram view parameters are used by tt-metal and are not supported in UMD.
-# Coords for eth and worker dram endpoints are given in dram coordinates.
-# For example 0-2 means third core in the first dram cores array which would resolve to 0-11.
-dram_view_eth_endpoint:
-  [ 0-0, 0-0, 1-1, 1-1, 2-0, 2-0, 3-2, 3-2, 4-1, 4-1, 5-1, 5-1 ]
-
-dram_view_worker_endpoint:
-  [ 0-2, 0-1, 1-0, 1-2, 2-1, 2-2, 3-0, 3-1, 4-2, 4-0, 5-0, 5-2 ]
-
-dram_view_address_offsets:
-  [ 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824 ]
+# Dram view parameters are used by tt-metal and are not recognized by UMD.
+# Eth and worker dram endpoints represent subchannel id from dram array.
+# For example, a dram view where channel is 0 and worker_endpoint is 2 would resolve to dram core at position [0,2] which is 0-11.
+dram_views:
+  [
+    {
+      channel: 0,
+      eth_endpoint: 0,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 0,
+      eth_endpoint: 0,
+      worker_endpoint: 1,
+      address_offset: 1073741824
+    },
+    {
+      channel: 1,
+      eth_endpoint: 1,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 1,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 1073741824
+    },
+    {
+      channel: 2,
+      eth_endpoint: 0,
+      worker_endpoint: 1,
+      address_offset: 0
+    },
+    {
+      channel: 2,
+      eth_endpoint: 0,
+      worker_endpoint: 2,
+      address_offset: 1073741824
+    },
+    {
+      channel: 3,
+      eth_endpoint: 2,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 3,
+      eth_endpoint: 2,
+      worker_endpoint: 1,
+      address_offset: 1073741824
+    },
+    {
+      channel: 4,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 0
+    },
+    {
+      channel: 4,
+      eth_endpoint: 1,
+      worker_endpoint: 0,
+      address_offset: 1073741824
+    },
+    {
+      channel: 5,
+      eth_endpoint: 1,
+      worker_endpoint: 0,
+      address_offset: 0
+    },
+    {
+      channel: 5,
+      eth_endpoint: 1,
+      worker_endpoint: 2,
+      address_offset: 1073741824
+    }
+  ]
 
 dram_view_size:
   1073741824

--- a/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
@@ -1,7 +1,3 @@
-# soc-descriptor yaml
-# Anything using [#-#] is noc coordinates
-# Anything using [[#, #]] is logical coordinates (Can be relative)
-# relative index: 0 means first row, -1 means last row of functional grid...
 grid:
   x_size: 10
   y_size: 12
@@ -28,14 +24,20 @@ dram:
     [5-5, 5-6, 5-7]
   ]
 
-dram_preferred_eth_endpoint:
+# Dram view parameters are used by tt-metal and are not supported in UMD
+dram_view_eth_endpoint:
   [ 0-0, 0-0, 0-6, 0-6, 5-0, 5-0, 5-10, 5-10, 5-4, 5-4, 5-6, 5-6 ]
 
-dram_preferred_worker_endpoint:
-  [ 0-11, 0-1, 0-5, 0-7, 5-1, 5-11, 5-2, 5-9, 5-8, 5-3, 5-5, 5-7 ]
+# These are given in dram coordinates, for example 0-2 means first dram bank array,
+# third noc port core which would resolve to 0-11 in noc coordinates.
+dram_view_worker_endpoint:
+  [ 0-2, 0-1, 2-0, 2-2, 4-1, 4-2, 6-0, 6-1, 8-2, 8-0, 10-0, 10-2 ]
 
-dram_address_offsets:
+dram_view_address_offsets:
   [ 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824, 0, 1073741824 ]
+
+dram_view_size:
+  1073741824
 
 eth:
   [
@@ -69,7 +71,7 @@ worker_l1_size:
   1499136
 
 dram_bank_size:
-  1073741824
+  2147483648
 
 eth_l1_size:
   262144

--- a/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml
@@ -18,12 +18,12 @@ dram:
     [5-5, 5-6, 5-7]
   ]
 
-# Dram view parameters are used by tt-metal and are not supported in UMD
+# Dram view parameters are used by tt-metal and are not supported in UMD.
+# Coords for eth and worker dram endpoints are given in dram coordinates.
+# For example 0-2 means third core in the first dram cores array which would resolve to 0-11.
 dram_view_eth_endpoint:
-  [ 0-0, 0-0, 0-6, 0-6, 5-0, 5-0, 5-10, 5-10, 5-4, 5-4, 5-6, 5-6 ]
+  [ 0-0, 0-0, 1-1, 1-1, 2-0, 2-0, 3-2, 3-2, 4-1, 4-1, 5-1, 5-1 ]
 
-# These are given in dram coordinates, for example 0-2 means first dram bank array,
-# third noc port core which would resolve to 0-11 in noc coordinates.
 dram_view_worker_endpoint:
   [ 0-2, 0-1, 1-0, 1-2, 2-1, 2-2, 3-0, 3-1, 4-2, 4-0, 5-0, 5-2 ]
 

--- a/tt_metal/soc_descriptors/wormhole_b0_versim.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_versim.yaml
@@ -13,14 +13,15 @@ dram:
     [0-0, 0-1],
   ]
 
-dram_view_eth_endpoint:
-  [ 0-0 ]
-
-dram_view_worker_endpoint:
-  [ 0-1 ]
-
-dram_view_address_offsets:
-  [ 0 ]
+dram_views:
+  [
+    {
+      channel: 0,
+      eth_endpoint: 0,
+      worker_endpoint: 1,
+      address_offset: 0
+    }
+  ]
 
 dram_view_size:
   1073741824

--- a/tt_metal/soc_descriptors/wormhole_b0_versim.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_versim.yaml
@@ -1,7 +1,3 @@
-# soc-descriptor yaml
-# Anything using [#-#] is noc coordinates
-# Anything using [[#, #]] is logical coordinates (Can be relative)
-# relative index: 0 means first row, -1 means last row of functional grid...
 grid:
   x_size: 2
   y_size: 2
@@ -17,14 +13,17 @@ dram:
     [0-0, 0-1],
   ]
 
-dram_preferred_eth_endpoint:
+dram_view_eth_endpoint:
   [ 0-0 ]
 
-dram_preferred_worker_endpoint:
+dram_view_worker_endpoint:
   [ 0-1 ]
 
-dram_address_offsets:
+dram_view_address_offsets:
   [ 0 ]
+
+dram_view_size:
+  1073741824
 
 eth:
   [ ]

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -19,13 +19,8 @@ void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t
 void memset_dram(std::vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory to all channels and subchannels at a specific start address.
     const metal_SocDescriptor& sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
-    for (uint32_t dram_src_channel_id = 0; dram_src_channel_id < sdesc.dram_cores.size(); dram_src_channel_id++) {
-        for (uint32_t dram_src_subchannel_id = 0;
-             dram_src_subchannel_id < sdesc.dram_cores.at(dram_src_channel_id).size();
-             dram_src_subchannel_id++) {
-            tt::Cluster::instance().write_dram_vec(
-                mem_vec, tt_target_dram{chip_id, dram_src_channel_id, dram_src_subchannel_id}, start_addr);
-        }
+    for (uint32_t dram_src_channel_id = 0; dram_src_channel_id < sdesc.get_num_dram_views(); dram_src_channel_id++) {
+        tt::Cluster::instance().write_dram_vec(mem_vec, tt_target_dram{chip_id, dram_src_channel_id}, start_addr);
     }
 }
 

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -19,8 +19,13 @@ void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t
 void memset_dram(std::vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory to all channels and subchannels at a specific start address.
     const metal_SocDescriptor& sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
-    for (uint32_t dram_src_channel_id = 0; dram_src_channel_id < sdesc.get_num_dram_views(); dram_src_channel_id++) {
-        tt::Cluster::instance().write_dram_vec(mem_vec, tt_target_dram{chip_id, dram_src_channel_id}, start_addr);
+    for (uint32_t dram_view = 0; dram_view < sdesc.get_num_dram_views(); dram_view++) {
+        for (uint32_t dram_src_subchannel_id = 0;
+             dram_src_subchannel_id < sdesc.dram_cores.at(sdesc.get_channel_for_dram_view(dram_view)).size();
+             dram_src_subchannel_id++) {
+            tt::Cluster::instance().write_dram_vec(
+                mem_vec, tt_target_dram{chip_id, dram_view, dram_src_subchannel_id}, start_addr);
+        }
     }
 }
 

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -588,7 +588,7 @@ void InitDeviceProfiler(IDevice* device) {
             }
         }
 
-        uint32_t dramBankCount = tt::Cluster::instance().get_soc_desc(device_id).get_num_dram_channels();
+        uint32_t dramBankCount = tt::Cluster::instance().get_soc_desc(device_id).get_num_dram_views();
         uint32_t coreCountPerDram =
             tt::Cluster::instance().get_soc_desc(device_id).profiler_ceiled_core_count_perf_dram_bank;
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -296,7 +296,7 @@ bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addres
         address >= device->get_base_allocator_addr(HalMemType::DRAM),
         "Cannot write to reserved DRAM region, addresses [0, {}) are reserved!",
         device->get_base_allocator_addr(HalMemType::DRAM));
-    tt::Cluster::instance().write_dram_vec(host_buffer, tt_target_dram{device->id(), dram_channel, 0}, address);
+    tt::Cluster::instance().write_dram_vec(host_buffer, tt_target_dram{device->id(), dram_channel}, address);
     return pass;
 }
 
@@ -304,7 +304,7 @@ bool ReadFromDeviceDRAMChannel(
     IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer) {
     bool pass = true;
     tt::Cluster::instance().dram_barrier(device->id());
-    tt::Cluster::instance().read_dram_vec(host_buffer, size, tt_target_dram{device->id(), dram_channel, 0}, address);
+    tt::Cluster::instance().read_dram_vec(host_buffer, size, tt_target_dram{device->id(), dram_channel}, address);
     return pass;
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -296,7 +296,7 @@ bool WriteToDeviceDRAMChannel(IDevice* device, int dram_channel, uint32_t addres
         address >= device->get_base_allocator_addr(HalMemType::DRAM),
         "Cannot write to reserved DRAM region, addresses [0, {}) are reserved!",
         device->get_base_allocator_addr(HalMemType::DRAM));
-    tt::Cluster::instance().write_dram_vec(host_buffer, tt_target_dram{device->id(), dram_channel}, address);
+    tt::Cluster::instance().write_dram_vec(host_buffer, tt_target_dram{device->id(), dram_channel, 0}, address);
     return pass;
 }
 
@@ -304,7 +304,7 @@ bool ReadFromDeviceDRAMChannel(
     IDevice* device, int dram_channel, uint32_t address, uint32_t size, std::vector<uint32_t>& host_buffer) {
     bool pass = true;
     tt::Cluster::instance().dram_barrier(device->id());
-    tt::Cluster::instance().read_dram_vec(host_buffer, size, tt_target_dram{device->id(), dram_channel}, address);
+    tt::Cluster::instance().read_dram_vec(host_buffer, size, tt_target_dram{device->id(), dram_channel, 0}, address);
     return pass;
 }
 


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/17002

### Problem description
Currently, UMD doesn't handle well duplicate cores in soc descriptor. What was done in wormhole yaml as part of https://github.com/tenstorrent/tt-metal/issues/476 conflates two things, which this PR tries to separate:
- What is the actual layout of the chip
- How are those elements used

This PR now adds a concept of "dram view" which is separate from "dram" array describing a layout. I tried to keep the scope of changes minimal. Dram view size is also now different than dram bank size (which is the actual size).
The soc descriptor part which is read and used only by metal is now clearly defined in the yaml, and it won't affect UMD at all.

Motivation: This was blocking me from making further changes towards the new UMD api using CoreCoords. The translation between the coordinate systems (specifically logical) is ambiguous. Also if we had an assert in UMD to explicitly block adding double physical coordinates, this would've surfaced earlier.

### What's changed
- Added "view' to relevant structures
- Changed how the rest of the code interfaces with the soc_descriptor so that this dram_view id is now expected, rather than logical coordinate to dram array
- Changed the preferred_worker array to point relatively to the original dram core array, rather then it defining it's own physical coordinates.
- Changed other yamls accordingly
- Cleaned up outdated comments from yamls
- Introduced dram_view_size which is different than dram_bank_size. The former represents your logical view, the latter represent the actual layout which is read by UMD.

### Testing
I've added prints to get_address_offset and get_preferred_worker_core_for_dram_channel, and verified when running unit_tests_device locally that the return values are the same, and that the calls to these functions had same arguments (also same number of calls). 
Also added prints to read_dram_vec and write_dram_vec, and ran test CommandQueueSingleCardBufferFixture.WriteOneTileAcrossAllDramBanksTwiceRoundRobin
to verify the output is the same for all the calls. So no functional change is expected. I've added a comment to the PR with the whole output.

### Checklist
All runs on brosko/soc_new_api2 :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13073737238
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070961923
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070963624
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/13070965877
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070967812
- [x] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070969601
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070971060
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070972382
- [x] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070974073
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13070976159
