### PR TITLE
#0: TT-Mesh bug fix MeshCQ/MeshWorkload on device indexing

### DIFF
--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -234,7 +234,7 @@ void MeshCommandQueue::enqueue_write_shard(
     std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking) {
     // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
     // We should not be querying SubDevices from device 0.
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device(0)->get_sub_device_ids());
+    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
     std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
     expected_num_workers_completed[0] = expected_num_workers_completed_;
     auto shard = mesh_buffer->get_device_buffer(coord);
@@ -250,7 +250,7 @@ void MeshCommandQueue::enqueue_read_shard(
     TT_FATAL(blocking, "Only blocking reads are currently supported from MeshBuffer shards.");
     // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
     // We should not be querying SubDevices from device 0.
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device(0)->get_sub_device_ids());
+    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
     std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
     expected_num_workers_completed[0] = expected_num_workers_completed_;
     auto shard = mesh_buffer->get_device_buffer(coord);
@@ -401,7 +401,7 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
     const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking) {
     // TODO: Add proper support for SubDevices once SubDeviceManager and allocator are moved up to MeshDevice
     // We should not be querying SubDevices from device 0.
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device(0)->get_sub_device_ids());
+    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
     std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
     expected_num_workers_completed[0] = expected_num_workers_completed_;
 
@@ -432,7 +432,7 @@ void MeshCommandQueue::enqueue_read_mesh_buffer(
     void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
     TT_FATAL(
         buffer->global_layout() == MeshBufferLayout::SHARDED, "Can only read a Sharded MeshBuffer from a MeshDevice.");
-    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device(0)->get_sub_device_ids());
+    auto sub_device_ids = tt::stl::Span<const SubDeviceId>(mesh_device_->get_device_index(0)->get_sub_device_ids());
     std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed;
     expected_num_workers_completed[0] = expected_num_workers_completed_;
     this->read_sharded_buffer(*buffer, host_data, expected_num_workers_completed, sub_device_ids);

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -30,11 +30,11 @@ void MeshWorkload::compile(MeshDevice* mesh_device) {
     // 2. Allocate and Validate CBs
     // 3. Finalize: Compute relative offsets for all data structures in L1
     for (auto& [device_range, program] : programs_) {
-        program.compile(mesh_device->get_device(0));
-        program.allocate_circular_buffers(mesh_device->get_device(0));
-        tt::tt_metal::detail::ValidateCircularBufferRegion(program, mesh_device->get_device(0));
+        program.compile(mesh_device->get_device_index(0));
+        program.allocate_circular_buffers(mesh_device->get_device_index(0));
+        tt::tt_metal::detail::ValidateCircularBufferRegion(program, mesh_device->get_device_index(0));
     }
-    program_dispatch::finalize_program_offsets(*this, mesh_device->get_device(0));
+    program_dispatch::finalize_program_offsets(*this, mesh_device->get_device_index(0));
 }
 
 void MeshWorkload::load_binaries(MeshCommandQueue& mesh_cq) {
@@ -258,7 +258,7 @@ uint32_t MeshWorkload::get_sem_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t sem_size = 0;
     uint32_t program_idx = 0;
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->get_device_index(0);
     for (auto& [device_range, program] : programs_) {
         if (program_idx) {
             TT_ASSERT(sem_size == program.get_sem_size(device, logical_core, core_type));
@@ -282,7 +282,7 @@ uint32_t MeshWorkload::get_cb_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t cb_size = 0;
     uint32_t program_idx = 0;
-    IDevice* device = mesh_device->get_device(0);
+    IDevice* device = mesh_device->get_device_index(0);
     for (auto& [device_range, program] : programs_) {
         if (program_idx) {
             TT_ASSERT(cb_size == program.get_cb_size(device, logical_core, core_type));


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We are inappropriately using `mesh_device_->get_device(0)` when we should be calling `mesh_device_->get_device_index(0)`. This bug manifests when we open a `MeshDevice` that doesn't contain device_id = 0

### What's changed
Replaced it with correct APIs

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
