### PR TITLE
#0: Add missing include for `work_split.hpp`

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/tt_log.h>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/work_split.hpp>
 #include "ttnn/operation.hpp"
 #include <algorithm>
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
https://github.com/tenstorrent/tt-metal/pull/17136 causes a build failure on main.

### What's changed
Adding an include for `work_split` fixes the issue.

### Checklist
Compiled locally and tested the build works.
