### PR TITLE
#16380: add nD support for generic reductions

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_grayskull
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -78,6 +79,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@skip_for_grayskull("Not a tile size multiple, may fail on GS if run all tests. #17084")
 @pytest.mark.parametrize("dim_1", [1])
 @pytest.mark.parametrize("dim_2", [2])
 @pytest.mark.parametrize("dim_3", [3])
@@ -103,6 +105,7 @@ def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@skip_for_grayskull("Not a tile size multiple, may fail on GS if run all tests. #17084")
 @pytest.mark.parametrize("dim_1", [1])
 @pytest.mark.parametrize("dim_2", [2])
 @pytest.mark.parametrize("dim_3", [3])
@@ -128,6 +131,7 @@ def test_sum_7d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@skip_for_grayskull("Not a tile size multiple, may fail on GS if run all tests. #17084")
 @pytest.mark.parametrize("dim_1", [1])
 @pytest.mark.parametrize("dim_2", [2])
 @pytest.mark.parametrize("dim_3", [3])
@@ -152,6 +156,7 @@ def test_sum_6d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@skip_for_grayskull("Not a tile size multiple, may fail on GS if run all tests. #17084")
 @pytest.mark.parametrize("dim_1", [33])
 @pytest.mark.parametrize("dim_2", [5])
 @pytest.mark.parametrize("dim_3", [7])
@@ -175,8 +180,8 @@ def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keep
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("batch_size", [3, 32])
-@pytest.mark.parametrize("c", [5, 32])
+@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("c", [32])
 @pytest.mark.parametrize("h", [37])
 @pytest.mark.parametrize("w", [63])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -58,7 +58,7 @@ def test_var(device, batch_size, h, w, dim, keepdim):
 @pytest.mark.parametrize("h", [67])
 @pytest.mark.parametrize("w", [77])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
-@pytest.mark.parametrize("keepdim", [True])
+@pytest.mark.parametrize("keepdim", [True, False])
 def test_prod(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -58,7 +58,7 @@ def test_var(device, batch_size, h, w, dim, keepdim):
 @pytest.mark.parametrize("h", [67])
 @pytest.mark.parametrize("w", [77])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
-@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("keepdim", [True])
 def test_prod(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 
@@ -78,8 +78,105 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("batch_size", [32])
-@pytest.mark.parametrize("c", [32])
+@pytest.mark.parametrize("dim_1", [1])
+@pytest.mark.parametrize("dim_2", [2])
+@pytest.mark.parametrize("dim_3", [3])
+@pytest.mark.parametrize("dim_4", [4])
+@pytest.mark.parametrize("dim_5", [4])
+@pytest.mark.parametrize("dim_6", [6])
+@pytest.mark.parametrize("dim_7", [7])
+@pytest.mark.parametrize("dim_8", [8])
+@pytest.mark.parametrize("dim", [[3, 7]])
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim_1", [1])
+@pytest.mark.parametrize("dim_2", [2])
+@pytest.mark.parametrize("dim_3", [3])
+@pytest.mark.parametrize("dim_4", [4])
+@pytest.mark.parametrize("dim_5", [5])
+@pytest.mark.parametrize("dim_6", [6])
+@pytest.mark.parametrize("dim_7", [7])
+@pytest.mark.parametrize("dim", [[2, 5]])
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_sum_7d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim_1", [1])
+@pytest.mark.parametrize("dim_2", [2])
+@pytest.mark.parametrize("dim_3", [3])
+@pytest.mark.parametrize("dim_4", [4])
+@pytest.mark.parametrize("dim_5", [5])
+@pytest.mark.parametrize("dim_6", [6])
+@pytest.mark.parametrize("dim", [[1, 4], -1, None])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_6d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim_1", [33])
+@pytest.mark.parametrize("dim_2", [5])
+@pytest.mark.parametrize("dim_3", [7])
+@pytest.mark.parametrize("dim_4", [2])
+@pytest.mark.parametrize("dim_5", [59])
+@pytest.mark.parametrize("dim", [[1, 4], -1, None])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("batch_size", [3, 32])
+@pytest.mark.parametrize("c", [5, 32])
 @pytest.mark.parametrize("h", [37])
 @pytest.mark.parametrize("w", [63])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])
@@ -103,7 +200,7 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [31])
 @pytest.mark.parametrize("w", [32])
