### PR TITLE
#17203: Remove work executor from `MeshDevice`

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -15,7 +15,6 @@
 #include "mesh_device_view.hpp"
 #include "sub_device_types.hpp"
 #include "span.hpp"
-#include "work_executor.hpp"
 
 namespace tt::tt_metal {
 
@@ -62,7 +61,6 @@ private:
     std::weak_ptr<MeshDevice> parent_mesh_;  // Submesh created with reference to parent mesh
     std::unique_ptr<MeshCommandQueue> mesh_command_queue_;
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
-    std::unique_ptr<WorkExecutor> work_executor_;
 
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;


### PR DESCRIPTION
### Ticket
#17203

### Problem description
`WorkExecutor` is needed for enabling `push_work` to run asynchronously. We don't want and don't need that for `MeshDevice`.

### What's changed
Remove `WorkExecutor` member from `MeshDevice`. There is no change in behavior, as `WorkExecutor` was initialized in the synchronous mode - the work was executed inline either way. This PR simplifies the code, aligning us with the TTNN integration plan.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13093222031)
