### PR TITLE
#17013: Update add_bw doc

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -713,7 +713,8 @@ void bind_binary_bw(
     py::module& module,
     const binary_backward_operation_t& operation,
     const std::string_view description,
-    const std::string_view supported_dtype = "BFLOAT16") {
+    const std::string_view supported_dtype = "BFLOAT16",
+    const std::string_view note = "") {
     auto doc = fmt::format(
         R"doc(
 
@@ -747,6 +748,8 @@ void bind_binary_bw(
 
             bfloat8_b/bfloat4_b is only supported on TILE_LAYOUT
 
+            {4}
+
         Example:
             >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
@@ -762,7 +765,8 @@ void bind_binary_bw(
         operation.base_name(),
         operation.python_fully_qualified_name(),
         description,
-        supported_dtype);
+        supported_dtype,
+        note);
 
     bind_registered_operation(
         module,
@@ -1183,7 +1187,8 @@ void py_module(py::module& module) {
         module,
         ttnn::add_bw,
         R"doc(Performs backward operations for add of :attr:`input_tensor_a` and :attr:`input_tensor_b` or :attr:`scalar` with given :attr:`grad_tensor`.)doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B)doc",
+        R"doc(Sharding is not supported if both inputs are tensors.)doc");
 
     detail::bind_binary_bw(
         module,


### PR DESCRIPTION
### Ticket
#17013

### Problem description
ttnn.add_bw doesn't support sharded memory config when input_tensor_a and input_tensor_b are of type ttnn.Tensor. Needs to be updated in documentation.

### What's changed
Updated add_bw document to note `ttnn.Tensor` inputs does not support sharded memory config.

<img width="1327" alt="Screenshot 2025-01-30 at 18 53 33" src="https://github.com/user-attachments/assets/a40b2a3a-b5c7-473c-b6b4-e4e0720f3e61" />

### Documentation
<img width="1114" alt="Screenshot 2025-01-31 at 15 55 35" src="https://github.com/user-attachments/assets/e6185b66-85f8-424a-a4b2-a69fd2956c5f" />


### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13070543722 - PASSED
