### PR TITLE
#17218: Add output_dtype support for binary_ng 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_sub_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_sub_typecast.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+import pytest
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.eltwise.test_binary_bcast import rand_bf16_gen
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype,",
+    [
+        (ttnn.bfloat16, ttnn.bfloat8_b),
+        (ttnn.bfloat16, ttnn.bfloat4_b),
+    ],
+)
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        ([1, 1, 32, 32], [1, 1, 32, 32]),
+        ([3, 1, 64, 64], [3, 1, 64, 64]),
+        ([128, 128], [128, 128]),
+        ([5, 2, 96], [5, 2, 96]),
+        ([5, 3, 128, 64], [1, 3, 128, 1]),
+        ([5, 3, 32, 32], [1, 1, 1, 32]),
+        ([5, 1, 1, 128], [5, 1, 1, 1]),
+        ([1, 71, 7, 7], [7, 7]),
+    ),
+)
+def test_sub_with_fp_dtypes(device, a_shape, b_shape, input_dtype, output_dtype):
+    # x_torch = torch.ones(a_shape, dtype=torch.bfloat16) * 16.76255246
+    # y_torch = torch.ones(b_shape, dtype=torch.bfloat16) * 4.257
+    x_torch, _ = rand_bf16_gen(a_shape, device, min=-100, max=100)
+    y_torch, _ = rand_bf16_gen(b_shape, device, min=-100, max=100)
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    z_torch = golden_fn(x_torch, y_torch)
+    # z_torch = z_torch.to(torch.int32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)  # 16.75
+    y_tt = ttnn.from_torch(y_torch, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)  # 4.25
+
+    z_tt_sub = ttnn.experimental.sub(x_tt, y_tt, dtype=output_dtype)
+    tt_out = ttnn.to_torch(z_tt_sub, dtype=torch.int32)
+
+    # print(x_tt)
+    # print(y_tt)
+    # print(f"Input dtype: {input_dtype}, Output dtype: {output_dtype}")
+    # print("z_torch:", z_torch)
+    # out = ttnn.to_torch(z_tt_sub)
+    # print("tt_out:", z_tt_sub)
+    pcc = 0.999
+    if output_dtype == ttnn.bfloat4_b:
+        pcc = 0.9
+
+    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= pcc
+    assert status
+
+
+# (ttnn.bfloat16, ttnn.bfloat8_b),  16.76255246 (16.75 in tt)  - 4.257(4.25 in tt) = tt 12.5, torch w/o typecast 12.5
+# (ttnn.bfloat16, ttnn.bfloat8_b),  -16.76255246  - 4.257 = tt -21.0, torch w/o typecast -21.0
+# (ttnn.bfloat16, ttnn.bfloat4_b), 16.76255246  - 4.257 = tt 12, torch w/o typecast 12.5
+# (ttnn.bfloat16, ttnn.bfloat4_b), -16.76255246  - 4.257 = tt -20.0, torch w/o typecast -21.0
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype,",
+    [
+        (ttnn.bfloat16, ttnn.uint16),  # only +ve output values work w typecast, -ve output values become 0s
+        # (ttnn.bfloat16, ttnn.int32),  # both +ve and -ve output values s=typecasted
+        (ttnn.bfloat16, ttnn.uint32),  # only +ve output values work w typecast, -ve output values become 0s
+    ],
+)
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        ([1, 1, 32, 32], [1, 1, 32, 32]),
+        ([3, 1, 64, 64], [3, 1, 64, 64]),
+        ([128, 128], [128, 128]),
+        ([5, 2, 96], [5, 2, 96]),
+        ([5, 3, 128, 64], [1, 3, 128, 1]),
+        ([5, 3, 32, 32], [1, 1, 1, 32]),
+        ([5, 1, 1, 128], [5, 1, 1, 1]),
+        ([1, 71, 7, 7], [7, 7]),
+    ),
+)
+def test_sub_with_uint_dtypes(device, a_shape, b_shape, input_dtype, output_dtype):
+    # x_torch = torch.ones(a_shape, dtype=torch.bfloat16) * 16.76255246
+    # y_torch = torch.ones(b_shape, dtype=torch.bfloat16) * 4.257
+    x_torch, _ = rand_bf16_gen(a_shape, device, min=50, max=100)
+    y_torch, _ = rand_bf16_gen(b_shape, device, min=10, max=30)
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    z_torch = golden_fn(x_torch, y_torch)
+    z_torch = z_torch.to(torch.int32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)  # 16.75
+    y_tt = ttnn.from_torch(y_torch, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)  # 4.25
+
+    z_tt_sub = ttnn.experimental.sub(x_tt, y_tt, dtype=output_dtype)
+    tt_out = ttnn.to_torch(z_tt_sub, dtype=torch.int32)
+
+    # print(f"Input dtype: {input_dtype}, Output dtype: {output_dtype}")
+    # print("z_torch:", z_torch)
+    # print("tt_out:", z_tt_sub)
+
+    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.99
+    assert status
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype,",
+    [
+        (ttnn.bfloat16, ttnn.int32),  # both +ve and -ve output values s=typecasted
+    ],
+)
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        ([1, 1, 32, 32], [1, 1, 32, 32]),
+        ([3, 1, 64, 64], [3, 1, 64, 64]),
+        ([128, 128], [128, 128]),
+        ([5, 2, 96], [5, 2, 96]),
+        ([5, 3, 128, 64], [1, 3, 128, 1]),
+        ([5, 3, 32, 32], [1, 1, 1, 32]),
+        ([5, 1, 1, 128], [5, 1, 1, 1]),
+        ([1, 71, 7, 7], [7, 7]),
+    ),
+)
+def test_sub_with_int_dtypes(device, a_shape, b_shape, input_dtype, output_dtype):
+    # x_torch = torch.ones(a_shape, dtype=torch.bfloat16) * 16.76255246
+    # y_torch = torch.ones(b_shape, dtype=torch.bfloat16) * 4.257
+    x_torch, _ = rand_bf16_gen(a_shape, device, min=-100, max=100)
+    y_torch, _ = rand_bf16_gen(b_shape, device, min=-90, max=90)
+    golden_fn = ttnn.get_golden_function(ttnn.experimental.sub)
+    z_torch = golden_fn(x_torch, y_torch)
+    z_torch = z_torch.to(torch.int32)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)  # 16.75
+    y_tt = ttnn.from_torch(y_torch, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)  # 4.25
+
+    z_tt_sub = ttnn.experimental.sub(x_tt, y_tt, dtype=output_dtype)
+    tt_out = ttnn.to_torch(z_tt_sub, dtype=torch.int32)
+
+    # print(f"Input dtype: {input_dtype}, Output dtype: {output_dtype}")
+    # print("z_torch:", z_torch)
+    # print("tt_out:", z_tt_sub)
+
+    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.99
+    assert status
+
+
+# (ttnn.bfloat16, ttnn.uint16) 16.76255246 (16.75 in tt)  - 4 = tt 13, torch w/o typecast 12.7500, w int typecast 12
+# (ttnn.bfloat16, ttnn.uint16) -16.76255246  - 4 = tt 0, torch w/o typecast -20.7500
+# (ttnn.bfloat16, ttnn.int32), 16.76255246  - 4 = tt 12, torch w typecast 12, w int typecast 12
+# (ttnn.bfloat16, ttnn.int32), -16.76255246  - 4 = tt -20, torch w typecast -20
+# (ttnn.bfloat16, ttnn.uint32), 16.76255246  - 4 = tt 12, torch w/o typecast 12.7500, w int typecast 12
+# (ttnn.bfloat16, ttnn.uint32), -16.76255246  - 4 = tt 0, torch w/o typecast -20.7500

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -59,23 +59,18 @@ Tensor BinaryNg<binary_op_type>::invoke(
     } else {
         Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
         Tensor input_b = typecast_to(DataType::BFLOAT16, input_tensor_b);
-        const auto output_tensor = output_preallocated and typecast_out
-                                       ? ttnn::typecast(*optional_output_tensor, DataType::BFLOAT16)
-                                       : optional_output_tensor;
 
-        Tensor result = ttnn::prim::binary_ng(
+        return ttnn::prim::binary_ng(
             queue_id,
             input_a,
             input_b,
             binary_op_type,
-            input_a.get_dtype(),
+            out_dtype,
             input_a.memory_config(),
-            output_tensor,
+            optional_output_tensor,
             lhs_activations,
             rhs_activations,
             post_activations);
-
-        return typecast_out ? ttnn::typecast(result, out_dtype, std::nullopt, optional_output_tensor) : result;
     }
 }
 
