### PR TITLE
Ncvetkovic/17132 max pool then pack untilize

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -344,6 +344,7 @@ def run_reduce_sum_h(device, batch_size, h, w, dim):
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
+@skip_for_grayskull("Not a tile size multiple, will fail on GS. #17132")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 4096}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -7,9 +7,9 @@ import pytest
 import torch
 
 import ttnn
+
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_grayskull
-from models.utility_functions import torch_random
+from models.utility_functions import skip_for_grayskull, torch_random
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -307,57 +307,57 @@ def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-# def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
-#     torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
-#     batch_size, in_c, in_h, in_w = input_shape
+def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    batch_size, in_c, in_h, in_w = input_shape
+    input_tensor = torch.permute(torch_input, (0, 2, 3, 1))
+    input_tensor = torch.reshape(input_tensor, (1, 1, -1, in_c))
+    input_tensor = ttnn.from_torch(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    output_tensor = ttnn.max_pool2d(
+        input_tensor,
+        batch_size,
+        in_h,
+        in_w,
+        in_c,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+    )
 
-#     input_tensor = torch.permute(torch_input, (0, 2, 3, 1))
-#     input_tensor = torch.reshape(input_tensor, (1, 1, -1, in_c))
-#     input_tensor = ttnn.from_torch(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-#     output_tensor = ttnn.max_pool2d(
-#         input_tensor,
-#         batch_size,
-#         in_h,
-#         in_w,
-#         in_c,
-#         kernel_size,
-#         stride,
-#         padding,
-#         dilation,
-#     )
+    torch_output_tensor = torch.nn.functional.max_pool2d(torch_input, kernel_size, stride, padding)
 
-#     expected_output = torch.nn.functional.max_pool2d(torch_input, kernel_size, stride, padding)
+    output_tensor = ttnn.to_torch(output_tensor)
+    _, out_c, out_h, out_w = torch_output_tensor.shape
+    output_tensor = torch.reshape(output_tensor, (batch_size, out_h, out_w, out_c))
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+    assert_with_pcc(output_tensor, torch_output_tensor)
 
-#     output_tensor = ttnn.to_torch(output_tensor)
-#     _, out_c, out_h, out_w = expected_output.shape
-#     output_tensor = torch.reshape(output_tensor, (batch_size, out_h, out_w, out_c))
-#     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
-#     print(output_tensor.shape)
-#     assert_with_pcc(output_tensor, expected_output)
 
-# def run_reduce_sum_h(device, batch_size, h, w, dim):
-#     torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
+def run_reduce_sum_h(device, batch_size, h, w, dim):
+    torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=True, dtype=torch.bfloat16)
 
-#     # torch output
-#     torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=True, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.mean(input_tensor, dim=dim)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor)
 
-#     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-#     # ttnn output
-#     output_tensor = ttnn.mean(input_tensor, dim=dim)
 
-#     output_tensor = ttnn.to_torch(output_tensor)
-#     assert_with_pcc(torch_output_tensor, output_tensor)
-
-# @pytest.mark.parametrize("input_shape",
-#     (1, 32, 2, 2),  # Single core
-#     (1, 32, 32, 32),  # Multi core face height default
-#     (1, 192, 56, 56),  # Multi core face height not default
-# )
-# @pytest.mark.parametrize("kernel_size",
-#     (2, 2),  # Small kernel
-#     (5, 5),  # Large kernel
-# )
-# def test_run_reduce_sum_h_after_max_pool(input_shape, kernel_size, device):
-#     device = ttnn.open_device(device_id=0, l1_small_size=4096)
-#     run_maxpool(device, input_shape, kernel_size, kernel_size, (0, 0), (1, 1))
-#     run_reduce_sum_h(device, 1, 32, 32, -2)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 4096}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 192, 56, 56),  # Multi core face height not default
+    ],
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    [
+        (2, 2),  # Small kernel
+        (5, 5),  # Large kernel
+    ],
+)
+def test_run_reduce_sum_h_after_max_pool(device, input_shape, kernel_size):
+    run_maxpool(device, input_shape, kernel_size, kernel_size, (0, 0), (1, 1))
+    run_reduce_sum_h(device, 1, 32, 32, -2)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -206,7 +206,6 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
  * LLK PACK UNTILIZE
  *************************************************************************/
 template <
-    bool is_fp32_dest_acc_en /* Not used on BH */,
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -168,6 +168,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
  * LLK PACK UNTILIZE
  *************************************************************************/
 template <
+    bool is_fp32_dest_acc_en /* Not used on BH */,
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -79,6 +79,7 @@ template <bool untilize = false, bool is_fp32_dest_acc_en = false, bool tilize =
 inline void llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
