### PR TITLE
#0: Remove TT_ASSERT statement that break tt-train in debug mode

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -364,8 +364,6 @@ std::shared_ptr<Buffer> Buffer::create(
 }
 
 void Buffer::allocate_impl() {
-    TT_ASSERT(tt::tt_metal::detail::InWorkerThread(), "Buffer allocation must be called from worker thread");
-
     if (GraphTracker::instance().hook_allocate(this)) {
         address_ = 0;
     } else {
@@ -411,7 +409,6 @@ void Buffer::deleter(Buffer* buffer) {
 }
 
 void Buffer::deallocate_impl() {
-    TT_ASSERT(tt::tt_metal::detail::InWorkerThread(), "Buffer deallocation must be called from worker thread");
     if (allocation_status_.load(std::memory_order::relaxed) != AllocationStatus::ALLOCATED) {
         return;
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The assertions introduced in #17203 to highlight the fact that the alloc / dealloc are called from the worker threads through `push_work`. This isn't true apparently - most likely in non-async mode `InWorkerThread` returns `false` always.

### What's changed
Remove the assertions.

### Checklist
@rfurko-tt reported that tt-train tests (`N300UtilsTest`) are failing in debug mode. I compiled and ran locally to confirm the fix resolves the issue.
