### PR TITLE
Optimize EDM-fabric flow-control protocols

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -154,12 +154,10 @@ void kernel_main() {
                     packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader),
                     static_cast<uint8_t>(dest_noc_x),
                     static_cast<uint8_t>(dest_noc_y)});
-                DPRINT << "Wait EDMF\n";
                 {
                     DeviceZoneScopedN("WR-FWD-WAIT");
                     fabric_connection.get_forward_connection().wait_for_empty_write_slot();
                 }
-                DPRINT << "Got it\n";
                 fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
                     source_l1_buffer_address, packet_payload_size_bytes);
                 fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
@@ -173,12 +171,10 @@ void kernel_main() {
                     packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader),
                     static_cast<uint8_t>(dest_noc_x),
                     static_cast<uint8_t>(dest_noc_y)});
-                DPRINT << "Wait EDMR\n";
                 {
                     DeviceZoneScopedN("WR-BWD-WAIT");
                     fabric_connection.get_backward_connection().wait_for_empty_write_slot();
                 }
-                DPRINT << "Got it\n";
                 fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
                     source_l1_buffer_address, packet_payload_size_bytes);
                 fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -89,14 +89,6 @@ void kernel_main() {
     const size_t start_sync_val = total_workers_per_sync;
     const size_t finish_sync_val = 3 * total_workers_per_sync;
 
-    DPRINT << "Writing " << (uint32_t)num_mcasts << " mcasts\n";
-    DPRINT << "Writing " << (uint32_t)num_unicasts << " unicasts\n";
-    DPRINT << "Mcast fwd hops: " << (uint32_t)mcast_fwd_hops << "\n";
-    DPRINT << "Mcast bwd hops: " << (uint32_t)mcast_bwd_hops << "\n";
-    DPRINT << "Unicast hops: " << (uint32_t)unicast_hops << "\n";
-    DPRINT << "Has fwd conn: " << (uint32_t)fabric_connection.has_forward_connection() << "\n";
-    DPRINT << "Has bwd conn: " << (uint32_t)fabric_connection.has_backward_connection() << "\n";
-    DPRINT << "Open connection\n";
     fabric_connection.open();
 
     cb_reserve_back(source_l1_cb_index, 1);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -154,7 +154,6 @@ void kernel_main() {
                     packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader),
                     static_cast<uint8_t>(dest_noc_x),
                     static_cast<uint8_t>(dest_noc_y)});
-                // auto &fwd_conn = fabric_connection.get_forward_connection();
                 DPRINT << "Wait EDMF\n";
                 {
                     DeviceZoneScopedN("WR-FWD-WAIT");
@@ -174,7 +173,6 @@ void kernel_main() {
                     packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader),
                     static_cast<uint8_t>(dest_noc_x),
                     static_cast<uint8_t>(dest_noc_y)});
-                // auto &bwd_conn = fabric_connection.get_backward_connection();
                 DPRINT << "Wait EDMR\n";
                 {
                     DeviceZoneScopedN("WR-BWD-WAIT");
@@ -187,7 +185,6 @@ void kernel_main() {
                     (uint32_t)mcast_bwd_packet_header, sizeof(tt::fabric::PacketHeader));
             }
             {
-                // DeviceZoneScopedN("WR-FLUSH");
                 noc_async_writes_flushed();
             }
         }
@@ -224,5 +221,5 @@ void kernel_main() {
         DeviceZoneScopedN("WR-CLOSE");
         fabric_connection.close();
     }
-    // noc_async_write_barrier();
+    noc_async_write_barrier();
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -151,7 +151,7 @@ void kernel_main() {
                 DeviceZoneScopedN("WR-FWD");
                 mcast_fwd_packet_header->to_noc_unicast(NocUnicastCommandHeader{
                     dest_bank_addr,
-                    packet_payload_size_bytes,
+                    packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader),
                     static_cast<uint8_t>(dest_noc_x),
                     static_cast<uint8_t>(dest_noc_y)});
                 // auto &fwd_conn = fabric_connection.get_forward_connection();
@@ -171,7 +171,7 @@ void kernel_main() {
                 DeviceZoneScopedN("WR-BWD");
                 mcast_bwd_packet_header->to_noc_unicast(NocUnicastCommandHeader{
                     dest_bank_addr,
-                    packet_payload_size_bytes,
+                    packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader),
                     static_cast<uint8_t>(dest_noc_x),
                     static_cast<uint8_t>(dest_noc_y)});
                 // auto &bwd_conn = fabric_connection.get_backward_connection();

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "dataflow_api.h"
+
+#include <cstdint>
+#include <cstddef>
+
+void kernel_main() {
+    DeviceZoneScopedN("TEST-FULL");
+    using namespace tt::fabric;
+    size_t arg_idx = 0;
+
+    const size_t dest_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    const size_t packet_payload_size_bytes = get_arg_val<uint32_t>(arg_idx++);
+    const size_t dest_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const size_t dest_noc_y = get_arg_val<uint32_t>(arg_idx++);
+
+    const size_t num_mcasts = get_arg_val<uint32_t>(arg_idx++);
+    const size_t mcast_fwd_hops = get_arg_val<uint32_t>(arg_idx++);
+    const size_t mcast_bwd_hops = get_arg_val<uint32_t>(arg_idx++);
+
+    const size_t num_unicasts = get_arg_val<uint32_t>(arg_idx++);
+    const size_t unicast_hops = get_arg_val<uint32_t>(arg_idx++);
+    const bool unicast_is_fwd = get_arg_val<uint32_t>(arg_idx++) != 0;
+
+    const size_t source_l1_buffer_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t packet_header_cb = get_arg_val<uint32_t>(arg_idx++);
+    const size_t packet_header_size_in_headers = get_arg_val<uint32_t>(arg_idx++);
+
+    auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
+
+    ASSERT(fabric_connection.is_logically_connected());
+
+    if (!fabric_connection.is_logically_connected()) {
+        return;
+    }
+
+    DPRINT << "Writing " << (uint32_t)num_mcasts << " mcasts\n";
+    DPRINT << "Writing " << (uint32_t)num_unicasts << " unicasts\n";
+    DPRINT << "Mcast fwd hops: " << (uint32_t)mcast_fwd_hops << "\n";
+    DPRINT << "Mcast bwd hops: " << (uint32_t)mcast_bwd_hops << "\n";
+    DPRINT << "Unicast hops: " << (uint32_t)unicast_hops << "\n";
+    DPRINT << "Has fwd conn: " << (uint32_t)fabric_connection.has_forward_connection() << "\n";
+    DPRINT << "Has bwd conn: " << (uint32_t)fabric_connection.has_backward_connection() << "\n";
+    DPRINT << "Open connection\n";
+    fabric_connection.open();
+
+    cb_reserve_back(packet_header_cb, packet_header_size_in_headers);
+    const auto packet_header_buffer_address = get_write_ptr(packet_header_cb);
+    auto* mcast_fwd_packet_header = reinterpret_cast<PacketHeader*>(packet_header_buffer_address);
+    auto* mcast_bwd_packet_header =
+        reinterpret_cast<PacketHeader*>(packet_header_buffer_address + sizeof(tt::fabric::PacketHeader));
+    auto* unicast_packet_header =
+        reinterpret_cast<PacketHeader*>(packet_header_buffer_address + sizeof(tt::fabric::PacketHeader) * 2);
+
+    mcast_fwd_packet_header->to_write().to_chip_multicast(
+        MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_fwd_hops)});
+    mcast_bwd_packet_header->to_write().to_chip_multicast(
+        MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_bwd_hops)});
+    unicast_packet_header->to_write().to_chip_unicast(UnicastRoutingCommandHeader{static_cast<uint8_t>(unicast_hops)});
+
+    {
+        DeviceZoneScopedN("MAIN-WRITE-ZONE");
+        for (size_t i = 0; i < num_mcasts; i++) {
+            noc_async_write(
+                source_l1_buffer_address,
+                safe_get_noc_addr(static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr),
+                packet_payload_size_bytes);
+            if (fabric_connection.has_forward_connection()) {
+                mcast_fwd_packet_header->to_noc_unicast(NocUnicastCommandHeader{
+                    dest_bank_addr,
+                    packet_payload_size_bytes,
+                    static_cast<uint8_t>(dest_noc_x),
+                    static_cast<uint8_t>(dest_noc_y)});
+                // auto &fwd_conn = fabric_connection.get_forward_connection();
+                DPRINT << "Wait EDMF\n";
+                fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+                DPRINT << "Got it\n";
+                fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
+                    source_l1_buffer_address, packet_payload_size_bytes);
+                fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                    (uint32_t)mcast_fwd_packet_header, sizeof(tt::fabric::PacketHeader));
+            }
+
+            if (fabric_connection.has_backward_connection()) {
+                mcast_bwd_packet_header->to_noc_unicast(NocUnicastCommandHeader{
+                    dest_bank_addr,
+                    packet_payload_size_bytes,
+                    static_cast<uint8_t>(dest_noc_x),
+                    static_cast<uint8_t>(dest_noc_y)});
+                // auto &bwd_conn = fabric_connection.get_backward_connection();
+                DPRINT << "Wait EDMR\n";
+                fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+                DPRINT << "Got it\n";
+                fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
+                    source_l1_buffer_address, packet_payload_size_bytes);
+                fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+                    (uint32_t)mcast_bwd_packet_header, sizeof(tt::fabric::PacketHeader));
+            }
+            noc_async_writes_flushed();
+        }
+    }
+
+    for (size_t i = 0; i < num_unicasts; i++) {
+        auto& fabric_conn =
+            unicast_is_fwd ? fabric_connection.get_forward_connection() : fabric_connection.get_backward_connection();
+        unicast_packet_header->to_noc_unicast(NocUnicastCommandHeader{
+            dest_bank_addr,
+            packet_payload_size_bytes,
+            static_cast<uint8_t>(dest_noc_x),
+            static_cast<uint8_t>(dest_noc_y)});
+        fabric_conn.wait_for_empty_write_slot();
+        fabric_conn.send_payload_without_header_non_blocking_from_address(
+            source_l1_buffer_address, packet_payload_size_bytes);
+        fabric_conn.send_payload_flush_blocking_from_address(
+            (uint32_t)unicast_packet_header, sizeof(tt::fabric::PacketHeader));
+    }
+
+    // noc_async_write_barrier();
+    fabric_connection.close();
+    // noc_async_write_barrier();
+}

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -150,8 +150,6 @@ void kernel_main() {
             packet_header.reserved2 = 0x1111;  // debug only
         }
 
-        uint64_t buffer_address = sender.edm_buffer_addr +
-                                  (*sender.buffer_index_ptr * (sender.buffer_size_bytes + sizeof(eth_channel_sync_t)));
         sender.send_payload_blocking_from_address(packet_addr, packet_size);
         noc_async_writes_flushed();
         cb_pop_front(cb_id_in0, pages_to_send);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -229,11 +229,9 @@ static void build_and_enqueue(const std::vector<IDevice*>& devices, std::vector<
         devices.size() == programs.size(),
         "Number of devices must match number of programs when calling build_and_enqueue in test");
     for (size_t i = 0; i < devices.size(); i++) {
-        log_info(tt::LogTest, "Compiling program for device {}", i);
         tt::tt_metal::detail::CompileProgram(devices[i], programs[i]);
     }
     for (size_t i = 0; i < devices.size(); i++) {
-        log_info(tt::LogTest, "Enqueuing program for device {}", i);
         tt_metal::EnqueueProgram(devices[i]->command_queue(), programs[i], false);
     }
 }
@@ -2821,11 +2819,9 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
 
 static void wait_for_worker_subdevice_program_completion(
     const std::vector<IDevice*>& devices, const std::optional<SubdeviceInfo>& subdevice_managers) {
-    log_info(tt::LogTest, "Waiting for Op finish");
     std::ranges::for_each(devices, [&](IDevice* d) {
         tt_metal::Finish(d->command_queue(), {subdevice_managers->worker_subdevice_id.at(d->id())});
     });
-    log_info(tt::LogTest, "Main op done");
 }
 
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
@@ -3156,7 +3152,6 @@ void RunWriteThroughputStabilityTestWIthPersistentFabric(
 
     for (size_t i = 0; i < num_op_invocations; i++) {
         log_info(tt::LogTest, "Iteration: {}", i);
-        log_info(tt::LogTest, "Building and enqueing worker programs");
         build_and_enqueue(worker_devices, programs);
 
         log_info(tt::LogTest, "Waiting for Op finish on all devices");
@@ -3500,39 +3495,84 @@ TEST(EdmFabric, BasicMcastThroughputTest_5) {
     const size_t num_op_invocations = 20000;
     RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_6) {
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 8000;
     RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_7) {
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1000;
     RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_8) {
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
     const size_t num_mcasts = 50000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 200;
     RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_9) {
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 150;
     RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_10) {
+// DISABLED due to long runtime
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 50;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 100;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 50;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 20;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 10;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+// DISABLED due to long runtime
+TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 5;
     RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1478,7 +1478,8 @@ bool TestMultiInputReaderKernel(
 ///  MESSAGE COUNT TERMINATION MODE
 ////////////////////////////////////////////////////////////////////
 
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_SingleMessage) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_FabricEDMLoopback_With_Workers_SingleMessage) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 1;
     const bool src_is_dram = true;
@@ -1489,7 +1490,8 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_SingleMessage) {
 }
 
 // Will wrapp sender but not receiver buffers
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_FabricEDMLoopback_With_Workers_2_messages) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 2;
     const bool src_is_dram = true;