+    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
@@ -89,6 +90,7 @@ inline void llk_pack_untilize_hw_configure(
         pack_dst_format[output_id],
         tile_size,
         face_r_dim,
+        tile_c_dim,
         num_faces,
         partial_face,
         narrow_tile,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -75,6 +75,44 @@ inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
     llk_pack_hw_configure<untilize, is_fp32_dest_acc_en, tilize>(&llk_pack_params);
 }
 
+template <bool untilize = false, bool is_fp32_dest_acc_en = false, bool tilize = false>
+inline void llk_pack_untilize_hw_configure(
+    const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
+    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
+    const bool partial_face = get_output_partial_face(output_id);
+    const bool narrow_tile = get_output_narrow_tile(output_id);
+
+    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
+
+    _llk_pack_hw_configure_<untilize, is_fp32_dest_acc_en, tilize>(
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        tile_size,
+        face_r_dim,
+        num_faces,
+        partial_face,
+        narrow_tile,
+        pack_params->relu_config.val);
+}
+
+template <
+    bool untilize = false,
+    bool is_fp32_dest_acc_en = false,
+    ReluType relu_type = ReluType::NO_RELU,
+    std::uint32_t relu_threshold = 0,
+    bool tilize = false>
+inline void llk_pack_untilize_hw_configure_disaggregated(
+    std::uint32_t pack_output, std::uint32_t face_r_dim = 16, std::uint32_t num_faces = 4) {
+    llk_pack_params_t llk_pack_params = {
+        .pack_output = pack_output,
+        .relu_config = {
+            .f = {
+                .ApplyRelu = (std::uint32_t)relu_type,
+                .Threshold = relu_threshold,
+            }}};
+    llk_pack_untilize_hw_configure<untilize, is_fp32_dest_acc_en, tilize>(&llk_pack_params, face_r_dim, num_faces);
+}
+
 template <bool untilize = false, PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en = false>
 inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
@@ -60,24 +60,6 @@ inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
     llk_pack_hw_configure<untilize, is_fp32_dest_acc_en>(&llk_pack_params);
 }
 
-template <
-    bool untilize = false,
-    bool is_fp32_dest_acc_en = false,
-    ReluType relu_type = ReluType::NO_RELU,
-    std::uint32_t relu_threshold = 0,
-    bool tilize = false /*unused*/>
-inline void llk_pack_untilize_hw_configure_disaggregated(
-    std::uint32_t pack_output, std::uint32_t face_r_dim = 16 /*unused*/, std::uint32_t num_faces = 4 /*unused*/) {
-    llk_pack_params_t llk_pack_params = {
-        .pack_output = pack_output,
-        .relu_config = {
-            .f = {
-                .ApplyRelu = (std::uint32_t)relu_type,
-                .Threshold = relu_threshold,
-            }}};
-    llk_pack_hw_configure<untilize>(&llk_pack_params);
-}
-
 template <bool untilize = false, PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en = false /*not used*/>
 inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
@@ -129,6 +129,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
  *************************************************************************/
 
 template <
+    bool is_fp32_dest_acc_en /* Not used on GS */,
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
@@ -147,7 +147,6 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en /* Not used on GS */,
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
@@ -45,7 +45,7 @@ inline void llk_pack_hw_configure(const llk_pack_params_t* pack_params) {
 
 template <
     bool untilize = false,
-    bool is_fp32_dest_acc_en = false /*not used*/,
+    bool is_fp32_dest_acc_en = false /*unused*/,
     ReluType relu_type = ReluType::NO_RELU,
     std::uint32_t relu_threshold = 0,
     bool tilize = false /*unused*/>
@@ -58,6 +58,24 @@ inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
                 .Threshold = relu_threshold,
             }}};
     llk_pack_hw_configure<untilize, is_fp32_dest_acc_en>(&llk_pack_params);
