### PR TITLE
Move dispatch_s queries out of the device interface to a dedicated dispatch query layer

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -187,9 +187,6 @@ public:
 
     virtual std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) = 0;
 
-    virtual bool dispatch_s_enabled() const = 0;
-    virtual bool distributed_dispatcher() const = 0;
-    virtual NOC dispatch_go_signal_noc() const = 0;
     virtual size_t get_device_kernel_defines_hash() = 0;
 
     virtual uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -176,9 +176,6 @@ public:
 
     std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) override;
 
-    bool dispatch_s_enabled() const override;
-    bool distributed_dispatcher() const override;
-    NOC dispatch_go_signal_noc() const override;
     size_t get_device_kernel_defines_hash() override;
 
     uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const override;

--- a/tt_metal/api/tt-metalium/dispatch_core_manager.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_manager.hpp
@@ -423,5 +423,4 @@ class dispatch_core_manager {
 
 };
 
-
 }   // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -174,10 +174,8 @@ public:
     program_cache::detail::ProgramCache& get_program_cache() override;
     std::size_t num_program_cache_entries() override;
     HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core) const override;
-    std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) override;
-    bool dispatch_s_enabled() const override;
-    bool distributed_dispatcher() const override;
-    NOC dispatch_go_signal_noc() const override;
+    std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(
+        const std::vector<CoreRange>& ranges, const CoreType core_type) override;
     size_t get_device_kernel_defines_hash() override;
     uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const override;
     uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -666,18 +666,7 @@ std::vector<std::pair<transfer_info_cores, uint32_t>> MeshDevice::extract_dst_no
     TT_THROW("extract_dst_noc_multicast_info() is not supported on MeshDevice - use individual devices instead");
     return reference_device()->extract_dst_noc_multicast_info(ranges, core_type);
 }
