### PR TITLE
#17312: Fix type error when saving report config to json file

### DIFF
--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -7,6 +7,7 @@ import json
 import importlib
 import os
 import pathlib
+import re
 from types import ModuleType
 
 from loguru import logger
@@ -58,7 +59,7 @@ def save_config_to_json_file(json_path):
     with open(json_path, "w") as f:
         normalized_config = {}
         for key in dir(CONFIG):
-            if "__" in key:
+            if re.match("^_.+_$", key):
                 continue
             value = getattr(CONFIG, key)
             if isinstance(value, pathlib.Path):


### PR DESCRIPTION
### Ticket
[#17312](https://github.com/tenstorrent/tt-metal/issues/17312)

### Problem description

Running pytest with the `TTNN_CONFIG_OVERRIDES` environment variable set to enable detailed buffer reports will fail with `TypeError: Object of type method is not JSON serializable` if a `config.json` file does not already exist in the report directory.

Debugging the issue with pdb I determined that the cause of the problem was due to an unexpected `_pybind11_conduit_v1_` key in the `normalized_config` dict that is written to the `config.json` file in the `ttnn.save_config_to_json_file` function.

There was logic in this function already to ignore dunder methods and attributes from the original `CONFIG` object, but the `if "__" in key:` check that matched regular Python special attributes didn't match the `_pybind11_conduit_v1_` attribute returned by `dir(CONFIG)`.

I experienced this issue personally every time I deleted the reports directory, which I was doing frequently to ensure that each report only had data from a single run.

Oddly, it would only fail on the first run after deleting the reports directory, and on subsequent runs of pytest it would work and write the `config.json` file fine. This leads me to believe that this `_pybind11_conduit_v1_`  property did not always exist on the `CONFIG` object, but understanding why was outside the scope of my debugging to unblock me.

The issue was also reported to us by another user.

### What's changed

I have changed the logic in `ttnn.save_config_to_json_file` so that instead of ignoring any config attributes with `__` in their name, it instead ignores any config attributes that start and end with an underscore. This preserves the original intention of ignoring the standard Python special attributes, but also any other pseudo-special attributes like this one.

This solution generalizes things a bit, without explicitly excluding the `_pybind11_conduit_v1_` attribute. Alternatively, we could be explicit about it by changing it to:

```
if "__" in key or key == "_pybind11_conduit_v1_":
    continue
```

I preferred the regex approach and think there's no performance implication since it's just writing a small config object once when a new report is created.

### Checklist
- [X] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
