### PR TITLE
Replace ListMeshToTensor with utility method

### DIFF
--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -196,7 +196,7 @@ def run_test_FalconModel_inference(
                 use_cache=use_cache,
             )
             # output of model is replicated
-            tensors = ttnn.shardedtensor_to_tensorlist(tt_out)
+            tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(tt_out)
             tt_outs.append(tensors[0].squeeze(1))
 
         tt_out = torch.vstack(tt_outs)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -196,7 +196,7 @@ def run_test_FalconModel_inference(
                 use_cache=use_cache,
             )
             # output of model is replicated
-            tensors = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ListMeshToTensor(mesh_device))
+            tensors = ttnn.shardedtensor_to_tensorlist(tt_out)
             tt_outs.append(tensors[0].squeeze(1))
 
         tt_out = torch.vstack(tt_outs)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -213,7 +213,7 @@ def run_test_FalconModel_inference(
             use_cache=use_cache,
         )
         # Output of model is replicated
-        tensors = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ListMeshToTensor(mesh_device))
+        tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(tt_out)
         tt_out = tensors[0].squeeze(1).transpose(0, 1)
 
     # check outputs ----------------------------------------------------------------------

--- a/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
@@ -6,7 +6,7 @@ from loguru import logger
 import torch
 from torch import nn
 import ttnn
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 
 import scipy

--- a/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
@@ -337,7 +337,7 @@ def run_test_LlamaAttention_inference(
             attn_mask,
             mode=mode,
         )
-        # tt_out = ttnn.shardedtensor_to_tensorlist(tt_out)
+        # tt_out = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(tt_out)
 
         tt_out = ttnn.to_torch(
             tt_out, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(3, 1), cluster_shape=cluster_shape)

--- a/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
@@ -337,7 +337,7 @@ def run_test_LlamaAttention_inference(
             attn_mask,
             mode=mode,
         )
-        # tt_out = ttnn.to_torch(tt_out, mesh_composer=ListMeshToTensor(mesh_device))[0]
+        # tt_out = ttnn.shardedtensor_to_tensorlist(tt_out)
 
         tt_out = ttnn.to_torch(
             tt_out, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(3, 1), cluster_shape=cluster_shape)

--- a/tests/ttnn/distributed/test_multidevice_TG.py
+++ b/tests/ttnn/distributed/test_multidevice_TG.py
@@ -16,7 +16,6 @@ from ttnn import (
     ReplicateTensorToMesh,
     ConcatMeshToTensor,
     ConcatMesh2dToTensor,
-    ListMeshToTensor,
     MeshToTensor,
 )
 from models.utility_functions import nearest_32
@@ -384,7 +383,7 @@ def test_galaxy_eltwise_add(M, N, mesh_device):
         memory_config=LN_OUTPUT_MEMCFG,
     )
 
-    out = ttnn.to_torch(out, mesh_composer=ListMeshToTensor(mesh_device))[0]
+    out = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(out)[0]
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99999)
     logger.info(f"PCC value: {out_pcc}")
@@ -564,19 +563,15 @@ def test_galaxy_nlp_create_heads_decode(
     )
 
     # compare
-    q_heads_tt_cpu = ttnn.to_torch(q_heads_tt, mesh_composer=ListMeshToTensor(mesh_device))[0][..., :n_local_heads, :]
+    q_heads_tt_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(q_heads_tt)[0][..., :n_local_heads, :]
     out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_q}")
 
-    k_heads_tt_cpu = ttnn.to_torch(k_heads_tt, mesh_composer=ListMeshToTensor(mesh_device))[0][
-        ..., :n_local_kv_heads, :
-    ]
+    k_heads_tt_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(k_heads_tt)[0][..., :n_local_kv_heads, :]
     out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_k}")
 
-    v_heads_tt_cpu = ttnn.to_torch(v_heads_tt, mesh_composer=ListMeshToTensor(mesh_device))[0][
-        ..., :n_local_kv_heads, :
-    ]
+    v_heads_tt_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(v_heads_tt)[0][..., :n_local_kv_heads, :]
     out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_v}")
 
@@ -690,8 +685,8 @@ def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_k
     query_layer_gt = q_heads_pt @ rot_mat_pt
     key_layer_gt = k_heads_pt @ rot_mat_pt
 
