### PR TITLE
[Llama3.2-11b-vision] Add max_cross_attn_tokens property to vLLM generator class

### DIFF
--- a/models/demos/llama3/tt/generator_vllm.py
+++ b/models/demos/llama3/tt/generator_vllm.py
@@ -96,6 +96,10 @@ class TtMllamaForConditionalGeneration(LlamaGenerator, SupportsMultiModal):
     def cache_path(self):
         return self.model_args.model_cache_path
 
+    @property
+    def max_cross_attn_tokens(self):
+        return self.model_args.vision_max_num_chunks * nearest_32(self.model_args.vision_chunk_ntok)
+
     def prefill_forward(
         self,
         tokens: torch.Tensor,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/vllm/issues/53

### Problem description
- vLLM was providing cross block tables of a different shape (0 blocks) for text-only prompts, while a constant shape is required when tracing is enabled.

### What's changed
- Added the `max_cross_attn_tokens` property to the llama11b-vision vLLM generator class so it can be used in vLLM to pad cross block tables to a constant number of blocks (also relevant in the future for supporting multi-image prompts)
- This PR is required by https://github.com/tenstorrent/vllm/pull/57

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
