### PR TITLE
#17374: Add concurrency group for _produce-data.yaml

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -48,7 +48,7 @@ on:
       - completed
 
 concurrency:
-  group: produce-data
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -47,6 +47,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: produce-data
+  cancel-in-progress: false
+
 jobs:
   produce-cicd-data:
     if: |


### PR DESCRIPTION
### Ticket
[17374](https://github.com/tenstorrent/tt-metal/issues/17374)

### Problem description
Produce data jobs get spawned in parallel.
When the jobs all access GH api at once we may encounter rate limiting, causing the jobs to fail.

### What's changed
Add concurrency group so that produce data runs in FIFO manner.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