@@ -141,23 +136,18 @@ Tensor BinaryNg<binary_op_type>::invoke(
             post_activations);
     } else {
         Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
-        const auto output_tensor = output_preallocated and typecast_out
-                                       ? ttnn::typecast(*optional_output_tensor, DataType::BFLOAT16)
-                                       : optional_output_tensor;
 
-        Tensor result = ttnn::prim::binary_ng(
+        return ttnn::prim::binary_ng(
             queue_id,
             input_a,
             scalar,
             binary_op_type,
-            input_a.get_dtype(),
+            out_dtype,
             input_a.memory_config(),
-            output_tensor,
+            optional_output_tensor,
             lhs_activations,
             rhs_activations,
             post_activations);
-
-        return typecast_out ? ttnn::typecast(result, out_dtype, std::nullopt, optional_output_tensor) : result;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -394,7 +394,7 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     const auto op_config = is_sfpu_op ? OpConfig(op_type, std::in_place_type<OpConfig::SfpuBinaryOp>)
                                       : OpConfig(op_type, std::in_place_type<OpConfig::FpuBinaryOp>);
 
-    auto compute_kernel_defines = op_config.as_defines(a.get_dtype());
+    auto compute_kernel_defines = op_config.as_defines(a.get_dtype(), c.get_dtype());
 
     {
         ttnn::SmallVector<unary::UnaryWithParam> lhs_activations = operation_attributes.lhs_activations;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -271,7 +271,46 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
     }
 }
 
-std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
+std::map<std::string, std::string> output_typecast(DataType input_dtype, DataType output_dtype) {
+    std::map<std::string, std::string> type_defines;
+    if (input_dtype != output_dtype && ((input_dtype == DataType::BFLOAT16 && output_dtype == DataType::UINT16) ||
+                                        (input_dtype == DataType::BFLOAT16 && output_dtype == DataType::INT32) ||
+                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::BFLOAT16) ||
+                                        (input_dtype == DataType::INT32 && output_dtype == DataType::BFLOAT16) ||
+                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::BFLOAT16) ||
+                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::UINT16) ||
+                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::FLOAT32) ||
+                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::INT32) ||
+                                        (input_dtype == DataType::INT32 && output_dtype == DataType::FLOAT32) ||
+                                        (input_dtype == DataType::BFLOAT8_B && output_dtype == DataType::UINT16) ||
+                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::BFLOAT8_B) ||
+                                        (input_dtype == DataType::BFLOAT8_B && output_dtype == DataType::INT32) ||
+                                        (input_dtype == DataType::INT32 && output_dtype == DataType::BFLOAT8_B) ||
+                                        (input_dtype == DataType::BFLOAT16 && output_dtype == DataType::UINT32) ||
+                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::BFLOAT16) ||
+                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::UINT32) ||
+                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::FLOAT32) ||
+                                        (input_dtype == DataType::BFLOAT8_B && output_dtype == DataType::UINT32) ||
+                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::BFLOAT8_B) ||
+                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::UINT32) ||
+                                        (input_dtype == DataType::BFLOAT4_B && output_dtype == DataType::UINT32) ||
+                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::BFLOAT4_B) ||
+                                        (input_dtype == DataType::BFLOAT4_B && output_dtype == DataType::UINT16) ||
+                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::BFLOAT4_B) ||
+                                        (input_dtype == DataType::BFLOAT4_B && output_dtype == DataType::INT32) ||
+                                        (input_dtype == DataType::INT32 && output_dtype == DataType::BFLOAT4_B))) {
+        TT_ASSERT(defines.count("TYPE_CHAIN") == 0, "TYPE_CHAIN already defined");
+
+        auto in_dataformat = (uint32_t)datatype_to_dataformat_converter(input_dtype);
+        auto out_dataformat = (uint32_t)datatype_to_dataformat_converter(output_dtype);
+        type_defines["TYPE_INIT"] = "typecast_tile_init();";
+        type_defines.insert({"TYPE_OP", fmt::format("typecast_tile<{0}u, {1}u>", in_dataformat, out_dataformat)});
+        type_defines.insert({"SFPU_OP_TYPECAST_INCLUDE", "1"});
+    }
+    return type_defines;
+}
+
+std::map<std::string, std::string> OpConfig::as_defines(DataType in_dtype, DataType out_dtype) const {
     std::map<std::string, std::string> defines;
 
     if (!is_sfpu_op()) {
@@ -279,9 +318,13 @@ std::map<std::string, std::string> OpConfig::as_defines(DataType dtype) const {
         auto binary_op_str = magic_enum::enum_name(fpu_binary_op);
         defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});
         defines["BINARY_OP_TYPE"] = fmt::format("EltwiseBinaryType::ELW{}", binary_op_str);
+        auto type_def = output_typecast(in_dtype, out_dtype);
+        if (in_dtype != out_dtype) {
+            defines.insert(type_def.begin(), type_def.end());
+        }
         return defines;
     } else {
-        auto&& [tile_init, tile_fn] = get_sfpu_init_fn(std::get<SfpuBinaryOp>(binary_op), dtype);
+        auto&& [tile_init, tile_fn] = get_sfpu_init_fn(std::get<SfpuBinaryOp>(binary_op), in_dtype);
         defines["BINARY_SFPU_INIT"] = std::move(tile_init);
         defines["BINARY_SFPU_OP"] = std::move(tile_fn);
         return defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -275,31 +275,10 @@ std::map<std::string, std::string> output_typecast(DataType input_dtype, DataTyp
     std::map<std::string, std::string> type_defines;
     if (input_dtype != output_dtype && ((input_dtype == DataType::BFLOAT16 && output_dtype == DataType::UINT16) ||
                                         (input_dtype == DataType::BFLOAT16 && output_dtype == DataType::INT32) ||
-                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::BFLOAT16) ||
-                                        (input_dtype == DataType::INT32 && output_dtype == DataType::BFLOAT16) ||
-                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::BFLOAT16) ||
-                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::UINT16) ||
-                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::FLOAT32) ||
-                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::INT32) ||
-                                        (input_dtype == DataType::INT32 && output_dtype == DataType::FLOAT32) ||
-                                        (input_dtype == DataType::BFLOAT8_B && output_dtype == DataType::UINT16) ||
-                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::BFLOAT8_B) ||
-                                        (input_dtype == DataType::BFLOAT8_B && output_dtype == DataType::INT32) ||
-                                        (input_dtype == DataType::INT32 && output_dtype == DataType::BFLOAT8_B) ||
                                         (input_dtype == DataType::BFLOAT16 && output_dtype == DataType::UINT32) ||
