### PR TITLE
llama3 lm head data parallel

### DIFF
--- a/models/demos/llama3/tests/test_lm_head.py
+++ b/models/demos/llama3/tests/test_lm_head.py
@@ -13,6 +13,9 @@ from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Colum
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
+    skip_for_parallelism,
+    skip_for_batch_parallelism,
+    skip_for_model_parallelism,
 )
 from models.utility_functions import skip_for_grayskull
 
@@ -24,8 +27,12 @@ from models.utility_functions import skip_for_grayskull
     (32,),
 )
 @pytest.mark.parametrize(
-    "batch_size",
-    (1,),
+    "batch_dp_tp",
+    [
+        (1, 1, 2),
+        (2, 2, 1),
+    ],
+    ids=lambda args: "batch_{}_dp_{}_tp_{}".format(*args),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -36,12 +43,35 @@ from models.utility_functions import skip_for_grayskull
     ],
     indirect=True,
 )
-def test_llama_lm_head_inference(seq_len, batch_size, mesh_device, use_program_cache, reset_seeds):
+def test_llama_lm_head_inference(seq_len, batch_dp_tp, mesh_device, use_program_cache, reset_seeds):
+    batch_size, data_parallel, tensor_parallel = batch_dp_tp
+
+    skip, reason = skip_for_batch_parallelism(batch_size, data_parallel)
+    if skip:
+        pytest.skip(reason)
+
+    skip, reason = skip_for_parallelism(
+        mesh_device.get_num_devices() if mesh_device else 0, data_parallel, tensor_parallel
+    )
+    if skip:
+        pytest.skip(reason)
+    skip, reason = skip_for_model_parallelism(data_parallel)
+    if skip:
+        pytest.skip(reason)
+
     dtype = ttnn.bfloat8_b
 
     mesh_device.enable_async(True)
+    if data_parallel > 1:
+        mesh_device.reshape(ttnn.MeshShape(mesh_device.get_num_devices(), 1))
 
-    model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=seq_len)
+    model_args = TtModelArgs(
+        mesh_device,
+        max_batch_size=batch_size,
+        data_parallel=data_parallel,
+        tensor_parallel=tensor_parallel,
+        max_seq_len=seq_len,
+    )
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()
 
@@ -64,13 +94,15 @@ def test_llama_lm_head_inference(seq_len, batch_size, mesh_device, use_program_c
         weight_cache_path=model_args.weight_cache_path(dtype),
     )
 
-    torch_input = torch.randn(1, 1, seq_len, model_args.dim)
+    torch_input = torch.randn(batch_size, 1, seq_len, model_args.dim)
     reference_output = reference_model(torch_input)
+
+    dims = (0, None) if data_parallel > 1 else (None, None)
     tt_input = ttnn.from_torch(
         torch_input,
         device=mesh_device,
         mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(None, 3) if model_args.is_galaxy else (None, None), mesh_shape=model_args.cluster_shape
+            mesh_device, dims=(None, 3) if model_args.is_galaxy else dims, mesh_shape=model_args.cluster_shape
         ),
         dtype=ttnn.bfloat8_b,
         memory_config=model_args.model_config["LM_HEAD_INPUT_MEMCFG"],
@@ -79,10 +111,12 @@ def test_llama_lm_head_inference(seq_len, batch_size, mesh_device, use_program_c
 
     logger.info("Run Llama_LM_Head")
     tt_output = tt_model(tt_input)
+
+    dims = (0, 3) if data_parallel > 1 else (1, 3)
     tt_output_torch = ttnn.to_torch(
         tt_output,
         mesh_composer=ttnn.ConcatMesh2dToTensor(
-            mesh_device, model_args.cluster_shape, dims=(3, 1) if model_args.is_galaxy else (1, 3)
+            mesh_device, model_args.cluster_shape, dims=(3, 1) if model_args.is_galaxy else dims
         ),
     )
     tt_output_torch = tt_output_torch[:, 0:1, :, : model_args.vocab_size]

--- a/models/demos/llama3/tt/multimodal/llama_vision_model.py
+++ b/models/demos/llama3/tt/multimodal/llama_vision_model.py
@@ -322,7 +322,7 @@ class CrossAttentionTransformer(torch.nn.Module):
             full_text_mask, (0, 0, 0, padded_seq_len - full_text_mask.shape[2]), "constant", 0
         )
         full_text_mask_expand_1NSH = full_text_mask.expand(
-            -1, self.configuration.n_heads // self.configuration.num_devices, -1, self.configuration.head_dim
+            -1, self.configuration.n_heads // self.configuration.num_devices_tp, -1, self.configuration.head_dim
         )
         tt_full_text_mask_expand_1NSH = ttnn.from_torch(
             full_text_mask_expand_1NSH,
@@ -500,7 +500,9 @@ class CrossAttentionTransformer(torch.nn.Module):
                 [xattn_mask, torch.zeros(1, 1, B - unpadded_batch_size, xattn_mask.shape[-1])], dim=2
             )
 
-        xattn_mask_expand = xattn_mask.expand(-1, self.configuration.n_heads // self.configuration.num_devices, -1, -1)
+        xattn_mask_expand = xattn_mask.expand(
+            -1, self.configuration.n_heads // self.configuration.num_devices_tp, -1, -1
+        )
         xattn_mask_expand = xattn_mask_expand.transpose(1, 2).contiguous()
 
         tt_xattn_mask = ttnn.from_torch(
@@ -520,7 +522,7 @@ class CrossAttentionTransformer(torch.nn.Module):
                 [full_text_mask, torch.zeros(1, 1, B - unpadded_batch_size, full_text_mask.shape[-1])], dim=2
             )
         full_text_mask_expand_1NSH = full_text_mask.expand(
-            -1, self.configuration.n_heads // self.configuration.num_devices, -1, self.configuration.head_dim
+            -1, self.configuration.n_heads // self.configuration.num_devices_tp, -1, self.configuration.head_dim
         )
         full_text_mask_expand_1NSH = full_text_mask_expand_1NSH.transpose(1, 2).contiguous()
         tt_full_text_mask_expand_1NSH = ttnn.from_torch(
@@ -579,7 +581,7 @@ class CrossAttentionTransformer(torch.nn.Module):
                 [
                     S,
                     B,
-                    self.configuration.n_heads // self.configuration.num_devices,
+                    self.configuration.n_heads // self.configuration.num_devices_tp,
                     tt_xattn_mask.shape[-1],
                 ],
                 [S, B, 32, tt_xattn_mask.shape[-1]],
@@ -592,7 +594,7 @@ class CrossAttentionTransformer(torch.nn.Module):
                 [
                     S,
                     B,
-                    self.configuration.n_heads // self.configuration.num_devices,
+                    self.configuration.n_heads // self.configuration.num_devices_tp,
                     self.configuration.head_dim,
                 ],
                 [


### PR DESCRIPTION
#### Code changes
Addition of data parallelism for llama3 lm head module (plus fix for failing llama3 vision demo tests).

#### Testing
Tested locally on N300 with `pytest models/demos/llama3/tests/test_lm_head.py`, all tests pass.

#### CI runs

- [(Single card) Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/13075611598)
- [(Single card) Demo + Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/13075602995)
- [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/13075597101)
