### PR TITLE
Test for a bad state before building

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -139,6 +139,10 @@ jobs:
             if [ "${{ inputs.tracy }}" = "true" ]; then
               build_command="$build_command --enable-profiler"
             fi
+
+            [ -n "$(find . -maxdepth 1 -type d -name 'build*' -print -quit)" ] &&
+              { echo "!!! ALERT !!! This should never happen, but does explain an issue we've been hunting. Please send a link to this job to Metal Infra.  kthxbye."; exit 1; }
+
             nice -n 19 $build_command
             ccache -s > build/ccache.stats
       - name: Publish Ccache summary


### PR DESCRIPTION
### Ticket
#17335

### Problem description
We've sometimes seen a build failure that can be explained by having an old build dir laying around.
But that should never be the case.

### What's changed
Put in a check to draw attention if ever it IS the case that we have an old build dir laying around when we should be clean.

