### PR TITLE
#17201: Implement IDevice tracing APIs for MeshDevice

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -545,20 +545,24 @@ CommandQueue& MeshDevice::command_queue(size_t cq_id) {
 
 // Trace management
 void MeshDevice::begin_trace(const uint8_t cq_id, const uint32_t tid) {
-    TT_THROW("begin_trace() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->begin_trace(cq_id, tid);
+    for (auto& device : scoped_devices_->get_devices()) {
+        device->begin_trace(cq_id, tid);
+    }
 }
 void MeshDevice::end_trace(const uint8_t cq_id, const uint32_t tid) {
-    TT_THROW("end_trace() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->end_trace(cq_id, tid);
+    for (auto& device : scoped_devices_->get_devices()) {
+        device->end_trace(cq_id, tid);
+    }
 }
 void MeshDevice::replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) {
-    TT_THROW("replay_trace() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->replay_trace(cq_id, tid, blocking);
+    for (auto& device : scoped_devices_->get_devices()) {
+        device->replay_trace(cq_id, tid, blocking);
+    }
 }
 void MeshDevice::release_trace(const uint32_t tid) {
-    TT_THROW("release_trace() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->release_trace(tid);
+    for (auto& device : scoped_devices_->get_devices()) {
+        device->release_trace(tid);
+    }
 }
 std::shared_ptr<TraceBuffer> MeshDevice::get_trace(uint32_t tid) {
     TT_THROW("get_trace() is not supported on MeshDevice - use individual devices instead");

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1402,42 +1402,54 @@ bool Device::using_fast_dispatch() const {
 }
 
 void Device::begin_trace(const uint8_t cq_id, const uint32_t tid) {
-    ZoneScoped;
-    TracyTTMetalBeginTrace(this->id(), tid);
-    TT_FATAL(
-        !this->command_queues_[cq_id]->tid().has_value(),
-        "CQ {} is already being used for tracing tid {}",
-        (uint32_t)cq_id,
-        tid);
-    this->mark_allocations_safe();
-    // Create an empty trace buffer here. This will get initialized in end_trace
-    auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
-    TT_FATAL(
-        active_sub_device_manager->get_trace(tid) == nullptr,
-        "Trace already exists for tid {} on device {}'s active sub-device manager {}",
-        tid,
-        this->id_,
-        active_sub_device_manager->id());
-    auto& trace_buffer = active_sub_device_manager->create_trace(tid);
-    this->command_queues_[cq_id]->record_begin(tid, trace_buffer->desc);
+    this->push_work(
+        [this, cq_id, tid]() mutable {
+            ZoneScoped;
+
+            TracyTTMetalBeginTrace(this->id(), tid);
+            TT_FATAL(
+                !this->command_queues_[cq_id]->tid().has_value(),
+                "CQ {} is already being used for tracing tid {}",
+                (uint32_t)cq_id,
+                tid);
+            this->mark_allocations_safe();
+            // Create an empty trace buffer here. This will get initialized in end_trace
+            auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
+            TT_FATAL(
+                active_sub_device_manager->get_trace(tid) == nullptr,
+                "Trace already exists for tid {} on device {}'s active sub-device manager {}",
+                tid,
+                this->id_,
+                active_sub_device_manager->id());
+            auto& trace_buffer = active_sub_device_manager->create_trace(tid);
+            this->command_queues_[cq_id]->record_begin(tid, trace_buffer->desc);
+        },
+        false /* blocking */);
 }
 
 void Device::end_trace(const uint8_t cq_id, const uint32_t tid) {
-    ZoneScoped;
-    TracyTTMetalEndTrace(this->id(), tid);
-    TT_FATAL(
-        this->command_queues_[cq_id]->tid() == tid, "CQ {} is not being used for tracing tid {}", (uint32_t)cq_id, tid);
-    auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
-    auto trace_buffer = active_sub_device_manager->get_trace(tid);
-    TT_FATAL(
-        trace_buffer != nullptr,
-        "Trace instance {} must exist on device {}'s active sub-device manager {}",
-        tid,
-        this->id_,
-        active_sub_device_manager->id());
-    this->command_queues_[cq_id]->record_end();
-    Trace::initialize_buffer(this->command_queue(cq_id), trace_buffer);
-    this->mark_allocations_unsafe();
+    this->push_work(
+        [this, cq_id, tid]() mutable {
+            ZoneScoped;
+            TracyTTMetalEndTrace(this->id(), tid);
+            TT_FATAL(
+                this->command_queues_[cq_id]->tid() == tid,
+                "CQ {} is not being used for tracing tid {}",
+                (uint32_t)cq_id,
+                tid);
+            auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
+            auto trace_buffer = active_sub_device_manager->get_trace(tid);
+            TT_FATAL(
+                trace_buffer != nullptr,
+                "Trace instance {} must exist on device {}'s active sub-device manager {}",
+                tid,
+                this->id_,
+                active_sub_device_manager->id());
+            this->command_queues_[cq_id]->record_end();
+            Trace::initialize_buffer(this->command_queue(cq_id), trace_buffer);
+            this->mark_allocations_unsafe();
+        },
+        false /* blocking */);
 }
 
 // Load the TraceDescriptor for a given trace_id to the device. A combination of logic from begin/end_trace.
@@ -1459,33 +1471,47 @@ void Device::load_trace(const uint8_t cq_id, const uint32_t trace_id, const Trac
 }
 
 void Device::replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) {
-    ZoneScoped;
-    TracyTTMetalReplayTrace(this->id(), tid);
-    constexpr bool check = false;
-    auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
-    const auto& trace_buffer = active_sub_device_manager->get_trace(tid);
-    TT_FATAL(
-        trace_buffer != nullptr,
-        "Trace instance {} must exist on device {}'s active sub-device manager {}",
-        tid,
-        this->id_,
-        active_sub_device_manager->id());
-    if constexpr (check) {
-        Trace::validate_instance(*trace_buffer);
+    // If blocking, ensure that worker thread blocks until trace is completed
+    this->push_work(
+        [this, cq_id, tid, blocking]() mutable {
+            ZoneScoped;
+            TracyTTMetalReplayTrace(this->id(), tid);
+            constexpr bool check = false;
+            auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
+            const auto& trace_buffer = active_sub_device_manager->get_trace(tid);
+            TT_FATAL(
+                trace_buffer != nullptr,
+                "Trace instance {} must exist on device {}'s active sub-device manager {}",
+                tid,
+                this->id_,
+                active_sub_device_manager->id());
+            if constexpr (check) {
+                Trace::validate_instance(*trace_buffer);
+            }
+            EnqueueTrace(this->command_queue(cq_id), tid, blocking);
+        },
+        blocking);
+
+    // If blocking, wait until worker threads have completed
+    if (blocking) {
+        this->synchronize();
     }
-    EnqueueTrace(this->command_queue(cq_id), tid, blocking);
 }
 
 void Device::release_trace(const uint32_t tid) {
-    ZoneScoped;
-    TracyTTMetalReleaseTrace(this->id(), tid);
+    this->push_work(
+        [this, tid]() mutable {
+            ZoneScoped;
+            TracyTTMetalReleaseTrace(this->id(), tid);
 
-    sub_device_manager_tracker_->get_active_sub_device_manager()->release_trace(tid);
+            sub_device_manager_tracker_->get_active_sub_device_manager()->release_trace(tid);
 
-    // Only enable allocations once all captured traces are released
-    if (this->trace_buffers_size_ == 0) {
-        this->mark_allocations_safe();
-    }
+            // Only enable allocations once all captured traces are released
+            if (this->trace_buffers_size_ == 0) {
+                this->mark_allocations_safe();
+            }
+        },
+        false /* blocking */);
 }
 
 std::shared_ptr<TraceBuffer> Device::get_trace(uint32_t tid) {

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -292,14 +292,18 @@ void py_module(py::module& module) {
 
     module.def(
         "begin_trace_capture",
-        py::overload_cast<MeshDevice*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
+        [](MeshDevice* device, const uint8_t cq_id) {
+            return ttnn::operations::core::begin_trace_capture(device, cq_id);
+        },
         py::arg("mesh_device"),
         py::kw_only(),
         py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "end_trace_capture",
-        py::overload_cast<MeshDevice*, const uint32_t, const uint8_t>(&ttnn::operations::core::end_trace_capture),
+        [](MeshDevice* device, const uint32_t tid, const uint8_t cq_id) {
+            return ttnn::operations::core::end_trace_capture(device, tid, cq_id);
+        },
         py::arg("mesh_device"),
         py::arg("trace_id"),
         py::kw_only(),
@@ -307,7 +311,9 @@ void py_module(py::module& module) {
 
     module.def(
         "execute_trace",
-        py::overload_cast<MeshDevice*, const uint32_t, const uint8_t, bool>(&ttnn::operations::core::execute_trace),
+        [](MeshDevice* device, const uint32_t tid, const uint8_t cq_id, const bool blocking) {
+            return ttnn::operations::core::execute_trace(device, tid, cq_id, blocking);
+        },
         py::arg("mesh_device"),
         py::arg("trace_id"),
         py::kw_only(),
@@ -316,7 +322,7 @@ void py_module(py::module& module) {
 
     module.def(
         "release_trace",
-        py::overload_cast<MeshDevice*, const uint32_t>(&ttnn::operations::core::release_trace),
+        [](MeshDevice* device, const uint32_t tid) { return ttnn::operations::core::release_trace(device, tid); },
         py::arg("mesh_device"),
         py::arg("trace_id"));
 

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -71,16 +71,6 @@ void execute_trace(IDevice* device, const uint32_t tid, const uint8_t cq_id, boo
 
 void release_trace(IDevice* device, const uint32_t tid);
 
-// Trace APIs - Multi Device
-uint32_t begin_trace_capture(MeshDevice* device, const uint8_t cq_id = ttnn::DefaultQueueId);
-
-void end_trace_capture(MeshDevice* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId);
-
-void execute_trace(
-    MeshDevice* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId, bool blocking = true);
-
-void release_trace(MeshDevice* device, const uint32_t tid);
-
 }  // namespace core
 }  // namespace operations
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/17201)

### Problem description
MeshDevice not conforming to IDevice interface for tracing.

### What's changed
Implement IDevice tracing APIs for MeshDevice by pushing existing logic underneath MeshDevice APIs.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13123624495, https://github.com/tenstorrent/tt-metal/actions/runs/13143412279/job/36676364705
- [x] T3000 Regression Suite: https://github.com/tenstorrent/tt-metal/actions/runs/13123627671 (Some existing failures)