-bool MeshDevice::dispatch_s_enabled() const {
-    return validate_and_get_reference_value(
-        scoped_devices_->get_devices(), [](const auto& device) { return device->dispatch_s_enabled(); });
-}
-bool MeshDevice::distributed_dispatcher() const {
-    return validate_and_get_reference_value(
-        scoped_devices_->get_devices(), [](const auto& device) { return device->distributed_dispatcher(); });
-}
-NOC MeshDevice::dispatch_go_signal_noc() const {
-    return validate_and_get_reference_value(
-        scoped_devices_->get_devices(), [](const auto& device) { return device->dispatch_go_signal_noc(); });
-}
+
 size_t MeshDevice::get_device_kernel_defines_hash() {
     TT_THROW("get_device_kernel_defines_hash() is not supported on MeshDevice - use individual devices instead");
     return validate_and_get_reference_value(

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -23,6 +23,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/program/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/host_runtime_commands.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_query_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/hardware_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/launch_message_ring_buffer_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -869,18 +869,6 @@ void Device::clear_l1_state() {
     // TODO: clear idle eriscs as well
 }
 
-bool Device::dispatch_s_enabled() const {
-    // Dispatch_s is always enabled for Tensix Dispatch
-    // Conditionally enabled for Ethernet Dispatch - If a single CQ is being used
-    // This condition may be modified for BH
-    return (this->num_hw_cqs() == 1 or dispatch_core_manager::instance().get_dispatch_core_type(this->id()) == CoreType::WORKER);
-}
-
-bool Device::distributed_dispatcher() const {
-    // Ethernet dispatch with a single CQ. dispatch_s and dispatch_d are on different cores.
-    return (this->num_hw_cqs() == 1 and dispatch_core_manager::instance().get_dispatch_core_type(this->id())  == CoreType::ETH);
-}
-
 void Device::compile_command_queue_programs() {
     ZoneScoped;
     auto command_queue_program_ptr = std::make_unique<Program>();
@@ -1603,11 +1591,6 @@ uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data,
 
 CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
     return this->command_queues_[cq_id]->virtual_enqueue_program_dispatch_core();
-}
-
-// Main source to get NOC idx for dispatch core
-NOC Device::dispatch_go_signal_noc() const {
-    return this->dispatch_s_enabled() ? NOC::NOC_1 : NOC::NOC_0;
 }
 
 SubDeviceManagerId Device::get_active_sub_device_manager_id() const {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -18,6 +18,7 @@
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
 using namespace tt::tt_metal;
 
@@ -198,7 +199,10 @@ void DevicePool::initialize(
     tt::stl::Span<const std::uint32_t> l1_bank_remap) noexcept {
     ZoneScoped;
     log_debug(tt::LogMetal, "DevicePool initialize");
+    // Initialize the dispatch core manager, responsible for assigning dispatch cores
     tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_config, num_hw_cqs);
+    // Initialize the dispatch query layer, used by runtime command generation
+    tt_metal::DispatchQueryManager::initialize(num_hw_cqs);
 
     if (_inst == nullptr) {
         static DevicePool device_pool{};

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+
+namespace {
+
+CoreType dispatch_core_type() {
+    CoreType dispatch_core_type;
+    CoreType first_core_type;
+    for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
+        dispatch_core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(device_id);
+        if (device_id == 0) {
+            first_core_type = dispatch_core_type;
+        } else {
+            TT_FATAL(
+                dispatch_core_type == first_core_type,
+                "Expected the Dispatch Core Type to be consistent across physical devices");
+        }
+    }
+    return dispatch_core_type;
+}
+
+tt::tt_metal::DispatchQueryManager* inst = nullptr;
+
+}  // namespace
+namespace tt::tt_metal {
+
+void DispatchQueryManager::initialize(uint8_t num_hw_cqs) {
+    if (inst == nullptr) {
+        static DispatchQueryManager DispatchQueryManager(num_hw_cqs);
+        inst = &DispatchQueryManager;
+    } else if (num_hw_cqs != inst->num_hw_cqs_ or dispatch_core_type() != inst->dispatch_core_type_) {
+        inst->reset(num_hw_cqs);
+        inst->num_hw_cqs_ = num_hw_cqs;
+    }
+}
+
+const DispatchQueryManager& DispatchQueryManager::instance() {
+    TT_FATAL(inst != nullptr, "Trying to acess the dispatch query layer without initializing it.");
+    return *inst;
+}
+
+bool DispatchQueryManager::dispatch_s_enabled() const { return dispatch_s_enabled_; }
+
+bool DispatchQueryManager::distributed_dispatcher() const { return distributed_dispatcher_; }
+
+NOC DispatchQueryManager::go_signal_noc() const { return go_signal_noc_; }
+
+void DispatchQueryManager::reset(uint8_t num_hw_cqs) {
+    num_hw_cqs_ = num_hw_cqs;
+    dispatch_core_type_ = dispatch_core_type();
+    dispatch_s_enabled_ = (num_hw_cqs == 1 or dispatch_core_type_ == CoreType::WORKER);
+    distributed_dispatcher_ = (num_hw_cqs == 1 and dispatch_core_type_ == CoreType::ETH);
+    go_signal_noc_ = dispatch_s_enabled_ ? NOC::NOC_1 : NOC::NOC_0;
+}
+
+DispatchQueryManager::DispatchQueryManager(uint8_t num_hw_cqs) { this->reset(num_hw_cqs); }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <dispatch_core_manager.hpp>
+#include <tt-metalium/tt_cluster.hpp>
+
+namespace tt::tt_metal {
+
+// Interface through which device-dispatch characteristics can be queried.
+// This layer builds on top of the dispatch core manager (responsible for assigning
+// cores to specific dispatch tasks) and the Cluster (tracks multi-chip topology)
+// to provide users with higher level queries about the dispatch topology.
+
+// Any new functions querying dispatch state should be placed in this interface (along
+// with any existing functions that are in the device class but are exposing lower
+// level dispatch details to the user)
+class DispatchQueryManager {
+public:
+    DispatchQueryManager& operator=(const DispatchQueryManager&) = delete;
+    DispatchQueryManager& operator=(DispatchQueryManager&& other) noexcept = delete;
+    DispatchQueryManager(const DispatchQueryManager&) = delete;
+    DispatchQueryManager(DispatchQueryManager&& other) noexcept = delete;
+
+    static void initialize(uint8_t num_hw_cqs);
+    static const DispatchQueryManager& instance();
+    // dispatch_s related queries
+    bool dispatch_s_enabled() const;
+    bool distributed_dispatcher() const;
+    NOC go_signal_noc() const;
+
+private:
+    void reset(uint8_t num_hw_cqs);
+    DispatchQueryManager(uint8_t num_hw_cqs);
+
+    bool dispatch_s_enabled_ = false;
+    bool distributed_dispatcher_ = false;
+    NOC go_signal_noc_ = NOC::NOC_0;
+    uint8_t num_hw_cqs_ = 0;
+    CoreType dispatch_core_type_ = CoreType::WORKER;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -9,6 +9,7 @@
 
 #include <host_api.hpp>
 #include <tt_metal.hpp>
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
 using namespace tt::tt_metal;
 
@@ -57,7 +58,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             (hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
                 ? hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher = (GetCoreType() == CoreType::ETH);
+        static_config_.distributed_dispatcher = DispatchQueryManager::instance().distributed_dispatcher();
 
         static_config_.host_completion_q_wr_ptr =
             my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
@@ -157,7 +158,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             (hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
                 ? hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher = (GetCoreType() == CoreType::ETH);
+        static_config_.distributed_dispatcher = DispatchQueryManager::instance().distributed_dispatcher();
 
         static_config_.host_completion_q_wr_ptr =
             my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
@@ -181,7 +182,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         dependent_config_.upstream_sync_sem = prefetch_kernel->GetStaticConfig().downstream_sync_sem_id;
 
         // Downstream
-        if (device_->dispatch_s_enabled()) {
+        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 1);
             auto dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
@@ -232,7 +233,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         // Downstream, expect a MUX_D and a DISPATCH_S if enabled
         auto dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
         auto mux_kernel = dynamic_cast<MuxKernel*>(downstream_kernels_[0]);
-        if (device_->dispatch_s_enabled()) {
+        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 2);
             mux_kernel = dynamic_cast<MuxKernel*>(downstream_kernels_[1]);
             if (!dispatch_s_kernel) {

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -18,6 +18,7 @@
 #include <trace_buffer.hpp>
 #include <span.hpp>
 #include <tt_align.hpp>
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
 namespace tt::tt_metal {
 
@@ -304,7 +305,7 @@ void SubDeviceManager::populate_noc_data() {
     noc_mcast_data_start_index_.resize(num_sub_devices);
     noc_unicast_data_start_index_.resize(num_sub_devices);
 
-    NOC noc_index = device_->dispatch_go_signal_noc();
+    NOC noc_index = DispatchQueryManager::instance().go_signal_noc();
     uint32_t idx = 0;
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
         const auto& tensix_cores = sub_devices_[i].cores(HalProgrammableCoreType::TENSIX).merge_ranges();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -30,6 +30,7 @@
 #include <global_semaphore.hpp>
 #include <sub_device_types.hpp>
 #include <global_circular_buffer.hpp>
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/include/tt_metal/program.hpp"
 #include "tracy/Tracy.hpp"
 
@@ -990,6 +991,7 @@ IDevice* CreateDeviceMinimal(
     chip_id_t device_id, const uint8_t num_hw_cqs, const DispatchCoreConfig& dispatch_core_config) {
     ZoneScoped;
     tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_config, num_hw_cqs);
+    tt_metal::DispatchQueryManager::initialize(num_hw_cqs);
     auto dev = new Device(device_id, num_hw_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     return dev;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17291

### Problem description
Low level queries on `dispatch_s` parameters are currently being exposed through the `IDevice` class.
This is problematic for 2 reasons:
1. Such implementation details should not be externally exposed.
2. Adding implementations for these APIs to `MeshDevice` leads to code bloat and maintainability issues

### What's changed
Add a new class: `dispatch_query_manager` providing an interface for runtime logic to query dispatch attributes without going through the `IDevice` class.
Currently this interface is only implemented for `dispatch_s` related queries. It will be expanded more in future PRs (as more dispatch queries are moved out of the device interface) and as we add more dispatch functionality in general.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