-    query_layer_cpu = ttnn.to_torch(query_layer, mesh_composer=ListMeshToTensor(mesh_device))[0]
-    key_layer_cpu = ttnn.to_torch(key_layer, mesh_composer=ListMeshToTensor(mesh_device))[0]
+    query_layer_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(query_layer)[0]
+    key_layer_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(key_layer)[0]
 
     out_pass_q, out_pcc_q = comp_pcc(query_layer_cpu, query_layer_gt, pcc=0.999)
     logger.info(f"PCC value: {out_pcc_q}")
@@ -758,7 +753,7 @@ class TestUpdateCache:
             cachett = ttnn.fill_cache(cachett, xt, i)
             cache[i : i + 1, :, : x.shape[-2], :] = x
 
-        tt_got_back = ttnn.to_torch(cachett, mesh_composer=ListMeshToTensor(mesh_device))[0]
+        tt_got_back = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(cachett)[0]
         eq, output = comp_pcc(cache, tt_got_back)
         logger.info(output)
         assert eq
@@ -833,7 +828,7 @@ class TestUpdateCache:
         cachett = ttnn.update_cache(cachett, xt, cache_idx, batch_offset=batch_offset)
         cache[0:num_users, 0:num_heads, cache_idx : cache_idx + x.shape[-2], 0 : x.shape[-1]] = x
 
