### PR TITLE
Use padded shape to construct output memory config in `ttnn.view`

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -14,10 +14,10 @@
 namespace ttnn::operations::experimental::reshape {
 
 static MemoryConfig infer_output_memory_config(
-    const MemoryConfig& input_memory_config, const ttnn::SimpleShape& output_logical_shape) {
+    const MemoryConfig& input_memory_config, const ttnn::SimpleShape& output_padded_shape) {
     if (input_memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         auto shard_spec = input_memory_config.shard_spec.value();
-        shard_spec.shape[1] = output_logical_shape[-1];  // update output shard to match new shard width
+        shard_spec.shape[1] = output_padded_shape[-1];  // update output shard to match new shard width
         return MemoryConfig{input_memory_config.memory_layout, input_memory_config.buffer_type, shard_spec};
     } else {
         return input_memory_config;
@@ -29,7 +29,7 @@ Tensor tensor_reshape(
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::reshape", input_tensor, new_logical_shape, new_padded_shape);
 
-    const auto output_memory_config = infer_output_memory_config(input_tensor.memory_config(), new_logical_shape);
+    const auto output_memory_config = infer_output_memory_config(input_tensor.memory_config(), new_padded_shape);
     auto new_spec = ttnn::TensorSpec(
         new_logical_shape,
         TensorLayout::fromPaddedShape(


### PR DESCRIPTION
### Summary

Fixes broken test on main:

```sh
pytest -sv tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit_wh.py::test_vit[sequence_size=224-image_channels=3-image_size=224-batch_size=8-model_name=google/vit-base-patch16-224]
```


### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
