### PR TITLE
Add TT-Mesh tests to N300 post commit

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -62,11 +62,9 @@ jobs:
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth_${{ inputs.arch }}"},
           {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
-          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }} --gtest_filter=MeshDeviceSuite.*"},
-
+          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }}"},
           {name: lightmetal, cmd: "./build/test/tt_metal/unit_tests_lightmetal"},
           {name: dispatch multicmd queue, cmd: "TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch_${{ inputs.arch }} --gtest_filter=MultiCommandQueue*Fixture.*"},
-
           {name: ttnn cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn},
           {name: ttnn ccl cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_ccl},
           {name: ttnn tensor cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn_tensor},

--- a/tests/tt_metal/distributed/test_distributed.cpp
+++ b/tests/tt_metal/distributed/test_distributed.cpp
@@ -9,7 +9,7 @@
 namespace tt::tt_metal::distributed::test {
 namespace {
 
-TEST_F(T3000MultiDeviceFixture, SimpleMeshDeviceTest) {
+TEST_F(T3000MeshDeviceFixture, SimpleMeshDeviceTest) {
     EXPECT_EQ(mesh_device_->num_devices(), 8);
     EXPECT_EQ(mesh_device_->num_rows(), 2);
     EXPECT_EQ(mesh_device_->num_cols(), 4);

--- a/tests/tt_metal/distributed/test_mesh_allocator.cpp
+++ b/tests/tt_metal/distributed/test_mesh_allocator.cpp
@@ -10,7 +10,7 @@
 
 namespace tt::tt_metal::distributed::test {
 
-using MeshAllocatorTest = T3000MultiDeviceFixture;
+using MeshAllocatorTest = T3000MeshDeviceFixture;
 
 TEST_F(MeshAllocatorTest, BasicAllocationSanityCheck) {
     const size_t allocation_size = 1024 * 8;  // 1KB

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -14,9 +14,10 @@
 namespace tt::tt_metal::distributed::test {
 namespace {
 
-using MeshEventsTest = T3000MultiCQMultiDeviceFixture;
+using MeshEventsTestT3000 = T3000MultiCQMeshDeviceFixture;
+using MeshEventsTestSuite = GenericMultiCQMeshDeviceFixture;
 
-TEST_F(MeshEventsTest, ReplicatedAsyncIO) {
+TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
     uint32_t NUM_TILES = 1000;
     uint32_t num_iterations = 20;
     int32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
@@ -61,7 +62,7 @@ TEST_F(MeshEventsTest, ReplicatedAsyncIO) {
     }
 }
 
-TEST_F(MeshEventsTest, ShardedAsyncIO) {
+TEST_F(MeshEventsTestT3000, ShardedAsyncIO) {
     uint32_t num_iterations = 20;
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
 
@@ -108,7 +109,7 @@ TEST_F(MeshEventsTest, ShardedAsyncIO) {
     }
 }
 
-TEST_F(MeshEventsTest, AsyncWorkloadAndIO) {
+TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
     uint32_t num_iters = 5;
     std::vector<std::shared_ptr<MeshBuffer>> src0_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> src1_bufs = {};
@@ -119,8 +120,8 @@ TEST_F(MeshEventsTest, AsyncWorkloadAndIO) {
     auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, src0_bufs, src1_bufs, output_bufs);
     auto mesh_workload = CreateMeshWorkload();
-    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {3, 0});
-    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {3, 1});
+    LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {mesh_device_->num_cols() - 1, 0});
+    LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {mesh_device_->num_cols() - 1, 1});
 
     AddProgramToMeshWorkload(mesh_workload, *programs[0], devices_0);
     AddProgramToMeshWorkload(mesh_workload, *programs[1], devices_1);
@@ -189,7 +190,7 @@ TEST_F(MeshEventsTest, AsyncWorkloadAndIO) {
     }
 }
 
-TEST_F(MeshEventsTest, CustomDeviceRanges) {
+TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
     uint32_t NUM_TILES = 1000;
     uint32_t num_iterations = 20;
     int32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
@@ -209,8 +210,8 @@ TEST_F(MeshEventsTest, CustomDeviceRanges) {
     for (std::size_t i = 0; i < num_iterations; i++) {
         std::vector<uint32_t> src_vec(NUM_TILES * single_tile_size / sizeof(uint32_t), i);
         std::iota(src_vec.begin(), src_vec.end(), i);
-        LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {3, 0});
-        LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {3, 1});
+        LogicalDeviceRange devices_0 = LogicalDeviceRange({0, 0}, {mesh_device_->num_cols() - 1, 0});
+        LogicalDeviceRange devices_1 = LogicalDeviceRange({0, 1}, {mesh_device_->num_cols() - 1, 1});
 
         std::vector<std::vector<uint32_t>> readback_vecs = {};
         std::shared_ptr<MeshEvent> event_0 = std::make_shared<MeshEvent>();

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -12,9 +12,9 @@
 namespace tt::tt_metal::distributed::test {
 namespace {
 
-using MeshSubDeviceTest = T3000MultiDeviceFixture;
+using MeshSubDeviceTestSuite = GenericMeshDeviceFixture;
 
-TEST_F(MeshSubDeviceTest, SyncWorkloadsOnSubDevice) {
+TEST_F(MeshSubDeviceTestSuite, SyncWorkloadsOnSubDevice) {
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
 
@@ -43,7 +43,7 @@ TEST_F(MeshSubDeviceTest, SyncWorkloadsOnSubDevice) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshSubDeviceTest, DataCopyOnSubDevices) {
+TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {0, 0}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(CoreRange({1, 1}, {1, 1}))});
     SubDevice sub_device_3(std::array{CoreRangeSet(CoreRange({2, 2}, {2, 2}))});
@@ -136,7 +136,7 @@ TEST_F(MeshSubDeviceTest, DataCopyOnSubDevices) {
     }
 }
 
-TEST_F(MeshSubDeviceTest, SubDeviceSwitching) {
+TEST_F(MeshSubDeviceTestSuite, SubDeviceSwitching) {
     // Sub Devices for config 0
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -50,55 +50,122 @@ protected:
     }
 };
 
-class T3000MultiDeviceFixture : public ::testing::Test {
+class MeshDeviceFixtureBase : public ::testing::Test {
 protected:
-    virtual void SetUp() override {
-        using tt::tt_metal::distributed::MeshDevice;
-        using tt::tt_metal::distributed::MeshDeviceConfig;
-        using tt::tt_metal::distributed::MeshShape;
+    using MeshDevice = ::tt::tt_metal::distributed::MeshDevice;
+    using MeshDeviceConfig = ::tt::tt_metal::distributed::MeshDeviceConfig;
+    using MeshShape = ::tt::tt_metal::distributed::MeshShape;
 
+    enum class MeshDeviceType {
+        N300,
+        T3000,
+    };
+
+    struct Config {
+        // If unset, the mesh device type will be deduced automatically based on the connected devices.
+        // The associated test will be run if the connected cluster corresponds to a supported topology.
+        std::optional<MeshDeviceType> mesh_device_type;
+        int num_cqs = 1;
+    };
+
+    MeshDeviceFixtureBase(const Config& fixture_config) : config_(fixture_config) {}
+
+    void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         if (slow_dispatch) {
-            GTEST_SKIP() << "Skipping Multi-Device test suite, since it can only be run in Fast Dispatch Mode.";
+            GTEST_SKIP() << "Skipping Mesh-Device test suite, since it can only be run in Fast Dispatch Mode.";
         }
-        if (num_devices < 8 or arch != tt::ARCH::WORMHOLE_B0) {
-            GTEST_SKIP() << "Skipping T3K Multi-Device test suite on non T3K machine.";
+
+        const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        if (arch != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "Skipping MeshDevice test suite on a non-wormhole machine.";
         }
-        create_mesh_device();
+
+        const auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+        const auto mesh_device_type = derive_mesh_device_type(num_devices);
+        if (!mesh_device_type) {
+            GTEST_SKIP() << fmt::format(
+                "Skipping MeshDevice test suite on a machine with an unsupported number of devices {}.", num_devices);
+        }
+
+        if (config_.mesh_device_type.has_value() && *config_.mesh_device_type != *mesh_device_type) {
+            GTEST_SKIP() << fmt::format(
+                "Skipping MeshDevice test suite on a {} machine that does not match the configured mesh device type {}",
+                magic_enum::enum_name(*mesh_device_type),
+                magic_enum::enum_name(*config_.mesh_device_type));
+        }
+
+        // Use ethernet dispatch for more than 1 CQ on T3K/N300
+        DispatchCoreType core_type = (config_.num_cqs >= 2) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
+        mesh_device_ = MeshDevice::create(
+            MeshDeviceConfig{.mesh_shape = get_mesh_shape(*mesh_device_type)}, 0, 0, config_.num_cqs, core_type);
     }
 
     void TearDown() override {
         if (!mesh_device_) {
             return;
         }
-
         mesh_device_->close();
         mesh_device_.reset();
     }
 
-protected:
-    virtual void create_mesh_device() {
-        using tt::tt_metal::distributed::MeshDevice;
-        using tt::tt_metal::distributed::MeshDeviceConfig;
-        using tt::tt_metal::distributed::MeshShape;
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
 
-        mesh_device_ = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape{2, 4}});
+private:
+    // Returns the mesh shape for a given mesh device type.
+    MeshShape get_mesh_shape(MeshDeviceType mesh_device_type) {
+        switch (mesh_device_type) {
+            case MeshDeviceType::N300: return MeshShape(2, 1);
+            case MeshDeviceType::T3000: return MeshShape(2, 4);
+            default: TT_FATAL(false, "Querying shape for unspecified Mesh Type.");
+        }
     }
 
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
+    // Determines the mesh device type based on the number of devices.
+    std::optional<MeshDeviceType> derive_mesh_device_type(size_t num_devices) {
+        switch (num_devices) {
+            case 2: return MeshDeviceType::N300;
+            case 8: return MeshDeviceType::T3000;
+            default: return std::nullopt;
+        }
+    }
+
+    Config config_;
 };
 
-class T3000MultiCQMultiDeviceFixture : public T3000MultiDeviceFixture {
+// Fixtures that determine the mesh device type automatically.
+// The associated test will be run if the topology is supported.
+class GenericMeshDeviceFixture : public MeshDeviceFixtureBase {
 protected:
-    // Override only the mesh device creation logic
-    void create_mesh_device() override {
-        using tt::tt_metal::distributed::MeshDevice;
-        using tt::tt_metal::distributed::MeshDeviceConfig;
-        using tt::tt_metal::distributed::MeshShape;
+    GenericMeshDeviceFixture() : MeshDeviceFixtureBase(Config{.num_cqs = 1}) {}
+};
 
-        mesh_device_ =
-            MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape{2, 4}}, 0, 0, 2, DispatchCoreType::ETH);
-    }
+class GenericMultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {
+protected:
+    GenericMultiCQMeshDeviceFixture() : MeshDeviceFixtureBase(Config{.num_cqs = 2}) {}
+};
+
+// Fixtures that specify the mesh device type explicitly.
+// The associated test will be run if the cluster topology matches
+// what is specified.
+class N300MeshDeviceFixture : public MeshDeviceFixtureBase {
+protected:
+    N300MeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_type = MeshDeviceType::N300}) {}
+};
+
+class T3000MeshDeviceFixture : public MeshDeviceFixtureBase {
+protected:
+    T3000MeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_type = MeshDeviceType::T3000}) {}
+};
+
+class N300MultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {
+protected:
+    N300MultiCQMeshDeviceFixture() :
+        MeshDeviceFixtureBase(Config{.mesh_device_type = MeshDeviceType::N300, .num_cqs = 2}) {}
+};
+
+class T3000MultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {
+protected:
+    T3000MultiCQMeshDeviceFixture() :
+        MeshDeviceFixtureBase(Config{.mesh_device_type = MeshDeviceType::T3000, .num_cqs = 2}) {}
 };


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
`MeshWorkload` and `MeshBuffer` tests were not running on post-commit, which can cause breaking commits to get merged.

### What's changed
Add N300 Post-Commit TT-Mesh test suite and disable tests running `MeshWorkloads` on active eth (currently broken and a legacy feature ... fix staged on this PR: https://github.com/tenstorrent/tt-metal/pull/17462).

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
