### PR TITLE
#0: Change noc_inline_dw_write to use write_at_cmd_buf

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1889,7 +1889,7 @@ void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF, uint8_t 
     DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
     noc_fast_write_dw_inline<proc_type, noc_mode>(
         noc,
-        write_reg_cmd_buf,
+        write_at_cmd_buf,
         val,
         addr,
         be,  // byte-enable


### PR DESCRIPTION
to avoid overwriting cached register values of write_reg_cmd_buf

### Ticket
Link to Github Issue

### Problem description
`noc_fast_write_dw_inline` uses `NCRISC_WR_REG_CMD_BUF` and programs `NOC_TARG_ADDR_COORDINATE`, but for this cmd buf we assumed nothing modifies it and we "cache" it by only programming once at the start. The noc uni/mcast semaphore apis also use this cmd buf and assume the value of `NOC_TARG_ADDR_COORDINATE` is already preprogrammed. This causes issues/hangs if one of the sem apis is called after `noc_fast_write_dw_inline`, even if this happens in a subsequent kernel since we don't reprogram these registers between ops to save init time.

### What's changed
Move `noc_fast_write_dw_inline` to use the atomic cmd buffer. The two "cached" registers of the atomic cmd buf is not touched by the inline write, so this should be safe.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13061925214
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13062639042
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
