### PR TITLE
llama3 embedding data parallel

### DIFF
--- a/models/demos/llama3/tests/test_llama_embedding.py
+++ b/models/demos/llama3/tests/test_llama_embedding.py
@@ -9,7 +9,13 @@ import ttnn
 from models.demos.llama3.tt.llama_embedding import TtLlamaEmbedding
 from models.demos.llama3.tt.model_config import TtModelArgs
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
-from models.utility_functions import comp_pcc, comp_allclose, skip_for_batch_parallelism, skip_for_parallelism
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+    skip_for_batch_parallelism,
+    skip_for_parallelism,
+    skip_for_model_parallelism,
+)
 from models.utility_functions import skip_for_grayskull
 from models.demos.llama3.tt.llama_common import HostEmbedding
 
@@ -45,6 +51,10 @@ def test_llama_embedding(max_seq_len, batch_dp_tp, mesh_device, use_program_cach
     )
     if skip:
         pytest.skip(reason)
+    skip, reason = skip_for_model_parallelism(data_parallel)
+    if skip:
+        pytest.skip(reason)
+
     dtype = ttnn.bfloat16
     mesh_device.enable_async(True)
 

--- a/models/demos/llama3/tests/test_llama_embedding.py
+++ b/models/demos/llama3/tests/test_llama_embedding.py
@@ -9,10 +9,7 @@ import ttnn
 from models.demos.llama3.tt.llama_embedding import TtLlamaEmbedding
 from models.demos.llama3.tt.model_config import TtModelArgs
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
-from models.utility_functions import (
-    comp_pcc,
-    comp_allclose,
-)
+from models.utility_functions import comp_pcc, comp_allclose, skip_for_batch_parallelism, skip_for_parallelism
 from models.utility_functions import skip_for_grayskull
 from models.demos.llama3.tt.llama_common import HostEmbedding
 
@@ -29,18 +26,38 @@ from models.demos.llama3.tt.llama_common import HostEmbedding
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch_size",
-    (1,),
+    "batch_dp_tp",
+    [(1, 1, 2), (2, 2, 1), (4, 2, 1)],
+    ids=lambda args: "batch_{}_dp_{}_tp_{}".format(*args),
 )
 @pytest.mark.parametrize(
     "max_seq_len",
     (128,),  # For decode-only unit test, there's no need to run with large sequence lengths
 )
-def test_llama_embedding(max_seq_len, batch_size, mesh_device, use_program_cache, reset_seeds, ensure_gc):
+def test_llama_embedding(max_seq_len, batch_dp_tp, mesh_device, use_program_cache, reset_seeds, ensure_gc):
+    batch_size, data_parallel, tensor_parallel = batch_dp_tp
+
+    skip, reason = skip_for_batch_parallelism(batch_size, data_parallel)
+    if skip:
+        pytest.skip(reason)
+    skip, reason = skip_for_parallelism(
+        mesh_device.get_num_devices() if mesh_device else 0, data_parallel, tensor_parallel
+    )
+    if skip:
+        pytest.skip(reason)
     dtype = ttnn.bfloat16
     mesh_device.enable_async(True)
 
-    model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
+    if data_parallel > 1:
+        mesh_device.reshape(ttnn.MeshShape(mesh_device.get_num_devices(), 1))
+
+    model_args = TtModelArgs(
+        mesh_device,
+        max_batch_size=batch_size,
+        data_parallel=data_parallel,
+        tensor_parallel=tensor_parallel,
+        max_seq_len=max_seq_len,
+    )
     model_args.n_layers = 1
 
     state_dict = model_args.load_state_dict()
@@ -61,7 +78,7 @@ def test_llama_embedding(max_seq_len, batch_size, mesh_device, use_program_cache
         dtype=dtype,
     )
 
-    prompts = ["Joy"] * 32
+    prompts = ["Joy"] * batch_size  # 32
     pt_input = torch.tensor([tokenizer.encode(prompt, bos=False, eos=False) for prompt in prompts])
     reference_output = reference_emb(pt_input)
     logger.info(f"reference_output: {reference_output.shape}")
