### PR TITLE
Make runtime_args_ptr const ref to solve clang-tidy error due to 58f9654bc

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -205,7 +205,7 @@ void EnqueueGetBufferAddr(uint32_t* dst_buf_addr, const Buffer* buffer, bool blo
 void EnqueueSetRuntimeArgs(
     const std::shared_ptr<Kernel>& kernel,
     const CoreCoord& core_coord,
-    std::shared_ptr<RuntimeArgs> runtime_args_ptr,
+    const std::shared_ptr<RuntimeArgs>& runtime_args_ptr,
     bool blocking);
 void EnqueueAddBufferToProgram(
     const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -466,7 +466,7 @@ void EnqueueAddBufferToProgram(
 void EnqueueSetRuntimeArgs(
     const std::shared_ptr<Kernel>& kernel,
     const CoreCoord& core_coord,
-    std::shared_ptr<RuntimeArgs> runtime_args_ptr,
+    const std::shared_ptr<RuntimeArgs>& runtime_args_ptr,
     bool blocking) {
     std::vector<uint32_t> resolved_runtime_args = {};
     resolved_runtime_args.reserve(runtime_args_ptr->size());


### PR DESCRIPTION
### Ticket
FYI @tt-rkim 
Related to @ayerofieiev-tt  ticket https://github.com/tenstorrent/tt-metal/issues/17208

### Problem description
clang-tidy on CI ([link](https://github.com/tenstorrent/tt-metal/actions/runs/13039390588/job/36414797756)) failing wtih this error since commit https://github.com/tenstorrent/tt-metal/commit/58f9654bc8511e43a0856d607833cd700d8a2e3d

```
/home/ubuntu/actions-runner-2/_work/tt-metal/tt-metal/tt_metal/impl/dispatch/command_queue.cpp:469:34: error: the parameter 'runtime_args_ptr' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  469 |     std::shared_ptr<RuntimeArgs> runtime_args_ptr,
      |                                  ^
      |     const                       &
200249 warnings generated.
Suppressed 200310 warnings (200248 in non-user code, 62 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
```

### What's changed

 - Make this argument const ref as suggested and kicked off code-analysis job on this branch here: https://github.com/tenstorrent/tt-metal/actions/runs/13053370584

### Checklist
- [ ] Code Analyis job previously failing
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