-                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::BFLOAT16) ||
-                                        (input_dtype == DataType::FLOAT32 && output_dtype == DataType::UINT32) ||
-                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::FLOAT32) ||
-                                        (input_dtype == DataType::BFLOAT8_B && output_dtype == DataType::UINT32) ||
-                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::BFLOAT8_B) ||
-                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::UINT32) ||
-                                        (input_dtype == DataType::BFLOAT4_B && output_dtype == DataType::UINT32) ||
-                                        (input_dtype == DataType::UINT32 && output_dtype == DataType::BFLOAT4_B) ||
-                                        (input_dtype == DataType::BFLOAT4_B && output_dtype == DataType::UINT16) ||
-                                        (input_dtype == DataType::UINT16 && output_dtype == DataType::BFLOAT4_B) ||
-                                        (input_dtype == DataType::BFLOAT4_B && output_dtype == DataType::INT32) ||
-                                        (input_dtype == DataType::INT32 && output_dtype == DataType::BFLOAT4_B))) {
-        TT_ASSERT(defines.count("TYPE_CHAIN") == 0, "TYPE_CHAIN already defined");
+                                        (input_dtype == DataType::BFLOAT16 && output_dtype == DataType::BFLOAT8_B) ||
+                                        (input_dtype == DataType::BFLOAT16 && output_dtype == DataType::BFLOAT4_B))) {
+        TT_ASSERT(type_defines.count("TYPE_CHAIN") == 0, "TYPE_CHAIN already defined");
 
         auto in_dataformat = (uint32_t)datatype_to_dataformat_converter(input_dtype);
         auto out_dataformat = (uint32_t)datatype_to_dataformat_converter(output_dtype);
@@ -319,9 +298,7 @@ std::map<std::string, std::string> OpConfig::as_defines(DataType in_dtype, DataT
         defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});
         defines["BINARY_OP_TYPE"] = fmt::format("EltwiseBinaryType::ELW{}", binary_op_str);
         auto type_def = output_typecast(in_dtype, out_dtype);
