### PR TITLE
#13856: update gelu_bw op documentation on bfloat8_b limitations

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -312,7 +312,8 @@ void bind_binary_backward_bias_gelu(
     const std::string& parameter_b_doc,
     string parameter_b_value,
     const std::string& description,
-    const std::string& supported_dtype = "BFLOAT16") {
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string_view note = "") {
     auto doc = fmt::format(
         R"doc(
 
@@ -345,6 +346,8 @@ void bind_binary_backward_bias_gelu(
 
             bfloat8_b/bfloat4_b is only supported on TILE_LAYOUT
 
+            {9}
+
         Example:
 
             >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
@@ -361,7 +364,8 @@ void bind_binary_backward_bias_gelu(
         parameter_b_doc,
         parameter_b_value,
         description,
-        supported_dtype);
+        supported_dtype,
+        note);
 
     bind_registered_operation(
         module,
@@ -1322,7 +1326,8 @@ void py_module(py::module& module) {
         "none",
         R"doc(Performs backward operations for bias_gelu on :attr:`input_tensor_a` and :attr:`input_tensor_b` or :attr:`input_tensor` and :attr:`bias`, with given :attr:`grad_tensor` using given :attr:`approximate` mode.
         :attr:`approximate` mode can be 'none', 'tanh'.)doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16)doc",
+        R"doc(For more details about BFLOAT8_B, refer to the `BFLOAT8_B limitations <../tensor.html#limitation-of-bfloat8-b>`_.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -1376,7 +1376,9 @@ void py_module(py::module& module) {
         "Approximation type",
         "none",
         R"doc(Performs backward operations for gelu on :attr:`input_tensor`, with given :attr:`grad_tensor` using given :attr:`approximate` mode.
-        :attr:`approximate` mode can be 'none', 'tanh'.)doc");
+        :attr:`approximate` mode can be 'none', 'tanh'.)doc",
+        R"doc(BFLOAT16)doc",
+        R"doc(For more details about BFLOAT8_B, refer to the `BFLOAT8_B limitations <../tensor.html#limitation-of-bfloat8-b>`_.)doc");
 
     detail::bind_unary_backward_unary_optional_float(
         module,


### PR DESCRIPTION
### Ticket
Link to Github Issue #13856

### Problem description
Since gelu_bw ops uses `ttnn::exp` in its implementation, beyond a certain input range  the output is very a large number and will cause flushing of nearby values. `bfloat8_b` is a block format datatype with shared exponent for every 16 consecutive elements. 
Also, we do not have support to store -0.0 which again causes drop in PCC
https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/tensor.html#limitation-of-bfloat8-b
For more details: [link](https://github.com/tenstorrent/tt-metal/issues/14672#issuecomment-2553691938)

### What's changed
Updated docs on the limitations of using `bfloat8_b` dtype for the `gelu_bw` and `bias_gelu_bw` ops

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13134059505
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
