### PR TITLE
#17483: Fix untilize with unpad for 1d tensors

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py
@@ -175,3 +175,9 @@ def test_run_untilize_5d(dtype, shape, device):
         passing1 = torch.equal(inp, our_untilized)
 
     assert passing1
+
+
+def test_regression_untilize_1d(device):
+    input = ttnn.ones([1280], ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    out_untilized = ttnn.to_layout(input, layout=ttnn.ROW_MAJOR_LAYOUT)
+    assert out_untilized is not None

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -146,7 +146,7 @@ Tensor to_layout_impl(
                 output_memory_config =
                     tt::tt_metal::MemoryConfig{memory_config.memory_layout, memory_config.buffer_type};
             }
-            Shape output_tensor_end(SmallVector<uint32_t>(tensor.get_padded_shape().rank(), 0));
+            Shape output_tensor_end(SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
             int logical_rank = tensor.get_logical_shape().rank();
             for (int index = -1; index >= -logical_rank; --index) {
                 output_tensor_end[index] = tensor.get_logical_shape()[index] - 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -72,7 +72,7 @@ std::vector<ttnn::TensorSpec> UntilizeWithUnpadding::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     SmallVector<uint32_t> out_shape;
     const auto& input_tensor_a = input_tensors.at(0);
-    auto rank = input_tensor_a.get_padded_shape().rank();
+    size_t rank = input_tensor_a.logical_shape().rank();
     out_shape.reserve(rank);
     for (uint32_t i = 0; i < rank; i++) {
         out_shape.push_back(this->output_tensor_end[i] + 1);


### PR DESCRIPTION
Recent changes for swapping out ttnn::Shape,
and LegacyShape broke the functionality of running untilize on 1d tensors.
This broke the stable diffusion model where bias
is a 1d tensor that is untilized.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17483)

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13102647600)
- [x] [Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml)