+}
+
+template <
+    bool untilize = false,
+    bool is_fp32_dest_acc_en = false,
+    ReluType relu_type = ReluType::NO_RELU,
+    std::uint32_t relu_threshold = 0,
+    bool tilize = false /*unused*/>
+inline void llk_pack_untilize_hw_configure_disaggregated(
+    std::uint32_t pack_output, std::uint32_t face_r_dim = 16 /*unused*/, std::uint32_t num_faces = 4 /*unused*/) {
+    llk_pack_params_t llk_pack_params = {
+        .pack_output = pack_output,
+        .relu_config = {
+            .f = {
+                .ApplyRelu = (std::uint32_t)relu_type,
+                .Threshold = relu_threshold,
+            }}};
+    llk_pack_hw_configure<untilize>(&llk_pack_params);
 }
 
 template <bool untilize = false, PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en = false /*not used*/>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -193,6 +193,19 @@ inline void llk_pack_untilize_init(
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
 
+    // Reconfigure pack_reads_per_xy_plane with the new face_r_dim.
+    // Has to be called before the next code block to ensure
+    // proper Z and W counter configuration
+    _llk_pack_hw_configure_<true, is_fp32_dest_acc_en>(
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        get_local_cb_interface(output_id).fifo_page_size,
+        face_r_dim,
+        num_faces,
+        false /* partial_face */,
+        false /* narrow_tile */,
+        0 /* relu_config */);
+
     // Pack row by row
     if constexpr (diagonal) {
         TT_SETADCXX(p_setadc::PAC, 1 - 1, 0x0);
@@ -201,30 +214,6 @@ inline void llk_pack_untilize_init(
     } else {
         TT_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
     }
-    // -------------- Issue tt-metal#17132 unblocker ---------------
-    // Reconfigure pack_reads_per_xy_plane with the new face_r_dim
-    // --------------------------------------------------------------
-    // Check why this cannot be done via the _llk_pack_hw_configure_:
-    //
-    // _llk_pack_hw_configure_<true, is_fp32_dest_acc_en>(
-    //     pack_src_format[output_id],
-    //     pack_dst_format[output_id],
-    //     get_local_cb_interface(output_id).fifo_page_size,
-    //     face_r_dim,
-    //     num_faces,
-    //     false /* partial_face */,
-    //     false /* narrow_tile */,
-    //     0 /* relu_config */);
-
-    volatile uint* cfg = get_cfg_pointer();  // Get pointer to registers for current state ID
-    pack_counters_u pack_counters;
-    pack_counters.val = 0;
-    pack_counters.f.pack_reads_per_xy_plane = face_r_dim;  // Number of reads per face
-                                                           // Used for resetting tile posistion generator for edge masks
-    for (uint i = 0; i < 4; i++) {
-        cfg[PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32 + i] = pack_counters.val;  // disable auto last generation
-    }
-    // -------------- Issue tt-metal#17132 unblocker ---------------
 }
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -180,6 +180,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
  *************************************************************************/
 
 template <
+    bool is_fp32_dest_acc_en,
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,
@@ -198,8 +199,18 @@ inline void llk_pack_untilize_init(
     } else if constexpr (narrow_row) {
         TT_SETADCXX(p_setadc::PAC, row_num_datums - 1, 0x0);
     } else {
-        TT_SETADCXX(p_setadc::PAC, FACE_R_DIM - 1, 0x0);
+        TT_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
     }
+    //
+    _llk_pack_hw_configure_<true, is_fp32_dest_acc_en>(
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        get_local_cb_interface(output_id).fifo_page_size,
+        face_r_dim,
+        num_faces,
+        false /* partial_face */,
+        false /* narrow_tile */,
+        0 /* relu_config */);
 }
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -201,7 +201,7 @@ inline void llk_pack_untilize_init(
     } else {
         TT_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
     }
-    //
+    // Reconfigure pack_reads_per_xy_plane with the new face_r_dim
     _llk_pack_hw_configure_<true, is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -73,6 +73,44 @@ inline void llk_pack_hw_configure_disaggregated(std::uint32_t pack_output) {
     llk_pack_hw_configure<untilize, is_fp32_dest_acc_en>(&llk_pack_params);
 }
 
+template <bool untilize = false, bool is_fp32_dest_acc_en = false>
+inline void llk_pack_untilize_hw_configure(
+    const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
+    const std::uint32_t output_id = get_output_id(pack_params->pack_output);
+    const bool partial_face = get_output_partial_face(output_id);
+    const bool narrow_tile = get_output_narrow_tile(output_id);
+
+    const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
+
+    _llk_pack_hw_configure_<untilize, is_fp32_dest_acc_en>(
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        tile_size,
+        face_r_dim,
+        num_faces,
+        partial_face,
+        narrow_tile,
+        pack_params->relu_config.val);
+}
+
+template <
+    bool untilize = false,
+    bool is_fp32_dest_acc_en = false,
+    ReluType relu_type = ReluType::NO_RELU,
+    std::uint32_t relu_threshold = 0,
+    bool tilize = false /*unused*/>
+inline void llk_pack_untilize_hw_configure_disaggregated(
+    std::uint32_t pack_output, std::uint32_t face_r_dim = 16, std::uint32_t num_faces = 4) {
+    llk_pack_params_t llk_pack_params = {
+        .pack_output = pack_output,
+        .relu_config = {
+            .f = {
+                .ApplyRelu = (std::uint32_t)relu_type,
+                .Threshold = relu_threshold,
+            }}};
+    llk_pack_untilize_hw_configure<untilize, is_fp32_dest_acc_en>(&llk_pack_params, face_r_dim, num_faces);
+}
+
 template <bool untilize = false, PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en = false>
 inline void llk_pack_reduce_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
