### PR TITLE
#13628: Update logit logic

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -828,13 +828,24 @@ Tensor _logit(const Tensor& input_a, float eps, const std::optional<MemoryConfig
         tt::tt_metal::experimental::hal::get_inf(),
         std::nullopt,
         output_mem_config);
-    Tensor logit_result = ttnn::where(
-        ttnn::eq(logit_input, 1.0, std::nullopt, output_mem_config),
-        t_inf,
-        ttnn::where(
-            ttnn::ltz(log_input, output_mem_config),
-            tt::tt_metal::experimental::hal::get_nan(),
-            ttnn::log(log_input, output_mem_config)));
+    Tensor logit_result;
+    if (eps == 0.0 || eps == 1.0) {
+        logit_result = ttnn::where(
+            ttnn::eqz(logit_input, output_mem_config),
+            t_inf,
+            ttnn::where(
+                ttnn::eq(logit_input, 1.0, std::nullopt, output_mem_config),
+                tt::tt_metal::experimental::hal::get_inf(),
+                ttnn::log(log_input, output_mem_config)));
+    } else {
+        logit_result = ttnn::where(
+            ttnn::eq(logit_input, 1.0, std::nullopt, output_mem_config),
+            t_inf,
+            ttnn::where(
+                ttnn::ltz(log_input, output_mem_config),
+                tt::tt_metal::experimental::hal::get_nan(),
+                ttnn::log(log_input, output_mem_config)));
+    }
     return logit_result;
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #13628 

### Problem description
ttnn.logit operation fails with low PCC when eps == 0 and input type is bfloat16

### What's changed
Updated the logic to address infinite and NaN cases in various inputs by leveraging a where condition.
If eps equals 0 or 1, the function returns only -inf and inf; otherwise, it returns inf and nan.
### Checklist
- [x] [All Post commit CI.](https://github.com/tenstorrent/tt-metal/actions/runs/13106668692)

