### PR TITLE
Address clang tidy error

### DIFF
--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -438,7 +438,7 @@ void DeallocateBuffer(Buffer& buffer);
 *  | program  | The program getting ownership of the buffer  | Program &                      |             | Yes      |
 */
 // clang-format on
-void AssignGlobalBufferToProgram(std::shared_ptr<Buffer> buffer, Program& program);
+void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program);
 
 // clang-format off
 // ==================================================
@@ -507,7 +507,7 @@ void SetRuntimeArgs(
     IDevice* device,
     const std::shared_ptr<Kernel>& kernel,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    std::shared_ptr<RuntimeArgs> runtime_args);
+    const std::shared_ptr<RuntimeArgs>& runtime_args);
 
 // clang-format off
 /**

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1280,7 +1280,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDevic
 
 void DeallocateBuffer(Buffer& buffer) { buffer.deallocate(); }
 
-void AssignGlobalBufferToProgram(std::shared_ptr<Buffer> buffer, Program& program) {
+void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program) {
     detail::DispatchStateCheck(not buffer->device()->using_slow_dispatch());
     program.add_buffer(buffer);
 }
@@ -1315,7 +1315,7 @@ void SetRuntimeArgs(
     IDevice* device,
     const std::shared_ptr<Kernel>& kernel,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-    std::shared_ptr<RuntimeArgs> runtime_args) {
+    const std::shared_ptr<RuntimeArgs>& runtime_args) {
     detail::DispatchStateCheck(not device->using_slow_dispatch());
     SetRuntimeArgsImpl(kernel, core_spec, std::move(runtime_args), false);
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
This slipped in to `main` and Clang-Tidy is flagging it on every run.

### What's changed
Avoided an unnecessary copy.