-@pytest.mark.parametrize("dim", [[0, 2], [0, 1, 2]])
+@pytest.mark.parametrize("dim", [[0, 2], [0, 1, 2], None])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_3d_tensor_dims(device, c, h, w, dim, keepdim):
     torch.manual_seed(0)
@@ -123,7 +220,7 @@ def test_sum_3d_tensor_dims(device, c, h, w, dim, keepdim):
 
 @pytest.mark.parametrize("h", [41])
 @pytest.mark.parametrize("w", [31])
-@pytest.mark.parametrize("dim", [0, 1, [0, 1]])
+@pytest.mark.parametrize("dim", [0, 1, [0, 1], None])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_2d_tensor_dims(device, h, w, dim, keepdim):
     torch.manual_seed(0)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -250,7 +250,39 @@ ttnn::Shape tiling_reshape_corrector(const ttnn::Shape& shape, const uint32_t ti
         case 4:
             return ttnn::Shape({shape[0],shape[1],shape[2],shape[3]},{padded[0],padded[1],padded[2]+correction_2,padded[3]+correction_1});
             break;
-
+        case 5:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4]},
+                {padded[0], padded[1], padded[2], padded[3] + correction_2, padded[4] + correction_1});
+            break;
+        case 6:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]},
+                {padded[0], padded[1], padded[2], padded[3], padded[4] + correction_2, padded[5] + correction_1});
+            break;
+        case 7:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4], shape[5], shape[6]},
+                {padded[0],
+                 padded[1],
+                 padded[2],
+                 padded[3],
+                 padded[4],
+                 padded[5] + correction_2,
+                 padded[6] + correction_1});
+            break;
+        case 8:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4], shape[5], shape[6], shape[7]},
+                {padded[0],
+                 padded[1],
+                 padded[2],
+                 padded[3],
+                 padded[4],
+                 padded[5],
+                 padded[6] + correction_2,
+                 padded[7] + correction_1});
+            break;
     }
     return shape;
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
@@ -63,8 +64,7 @@ static Tensor reduce_impl(
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool reshape) {
+    float scalar) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     auto input_shape = input_tensor_arg.get_logical_shape();
     auto rank = input_shape.size();
@@ -82,25 +82,21 @@ static Tensor reduce_impl(
         }
     }
 