-        if (in_dtype != out_dtype) {
-            defines.insert(type_def.begin(), type_def.end());
-        }
+        defines.insert(type_def.begin(), type_def.end());
         return defines;
     } else {
         auto&& [tile_init, tile_fn] = get_sfpu_init_fn(std::get<SfpuBinaryOp>(binary_op), in_dtype);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -60,7 +60,7 @@ struct OpConfig {
     template <class EnumT>
     OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>);
 
-    std::map<std::string, std::string> as_defines(DataType dtype) const;
+    std::map<std::string, std::string> as_defines(DataType in_dtype, DataType out_dtype) const;
 
     std::optional<unary::UnaryOpType> process_lhs{};
     std::optional<unary::UnaryOpType> process_rhs{};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -49,6 +49,12 @@ ALWI void process_tile(
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
         PROCESS_POST_ACTIVATIONS(0);
+#ifdef TYPE_INIT
+        TYPE_INIT
+#endif
+#ifdef TYPE_OP
+        TYPE_OP(0);
+#endif
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -47,6 +47,12 @@ void MAIN {
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
         PROCESS_POST_ACTIVATIONS(0);
+#ifdef TYPE_INIT
+        TYPE_INIT
+#endif
+#ifdef TYPE_OP
+        TYPE_OP(0);
+#endif
         tile_regs_commit();
 
         tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -46,6 +46,12 @@ void MAIN {
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
         PROCESS_POST_ACTIVATIONS(0);
+#ifdef TYPE_INIT
+        TYPE_INIT
+#endif
+#ifdef TYPE_OP
+        TYPE_OP(0);
+#endif
         tile_regs_commit();
 
         tile_regs_wait();


### PR DESCRIPTION
### Ticket
Link to Github Issue #17218 

### Problem description
`output_dtype` support for binary_ng is not provided at kernel level

### What's changed
Add typecast support at kernel-level so that we can avoid using `ttnn::typecast` explicitly on the result.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13138191266
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
