### PR TITLE
#0: Modify DeviceRange semantics to match CoreRange

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -522,7 +522,7 @@ TEST_F(MeshWorkloadTest, MeshWorkloadOnActiveEth) {
                 IDevice* device = mesh_device_->get_device(logical_y, logical_x);
                 auto programs = create_random_programs(
                     1, mesh_device_->compute_with_storage_grid_size(), seed, device->get_active_ethernet_cores(true));
-                LogicalDeviceRange devices = {{logical_x, logical_y}, {logical_x + 1, logical_y + 1}};
+                LogicalDeviceRange devices = {{logical_x, logical_y}, {logical_x, logical_y}};
                 AddProgramToMeshWorkload(*workload, *programs[0], devices);
             }
         }
@@ -560,7 +560,7 @@ TEST_F(MeshWorkloadTest, MeshWorkloadMixedTensixEth) {
         for (std::size_t logical_x = 0; logical_x < mesh_device_->num_cols(); logical_x++) {
             for (std::size_t logical_y = 0; logical_y < mesh_device_->num_rows(); logical_y++) {
                 IDevice* device = mesh_device_->get_device(logical_y, logical_x);
-                LogicalDeviceRange devices = {{logical_x, logical_y}, {logical_x + 1, logical_y + 1}};
+                LogicalDeviceRange devices = {{logical_x, logical_y}, {logical_x, logical_y}};
                 if (run_on_eth) {
                     auto programs = create_random_programs(
                         1,
@@ -609,7 +609,7 @@ TEST_F(MeshWorkloadTest, MeshWorkloadOnActiveEthRandomGridSize) {
                 IDevice* device = mesh_device_->get_device(logical_y, logical_x);
                 auto programs = create_random_programs(
                     1, mesh_device_->compute_with_storage_grid_size(), seed, device->get_active_ethernet_cores(true));
-                LogicalDeviceRange devices = {{logical_x, logical_y}, {logical_x + 1, logical_y + 1}};
+                LogicalDeviceRange devices = {{logical_x, logical_y}, {logical_x, logical_y}};
                 AddProgramToMeshWorkload(*workload, *programs[0], devices);
             }
         }
@@ -645,13 +645,13 @@ TEST_F(MeshWorkloadTest, SimultaneousMeshWorkloads) {
     for (int i = 0; i < num_programs; i += 2) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
         if (i % 2) {
-            LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {4, 1});
-            LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {4, 2});
+            LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {3, 0});
+            LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {3, 1});
             AddProgramToMeshWorkload(*random_workload, *programs[i], devices_0);
             AddProgramToMeshWorkload(*random_workload, *programs[i + 1], devices_1);
         } else {
-            LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {2, 2});
-            LogicalDeviceRange devices_1 = LogicalDeviceRange({2, 0}, {4, 2});
+            LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {1, 1});
+            LogicalDeviceRange devices_1 = LogicalDeviceRange({2, 0}, {3, 1});
             AddProgramToMeshWorkload(*random_workload, *programs[i], devices_0);
             AddProgramToMeshWorkload(*random_workload, *programs[i + 1], devices_1);
         }
@@ -661,10 +661,10 @@ TEST_F(MeshWorkloadTest, SimultaneousMeshWorkloads) {
     programs = create_random_programs(num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     for (int i = 0; i < num_programs; i += 4) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
-        LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {1, 2});
-        LogicalDeviceRange devices_1 = LogicalDeviceRange({1, 0}, {2, 2});
-        LogicalDeviceRange devices_2 = LogicalDeviceRange({2, 0}, {3, 2});
-        LogicalDeviceRange devices_3 = LogicalDeviceRange({3, 0}, {4, 2});
+        LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {0, 1});
+        LogicalDeviceRange devices_1 = LogicalDeviceRange({1, 0}, {1, 1});
+        LogicalDeviceRange devices_2 = LogicalDeviceRange({2, 0}, {2, 1});
+        LogicalDeviceRange devices_3 = LogicalDeviceRange({3, 0}, {3, 1});
         AddProgramToMeshWorkload(*random_workload, *programs[i], devices_0);
         AddProgramToMeshWorkload(*random_workload, *programs[i + 1], devices_1);
         AddProgramToMeshWorkload(*random_workload, *programs[i + 2], devices_2);
