### PR TITLE
Add fixes to support unpadded inner dim for pf + mm.

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
@@ -242,7 +242,7 @@ def run_multi_core_matmul_1d(
         ttnn.BufferType.L1,
         ttnn.ShardSpec(
             core_range_set,
-            [K_padded, N_per_shard],
+            [K, N_per_shard],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
@@ -139,6 +139,7 @@ def run_multi_core_matmul_1d(
     pcc_threshold=0.98,
     use_physical_to_logical_mapping=True,
     hop_grid=None,
+    in1_is_dram_interleaved=False,
 ):
     assert not has_bias, "Bias not supported for gather_in0 mode."
     if not isinstance(grid, tuple) and not use_arbitrary_cores:
@@ -237,14 +238,18 @@ def run_multi_core_matmul_1d(
         ),
     )
 
-    in1_sharded_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(
-            core_range_set,
-            [K, N_per_shard],
-            ttnn.ShardOrientation.ROW_MAJOR,
-        ),
+    in1_sharded_mem_config = (
+        ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                core_range_set,
+                [K, N_per_shard],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+        if not in1_is_dram_interleaved
+        else ttnn.DRAM_MEMORY_CONFIG
     )
 
     output_sharded_mem_config = ttnn.MemoryConfig(
@@ -326,6 +331,85 @@ def run_multi_core_matmul_1d(
 
     # Check program cache
     assert device.num_program_cache_entries() == 1  # Only 1 op
+
+
+@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
+@pytest.mark.skipif(is_blackhole(), reason="Test suite for GS only")
+@pytest.mark.parametrize("has_bias", [False], ids=["no_bias"])
+@pytest.mark.parametrize(
+    "B, M, K, N, in0_dtype, in1_dtype, fidelity, packer_l1_acc, fp32_acc_mode, grid",
+    [
+        (1, 32, 2048, 3584, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, True, True, (8, 3)),
+        (1, 32, 2048, 16 * 1024, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, False, False, (8, 4)),
+        (1, 32, 7520, 8192, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.MathFidelity.HiFi4, True, True, (6, 7)),
+    ],
+)
+@pytest.mark.parametrize(
+    "activation",
+    [
+        None,
+    ],
+)
+@pytest.mark.parametrize(
+    "use_arbitrary_cores, hop_grid",
+    [
+        (False, None),
+        (False, [(3, 6)]),
+        (True, None),
+    ],
+)
+@pytest.mark.parametrize(
+    "in1_is_dram_interleaved",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "num_iters",
+    [
+        3,
+    ],
+)
+def test_multi_core_matmul_1d_in1_dram_wh(
+    device,
+    in0_dtype,
+    in1_dtype,
+    fidelity,
+    has_bias,
+    fp32_acc_mode,
+    packer_l1_acc,
+    B,
+    M,
+    K,
+    N,
+    activation,
+    grid,
+    hop_grid,
+    use_arbitrary_cores,
+    in1_is_dram_interleaved,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+):
+    run_multi_core_matmul_1d(
+        device,
+        in0_dtype,
+        in1_dtype,
+        fidelity,
+        has_bias,
+        fp32_acc_mode,
+        packer_l1_acc,
+        B,
+        M,
+        K,
+        N,
+        activation,
+        grid,
+        use_arbitrary_cores,
+        num_iters,
+        hop_grid=hop_grid,
+        in1_is_dram_interleaved=in1_is_dram_interleaved,
+    )
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -238,7 +238,8 @@ def run_prefetcher_mm(
 
     tt_tensors_all = []
     for tid in range(num_tensors * num_layers):
-        K, N = padded_shapes[tid % num_tensors]
+        K, _ = input_shapes[tid % num_tensors]
+        _, N = padded_shapes[tid % num_tensors]
         input_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.DRAM,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -150,6 +150,7 @@ void MAIN {
     constexpr uint32_t batch = get_compile_time_arg_val(13);                   // batch dim
     constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(14);     // number of tiles in out_block
     constexpr bool untilize_out = get_compile_time_arg_val(15);                // untilize output
+    constexpr bool in1_is_dram_interleaved = get_compile_time_arg_val(16);     // in1 is in dram
     constexpr uint32_t ring_size = num_blocks;
 
     // Runtime args
@@ -223,6 +224,11 @@ void MAIN {
             const uint32_t curr_ring_idx = (ring_idx + block) % ring_size;
             uint32_t unpadded_in0_block_w = unpadded_in0_shard_widths_in_tiles[curr_ring_idx];
 
+            // Wait for in1 block
+            if constexpr (in1_is_dram_interleaved) {
+                cb_wait_front(in1_cb_id, in1_block_num_tiles);
+            }
+
             const uint32_t input0_cb_id = block == 0 ? in0_cb_id : in2_cb_id;
             bool last_out = block == (num_blocks - 1);
 // Configure packer once for pack out without Bias
@@ -258,7 +264,8 @@ void MAIN {
 #ifdef ENABLE_GLOBAL_CB
                 int in1_index_subblock_offset = 0;
 #else
-                int in1_index_subblock_offset = in1_block_num_tiles * (curr_ring_idx);
+                // This should always be 0 when reading in1 from DRAM
+                int in1_index_subblock_offset = in1_is_dram_interleaved ? 0 : in1_block_num_tiles * (curr_ring_idx);
 #endif
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
                     tile_regs_acquire();
@@ -377,6 +384,9 @@ void MAIN {
 #endif
 
             cb_pop_front(input0_cb_id, in0_block_num_tiles);
+            if constexpr (in1_is_dram_interleaved) {
+                cb_pop_front(in1_cb_id, in1_block_num_tiles);
+            }
 #ifdef ENABLE_GLOBAL_CB
             curr_in1_block_index = next_in1_block_index;
             UNPACK((update_local_cb_rd_ptr(in1_cb_id, next_in1_rd_ptr_addr)));

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -8,20 +8,58 @@
 #include "hostdevcommon/common_values.hpp"
 #include "remote_circular_buffer_api.h"
 #include "debug/dprint.h"
+#include "debug/dprint_tile.h"
+
+template <bool DRAM, uint32_t tile_hw>
+void read_block_from_dram(
+    uint32_t cb_id,
+    InterleavedAddrGenFast<DRAM, tile_hw> s1,
+    uint32_t tensor_width_in_tiles,
+    uint32_t block_w_idx,
+    uint32_t block_h_idx,
+    uint32_t block_w_t,
+    uint32_t block_h_t,
+    uint32_t tile_size_bytes) {
+    uint32_t l1_write_addr = get_write_ptr(cb_id);
+
+    // Horizontal idx + vertical idx * width = row major index
+    uint32_t block_tile_id = block_w_idx * block_w_t + (block_h_idx * block_h_t) * tensor_width_in_tiles;
+    for (uint32_t h = 0; h < block_h_t; ++h) {
+        uint32_t tile_id = block_tile_id + h * tensor_width_in_tiles;
+        for (uint32_t w = 0; w < block_w_t; ++w) {
+            noc_async_read_tile(tile_id + w, s1, l1_write_addr);
+            l1_write_addr += tile_size_bytes;
+        }
+    }
+    noc_async_read_barrier();
+}
 
 void kernel_main() {
     // Compile time args
-    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(0);
-    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(1);
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
-    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(3);
-    constexpr uint32_t batch = get_compile_time_arg_val(4);
+    constexpr const bool in1_is_dram_interleaved = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_block_height_in_tiles = get_compile_time_arg_val(1);  // Padded block shape
+    constexpr uint32_t in1_block_width_in_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in1_tensor_width_in_tiles = get_compile_time_arg_val(3);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);
+    constexpr uint32_t batch = get_compile_time_arg_val(5);
+
+    uint32_t rt_args_idx = 0;
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
 
     constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
     constexpr uint32_t sync_cb = tt::CBIndex::c_3;
     constexpr uint32_t sync_cb2 = tt::CBIndex::c_4;
     constexpr uint32_t remote_cb_id = tt::CBIndex::c_31;
-    constexpr uint32_t shard_size_in_tiles = shard_width_in_tiles * shard_height_in_tiles;
+
+    const uint32_t in1_block_num_tiles = in1_block_height_in_tiles * in1_block_width_in_tiles;
+
+    // Address setup
+    constexpr const uint32_t in1_tile_hw = get_tile_hw(cb_id_in1);
+    constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
+    const InterleavedAddrGenFast<in1_is_dram_interleaved, in1_tile_hw> s1 = {
+        .bank_base_address = in1_tensor_addr, .page_size = in1_single_tile_size_bytes, .data_format = in1_data_format};
 
     for (uint32_t b = 0; b < batch; ++b) {
         cb_reserve_back(sync_cb2, 1);
@@ -30,6 +68,24 @@ void kernel_main() {
 #endif
 
         cb_push_back(sync_cb2, 1);
+
+        if constexpr (in1_is_dram_interleaved) {
+            for (uint32_t block = 0; block < num_blocks; ++block) {
+                uint32_t block_idx = (ring_idx + block) % num_blocks;
+
+                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                read_block_from_dram(
+                    cb_id_in1,
+                    s1,
+                    in1_tensor_width_in_tiles,
+                    ring_idx,
+                    block_idx,
+                    in1_block_width_in_tiles,
+                    in1_block_height_in_tiles,
+                    in1_single_tile_size_bytes);
+                cb_push_back(cb_id_in1, in1_block_num_tiles);
+            }
+        }
 
 #ifdef ENABLE_GLOBAL_CB
         cb_wait_front(sync_cb, 1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1564,12 +1564,16 @@ void Matmul::validate(
                 // Gather in0 specific validation
                 if (program_config.gather_in0) {
                     TT_FATAL(
+                        program_config.num_global_cb_receivers > 0, "Num global CB receivers must be greater than 0.");
+                    TT_FATAL(
                         input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
                         "Input tensor A must be width sharded when using gather_in0.");
                     TT_FATAL(
-                        input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
-                        "Input tensor B must be width sharded when using gather_in0.");
-                    if (!this->global_cb.has_value()) {
+                        input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
+                            (input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED &&
+                             input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM),
+                        "Input tensor B must be width sharded or DRAM interleaved when using gather_in0.");
+                    if (!this->global_cb.has_value() && input_tensor_b.is_sharded()) {
                         TT_FATAL(
                             input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid,
                             "Input tensor A and B must be sharded on the same cores "
@@ -1580,6 +1584,25 @@ void Matmul::validate(
                     TT_FATAL(
                         this->output_mem_config.shard_spec.has_value(),
                         "Output shard spec must be provided when using gather_in0.");
+
+                    if (!input_tensor_b.is_sharded()) {
+                        TT_FATAL(
+                            !this->global_cb.has_value(),
+                            "Global CB is not supported for DRAM_INTERLEAVED in1 when using gather_in0.");
+                        TT_FATAL(
+                            input_tensor_b.get_layout() == Layout::TILE,
+                            "Input tensor B must be TILE_LAYOUT when DRAM_INTERLEAVED when using gather_in0.");
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().grid == this->output_mem_config.shard_spec.value().grid,
+                            "Input tensor A and output tensor must be sharded on the same cores when using gather_in0 "
+                            "and in1 is DRAM_INTERLEAVED.");
+                    }
+
+                    if (!this->global_cb.has_value()) {
+                        TT_FATAL(
+                            program_config.num_global_cb_receivers == 1,
+                            "Num global CB receivers must be 1 when global CB is not provided.");
+                    }
 
                     TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1701,6 +1701,7 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
 operation::ProgramWithCallbacks create_program_gather_in0(
     tt_metal::Program& program,
     const Tensor& a,
+    const Tensor& b,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1732,6 +1733,8 @@ operation::ProgramWithCallbacks create_program_gather_in0(
     bool untilize_out,
     const std::optional<const tt::tt_metal::v1::experimental::GlobalCircularBuffer>& global_cb,
     uint32_t num_global_cb_receivers) {
+    const bool in1_is_dram_interleaved = in1_buffer->is_dram() && !b.is_sharded();
+
     /* Core setup */
     constexpr bool row_major = true;
     CoreRangeSet all_cores = a.shard_spec().value().grid;
@@ -1773,10 +1776,19 @@ operation::ProgramWithCallbacks create_program_gather_in0(
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
     /* in1 */
-    uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_tile_shape()[0];
-    uint32_t in1_shard_width_in_tiles =
-        in1_buffer->shard_spec().shape()[1] / in1_tile.get_tile_shape()[1] / num_global_cb_receivers;
-    uint32_t in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
+    uint32_t in1_shard_height_in_tiles = 0;
+    uint32_t in1_shard_width_in_tiles = 0;
+    uint32_t in1_CB_tiles = 0;
+    uint32_t in1_tensor_width_in_tiles = b.get_padded_shape()[-1] / in1_tile.get_tile_shape()[1];
+
+    if (!in1_is_dram_interleaved) {
+        in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_tile_shape()[0];
+        in1_shard_width_in_tiles =
+            in1_buffer->shard_spec().shape()[1] / in1_tile.get_tile_shape()[1] / num_global_cb_receivers;
+        in1_CB_tiles = in1_shard_height_in_tiles * in1_shard_width_in_tiles;
+    } else {
+        in1_CB_tiles = 2 * in0_shard_width_in_tiles * per_core_N;  // Double buffered
+    }
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
 
     /* in2 */
@@ -1804,7 +1816,8 @@ operation::ProgramWithCallbacks create_program_gather_in0(
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
     uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
     uint32_t in1_num_subblocks = per_core_N / out_subblock_w;
-    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
+    uint32_t in1_block_height_in_tiles = in0_block_w;
+    uint32_t in1_block_num_tiles = out_subblock_w * in1_block_height_in_tiles * in1_num_subblocks;
     uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size;
     uint32_t in1_tensor_size_bytes = in1_block_num_tiles * num_blocks * in1_single_tile_size;
     uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
@@ -1820,11 +1833,12 @@ operation::ProgramWithCallbacks create_program_gather_in0(
     };
 
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
-        (std::uint32_t)in1_shard_width_in_tiles,  // in1_shard_width_in_tiles
-        (std::uint32_t)in1_shard_height_in_tiles,
-        (std::uint32_t)num_blocks,           // num_blocks
-        (std::uint32_t)in1_block_num_tiles,  // in1_block_num_tiles
-        (std::uint32_t)B,                    // batch
+        (std::uint32_t)in1_is_dram_interleaved,    // in1_is_dram_interleaved
+        (std::uint32_t)in1_block_height_in_tiles,  // in1_block_height_in_tiles
+        (std::uint32_t)per_core_N,                 // in1_block_width_in_tiles
+        (std::uint32_t)in1_tensor_width_in_tiles,  // in1_tensor_width_in_tiles
+        (std::uint32_t)num_blocks,                 // num_blocks
+        (std::uint32_t)B,                          // batch
     };
 
     std::vector<uint32_t> compute_kernel_args = {
@@ -1847,7 +1861,8 @@ operation::ProgramWithCallbacks create_program_gather_in0(
         B,                       // batch
         out_block_tiles,         // out_block_num_tiles
 
-        untilize_out,  // untilize_out
+        untilize_out,             // untilize_out
+        in1_is_dram_interleaved,  // in1_is_dram_interleaved
     };
 
     /* Kernel defines */
@@ -1939,8 +1954,10 @@ operation::ProgramWithCallbacks create_program_gather_in0(
         tt_metal::CircularBufferConfig src1_cb_config =
             tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
                 .set_page_size(src1_cb_index, in1_single_tile_size)
-                .set_tile_dims(src1_cb_index, in1_tile)
-                .set_globally_allocated_address(*in1_buffer);
+                .set_tile_dims(src1_cb_index, in1_tile);
+        if (!in1_is_dram_interleaved) {
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
+        }
         cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     }
 
@@ -2036,6 +2053,14 @@ operation::ProgramWithCallbacks create_program_gather_in0(
             mm_in0_args.end(), unpadded_in0_shard_widths_in_tiles.begin(), unpadded_in0_shard_widths_in_tiles.end());
         tt_metal::SetRuntimeArgs(program, mm_kernel_in0_id, core, mm_in0_args);
 
+        /* in1 */
+        std::vector<uint32_t> mm_in1_args = {
+            in1_buffer->address(),  // in1_tensor_addr
+            i,                      // ring_idx
+        };
+
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_args);
+
         /* compute */
         std::vector<uint32_t> mm_kernel_compute_args = {
             i,  // ring_idx
@@ -2100,6 +2125,15 @@ operation::ProgramWithCallbacks create_program_gather_in0(
             }
             if (out_sharded) {
                 UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            }
+
+            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in1_sender_writer_id);
+            for (uint32_t i = 0; i < num_cores; ++i) {
+                const auto& core = cores[i];
+                auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
+
+                /* in1 */
+                writer_runtime_args[0] = src_buffer_b->address();
             }
         };
 
@@ -2237,6 +2271,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
         return reuse_mcast_1d_optimized_helpers::create_program_gather_in0(
             program,
             a,
+            b,
             device,
             math_fidelity,
             fp32_dest_acc_en,

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op_multi_core.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/hal_exp.hpp>
+#include <tt-metalium/math.hpp>
 
 #include <tt-metalium/global_circular_buffer_impl.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
@@ -82,6 +83,7 @@ operation::ProgramWithCallbacks dram_prefetcher_multi_core(
         uint32_t height_in_tiles = tensor_buffers[t]->shard_spec().shape()[0] / tensor_tiles[t].get_tile_shape()[0];
         uint32_t width_in_tiles = tensor_buffers[t]->shard_spec().shape()[1] / tensor_tiles[t].get_tile_shape()[1];
 
+        height_in_tiles = tt::div_up(height_in_tiles, num_blocks) * num_blocks;
         tensor_shapes[t][0] = height_in_tiles;
         tensor_shapes[t][1] = width_in_tiles;
         tensor_block_num_tiles[t] = height_in_tiles * width_in_tiles / num_blocks;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op_multi_core.cpp
@@ -83,7 +83,7 @@ operation::ProgramWithCallbacks dram_prefetcher_multi_core(
         uint32_t height_in_tiles = tensor_buffers[t]->shard_spec().shape()[0] / tensor_tiles[t].get_tile_shape()[0];
         uint32_t width_in_tiles = tensor_buffers[t]->shard_spec().shape()[1] / tensor_tiles[t].get_tile_shape()[1];
 
-        height_in_tiles = tt::div_up(height_in_tiles, num_blocks) * num_blocks;
+        height_in_tiles = tt::round_up(height_in_tiles, num_blocks);
         tensor_shapes[t][0] = height_in_tiles;
         tensor_shapes[t][1] = width_in_tiles;
         tensor_block_num_tiles[t] = height_in_tiles * width_in_tiles / num_blocks;


### PR DESCRIPTION
### Ticket
- #17060
- #16948

### Problem description
With the new validation being added to tensor_spec, the current implementation of ring matmul with unpadded shapes fails. 

Also, the matmul currently does not support DRAM interleaved in1 weights, which is required for matmuls with large weights that cannot fit in L1 (such as the LM head in Llama).

### What's changed
- Internally round up the inner dim
- Add support for DRAM_INTERLEAVED in1

### Checklist
- [ ] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13079865530)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes (DRAM Prefetcher: https://github.com/tenstorrent/tt-metal/actions/runs/13079871657)
