### PR TITLE
Always flatten convolution input tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -562,8 +562,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     // check is for 16-byte alignment
     TT_FATAL(
         input_channels_padded % 16 == 0,
-        "Expected input channels to be padded for 16 byte alignment in L1");  // TODO: For bfp16, check if its divisible
-                                                                              // by 8 not 16.
+        "Expected input channels to be padded for 16 byte alignment in L1 ({} % 16 != 0)",
+        input_channels_padded);  // TODO: For bfp16, check if its divisible by 8 not 16.
     // Always use split reader for first conv in resnet which has input channels = 16
     // TODO: Expose option to split readers for 1D convs to python?
     // bool split_reader = use_shallow_conv_variant;


### PR DESCRIPTION
### Ticket
#17247

### Problem description
The following test was failing when TT_ASSERT was converted to TT_FATAL:

```sh
pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_xlarge_new.py::test_resnet_50[batch_size=1-act_dtype=DataType.BFLOAT8_B-weight_dtype=DataType.BFLOAT8_B-math_fidelity=MathFidelity.LoFi-device_params={'l1_small_size': 24576}]
```

This error was triggering when creating the halo output tensor, due to an assumption that the input tensor was flattened. 

### What's changed
The input tensor to halo was not flattened by the convolution op (as expected by the halo op) due to an edge case where the input tensor was already sharded and did not need to be re-sharded, but was not flattened.

I have updated the convolution code to ALWAYS flatten, since downstream code assumes this to be the case.

### Checklist
- [x] Post commit (TT_FATAL): https://github.com/tenstorrent/tt-metal/actions/runs/13084004490
- [x] Model regression CI testing passes (TT_FATAL): https://github.com/tenstorrent/tt-metal/actions/runs/13084014280
- [ ] Post commit (TT_ASSERT): https://github.com/tenstorrent/tt-metal/actions/runs/13118049783
- [ ] Model regression CI testing passes (TT_ASSERT):  https://github.com/tenstorrent/tt-metal/actions/runs/13118060514
- [x] Device performance regression: https://github.com/tenstorrent/tt-metal/actions/runs/13116052842
