### PR TITLE
Revert "#17374: Add concurrency group for _produce-data.yaml"

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -47,10 +47,6 @@ on:
     types:
       - completed
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
   produce-cicd-data:
     if: |


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#17402

It's cancelling because the group is based on commit hash, not workflow run
Will fix but reverting first