@@ -675,14 +675,14 @@ TEST_F(MeshWorkloadTest, SimultaneousMeshWorkloads) {
     programs = create_random_programs(num_heterogeneous_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     for (int i = 0; i < num_heterogeneous_programs; i += 8) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
-        LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {1, 1});
-        LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {1, 2});
-        LogicalDeviceRange devices_2 = LogicalDeviceRange({1, 0}, {2, 1});
-        LogicalDeviceRange devices_3 = LogicalDeviceRange({1, 1}, {2, 2});
-        LogicalDeviceRange devices_4 = LogicalDeviceRange({2, 0}, {3, 1});
-        LogicalDeviceRange devices_5 = LogicalDeviceRange({2, 1}, {3, 2});
-        LogicalDeviceRange devices_6 = LogicalDeviceRange({3, 0}, {4, 1});
-        LogicalDeviceRange devices_7 = LogicalDeviceRange({3, 1}, {4, 2});
+        LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {0, 0});
+        LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {0, 1});
+        LogicalDeviceRange devices_2 = LogicalDeviceRange({1, 0}, {1, 0});
+        LogicalDeviceRange devices_3 = LogicalDeviceRange({1, 1}, {1, 1});
+        LogicalDeviceRange devices_4 = LogicalDeviceRange({2, 0}, {2, 0});
+        LogicalDeviceRange devices_5 = LogicalDeviceRange({2, 1}, {2, 1});
+        LogicalDeviceRange devices_6 = LogicalDeviceRange({3, 0}, {3, 0});
+        LogicalDeviceRange devices_7 = LogicalDeviceRange({3, 1}, {3, 1});
 
         AddProgramToMeshWorkload(*random_workload, *programs[i], devices_0);
         AddProgramToMeshWorkload(*random_workload, *programs[i + 1], devices_1);
@@ -726,7 +726,7 @@ TEST_F(MeshWorkloadTest, RandomizedMeshWorkload) {
     log_info(tt::LogTest, "Compile and load {} MeshWorkloads", num_programs);
     for (int i = 0; i < num_programs; i += 1) {
         // Choose a grid of random dimensions and run a MeshWorkload on it
-        LogicalDeviceRange device_range = LogicalDeviceRange({0, 0}, {gen_x(rng), gen_y(rng)});
+        LogicalDeviceRange device_range = LogicalDeviceRange({0, 0}, {gen_x(rng) - 1, gen_y(rng) - 1});
         auto random_workload = std::make_shared<MeshWorkload>();
         AddProgramToMeshWorkload(*random_workload, *programs[i], device_range);
         EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, false);
@@ -753,8 +753,8 @@ TEST_F(MeshWorkloadTest, EltwiseBinaryMeshWorkload) {
 
     auto programs = create_eltwise_bin_programs(mesh_device_, src0_bufs, src1_bufs, output_bufs);
     auto mesh_workload = CreateMeshWorkload();
-    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {4, 1});
-    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {4, 2});
+    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {3, 0});
+    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {3, 1});
     AddProgramToMeshWorkload(mesh_workload, *programs[0], devices_0);
     AddProgramToMeshWorkload(mesh_workload, *programs[1], devices_1);
     std::vector<uint32_t> src0_vec = create_constant_vector_of_bfloat16(src0_bufs[0]->size(), 2);
@@ -864,8 +864,8 @@ TEST_F(MeshWorkloadTest, MeshWorkloadSanity) {
     }
     auto program_1 = initialize_dummy_program(worker_grid_size);
     auto mesh_workload = MeshWorkload();
-    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {4, 1});
-    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {4, 2});
+    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {3, 0});
+    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {3, 1});
     AddProgramToMeshWorkload(mesh_workload, program, devices_0);
     AddProgramToMeshWorkload(mesh_workload, *program_1, devices_1);
 