@@ -1499,7 +1501,8 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_2_messages) {
     ASSERT_EQ(result, 0);
 }
 // Will wrapp sender but not receiver buffers
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_FabricEDMLoopback_With_Workers_10_messages) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 10;
     const bool src_is_dram = true;
@@ -1510,7 +1513,8 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_10_messages) {
 }
 
 // Will wrapp sender and receiver buffers
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_FabricEDMLoopback_With_Workers_20_messages) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 20;
     const bool src_is_dram = true;
@@ -1520,7 +1524,8 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_20_messages) {
     ASSERT_EQ(result, 0);
 }
 
-TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_FabricEDMLoopback_With_Workers) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 10000;
     const bool src_is_dram = true;
@@ -1588,7 +1593,8 @@ TEST(WorkerFabricEdmDatapath, FabricEDMLoopback_With_Workers_PersistentFabric) {
 
 ////////////////////////////////
 
-TEST(WorkerFabricEdmDatapath, LineFabricMcast_SingleMessage_SingleSource) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_LineFabricMcast_SingleMessage_SingleSource) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 1;
     const bool src_is_dram = true;
@@ -1603,7 +1609,8 @@ TEST(WorkerFabricEdmDatapath, LineFabricMcast_SingleMessage_SingleSource) {
 }
 
 // Non-functional on harvested parts. Needs testing on unharvested parts.
-TEST(WorkerFabricEdmDatapath, LineFabricMcast_ManyMessages_SingleSource) {
+// Disabled non persistent fabric tests - non-persistent fabric mode not supported
+TEST(WorkerFabricEdmDatapath, DISABLED_LineFabricMcast_ManyMessages_SingleSource) {
     const uint32_t page_size = 2048;
     const uint32_t num_pages_total = 10000;
     const bool src_is_dram = true;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -2942,12 +2942,23 @@ struct WriteThroughputStabilityTestWithPersistentFabricParams {
     bool line_sync = false;
 };
 
-void RunWriteThroughputStabilityTestWIthPersistentFabric(
+void RunWriteThroughputStabilityTestWithPersistentFabric(
     size_t num_mcasts,
     size_t num_unicasts,
     size_t num_links,
     size_t num_op_invocations,
     const WriteThroughputStabilityTestWithPersistentFabricParams& params = {}) {
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices < 4) {
+        log_info("This test can only be run on T3000 devices");
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_info("Test must be run on WH");
+        return 0;
+    }
+
     size_t line_size = params.line_size;
     size_t num_devices_with_workers = params.num_devices_with_workers;
     if (num_devices_with_workers == 0) {
@@ -3190,7 +3201,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     params.line_size = 2;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
@@ -3202,7 +3213,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
@@ -3213,7 +3224,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device) {
@@ -3226,7 +3237,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Devic
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
@@ -3237,7 +3248,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device) {
@@ -3250,7 +3261,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2D
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 // hangs if run back-to-back but passes if run separately. Also passes if only one test run before
@@ -3262,7 +3273,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
@@ -3273,7 +3284,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
@@ -3285,7 +3296,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast_LineSy
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
@@ -3297,7 +3308,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast_LineSync) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_LineSync) {
@@ -3308,7 +3319,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_LineSyn
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Device_LineSync) {
@@ -3321,7 +3332,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Devic
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_LineSync) {
@@ -3332,7 +3343,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_LineSy
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2Device_LineSync) {
@@ -3345,7 +3356,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2D
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 // hangs if run back-to-back but passes if run separately. Also passes if only one test run before
@@ -3357,7 +3368,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_Li
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
@@ -3371,7 +3382,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFill
     params.line_size = line_size;
     params.line_sync = line_sync;
     params.num_devices_with_workers = 1;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_LineSync) {
@@ -3384,7 +3395,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFill
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 // hangs if run back-to-back but passes if run separately. Also passes if only one test run before
@@ -3396,7 +3407,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFill
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync) {
@@ -3407,7 +3418,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap_LineSync)
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
@@ -3421,7 +3432,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf_2Device) {
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = report_performance;
     params.line_size = line_size;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
@@ -3432,7 +3443,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf0) {
     const size_t num_op_invocations = 1;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = true;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
@@ -3442,7 +3453,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
     const size_t num_op_invocations = 1;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = true;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
@@ -3454,7 +3465,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_0) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = 2;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_1) {
@@ -3463,7 +3474,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_1) {
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
     const bool line_sync = false;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_2) {
     const size_t num_mcasts = 50000;
@@ -3471,21 +3482,21 @@ TEST(EdmFabric, BasicMcastThroughputTest_2) {
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
 
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_3) {
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_4) {
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_5) {
@@ -3493,7 +3504,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_5) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 20000;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
@@ -3501,7 +3512,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_6) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 8000;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
@@ -3509,7 +3520,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_7) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1000;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
@@ -3517,7 +3528,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_8) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 200;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
@@ -3525,7 +3536,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_9) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 150;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
@@ -3533,7 +3544,7 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 50;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
@@ -3541,7 +3552,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 100;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
@@ -3549,7 +3560,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 50;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
@@ -3557,7 +3568,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 20;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
@@ -3565,7 +3576,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 10;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 // DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
@@ -3573,7 +3584,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 5;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
 
 TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
@@ -3584,7 +3595,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_0_WithLineSync) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
@@ -3595,7 +3606,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_1_WithLineSync) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
@@ -3606,7 +3617,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_2_WithLineSync) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
@@ -3617,7 +3628,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_3_WithLineSync) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
@@ -3628,6 +3639,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
-    RunWriteThroughputStabilityTestWIthPersistentFabric(
+    RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -2952,11 +2952,11 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 4) {
         log_info("This test can only be run on T3000 devices");
-        return 0;
+        return;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
         log_info("Test must be run on WH");
-        return 0;
+        return;
     }
 
     size_t line_size = params.line_size;
@@ -3059,10 +3059,10 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
         const size_t line_index = i;
         auto& program = programs[i];
         auto* device = devices[i];
-        const size_t dest_noc_x = device->worker_core_from_logical_core(dest_core_coord).x;  // TODO;
-        const size_t dest_noc_y = device->worker_core_from_logical_core(dest_core_coord).y;  // TODO;
-        const size_t sync_core_noc_x = device->worker_core_from_logical_core(sync_core_coord).x;  // TODO;
-        const size_t sync_core_noc_y = device->worker_core_from_logical_core(sync_core_coord).y;  // TODO;
+        const size_t dest_noc_x = device->worker_core_from_logical_core(dest_core_coord).x;
+        const size_t dest_noc_y = device->worker_core_from_logical_core(dest_core_coord).y;
+        const size_t sync_core_noc_x = device->worker_core_from_logical_core(sync_core_coord).x;
+        const size_t sync_core_noc_y = device->worker_core_from_logical_core(sync_core_coord).y;
 
         IDevice* backward_device = i == 0 ? nullptr : devices[i - 1];
         IDevice* forward_device = i == line_size - 1 ? nullptr : devices[i + 1];
@@ -3264,7 +3264,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2D
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-// hangs if run back-to-back but passes if run separately. Also passes if only one test run before
 TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
     const size_t num_mcasts = 18;
     const size_t num_unicasts = 0;
@@ -3359,7 +3358,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2D
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-// hangs if run back-to-back but passes if run separately. Also passes if only one test run before
 TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_LineSync) {
     const size_t num_mcasts = 18;
     const size_t num_unicasts = 0;
@@ -3398,7 +3396,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFill
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-// hangs if run back-to-back but passes if run separately. Also passes if only one test run before
 TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_LineSync) {
     const size_t num_mcasts = 36;
     const size_t num_unicasts = 0;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -3261,7 +3261,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_9) {
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
-    const size_t num_op_invocations = 2000;
+    const size_t num_op_invocations = 200;
     const bool report_performance = false;
     RunWriteThroughputStabilityTestWIthPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, report_performance);
@@ -3270,7 +3270,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_10) {
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
-    const size_t num_op_invocations = 200;
+    const size_t num_op_invocations = 150;
     const bool report_performance = false;
     RunWriteThroughputStabilityTestWIthPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, report_performance);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel.hpp>
+#include "tt-metalium/kernel_types.hpp"
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "ttnn/common/constants.hpp"
@@ -221,6 +222,18 @@ std::tuple<std::shared_ptr<Buffer>, std::vector<uint32_t>> build_input_buffer(
         first_device, test_config.size_bytes, test_config.page_size_bytes, test_config.input_buffer_type});
     tt_metal::detail::WriteToBuffer(local_input_buffer, inputs);
     return {local_input_buffer, inputs};
+}
+
+static void build_and_enqueue(const std::vector<IDevice*>& devices, std::vector<Program>& programs) {
+    TT_FATAL(
+        devices.size() == programs.size(),
+        "Number of devices must match number of programs when calling build_and_enqueue in test");
+    for (size_t i = 0; i < devices.size(); i++) {
+        tt::tt_metal::detail::CompileProgram(devices[i], programs[i]);
+    }
+    for (size_t i = 0; i < devices.size(); i++) {
+        tt_metal::EnqueueProgram(devices[i]->command_queue(), programs[i], false);
+    }
 }
 
 struct EthLinkHop {
@@ -1074,12 +1087,7 @@ void setup_test_with_persistent_fabric(
 
         log_info(tt::LogTest, "Building EDM kernels");
         line_fabric->build_kernels();
-        for (size_t i = 0; i < devices.size(); i++) {
-            tt::tt_metal::detail::CompileProgram(devices[i], fabric_programs->at(i));
-        }
-        for (size_t i = 0; i < devices.size(); i++) {
-            tt_metal::EnqueueProgram(devices[i]->command_queue(), fabric_programs->at(i), false);
-        }
+        build_and_enqueue(devices, *fabric_programs);
     }
 }
 
@@ -2809,6 +2817,15 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
     log_info(tt::LogTest, "Finished");
 }
 
+static void wait_for_worker_subdevice_program_completion(
+    const std::vector<IDevice*>& devices, const std::optional<SubdeviceInfo>& subdevice_managers) {
+    log_info(tt::LogTest, "Waiting for Op finish");
+    std::ranges::for_each(devices, [&](IDevice* d) {
+        tt_metal::Finish(d->command_queue(), {subdevice_managers->worker_subdevice_id.at(d->id())});
+    });
+    log_info(tt::LogTest, "Main op done");
+}
+
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
 void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_links, ttnn::Shape const& input_shape) {
     log_info(tt::LogTest, "entering test");
@@ -2892,10 +2909,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
         true);
 
     // wait for op completion
-    log_info(tt::LogTest, "Waiting for Op finish");
-    std::ranges::for_each(devices, [&](IDevice* d) {
-        tt_metal::Finish(d->command_queue(), {subdevice_managers->worker_subdevice_id.at(d->id())});
-    });
+    wait_for_worker_subdevice_program_completion(devices, subdevice_managers);
     log_info(tt::LogTest, "Main op done");
 
     log_info(tt::LogTest, "Fabric teardown");