@@ -192,19 +230,6 @@ inline void llk_pack_untilize_init(
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
-
-    // Reconfigure pack_reads_per_xy_plane with the new face_r_dim.
-    // Has to be called before the next code block to ensure
-    // proper Z and W counter configuration
-    _llk_pack_hw_configure_<true, is_fp32_dest_acc_en>(
-        pack_src_format[output_id],
-        pack_dst_format[output_id],
-        get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
-        num_faces,
-        false /* partial_face */,
-        false /* narrow_tile */,
-        0 /* relu_config */);
 
     // Pack row by row
     if constexpr (diagonal) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -218,7 +218,6 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
  *************************************************************************/
 
 template <
-    bool is_fp32_dest_acc_en,
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool diagonal = false,

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -77,7 +77,7 @@ template <
     std::uint32_t row_num_datums = TILE_C_DIM>
 ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
     PACK((llk_pack_untilize_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
-    PACK((llk_pack_untilize_init<DST_ACCUM_MODE, block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
+    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         ocb, face_r_dim, num_faces)));
     PACK((llk_init_packer_dest_offset_registers<true, diagonal>()));
 

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -25,7 +25,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_hw_configure_disaggregated<true>(icb, icb)));
 
     PACK((llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb)));
-    PACK((llk_pack_untilize_init<DST_ACCUM_MODE, block_ct_dim, full_ct_dim>(ocb)));
+    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
     PACK((llk_pack_dest_init<true, DST_ACCUM_MODE>()));
 
     UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -76,7 +76,11 @@ template <
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM>
 ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
+#ifndef ARCH_GRAYSKULL
+    // A workaround for tt-metal#17132. This is not needed for Grayskull,
+    // as it breaks the packer. Should be addressed more systematically.
     PACK((llk_pack_untilize_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
+#endif
     PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         ocb, face_r_dim, num_faces)));
     PACK((llk_init_packer_dest_offset_registers<true, diagonal>()));

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -25,7 +25,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_hw_configure_disaggregated<true>(icb, icb)));
 
     PACK((llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb)));
-    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb)));
+    PACK((llk_pack_untilize_init<DST_ACCUM_MODE, block_ct_dim, full_ct_dim>(ocb)));
     PACK((llk_pack_dest_init<true, DST_ACCUM_MODE>()));
 
     UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
@@ -76,7 +76,7 @@ template <
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM>
 ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
-    PACK((llk_pack_untilize_init<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
+    PACK((llk_pack_untilize_init<DST_ACCUM_MODE, block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         ocb, face_r_dim, num_faces)));
     PACK((llk_init_packer_dest_offset_registers<true, diagonal>()));
 

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -76,6 +76,7 @@ template <
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM>
 ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
+    PACK((llk_pack_untilize_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb, face_r_dim, num_faces)));
     PACK((llk_pack_untilize_init<DST_ACCUM_MODE, block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         ocb, face_r_dim, num_faces)));
     PACK((llk_init_packer_dest_offset_registers<true, diagonal>()));

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
@@ -78,7 +78,7 @@ void MAIN {
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
     tilizeA_B_reduce_init(in_cb_id, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
-    pack_untilize_dst_init_short(out_cb_id, num_out_rows, num_faces_in_tile);
+    pack_untilize_dst_init_short<in_ntiles_c>(out_cb_id, num_out_rows, num_faces_in_tile);
 
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core; ++i) {


### PR DESCRIPTION
### Ticket
#17132 

### Problem description
Whenever a `face_r_dim` value different from default is passed to `pack_untilize_dst_init_short`, PACK reads per XY plane are incorrectly set, leading to an undesired behavior of the XY position generator. In other words, if some kernel sets `pack_reads_per_xy_plane` to be less than the amount of expected PACK reads for XY plane, the next kernel will see bad XY positions, unless there's a reset between the two kernels.

This behavior is observed on WH_B0. Since we use different packer edge masks on BH, the behavior is only not observed there, although there as well `y_pos` will have a wrong value at the end of max_pool.

### What's changed
We have added a new API called `llk_pack_untilize_hw_configure_disaggregated` which is called from `pack_untilize_dst_init_short`, and should set `pack_reads_per_xy_plane` to the correct value. This is not done on GS since it messes up the functionality, a separate issue will be created to track that.

### Checklist
- [x] Post commit CI passes - [#25370](https://github.com/tenstorrent/tt-metal/actions/runs/13165297340) ✅ 
- [x] Blackhole Post commit (if applicable) - [#3378](https://github.com/tenstorrent/tt-metal/actions/runs/13167638736) ✅
- [x] Model regression CI testing passes (if applicable) - [#7465](https://github.com/tenstorrent/tt-metal/actions/runs/13161838666) ✅ 
- [x] Device performance regression CI testing passes (if applicable) [#4799](https://github.com/tenstorrent/tt-metal/actions/runs/13167667817) ✅ 
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes - [#167](https://github.com/tenstorrent/tt-metal/actions/runs/13167693654) ✅ 
- [x] New/Existing tests provide coverage for changes