-    auto input_tensor = ttnn::unsqueeze_to_4D(input_tensor_arg);
-
     Tensor output_tensor;
     float pad_value = get_pad_value(reduce_type);
     bool single_reduce_op = (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
                             (dim.size() == 2 && dim[1] == rank - 1 && dim[0] == rank - 2);
     if (!single_reduce_op) {
-        auto reduce_4d_loop = [&](const bool use_reduce_type) -> Tensor {
-            Tensor output_tensor = input_tensor;
-            int offset = 4 - rank;
+        auto reduce_nd_loop = [&](const bool use_reduce_type) -> Tensor {
+            Tensor output_tensor = input_tensor_arg;
             for (int i_dim = rank - 1; i_dim >= 0; i_dim--) {
                 bool found = std::find(dim.begin(), dim.end(), i_dim) != dim.end();
                 if (found) {
                     bool transpose = i_dim < rank - 2;
-                    int adjusted_dim = offset + i_dim;
-                    int reduce_dim = adjusted_dim;
+                    int reduce_dim = i_dim;
                     if (transpose) {
-                        output_tensor = ttnn::transpose(output_tensor, adjusted_dim, -2, memory_config, pad_value);
-                        reduce_dim = 2;
+                        output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
+                        reduce_dim = rank - 2;
                     }
                     if (use_reduce_type) {
                         output_tensor = reduce_impl<reduce_type>(
@@ -109,8 +105,7 @@ static Tensor reduce_impl(
                             /*keepdim=*/true,
                             memory_config,
                             compute_kernel_config,
-                            scalar,
-                            /*reshape=*/false);
+                            scalar);
                     } else {
                         output_tensor = reduce_impl<ReduceType::Sum>(
                             output_tensor,
@@ -118,11 +113,10 @@ static Tensor reduce_impl(
                             /*keepdim=*/true,
                             memory_config,
                             compute_kernel_config,
-                            scalar,
-                            /*reshape=*/false);
+                            scalar);
                     }
                     if (transpose) {
-                        output_tensor = ttnn::transpose(output_tensor, adjusted_dim, -2, memory_config, pad_value);
+                        output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
                     }
                 }
             }
@@ -131,11 +125,11 @@ static Tensor reduce_impl(
         constexpr bool linear_type =
             reduce_type == ReduceType::Sum || reduce_type == ReduceType::Max || reduce_type == ReduceType::Min;
         if (dim.size() == 1 || linear_type) {
-            output_tensor = reduce_4d_loop(/*use_reduce_type=*/true);
+            output_tensor = reduce_nd_loop(/*use_reduce_type=*/true);
         } else if constexpr (reduce_type == ReduceType::Mean) {
-            output_tensor = reduce_4d_loop(
+            output_tensor = reduce_nd_loop(
                 /*use_reduce_type=*/false);
-            float inv_volume = 1.0f / input_tensor.get_logical_volume();
+            float inv_volume = 1.0f / input_tensor_arg.get_logical_volume();
             output_tensor = ttnn::mul_sfpu(inv_volume, output_tensor, memory_config);
         } else {
             TT_THROW("Unsupported reduction operation");
@@ -156,6 +150,10 @@ static Tensor reduce_impl(
         for (int axis : dim) {
             reduced_volume *= input_shape[axis];
         }
+
+        auto input_tensor = (rank > 4)   ? data_movement::squeeze_from_ND_to_4D(input_tensor_arg)
+                            : (rank < 4) ? ttnn::unsqueeze_to_4D(input_tensor_arg)
+                                         : input_tensor_arg;
 
         if constexpr (reduce_type == ReduceType::Sum) {
             output_tensor = tt::tt_metal::reduce(
@@ -197,10 +195,7 @@ static Tensor reduce_impl(
             TT_THROW("Unsupported reduction operation");
         }
     }
-
-    if (reshape) {
-        output_tensor = ttnn::reshape(output_tensor, ttnn::SimpleShape{output_shape});
-    }
+    output_tensor = ttnn::reshape(output_tensor, ttnn::SimpleShape{output_shape});
     return output_tensor;
 }
 
@@ -222,15 +217,14 @@ static Tensor std_var_impl(
     }
 
     auto mean_tensor = reduce_impl<ReduceType::Sum>(
-        input_tensor_arg, dim, keepdim, memory_config_arg, compute_kernel_config, 1.0 / reduced_volume, true);
+        input_tensor_arg, dim, keepdim, memory_config_arg, compute_kernel_config, 1.0 / reduced_volume);
     auto mean_square_tensor = reduce_impl<ReduceType::Sum>(
         ttnn::pow(input_tensor_arg, 2.0f, memory_config),
         dim,
         keepdim,
         memory_config_arg,
         compute_kernel_config,
-        1.0 / reduced_volume,
-        true);
+        1.0 / reduced_volume);
     Tensor output_tensor =
         ttnn::subtract(mean_square_tensor, ttnn::pow(mean_tensor, 2.0f, memory_config), std::nullopt, memory_config);
     if constexpr (reduce_type == ReduceType::Std) {
@@ -254,7 +248,7 @@ Tensor Reduce<reduce_type>::invoke(
     if constexpr (reduce_type == ReduceType::Std || reduce_type == ReduceType::Var) {
         return std_var_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config);
     }
-    return reduce_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, true);
+    return reduce_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar);
 }
 
 Tensor pool_sum(
@@ -269,8 +263,7 @@ Tensor pool_sum(
         /*keepdim=*/true,
         memory_config_arg,
         compute_kernel_config,
-        scalar,
-        /*reshape=*/true);
+        scalar);
 }
 
 template class Reduce<ReduceType::Sum>;


### PR DESCRIPTION
### Ticket
Link to Github Issue #16380

### Problem description
- generic reductions do not support tensors with rank greater than 4

### What's changed
- only change tensors to be rank 4 when calling the ops that run on the device, and outside of that leave the rank as is, allowing nD tensor support
- also tiling correction needs to be extended to 8d

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13074810420/job/36484687679 has only one error: `The self-hosted runner: tt-metal-ci-vm-96 lost communication with the server` in a job that passed in.a previous run https://github.com/tenstorrent/tt-metal/actions/runs/13073025674
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13062110967
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13062115226
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13072996613
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