@@ -69,7 +86,11 @@ def test_llama_embedding(max_seq_len, batch_size, mesh_device, use_program_cache
     tt_input = ttnn.from_torch(
         pt_input.squeeze(1),
         device=mesh_device,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(0, None) if model_args.num_devices_dp > 1 else (None, None),
+            mesh_shape=model_args.cluster_shape,
+        ),
         dtype=ttnn.uint32,
         layout=ttnn.ROW_MAJOR_LAYOUT,
     )

--- a/models/demos/llama3/tests/test_llama_mlp.py
+++ b/models/demos/llama3/tests/test_llama_mlp.py
@@ -10,7 +10,13 @@ import ttnn
 from models.demos.llama3.tt.llama_mlp import TtLlamaMLP
 from models.demos.llama3.tt.model_config import TtModelArgs
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import FeedForward
-from models.utility_functions import comp_pcc, comp_allclose, skip_for_parallelism, skip_for_batch_parallelism
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+    skip_for_parallelism,
+    skip_for_batch_parallelism,
+    skip_for_model_parallelism,
+)
 from models.utility_functions import skip_for_grayskull
 
 
@@ -55,6 +61,10 @@ def test_llama_mlp_inference(seq_len, batch_dp_tp, mesh_device, use_program_cach
     skip, reason = skip_for_parallelism(
         mesh_device.get_num_devices() if mesh_device else 0, data_parallel, tensor_parallel
     )
+    if skip:
+        pytest.skip(reason)
+
+    skip, reason = skip_for_model_parallelism(data_parallel)
     if skip:
         pytest.skip(reason)
 

--- a/models/demos/llama3/tests/test_llama_rms_norm.py
+++ b/models/demos/llama3/tests/test_llama_rms_norm.py
@@ -9,7 +9,13 @@ import ttnn
 from models.common.rmsnorm import RMSNorm as TtRMSNorm
 from models.demos.llama3.tt.model_config import TtModelArgs
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import RMSNorm as RefRMSNorm
-from models.utility_functions import comp_pcc, comp_allclose, skip_for_parallelism, skip_for_batch_parallelism
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+    skip_for_parallelism,
+    skip_for_batch_parallelism,
+    skip_for_model_parallelism,
+)
 from models.utility_functions import skip_for_grayskull
 from models.demos.llama3.tt.distributed_norm import DistributedNorm
 
