### PR TITLE
#0: fix bug in createqkv

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -359,7 +359,9 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
             process_qv,                        // read and write q and v heads
             process_k,                         // read and write k heads
             batch_offset.has_value() ? 1 : 0,  // use_batch_offset
-            batch_offset->buffer()->buffer_type() == tt_metal::BufferType::DRAM ? (uint32_t)1 : (uint32_t)0,
+            batch_offset.has_value() && batch_offset->buffer()->buffer_type() == tt_metal::BufferType::DRAM
+                ? (uint32_t)1
+                : (uint32_t)0,
             batch_offset_index_stick_size,
             batch_offset_cb_index_reader};
         auto q_reader_kernel_id = tt_metal::CreateKernel(


### PR DESCRIPTION
### Desciption
This fixes the failure for `llama3/test/test_llama_attention.py` in CI introduced by following [PR](https://github.com/tenstorrent/tt-metal/pull/16416) for slicing support in `ttnn.nlp_create_QKV_heads_decode` when one of the optional tensor argument buffer is read even though its value doesn't exist.

### Error
https://github.com/tenstorrent/tt-metal/actions/runs/13076612535/job/36490477945
```
ttnn::tensor::buffer(): Expected Tensor with DeviceStorage, got StorageType::OWNED
backtrace:
 --- void tt::assert::tt_throw_impl<fmt::v11::basic_format_string<char, tt::tt_metal::StorageType const&>, tt::tt_metal::StorageType>(char const*, int, char const*, char const*, fmt::v11::basic_format_string<char, tt::tt_metal::StorageType const&> const&, tt::tt_metal::StorageType const&)
 --- /home/ubuntu/actions-runner/_work/tt-metal/tt-metal/ttnn/ttnn/_ttnn.so(+0x5123de) [0x7f21d2be33de]
 --- ttnn::operations::experimental::transformer::multi_core_nlp_create_qkv_heads_decode_sharded_input(tt::tt_metal::Tensor const&, unsigned int, unsigned int, unsigned int, bool, std::__1::optional<tt::tt_metal::Tensor const> const&, std::__1::optional<unsigned int const>, std::__1::vector<tt::tt_metal::Tensor, std::__1::allocator<tt::tt_metal::Tensor>>&, tt::umd::xy_pair)
```