@@ -930,7 +930,7 @@ TEST_F(MeshWorkloadTest, MeshWorkloadCBUpdate) {
     initialize_dummy_kernels(*program, cr_set);
 
     auto mesh_workload = CreateMeshWorkload();
-    LogicalDeviceRange devices = LogicalDeviceRange({0, 0}, {4, 2});
+    LogicalDeviceRange devices = LogicalDeviceRange({0, 0}, {3, 1});
 
     AddProgramToMeshWorkload(mesh_workload, *program, devices);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
@@ -960,7 +960,7 @@ TEST_F(MeshWorkloadTest, MeshWorkloadSemaphoreSanity) {
         expected_semaphore_values.push_back(sem);
     }
     auto mesh_workload = CreateMeshWorkload();
-    LogicalDeviceRange devices = LogicalDeviceRange({0, 0}, {4, 2});
+    LogicalDeviceRange devices = LogicalDeviceRange({0, 0}, {3, 1});
     AddProgramToMeshWorkload(mesh_workload, program, devices);
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device_->mesh_command_queue());
@@ -986,8 +986,8 @@ TEST_F(MeshWorkloadTest, MeshWorkloadSemaphoreDifferentPrograms) {
         expected_semaphore_values_1.push_back(sem + 1);
     }
     auto mesh_workload = CreateMeshWorkload();
-    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {4, 1});
-    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {4, 2});
+    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {3, 0});
+    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {3, 1});
 
     AddProgramToMeshWorkload(mesh_workload, program0, devices_0);
     AddProgramToMeshWorkload(mesh_workload, program1, devices_1);

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -127,8 +127,9 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
             mesh_workload.get_program_binary_status(mesh_device_id),
             std::pair<bool, int>(unicast_go_signals, this->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id)));
 
-        for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x; logical_x++) {
-            for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y;
+        for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x + 1;
+             logical_x++) {
+            for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y + 1;
                  logical_y++) {
                 experimental::write_program_commands(
                     this->mesh_device_->get_device(logical_y, logical_x)->command_queue(this->id_),
@@ -407,8 +408,9 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
     expected_num_workers_completed[0] = expected_num_workers_completed_;
 
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
-        for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x; logical_x++) {
-            for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y;
+        for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x + 1;
+             logical_x++) {
+            for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y + 1;
                  logical_y++) {
                 auto device_shard_view = buffer.get_device_buffer(Coordinate(logical_y, logical_x));
                 this->write_shard_to_device(
@@ -425,7 +427,7 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
 
 void MeshCommandQueue::enqueue_write_mesh_buffer(
     const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
-    LogicalDeviceRange mesh_device_extent({0, 0}, {buffer->device()->num_cols(), buffer->device()->num_rows()});
+    LogicalDeviceRange mesh_device_extent({0, 0}, {buffer->device()->num_cols() - 1, buffer->device()->num_rows() - 1});
     this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
 }
 

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -33,8 +33,8 @@ int main(int argc, char** argv) {
     // this program by enqueueing it across all devices in our 2x4 mesh.
     auto mesh_workload = CreateMeshWorkload();
     auto target_devices = LogicalDeviceRange{
-        DeviceCoord{0, 0} /* start_coord */,
-        DeviceCoord{mesh_device->num_cols(), mesh_device->num_rows()} /* end_coord */
+        DeviceCoord{0, 0} /* start_coord */, DeviceCoord{mesh_device->num_cols() - 1, mesh_device->num_rows() - 1}
+        /* end_coord */
     };
 
     AddProgramToMeshWorkload(mesh_workload, example_program, target_devices);

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -129,8 +129,8 @@ int main(int argc, char** argv) {
     // Create mesh workload and broadcast the program across all devices
     auto mesh_workload = CreateMeshWorkload();
     auto device_range = LogicalDeviceRange{
-        DeviceCoord{0, 0} /* start_coord */,
-        DeviceCoord{mesh_device->num_cols(), mesh_device->num_rows()} /* end_coord */
+        DeviceCoord{0, 0} /* start_coord */, DeviceCoord{mesh_device->num_cols() - 1, mesh_device->num_rows() - 1}
+        /* end_coord */
     };
 
     AddProgramToMeshWorkload(mesh_workload, program, device_range);


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
  - `LogicalDeviceRange` and `CoreRange` semantics are incompatible, which can confuse developers
  - `CoreRange` iterators include the user specified end in tt-metal, which is not currently true for `LogicalDeviceRange`
  - These semantics should translate to `LogicalDeviceRange`

### What's changed
Modify TT-Mesh tests and its use of `LogicalDeviceRange` to mirror `CoreRange`.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
