### PR TITLE
Step 1 of normalizing Boost as a dependency

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -13,6 +13,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
 fetch_boost_library(core)
 fetch_boost_library(smart_ptr)
 fetch_boost_library(container)
+fetch_boost_library(interprocess)
 
 add_library(span INTERFACE)
 target_link_libraries(span INTERFACE Boost::core)


### PR DESCRIPTION
### Ticket
#17441

### Problem description
Current method of fetching Boost is problematic for packaging and using system Boost.

### What's changed
Step 1 in the migration dance across TT-Metalium && TT-UMD:
* Satisfy TT-UMD's need for Boost::Interprocess

See the ticket for the rest of the song'n'dance.