@@ -2922,4 +2936,265 @@ TEST(CclAsyncOp, DISABLED_AllGather_PersistentFabric_Dim3_Links2_Shape1_1_32_128
 // Mesh device setup seems to not provide the correct configuration for multi-link? To be investigated
 TEST(CclAsyncOp, DISABLED_AllGather_PersistentFabric_Dim3_Links2_Shape1_1_32_8192) {
     run_all_gather_with_persistent_fabric(3, 2, ttnn::Shape({1, 1, 32, 8192}));
+}
+
+void RunWriteThroughputStabilityTestWIthPersistentFabric(
+    size_t num_mcasts, size_t num_unicasts, size_t num_links, size_t num_op_invocations) {
+    using namespace ttnn::ccl;
+
+    auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
+
+    static constexpr size_t line_size = 4;
+    static constexpr size_t source_l1_buffer_address = 1000000;
+    static constexpr uint32_t packet_header_cb_index = tt::CB::c_in0;
+    static constexpr size_t packet_header_cb_size_in_headers = 4;
+    static constexpr bool enable_persistent_fabric_mode = true;
+    static constexpr size_t packet_payload_size_bytes = 4096;
+    static constexpr size_t dest_buffer_size = packet_payload_size_bytes * 4;
+    static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
+
+    T3000TestDevice test_fixture;
+    auto view = test_fixture.mesh_device_->get_view();
+
+    // Get the inner 4 device ring on a WH T3K device so that we can use both links for all devices
+    std::vector<IDevice*> devices = {
+        view.get_device(0, 1), view.get_device(0, 2), view.get_device(1, 2), view.get_device(1, 1)};
+    // build the mesh device
+
+    // Persistent Fabric Setup
+    std::vector<Program> dummy_worker_programs;
+    std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
+    std::optional<std::vector<Program>> fabric_programs;
+    std::vector<Program*> fabric_program_ptrs;
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
+    setup_test_with_persistent_fabric(
+        devices,
+        dummy_worker_programs,
+        subdevice_managers,
+        fabric_programs,
+        fabric_program_ptrs,
+        fabric_handle,
+        enable_persistent_fabric_mode,
+        num_links);
+
+    // Other boiler plate setup
+    CoreRangeSet worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_links - 1, 0)));
+    auto worker_cores_vec = corerange_to_cores(worker_cores, std::nullopt, false);
+    auto dest_core_coord = CoreCoord(0, 0);
+    ttnn::SmallVector<std::shared_ptr<Buffer>> device_dest_buffers;
+    device_dest_buffers.reserve(line_size);
+    for (auto* d : devices) {
+        auto local_input_buffer =
+            CreateBuffer(InterleavedBufferConfig{d, dest_buffer_size, dest_buffer_size, BufferType::L1});
+        device_dest_buffers.push_back(local_input_buffer);
+    }
+
+    size_t dest_bank_addr = device_dest_buffers[0]->address();
+    TT_FATAL(
+        std::all_of(
+            device_dest_buffers.begin(),
+            device_dest_buffers.end(),
+            [dest_bank_addr](const auto& buffer) { return buffer->address() == dest_bank_addr; }),
+        "Test setup error: all destination buffers must have the same bank address across devices");
+
+    // Worker program setup
+    std::vector<Program> programs(line_size);
+    TT_FATAL(
+        programs.size() == devices.size(),
+        "Test misconfiguration. Mismatch in line size and devices. Expected line size of {} but got {} devices "
+        "instead.",
+        line_size,
+        devices.size());
+    for (size_t i = 0; i < line_size; i++) {
+        const size_t line_index = i;
+        auto& program = programs[i];
+        auto* device = devices[i];
+        const size_t dest_noc_x = device->worker_core_from_logical_core(dest_core_coord).x;  // TODO;
+        const size_t dest_noc_y = device->worker_core_from_logical_core(dest_core_coord).y;  // TODO;
+
+        IDevice* backward_device = i == 0 ? nullptr : devices[i - 1];
+        IDevice* forward_device = i == line_size - 1 ? nullptr : devices[i + 1];
+
+        // Initialize the fabric handle for worker connection
+        bool start_of_line = line_index == 0;
+        bool end_of_line = line_index == line_size - 1;
+        bool has_forward_connection = !end_of_line;
+        bool has_backward_connection = !start_of_line;
+        bool unicast_forward = !end_of_line;
+        size_t mcast_fwd_hops = line_size - line_index - 1;
+        size_t mcast_bwd_hops = line_index;
+        size_t unicast_hops = unicast_forward ? mcast_fwd_hops : mcast_bwd_hops;
+
+        auto local_device_fabric_handle =
+            ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+                device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+
+        // reserve CB
+        tt_metal::CircularBufferConfig cb_src0_config =
+            tt_metal::CircularBufferConfig(
+                packet_header_cb_size_in_headers * sizeof(tt::fabric::PacketHeader), {{packet_header_cb_index, cb_df}})
+                .set_page_size(packet_header_cb_index, sizeof(tt::fabric::PacketHeader));
+        CBHandle sender_workers_cb = CreateCircularBuffer(program, worker_cores, cb_src0_config);
+
+        TT_FATAL(
+            local_device_fabric_handle.get_num_links() == num_links,
+            "Error in test setup. Expected two links between devices but got {} links for device {}",
+            local_device_fabric_handle.get_num_links(),
+            device->id());
+
+        std::vector<uint32_t> worker_ct_args = {
+
+        };
+
+        auto worker_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp",
+            worker_cores,
+            tt_metal::WriterDataMovementConfig(worker_ct_args));
+        for (size_t l = 0; l < num_links; l++) {
+            auto worker_core = worker_cores_vec[l];
+            auto build_connection_args = [&local_device_fabric_handle, device, &program, &worker_core](
+                                             bool is_connected_in_direction,
+                                             ttnn::ccl::EdmLineFabricOpInterface::Direction direction,
+                                             std::vector<uint32_t>& rt_args_out) {
+                rt_args_out.push_back(is_connected_in_direction);
+                if (is_connected_in_direction) {
+                    const auto connection = local_device_fabric_handle.uniquely_connect_worker(device, direction);
+                    const auto new_rt_args =
+                        ttnn::ccl::worker_detail::generate_edm_connection_rt_args(connection, program, {worker_core});
+                    log_info(
+                        tt::LogTest,
+                        "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
+                        device->id(),
+                        direction,
+                        connection.edm_noc_x,
+                        connection.edm_noc_y);
+                    std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args_out));
+                }
+            };
+            // RT ARGS
+            std::vector<uint32_t> rt_args = {
+                dest_bank_addr,
+                packet_payload_size_bytes,
+                dest_noc_x,
+                dest_noc_y,
+
+                num_mcasts,
+                mcast_fwd_hops,
+                mcast_bwd_hops,
+
+                num_unicasts,
+                unicast_hops,
+                unicast_forward,
+
+                source_l1_buffer_address,
+                packet_header_cb_index,
+                packet_header_cb_size_in_headers,
+            };
+
+            build_connection_args(has_forward_connection, ttnn::ccl::EdmLineFabricOpInterface::FORWARD, rt_args);
+            build_connection_args(has_backward_connection, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD, rt_args);
+
+            tt_metal::SetRuntimeArgs(program, worker_kernel_id, worker_core, rt_args);
+        }
+    }
+
+    for (size_t i = 0; i < num_op_invocations; i++) {
+        log_info(tt::LogTest, "Iteration: {}", i);
+        log_info(tt::LogTest, "Building and enqueing worker programs");
+        build_and_enqueue(devices, programs);
+
+        log_info(tt::LogTest, "Waiting for Op finish on all devices");
+        wait_for_worker_subdevice_program_completion(devices, subdevice_managers);
+        log_info(tt::LogTest, "Main op done");
+    }
+
+    log_info(tt::LogTest, "Fabric teardown");
+    persistent_fabric_teardown_sequence(
+        devices, subdevice_managers, fabric_handle.value(), tt::fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+
+    log_info(tt::LogTest, "Waiting for teardown completion");
+    for (auto d : devices) {
+        tt_metal::Synchronize(d, ttnn::DefaultQueueId);
+    }
+    log_info(tt::LogTest, "Finished");
+}
+
+TEST(EdmFabric, BasicMcastThroughputTest_0) {
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_1) {
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_2) {
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_3) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_4) {
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 1;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+
+TEST(EdmFabric, BasicMcastThroughputTest_5) {
+    const size_t num_mcasts = 1;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 20000;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_6) {
+    const size_t num_mcasts = 100;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 8000;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_7) {
+    const size_t num_mcasts = 1000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 2000;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_8) {
+    const size_t num_mcasts = 50000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 2000;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_9) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 2000;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_10) {
+    const size_t num_mcasts = 800000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 2;
+    const size_t num_op_invocations = 200;
+    RunWriteThroughputStabilityTestWIthPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
@@ -7,7 +7,12 @@ from loguru import logger
 
 
 def create_and_load_sub_device_manager_with_fabric_interface(
-    mesh_device, worker_sub_devices, ccl_worker_sub_device_id, local_allocator_size, enable_persistent_fabric=True
+    mesh_device,
+    worker_sub_devices,
+    ccl_worker_sub_device_id,
+    local_allocator_size,
+    enable_persistent_fabric=True,
+    wrap_fabric_around_mesh=False,
 ):
     assert ccl_worker_sub_device_id < len(worker_sub_devices)
     mesh_sub_device_manager_id, fabric_subdevice_id = mesh_device.create_sub_device_manager_with_fabric(
@@ -16,7 +21,7 @@ def create_and_load_sub_device_manager_with_fabric_interface(
     # fabric sub-device id can also be queried from device, no need to explicitly pass it in
     mesh_device.load_sub_device_manager(mesh_sub_device_manager_id)
     if enable_persistent_fabric:
-        ttnn.initialize_edm_fabric(mesh_device)
+        ttnn.initialize_edm_fabric(mesh_device, wrap_fabric_around_mesh=wrap_fabric_around_mesh)
     return mesh_sub_device_manager_id
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -139,6 +139,7 @@ def run_all_gather_impl(
     cluster_axis=None,
     create_persistent_fabric=True,
     teardown_persistent_fabric=True,
+    wrap_fabric_around_mesh=False,
 ):
     enable_persistent_fabric = True
     if num_iters < 1:
@@ -162,7 +163,12 @@ def run_all_gather_impl(
     sub_device_stall_group = [worker_sub_device_id]
     if create_persistent_fabric:
         mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
-            mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
+            mesh_device,
+            [worker_sub_device],
+            0,
+            0,
+            enable_persistent_fabric,
+            wrap_fabric_around_mesh=wrap_fabric_around_mesh,
         )
         mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
@@ -312,12 +318,14 @@ def run_all_gather_impl(
         (4, 1, [1, 1, 64, 512], 3, ttnn.TILE_LAYOUT),
         # (4, 1, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
         # (4, 1, [1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 1, 32, 1280], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
         ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
@@ -353,10 +361,12 @@ def test_all_gather(
         layout,
         use_program_cache,
         function_level_defaults,
-        all_gather_topology=ttnn.Topology.Ring,
+        all_gather_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
         enable_async=enable_async,
         rand_tensor=True,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
         mem_config=mem_config,
     )
 
@@ -422,7 +432,7 @@ def test_all_gather(
         ),
     ],
 )
-@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
     "input_dtype",
     [
@@ -432,8 +442,7 @@ def test_all_gather(
 @pytest.mark.parametrize("num_iters", [8])
 @pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_sharded(
-    t3k_mesh_device,
-    # pcie_mesh_device,
+    pcie_mesh_device,
     num_devices,
     output_shape,
     dim,
@@ -449,7 +458,7 @@ def test_all_gather_sharded(
     tensor_mem_layout,
 ):
     run_all_gather_impl(
-        t3k_mesh_device,
+        pcie_mesh_device,
         num_devices,
         output_shape,
         dim,
@@ -458,7 +467,7 @@ def test_all_gather_sharded(
         layout,
         use_program_cache,
         function_level_defaults,
-        all_gather_topology=ttnn.Topology.Ring,
+        all_gather_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
         enable_async=enable_async,
         rand_tensor=True,
@@ -467,6 +476,7 @@ def test_all_gather_sharded(
         tensor_mem_layout=tensor_mem_layout,
         create_persistent_fabric=True,
         teardown_persistent_fabric=True,
+        wrap_fabric_around_mesh=True,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -436,7 +436,7 @@ def test_all_gather(
         ),
     ],
 )
-@pytest.mark.parametrize("num_links", [1, 2])
+@pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -436,7 +436,7 @@ def test_all_gather(
         ),
     ],
 )
-@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("num_links", [1, 2])
 @pytest.mark.parametrize(
     "input_dtype",
     [

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
@@ -18,7 +18,12 @@ void py_bind_common(pybind11::module& module) {
         .value("Ring", ttnn::ccl::Topology::Ring)
         .value("Linear", ttnn::ccl::Topology::Linear);
 
-    module.def("initialize_edm_fabric", &ttnn::ccl::initialize_edm_fabric, py::arg("mesh_device"), py::kw_only());
+    module.def(
+        "initialize_edm_fabric",
+        &ttnn::ccl::initialize_edm_fabric,
+        py::arg("mesh_device"),
+        py::kw_only(),
+        py::arg("wrap_fabric_around_mesh") = false);
 
     module.def("teardown_edm_fabric", &ttnn::ccl::teardown_edm_fabric, py::arg("mesh_device"), py::kw_only());
 }

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -1038,6 +1038,24 @@ static void log_command_stream(ttnn::ccl::cmd::CclHostLowLevelCommandSequence co
     }
 }
 
+std::vector<uint32_t> generate_edm_connection_rt_args(
+    ttnn::ccl::SenderWorkerAdapterSpec const& connection_info,
+    Program &program,
+    CoreRangeSet worker_cores) {
+    std::vector<uint32_t> new_rt_args;
+    auto worker_flow_control_semaphore_id = CreateSemaphore(program, worker_cores, 0);
+    auto worker_teardown_semaphore_id = CreateSemaphore(program, worker_cores, 0);
+    auto worker_buffer_index_semaphore_id = CreateSemaphore(program, worker_cores, 0);
+    append_worker_to_fabric_edm_sender_rt_args(
+        connection_info,
+        worker_flow_control_semaphore_id,
+        worker_teardown_semaphore_id,
+        worker_buffer_index_semaphore_id,
+        new_rt_args);
+
+    return new_rt_args;
+}
+
 void generate_multi_input_command_stream_kernel_rt_args(
     Program& program,
     KernelHandle kernel_id,
@@ -1145,29 +1163,16 @@ void generate_multi_input_command_stream_kernel_rt_args(
         // else: Interleaved addrgen passes no additional args - we specify interleaved addrgen as the default
     }
 
-    rt_args.push_back(forward_fabric_connections.has_value());
     if (forward_fabric_connections.has_value()) {
-        auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, worker_core_range, 0);
-        auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, worker_core_range, 0);
-        auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, worker_core_range, 0);
-        append_worker_to_fabric_edm_sender_rt_args(
-            forward_fabric_connections.value(),
-            sender_worker_flow_control_semaphore_id,
-            sender_worker_teardown_semaphore_id,
-            sender_worker_buffer_index_semaphore_id,
-            rt_args);
+        const auto new_rt_args =
+            generate_edm_connection_rt_args(*forward_fabric_connections, program, worker_core_range);
+        std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args));
     }
     rt_args.push_back(backward_fabric_connections.has_value());
     if (backward_fabric_connections.has_value()) {
-        auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, worker_core_range, 0);
-        auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, worker_core_range, 0);
-        auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, worker_core_range, 0);
-        append_worker_to_fabric_edm_sender_rt_args(
-            backward_fabric_connections.value(),
-            sender_worker_flow_control_semaphore_id,
-            sender_worker_teardown_semaphore_id,
-            sender_worker_buffer_index_semaphore_id,
-            rt_args);
+        const auto new_rt_args =
+            generate_edm_connection_rt_args(*backward_fabric_connections, program, worker_core_range);
+        std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args));
     }
 
     for (size_t i = 0; i < num_command_streams; i++) {

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -1163,6 +1163,7 @@ void generate_multi_input_command_stream_kernel_rt_args(
         // else: Interleaved addrgen passes no additional args - we specify interleaved addrgen as the default
     }
 
+    rt_args.push_back(forward_fabric_connections.has_value());
     if (forward_fabric_connections.has_value()) {
         const auto new_rt_args =
             generate_edm_connection_rt_args(*forward_fabric_connections, program, worker_core_range);

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
@@ -62,6 +62,12 @@ void generate_ccl_command_stream_to_kernel_args(
     ttnn::ccl::tensor_address_runtime_args_overrider *rt_args_overrider_out,
     std::vector<uint32_t>& rt_args_out);
 
+/*
+ * @return the runtime args
+ */
+std::vector<uint32_t> generate_edm_connection_rt_args(
+    const ttnn::ccl::SenderWorkerAdapterSpec& connection_info, Program& program, CoreRangeSet worker_cores);
+
 // TODO: eventually take a fabric handle
 void generate_multi_input_command_stream_kernel_rt_args(
     Program& program,

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
+
 class FabricConnectionManager final {
 public:
     // return if there is/should be a connection - doesn't return whether or not the connection

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -1067,7 +1067,6 @@ void kernel_main() {
     }
 
     if (fabric_connection.is_logically_connected()) {
-        DPRINT << "close\n";
         fabric_connection.close();
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -1067,6 +1067,7 @@ void kernel_main() {
     }
 
     if (fabric_connection.is_logically_connected()) {
+        DPRINT << "close\n";
         fabric_connection.close();
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -603,12 +603,19 @@ EdmLineFabricOpInterface EdmLineFabricOpInterface::build_program_builder_worker_
 
 EdmLineFabricOpInterface EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
     IDevice* local_device,
-    std::optional<IDevice*> forward_device,
-    std::optional<IDevice*> backward_device,
+    IDevice* forward_device,
+    IDevice* backward_device,
     Program* program,
     bool enable_persistent_mode,
     std::optional<size_t> desired_num_links) {
-    return EdmLineFabricOpInterface(local_device, forward_device, backward_device, program, enable_persistent_mode, desired_num_links, true);
+    return EdmLineFabricOpInterface(
+        local_device,
+        forward_device == nullptr ? std::nullopt : std::optional<IDevice*>(forward_device),
+        backward_device == nullptr ? std::nullopt : std::optional<IDevice*>(backward_device),
+        program,
+        enable_persistent_mode,
+        desired_num_links,
+        true);
 }
 
 void EdmLineFabricOpInterface::build_kernels() const {

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -44,6 +44,34 @@ namespace ttnn::ccl {
 
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     std::size_t channel_buffer_size_bytes, std::size_t sender_ratio_size, std::size_t receiver_ratio_size) {
+    TT_FATAL(
+        (receiver_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_0_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_1_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_channel_0_buffer_index_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_channel_0_worker_conn_info_base_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_channel_0_local_flow_control_semaphore_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_channel_0_producer_terminate_connection_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_channel_1_local_flow_control_semaphore_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+    TT_FATAL(
+        (sender_channel_1_producer_terminate_connection_address % eth_word_l1_alignment == 0),
+        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+
     TT_FATAL(sender_channel_1_buffer_index_address != sender_channel_0_buffer_index_address, "FabricEriscDatamoverConfig was constructed with illegal buffer index address");
     const size_t min_buffer_size = sizeof(tt::fabric::PacketHeader) + 2 * FabricEriscDatamoverConfig::eth_channel_sync_size;
     TT_FATAL(channel_buffer_size_bytes >= min_buffer_size, "FabricEriscDatamoverConfig was constructed with `channel_buffer_size_bytes` argument set smaller than minimum size of {}", min_buffer_size);

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -190,9 +190,9 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     receiver_channel_local_buffer_index_address(config.receiver_channel_local_buffer_index_address),
 
     local_sender_channel_0_buffer_address(config.sender_0_channel_base_address),
-    local_sender_channel_0_connection_info_addr(config.sender_channel_0_worker_connection_info_address),
+    local_sender_channel_0_connection_info_addr(config.sender_channel_0_worker_conn_info_base_address),
     local_sender_channel_1_buffer_address(config.sender_1_channel_base_address),
-    local_sender_channel_1_connection_info_addr(config.sender_channel_1_worker_connection_info_address),
+    local_sender_channel_1_connection_info_addr(config.sender_channel_1_worker_conn_info_base_address),
     local_receiver_channel_buffer_address(config.receiver_channel_base_address),
 
     termination_signal_ptr(config.termination_signal_address),
@@ -221,9 +221,9 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         this->receiver_num_buffers,
 
         config.sender_0_channel_base_address,
-        config.sender_channel_0_worker_connection_info_address,
+        config.sender_channel_0_worker_conn_info_base_address,
         config.sender_1_channel_base_address,
-        config.sender_channel_1_worker_connection_info_address,
+        config.sender_channel_1_worker_conn_info_base_address,
         config.receiver_channel_base_address,
         config.receiver_channel_base_address,
 
@@ -349,34 +349,32 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_worker_
         log_trace(tt::LogOp, "Building connection to non-persistent fabric");
     }
     TT_FATAL(sender_channel_0_buffer_index_semaphore_id != sender_channel_0_flow_control_semaphore_id, "Internal error - sender_channel_0_buffer_index_semaphore_id and sender_channel_0_flow_control_semaphore_id aliased eachother");
-    return SenderWorkerAdapterSpec {
+    return SenderWorkerAdapterSpec{
         this->my_noc_x,
         this->my_noc_y,
         this->local_sender_channel_0_buffer_address,
         this->sender_0_num_buffers,
         this->sender_channel_0_flow_control_semaphore_id,
         this->sender_channel_0_connection_semaphore_id,
-        this->config.sender_channel_0_worker_connection_info_address,
+        this->config.sender_channel_0_worker_conn_info_base_address,
         this->config.channel_buffer_size_bytes,
         this->sender_channel_0_buffer_index_semaphore_id,
-        this->enable_persistent_mode
-    };
+        this->enable_persistent_mode};
 }
 
 
 SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_channel() const {
-    return SenderWorkerAdapterSpec {
+    return SenderWorkerAdapterSpec{
         this->my_noc_x,
         this->my_noc_y,
         this->local_sender_channel_1_buffer_address,
         this->sender_1_num_buffers,
         this->sender_channel_1_flow_control_semaphore_id,
         this->sender_channel_1_connection_semaphore_id,
-        this->config.sender_channel_1_worker_connection_info_address,
+        this->config.sender_channel_1_worker_conn_info_base_address,
         this->config.channel_buffer_size_bytes,
         this->sender_channel_1_buffer_index_semaphore_id,
-        false
-    };
+        false};
 }
 
 void FabricEriscDatamoverBuilder::connect_to_downstream_edm(FabricEriscDatamoverBuilder const& downstream_edm) {

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -211,6 +211,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
     log_trace(tt::LogTest, "Sender 1 channel address: {}", this->local_sender_channel_1_buffer_address);
     log_trace(tt::LogTest, "Receiver num buffers: {}", this->receiver_num_buffers);
     log_trace(tt::LogTest, "Receiver channel address: {}", this->local_receiver_channel_buffer_address);
+
     return std::vector<uint32_t>{
         this->firmware_context_switch_interval,
         is_handshake_master,
@@ -231,7 +232,23 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         config.sender_1_channel_base_address,
 
         this->termination_signal_ptr,
-        this->enable_persistent_mode};
+        this->enable_persistent_mode,
+
+        // fabric counters
+        FabricEriscDatamoverConfig::enable_fabric_counters,
+        config.receiver_channel_counters_address,
+        config.sender_channel_0_counters_address,
+        config.sender_channel_1_counters_address,
+
+        // fabric pkt header recording
+        FabricEriscDatamoverConfig::enable_fabric_pkt_header_recording,
+
+        config.receiver_completed_packet_header_cb_address,
+        FabricEriscDatamoverConfig::receiver_completed_packet_header_cb_size_headers,
+        config.sender_0_completed_packet_header_cb_address,
+        FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers,
+        config.sender_1_completed_packet_header_cb_address,
+        FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers};
 }
 
 std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -16,6 +16,7 @@
 
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_counters.hpp"
 
+#include <tt-metalium/assert.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/program_impl.hpp>
 #include <tt-metalium/hal_exp.hpp>
@@ -31,6 +32,7 @@ namespace ccl {
 struct FabricEriscDatamoverConfig {
     static constexpr std::size_t field_size = 16;
     static constexpr std::size_t buffer_alignment = 32;
+    static constexpr std::size_t eth_word_l1_alignment = 16;
     static_assert(((buffer_alignment - 1) & buffer_alignment) == 0);
     static constexpr bool enable_fabric_counters = false;
     static constexpr bool enable_fabric_pkt_header_recording = false;

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -167,6 +167,8 @@ size_t log_worker_to_fabric_edm_sender_rt_args(std::vector<uint32_t> const& args
 class FabricEriscDatamoverBuilder {
    public:
        static constexpr size_t default_firmware_context_switch_interval = 200000;
+       // payload only, no header
+       static constexpr size_t default_packet_payload_size_bytes = 4096;
 
        FabricEriscDatamoverBuilder(
            const CoreCoord& my_eth_core_logical,
@@ -354,7 +356,7 @@ class EdmLineFabricOpInterface {
     size_t firmware_context_switch_interval = FabricEriscDatamoverBuilder::default_firmware_context_switch_interval;
 };
 
-void initialize_edm_fabric(distributed::MeshDevice* mesh_device);
+void initialize_edm_fabric(distributed::MeshDevice* mesh_device, bool wrap_fabric_around_mesh = false);
 void teardown_edm_fabric(distributed::MeshDevice* mesh_device);
 
 };  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -41,10 +41,25 @@ struct FabricEriscDatamoverConfig {
 
     // ----------- Sender Channel 0
     std::size_t sender_channel_0_buffer_index_address = termination_signal_address + field_size;
-    std::size_t sender_channel_0_worker_connection_info_address =
-        sender_channel_0_buffer_index_address + field_size;
+    // Connection info layout:
+    // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
+    // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
+    // 2: WorkerXY (as uint32_t)
+    // 3: Hold's EDM's rdptr for the buffer index in the channel
+    std::size_t sender_channel_0_worker_conn_info_base_address = sender_channel_0_buffer_index_address + field_size;
+    //
+    // std::size_t sender_channel_0_conn_info_worker_rdptr_address_address =
+    //     sender_channel_0_worker_conn_info_base_address;
+    // std::size_t sender_channel_0_conn_info_worker_teardown_semaphore_address =
+    //     sender_channel_0_conn_info_worker_rdptr_address_address + field_size;
+    // std::size_t sender_channel_0_conn_info_worker_xy_address =
+    //     sender_channel_0_conn_info_worker_teardown_semaphore_address + field_size;
+    // std::size_t sender_channel_0_conn_info_edm_rdptr_address_address =
+    //     sender_channel_0_conn_info_worker_xy_address + field_size;
+    //
     std::size_t sender_channel_0_local_flow_control_semaphore_address =
-        sender_channel_0_worker_connection_info_address + field_size;
+        sender_channel_0_worker_conn_info_base_address + sizeof(tt::fabric::EDMChannelWorkerLocationInfo);
+    // sender_channel_0_conn_info_edm_rdptr_address_address + field_size;
     std::size_t sender_channel_0_producer_terminate_connection_address =
         sender_channel_0_local_flow_control_semaphore_address + field_size;
     // persistent mode field
@@ -54,17 +69,33 @@ struct FabricEriscDatamoverConfig {
     std::size_t sender_channel_0_buffer_index_semaphore_address =
         sender_channel_0_connection_semaphore_address + field_size;
 
-    static_assert(field_size >= sizeof(tt::fabric::EDMChannelWorkerLocationInfo));
+    static_assert(sizeof(tt::fabric::EDMChannelWorkerLocationInfo) % field_size == 0);
 
     // ----------- Sender Channel 1
     std::size_t sender_channel_1_buffer_index_address =
         sender_channel_0_buffer_index_semaphore_address + field_size;
-    std::size_t sender_channel_1_worker_connection_info_address =
-        sender_channel_1_buffer_index_address + field_size;
+    // Connection info layout:
+    // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
+    // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
+    // 2: WorkerXY (as uint32_t)
+    // 3: Hold's EDM's rdptr for the buffer index in the channel
+    std::size_t sender_channel_1_worker_conn_info_base_address = sender_channel_1_buffer_index_address + field_size;
+    //
+    // std::size_t sender_channel_1_conn_info_worker_rdptr_address_address =
+    //     sender_channel_1_worker_conn_info_base_address;
+    // std::size_t sender_channel_1_conn_info_worker_teardown_semaphore_address =
+    //     sender_channel_1_conn_info_worker_rdptr_address_address + field_size;
+    // std::size_t sender_channel_1_conn_info_worker_xy_address =
+    //     sender_channel_1_conn_info_worker_teardown_semaphore_address + field_size;
+    // std::size_t sender_channel_1_conn_info_edm_rdptr_address_address =
+    //     sender_channel_1_conn_info_worker_xy_address + field_size;
+    ////
     std::size_t sender_channel_1_local_flow_control_semaphore_address =
-        sender_channel_1_worker_connection_info_address + field_size;
+        sender_channel_1_worker_conn_info_base_address + sizeof(tt::fabric::EDMChannelWorkerLocationInfo);
+    // sender_channel_1_conn_info_edm_rdptr_address_address + field_size;
     std::size_t sender_channel_1_producer_terminate_connection_address =
         sender_channel_1_local_flow_control_semaphore_address + field_size;
+
     // persistent mode field
     std::size_t sender_channel_1_connection_semaphore_address =
         sender_channel_1_producer_terminate_connection_address + field_size;

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -36,7 +36,8 @@ struct FabricEriscDatamoverConfig {
     std::size_t handshake_addr = tt::tt_metal::experimental::hal::get_erisc_l1_unreserved_base()/* + 1024*/;
     std::size_t edm_channel_ack_addr = handshake_addr + eth_channel_sync_size;
     std::size_t termination_signal_address =
-        edm_channel_ack_addr + (2 * eth_channel_sync_size);  // pad extra bytes to match old EDM so handshake logic will still work
+        edm_channel_ack_addr +
+        (4 * eth_channel_sync_size);  // pad extra bytes to match old EDM so handshake logic will still work
 
     // ----------- Sender Channel 0
     std::size_t sender_channel_0_buffer_index_address = termination_signal_address + field_size;
@@ -253,7 +254,13 @@ class EdmLineFabricOpInterface {
     EdmLineFabricOpInterface (IDevice* local_device, std::optional<IDevice*> forward_device, std::optional<IDevice*> backward_device,  Program* program, bool enable_persistent_mode, std::optional<size_t> desired_num_links, bool build_in_worker_connection_mode = false);
 
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(std::vector<IDevice*> const& device_sequence, std::vector<Program*> const& program_sequence, bool enable_persistent_mode, std::optional<size_t> desired_num_links = std::nullopt);
-    static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(IDevice* local_device, std::optional<IDevice*> forward_device, std::optional<IDevice*> backward_device,  Program* program, bool enable_persistent_mode, std::optional<size_t> desired_num_links = std::nullopt);
+    static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
+        IDevice* local_device,
+        IDevice* forward_device,
+        IDevice* backward_device,
+        Program* program,
+        bool enable_persistent_mode,
+        std::optional<size_t> desired_num_links = std::nullopt);
 
     // Will create a connection adapter for a worker which can be used to pass args to the worker kernel talking to the
     // corresponding fabric endpoint. This interface will guarantee unique connections only so requesting more unique connections

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -80,16 +80,6 @@ struct FabricEriscDatamoverConfig {
     // 2: WorkerXY (as uint32_t)
     // 3: Hold's EDM's rdptr for the buffer index in the channel
     std::size_t sender_channel_0_worker_conn_info_base_address = sender_channel_0_buffer_index_address + field_size;
-    //
-    // std::size_t sender_channel_0_conn_info_worker_rdptr_address_address =
-    //     sender_channel_0_worker_conn_info_base_address;
-    // std::size_t sender_channel_0_conn_info_worker_teardown_semaphore_address =
-    //     sender_channel_0_conn_info_worker_rdptr_address_address + field_size;
-    // std::size_t sender_channel_0_conn_info_worker_xy_address =
-    //     sender_channel_0_conn_info_worker_teardown_semaphore_address + field_size;
-    // std::size_t sender_channel_0_conn_info_edm_rdptr_address_address =
-    //     sender_channel_0_conn_info_worker_xy_address + field_size;
-    //
     std::size_t sender_channel_0_local_flow_control_semaphore_address =
         sender_channel_0_worker_conn_info_base_address + sizeof(tt::fabric::EDMChannelWorkerLocationInfo);
     // sender_channel_0_conn_info_edm_rdptr_address_address + field_size;
@@ -113,16 +103,6 @@ struct FabricEriscDatamoverConfig {
     // 2: WorkerXY (as uint32_t)
     // 3: Hold's EDM's rdptr for the buffer index in the channel
     std::size_t sender_channel_1_worker_conn_info_base_address = sender_channel_1_buffer_index_address + field_size;
-    //
-    // std::size_t sender_channel_1_conn_info_worker_rdptr_address_address =
-    //     sender_channel_1_worker_conn_info_base_address;
-    // std::size_t sender_channel_1_conn_info_worker_teardown_semaphore_address =
-    //     sender_channel_1_conn_info_worker_rdptr_address_address + field_size;
-    // std::size_t sender_channel_1_conn_info_worker_xy_address =
-    //     sender_channel_1_conn_info_worker_teardown_semaphore_address + field_size;
-    // std::size_t sender_channel_1_conn_info_edm_rdptr_address_address =
-    //     sender_channel_1_conn_info_worker_xy_address + field_size;
-    ////
     std::size_t sender_channel_1_local_flow_control_semaphore_address =
         sender_channel_1_worker_conn_info_base_address + sizeof(tt::fabric::EDMChannelWorkerLocationInfo);
     // sender_channel_1_conn_info_edm_rdptr_address_address + field_size;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_counters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_counters.hpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::fabric {
+
+struct EdmFabricReceiverChannelCounters {
+    uint32_t n_pkts_processed = 0;
+    uint32_t n_pkts_fwded = 0;
+    uint32_t n_pkts_written_locally = 0;
+    uint32_t n_pkts_rx_acked = 0;
+    uint32_t n_pkts_completion_acked = 0;
+
+    uint32_t n_fabric_mcast_noc_atomic_processed = 0;
+    uint32_t n_fabric_mcast_noc_write_processed = 0;
+    uint32_t n_fabric_unicast_noc_atomic_processed = 0;
+    uint32_t n_fabric_unicast_noc_write_processed = 0;
+
+    EdmFabricReceiverChannelCounters() = default;
+};
+static constexpr uint32_t receiver_channel_counters_l1_size = sizeof(EdmFabricReceiverChannelCounters);
+
+struct EdmFabricSenderChannelCounters {
+    uint32_t n_lifetime_connections = 0;
+
+    uint32_t n_lifetime_pkts_received = 0;
+    uint32_t n_lifetime_pkts_fwded = 0;
+    uint32_t n_lifetime_pkts_acked = 0;
+    uint32_t n_lifetime_pkts_complete = 0;
+
+    uint32_t n_lifetime_fabric_mcast_noc_atomic_pkts = 0;
+    uint32_t n_lifetime_fabric_mcast_noc_write_pkts = 0;
+    uint32_t n_lifetime_fabric_unicast_noc_atomic_pkts = 0;
+    uint32_t n_lifetime_fabric_unicast_noc_write_pkts = 0;
+
+    uint32_t n_connection_pkts_received = 0;
+    uint32_t n_connection_pkts_fwded = 0;
+    uint32_t n_connection_pkts_acked = 0;
+    uint32_t n_connection_pkts_complete = 0;
+
+    uint32_t n_connection_fabric_mcast_noc_atomic_pkts = 0;
+    uint32_t n_connection_fabric_mcast_noc_write_pkts = 0;
+    uint32_t n_connection_fabric_unicast_noc_atomic_pkts = 0;
+    uint32_t n_connection_fabric_unicast_noc_write_pkts = 0;
+
+    void add_connection() volatile {
+        this->n_lifetime_connections++;
+        this->reset_connection_counters();
+    }
+
+    void add_pkt_received() volatile {
+        this->n_lifetime_pkts_received++;
+        this->n_connection_pkts_received++;
+    }
+
+    void add_pkt_sent() volatile {
+        this->n_lifetime_pkts_fwded++;
+        this->n_connection_pkts_fwded++;
+    }
+
+    void reset_connection_counters() volatile {
+        this->n_connection_pkts_received = 0;
+        this->n_connection_pkts_fwded = 0;
+        this->n_connection_pkts_acked = 0;
+        this->n_connection_pkts_complete = 0;
+
+        this->n_connection_fabric_mcast_noc_atomic_pkts = 0;
+        this->n_connection_fabric_mcast_noc_write_pkts = 0;
+        this->n_connection_fabric_unicast_noc_atomic_pkts = 0;
+        this->n_connection_fabric_unicast_noc_write_pkts = 0;
+    }
+};
+static constexpr uint32_t sender_channel_counters_l1_size = sizeof(EdmFabricSenderChannelCounters);
+
+}  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -17,8 +17,9 @@
 namespace tt::fabric {
 
 struct WorkerToFabricEdmSender {
+    static constexpr uint32_t unused_connection_value = 0;
     static constexpr uint32_t open_connection_value = 1;
-    static constexpr uint32_t close_connection_value = 0;
+    static constexpr uint32_t close_connection_request_value = 2;
 
     WorkerToFabricEdmSender() : from_remote_buffer_slot_rdptr_ptr(nullptr) {}
 
@@ -185,7 +186,7 @@ struct WorkerToFabricEdmSender {
             get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr) & ~(uint64_t)NOC_COORDINATE_MASK;
 
         const uint64_t dest_edm_connection_state_addr = dest_noc_addr_coord_only | edm_connection_handshake_l1_addr;
-        noc_inline_dw_write(dest_edm_connection_state_addr, close_connection_value);
+        noc_inline_dw_write(dest_edm_connection_state_addr, close_connection_request_value);
 
         // buffer index stored at location after handshake addr
         const uint64_t remote_buffer_index_addr = dest_noc_addr_coord_only | edm_buffer_index_addr;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -12,7 +12,6 @@
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"
 #include "debug/assert.h"
 #include "debug/dprint.h"
-
 #include <cstdint>
 
 namespace tt::fabric {
@@ -103,14 +102,9 @@ struct WorkerToFabricEdmSender {
         ASSERT(buffer_size_bytes > 0);
     }
 
-    // [[nodiscard]] FORCE_INLINE bool consumer_has_space() const { return *this->from_remote_buffer_slot_rdptr_ptr == 1; }
-    // FORCE_INLINE void clear_flow_control_semaphore() const { noc_semaphore_set(this->from_remote_buffer_slot_rdptr_ptr, 0); }
-
     FORCE_INLINE bool edm_has_space_for_packet() const {
         auto const wrptr = *this->buffer_slot_wrptr_ptr;
         auto const rdptr = *this->from_remote_buffer_slot_rdptr_ptr;
-        DPRINT << "edm buf space check rdptr: " << (uint32_t)rdptr << "\n";
-        DPRINT << "wrptr: " << (uint32_t)wrptr << "\n";
         bool wrptr_ge_rptr = wrptr >= rdptr;
         // TODO: optimize to *= -1 and mask (bit hacks)
         uint8_t slots_used = wrptr_ge_rptr ? (wrptr - rdptr) : ((2 * this->num_buffers_per_channel) - rdptr) + wrptr;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -122,7 +122,6 @@ struct WorkerToFabricEdmSender {
         auto const wrptr = *this->buffer_slot_wrptr_ptr;
         auto const rdptr = *this->from_remote_buffer_slot_rdptr_ptr;
         bool wrptr_ge_rptr = wrptr >= rdptr;
-        // TODO: optimize to *= -1 and mask (bit hacks)
         uint8_t slots_used = wrptr_ge_rptr ? (wrptr - rdptr) : ((2 * this->num_buffers_per_channel) - rdptr) + wrptr;
         return slots_used < this->num_buffers_per_channel;
     }
@@ -227,7 +226,6 @@ struct WorkerToFabricEdmSender {
     volatile uint32_t* worker_teardown_addr;
     size_t edm_buffer_base_addr;
 
-    // the
     // TODO: keep a local copy that we use during the lifetime of the channel to avoid repeated L1 reads
     size_t* buffer_slot_wrptr_ptr;
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -163,7 +163,8 @@ struct WorkerToFabricEdmSender {
 
     FORCE_INLINE void open() {
         const auto dest_noc_addr_coord_only =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr) & ~(uint64_t)NOC_COORDINATE_MASK;
+            // get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr) & ~(uint64_t)NOC_COORDINATE_MASK;
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0);
 
         const uint64_t remote_buffer_index_addr = dest_noc_addr_coord_only | edm_buffer_index_addr;
         ASSERT(remote_buffer_index_addr > 0);
@@ -171,7 +172,7 @@ struct WorkerToFabricEdmSender {
         DPRINT << "Reading buffer_slot_wrptr_ptr frmo: " << (uint64_t)remote_buffer_index_addr << "\n";
 
         tt::fabric::EDMChannelWorkerLocationInfo* worker_location_info_ptr = reinterpret_cast<tt::fabric::EDMChannelWorkerLocationInfo*>(edm_worker_location_info_addr);
-        const uint64_t edm_rdptr_addr = dest_noc_addr_coord_only | reinterpret_cast<uint64_t>(&(worker_location_info_ptr->edm_rdptr));
+        const uint64_t edm_rdptr_addr = dest_noc_addr_coord_only | reinterpret_cast<size_t>(edm_worker_location_info_addr + offsetof(tt::fabric::EDMChannelWorkerLocationInfo, edm_rdptr));
         noc_async_read(edm_rdptr_addr, reinterpret_cast<size_t>(this->from_remote_buffer_slot_rdptr_ptr), sizeof(uint32_t));
         // TODO: Need to change byte enable to be word enable
         const uint64_t dest_edm_location_info_addr            = dest_noc_addr_coord_only | edm_worker_location_info_addr;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -142,6 +142,9 @@ struct WorkerToFabricEdmSender {
     FORCE_INLINE void send_payload_flush_blocking_from_address(uint32_t source_address, size_t size_bytes) {
         send_payload_from_address_impl<ttnn::ccl::EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING>(source_address, size_bytes);
     }
+    FORCE_INLINE void send_payload_flush_non_blocking_from_address(uint32_t source_address, size_t size_bytes) {
+        send_payload_from_address_impl<ttnn::ccl::EDM_IO_BLOCKING_MODE::NON_BLOCKING>(source_address, size_bytes);
+    }
     FORCE_INLINE void send_payload_blocking_from_address(uint32_t source_address, size_t size_bytes) {
         send_payload_from_address_impl<ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING>(source_address, size_bytes);
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -155,7 +155,7 @@ struct WorkerToFabricEdmSender {
 
     static constexpr size_t edm_sender_channel_field_stride_bytes = 16;
 
-    FORCE_INLINE void open() {
+    void open() {
         const auto dest_noc_addr_coord_only =
             // get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr) & ~(uint64_t)NOC_COORDINATE_MASK;
             get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0);
@@ -183,7 +183,7 @@ struct WorkerToFabricEdmSender {
         ASSERT(*this->buffer_slot_wrptr_ptr < 20);
     }
 
-    FORCE_INLINE void close() {
+    void close() {
         const auto dest_noc_addr_coord_only =
             get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr) & ~(uint64_t)NOC_COORDINATE_MASK;
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -185,7 +185,7 @@ tt::fabric::SendStatus forward_payload_to_downstream_edm(
     ) {
     DPRINT << "Fwding pkt to downstream\n";
     // TODO: PERF - this should already be getting checked by the caller so this should be redundant make it an ASSERT
-    bool safe_to_send = downstream_edm_interface.consumer_has_space();
+    bool safe_to_send = downstream_edm_interface.edm_has_space_for_packet();
     if (!safe_to_send) {
         return tt::fabric::SendStatus::NOT_SENT;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -59,6 +59,7 @@ void print_pkt_header_noc_fields(volatile tt::fabric::PacketHeader *const packet
             break;
         }
         case tt::fabric::NocSendType::NOC_MULTICAST: {
+            ASSERT(false); // unimplemented
             break;
         }
     }
@@ -177,28 +178,23 @@ void update_packet_header_for_next_hop(volatile tt::fabric::PacketHeader * packe
 // Modifies the packet header (decrements hop counts) so ...
 //
 // !!!WARNING!!!
-// !!!WARNING!!! do NOT call before determining if the packet should be consumed locally or forwarded
+// !!!WARNING!!! * do NOT call before determining if the packet should be consumed locally or forwarded
+// !!!WARNING!!! * ENSURE DOWNSTREAM EDM HAS SPACE FOR PACKET BEFORE CALLING
 // !!!WARNING!!!
-tt::fabric::SendStatus forward_payload_to_downstream_edm(
+void forward_payload_to_downstream_edm(
     volatile tt::fabric::PacketHeader *packet_header,
     tt::fabric::WorkerToFabricEdmSender &downstream_edm_interface
     ) {
     DPRINT << "Fwding pkt to downstream\n";
     // TODO: PERF - this should already be getting checked by the caller so this should be redundant make it an ASSERT
-    bool safe_to_send = downstream_edm_interface.edm_has_space_for_packet();
-    if (!safe_to_send) {
-        return tt::fabric::SendStatus::NOT_SENT;
-    }
+    ASSERT(downstream_edm_interface.edm_has_space_for_packet()); // best effort check
 
     // This is a good place to print the packet header for debug if you are trying to inspect packets
     // because it is before we start manipulating the header for forwarding
     update_packet_header_for_next_hop(packet_header);
-
     downstream_edm_interface.send_payload_blocking_from_address(
         reinterpret_cast<size_t>(packet_header),
         packet_header->get_payload_size_including_header());
-
-    return tt::fabric::SendStatus::SENT_PAYLOAD_AND_SYNC;
 }
 
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp
@@ -48,10 +48,26 @@ enum SendStatus : uint8_t {
 
 struct EDMChannelWorkerLocationInfo {
     uint32_t worker_semaphore_address;
+    uint32_t align_pad_0;  // Padding added for safe reading over noc
+    uint32_t align_pad_1;
+    uint32_t align_pad_2;
+
     uint32_t worker_teardown_semaphore_address;
+    uint32_t align_pad_3;  // Padding added for safe reading over noc
+    uint32_t align_pad_4;
+    uint32_t align_pad_5;
+
     ttnn::ccl::WorkerXY worker_xy;
+    uint32_t align_pad_6;  // Padding added for safe reading over noc
+    uint32_t align_pad_7;
+    uint32_t align_pad_8;
+
+    uint32_t edm_rdptr = 0;
+    uint32_t align_pad_9;  // Padding added for safe reading over noc
+    uint32_t align_pad_10;
+    uint32_t align_pad_11;
 };
 
-static_assert(sizeof(EDMChannelWorkerLocationInfo) <= 16);
+static_assert(sizeof(EDMChannelWorkerLocationInfo) <= 64);
 
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -560,7 +560,9 @@ bool run_sender_channel_state_machine_step(
         } break;
 
         case SenderState::SENDER_WAIT_WORKER_HANDSHAKE:
-            if (local_sender_channel_worker_interface.connection_is_live()) {
+            // We check for teardown request as well because it is possible that the worker completed the following
+            // sequence between EDM visits to this sender channel
+            if (local_sender_channel_worker_interface.connection_is_live() || local_sender_channel_worker_interface.has_worker_teardown_request()) {
                 bool is_safe_to_receive_next_message = local_sender_channel.eth_is_receiver_channel_send_acked() ||
                                                        local_sender_channel.eth_is_receiver_channel_send_done();
                 if (is_safe_to_receive_next_message) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -578,7 +578,6 @@ void receiver_forward_packet(
     volatile tt::fabric::PacketHeader const &packet_header = *packet_start;
     ASSERT(tt::fabric::is_valid(const_cast<tt::fabric::PacketHeader const &>(packet_header)));
     auto forward_status = get_packet_local_forward_type(packet_header);
-
     switch (forward_status) {
         case PACKET_FORWARD_LOCAL_ONLY: {
             execute_chip_unicast_to_local_chip(packet_start);
@@ -786,7 +785,7 @@ void run_receiver_channel_state_machine_step(
             bool got_payload = local_receiver_channel.eth_bytes_are_available_on_channel(receiver_buffer_index);
             if (got_payload) {
                 bool can_ack = !eth_txq_is_busy();
-                if (eth_txq_is_busy()) {
+                if (!can_ack) {
                     DPRINT << "EDMR eth_txq_is_busy\n";
                 }
                 if (can_ack) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -803,8 +803,8 @@ bool all_channels_drained(tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &lo
                           std::array<tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &local_sender_channel_worker_interfaces) {
 
     bool eth_buffers_drained =
-        local_sender_channel_worker_interfaces[0].has_unacked_sends() &&
-        local_sender_channel_worker_interfaces[1].has_unacked_sends() &&
+        !local_sender_channel_worker_interfaces[0].has_unacked_sends() &&
+        !local_sender_channel_worker_interfaces[1].has_unacked_sends() &&
         local_receiver_channel.all_buffers_drained();
 
     bool sender0_has_unsent_packets = local_sender_channel_worker_interfaces[0].has_unsent_payload();

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -384,10 +384,6 @@ void send_next_data(
     auto local_sender_wrptr_buffer_index = local_sender_wrptr.get_buffer_index();
 
     // auto status = tt::fabric::SendStatus::NOT_SENT;
-    if (eth_txq_is_busy()) {
-        DPRINT << "TRIED TO SEND_DATA WHEN TXQ IS BUSY\n";
-        while (1) {run_routing();}
-    }
     ASSERT(!eth_txq_is_busy());
 
     // status = tt::fabric::SendStatus::SENT_PAYLOAD_AND_SYNC;
@@ -426,14 +422,7 @@ void send_next_data(
         // We weren't able to send the channel_sync_t in one shot with the payload so we need to send a second
         // packet
         // TODO: TUNING - consider busy waiting for a maximum amount of time
-        while (eth_txq_is_busy()) {
-            DPRINT << "Waiting for txq to be free\n";
-            run_routing();
-        }
-        if (eth_txq_is_busy()) {
-            DPRINT << "TRIED TO SEND_CHANNEL_SYNC WHEN TXQ IS BUSY\n";
-            while (1) {run_routing();}
-        }
+        while (eth_txq_is_busy()) {}
         send_channel_sync(
             sender_buffer_channel, local_sender_wrptr, receiver_buffer_channel, remote_receiver_wrptr);
         // } else {
@@ -515,10 +504,6 @@ void receiver_send_received_ack(
     ASSERT(!eth_txq_is_busy());
     DPRINT << "EDMR rsa to " << (uint32_t)sender_buffer_channel.get_bytes_sent_address(sender_ackptr_buffer_index) << " for source channel " << (uint32_t)src_id << "\n";
     DPRINT << "\tbuffer_index " << (uint32_t)sender_ackptr_buffer_index  << "\n";
-    if (eth_txq_is_busy()) {
-        DPRINT << "TRIED TO WRITE WHEN TXQ IS BUSY\n";
-        while (1) {run_routing();}
-    }
     internal_::eth_send_packet_unsafe(
         0,
         local_ack_channel_sync_src_addr >> 4,

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -401,7 +401,7 @@ template <uint8_t SENDER_NUM_BUFFERS, uint8_t RECEIVER_NUM_BUFFERS>
 void send_next_data(
     tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS> &sender_buffer_channel,
     tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS> &sender_worker_interface,
-    tt::fabric::OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &outbound_to_receiver_channel_pointers,
+    OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &outbound_to_receiver_channel_pointers,
     tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &receiver_buffer_channel) {
 
     auto &remote_receiver_wrptr = outbound_to_receiver_channel_pointers.wrptr;
@@ -601,7 +601,7 @@ template <bool enable_packet_header_recording, bool enable_fabric_counters, uint
 bool run_sender_channel_step(
     tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS> &local_sender_channel,
     tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS> &local_sender_channel_worker_interface,
-    tt::fabric::OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &outbound_to_receiver_channel_pointers,
+    OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &outbound_to_receiver_channel_pointers,
     tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &remote_receiver_channel,
     volatile tt::fabric::EdmFabricSenderChannelCounters* sender_channel_counters,
     PacketHeaderRecorder &packet_header_recorder,
@@ -725,7 +725,7 @@ void run_receiver_channel_step(
     tt::fabric::WorkerToFabricEdmSender &downstream_edm_interface,
     volatile tt::fabric::EdmFabricReceiverChannelCounters *receiver_channel_counters_ptr,
     std::array<tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &remote_eth_sender_wrptrs,
-    tt::fabric::ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &receiver_channel_pointers,
+    ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &receiver_channel_pointers,
     PacketHeaderRecorder &packet_header_recorder,
     ReceiverState *const receiver_state_out) {
 
@@ -847,8 +847,8 @@ void run_fabric_edm_main_loop(
     std::array<tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> remote_eth_sender_wrptrs {
         tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>(),
         tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>()};
-    tt::fabric::OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> outbound_to_receiver_channel_pointers;
-    tt::fabric::ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> receiver_channel_pointers;
+    OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> outbound_to_receiver_channel_pointers;
+    ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> receiver_channel_pointers;
     std::array<bool, NUM_SENDER_CHANNELS> channel_connection_established = {false, false};
 
     while (!got_immediate_termination_signal(termination_signal_ptr)) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -563,14 +563,17 @@ bool run_sender_channel_state_machine_step(
             // We check for teardown request as well because it is possible that the worker completed the following
             // sequence between EDM visits to this sender channel
             if (local_sender_channel_worker_interface.connection_is_live() || local_sender_channel_worker_interface.has_worker_teardown_request()) {
+                DPRINT << "EDMS " << (uint32_t)sender_channel_index << " handshake complete\n";
+                DPRINT << "EDM ch " << (uint32_t)sender_channel_index << " wkr con ntfy wrkr\n";
+                DPRINT << "\tl1 worker info ptr: " << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr << "\n";
+                DPRINT << "\tworker.x=" << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr->worker_xy.x << ", .y=" << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr->worker_xy.y << ", sem_addr=" << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr->worker_semaphore_address << "\n";
+                sender_notify_workers_if_buffer_available_sequence(local_sender_channel_worker_interface, local_sender_channel);
+
+                // We are full so we need to go to wait for eth state so we can get the ack to free up space
+                // Future implementation will not have these discrete states so we can avoid these types of issues
                 bool is_safe_to_receive_next_message = local_sender_channel.eth_is_receiver_channel_send_acked() ||
                                                        local_sender_channel.eth_is_receiver_channel_send_done();
                 if (is_safe_to_receive_next_message) {
-                    DPRINT << "EDMS " << (uint32_t)sender_channel_index << " handshake complete\n";
-                    DPRINT << "EDM ch " << (uint32_t)sender_channel_index << " wkr con ntfy wrkr\n";
-                    DPRINT << "\tl1 worker info ptr: " << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr << "\n";
-                    DPRINT << "\tworker.x=" << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr->worker_xy.x << ", .y=" << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr->worker_xy.y << ", sem_addr=" << (uint32_t)local_sender_channel_worker_interface.worker_location_info_ptr->worker_semaphore_address << "\n";
-                    sender_notify_workers_if_buffer_available_sequence(local_sender_channel_worker_interface, local_sender_channel);
                     *sender_state_out = SenderState::SENDER_WAITING_FOR_WORKER;
                 } else {
                     *sender_state_out = SenderState::SENDER_WAITING_FOR_ETH;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -392,36 +392,5 @@ struct EdmChannelWorkerInterface {
     ChannelBufferPointer<NUM_BUFFERS> local_rdptr; // also used as completion_ptr
 };
 
-template <uint8_t RECEIVER_NUM_BUFFERS>
-struct OutboundReceiverChannelPointers {
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wrptr;
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> ack_ptr;
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> completion_ptr;
-
-    bool has_space_for_packet() const {
-        // DPRINT << "EDMS has_space_for_packet: " << (uint32_t)completion_ptr.distance_behind(wrptr) << " < " << (uint32_t)RECEIVER_NUM_BUFFERS << ", completion_ptr: " << (uint32_t)completion_ptr.get_ptr() << ", wrptr: " << (uint32_t)wrptr.get_ptr() << "\n";
-        return completion_ptr.distance_behind(wrptr) < RECEIVER_NUM_BUFFERS;
-    }
-
-    bool has_unacknowledged_eth_packets() const {
-        return ack_ptr.get_ptr() != wrptr.get_ptr();
-    }
-
-    bool has_incomplete_eth_packets() const {
-        return completion_ptr.get_ptr() != wrptr.get_ptr();
-    }
-
-    bool has_unacknowledged_or_incomplete_eth_packets() const {
-        return has_incomplete_eth_packets() || has_unacknowledged_eth_packets();
-    }
-};
-
-template <uint8_t RECEIVER_NUM_BUFFERS>
-struct ReceiverChannelPointers {
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wr_sent_ptr;
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wr_flush_ptr;
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> ack_ptr;
-    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> completion_ptr;
-};
 
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -18,20 +18,124 @@
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
 
 namespace tt::fabric {
+
+template <typename T, typename Parameter>
+class NamedType
+{
+public:
+    explicit NamedType(T const& value) : value_(value) {}
+    explicit NamedType(T&& value) : value_(std::move(value)) {}
+    NamedType<T,Parameter> &operator=(NamedType<T,Parameter> const& rhs) = default;
+    T& get() { return value_; }
+    T const& get() const {return value_; }
+    operator T() const { return value_; }
+    operator T&() { return value_; }
+private:
+    T value_;
+};
+
+using BufferIndex = NamedType<uint8_t, struct BufferIndexType>;
+using BufferPtr = NamedType<uint8_t, struct BufferPtrType>;
+
+
 // Increments val and wraps to 0 if it reaches limit
-template <typename T, size_t LIMIT>
+template <size_t LIMIT, typename T>
 auto wrap_increment(T val) -> T {
     static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
+    constexpr bool is_pow2 = (LIMIT & (LIMIT - 1)) == 0;
     if constexpr (LIMIT == 1) {
         return val;
     } else if constexpr (LIMIT == 2) {
         return 1 - val;
-    } else if constexpr ((LIMIT > 0) && (LIMIT & (LIMIT - 1)) == 0) {
+    } else if constexpr (is_pow2) {
         return (val + 1) & (LIMIT - 1);
     } else {
-        return (val == LIMIT - 1) ? 0 : val + 1;
+        return (val == static_cast<T>(LIMIT - 1)) ? static_cast<T>(0) : static_cast<T>(val + 1);
     }
 }
+
+template <uint8_t NUM_BUFFERS>
+auto normalize_ptr(BufferPtr ptr) -> BufferIndex {
+    static_assert(NUM_BUFFERS != 0, "normalize_ptr called with NUM_BUFFERS of 0; it must be greater than 0");
+    constexpr bool is_size_pow2 = (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
+    constexpr bool is_size_2 = NUM_BUFFERS == 2;
+    constexpr bool is_size_1 = NUM_BUFFERS == 1;
+    constexpr uint8_t wrap_mask = NUM_BUFFERS - 1;
+    if constexpr (is_size_pow2) {
+        return BufferIndex{ptr & wrap_mask};
+    } else if constexpr (is_size_2) {
+        return BufferIndex{(uint8_t)1 - ptr};
+    } else if constexpr (is_size_1) {
+        return BufferIndex{0};
+    } else {
+        // note it may make sense to calculate this only when we increment
+        // which will save calculations overall (but may add register pressure)
+        // and introduce undesirable loads
+        bool normalize = ptr >= NUM_BUFFERS;
+        uint8_t normalized_ptr = ptr.get() - static_cast<uint8_t>(normalize * NUM_BUFFERS);
+        ASSERT(normalized_ptr < NUM_BUFFERS);
+        return BufferIndex{normalized_ptr};
+    }
+}
+
+
+template <uint8_t NUM_BUFFERS>
+class ChannelBufferPointer {
+    static_assert(NUM_BUFFERS <= std::numeric_limits<uint8_t>::max() / 2, "NUM_BUFFERS must be less than or half of std::numeric_limits<uint8_t>::max() due to the internal implementation");
+    public:
+    static constexpr bool is_size_pow2 = (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
+    static constexpr bool is_size_2 = NUM_BUFFERS == 2;
+    static constexpr bool is_size_1 = NUM_BUFFERS == 1;
+    static constexpr uint8_t ptr_wrap_size = 2 * NUM_BUFFERS;
+
+    // Only to use if is_size_pow2
+    static constexpr uint8_t ptr_wrap_mask = (2 * NUM_BUFFERS) - 1;
+    static constexpr uint8_t buffer_wrap_mask = NUM_BUFFERS - 1;
+    ChannelBufferPointer() : ptr(0) {}
+    /*
+     * Returns the "raw" pointer - not usable to index the buffer channel
+     */
+    BufferPtr get_ptr() const {
+        return this->ptr;
+    }
+
+    bool is_caught_up_to(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
+        return this->is_caught_up_to(leading_ptr.get_ptr());
+    }
+    uint8_t distance_behind(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
+        return this->distance_behind(leading_ptr.get_ptr());
+    }
+
+    /*
+     * Returns the buffer index pointer which is usable to index into the buffer memory
+     */
+    BufferIndex get_buffer_index() const {
+        return BufferIndex{normalize_ptr<NUM_BUFFERS>(this->ptr)};
+    }
+
+    void increment() {
+        this->ptr = wrap_increment<2*NUM_BUFFERS>(this->ptr);
+    }
+
+    private:
+    // Make these private to make sure caller doesn't accidentally mix two pointers pointing to
+    // different sized channels
+    bool is_caught_up_to(BufferPtr const& leading_ptr) const {
+        return this->get_ptr() == leading_ptr;
+    }
+    uint8_t distance_behind(BufferPtr const& leading_ptr) const {
+        bool leading_gte_trailing_ptr = leading_ptr >= this->ptr;
+        if constexpr (is_size_pow2) {
+            return (leading_ptr - this->ptr) & ptr_wrap_mask;
+        } else {
+            return leading_gte_trailing_ptr ?
+                leading_ptr - this->ptr :
+                ptr_wrap_size - (this->ptr - leading_ptr);
+        }
+    }
+    BufferPtr ptr = BufferPtr{0};
+};
+
 
 template <typename T>
 FORCE_INLINE auto wrap_increment(T val, size_t max) {
@@ -66,7 +170,6 @@ class EthChannelBuffer final {
         buffer_size_in_bytes(buffer_size_bytes),
         eth_transaction_ack_word_addr(eth_transaction_ack_word_addr),
         max_eth_payload_size_in_bytes(buffer_size_in_bytes + sizeof(eth_channel_sync_t)),
-        buff_idx(0),
         channel_id(channel_id) {
         for (uint8_t i = 0; i < NUM_BUFFERS; i++) {
             this->buffer_addresses[i] =
@@ -84,72 +187,73 @@ class EthChannelBuffer final {
             ASSERT((uint32_t)channel_bytes_acked_addresses[i] != (uint32_t)(channel_bytes_sent_addresses[i]));
             *(channel_bytes_sent_addresses[i]) = 0;
             *(channel_bytes_acked_addresses[i]) = 0;
+            *(channel_src_id_addresses[i]) = 0x1c0ffee1;
+            (channel_src_id_addresses[i])[1] = 0x1c0ffee2;
+
             // Note we don't need to overwrite the `channel_src_id_addresses` except for perhapse
             // debug purposes where we may wish to tag this with a special value
         }
     }
 
-    [[nodiscard]] FORCE_INLINE size_t get_current_buffer_address() const {
-        return this->buffer_addresses[this->buffer_index()];
+    [[nodiscard]] FORCE_INLINE size_t get_buffer_address(BufferIndex const& buffer_index) const {
+        return this->buffer_addresses[buffer_index];
     }
 
-    [[nodiscard]] FORCE_INLINE volatile PacketHeader *get_current_packet_header() const {
-        return reinterpret_cast<volatile PacketHeader *>(this->buffer_addresses[this->buffer_index()]);
+    [[nodiscard]] FORCE_INLINE volatile PacketHeader *get_packet_header(BufferIndex const& buffer_index) const {
+        return reinterpret_cast<volatile PacketHeader *>(this->buffer_addresses[buffer_index]);
     }
 
-    [[nodiscard]] FORCE_INLINE size_t get_current_payload_size() const {
-        return get_current_packet_header()->get_payload_size_including_header();
+    [[nodiscard]] FORCE_INLINE size_t get_payload_size(BufferIndex const& buffer_index) const {
+        return get_packet_header(buffer_index)->get_payload_size_including_header();
     }
-    [[nodiscard]] FORCE_INLINE size_t get_current_payload_plus_channel_sync_size() const {
-        return get_current_packet_header()->get_payload_size_including_header() + sizeof(eth_channel_sync_t);
+    [[nodiscard]] FORCE_INLINE size_t get_payload_plus_channel_sync_size(BufferIndex const& buffer_index) const {
+        return get_packet_header(buffer_index)->get_payload_size_including_header() + sizeof(eth_channel_sync_t);
     }
 
     // TODO: Split off into two separate functions:
     //       volatile tt_l1_ptr size_t *get_current_bytes_sent_ptr() const
-    //       size_t get_current_bytes_sent_address() const
-    [[nodiscard]] FORCE_INLINE volatile tt_l1_ptr size_t *get_current_bytes_sent_address() const {
-        return this->channel_bytes_sent_addresses[this->buffer_index()];
+    //       size_t get_bytes_sent_address() const
+    [[nodiscard]] FORCE_INLINE volatile tt_l1_ptr size_t *get_bytes_sent_address(BufferIndex const& buffer_index) const {
+        return this->channel_bytes_sent_addresses[buffer_index];
     }
 
-    [[nodiscard]] FORCE_INLINE volatile tt_l1_ptr size_t *get_current_bytes_acked_address() const {
-        return this->channel_bytes_acked_addresses[this->buffer_index()];
+    [[nodiscard]] FORCE_INLINE volatile tt_l1_ptr size_t *get_bytes_acked_address(BufferIndex const& buffer_index) const {
+        return this->channel_bytes_acked_addresses[buffer_index];
     }
 
-    [[nodiscard]] FORCE_INLINE volatile tt_l1_ptr size_t *get_current_src_id_address() const {
-        return this->channel_src_id_addresses[this->buffer_index()];
+    [[nodiscard]] FORCE_INLINE volatile tt_l1_ptr size_t *get_src_id_address(BufferIndex const& buffer_index) const {
+        return this->channel_src_id_addresses[buffer_index];
     }
 
-    [[nodiscard]] FORCE_INLINE size_t get_channel_buffer_max_size_in_bytes() const {
+    [[nodiscard]] FORCE_INLINE size_t get_channel_buffer_max_size_in_bytes(BufferIndex const& buffer_index) const {
         return this->buffer_size_in_bytes;
     }
 
     // Doesn't return the message size, only the maximum eth payload size
-    [[nodiscard]] FORCE_INLINE size_t get_current_max_eth_payload_size() const {
+    [[nodiscard]] FORCE_INLINE size_t get_max_eth_payload_size() const {
         return this->max_eth_payload_size_in_bytes;
     }
 
     [[nodiscard]] FORCE_INLINE size_t get_id() const { return this->channel_id; }
 
-    [[nodiscard]] FORCE_INLINE bool eth_is_receiver_channel_send_done() const {
-        return *(this->get_current_bytes_sent_address()) == 0;
+    [[nodiscard]] FORCE_INLINE bool eth_is_receiver_channel_send_done(BufferIndex const& buffer_index) const {
+        return *(this->get_bytes_sent_address(buffer_index)) == 0;
     }
-    [[nodiscard]] FORCE_INLINE bool eth_bytes_are_available_on_channel() const {
-        return *(this->get_current_bytes_sent_address()) != 0;
+    [[nodiscard]] FORCE_INLINE bool eth_bytes_are_available_on_channel(BufferIndex const& buffer_index) const {
+        return *(this->get_bytes_sent_address(buffer_index)) != 0;
     }
-    [[nodiscard]] FORCE_INLINE bool eth_is_receiver_channel_send_acked() const {
-        return *(this->get_current_bytes_acked_address()) != 0;
+    [[nodiscard]] FORCE_INLINE bool eth_is_receiver_channel_send_acked(BufferIndex const& buffer_index) const {
+        return *(this->get_bytes_acked_address(buffer_index)) != 0;
     }
-    FORCE_INLINE void eth_clear_sender_channel_ack() const {
-        *(this->channel_bytes_acked_addresses[this->buffer_index()]) = 0;
+    FORCE_INLINE void eth_clear_sender_channel_ack(BufferIndex const& buffer_index) const {
+        *(this->channel_bytes_acked_addresses[buffer_index]) = 0;
+    }
+    [[nodiscard]] FORCE_INLINE bool eth_is_acked_or_completed(BufferIndex const& buffer_index) const {
+        return eth_is_receiver_channel_send_acked(buffer_index) || eth_is_receiver_channel_send_done(buffer_index);
     }
 
     [[nodiscard]] FORCE_INLINE size_t get_eth_transaction_ack_word_addr() const {
         return this->eth_transaction_ack_word_addr;
-    }
-
-    FORCE_INLINE void advance_buffer_index() {
-        this->buff_idx = wrap_increment<decltype(this->buff_idx), 2 * NUM_BUFFERS>(this->buff_idx);
-        DPRINT << "new buff_idx: " << (uint32_t)this->buff_idx << "\n";
     }
 
     [[nodiscard]] FORCE_INLINE bool all_buffers_drained() const {
@@ -160,20 +264,19 @@ class EthChannelBuffer final {
         return drained;
     }
 
-    /*
-     * NOT used directly to index the buffers list
-     */
-    [[nodiscard]] FORCE_INLINE uint8_t get_rdptr() const {
-        return this->buff_idx;
+    bool needs_to_send_channel_sync() const {
+        return this->need_to_send_channel_sync;
+    }
+
+    void set_need_to_send_channel_sync(bool need_to_send_channel_sync) {
+        this->need_to_send_channel_sync = need_to_send_channel_sync;
+    }
+
+    void clear_need_to_send_channel_sync() {
+        this->need_to_send_channel_sync = false;
     }
 
    private:
-    FORCE_INLINE auto buffer_index() const {
-        bool normalize = buff_idx >= NUM_BUFFERS;
-        auto normalized_buff_idx = buff_idx - (normalize * NUM_BUFFERS);
-        ASSERT(normalized_buff_idx < NUM_BUFFERS);
-        return normalized_buff_idx;
-    }
 
     std::array<size_t, NUM_BUFFERS> buffer_addresses;
     std::array<volatile tt_l1_ptr size_t *, NUM_BUFFERS> channel_bytes_sent_addresses;
@@ -185,13 +288,19 @@ class EthChannelBuffer final {
     // Includes header + payload + channel_sync
     const std::size_t eth_transaction_ack_word_addr;
     const std::size_t max_eth_payload_size_in_bytes;
-    uint8_t buff_idx;
     uint8_t channel_id;
 };
 
+
+template <uint8_t NUM_BUFFERS>
 struct EdmChannelWorkerInterface {
     EdmChannelWorkerInterface() :
-        worker_location_info_ptr(nullptr), remote_producer_wrptr(nullptr), connection_live_semaphore(nullptr) {}
+        worker_location_info_ptr(nullptr),
+        remote_producer_wrptr(nullptr),
+        connection_live_semaphore(nullptr),
+        local_wrptr(),
+        local_ackptr(),
+        local_rdptr() {}
     EdmChannelWorkerInterface(
         // TODO: PERF: See if we can make this non-volatile and then only
         // mark it volatile when we know we need to reload it (i.e. after we receive a
@@ -205,17 +314,23 @@ struct EdmChannelWorkerInterface {
         volatile tt_l1_ptr uint32_t *const connection_live_semaphore) :
         worker_location_info_ptr(worker_location_info_ptr),
         remote_producer_wrptr(remote_producer_wrptr),
-        connection_live_semaphore(connection_live_semaphore){
+        connection_live_semaphore(connection_live_semaphore),
+        local_wrptr(),
+        local_ackptr(),
+        local_rdptr() {
         DPRINT << "EDM  my_x: " << (uint32_t)my_x[0] << ", my_y: " << (uint32_t)my_y[0] << " rdptr set to 0 at " << (uint32_t)(void*)&(worker_location_info_ptr->edm_rdptr) << "\n";
         *reinterpret_cast<volatile uint32_t*>(&(worker_location_info_ptr->edm_rdptr)) = 0;
         }
 
     // Flow control methods
     //
-    [[nodiscard]] FORCE_INLINE bool has_payload(uint8_t local_rdptr) {
-        // DPRINT << "\t*remote_producer_wrptr: " << (uint32_t)*remote_producer_wrptr << "\n";
-        // DPRINT << "\tlocal_rdpt: " << (uint32_t)local_rdptr << "\n";
-        return local_rdptr != *remote_producer_wrptr;
+    // local_wrptr trails from_remote_wrptr
+    // we have new data if they aren't equal
+    [[nodiscard]] FORCE_INLINE bool has_unsent_payload() {
+        return local_wrptr.get_ptr() != *remote_producer_wrptr;
+    }
+    [[nodiscard]] FORCE_INLINE bool has_unacked_sends() {
+        return local_ackptr.get_ptr() != local_wrptr.get_ptr();
     }
 
     // FORCE_INLINE void clear_local_semaphore() { noc_semaphore_set(remote_producer_wrptr, 0); }
@@ -224,17 +339,13 @@ struct EdmChannelWorkerInterface {
         return worker_location_info_ptr->worker_semaphore_address;
     }
 
-    FORCE_INLINE void update_worker_read_ptr(uint8_t new_rdptr) {
+    FORCE_INLINE void update_worker_copy_of_read_ptr() {
         auto const &worker_info = *worker_location_info_ptr;
         uint64_t worker_semaphore_address = get_noc_addr(
             (uint32_t)worker_info.worker_xy.x, (uint32_t)worker_info.worker_xy.y, worker_info.worker_semaphore_address);
-        DPRINT << "EDM ntf wrkr sem @" << (uint64_t)worker_semaphore_address << ", val = " << (uint32_t)new_rdptr << "\n";
-        noc_inline_dw_write(worker_semaphore_address, new_rdptr);
+        DPRINT << "EDM ntf wrkr sem @" << (uint64_t)worker_semaphore_address << ", val = " << (uint32_t)local_ackptr.get_ptr() << "\n";
+        noc_inline_dw_write(worker_semaphore_address, local_ackptr.get_ptr());
     }
-    // void increment_worker_semaphore() const {
-
-    //     noc_semaphore_inc(worker_semaphore_address, 1);
-    // }
 
     // Connection management methods
     //
@@ -252,12 +363,57 @@ struct EdmChannelWorkerInterface {
         noc_semaphore_inc(worker_semaphore_address, 1);
     }
 
+    bool all_eth_packets_acked() const {
+        return this->local_ackptr.is_caught_up_to(this->local_wrptr);
+    }
+    bool all_eth_packets_completed() const {
+        return this->local_rdptr.is_caught_up_to(this->local_wrptr);
+    }
+
+
+    // Call to keep the connection info fresh.
+    // Eventually TODO is to consolidate this with `local_rdptr` in this class too
+    // void propagate_ackptr_to_connection_info(BufferPtr const& rdptr) {
+    //     worker_location_info_ptr->edm_rdptr = rdptr;
+    // }
+    void propagate_ackptr_to_connection_info() {
+        worker_location_info_ptr->edm_rdptr = local_ackptr.get_ptr();
+    }
+
     [[nodiscard]] FORCE_INLINE bool has_worker_teardown_request() const { return *connection_live_semaphore == tt::fabric::WorkerToFabricEdmSender::close_connection_request_value; }
     [[nodiscard]] FORCE_INLINE bool connection_is_live() const { return *connection_live_semaphore == tt::fabric::WorkerToFabricEdmSender::open_connection_value; }
 
     volatile EDMChannelWorkerLocationInfo *worker_location_info_ptr;
     volatile tt_l1_ptr uint32_t *const remote_producer_wrptr;
     volatile tt_l1_ptr uint32_t *const connection_live_semaphore;
+
+    ChannelBufferPointer<NUM_BUFFERS> local_wrptr;
+    ChannelBufferPointer<NUM_BUFFERS> local_ackptr;
+    ChannelBufferPointer<NUM_BUFFERS> local_rdptr; // also used as completion_ptr
+};
+
+template <uint8_t RECEIVER_NUM_BUFFERS>
+struct OutboundReceiverChannelPointers {
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wrptr;
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> ack_ptr;
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> completion_ptr;
+
+    bool has_space_for_packet() const {
+        // DPRINT << "EDMS has_space_for_packet: " << (uint32_t)completion_ptr.distance_behind(wrptr) << " < " << (uint32_t)RECEIVER_NUM_BUFFERS << ", completion_ptr: " << (uint32_t)completion_ptr.get_ptr() << ", wrptr: " << (uint32_t)wrptr.get_ptr() << "\n";
+        return completion_ptr.distance_behind(wrptr) < RECEIVER_NUM_BUFFERS;
+    }
+
+    bool has_unacknowledged_eth_packets() const {
+        return ack_ptr.get_ptr() != wrptr.get_ptr();
+    }
+
+    bool has_incomplete_eth_packets() const {
+        return completion_ptr.get_ptr() != wrptr.get_ptr();
+    }
+
+    bool has_unacknowledged_or_incomplete_eth_packets() const {
+        return has_incomplete_eth_packets() || has_unacknowledged_eth_packets();
+    }
 };
 
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -169,9 +169,10 @@ class EthChannelBuffer final {
 
    private:
     FORCE_INLINE auto buffer_index() const {
-        ASSERT(this->buff_idx < NUM_BUFFERS);
         bool normalize = buff_idx >= NUM_BUFFERS;
-        return buff_idx - (normalize * NUM_BUFFERS);
+        auto normalized_buff_idx = buff_idx - (normalize * NUM_BUFFERS);
+        ASSERT(normalized_buff_idx < NUM_BUFFERS);
+        return normalized_buff_idx;
     }
 
     std::array<size_t, NUM_BUFFERS> buffer_addresses;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -416,4 +416,12 @@ struct OutboundReceiverChannelPointers {
     }
 };
 
+template <uint8_t RECEIVER_NUM_BUFFERS>
+struct ReceiverChannelPointers {
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wr_sent_ptr;
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wr_flush_ptr;
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> ack_ptr;
+    ChannelBufferPointer<RECEIVER_NUM_BUFFERS> completion_ptr;
+};
+
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
@@ -156,9 +156,19 @@ operation::ProgramWithCallbacks all_gather_async_multi_core_with_workers(
     std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
         enable_persistent_fabric_mode
             ? ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
-                  device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links)
+                  device,
+                  forward_device.value_or(nullptr),
+                  backward_device.value_or(nullptr),
+                  &program,
+                  enable_persistent_fabric_mode,
+                  num_links)
             : ccl::EdmLineFabricOpInterface(
-                  device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+                  device,
+                  forward_device.value_or(nullptr),
+                  backward_device.value_or(nullptr),
+                  &program,
+                  enable_persistent_fabric_mode,
+                  num_links);
 
     LineTopology line_topology(ring_size, ring_index);
 


### PR DESCRIPTION
# Ticket
https://github.com/tenstorrent/tt-metal/issues/17425
https://github.com/tenstorrent/tt-metal/issues/17427
https://github.com/tenstorrent/tt-metal/issues/17428

# Problem description
The fabric EDM implementation implementation from a flow-control protocol perspective is very unopotimized - leading to most of the components in the data-path being forced to operate in near-locksteap. This PR addresses most of the flow-control protocol concerns.

# What's changed
(Note the majority of the line changes - around 1000 - are test changes/additions)
This PR updated the flow-control protocol for 3 of the 4 primary pieces of the EDM-fabric datapath:
* Worker -> EDM
* EDM sender channel(s)
* EDM receiver

It's essentially a rewrite for the majority of the fabric EDM.

The fourth piece of the data-path that is not updated is the sender -> receiver flow control over ethernet. This is a future change and is tracked through this issue: https://github.com/tenstorrent/tt-metal/issues/17430

## Worker -> EDM Adapter:
The WorkerToFabricEdmSender acts as an adapter between the worker and the EDM, it hides details
of the communication between worker and EDM to provide flexibility for the implementation to change
over time without kernel updates. Additionally, details for adapter setup w.r.t runtime args is also hidden.
The main functionality provided is:
- Opening a connection with the EDM
- Closing a connection with the EDM
- Flow control protocol between worker and EDM

### Flow Control Protocol:
The flow control protocol is rd/wr ptr based and is implemented as follows (from the worker's perspective):
The adapter has a local write pointer (wrptr) which is used to track the next buffer slot to write to. The adapter
also has a local memory slot that holds the remote read pointer (rdptr) of the EDM. The adapter uses the difference
between these two pointers (where rdptr trails wrptr) to determine if the EDM has space to accept a new packet.

As the adapter writes into the EDM, it updates the local wrptr. As the EDM reads from its local L1 channel buffer,
it will notify the worker/adapter (here) by updating the worker remote_rdptr to carry the value of the EDM rdptr.

## EDM <-> EDM Channel Flow Control
The flow control protocol between EDM channels is built on a rd/wr ptr based protocol where pointers are
to buffer slots within the channel (as opposed so something else like byte or word offset). Ptrs are
free to advance independently from each other as long as there is no overflow or underflow.

### Sender Channel Flow Control
Both sender channels share the same flow control view into the receiver channel. This is because both channels
write to the same receiver channel.
* wrptr:
  * points to next buffer slot to write to into the remote (over Ethernet) receiver channel.
  * leads other pointers
  * writer updates for every new packet
  * `has_data_to_send(): local_wrptr != remote_sender_wrptr`
* ackptr
  * trails `wrptr`
  * advances as the channel receives acknowledgements from the receiver
    * as this advances, the sender channel can notify the upstream worker of additional space in sender channel buffer
* completion_ptr:
  * trails `local_wrptr`
  * "rdptr" from remote sender's perspective
  * advances as packets completed by receiver
    * as this advances, the sender channel can write additional packets to the receiver at this slot

### Receiver Channel Flow Control
* ackptr/rdptr:
  * leads all pointers
  * indicates the next buffer slot we expect data to arrive (from remote sender) at
    * advances as packets are received (and acked)
  * make sure not to overlap completion pointer
* wr_sent_ptr:
  * trails `ackptr`
  * indicates the buffer slot currently being processed, written out
    * advances after all forwding writes (to noc or downstream EDM) are initiated
* wr_flush_ptr:
  * trails `wr_sent_ptr`
  * advances as writes are flushed
* completion_ptr:
  * trails `wr_flush_ptr`
  * indicates the next receiver buffer slot in the receiver channel to send completion acks for


### Checklist
- [x] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/13124332374
  - latest:https://github.com/tenstorrent/tt-metal/actions/runs/13143779893 
- [ ] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13139757409 (failed with regressions)
  - [x] https://github.com/tenstorrent/tt-metal/actions/runs/13143675281 (regression fixes applied) 
- [x] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13121494829
  - same failures as on main
- [x] TG nightly: https://github.com/tenstorrent/tt-metal/actions/runs/13121489574
  - same failures as on main
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