-        tt_got_back = ttnn.to_torch(cachett, mesh_composer=ListMeshToTensor(mesh_device))[0]
+        tt_got_back = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(cachett)[0]
 
         eq_cache, output_cache = comp_pcc(cache, tt_got_back)  # checks the entire kv cache
         eq_update, output_update = comp_pcc(
@@ -978,7 +973,7 @@ def run_test_sdpa_decode_single_iter(
         memory_config=height_sharded_memcfg if sharded_out else dram_memcfg,
     )
 
-    tt_back = ttnn.to_torch(tt_back, mesh_composer=ListMeshToTensor(mesh_device))[0]
+    tt_back = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(tt_back)[0]
     tt_back = tt_back[:, :, :nh, :]
 
     Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, d
@@ -1078,7 +1073,7 @@ def test_galaxy_nlp_concat_heads_decode(
     concat_head_output_pt = concat_head_input[:, :, :n_local_heads].reshape(1, 1, batch, head_dim * n_local_heads)
 
     # Compare
-    concat_head_output_tt_cpu = ttnn.to_torch(concat_head_output, mesh_composer=ListMeshToTensor(mesh_device))[0]
+    concat_head_output_tt_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(concat_head_output)[0]
     concat_head_output_tt_unpadded = concat_head_output_tt_cpu[:, :, :batch, :]
     out_pass, output_pcc = comp_pcc(concat_head_output_tt_unpadded, concat_head_output_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc}")
@@ -1172,7 +1167,7 @@ def test_galaxy_layernorm(M, N, mesh_device):
 
     # Compare
     beta = torch.zeros(1, 1, N // 32, 32)
-    norm_output_tt_cpu = ttnn.to_torch(norm_output, mesh_composer=ListMeshToTensor(mesh_device))[0]
+    norm_output_tt_cpu = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(norm_output)[0]
     ref_rmsnorm = rmsnorm(layernorm_input, norm_weights.flatten(), beta.flatten(), norm_eps)
 
     out_pass, output_pcc = comp_pcc(norm_output_tt_cpu, ref_rmsnorm, pcc=0.999)
@@ -1420,7 +1415,7 @@ def test_line_all_gather_column_major(mesh_device):
     ttnn_tensor = ttnn.all_gather(
         ttnn_tensor, dim=3, cluster_axis=0, mesh_device=mesh_device, num_links=1, topology=ttnn.Topology.Linear
     )
-    tt_outputs = ttnn.to_torch(ttnn_tensor, mesh_composer=ListMeshToTensor(mesh_device))
+    tt_outputs = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(ttnn_tensor)
     for output in tt_outputs[1:]:
         assert output.shape == (1, 1, 32, 32 * 8)
         assert torch.allclose(output, tt_outputs[0])

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -258,7 +258,7 @@ def test_full_multi_device(mesh_device, input_shape, fill_value, layout):
 
     tensor = ttnn.full(input_shape, device=mesh_device, fill_value=fill_value, layout=layout)
     assert ttnn.is_tensor_storage_on_device(tensor)
-    output_tensors = ttnn.shardedtensor_to_tensorlist(tensor)
+    output_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(tensor)
     for output_tensor in output_tensors:
         assert_with_pcc(torch_tensor, output_tensor, 0.9999)
         assert torch.allclose(torch_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -321,7 +321,7 @@ def test_arange_multi_device(mesh_device, start, end, step):
     )
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
-    output_tensors = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ListMeshToTensor(mesh_device))
+    output_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(output_tensor)
     for output_tensor in output_tensors:
         output_tensor = output_tensor[-1, -1, -1, :]
         if divup((end - start), step) % 2 != 0:
@@ -368,7 +368,7 @@ def test_empty_multi_device(mesh_device, input_shapes):
     output_tensor = ttnn.empty(input_shapes, ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device, ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
-    output_tensors = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ListMeshToTensor(mesh_device))
+    output_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(output_tensor)
     for output_tensor in output_tensors:
         assert list(torch_output_tensor.shape) == list(output_tensor.shape)
 
@@ -416,6 +416,6 @@ def test_empty_like_multi_device(mesh_device, input_shapes):
     output_tensor = ttnn.empty_like(input_tensor, layout=ttnn.TILE_LAYOUT)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
-    output_tensors = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ListMeshToTensor(mesh_device))
+    output_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(output_tensor)
     for output_tensor in output_tensors:
         assert list(torch_input_tensor.shape) == list(output_tensor.shape)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -258,8 +258,7 @@ def test_full_multi_device(mesh_device, input_shape, fill_value, layout):
 
     tensor = ttnn.full(input_shape, device=mesh_device, fill_value=fill_value, layout=layout)
     assert ttnn.is_tensor_storage_on_device(tensor)
-    output_tensors = ttnn.to_torch(tensor, mesh_composer=ttnn.ListMeshToTensor(mesh_device))
-
+    output_tensors = ttnn.shardedtensor_to_tensorlist(tensor)
     for output_tensor in output_tensors:
         assert_with_pcc(torch_tensor, output_tensor, 0.9999)
         assert torch.allclose(torch_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
@@ -77,7 +77,9 @@ def test_tensor_preallocation_and_write_apis(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         ttnn.copy_host_to_device_tensor(tt_input_tensor_a, preallocated_tensor)
-        readback_tensors = ttnn.shardedtensor_to_tensorlist(preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+        readback_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(
+            preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
+        )
         for readback_tensor in readback_tensors:
             allclose, output = comp_pcc(readback_tensor, input_tensor_a)
             assert allclose, f"FAILED: {output}"

--- a/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
@@ -77,10 +77,7 @@ def test_tensor_preallocation_and_write_apis(
             mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         ttnn.copy_host_to_device_tensor(tt_input_tensor_a, preallocated_tensor)
-        readback_tensors = ttnn.to_torch(
-            preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT),
-            mesh_composer=ttnn.ListMeshToTensor(mesh_device),
-        )
+        readback_tensors = ttnn.shardedtensor_to_tensorlist(preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
         for readback_tensor in readback_tensors:
             allclose, output = comp_pcc(readback_tensor, input_tensor_a)
             assert allclose, f"FAILED: {output}"

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -11,7 +11,7 @@ from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 
 #######
@@ -183,7 +183,7 @@ def test_multi_device_check_per_device_shard(mesh_device, layout, memory_config,
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 def test_multi_device_replicate(mesh_device, shape, layout, memory_config):
     """Test ReplicateTensorToMesh to broadcast a tensor across multiple devices"""
-    from ttnn import ReplicateTensorToMesh, ListMeshToTensor
+    from ttnn import ReplicateTensorToMesh
 
     full_tensor = torch.rand(shape, dtype=torch.bfloat16)
 
@@ -196,7 +196,7 @@ def test_multi_device_replicate(mesh_device, shape, layout, memory_config):
     )
     ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
     ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-    loopback_replicated_tensors = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(mesh_device))
+    loopback_replicated_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(ttnn_loop_back_tensor)
     for loopback_replicated_tensor in loopback_replicated_tensors:
         assert torch.all(full_tensor == loopback_replicated_tensor)
 

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -100,7 +100,7 @@ def test_multi_device_replicate(pcie_mesh_device, shape, layout, memory_config):
         )
         ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_mesh_device)
         ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-        loopback_replicated_tensors = ttnn.shardedtensor_to_tensorlist(ttnn_loop_back_tensor)
+        loopback_replicated_tensors = ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(ttnn_loop_back_tensor)
         for loopback_replicated_tensor in loopback_replicated_tensors:
             assert torch.all(full_tensor == loopback_replicated_tensor)
 

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -84,7 +84,7 @@ def test_multi_device_check_per_device_shard(pcie_mesh_device, layout, memory_co
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 def test_multi_device_replicate(pcie_mesh_device, shape, layout, memory_config):
     """Test ReplicateTensorToMesh to broadcast a tensor across multiple devices"""
-    from ttnn import ReplicateTensorToMesh, ListMeshToTensor
+    from ttnn import ReplicateTensorToMesh
 
     pcie_mesh_device.enable_async(True)
 
@@ -100,9 +100,7 @@ def test_multi_device_replicate(pcie_mesh_device, shape, layout, memory_config):
         )
         ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_mesh_device)
         ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-        loopback_replicated_tensors = ttnn.to_torch(
-            ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(pcie_mesh_device)
-        )
+        loopback_replicated_tensors = ttnn.shardedtensor_to_tensorlist(ttnn_loop_back_tensor)
         for loopback_replicated_tensor in loopback_replicated_tensors:
             assert torch.all(full_tensor == loopback_replicated_tensor)
 

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -10,7 +10,7 @@ import tempfile
 from loguru import logger
 import os
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512)])

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -10,7 +10,7 @@ import tempfile
 from loguru import logger
 import os
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 

