### PR TITLE
#0: Only produce cicd data on workflow runs that are success/failure/cancelled (ignore skipped runs)

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -49,6 +49,7 @@ on:
 
 jobs:
   produce-cicd-data:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -145,6 +146,7 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U014XCQ9CF8 # tt-rkim
   test-produce-complete-benchmark-with-environment:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -49,7 +49,12 @@ on:
 
 jobs:
   produce-cicd-data:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
+    if: |
+      # Check if triggered by `workflow_run` with specific conclusion states,
+      # or if it's triggered by `workflow_call` or `workflow_dispatch`
+      ${{ github.event_name == 'workflow_run' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled') }} ||
+      ${{ github.event_name == 'workflow_call' }} ||
+      ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -146,7 +151,12 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U014XCQ9CF8 # tt-rkim
   test-produce-complete-benchmark-with-environment:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
+    if: |
+      # Check if triggered by `workflow_run` with specific conclusion states,
+      # or if it's triggered by `workflow_call` or `workflow_dispatch`
+      ${{ github.event_name == 'workflow_run' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled') }} ||
+      ${{ github.event_name == 'workflow_call' }} ||
+      ${{ github.event_name == 'workflow_dispatch' }}    
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -156,7 +156,7 @@ jobs:
       # or if it's triggered by `workflow_call` or `workflow_dispatch`
       ${{ github.event_name == 'workflow_run' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled') }} ||
       ${{ github.event_name == 'workflow_call' }} ||
-      ${{ github.event_name == 'workflow_dispatch' }}    
+      ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Ticket


### Problem description
PR Gate has a lot of skipped runs that are causing _produce_data.yaml to fetch and push empty cicd data for superset (PR gate skips old runs that haven't started when a new commit is added to a developer's branch).
This has the unintended side effect of causing rate limiting on GH api side.

### What's changed
Only trigger _produce_data.yaml jobs on
- workflow_run when `github.event.workflow_run.conclusion` is success/failure/cancelled (ignore skipped)
- workflow_call
- workflow_dispatch

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