@@ -62,6 +68,10 @@ def test_llama_rms_norm_inference(
     skip, reason = skip_for_parallelism(
         mesh_device.get_num_devices() if mesh_device else 0, data_parallel, tensor_parallel
     )
+    if skip:
+        pytest.skip(reason)
+
+    skip, reason = skip_for_model_parallelism(data_parallel)
     if skip:
         pytest.skip(reason)
 

--- a/models/demos/llama3/tt/llama_embedding.py
+++ b/models/demos/llama3/tt/llama_embedding.py
@@ -28,7 +28,11 @@ class TtLlamaEmbedding(LightweightModule):
             torch_weight,
             dtype=dtype,
             device=self.mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device=mesh_device, dims=(None, 3), mesh_shape=args.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device=mesh_device,
+                dims=(None, 3) if args.num_devices_tp > 1 else (None, None),
+                mesh_shape=args.cluster_shape,
+            ),
             layout=ttnn.ROW_MAJOR_LAYOUT,
             memory_config=args.get_model_config()["EMB_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name,

--- a/models/demos/llama3/tt/multimodal/llama_cross_attention.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_attention.py
@@ -65,8 +65,8 @@ class TtLlamaCrossAttention(LightweightModule):
         wo_str = f"{state_dict_prefix}wo.weight"
 
         # when splitting the devices, we need to make sure that the number of heads is divisible by the number of devices
-        assert self.n_heads % configuration.num_devices == 0
-        assert self.n_kv_heads % configuration.num_devices == 0
+        assert self.n_heads % self.num_devices == 0
+        assert self.n_kv_heads % self.num_devices == 0
 
         # TODO DRAM Shard the weights (see llama3 text)
         self.wq = ttnn.as_tensor(

--- a/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -85,7 +85,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         # TODO: Generalize LMHead, maybe use llama_model's single-tile-sequence LMHead
         lm_head_torch = self.state_dict[f"{state_dict_prefix}output.weight"].transpose(-1, -2)
         total_splits = 8  # Arbitrary value which allows whole-tile splits in LM Head
-        num_splits = total_splits // self.configuration.num_devices
+        num_splits = total_splits // self.configuration.num_devices_tp
         lm_head_torch = torch.chunk(lm_head_torch, num_splits, dim=-1)
 
         cache_name = lambda name, suffix, split: weight_cache_path / (state_dict_prefix + f"{name}{suffix}{split}")
@@ -341,7 +341,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
 
-            if self.configuration.num_devices > 1:
+            if self.configuration.num_devices_tp > 1:
                 output = ttnn.all_gather(output, dim=3, num_links=1, topology=ttnn.Topology.Linear)
             outputs.append(output)
 

--- a/models/demos/llama3/tt/multimodal/llama_image_attention.py
+++ b/models/demos/llama3/tt/multimodal/llama_image_attention.py
@@ -60,8 +60,8 @@ class TtLlamaImageAttention(LightweightModule):
         wo_str = f"{state_dict_prefix}wo.weight"
 
         # when splitting the devices, we need to make sure that the number of heads is divisible by the number of devices
-        assert self.n_heads % configuration.num_devices == 0
-        assert self.n_kv_heads % configuration.num_devices == 0
+        assert self.n_heads % self.num_devices == 0
+        assert self.n_kv_heads % self.num_devices == 0
 
         # Pad head_dim to multiple of 32
         def pad_head_dim(weight, heads_out=True):
@@ -87,7 +87,7 @@ class TtLlamaImageAttention(LightweightModule):
         wv_padded = pad_head_dim(self.state_dict[wv_str])
         wo_padded = pad_head_dim(self.state_dict[wo_str], heads_out=False)
         wq_chunked, wk_chunked, wv_chunked = (
-            torch.chunk(w, configuration.num_devices) for w in [wq_padded, wk_padded, wv_padded]
+            torch.chunk(w, self.num_devices) for w in [wq_padded, wk_padded, wv_padded]
         )
 
         self.wqkv = ttnn.as_tensor(
@@ -113,7 +113,7 @@ class TtLlamaImageAttention(LightweightModule):
                         ],
                         dim=-1,
                     )
-                    for i in range(configuration.num_devices)
+                    for i in range(self.num_devices)
                 ],
                 dim=-1,
             ),