--- a/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
@@ -10,7 +10,7 @@ import tempfile
 from loguru import logger
 import os
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -10,7 +10,7 @@ import tempfile
 from loguru import logger
 import os
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -7,9 +7,12 @@
 #include <utility>
 
 #include "tt-metalium/assert.hpp"
+<<<<<<< HEAD
 #include "tt-metalium/bfloat16.hpp"
 #include "tt-metalium/core_coord.hpp"
 #include "tt-metalium/overloaded.hpp"
+=======
+>>>>>>> change assert to tt_throw to satisfy compiler
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -27,6 +30,26 @@ namespace ttnn::distributed {
 
 namespace py = pybind11;
 
+<<<<<<< HEAD
+=======
+py::object get_torch_type(DataType& dtype, const py::object& torch) {
+    if (dtype == DataType::UINT8) {
+        return torch.attr("uint8");
+    } else if (dtype == DataType::UINT16) {
+        return torch.attr("int16");
+    } else if (dtype == DataType::INT32) {
+        return torch.attr("int32");
+    } else if (dtype == DataType::UINT32) {
+        return torch.attr("int32");
+    } else if (dtype == DataType::FLOAT32) {
+        return torch.attr("float32");
+    } else if (dtype == DataType::BFLOAT16) {
+        return torch.attr("bfloat16");
+    }
+    TT_THROW("Unsupported DataType: {}", dtype);
+}
+
+>>>>>>> change assert to tt_throw to satisfy compiler
 // duplicated from pytensor.cpp
 template <typename T>
 owned_buffer::Buffer<T> create_row_major_owned_buffer(

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -12,11 +12,14 @@
 #include "tt-metalium/bfloat16.hpp"
 #include "tt-metalium/core_coord.hpp"
 #include "tt-metalium/overloaded.hpp"
+<<<<<<< HEAD
 =======
 >>>>>>> change assert to tt_throw to satisfy compiler
 =======
 #include "tt-metalium/core_coord.hpp"
 >>>>>>> add get_mesh_device_core_grid
+=======
+>>>>>>> fix module names and variant unpacking
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -34,6 +37,7 @@ namespace ttnn::distributed {
 
 namespace py = pybind11;
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 py::object get_torch_type(DataType& dtype, const py::object& torch) {
@@ -54,6 +58,8 @@ py::object get_torch_type(DataType& dtype, const py::object& torch) {
 }
 
 >>>>>>> change assert to tt_throw to satisfy compiler
+=======
+>>>>>>> fix module names and variant unpacking
 // duplicated from pytensor.cpp
 template <typename T>
 owned_buffer::Buffer<T> create_row_major_owned_buffer(
@@ -123,6 +129,7 @@ OwnedBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool lega
                                       uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile)
                                 : unpack_bfp4_tiles_into_float_vec(
                                       uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+<<<<<<< HEAD
                         std::vector<bfloat16> bfloat16_unpacked_data;
                         bfloat16_unpacked_data.reserve(float_unpacked_data.size());
                         std::transform(
@@ -133,6 +140,10 @@ OwnedBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool lega
                         auto input_bfloat16_buffer = owned_buffer::create<bfloat16>(std::move(bfloat16_unpacked_data));
                         return create_row_major_owned_buffer(
                             std::move(input_bfloat16_buffer), tensor_spec, legacy_output);
+=======
+                        auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+                        return create_row_major_owned_buffer(std::move(input_float_buffer), tensor_spec, legacy_output);
+>>>>>>> fix module names and variant unpacking
                     }
                     default: {
                         TT_THROW("Unsupported DataType: {}", tt_dtype);
@@ -162,10 +173,13 @@ py::object get_torch_type(DataType& dtype, const py::object& torch) {
         return torch.attr("float32");
     } else if (dtype == DataType::BFLOAT16) {
         return torch.attr("bfloat16");
+<<<<<<< HEAD
     } else if (dtype == DataType::BFLOAT4_B) {
         return torch.attr("bfloat16");
     } else if (dtype == DataType::BFLOAT8_B) {
         return torch.attr("bfloat16");
+=======
+>>>>>>> fix module names and variant unpacking
     }
     TT_THROW("Unsupported DataType: {}", dtype);
 }
@@ -397,13 +411,6 @@ void py_module(py::module& module) {
             )doc")
         .def("__repr__", &MeshDevice::to_string)
         .def(
-            "get_mesh_device_core_grid",
-            [](MeshDevice& mesh_device) {
-                CoreCoord coords = mesh_device.compute_with_storage_grid_size();
-                new CoreGrid(coords.x, coords.y);
-            },
-            py::arg("mesh_device"))
-        .def(
             "create_sub_device_manager",
             [](MeshDevice& self, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {
                 return self.mesh_create_sub_device_manager(sub_devices, local_l1_size);
@@ -563,6 +570,7 @@ void py_module(py::module& module) {
             return tensorlist_local;
         },
         py::arg("tensor"),
+<<<<<<< HEAD
         py::kw_only(),
         R"doc(
             Convert a sharded multidevice tensor into a locally stored (StorageType::OWNED) list of tensors,
@@ -572,6 +580,9 @@ void py_module(py::module& module) {
             Returns:
                 List[torch.tensor]: A list of locally stored tensors representing the multidevice shards.
         )doc");
+=======
+        py::kw_only());
+>>>>>>> fix module names and variant unpacking
     module.def("get_t3k_physical_device_ids_ring", &get_t3k_physical_device_ids_ring);
 }
 

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/pytypes.h>
 #include <utility>
 
+#include "tt-metalium/assert.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
@@ -35,9 +36,8 @@ py::object get_torch_type(DataType& dtype, const py::object& torch) {
         return torch.attr("float32");
     } else if (dtype == DataType::BFLOAT16) {
         return torch.attr("bfloat16");
-    } else {
-        static_assert("Unsupported buffer!");
     }
+    TT_THROW("Unsupported DataType: {}", dtype);
 }
 
 // duplicated from pytensor.cpp

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
@@ -347,6 +348,13 @@ void py_module(py::module& module) {
                     2. For Grid-to-Grid or Line-to-Grid reshaping: physical connectivity must be possible with current devices
             )doc")
         .def("__repr__", &MeshDevice::to_string)
+        .def(
+            "get_mesh_device_core_grid",
+            [](MeshDevice& mesh_device) {
+                CoreCoord coords = mesh_device.compute_with_storage_grid_size();
+                new CoreGrid(coords.x, coords.y);
+            },
+            py::arg("mesh_device"))
         .def(
             "create_sub_device_manager",
             [](MeshDevice& self, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -8,11 +8,15 @@
 
 #include "tt-metalium/assert.hpp"
 <<<<<<< HEAD
+<<<<<<< HEAD
 #include "tt-metalium/bfloat16.hpp"
 #include "tt-metalium/core_coord.hpp"
 #include "tt-metalium/overloaded.hpp"
 =======
 >>>>>>> change assert to tt_throw to satisfy compiler
+=======
+#include "tt-metalium/core_coord.hpp"
+>>>>>>> add get_mesh_device_core_grid
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -392,6 +396,13 @@ void py_module(py::module& module) {
                     2. For Grid-to-Grid or Line-to-Grid reshaping: physical connectivity must be possible with current devices
             )doc")
         .def("__repr__", &MeshDevice::to_string)
+        .def(
+            "get_mesh_device_core_grid",
+            [](MeshDevice& mesh_device) {
+                CoreCoord coords = mesh_device.compute_with_storage_grid_size();
+                new CoreGrid(coords.x, coords.y);
+            },
+            py::arg("mesh_device"))
         .def(
             "create_sub_device_manager",
             [](MeshDevice& self, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 #include "pybind11/pybind_fwd.hpp"
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 

--- a/ttnn/ttnn/distributed/__init__.py
+++ b/ttnn/ttnn/distributed/__init__.py
@@ -19,7 +19,6 @@ from .distributed import (
     ReplicateTensorToMesh,
     MeshToTensor,
     ConcatMeshToTensor,
-    ListMeshToTensor,
     visualize_mesh_device,
     ConcatMesh2dToTensor,
     distribute,

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -442,18 +442,6 @@ class ConcatMeshToTensor(MeshToTensor):
         return torch.cat(device_shards_converted_to_torch, dim=self.concat_dim)
 
 
-# TODO: #15061 - Remove this function, as it does not abide to the MeshToTensor interface.
-# Instead, lift this implementation to the caller.
-class ListMeshToTensor(MeshToTensor):
-    def __init__(self, mesh_device: MeshDevice):
-        self.mesh_device = mesh_device
-
-    def compose(self, tensor: ttnn.Tensor) -> List["torch.Tensor"]:
-        return [
-            ttnn.to_torch(tt_input_tensor, mesh_composer=None) for tt_input_tensor in ttnn.get_device_tensors(tensor)
-        ]
-
-
 @contextlib.contextmanager
 def distribute(default: Union[TensorToMesh, MeshToTensor]):
     """


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/15061)

### Problem description
ListMeshToTensor was a python class in distributed.py that didn't match the Xtensor->torch.tensor convention and instead output a list[torch.tensor]. I've created the utility method ttnn._ttnn.multi_device.shardedtensor_to_tensorlist(ttnn.tensor)->list[torch.tensor] instead.

### What's changed
Utility method shardedtensor_to_tensorlist was created by porting to_torch conversion fucntions over from pytensor.cpp. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes: [tests/ttnn/unit_tests/test_multi_device_async.py](https://github.com/tenstorrent/tt-metal/blob/8063f0ab02bec18561f9461e8d1ff868ba0eeaf0/tests/ttnn/unit_tests/test_multi_device_async.py#L87), [tests/ttnn/unit_tests/operations/test_creation.py](https://github.com/tenstorrent/tt-metal/blob/8063f0ab02bec18561f9461e8d1ff868ba0eeaf0/tests/ttnn/unit_tests/operations/test_creation.py#L261), [tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py](https://github.com/tenstorrent/tt-metal/blob/8063f0ab02bec18561f9461e8d1ff868ba0eeaf0/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py#L82), [tests/ttnn/distributed/test_multidevice_TG.py](https://github.com/tenstorrent/tt-metal/blob/8063f0ab02bec18561f9461e8d1ff868ba0eeaf0/tests/ttnn/distributed/test_multidevice_TG.py#L19), [models/demos/t3000/falcon40b/tests/test_falcon_model.py](https://github.com/tenstorrent/tt-metal/blob/8063f0ab02bec18561f9461e8d1ff868ba0eeaf0/models/demos/t3000/falcon40b/tests/test_falcon_model.py#L9)
