### PR TITLE
Use transaction id for eth receiver write to worker

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -80,7 +80,7 @@ def profile_results(sample_size, sample_count, channel_count, num_writes_skip_ba
 @pytest.mark.parametrize("sample_count", [256])
 @pytest.mark.parametrize("channel_count", [18])
 @pytest.mark.parametrize("num_writes_skip_barrier", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
-@pytest.mark.parametrize("sample_size", [16, 128, 256, 512, 1024, 4096, 8192])
+@pytest.mark.parametrize("sample_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
 def test_erisc_write_worker_latency(sample_count, sample_size, channel_count, num_writes_skip_barrier):
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
 

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -80,15 +80,15 @@ def profile_results(sample_size, sample_count, channel_count, num_writes_skip_ba
 
 
 @pytest.mark.skipif(is_grayskull(), reason="Unsupported on GS")
-@pytest.mark.parametrize("sample_count", [1])
+@pytest.mark.parametrize("sample_count", [256])
 @pytest.mark.parametrize("channel_count", [16])
 @pytest.mark.parametrize("num_writes_skip_barrier", [1])
-@pytest.mark.parametrize("sample_size", [16])
+@pytest.mark.parametrize("sample_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
 def test_erisc_write_worker_latency(sample_count, sample_size, channel_count, num_writes_skip_barrier):
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
 
     ARCH_NAME = os.getenv("ARCH_NAME")
-    cmd = f"\
+    cmd = f"TT_METAL_DEVICE_PROFILER=1 \
             {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm_{ARCH_NAME} \
                 {sample_count} \
                 {sample_size} \

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -83,7 +83,7 @@ def profile_results(sample_size, sample_count, channel_count):
 @pytest.mark.parametrize("channel_count", [16])
 @pytest.mark.parametrize(
     "sample_size_expected_latency",
-    [(16, 85.2), (128, 85.2), (256, 85.3), (512, 85.4), (1024, 87.2), (2048, 172.9), (4096, 339.9), (8192, 678.4)],
+    [(16, 86.2), (128, 86.2), (256, 86.4), (512, 86.5), (1024, 87.2), (2048, 172.9), (4096, 339.9), (8192, 678.4)],
 )
 def test_erisc_write_worker_latency(sample_count, sample_size_expected_latency, channel_count):
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from loguru import logger
+import pytest
+import csv
+from tt_metal.tools.profiler.process_device_log import import_log_run_stats
+import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+
+from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
+
+profiler_log_path = PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG
+
+FILE_NAME = PROFILER_LOGS_DIR / "test_ethernet_link_write_worker_latency.csv"
+
+if os.path.exists(FILE_NAME):
+    os.remove(FILE_NAME)
+
+
+def append_to_csv(file_path, header, data, write_header=True):
+    file_exists = os.path.isfile(file_path)
+    with open(file_path, "a", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        if not file_exists or write_header:
+            writer.writerow(header)
+        writer.writerows([data])
+
+
+def get_device_freq():
+    setup = device_post_proc_config.default_setup()
+    setup.deviceInputLog = profiler_log_path
+    deviceData = import_log_run_stats(setup)
+    freq = deviceData["deviceInfo"]["freq"]
+    return freq
+
+
+def profile_results(sample_size, sample_count, channel_count, num_writes_skip_barrier):
+    freq = get_device_freq() / 1000.0
+    setup = device_post_proc_config.default_setup()
+    setup.deviceInputLog = profiler_log_path
+    main_test_body_string = "MAIN-TEST-BODY"
+    setup.timerAnalysis = {
+        main_test_body_string: {
+            "across": "device",
+            "type": "adjacent",
+            "start": {"core": "ANY", "risc": "ERISC", "zone_name": main_test_body_string},
+            "end": {"core": "ANY", "risc": "ERISC", "zone_name": main_test_body_string},
+        },
+    }
+    devices_data = import_log_run_stats(setup)
+    device_0 = list(devices_data["devices"].keys())[0]
+    device_1 = list(devices_data["devices"].keys())[1]
+
+    # MAIN-TEST-BODY
+    main_loop_cycle = devices_data["devices"][device_0]["cores"]["DEVICE"]["analysis"][main_test_body_string]["stats"][
+        "Average"
+    ]
+    main_loop_latency = main_loop_cycle / freq / sample_count / channel_count
+    bw = sample_size / main_loop_latency
+
+    header = [
+        "SAMPLE_SIZE",
+        "NUM_WRITES_BEFORE_BARRIER",
+        "BW (B/c)",
+    ]
+    write_header = not os.path.exists(FILE_NAME)
+    append_to_csv(
+        FILE_NAME,
+        header,
+        [sample_size, num_writes_skip_barrier, bw],
+        write_header,
+    )
+    return main_loop_latency
+
+
+@pytest.mark.parametrize("sample_count", [256])
+@pytest.mark.parametrize("channel_count", [18])
+@pytest.mark.parametrize("num_writes_skip_barrier", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
+@pytest.mark.parametrize("sample_size", [16, 128, 256, 512, 1024, 4096, 8192])
+def test_erisc_write_worker_latency(sample_count, sample_size, channel_count, num_writes_skip_barrier):
+    os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
+
+    ARCH_NAME = os.getenv("ARCH_NAME")
+    cmd = f"TT_METAL_DEVICE_PROFILER=1 \
+            {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm_{ARCH_NAME} \
+                {sample_count} \
+                {sample_size} \
+                {channel_count} \
+                {num_writes_skip_barrier} \
+    #         "
+    print(cmd)
+    rc = os.system(cmd)
+    if rc != 0:
+        print("Error in running the test")
+        assert False
+
+    main_loop_latency = profile_results(sample_size, sample_count, channel_count, num_writes_skip_barrier)
+    print(f"sender_loop_latency {main_loop_latency}")
+    print(f"result BW (B/c): {sample_size / main_loop_latency}")
+
+    return True

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -11,6 +11,8 @@ import csv
 from tt_metal.tools.profiler.process_device_log import import_log_run_stats
 import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
 
+from models.utility_functions import is_grayskull
+
 from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
 
 profiler_log_path = PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG
@@ -77,6 +79,7 @@ def profile_results(sample_size, sample_count, channel_count, num_writes_skip_ba
     return main_loop_latency
 
 
+@pytest.mark.skipif(is_grayskull(), reason="Unsupported on GS")
 @pytest.mark.parametrize("sample_count", [256])
 @pytest.mark.parametrize("channel_count", [18])
 @pytest.mark.parametrize("num_writes_skip_barrier", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -80,15 +80,15 @@ def profile_results(sample_size, sample_count, channel_count, num_writes_skip_ba
 
 
 @pytest.mark.skipif(is_grayskull(), reason="Unsupported on GS")
-@pytest.mark.parametrize("sample_count", [256])
+@pytest.mark.parametrize("sample_count", [1])
 @pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("num_writes_skip_barrier", [1, 2, 3, 4, 5, 6, 7])
-@pytest.mark.parametrize("sample_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
+@pytest.mark.parametrize("num_writes_skip_barrier", [1])
+@pytest.mark.parametrize("sample_size", [16])
 def test_erisc_write_worker_latency(sample_count, sample_size, channel_count, num_writes_skip_barrier):
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
 
     ARCH_NAME = os.getenv("ARCH_NAME")
-    cmd = f"TT_METAL_DEVICE_PROFILER=1 \
+    cmd = f"\
             {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm_{ARCH_NAME} \
                 {sample_count} \
                 {sample_size} \

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_link_write_worker_with_transaction_id.py
@@ -81,8 +81,8 @@ def profile_results(sample_size, sample_count, channel_count, num_writes_skip_ba
 
 @pytest.mark.skipif(is_grayskull(), reason="Unsupported on GS")
 @pytest.mark.parametrize("sample_count", [256])
-@pytest.mark.parametrize("channel_count", [18])
-@pytest.mark.parametrize("num_writes_skip_barrier", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
+@pytest.mark.parametrize("channel_count", [16])
+@pytest.mark.parametrize("num_writes_skip_barrier", [1, 2, 3, 4, 5, 6, 7])
 @pytest.mark.parametrize("sample_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
 def test_erisc_write_worker_latency(sample_count, sample_size, channel_count, num_writes_skip_barrier):
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PERF_MICROBENCH_TESTS_SRCS
     ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
     ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
     ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+    ethernet/test_ethernet_write_worker_latency_no_edm.cpp
     ethernet/test_ethernet_hop_latencies_no_edm.cpp
     routing/test_tx_rx.cpp
     routing/test_mux_demux.cpp

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm.cpp
@@ -1,0 +1,282 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+#include <tuple>
+#include <map>
+
+#include "umd/device/types/arch.h"
+#include <tt-metalium/device_impl.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include "tt_backend_api_types.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel.hpp>
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+#include <tt-metalium/persistent_kernel_cache.hpp>
+
+// TODO: ARCH_NAME specific, must remove
+#include "eth_l1_address_map.h"
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+class N300TestDevice {
+public:
+    N300TestDevice() : device_open(false) {
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() >= 2 and
+            tt::tt_metal::GetNumPCIeDevices() >= 1) {
+            std::vector<chip_id_t> ids(num_devices_, 0);
+            std::iota(ids.begin(), ids.end(), 0);
+            devices_ = tt::tt_metal::detail::CreateDevices(ids);
+
+        } else {
+            TT_THROW("This suite can only be run on N300 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~N300TestDevice() {
+        if (device_open) {
+            TearDown();
+        }
+    }
+
+    void TearDown() {
+        device_open = false;
+        for (auto [device_id, device_ptr] : devices_) {
+            tt::tt_metal::CloseDevice(device_ptr);
+        }
+    }
+
+    std::map<chip_id_t, IDevice*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+private:
+    bool device_open;
+};
+
+struct ChipSenderReceiverEthCore {
+    CoreCoord sender_core;
+    CoreCoord receiver_core;
+};
+
+void validation(const std::shared_ptr<tt::tt_metal::Buffer>& worker_buffer) {
+    std::vector<uint8_t> golden_vec(worker_buffer->size(), 0);
+    std::vector<uint8_t> result_vec(worker_buffer->size(), 0);
+
+    for (int i = 0; i < worker_buffer->size(); ++i) {
+        golden_vec[i] = i;
+    }
+    tt::tt_metal::detail::ReadFromBuffer(worker_buffer, result_vec);
+
+    bool pass = golden_vec == result_vec;
+    TT_FATAL(pass, "validation failed");
+}
+
+std::vector<Program> build(
+    IDevice* device0,
+    IDevice* device1,
+    CoreCoord eth_sender_core,
+    CoreCoord eth_receiver_core,
+    CoreCoord worker_core,
+    std::size_t num_samples,
+    std::size_t sample_page_size,
+    std::size_t num_channels,
+    std::size_t num_writes_skip_barrier,
+    KernelHandle& local_kernel,
+    KernelHandle& remote_kernel,
+    std::shared_ptr<Buffer>& worker_buffer) {
+    Program program0;
+    Program program1;
+
+    // worker core coords
+    uint32_t worker_noc_x = device1->worker_core_from_logical_core(worker_core).x;
+    uint32_t worker_noc_y = device1->worker_core_from_logical_core(worker_core).y;
+
+    uint32_t worker_buffer_addr = worker_buffer->address();
+
+    bool use_transaction_id = false;
+    if (num_writes_skip_barrier != 0) {
+        use_transaction_id = true;
+    }
+
+    // eth core ct args
+    const std::vector<uint32_t>& eth_sender_ct_args = {num_channels};
+    const std::vector<uint32_t>& eth_receiver_ct_args = {
+        num_channels, worker_noc_x, worker_noc_y, worker_buffer_addr, use_transaction_id, num_writes_skip_barrier};
+
+    // eth core rt args
+    const std::vector<uint32_t>& eth_sender_rt_args = {
+        eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+        static_cast<uint32_t>(num_samples),
+        static_cast<uint32_t>(sample_page_size)};
+
+    std::vector<uint32_t> eth_receiver_rt_args = {
+        eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+        static_cast<uint32_t>(num_samples),
+        static_cast<uint32_t>(sample_page_size)};
+
+    local_kernel = tt_metal::CreateKernel(
+        program0,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
+        "ethernet_write_worker_latency_ubench_sender.cpp",
+        eth_sender_core,
+        tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_sender_ct_args});
+    tt_metal::SetRuntimeArgs(program0, local_kernel, eth_sender_core, eth_sender_rt_args);
+
+    remote_kernel = tt_metal::CreateKernel(
+        program1,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
+        "ethernet_write_worker_latency_ubench_receiver.cpp",
+        eth_receiver_core,
+        tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_receiver_ct_args});
+    tt_metal::SetRuntimeArgs(program1, remote_kernel, eth_receiver_core, eth_receiver_rt_args);
+
+    // Launch
+    try {
+        tt::tt_metal::detail::CompileProgram(device0, program0);
+        tt::tt_metal::detail::CompileProgram(device1, program1);
+    } catch (std::exception& e) {
+        log_error(tt::LogTest, "Failed compile: {}", e.what());
+        throw e;
+    }
+
+    std::vector<Program> programs;
+    programs.push_back(std::move(program0));
+    programs.push_back(std::move(program1));
+    return programs;
+}
+
+void run(
+    IDevice* device0, IDevice* device1, Program& program0, Program& program1, std::shared_ptr<Buffer>& worker_buffer) {
+    if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        std::thread th2 = std::thread([&] { tt_metal::detail::LaunchProgram(device0, program0); });
+        std::thread th1 = std::thread([&] { tt_metal::detail::LaunchProgram(device1, program1); });
+
+        th2.join();
+        th1.join();
+    } else {
+        tt_metal::EnqueueProgram(device0->command_queue(), program0, false);
+        tt_metal::EnqueueProgram(device1->command_queue(), program1, false);
+
+        std::cout << "Calling Finish" << std::endl;
+        tt_metal::Finish(device0->command_queue());
+        tt_metal::Finish(device1->command_queue());
+    }
+    tt::tt_metal::detail::DumpDeviceProfileResults(device0);
+    tt::tt_metal::detail::DumpDeviceProfileResults(device1);
+
+    validation(worker_buffer);
+}
+
+int main(int argc, char** argv) {
+    std::size_t arg_idx = 1;
+    std::size_t num_samples = std::stoi(argv[arg_idx++]);
+    std::size_t sample_page_size = std::stoi(argv[arg_idx++]);
+    std::size_t max_channels_per_direction = std::stoi(argv[arg_idx++]);
+    std::size_t num_writes_skip_barrier = std::stoi(argv[arg_idx++]);
+
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices < 2) {
+        log_info(tt::LogTest, "Need at least 2 devices to run this test");
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_info(tt::LogTest, "Test must be run on WH");
+        return 0;
+    }
+
+    std::cout << "setting up test fixture" << std::endl;
+    N300TestDevice test_fixture;
+    std::cout << "done setting up test fixture" << std::endl;
+
+    const auto& device_0 = test_fixture.devices_.at(0);
+    const auto& active_eth_cores = device_0->get_active_ethernet_cores(true);
+    auto eth_sender_core_iter = active_eth_cores.begin();
+    auto eth_sender_core_iter_end = active_eth_cores.end();
+    chip_id_t device_id = std::numeric_limits<chip_id_t>::max();
+    tt_xy_pair eth_receiver_core;
+    bool initialized = false;
+    tt_xy_pair eth_sender_core;
+    do {
+        TT_ASSERT(eth_sender_core_iter != eth_sender_core_iter_end);
+        std::tie(device_id, eth_receiver_core) = device_0->get_connected_ethernet_core(*eth_sender_core_iter);
+        eth_sender_core = *eth_sender_core_iter;
+        eth_sender_core_iter++;
+    } while (device_id != 1);
+
+    TT_ASSERT(device_id == 1);
+    const auto& device_1 = test_fixture.devices_.at(device_id);
+    // worker
+    auto worker_core = CoreCoord(0, 0);
+    // Add more configurations here until proper argc parsing added
+    bool success = false;
+    success = true;
+    std::cout << "STARTING" << std::endl;
+    try {
+        log_info(
+            tt::LogTest,
+            "num_samples: {}, sample_page_size: {}, num_channels_per_direction: {}",
+            num_samples,
+            sample_page_size,
+            max_channels_per_direction);
+        KernelHandle local_kernel;
+        KernelHandle remote_kernel;
+        try {
+            ShardSpecBuffer shard_spec = ShardSpecBuffer(
+                CoreRangeSet(std::set<CoreRange>({CoreRange(worker_core)})),
+                {1, sample_page_size},
+                ShardOrientation::ROW_MAJOR,
+                {1, sample_page_size},
+                {1, sample_page_size});
+            auto worker_buffer = CreateBuffer(tt::tt_metal::ShardedBufferConfig{
+                .device = device_1,
+                .size = sample_page_size,
+                .page_size = sample_page_size,
+                .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+                .shard_parameters = shard_spec});
+
+            auto programs = build(
+                device_0,
+                device_1,
+                eth_sender_core,
+                eth_receiver_core,
+                worker_core,
+                num_samples,
+                sample_page_size,
+                max_channels_per_direction,
+                num_writes_skip_barrier,
+                local_kernel,
+                remote_kernel,
+                worker_buffer);
+            run(device_0, device_1, programs[0], programs[1], worker_buffer);
+        } catch (std::exception& e) {
+            log_error(tt::LogTest, "Caught exception: {}", e.what());
+            test_fixture.TearDown();
+            return -1;
+        }
+    } catch (std::exception& e) {
+        test_fixture.TearDown();
+        return -1;
+    }
+
+    return success ? 0 : -1;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_write_worker_latency_no_edm.cpp
@@ -223,6 +223,9 @@ int main(int argc, char** argv) {
         eth_sender_core_iter++;
     } while (device_id != 1);
 
+    log_info("eth_sender_core: {}", eth_sender_core);
+    log_info("eth_receiver_core: {}", eth_receiver_core);
+
     TT_ASSERT(device_id == 1);
     const auto& device_1 = test_fixture.devices_.at(device_id);
     // worker

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -35,3 +35,8 @@ FORCE_INLINE void switch_context_if_debug() {
     internal_::risc_context_switch();
 #endif
 }
+
+template <typename T>
+bool is_power_of_two(T val) {
+    return (val & (val - 1)) == T(0);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <array>
+#include "eth_l1_address_map.h"
+#include "dataflow_api.h"
+#include "ethernet/dataflow_api.h"
+#include "debug/assert.h"
+#include "debug/dprint.h"
+
+// #define ENABLE_DEBUG 1
+
+struct eth_buffer_slot_sync_t {
+    volatile uint32_t bytes_sent;
+    volatile uint32_t receiver_ack;
+    volatile uint32_t src_id;
+
+    uint32_t reserved_2;
+};
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_channel_done(0);
+    }
+}
+
+FORCE_INLINE void switch_context_if_debug() {
+#if ENABLE_DEBUG
+    internal_::risc_context_switch();
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -10,6 +10,8 @@
 #include "debug/assert.h"
 #include "debug/dprint.h"
 
+// #define ENABLE_DEBUG 1
+
 FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
     if (is_sender) {
         eth_send_bytes(handshake_register_address, handshake_register_address, 16);
@@ -20,120 +22,250 @@ FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, 
     }
 }
 
-static constexpr uint32_t MAX_TRANSACTION_ID = 15;
+// static constexpr uint32_t MAX_TRANSACTION_ID = 15;
+// static constexpr uint32_t NUM_CHANNELS = get_compile_time_arg_val(0);
+// static constexpr uint32_t worker_noc_x = get_compile_time_arg_val(1);
+// static constexpr uint32_t worker_noc_y = get_compile_time_arg_val(2);
+// static constexpr uint32_t worker_buffer_addr = get_compile_time_arg_val(3);
+// static constexpr bool use_transaction_id = get_compile_time_arg_val(4) == 1;
+// static constexpr uint32_t num_writes_skip_barrier = get_compile_time_arg_val(5);
+
+// template <bool sending_tails>
+// FORCE_INLINE void run_loop_iteration(
+//     const std::array<uint32_t, NUM_CHANNELS>& channel_addrs,
+//     const std::array<volatile eth_channel_sync_t*, NUM_CHANNELS>& channel_sync_addrs,
+//     uint64_t worker_noc_addr,
+//     uint32_t message_size) {
+//     if constexpr (!sending_tails) {
+//         static uint32_t writes_count;
+
+//         for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
+//             if constexpr (use_transaction_id) {
+//                 uint32_t curr_transaction_id = i % MAX_TRANSACTION_ID + 1;
+
+//                 if (writes_count < num_writes_skip_barrier) {
+//                     // wait for sender data arrive
+//                     while (channel_sync_addrs[i]->bytes_sent == 0) {
+//                     }
+
+//                     noc_async_write_with_trid(channel_addrs[i], worker_noc_addr, message_size, curr_transaction_id);
+
+//                     channel_sync_addrs[i]->bytes_sent = 0;
+
+//                     DPRINT << "write CH: " << i << " tid: " << curr_transaction_id << ENDL();
+
+//                     // not using any barrier
+//                     writes_count++;
+//                 } else {
+//                     uint32_t prev_channel_id_to_ack = (NUM_CHANNELS - num_writes_skip_barrier + i) % NUM_CHANNELS;
+//                     uint32_t prev_transaction_id = prev_channel_id_to_ack % MAX_TRANSACTION_ID + 1;
+
+//                     // barrier on previous data
+//                     noc_async_write_barrier_with_trid(prev_transaction_id);
+
+//                     channel_sync_addrs[prev_channel_id_to_ack]->bytes_sent = 0;
+
+//                     // wait for txq to be ready, otherwise we'll
+//                     // hit a context switch in the send command
+//                     while (eth_txq_is_busy()) {
+//                     }
+//                     eth_send_bytes_over_channel_payload_only_unsafe(
+//                         reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+//                         reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+//                         sizeof(eth_channel_sync_t),
+//                         sizeof(eth_channel_sync_t),
+//                         sizeof(eth_channel_sync_t) >> 4);
+
+//                     DPRINT << "ack CH: " << prev_channel_id_to_ack << ENDL();
+//                     DPRINT << "wait tid: " << prev_transaction_id << ENDL();
+
+//                     // wait only after the ack is sent for the previous packet
+//                     while (channel_sync_addrs[i]->bytes_sent == 0) {
+//                     }
+
+//                     noc_async_write_with_trid(channel_addrs[i], worker_noc_addr, message_size, curr_transaction_id);
+
+//                     channel_sync_addrs[i]->bytes_sent = 0;
+
+//                     DPRINT << "write CH: " << i << " tid: " << curr_transaction_id << ENDL();
+//                 }
+//             } else {
+//                 // wait for sender data arrive
+//                 while (channel_sync_addrs[i]->bytes_sent == 0) {
+//                 }
+
+//                 channel_sync_addrs[i]->bytes_sent = 0;
+
+//                 // for current channel data, send it to worker core and perform barrier
+//                 noc_async_write(channel_addrs[i], worker_noc_addr, message_size);
+//                 noc_async_write_barrier();
+
+//                 // wait for txq to be ready, otherwise we'll
+//                 // hit a context switch in the send command
+//                 while (eth_txq_is_busy()) {
+//                 }
+//                 eth_send_bytes_over_channel_payload_only_unsafe(
+//                     reinterpret_cast<uint32_t>(channel_sync_addrs[i]),
+//                     reinterpret_cast<uint32_t>(channel_sync_addrs[i]),
+//                     sizeof(eth_channel_sync_t),
+//                     sizeof(eth_channel_sync_t),
+//                     sizeof(eth_channel_sync_t) >> 4);
+//             }
+//         }
+//     } else {
+//         // sending tails
+//         for (uint32_t i = 0; i < num_writes_skip_barrier; i++) {
+//             // barrier on previous data
+//             uint32_t prev_channel_id_to_ack = NUM_CHANNELS - num_writes_skip_barrier + i;
+//             uint32_t prev_transaction_id = prev_channel_id_to_ack % MAX_TRANSACTION_ID + 1;
+
+//             noc_async_write_barrier_with_trid(prev_transaction_id);
+
+//             DPRINT << "tails wait tid: " << prev_transaction_id << ENDL();
+//             DPRINT << "tails ack CH: " << prev_channel_id_to_ack << ENDL();
+
+//             channel_sync_addrs[prev_channel_id_to_ack]->bytes_sent = 0;
+
+//             // wait for txq to be ready, otherwise we'll
+//             // hit a context switch in the send command
+//             while (eth_txq_is_busy()) {
+//             }
+//             eth_send_bytes_over_channel_payload_only_unsafe(
+//                 reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+//                 reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+//                 sizeof(eth_channel_sync_t),
+//                 sizeof(eth_channel_sync_t),
+//                 sizeof(eth_channel_sync_t) >> 4);
+//         }
+//     }
+// }
+
 static constexpr uint32_t NUM_CHANNELS = get_compile_time_arg_val(0);
+static constexpr uint32_t MAX_NUM_TRANSACTION_ID =
+    NUM_CHANNELS / 2;  // the algorithm only works for NUM_CHANNELS divisible by MAX_NUM_TRANSACTION_ID
 static constexpr uint32_t worker_noc_x = get_compile_time_arg_val(1);
 static constexpr uint32_t worker_noc_y = get_compile_time_arg_val(2);
 static constexpr uint32_t worker_buffer_addr = get_compile_time_arg_val(3);
 static constexpr bool use_transaction_id = get_compile_time_arg_val(4) == 1;
 static constexpr uint32_t num_writes_skip_barrier = get_compile_time_arg_val(5);
 
-template <bool sending_tails>
-FORCE_INLINE void run_loop_iteration(
+FORCE_INLINE bool has_incoming_packet(volatile eth_channel_sync_t* channel_sync_addr) {
+    return channel_sync_addr->bytes_sent != 0;
+}
+
+FORCE_INLINE bool write_done(uint32_t tid) {
+    return ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, tid);
+}
+
+FORCE_INLINE void ack_complete(volatile eth_channel_sync_t* channel_sync_addr) {
+    channel_sync_addr->bytes_sent = 0;
+
+    // wait for txq to be ready, otherwise we'll
+    // hit a context switch in the send command
+    while (eth_txq_is_busy()) {
+#if ENABLE_DEBUG
+        internal_::risc_context_switch();
+#endif
+    }
+#if ENABLE_DEBUG
+    eth_send_bytes_over_channel_payload_only(
+#else
+    eth_send_bytes_over_channel_payload_only_unsafe(
+#endif
+        reinterpret_cast<uint32_t>(channel_sync_addr),
+        reinterpret_cast<uint32_t>(channel_sync_addr),
+        sizeof(eth_channel_sync_t),
+        sizeof(eth_channel_sync_t),
+        sizeof(eth_channel_sync_t) >> 4);
+}
+
+FORCE_INLINE void write_to_worker(
+    uint32_t channel_addr,
+    volatile eth_channel_sync_t* channel_sync_addr,
+    uint64_t worker_noc_addr,
+    uint32_t message_size,
+    uint32_t curr_tid_to_write) {
+    // write to local
+    noc_async_write_one_packet_with_trid(channel_addr, worker_noc_addr, message_size, curr_tid_to_write);
+
+    // reset sync
+    channel_sync_addr->bytes_sent = 0;
+}
+
+FORCE_INLINE void process_messages(
     const std::array<uint32_t, NUM_CHANNELS>& channel_addrs,
     const std::array<volatile eth_channel_sync_t*, NUM_CHANNELS>& channel_sync_addrs,
     uint64_t worker_noc_addr,
-    uint32_t message_size) {
-    if constexpr (!sending_tails) {
-        static uint32_t writes_count;
+    uint32_t message_size,
+    uint32_t num_messages) {
+    uint32_t total_msgs = num_messages * NUM_CHANNELS;
 
-        for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
-            if constexpr (use_transaction_id) {
-                uint32_t curr_transaction_id = i % MAX_TRANSACTION_ID + 1;
+    uint32_t chCount = 0;
+    uint32_t tidCount = 0;
 
-                if (writes_count < num_writes_skip_barrier) {
-                    // wait for sender data arrive
-                    while (channel_sync_addrs[i]->bytes_sent == 0) {
-                    }
+    DPRINT << "MAIN LOOP" << ENDL();
 
-                    noc_async_write_with_trid(channel_addrs[i], worker_noc_addr, message_size, curr_transaction_id);
+    // Variables to hold the pointer values
+    uint32_t ch = 0;
+    uint32_t tid = 0;
+    uint32_t curr_ch_to_ack = 0;
+    uint32_t curr_tid_to_write = 0;
 
-                    DPRINT << "write CH: " << i << " tid: " << curr_transaction_id << ENDL();
+    uint32_t i = 0;
+    while (i < total_msgs) {
+        ch = chCount % NUM_CHANNELS;                    // range: 0..17
+        tid = (tidCount % MAX_NUM_TRANSACTION_ID) + 1;  // range: 1..9
 
-                    // not using any barrier
-                    writes_count++;
-                } else {
-                    uint32_t prev_channel_id_to_ack = (NUM_CHANNELS - num_writes_skip_barrier + i) % NUM_CHANNELS;
-                    uint32_t prev_transaction_id = prev_channel_id_to_ack % MAX_TRANSACTION_ID + 1;
+        // 1) Check if there's an incoming packet for ch
+        if (has_incoming_packet(channel_sync_addrs[ch])) {
+            curr_tid_to_write = ch % MAX_NUM_TRANSACTION_ID + 1;
+            write_to_worker(
+                channel_addrs[ch], channel_sync_addrs[ch], worker_noc_addr, message_size, curr_tid_to_write);
 
-                    // barrier on previous data
-                    noc_async_write_barrier_with_trid(prev_transaction_id);
+            DPRINT << "write from ch: " << chCount << " with tid: " << curr_tid_to_write << ENDL();
 
-                    channel_sync_addrs[prev_channel_id_to_ack]->bytes_sent = 0;
-                    channel_sync_addrs[prev_channel_id_to_ack]->receiver_ack = 0;
-
-                    // wait for txq to be ready, otherwise we'll
-                    // hit a context switch in the send command
-                    while (eth_txq_is_busy()) {
-                    }
-                    eth_send_bytes_over_channel_payload_only_unsafe(
-                        reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
-                        reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
-                        sizeof(eth_channel_sync_t),
-                        sizeof(eth_channel_sync_t),
-                        sizeof(eth_channel_sync_t) >> 4);
-
-                    DPRINT << "ack CH: " << prev_channel_id_to_ack << ENDL();
-                    DPRINT << "wait tid: " << prev_transaction_id << ENDL();
-
-                    // wait only after the ack is sent for the previous packet
-                    while (channel_sync_addrs[i]->bytes_sent == 0) {
-                    }
-
-                    noc_async_write_with_trid(channel_addrs[i], worker_noc_addr, message_size, curr_transaction_id);
-
-                    DPRINT << "write CH: " << i << " tid: " << curr_transaction_id << ENDL();
-                }
-            } else {
-                // wait for sender data arrive
-                while (channel_sync_addrs[i]->bytes_sent == 0) {
-                }
-
-                channel_sync_addrs[i]->bytes_sent = 0;
-                channel_sync_addrs[i]->receiver_ack = 0;
-
-                // for current channel data, send it to worker core and perform barrier
-                noc_async_write(channel_addrs[i], worker_noc_addr, message_size);
-                noc_async_write_barrier();
-
-                // wait for txq to be ready, otherwise we'll
-                // hit a context switch in the send command
-                while (eth_txq_is_busy()) {
-                }
-                eth_send_bytes_over_channel_payload_only_unsafe(
-                    reinterpret_cast<uint32_t>(channel_sync_addrs[i]),
-                    reinterpret_cast<uint32_t>(channel_sync_addrs[i]),
-                    sizeof(eth_channel_sync_t),
-                    sizeof(eth_channel_sync_t),
-                    sizeof(eth_channel_sync_t) >> 4);
+            // Only increment chCount if we won't exceed tidCount + 17
+            // i.e. chCount < tidCount + 18
+            if (chCount < tidCount + NUM_CHANNELS) {
+                chCount++;
             }
+
+            i++;
         }
-    } else {
-        // sending tails
-        for (uint32_t i = 0; i < num_writes_skip_barrier; i++) {
-            // barrier on previous data
-            uint32_t prev_channel_id_to_ack = NUM_CHANNELS - num_writes_skip_barrier + i;
-            uint32_t prev_transaction_id = prev_channel_id_to_ack % MAX_TRANSACTION_ID + 1;
 
-            noc_async_write_barrier_with_trid(prev_transaction_id);
+        // 2) Check if the write for tid is done, make sure tid count is less than ch count so we never check barrier on
+        // the packet hasn't been sent
+        if (write_done(tid) && (tidCount < chCount)) {
+            curr_ch_to_ack = tidCount % NUM_CHANNELS;
+            ack_complete(channel_sync_addrs[curr_ch_to_ack]);
 
-            DPRINT << "tails wait tid: " << prev_transaction_id << ENDL();
-            DPRINT << "tails ack CH: " << prev_channel_id_to_ack << ENDL();
+            DPRINT << "ack to ch: " << curr_ch_to_ack << ENDL();
 
-            channel_sync_addrs[prev_channel_id_to_ack]->bytes_sent = 0;
-            channel_sync_addrs[prev_channel_id_to_ack]->receiver_ack = 0;
-
-            // wait for txq to be ready, otherwise we'll
-            // hit a context switch in the send command
-            while (eth_txq_is_busy()) {
-            }
-            eth_send_bytes_over_channel_payload_only_unsafe(
-                reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
-                reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
-                sizeof(eth_channel_sync_t),
-                sizeof(eth_channel_sync_t),
-                sizeof(eth_channel_sync_t) >> 4);
+            tidCount++;
         }
+
+#if ENABLE_DEBUG
+        internal_::risc_context_switch();
+#endif
+    }
+
+    DPRINT << "ACK TAIL" << ENDL();
+
+    // wait for some tail writes to finish so we can send ack to sender
+    while (tidCount < chCount) {
+        tid = (tidCount % MAX_NUM_TRANSACTION_ID) + 1;
+        if (write_done(tid)) {
+            curr_ch_to_ack = tidCount % NUM_CHANNELS;
+            ack_complete(channel_sync_addrs[curr_ch_to_ack]);
+
+            DPRINT << "ack to ch: " << curr_ch_to_ack << ENDL();
+
+            tidCount++;
+        }
+
+#if ENABLE_DEBUG
+        internal_::risc_context_switch();
+#endif
     }
 }
 
@@ -171,12 +303,13 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("MAIN-TEST-BODY");
-        for (uint32_t i = 0; i < num_messages; i++) {
-            run_loop_iteration<false>(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size);
-        }
+        process_messages(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size, num_messages);
+        // for (uint32_t i = 0; i < num_messages; i++) {
+        //     run_loop_iteration<false>(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size);
+        // }
 
-        if constexpr (use_transaction_id) {
-            run_loop_iteration<true>(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size);
-        }
+        // if constexpr (use_transaction_id) {
+        //     run_loop_iteration<true>(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size);
+        // }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -2,33 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <array>
-#include "eth_l1_address_map.h"
-#include "dataflow_api.h"
-#include "ethernet/dataflow_api.h"
-#include "debug/assert.h"
-#include "debug/dprint.h"
-
-// #define ENABLE_DEBUG 1
-
-struct eth_buffer_slot_sync_t {
-    volatile uint32_t bytes_sent;
-    volatile uint32_t receiver_ack;
-    volatile uint32_t src_id;
-
-    uint32_t reserved_2;
-};
-
-FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
-    if (is_sender) {
-        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
-        eth_wait_for_receiver_done();
-    } else {
-        eth_wait_for_bytes(16);
-        eth_receiver_channel_done(0);
-    }
-}
+#include "ethernet_write_worker_latency_ubench_common.hpp"
 
 static constexpr uint32_t NUM_BUFFER_SLOTS = get_compile_time_arg_val(0);
 static constexpr uint32_t MAX_NUM_TRANSACTION_ID =
@@ -38,12 +12,6 @@ static constexpr uint32_t worker_noc_y = get_compile_time_arg_val(2);
 static constexpr uint32_t worker_buffer_addr = get_compile_time_arg_val(3);
 static constexpr bool use_transaction_id = get_compile_time_arg_val(4) == 1;
 static constexpr uint32_t num_writes_skip_barrier = get_compile_time_arg_val(5);
-
-FORCE_INLINE void switch_context_if_debug() {
-#if ENABLE_DEBUG
-    internal_::risc_context_switch();
-#endif
-}
 
 FORCE_INLINE uint32_t advance_buffer_slot_ptr(uint32_t curr_ptr) { return (curr_ptr + 1) % NUM_BUFFER_SLOTS; }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -134,7 +134,7 @@ FORCE_INLINE void receiver_main_loop(
     uint32_t num_messages) {
     uint32_t total_msgs = num_messages * NUM_BUFFER_SLOTS;
 
-    DPRINT << "MAIN LOOP" << ENDL();
+    DPRINT << "RECEIVER MAIN LOOP" << ENDL();
 
     uint32_t buffer_read_ptr = 0;
     uint32_t buffer_write_ptr = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <array>
+#include "eth_l1_address_map.h"
+#include "dataflow_api.h"
+#include "ethernet/dataflow_api.h"
+#include "debug/assert.h"
+#include "debug/dprint.h"
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_channel_done(0);
+    }
+}
+
+static constexpr uint32_t MAX_TRANSACTION_ID = 15;
+static constexpr uint32_t NUM_CHANNELS = get_compile_time_arg_val(0);
+static constexpr uint32_t worker_noc_x = get_compile_time_arg_val(1);
+static constexpr uint32_t worker_noc_y = get_compile_time_arg_val(2);
+static constexpr uint32_t worker_buffer_addr = get_compile_time_arg_val(3);
+static constexpr bool use_transaction_id = get_compile_time_arg_val(4) == 1;
+static constexpr uint32_t num_writes_skip_barrier = get_compile_time_arg_val(5);
+
+template <bool sending_tails>
+FORCE_INLINE void run_loop_iteration(
+    const std::array<uint32_t, NUM_CHANNELS>& channel_addrs,
+    const std::array<volatile eth_channel_sync_t*, NUM_CHANNELS>& channel_sync_addrs,
+    uint64_t worker_noc_addr,
+    uint32_t message_size) {
+    if constexpr (!sending_tails) {
+        static uint32_t writes_count;
+
+        for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
+            if constexpr (use_transaction_id) {
+                uint32_t curr_transaction_id = i % MAX_TRANSACTION_ID + 1;
+
+                if (writes_count < num_writes_skip_barrier) {
+                    // wait for sender data arrive
+                    while (channel_sync_addrs[i]->bytes_sent == 0) {
+                    }
+
+                    noc_async_write_with_trid(channel_addrs[i], worker_noc_addr, message_size, curr_transaction_id);
+
+                    DPRINT << "write CH: " << i << " tid: " << curr_transaction_id << ENDL();
+
+                    // not using any barrier
+                    writes_count++;
+                } else {
+                    uint32_t prev_channel_id_to_ack = (NUM_CHANNELS - num_writes_skip_barrier + i) % NUM_CHANNELS;
+                    uint32_t prev_transaction_id = prev_channel_id_to_ack % MAX_TRANSACTION_ID + 1;
+
+                    // barrier on previous data
+                    noc_async_write_barrier_with_trid(prev_transaction_id);
+
+                    channel_sync_addrs[prev_channel_id_to_ack]->bytes_sent = 0;
+                    channel_sync_addrs[prev_channel_id_to_ack]->receiver_ack = 0;
+
+                    // wait for txq to be ready, otherwise we'll
+                    // hit a context switch in the send command
+                    while (eth_txq_is_busy()) {
+                    }
+                    eth_send_bytes_over_channel_payload_only_unsafe(
+                        reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+                        reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+                        sizeof(eth_channel_sync_t),
+                        sizeof(eth_channel_sync_t),
+                        sizeof(eth_channel_sync_t) >> 4);
+
+                    DPRINT << "ack CH: " << prev_channel_id_to_ack << ENDL();
+                    DPRINT << "wait tid: " << prev_transaction_id << ENDL();
+
+                    // wait only after the ack is sent for the previous packet
+                    while (channel_sync_addrs[i]->bytes_sent == 0) {
+                    }
+
+                    noc_async_write_with_trid(channel_addrs[i], worker_noc_addr, message_size, curr_transaction_id);
+
+                    DPRINT << "write CH: " << i << " tid: " << curr_transaction_id << ENDL();
+                }
+            } else {
+                // wait for sender data arrive
+                while (channel_sync_addrs[i]->bytes_sent == 0) {
+                }
+
+                channel_sync_addrs[i]->bytes_sent = 0;
+                channel_sync_addrs[i]->receiver_ack = 0;
+
+                // for current channel data, send it to worker core and perform barrier
+                noc_async_write(channel_addrs[i], worker_noc_addr, message_size);
+                noc_async_write_barrier();
+
+                // wait for txq to be ready, otherwise we'll
+                // hit a context switch in the send command
+                while (eth_txq_is_busy()) {
+                }
+                eth_send_bytes_over_channel_payload_only_unsafe(
+                    reinterpret_cast<uint32_t>(channel_sync_addrs[i]),
+                    reinterpret_cast<uint32_t>(channel_sync_addrs[i]),
+                    sizeof(eth_channel_sync_t),
+                    sizeof(eth_channel_sync_t),
+                    sizeof(eth_channel_sync_t) >> 4);
+            }
+        }
+    } else {
+        // sending tails
+        for (uint32_t i = 0; i < num_writes_skip_barrier; i++) {
+            // barrier on previous data
+            uint32_t prev_channel_id_to_ack = NUM_CHANNELS - num_writes_skip_barrier + i;
+            uint32_t prev_transaction_id = prev_channel_id_to_ack % MAX_TRANSACTION_ID + 1;
+
+            noc_async_write_barrier_with_trid(prev_transaction_id);
+
+            DPRINT << "tails wait tid: " << prev_transaction_id << ENDL();
+            DPRINT << "tails ack CH: " << prev_channel_id_to_ack << ENDL();
+
+            channel_sync_addrs[prev_channel_id_to_ack]->bytes_sent = 0;
+            channel_sync_addrs[prev_channel_id_to_ack]->receiver_ack = 0;
+
+            // wait for txq to be ready, otherwise we'll
+            // hit a context switch in the send command
+            while (eth_txq_is_busy()) {
+            }
+            eth_send_bytes_over_channel_payload_only_unsafe(
+                reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+                reinterpret_cast<uint32_t>(channel_sync_addrs[prev_channel_id_to_ack]),
+                sizeof(eth_channel_sync_t),
+                sizeof(eth_channel_sync_t),
+                sizeof(eth_channel_sync_t) >> 4);
+        }
+    }
+}
+
+void kernel_main() {
+    uint32_t arg_idx = 0;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
+
+    ASSERT(num_writes_skip_barrier <= NUM_CHANNELS);
+
+    std::array<uint32_t, NUM_CHANNELS> channel_addrs;
+    std::array<volatile eth_channel_sync_t*, NUM_CHANNELS> channel_sync_addrs;
+    {
+        uint32_t channel_addr = handshake_addr + sizeof(eth_channel_sync_t);
+        for (uint8_t i = 0; i < NUM_CHANNELS; i++) {
+            channel_addrs[i] = channel_addr;
+            channel_addr += message_size;
+            channel_sync_addrs[i] = reinterpret_cast<volatile eth_channel_sync_t*>(channel_addr);
+            channel_sync_addrs[i]->bytes_sent = 0;
+            channel_sync_addrs[i]->receiver_ack = 0;
+            channel_addr += sizeof(eth_channel_sync_t);
+        }
+    }
+
+    // Avoids hang in issue https://github.com/tenstorrent/tt-metal/issues/9963
+    for (uint32_t i = 0; i < 2000000000; i++) {
+        asm volatile("nop");
+    }
+
+    // worker noc address
+    uint64_t worker_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
+
+    eth_setup_handshake(handshake_addr, false);
+
+    {
+        DeviceZoneScopedN("MAIN-TEST-BODY");
+        for (uint32_t i = 0; i < num_messages; i++) {
+            run_loop_iteration<false>(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size);
+        }
+
+        if constexpr (use_transaction_id) {
+            run_loop_iteration<true>(channel_addrs, channel_sync_addrs, worker_noc_addr, message_size);
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -121,7 +121,7 @@ void kernel_main() {
     const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
 
-    ASSERT(num_writes_skip_barrier <= NUM_BUFFER_SLOTS);
+    ASSERT(is_power_of_two(NUM_BUFFER_SLOTS));
 
     std::array<uint32_t, NUM_BUFFER_SLOTS> buffer_slot_addrs;
     std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS> buffer_slot_sync_addrs;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -10,8 +10,6 @@ static constexpr uint32_t MAX_NUM_TRANSACTION_ID =
 static constexpr uint32_t worker_noc_x = get_compile_time_arg_val(1);
 static constexpr uint32_t worker_noc_y = get_compile_time_arg_val(2);
 static constexpr uint32_t worker_buffer_addr = get_compile_time_arg_val(3);
-static constexpr bool use_transaction_id = get_compile_time_arg_val(4) == 1;
-static constexpr uint32_t num_writes_skip_barrier = get_compile_time_arg_val(5);
 
 FORCE_INLINE uint32_t advance_buffer_slot_ptr(uint32_t curr_ptr) { return (curr_ptr + 1) % NUM_BUFFER_SLOTS; }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <array>
+#include "eth_l1_address_map.h"
+#include "ethernet/dataflow_api.h"
+#include "debug/assert.h"
+#include "debug/dprint.h"
+#include "debug/debug.h"
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_channel_done(0);
+    }
+}
+
+static constexpr uint32_t NUM_CHANNELS = get_compile_time_arg_val(0);
+
+template <bool waiting_tails>
+FORCE_INLINE void run_loop_iteration(
+    const std::array<uint32_t, NUM_CHANNELS>& channel_addrs,
+    const std::array<volatile eth_channel_sync_t*, NUM_CHANNELS>& channel_sync_addrs,
+    uint32_t full_payload_size,
+    uint32_t full_payload_size_eth_words) {
+    if constexpr (!waiting_tails) {
+        // send packet
+        for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
+            // wait for receiver ack compelete
+            while (channel_sync_addrs[i]->bytes_sent != 0) {
+            }
+
+            channel_sync_addrs[i]->bytes_sent = 1;
+            channel_sync_addrs[i]->receiver_ack = 0;
+            while (eth_txq_is_busy()) {
+            }
+            eth_send_bytes_over_channel_payload_only_unsafe(
+                channel_addrs[i], channel_addrs[i], full_payload_size, full_payload_size, full_payload_size_eth_words);
+        }
+    } else {
+        // waiting tails
+        for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
+            // wait for receiver ack compelete
+            while (channel_sync_addrs[i]->bytes_sent != 0) {
+            }
+        }
+    }
+}
+
+void kernel_main() {
+    uint32_t arg_idx = 0;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
+    bool is_sender_offset_0 = get_arg_val<uint32_t>(arg_idx++) == 1;
+
+    const uint32_t message_size_eth_words = message_size >> 4;
+
+    const uint32_t full_payload_size = message_size + sizeof(eth_channel_sync_t);
+    const uint32_t full_payload_size_eth_words = full_payload_size >> 4;
+
+    std::array<uint32_t, NUM_CHANNELS> channel_addrs;
+    std::array<volatile eth_channel_sync_t*, NUM_CHANNELS> channel_sync_addrs;
+    {
+        uint32_t channel_addr = handshake_addr + sizeof(eth_channel_sync_t);
+        for (uint8_t i = 0; i < NUM_CHANNELS; i++) {
+            channel_addrs[i] = channel_addr;
+            channel_addr += message_size;
+            channel_sync_addrs[i] = reinterpret_cast<volatile eth_channel_sync_t*>(channel_addr);
+            channel_addr += sizeof(eth_channel_sync_t);
+        }
+    }
+
+    // reset bytes_sent to 0s so first iter it won't block
+    for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
+        channel_sync_addrs[i]->bytes_sent = 0;
+    }
+
+    // assemble a packet filled with values
+    for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
+        tt_l1_ptr uint8_t* ptr = reinterpret_cast<tt_l1_ptr uint8_t*>(channel_addrs[i]);
+        for (uint32_t j = 0; j < message_size; j++) {
+            ptr[j] = j;
+        }
+    }
+
+    // Avoids hang in issue https://github.com/tenstorrent/tt-metal/issues/9963
+    for (uint32_t i = 0; i < 2000000000; i++) {
+        asm volatile("nop");
+    }
+    eth_setup_handshake(handshake_addr, true);
+
+    {
+        DeviceZoneScopedN("MAIN-TEST-BODY");
+        for (uint32_t i = 0; i < num_messages; i++) {
+            run_loop_iteration<false>(
+                channel_addrs, channel_sync_addrs, full_payload_size, full_payload_size_eth_words);
+        }
+        run_loop_iteration<true>(channel_addrs, channel_sync_addrs, full_payload_size, full_payload_size_eth_words);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
@@ -10,7 +10,7 @@
 #include "debug/dprint.h"
 #include "debug/debug.h"
 
-#define ENABLE_DEBUG 1
+// #define ENABLE_DEBUG 1
 
 struct eth_buffer_slot_sync_t {
     volatile uint32_t bytes_sent;
@@ -32,19 +32,21 @@ FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, 
 
 static constexpr uint32_t NUM_BUFFER_SLOTS = get_compile_time_arg_val(0);
 
+FORCE_INLINE void switch_context_if_debug() {
+#if ENABLE_DEBUG
+    internal_::risc_context_switch();
+#endif
+}
+
 FORCE_INLINE void wait_ack(volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr) {
     while (buffer_slot_sync_addr->bytes_sent != 0) {
-#if ENABLE_DEBUG
-        internal_::risc_context_switch();
-#endif
+        switch_context_if_debug();
     }
 }
 
 FORCE_INLINE void wait_eth_txq() {
     while (eth_txq_is_busy()) {
-#if ENABLE_DEBUG
-        internal_::risc_context_switch();
-#endif
+        switch_context_if_debug();
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
@@ -15,11 +15,7 @@ FORCE_INLINE void write_receiver(
     uint32_t full_payload_size_eth_words) {
     buffer_slot_sync_addr->bytes_sent = 1;
 
-#if ENABLE_DEBUG
-    eth_send_bytes_over_channel_payload_only(
-#else
     eth_send_bytes_over_channel_payload_only_unsafe(
-#endif
         buffer_slot_addr, buffer_slot_addr, full_payload_size, full_payload_size, full_payload_size_eth_words);
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
@@ -2,41 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <array>
-#include "eth_l1_address_map.h"
-#include "ethernet/dataflow_api.h"
-#include "debug/assert.h"
-#include "debug/dprint.h"
-#include "debug/debug.h"
-
-// #define ENABLE_DEBUG 1
-
-struct eth_buffer_slot_sync_t {
-    volatile uint32_t bytes_sent;
-    volatile uint32_t receiver_ack;
-    volatile uint32_t src_id;
-
-    uint32_t reserved_2;
-};
-
-FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
-    if (is_sender) {
-        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
-        eth_wait_for_receiver_done();
-    } else {
-        eth_wait_for_bytes(16);
-        eth_receiver_channel_done(0);
-    }
-}
+#include "ethernet_write_worker_latency_ubench_common.hpp"
 
 static constexpr uint32_t NUM_BUFFER_SLOTS = get_compile_time_arg_val(0);
-
-FORCE_INLINE void switch_context_if_debug() {
-#if ENABLE_DEBUG
-    internal_::risc_context_switch();
-#endif
-}
 
 FORCE_INLINE uint32_t advance_buffer_slot_ptr(uint32_t curr_ptr) { return (curr_ptr + 1) % NUM_BUFFER_SLOTS; }
 

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -139,7 +139,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_read_with_transaction_id_f
     return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
-template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -151,11 +151,16 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     bool linked,
     uint32_t num_dests,
     bool multicast_path_reserve,
-    bool posted = false) {
+    bool posted = false,
+    uint32_t trid = 0) {
     uint32_t noc_cmd_field =
         NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
         (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
         (posted ? 0 : NOC_CMD_RESP_MARKED);
+
+    if constexpr (use_trid) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
+    }
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
@@ -285,6 +290,11 @@ inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_writes_f
 
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_flushed(uint32_t noc) {
     return (NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED) == noc_nonposted_writes_acked[noc]);
+}
+
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_flushed(
+    uint32_t noc, uint32_t transcation_id) {
+    return (NOC_STATUS_READ_REG(noc, NIU_MST_WRITE_REQS_OUTGOING_ID(transcation_id)) == 0);
 }
 
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {
@@ -439,7 +449,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     ncrisc_noc_fast_read(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -451,10 +461,11 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     bool linked,
     uint32_t num_dests,
     bool multicast_path_reserve,
-    bool posted = false) {
+    bool posted = false,
+    uint32_t trid = 0) {
     while (len_bytes > NOC_MAX_BURST_SIZE) {
         while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_write<proc_type, noc_mode>(
+        ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
             noc,
             cmd_buf,
             src_addr,
@@ -465,14 +476,26 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
             linked,
             num_dests,
             multicast_path_reserve,
-            posted);
+            posted,
+            trid);
         src_addr += NOC_MAX_BURST_SIZE;
         dest_addr += NOC_MAX_BURST_SIZE;
         len_bytes -= NOC_MAX_BURST_SIZE;
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
-    ncrisc_noc_fast_write<proc_type, noc_mode>(
-        noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve, posted);
+    ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
+        noc,
+        cmd_buf,
+        src_addr,
+        dest_addr,
+        len_bytes,
+        vc,
+        mcast,
+        linked,
+        num_dests,
+        multicast_path_reserve,
+        posted,
+        trid);
 }
 
 template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC>

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -449,7 +449,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     ncrisc_noc_fast_read(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
+template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -463,24 +463,26 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     bool multicast_path_reserve,
     bool posted = false,
     uint32_t trid = 0) {
-    while (len_bytes > NOC_MAX_BURST_SIZE) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
-            noc,
-            cmd_buf,
-            src_addr,
-            dest_addr,
-            NOC_MAX_BURST_SIZE,
-            vc,
-            mcast,
-            linked,
-            num_dests,
-            multicast_path_reserve,
-            posted,
-            trid);
-        src_addr += NOC_MAX_BURST_SIZE;
-        dest_addr += NOC_MAX_BURST_SIZE;
-        len_bytes -= NOC_MAX_BURST_SIZE;
+    if constexpr (!one_packet) {
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            while (!noc_cmd_buf_ready(noc, cmd_buf));
+            ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
+                noc,
+                cmd_buf,
+                src_addr,
+                dest_addr,
+                NOC_MAX_BURST_SIZE,
+                vc,
+                mcast,
+                linked,
+                num_dests,
+                multicast_path_reserve,
+                posted,
+                trid);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dest_addr += NOC_MAX_BURST_SIZE;
+            len_bytes -= NOC_MAX_BURST_SIZE;
+        }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2022,7 +2022,7 @@ void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTD");
 }
 
-inline void noc_async_write_with_trid(
+inline void noc_async_write_one_packet_with_trid(
     std::uint32_t src_local_l1_addr,
     std::uint64_t dst_noc_addr,
     std::uint32_t size,
@@ -2031,7 +2031,7 @@ inline void noc_async_write_with_trid(
     WAYPOINT("NAWW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
 #ifndef ARCH_GRAYSKULL
-    ncrisc_noc_fast_write_any_len<proc_type, noc_mode, true>(
+    ncrisc_noc_fast_write_any_len<proc_type, noc_mode, true, true>(
         noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true, trid);
 #endif
     WAYPOINT("NAWD");

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2022,6 +2022,29 @@ void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTD");
 }
 
+inline void noc_async_write_with_trid(
+    std::uint32_t src_local_l1_addr,
+    std::uint64_t dst_noc_addr,
+    std::uint32_t size,
+    std::uint32_t trid,
+    uint8_t noc = noc_index) {
+    WAYPOINT("NAWW");
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+    ncrisc_noc_fast_write_any_len<proc_type, noc_mode, true>(
+        noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true, trid);
+    WAYPOINT("NAWD");
+}
+
+FORCE_INLINE
+void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
+    WAYPOINT("NWTW");
+#ifndef ARCH_GRAYSKULL
+    while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc, trid));
+#endif
+    invalidate_l1_cache();
+    WAYPOINT("NWTD");
+}
+
 template <bool DRAM>
 FORCE_INLINE uint64_t
 get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_t noc = noc_index) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2030,8 +2030,10 @@ inline void noc_async_write_with_trid(
     uint8_t noc = noc_index) {
     WAYPOINT("NAWW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+#ifndef ARCH_GRAYSKULL
     ncrisc_noc_fast_write_any_len<proc_type, noc_mode, true>(
         noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true, trid);
+#endif
     WAYPOINT("NAWD");
 }
 

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -138,7 +138,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_read_with_transaction_id_f
     return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
-template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -150,11 +150,16 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     bool linked,
     uint32_t num_dests,
     bool multicast_path_reserve,
-    bool posted = false) {
+    bool posted = false,
+    uint32_t trid = 0) {
     uint32_t noc_cmd_field =
         NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
         (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
         (posted ? 0 : NOC_CMD_RESP_MARKED);
+
+    if constexpr (use_trid) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
+    }
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
@@ -241,6 +246,11 @@ inline __attribute__((always_inline)) bool ncrisc_dynamic_noc_nonposted_writes_f
 
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_flushed(uint32_t noc) {
     return (NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED) == noc_nonposted_writes_acked[noc]);
+}
+
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_flushed(
+    uint32_t noc, uint32_t transcation_id) {
+    return (NOC_STATUS_READ_REG(noc, NIU_MST_WRITE_REQS_OUTGOING_ID(transcation_id)) == 0);
 }
 
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {
@@ -379,7 +389,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     ncrisc_noc_fast_read(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC>
+template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -391,10 +401,11 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     bool linked,
     uint32_t num_dests,
     bool multicast_path_reserve,
-    bool posted = false) {
+    bool posted = false,
+    uint32_t trid = 0) {
     while (len_bytes > NOC_MAX_BURST_SIZE) {
         while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_write<proc_type, noc_mode>(
+        ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
             noc,
             cmd_buf,
             src_addr,
@@ -405,14 +416,26 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
             linked,
             num_dests,
             multicast_path_reserve,
-            posted);
+            posted,
+            trid);
         src_addr += NOC_MAX_BURST_SIZE;
         dest_addr += NOC_MAX_BURST_SIZE;
         len_bytes -= NOC_MAX_BURST_SIZE;
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
-    ncrisc_noc_fast_write<proc_type, noc_mode>(
-        noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, multicast_path_reserve, posted);
+    ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
+        noc,
+        cmd_buf,
+        src_addr,
+        dest_addr,
+        len_bytes,
+        vc,
+        mcast,
+        linked,
+        num_dests,
+        multicast_path_reserve,
+        posted,
+        trid);
 }
 
 template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC>

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -389,7 +389,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     ncrisc_noc_fast_read(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
+template <uint32_t proc_type, uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool one_packet = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -403,24 +403,26 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     bool multicast_path_reserve,
     bool posted = false,
     uint32_t trid = 0) {
-    while (len_bytes > NOC_MAX_BURST_SIZE) {
-        while (!noc_cmd_buf_ready(noc, cmd_buf));
-        ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
-            noc,
-            cmd_buf,
-            src_addr,
-            dest_addr,
-            NOC_MAX_BURST_SIZE,
-            vc,
-            mcast,
-            linked,
-            num_dests,
-            multicast_path_reserve,
-            posted,
-            trid);
-        src_addr += NOC_MAX_BURST_SIZE;
-        dest_addr += NOC_MAX_BURST_SIZE;
-        len_bytes -= NOC_MAX_BURST_SIZE;
+    if constexpr (!one_packet) {
+        while (len_bytes > NOC_MAX_BURST_SIZE) {
+            while (!noc_cmd_buf_ready(noc, cmd_buf));
+            ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(
+                noc,
+                cmd_buf,
+                src_addr,
+                dest_addr,
+                NOC_MAX_BURST_SIZE,
+                vc,
+                mcast,
+                linked,
+                num_dests,
+                multicast_path_reserve,
+                posted,
+                trid);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dest_addr += NOC_MAX_BURST_SIZE;
+            len_bytes -= NOC_MAX_BURST_SIZE;
+        }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_write<proc_type, noc_mode, use_trid>(


### PR DESCRIPTION
### Ticket
Currently EDM uses barrier right after write to the worker through NoC, this has performance cost since the time that it waits for barrier could be doing sth else.

Instead of barrier right after we issue a NoC write, we use transaction id to tag the NoC packet. After we have issued several writes, the first write should already completed, and we can perform barrier on it with little cost.

The implementation is done by assigning a different transaction id to different channels (or the buffers in EDM), and round-robin through the ids.


### Checklist
- [ ] Post commit CI passes
- [ ] ubenchmark pipeline https://github.com/tenstorrent/tt-metal/actions/runs/13121471423
- [ ] blackhole  https://github.com/tenstorrent/tt-metal/actions/runs/13121479460
