### PR TITLE
Handle case where performance report only has unary ops

### DIFF
--- a/models/perf/perf_report.py
+++ b/models/perf/perf_report.py
@@ -6,7 +6,7 @@
 import sys
 import argparse
 import re
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from collections import defaultdict
 import pandas as pd
 
@@ -294,12 +294,16 @@ def analyze_op(row, prev_row):
     else:
         op_to_op_gap = Cell(None, unit="us", decimals=0)
 
-    output_datatype = row["OUTPUT_0_DATATYPE"]
-    input_0_datatype = row["INPUT_0_DATATYPE"]
-    input_1_datatype = row["INPUT_1_DATATYPE"]
+    def get_entry(k: str) -> Union[str, None]:
+        return row[k] if k in row else None
+
+    output_datatype = get_entry("OUTPUT_0_DATATYPE")
+    input_0_datatype = get_entry("INPUT_0_DATATYPE")
+    input_1_datatype = get_entry("INPUT_1_DATATYPE")
     output_datatype_cell = Cell(output_datatype)
     input_0_datatype_cell = Cell(input_0_datatype)
     input_1_datatype_cell = Cell(input_1_datatype)
+
     short_name = lambda n: {"BFLOAT16": "BF16", "BFLOAT8_B": "BFP8", "BFLOAT4_B": "BFP4"}.get(n, n)
 
     if "Matmul" in op_code.raw_value:


### PR DESCRIPTION
### Summary

This small change fixes a crash inside `perf_report.py` that occurs if you use a CSV perf sheet with only unary ops in it.

For example, running the tool with a CSV that contains a single call to `ttnn.reshard`:

```sh
python models/perf/perf_report.py /localdev/esmal/tt-metal/generated/profiler/reports/2025_01_31_19_51_21/ops_perf_results_2025_01_31_19_51_21.csv
Sorting CSV by 'HOST START TS' column...
No signposts found in the file. Using the entire file for analysis.
Traceback (most recent call last):
  File "/localdev/esmal/tt-metal/python_env/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3653, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 147, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 176, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7080, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7088, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'INPUT_1_DATATYPE'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "models/perf/perf_report.py", line 847, in <module>
    main(args.csv_file, args.signpost, args.ignore_signposts, args.min_percentage, id_range, args.csv, args.no_advice)
  File "models/perf/perf_report.py", line 755, in main
    op_data, current_gap = analyze_op(row, prev_row)
  File "models/perf/perf_report.py", line 299, in analyze_op
    input_1_datatype = row["INPUT_1_DATATYPE"]
  File "/localdev/esmal/tt-metal/python_env/lib/python3.8/site-packages/pandas/core/series.py", line 1007, in __getitem__
    return self._get_value(key)
  File "/localdev/esmal/tt-metal/python_env/lib/python3.8/site-packages/pandas/core/series.py", line 1116, in _get_value
    loc = self.index.get_loc(label)
  File "/localdev/esmal/tt-metal/python_env/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3655, in get_loc
    raise KeyError(key) from err
KeyError: 'INPUT_1_DATATYPE'
```

This change resolves this crash:

```sh
python models/perf/perf_report.py /localdev/esmal/tt-metal/generated/profiler/reports/2025_01_31_19_51_21/ops_perf_results_2025_01_31_19_51_21.csv
Sorting CSV by 'HOST START TS' column...
No signposts found in the file. Using the entire file for analysis.

__ Performance Report __
========================

ID  Total %  Bound  OP Code                 Device Time  Op-to-Op Gap  Cores  DRAM  DRAM %  FLOPs  FLOPs %  Math Fidelity
-------------------------------------------------------------------------------------------------------------------------
 2  100.0 %         ReshardDeviceOperation       262 us                   64                                 BF16 => BF16
-------------------------------------------------------------------------------------------------------------------------
    100.0 %         1 device ops, 0 host ops       262 us          0 us

__ Advice __
============
```