### PR TITLE
#17203: Remove 2 worker-queue related methods from IDevice

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -167,9 +167,7 @@ public:
     virtual void synchronize() = 0;
     virtual WorkExecutorMode get_worker_mode() = 0;
     virtual void set_worker_queue_mode(const WorkerQueueMode& mode) = 0;
-    virtual WorkerQueueMode get_worker_queue_mode() = 0;
     virtual bool is_worker_queue_empty() const = 0;
-    virtual bool can_use_passthrough_scheduling() const = 0;
 
     virtual void push_work(std::function<void()> work, bool blocking = false) = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -158,10 +158,10 @@ public:
     void enable_async(bool enable) override;
     void synchronize() override;
     WorkExecutorMode get_worker_mode() override { return work_executor_.get_worker_mode(); }
-    void set_worker_queue_mode(const WorkerQueueMode& mode) override { this->work_executor_.set_worker_queue_mode(mode); }
-    WorkerQueueMode get_worker_queue_mode() override { return this->work_executor_.get_worker_queue_mode(); }
+    void set_worker_queue_mode(const WorkerQueueMode& mode) override {
+        this->work_executor_.set_worker_queue_mode(mode);
+    }
     bool is_worker_queue_empty() const override { return work_executor_.worker_queue.empty(); }
-    bool can_use_passthrough_scheduling() const override;
 
     void push_work(std::function<void()> work, bool blocking) override;
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -165,9 +165,7 @@ public:
     void synchronize() override;
     WorkExecutorMode get_worker_mode() override;
     void set_worker_queue_mode(const WorkerQueueMode& mode) override;
-    WorkerQueueMode get_worker_queue_mode() override;
     bool is_worker_queue_empty() const override;
-    bool can_use_passthrough_scheduling() const override;
     void push_work(std::function<void()> work, bool blocking) override;
     void enable_program_cache() override;
     void disable_and_clear_program_cache() override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -654,9 +654,7 @@ WorkExecutorMode MeshDevice::get_worker_mode() { return this->work_executor_->ge
 void MeshDevice::set_worker_queue_mode(const WorkerQueueMode& mode) {
     this->work_executor_->set_worker_queue_mode(mode);
 }
-WorkerQueueMode MeshDevice::get_worker_queue_mode() { return this->work_executor_->get_worker_queue_mode(); }
 bool MeshDevice::is_worker_queue_empty() const { return this->work_executor_->worker_queue.empty(); }
-bool MeshDevice::can_use_passthrough_scheduling() const { return this->work_executor_->use_passthrough(); }
 void MeshDevice::push_work(std::function<void()> work, bool blocking) {
     this->work_executor_->push_work(std::move(work), blocking);
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1372,10 +1372,6 @@ CommandQueue& Device::command_queue(size_t cq_id) {
     return *command_queues_[cq_id];
 }
 
-bool Device::can_use_passthrough_scheduling() const {
-    return this->work_executor_.use_passthrough();
-}
-
 void Device::synchronize() {
     if (not this->initialized_) {
         log_warning("Attempting to synchronize Device {} which is not initialized. Ignoring...", this->id_);


### PR DESCRIPTION
### Ticket
#17203

### Problem description
`IDevice` has many low-level APIs that are either unused or are error prone and should be removed (e.g. switching worker queue mode on the fly, which shouldn't be needed).

### What's changed
Unused and can be removed:
1. `get_worker_queue_mode`
2. `can_use_passthrough_scheduling`

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13085302578)
- [X] New/Existing tests provide coverage for changes
