### PR TITLE
0: Fix Packed unicast size

### DIFF
--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -804,7 +804,7 @@ void insert_write_packed_payloads(
             tt::align(sizeof(CQDispatchCmd) + num_sub_cmds_in_cmd * sizeof(PackedSubCmd), l1_alignment);
         packed_cmd_payloads.emplace_back(num_sub_cmds_in_cmd, dispatch_cmd_sizeB + aligned_data_sizeB);
         rem_num_sub_cmds -= num_sub_cmds_in_cmd;
-        calculator.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
+        calculator.add_dispatch_write_packed<PackedSubCmd>(
             num_sub_cmds_in_cmd, sub_cmd_sizeB, packed_write_max_unicast_sub_cmds);
     }
 }


### PR DESCRIPTION
### Problem description
We're seeing a crash on MeshWorkloadTest.MeshWorkloadOnActiveEth

### What's changed
We were always calculating the size with multicast subcommands, which is incorrect. Use the appropriate subcommand type instead.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