--- a/models/demos/qwen/demo/demo.py
+++ b/models/demos/qwen/demo/demo.py
@@ -360,7 +360,7 @@ def run_qwen_demo(
                 current_rot_mat, rot_matrix = get_single_rot_mat(
                     model_args.head_dim,
                     mesh_device,
-                    model_args.num_devices_tp,
+                    model_args.num_devices,
                     start_pos=start_pos,
                 )
                 pt_decode_input = model_args.prepare_inputs_ttnn_decode(
@@ -378,7 +378,7 @@ def run_qwen_demo(
             pt_out.append(ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1))[0, 0, 0, :])
             ttnn.deallocate(tt_out)
         # Synchronize devices to ensure the profile captures the correct timing of all devices
-        for i in range(model_args.num_devices_tp):
+        for i in range(model_args.num_devices):
             ttnn.synchronize_device(mesh_device.get_devices()[i])
         profiler.end(f"inference_prefill", iteration=batch_idx)
         logger.info(f"Prefill finished")
@@ -409,7 +409,7 @@ def run_qwen_demo(
         current_rot_mat, rot_matrix = get_single_rot_mat(
             model_args.head_dim,
             mesh_device,
-            model_args.num_devices_tp,
+            model_args.num_devices,
             start_pos=decoding_pos[0] - 2,
         )
         profiler.end(f"get_single_rot_mat_decode_{batch_idx}")
@@ -430,7 +430,7 @@ def run_qwen_demo(
         logger.info(f"Compiling model trace...")
         decode_input = ttnn.unsqueeze_to_4D(tt_embd(tt_out_tok))
         tt_out = tt_model(decode_input, current_pos, rot_mat=current_rot_mat)
-        if tt_model.args.num_devices_tp > 1:
+        if tt_model.args.num_devices > 1:
             tt_out_gathered = ttnn.all_gather(tt_out, dim=3, num_links=1, topology=ttnn.Topology.Linear)
             ttnn.deallocate(tt_out)
         else:
@@ -451,7 +451,7 @@ def run_qwen_demo(
 
         decode_input = ttnn.unsqueeze_to_4D(tt_embd(tt_out_tok))
         tt_out = tt_model(decode_input, current_pos, rot_mat=current_rot_mat)
-        if tt_model.args.num_devices_tp > 1:
+        if tt_model.args.num_devices > 1:
             tt_out_gathered = ttnn.all_gather(tt_out, dim=3, num_links=1, topology=ttnn.Topology.Linear)
             ttnn.deallocate(tt_out)
         else:
@@ -470,12 +470,12 @@ def run_qwen_demo(
         current_pos_reset = ttnn.from_torch(
             torch.tensor(decoding_pos, dtype=torch.int32),
             dtype=ttnn.int32,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device) if tt_model.args.num_devices_tp > 1 else None,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device) if tt_model.args.num_devices > 1 else None,
         )
         tt_out_tok_reset = ttnn.from_torch(
             torch.nn.functional.pad(pt_out_batched.unsqueeze(0).unsqueeze(0).unsqueeze(0), (0, 31), "constant", 0),
             dtype=ttnn.uint32,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device) if tt_model.args.num_devices_tp > 1 else None,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device) if tt_model.args.num_devices > 1 else None,
         )
 
         ttnn.copy_host_to_device_tensor(current_pos_reset, current_pos)
@@ -563,7 +563,7 @@ def run_qwen_demo(
                 current_rot_mat_reset, rot_matrix_reset = get_single_rot_mat(
                     model_args.head_dim,
                     mesh_device,
-                    model_args.num_devices_tp,
+                    model_args.num_devices,
                     start_pos=decoding_pos[0] + iteration,
                     on_host=True,
                 )

--- a/models/demos/qwen/tests/test_qwen_attention.py
+++ b/models/demos/qwen/tests/test_qwen_attention.py
@@ -63,7 +63,7 @@ def test_qwen_attention_inference(mesh_device, use_program_cache, reset_seeds, e
     current_rot_mat, rot_matrix = get_single_rot_mat(
         model_args.head_dim,
         mesh_device,
-        model_args.num_devices_tp,
+        model_args.num_devices,
         start_pos=0,
     )
 

--- a/models/demos/qwen/tests/test_qwen_decoder.py
+++ b/models/demos/qwen/tests/test_qwen_decoder.py
@@ -58,7 +58,7 @@ def test_qwen_decoder_inference(mesh_device, use_program_cache, reset_seeds, ens
     current_rot_mat, rot_matrix = get_single_rot_mat(
         model_args.head_dim,
         mesh_device,
-        model_args.num_devices_tp,
+        model_args.num_devices,
         start_pos=0,
     )
 

--- a/models/demos/qwen/tests/test_qwen_model.py
+++ b/models/demos/qwen/tests/test_qwen_model.py
@@ -111,7 +111,7 @@ def test_qwen_model_inference(mesh_device, weights, layers, use_program_cache, r
     current_rot_mat, rot_matrix = get_single_rot_mat(
         model_args.head_dim,
         mesh_device,
-        model_args.num_devices_tp,
+        model_args.num_devices,
         start_pos=0,
     )
 
@@ -147,7 +147,7 @@ def test_qwen_model_inference(mesh_device, weights, layers, use_program_cache, r
         current_rot_mat, rot_matrix = get_single_rot_mat(
             model_args.head_dim,
             mesh_device,
-            model_args.num_devices_tp,
+            model_args.num_devices,
             start_pos=current_pos,
         )
         decode_input = model_args.prepare_inputs_ttnn_decode(

--- a/models/demos/qwen/tests/test_qwen_perf.py
+++ b/models/demos/qwen/tests/test_qwen_perf.py
@@ -138,7 +138,7 @@ def run_inference(tt_model, tt_embd, embd, encoded_prompts, generation_start_pos
     current_rot_mat, rot_matrix = get_single_rot_mat(
         tt_model.args.head_dim,
         tt_model.mesh_device,
-        tt_model.args.num_devices_tp,
+        tt_model.args.num_devices,
         start_pos=0,
     )
 
@@ -190,5 +190,5 @@ def run_inference(tt_model, tt_embd, embd, encoded_prompts, generation_start_pos
         profiler.end(f"model_run_for_inference_{i}")
 
     # Synchronize devices to ensure all profiling data is captured accurately
-    for i in range(tt_model.args.num_devices_tp):
+    for i in range(tt_model.args.num_devices):
         ttnn.synchronize_device(mesh_device.get_devices()[i])

--- a/models/demos/qwen/tt/distributed_norm.py
+++ b/models/demos/qwen/tt/distributed_norm.py
@@ -10,11 +10,11 @@ class DistributedNorm(LightweightModule):
     def __init__(self, norm, args):
         self.norm = norm
         self.args = args
-        norm_input_grid = args.dram_shard_core_grid_for_k(args.dim // args.num_devices_tp)
+        norm_input_grid = args.dram_shard_core_grid_for_k(args.dim // args.num_devices)
         self.gather_in_mem_cfg = ttnn.create_sharded_memory_config(
             (
                 args.tile_padded_batch_rows,
-                args.dim // args.num_devices_tp // norm_input_grid.num_cores,
+                args.dim // args.num_devices // norm_input_grid.num_cores,
             ),
             norm_input_grid,
             ttnn.ShardStrategy.WIDTH,

--- a/models/demos/qwen/tt/lm_head.py
+++ b/models/demos/qwen/tt/lm_head.py
@@ -24,7 +24,7 @@ class LMHead(LightweightModule):
         self.mesh_device = mesh_device
         self.dtype = dtype
         self.vocab_size = args.vocab_size
-        self.num_devices = args.num_devices_tp
+        self.num_devices = args.num_devices
 
         size_per_device = self.vocab_size // self.num_devices
 

--- a/models/demos/qwen/tt/qwen_attention.py
+++ b/models/demos/qwen/tt/qwen_attention.py
@@ -55,7 +55,7 @@ class TtQwenAttention(LightweightModule):
 
         self.state_dict = state_dict
         self.mesh_device = mesh_device
-        self.num_devices = configuration.num_devices_tp
+        self.num_devices = configuration.num_devices
 
         self.hidden_size = configuration.dim
         self.n_heads = configuration.n_heads
@@ -66,8 +66,8 @@ class TtQwenAttention(LightweightModule):
         self.paged_attention_config = configuration.paged_attention_config
         self.min_kv_prefill_shard_seqlen = configuration.min_kv_prefill_shard_seqlen
 
-        self.n_local_heads = self.n_heads // configuration.num_devices_tp
-        self.n_local_kv_heads = self.n_kv_heads // configuration.num_devices_tp
+        self.n_local_heads = self.n_heads // configuration.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // configuration.num_devices
 
         self.dtype = dtype
 
@@ -105,7 +105,7 @@ class TtQwenAttention(LightweightModule):
 
         # wqkv: 4096 x 3072 (2 devices): width-sharded on 12 banks, 3072 over 12 banks.
         wqkv_mem_config = configuration.create_dram_sharded_mem_config(
-            configuration.dim, configuration.qkv_size // configuration.num_devices_tp
+            configuration.dim, configuration.qkv_size // configuration.num_devices
         )
         self.wqkv = ttnn.as_tensor(
             torch.concat(
@@ -181,7 +181,7 @@ class TtQwenAttention(LightweightModule):
         else:  # For line topology we can't do all gather matmul for now, but we can height shard and reduce scatter
             # wo: 2048 (2devices) x 4096: width-sharded on 12 banks, 4224 over 12 banks.
             wo_mem_config = configuration.create_dram_sharded_mem_config(
-                configuration.dim // configuration.num_devices_tp, configuration.dim
+                configuration.dim // configuration.num_devices, configuration.dim
             )
             self.wo = ttnn.as_tensor(
                 torch.transpose(
@@ -201,7 +201,7 @@ class TtQwenAttention(LightweightModule):
             cache_k = torch.zeros(
                 (
                     self.paged_attention_config.max_num_blocks,
-                    self.n_kv_heads // configuration.num_devices_tp,
+                    self.n_kv_heads // configuration.num_devices,
                     self.paged_attention_config.block_size,
                     self.head_dim,
                 )
@@ -209,7 +209,7 @@ class TtQwenAttention(LightweightModule):
             cache_v = torch.zeros(
                 (
                     self.paged_attention_config.max_num_blocks,
-                    self.n_kv_heads // configuration.num_devices_tp,
+                    self.n_kv_heads // configuration.num_devices,
                     self.paged_attention_config.block_size,
                     self.head_dim,
                 )
@@ -336,7 +336,7 @@ class TtQwenAttention(LightweightModule):
 
         # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
         # v_heads [seqlen, n_kv_heads, bsz, head_dim]
-        # keys, [max_batch_size, n_kv_heads // configuration.num_devices_tp, sliding_window, head_dim]
+        # keys, [max_batch_size, n_kv_heads // configuration.num_devices, sliding_window, head_dim]
         ttnn.experimental.paged_update_cache(keys, k_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table)
         ttnn.experimental.paged_update_cache(
             values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table

--- a/models/demos/qwen/tt/qwen_mlp.py
+++ b/models/demos/qwen/tt/qwen_mlp.py
@@ -25,8 +25,8 @@ class TtQwenMLP(LightweightModule):
         else:
             cache_name = lambda name: weight_cache_path / (state_dict_prefix + f".{name}")
 
-        w1_w3_mem_config = args.create_dram_sharded_mem_config(args.dim, args.hidden_dim // args.num_devices_tp)
-        w2_mem_config = args.create_dram_sharded_mem_config(args.hidden_dim // args.num_devices_tp, args.dim)
+        w1_w3_mem_config = args.create_dram_sharded_mem_config(args.dim, args.hidden_dim // args.num_devices)
+        w2_mem_config = args.create_dram_sharded_mem_config(args.hidden_dim // args.num_devices, args.dim)
 
         name_dict = {
             "w1": "gate_proj",

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -1068,3 +1068,13 @@ def skip_for_parallelism(num_devices: int, data_parallel: int, tensor_parallel: 
         )
 
     return (False, "")
+
+
+def skip_for_model_parallelism(data_parallel: int):
+    model = os.getenv("LLAMA_DIR")
+    if (data_parallel > 1) and (("11B" in model) or ("70B" in model)):
+        return (
+            True,
+            f"Skipping test: Data parallelism ({data_parallel}) does support model size greater than 8B.",
+        )
+    return (False, "")


### PR DESCRIPTION
#### Code changes
Addition of data parallelism for llama3 embedding module(plus some CI fixes).
#### Testing
Tested locally on N300 with `pytest models/demos/llama3/tests/test_llama_embedding.py`, all tests pass. 
#### CI runs

- [(Single card) Models perf](https://github.com/tenstorrent/tt-metal/actions/runs/13011663398)
- [(Single card) Demo + Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/13011403767)
- [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/13028347394)