### PR TITLE
Fix debug checks for bank assignments when initializing the allocator

### DIFF
--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -77,6 +77,8 @@ protected:
     void init_one_bank_per_l1();
     void init_compute_and_storage_l1_bank_manager();
 
+    void validate_bank_assignments() const;
+
 private:
     void verify_safe_allocation() const;
 

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -13,9 +13,12 @@ namespace tt {
 
 namespace tt_metal {
 
-Allocator::Allocator(const AllocatorConfig& alloc_config) : config_(alloc_config) {
+Allocator::Allocator(const AllocatorConfig& alloc_config) : config_(alloc_config) {}
+
+void Allocator::validate_bank_assignments() const {
     TT_ASSERT(not bank_id_to_dram_channel_.empty() and not dram_channel_to_bank_ids_.empty());
-    TT_ASSERT(not bank_id_to_logical_core_.empty() and not bank_id_to_logical_core_.empty());
+    TT_ASSERT(dram_channel_to_bank_ids_.size() == config_.num_dram_channels);
+    TT_ASSERT(not bank_id_to_logical_core_.empty() and not logical_core_to_bank_ids_.empty());
 }
 
 void Allocator::init_one_bank_per_channel() {

--- a/tt_metal/impl/allocator/basic_allocator.cpp
+++ b/tt_metal/impl/allocator/basic_allocator.cpp
@@ -12,6 +12,7 @@ namespace tt_metal {
 BasicAllocator::BasicAllocator(const AllocatorConfig& alloc_config) : Allocator(alloc_config) {
     this->init_one_bank_per_channel();
     this->init_one_bank_per_l1();
+    this->validate_bank_assignments();
 }
 
 }  // namespace tt_metal

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -223,6 +223,7 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
 L1BankingAllocator::L1BankingAllocator(const AllocatorConfig& alloc_config) : Allocator(alloc_config) {
     this->init_one_bank_per_channel();
     this->init_compute_and_storage_l1_bank_manager();
+    this->validate_bank_assignments();
 }
 
 }  // namespace tt_metal


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Recent Allocator refactor caused debug checks for bank assignments to be hit before cores/dram channels get assigned to banks.

### What's changed
Add separate validation check

### Checklist
- [ ] Post commit CI passes 
