### PR TITLE
Add support for fabric 1D mcast

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -43,9 +43,15 @@ run_t3000_ttfabric_tests() {
 
   echo "LOG_METAL: Running run_t3000_ttfabric_tests"
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*T3k*
+  # Unicast tests
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
+  # Line Mcast tests
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --e_depth 3
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --w_depth 3
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --n_depth 1
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --s_depth 1
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -48,10 +48,10 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   # Line Mcast tests
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --e_depth 3
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --w_depth 3
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --n_depth 1
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 2 --num_dest_endpoints 2 --num_links 16 --s_depth 1
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 3
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 3
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 1
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 1
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -114,10 +114,15 @@ run_tg_tests() {
   elif [[ "$1" == "fabric" ]]; then
     echo "LOG_FABRIC: running run_tg_fabric_tests"
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
+    # Unicast tests
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
-
+    # Line Mcast tests
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --e_depth 7
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --w_depth 7
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --n_depth 3
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --s_depth 3
   elif [[ "$1" == "llama3-70b" ]]; then
     run_tg_llama3.1-70b_tests
 

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -119,10 +119,10 @@ run_tg_tests() {
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
     # Line Mcast tests
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --e_depth 7
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --w_depth 7
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --n_depth 3
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 4 --num_dest_endpoints 4 --num_links 16 --s_depth 3
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 7
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 7
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3
+    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 3
   elif [[ "$1" == "llama3-70b" ]]; then
     run_tg_llama3.1-70b_tests
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
@@ -144,7 +144,7 @@ inline bool test_buffer_handler_async_wr() {
                 target_address = base_target_address;
             }
 
-            packet_header.routing.flags = FORWARD;
+            packet_header.routing.flags = FORWARD | MCAST_DATA;
             packet_header.routing.packet_size_bytes = input_queue_state.curr_packet_size_words * PACKET_WORD_SIZE_BYTES;
             packet_header.routing.dst_mesh_id = dest_device >> 16;
             packet_header.routing.dst_dev_id = dest_device & 0xFFFF;
@@ -163,6 +163,11 @@ inline bool test_buffer_handler_async_wr() {
             packet_header.session.target_offset_l = target_address;
             packet_header.session.target_offset_h = noc_offset;
             target_address += packet_header.routing.packet_size_bytes - PACKET_HEADER_SIZE_BYTES;
+            // packet_header.packet_parameters.misc_parameters.words[1] = input_queue_state.packet_rnd_seed;
+            packet_header.packet_parameters.mcast_parameters.east = 7;
+            packet_header.packet_parameters.mcast_parameters.west = 0;
+            packet_header.packet_parameters.mcast_parameters.north = 0;
+            packet_header.packet_parameters.mcast_parameters.south = 0;
             tt_fabric_add_header_checksum(&packet_header);
             uint32_t words_left = words_to_init - words_initialized;
             bool split_header = words_left < PACKET_HEADER_SIZE_WORDS;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -92,7 +92,7 @@ inline std::vector<uint32_t> get_random_numbers_from_range(uint32_t start, uint3
 typedef struct test_board {
     std::vector<chip_id_t> available_chip_ids;
     std::vector<chip_id_t> physical_chip_ids;
-    std::vector<std::pair<chip_id_t, chip_id_t>> unicast_map;
+    std::vector<std::pair<chip_id_t, std::vector<chip_id_t>>> tx_rx_map;
     std::map<chip_id_t, IDevice*> device_handle_map;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane;
     uint32_t num_chips_to_use;
@@ -228,7 +228,41 @@ typedef struct test_board {
         }
     }
 
-    void generate_unicast_map(uint32_t num_hops) {
+    // TODO: This only supports 1d mcast right now, needs to be updated to support 2D mcast
+    // Note that this currently only considers intra-mesh mcast
+    // physical_start_chip_id here refers to the sender, not the mcast origin due to how we count depth
+    std::vector<chip_id_t> get_physical_mcast_chip_ids(
+        chip_id_t physical_start_chip_id, const std::unordered_map<RoutingDirection, uint32_t>& mcast_depth) {
+        std::vector<chip_id_t> physical_dsts;
+        // APIs use mesh chip id, so convert physical chip id to mesh chip id
+        auto [mesh_id, chip_id] = this->get_mesh_chip_id(physical_start_chip_id);
+        bool valid = true;
+        for (const auto& [routing_direction, num_hops_in_direction] : mcast_depth) {
+            for (auto j = 0; j < num_hops_in_direction; j++) {
+                auto neighbors = this->get_intra_chip_neighbors(mesh_id, chip_id, routing_direction);
+                if (neighbors.empty()) {
+                    valid = false;
+                    break;
+                }
+                // Assumes all neighbors are the same chip
+                chip_id = neighbors[0];
+                // convert mesh chip id to physical chip id
+                physical_dsts.push_back(
+                    this->control_plane->get_physical_chip_id_from_mesh_chip_id({mesh_id, chip_id}));
+            }
+            if (!valid) {
+                break;
+            }
+        }
+        if (valid) {
+            return physical_dsts;
+        } else {
+            return {};
+        }
+    }
+
+    void generate_tx_rx_map(
+        uint32_t num_hops, bool mcast, const std::unordered_map<RoutingDirection, uint32_t>& mcast_depth) {
         std::unordered_map<chip_id_t, std::vector<chip_id_t>> chip_neighbors;
         std::unordered_map<chip_id_t, std::vector<chip_id_t>> chip_n_hop_neighbors;
         std::vector<std::pair<chip_id_t, uint32_t>> n_hop_neighbors_cnt;
@@ -241,8 +275,20 @@ typedef struct test_board {
 
         // for default setting, generate a random unicast map
         if (DEFAULT_NUM_HOPS == num_hops) {
+            if (mcast) {
+                for (auto i = 0; i < physical_chip_ids.size(); i++) {
+                    auto physical_mcast_chip_ids = this->get_physical_mcast_chip_ids(physical_chip_ids[i], mcast_depth);
+                    if (!physical_mcast_chip_ids.empty()) {
+                        tx_rx_map.push_back({physical_chip_ids[i], std::move(physical_mcast_chip_ids)});
+                        // Generate only one mcast for now to avoid overlapping cores
+                        break;
+                    }
+                }
+                TT_FATAL(!tx_rx_map.empty(), "Failed to generate multicast map");
+                return;
+            }
             for (auto i = 0; i < physical_chip_ids.size(); i += 2) {
-                unicast_map.push_back({physical_chip_ids[i], physical_chip_ids[i + 1]});
+                tx_rx_map.push_back({physical_chip_ids[i], {physical_chip_ids[i + 1]}});
             }
             return;
         }
@@ -345,13 +391,29 @@ typedef struct test_board {
                 // throw std::runtime_error("No neighbor found for this chip");
             }
 
-            unicast_map.push_back({chip_id, selected_chip_id});
+            if (mcast) {
+                // TODO: This assumes line mcast from neighbor with 1 hop
+                auto physical_mcast_chip_ids = this->get_physical_mcast_chip_ids(chip_id, mcast_depth);
+                if (!physical_mcast_chip_ids.empty() && (physical_mcast_chip_ids[0] == selected_chip_id)) {
+                    tx_rx_map.push_back({chip_id, std::move(physical_mcast_chip_ids)});
+                } else {
+                    continue;
+                }
+            } else {
+                tx_rx_map.push_back({chip_id, {selected_chip_id}});
+            }
 
             // remove selected chip as it should not be picked again
             chip_n_hop_neighbors.erase(selected_chip_id);
 
             // remove the entry for current chip as it should not be picked again
             chip_n_hop_neighbors.erase(chip_id);
+        }
+
+        // error out if no valid tx rx mapping was found
+        // We should only be able to hit this assertion when looking for mcast destinations
+        if (!tx_rx_map.size()) {
+            throw std::runtime_error("No valid tx rx mapping found");
         }
     }
 
@@ -381,6 +443,11 @@ typedef struct test_board {
         chip_id_t dst_chip_id,
         chan_id_t src_chan_id) {
         return control_plane->get_fabric_route(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, src_chan_id);
+    }
+
+    inline std::vector<chip_id_t> get_intra_chip_neighbors(
+        mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) {
+        return control_plane->get_intra_chip_neighbors(src_mesh_id, src_chip_id, routing_direction);
     }
 
     inline void close_devices() { tt::tt_metal::detail::CloseDevices(device_handle_map); }
@@ -728,11 +795,15 @@ typedef struct test_device {
         }
     }
 
+    inline std::vector<chip_id_t> get_intra_chip_neighbors(RoutingDirection routing_direction) {
+        return board_handle->get_intra_chip_neighbors(mesh_id, logical_chip_id, routing_direction);
+    }
+
 } test_device_t;
 
 typedef struct test_traffic {
     std::shared_ptr<test_device_t> tx_device;
-    std::shared_ptr<test_device_t> rx_device;
+    std::vector<std::shared_ptr<test_device_t>> rx_devices;
     uint32_t num_tx_workers;
     uint32_t num_rx_workers;
     uint32_t target_address;
@@ -747,7 +818,7 @@ typedef struct test_traffic {
     std::vector<uint32_t> tx_to_rx_address_map;
     std::vector<std::vector<uint32_t>> rx_to_tx_address_map;
     std::vector<std::vector<uint32_t>> tx_results;
-    std::vector<std::vector<uint32_t>> rx_results;
+    std::vector<std::vector<std::vector<uint32_t>>> rx_results;
     uint32_t test_results_address;
     uint32_t rx_buf_size;
     uint32_t num_links_to_use;
@@ -755,14 +826,14 @@ typedef struct test_traffic {
 
     test_traffic(
         std::shared_ptr<test_device_t>& tx_device_,
-        std::shared_ptr<test_device_t>& rx_device_,
+        std::vector<std::shared_ptr<test_device_t>>& rx_devices_,
         uint32_t num_src_endpoints,
         uint32_t num_dest_endpoints,
         uint32_t target_address_,
         uint32_t num_hops,
         uint32_t num_links_) {
         tx_device = tx_device_;
-        rx_device = rx_device_;
+        rx_devices = rx_devices_;
         num_tx_workers = num_src_endpoints;
         num_rx_workers = num_dest_endpoints;
         target_address = target_address_;
@@ -779,7 +850,9 @@ typedef struct test_traffic {
 
         std::vector<CoreCoord> src_routers;
         std::vector<CoreCoord> dest_routers;
-        tx_device->get_available_router_cores(num_hops, rx_device, src_routers, dest_routers);
+        // For Unicast there is only one rx device
+        // For mcast, this only supports line mcast, we pass the last device as the rx device
+        tx_device->get_available_router_cores(num_hops, *rx_devices.rbegin(), src_routers, dest_routers);
         num_links_to_use = std::min(num_links_, (uint32_t)src_routers.size());
 
         _generate_tx_to_rx_mapping();
@@ -791,7 +864,8 @@ typedef struct test_traffic {
             // for bi-directional traffic leave the higher priority cores on the rx chip for tx kernels
             num_cores_to_skip = (num_rx_workers + num_links_to_use - 1) / num_links_to_use;
         }
-        rx_workers = rx_device->select_worker_cores(dest_routers, num_links_to_use, num_rx_workers, num_cores_to_skip);
+        // Assumes uniform worker grid across receiver chips
+        rx_workers = rx_devices[0]->select_worker_cores(dest_routers, num_links_to_use, num_rx_workers, num_cores_to_skip);
 
         // TODO: not the most optimum selection, might impact somewhat in bidirectional mode
         controller_logical_core = tx_device->select_random_worker_cores(1)[0];
@@ -802,7 +876,7 @@ typedef struct test_traffic {
         }
 
         for (auto& [router, noc, worker] : rx_workers) {
-            rx_virtual_cores.push_back(rx_device->device_handle->worker_core_from_logical_core(worker));
+            rx_virtual_cores.push_back(rx_devices[0]->device_handle->worker_core_from_logical_core(worker));
         }
     }
 
@@ -816,7 +890,7 @@ typedef struct test_traffic {
         tt_metal::NOC noc_id;
         std::vector<uint32_t> zero_buf(2, 0);
         CoreCoord router_virtual_core;
-        uint32_t mesh_chip_id = rx_device->mesh_chip_id;
+        uint32_t mesh_chip_id = rx_devices[0]->mesh_chip_id;
 
         // update the test results address, which will be used later for polling, collecting results
         test_results_address = test_results_address_;
@@ -868,7 +942,7 @@ typedef struct test_traffic {
             std::vector<uint32_t> runtime_args = {
                 time_seed,                                           // 0: time based seed
                 tx_device->get_endpoint_id(tx_core),                 // 1: src_endpoint_id
-                rx_device->get_noc_offset(rx_core),                  // 2: dest_noc_offset
+                rx_devices[0]->get_noc_offset(rx_core),                  // 2: dest_noc_offset
                 tx_device->get_noc_offset(controller_logical_core),  // 3: controller noc offset
                 router_virtual_core.x,                               // 4: router_x
                 router_virtual_core.y,                               // 5: router_y
@@ -930,33 +1004,37 @@ typedef struct test_traffic {
                     runtime_args.push_back(address);
                 }
             } else if (ATOMIC_INC == fabric_command) {
-                tt::llrt::write_hex_vec_to_core(
-                    rx_device->device_handle->id(), rx_virtual_cores[i], zero_buf, target_address);
+                for (const auto& rx_device : rx_devices) {
+                    tt::llrt::write_hex_vec_to_core(
+                        rx_device->device_handle->id(), rx_virtual_cores[i], zero_buf, target_address);
+                }
             }
 
-            // zero out the test results address, which will be used for polling
-            tt::llrt::write_hex_vec_to_core(
-                rx_device->device_handle->id(), rx_virtual_cores[i], zero_buf, test_results_address);
+            for (const auto& rx_device : rx_devices) {
+                // zero out the test results address, which will be used for polling
+                tt::llrt::write_hex_vec_to_core(
+                    rx_device->device_handle->id(), rx_virtual_cores[i], zero_buf, test_results_address);
 
-            log_info(
-                LogTest,
-                "Device: {}, RX kernel running on: logical: x={},y={}; virtual: x={},y={}",
-                rx_device->physical_chip_id,
-                rx_core.x,
-                rx_core.y,
-                rx_virtual_cores[i].x,
-                rx_virtual_cores[i].y);
-            auto kernel = tt_metal::CreateKernel(
-                rx_device->program_handle,
-                rx_kernel_src,
-                {rx_core},
-                tt_metal::DataMovementConfig{
-                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                    .noc = noc_id,
-                    .compile_args = rx_compile_args,
-                    .defines = defines});
+                log_info(
+                    LogTest,
+                    "Device: {}, RX kernel running on: logical: x={},y={}; virtual: x={},y={}",
+                    rx_device->physical_chip_id,
+                    rx_core.x,
+                    rx_core.y,
+                    rx_virtual_cores[i].x,
+                    rx_virtual_cores[i].y);
+                auto kernel = tt_metal::CreateKernel(
+                    rx_device->program_handle,
+                    rx_kernel_src,
+                    {rx_core},
+                    tt_metal::DataMovementConfig{
+                        .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                        .noc = noc_id,
+                        .compile_args = rx_compile_args,
+                        .defines = defines});
 
-            tt_metal::SetRuntimeArgs(rx_device->program_handle, kernel, rx_core, runtime_args);
+                tt_metal::SetRuntimeArgs(rx_device->program_handle, kernel, rx_core, runtime_args);
+            }
         }
     }
 
@@ -974,12 +1052,14 @@ typedef struct test_traffic {
     }
 
     void wait_for_rx_workers_to_finish() {
-        for (auto& rx_core : rx_virtual_cores) {
-            while (true) {
-                auto tx_status =
-                    tt::llrt::read_hex_vec_from_core(rx_device->device_handle->id(), rx_core, test_results_address, 4);
-                if ((tx_status[0] & 0xFFFF) != 0) {
-                    break;
+        for (const auto& rx_device : rx_devices) {
+            for (auto& rx_core : rx_virtual_cores) {
+                while (true) {
+                    auto tx_status =
+                        tt::llrt::read_hex_vec_from_core(rx_device->device_handle->id(), rx_core, test_results_address, 4);
+                    if ((tx_status[0] & 0xFFFF) != 0) {
+                        break;
+                    }
                 }
             }
         }
@@ -1001,15 +1081,19 @@ typedef struct test_traffic {
         }
 
         // collect rx results
-        for (uint32_t i = 0; i < num_rx_workers; i++) {
-            rx_results.push_back(tt::llrt::read_hex_vec_from_core(
-                rx_device->device_handle->id(), rx_virtual_cores[i], test_results_address, 128));
-            log_info(
-                LogTest,
-                "RX{} status = {}",
-                i,
-                packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
-            pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        rx_results.resize(rx_devices.size());
+        for (uint32_t d = 0; d < rx_devices.size(); d++) {
+            for (uint32_t i = 0; i < num_rx_workers; i++) {
+                rx_results[d].push_back(tt::llrt::read_hex_vec_from_core(
+                    rx_devices[d]->device_handle->id(), rx_virtual_cores[i], test_results_address, 128));
+                log_info(
+                    LogTest,
+                    "Device {} RX{} status = {}",
+                    rx_devices[d]->device_handle->id(),
+                    i,
+                    packet_queue_test_status_to_string(rx_results[d][i][PQ_TEST_STATUS_INDEX]));
+                pass &= (rx_results[d][i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+            }
         }
 
         return pass;
@@ -1020,19 +1104,21 @@ typedef struct test_traffic {
         uint64_t num_tx_words, num_tx_packets;
 
         // tally-up data words and number of packets from rx and tx
-        for (uint32_t i = 0; i < num_rx_workers; i++) {
-            num_tx_words = 0;
-            num_tx_packets = 0;
+        for (uint32_t d = 0; d < rx_devices.size(); d++) {
+            for (uint32_t i = 0; i < num_rx_workers; i++) {
+                num_tx_words = 0;
+                num_tx_packets = 0;
 
-            for (auto j : rx_to_tx_map[i]) {
-                num_tx_words += get_64b_result(tx_results[j], PQ_TEST_WORD_CNT_INDEX);
-                num_tx_packets += get_64b_result(tx_results[j], TX_TEST_IDX_NPKT);
-            }
-            pass &= (get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX) == num_tx_words);
-            pass &= (get_64b_result(rx_results[i], TX_TEST_IDX_NPKT) == num_tx_packets);
+                for (auto j : rx_to_tx_map[i]) {
+                    num_tx_words += get_64b_result(tx_results[j], PQ_TEST_WORD_CNT_INDEX);
+                    num_tx_packets += get_64b_result(tx_results[j], TX_TEST_IDX_NPKT);
+                }
+                pass &= (get_64b_result(rx_results[d][i], PQ_TEST_WORD_CNT_INDEX) == num_tx_words);
+                pass &= (get_64b_result(rx_results[d][i], TX_TEST_IDX_NPKT) == num_tx_packets);
 
-            if (!pass) {
-                break;
+                if (!pass) {
+                    break;
+                }
             }
         }
 
@@ -1083,16 +1169,18 @@ typedef struct test_traffic {
             */
         }
         total_tx_bw_2 = ((double)total_tx_words_sent) * PACKET_WORD_SIZE_BYTES / max_tx_elapsed_cycles;
-        for (uint32_t i = 0; i < num_rx_workers; i++) {
-            uint64_t words_received = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
-            uint32_t num_tx = rx_to_tx_map[i].size();
-            log_info(
-                LogTest,
-                "Device: {}, RX {}, num producers = {}, words received = {}",
-                rx_device->physical_chip_id,
-                i,
-                num_tx,
-                words_received);
+        for (uint32_t d = 0; d < rx_devices.size(); d++) {
+            for (uint32_t i = 0; i < num_rx_workers; i++) {
+                uint64_t words_received = get_64b_result(rx_results[d][i], PQ_TEST_WORD_CNT_INDEX);
+                uint32_t num_tx = rx_to_tx_map[i].size();
+                log_info(
+                    LogTest,
+                    "Device: {}, RX {}, num producers = {}, words received = {}",
+                    rx_devices[d]->physical_chip_id,
+                    i,
+                    num_tx,
+                    words_received);
+            }
         }
         // log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
         log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw_2);
@@ -1220,6 +1308,8 @@ int main(int argc, char **argv) {
 
     constexpr uint32_t default_atomic_increment = 4;
 
+    constexpr uint32_t default_multicast = 0;
+
     constexpr const char* default_board_type = "glx32";
 
     constexpr uint32_t default_num_traffic_devices = 0;
@@ -1311,6 +1401,24 @@ int main(int argc, char **argv) {
     uint32_t atomic_increment =
         test_args::get_command_option_uint32(input_args, "--atomic_increment", default_atomic_increment);
 
+    // Note here that currently mcast_depth considers the mcast origin as a hop, and not the distance from the origin
+    // This has side effects that specifying a depth of 0 or 1 will result in the same behavior
+    std::unordered_map<RoutingDirection, uint32_t> mcast_depth;
+    mcast_depth[RoutingDirection::E] = test_args::get_command_option_uint32(input_args, "--e_depth", default_multicast);
+    mcast_depth[RoutingDirection::W] = test_args::get_command_option_uint32(input_args, "--w_depth", default_multicast);
+    mcast_depth[RoutingDirection::N] = test_args::get_command_option_uint32(input_args, "--n_depth", default_multicast);
+    mcast_depth[RoutingDirection::S] = test_args::get_command_option_uint32(input_args, "--s_depth", default_multicast);
+    bool mcast = false;
+    for (const auto& [dir, depth] : mcast_depth) {
+        if (depth) {
+            // TODO: Remove once generic mcast is supported
+            if (mcast) {
+                throw std::runtime_error("Only 1 mcast direction is supported right now");
+            }
+            mcast = true;
+        }
+    }
+
     // assert((pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE
     // && rx_disable_header_check || (pkt_dest_size_choices_t)tx_pkt_dest_size_choice ==
     // pkt_dest_size_choices_t::RANDOM);
@@ -1345,6 +1453,14 @@ int main(int argc, char **argv) {
     uint32_t packet_size_kb =
         test_args::get_command_option_uint32(input_args, "--packet_size_kb", default_packet_size_kb);
     uint32_t max_packet_size_words = packet_size_kb * 1024 / PACKET_WORD_SIZE_BYTES;
+    // Only supports line mcast from neighbour
+    if (mcast && num_hops != default_num_hops && num_hops != 1) {
+        throw std::runtime_error("Only line mcast is supported right now");
+    }
+
+    if (mcast && bidirectional_traffic) {
+        throw std::runtime_error("Bidirectional traffic is not supported for mcast");
+    }
 
     bool pass = true;
     uint32_t num_available_devices, num_allocated_devices = 0;
@@ -1378,6 +1494,7 @@ int main(int argc, char **argv) {
     }
 
     global_rng.seed(prng_seed);
+    log_info(LogTest, "PRNG seed = {}", prng_seed);
 
     time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -1407,12 +1524,22 @@ int main(int argc, char **argv) {
 
         // if both left and right device IDs are specified, launch traffic only b/w them
         if ((default_test_device_id_l != test_device_id_l) && (default_test_device_id_r != test_device_id_r)) {
-            if (test_device_id_l == test_device_id_r) {
-                throw std::runtime_error("Left and right chips should be different");
+            if (mcast) {
+                // TODO: We require mcast origin to be the neighbor for now
+                // So get the path from test_device_id_l and verify the next chip is test_device_id_r
+                auto physical_mcast_chip_ids = test_board.get_physical_mcast_chip_ids(test_device_id_l, mcast_depth);
+                if (physical_mcast_chip_ids.empty() || physical_mcast_chip_ids[0] != test_device_id_r) {
+                    throw std::runtime_error("No multicast path found");
+                }
+                test_board.tx_rx_map.push_back({test_device_id_l, std::move(physical_mcast_chip_ids)});
+            } else {
+                if (test_device_id_l == test_device_id_r) {
+                    throw std::runtime_error("Left and right chips should be different");
+                }
+                test_board.tx_rx_map.push_back({test_device_id_l, {test_device_id_r}});
             }
-            test_board.unicast_map.push_back({test_device_id_l, test_device_id_r});
         } else {
-            test_board.generate_unicast_map(num_hops);
+            test_board.generate_tx_rx_map(num_hops, mcast, mcast_depth);
         }
 
         std::unordered_map<chip_id_t, std::shared_ptr<test_device_t>> test_devices;
@@ -1425,14 +1552,20 @@ int main(int argc, char **argv) {
 
         // init traffic
         chip_id_t tx_chip_id, rx_chip_id;
-        for (auto& [tx_chip_id, rx_chip_id] : test_board.unicast_map) {
+        for (auto& [tx_chip_id, rx_chip_ids] : test_board.tx_rx_map) {
             if (num_allocated_devices >= num_traffic_devices) {
                 break;
             }
 
+            std::vector<std::shared_ptr<test_device_t>> rx_devices;
+            rx_devices.reserve(rx_chip_ids.size());
+            for (auto& rx_chip_id : rx_chip_ids) {
+                rx_devices.push_back(test_devices[rx_chip_id]);
+            }
+
             test_traffic_t traffic(
                 test_devices[tx_chip_id],
-                test_devices[rx_chip_id],
+                rx_devices,
                 num_src_endpoints,
                 num_dest_endpoints,
                 target_address,
@@ -1441,9 +1574,10 @@ int main(int argc, char **argv) {
             fabric_traffic.push_back(traffic);
 
             if (bidirectional_traffic) {
+                std::vector<std::shared_ptr<test_device_t>> rx_devices = {test_devices[tx_chip_id]};
                 test_traffic_t traffic_r(
-                    test_devices[rx_chip_id],
-                    test_devices[tx_chip_id],
+                    test_devices[rx_chip_ids[0]],
+                    rx_devices,
                     num_src_endpoints,
                     num_dest_endpoints,
                     target_address,
@@ -1452,7 +1586,7 @@ int main(int argc, char **argv) {
                 fabric_traffic.push_back(traffic_r);
             }
 
-            num_allocated_devices += 2;
+            num_allocated_devices += 1 + rx_chip_ids.size();
         }
 
         // TODO: check this in a loop for all the devices involved in the traffic
@@ -1533,6 +1667,11 @@ int main(int argc, char **argv) {
             client_interface_addr,              // 20:
             client_pull_req_buf_addr,           // 21:
             fixed_async_wr_notif_addr,          // 22: use fixed addr for async wr atomic inc
+            mcast,                              // 23: mcast
+            mcast_depth[RoutingDirection::E],   // 24: mcast_e
+            mcast_depth[RoutingDirection::W],   // 25: mcast_w
+            mcast_depth[RoutingDirection::N],   // 26: mcast_n
+            mcast_depth[RoutingDirection::S],   // 27: mcast_s
         };
 
         std::vector<uint32_t> rx_compile_args = {
@@ -1579,7 +1718,6 @@ int main(int argc, char **argv) {
         for (auto& traffic : fabric_traffic) {
             traffic.wait_for_rx_workers_to_finish();
         }
-
         // terminate fabric routers
         for (auto& [chip_id, test_device] : test_devices) {
             test_device->terminate_gatekeeper_kernel();

--- a/tt_fabric/control_plane.cpp
+++ b/tt_fabric/control_plane.cpp
@@ -589,6 +589,17 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
     return route;
 }
 
+std::vector<chip_id_t> ControlPlane::get_intra_chip_neighbors(
+    mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const {
+    for (const auto& [_, routing_edge] :
+         this->routing_table_generator_->get_intra_mesh_connectivity()[src_mesh_id][src_chip_id]) {
+        if (routing_edge.port_direction == routing_direction) {
+            return routing_edge.connected_chip_ids;
+        }
+    }
+    return {};
+}
+
 void ControlPlane::configure_routing_tables() const {
     // Configure the routing tables on the chips
     TT_ASSERT(

--- a/tt_fabric/control_plane.cpp
+++ b/tt_fabric/control_plane.cpp
@@ -484,6 +484,7 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
                 tt_metal::hal.get_dev_addr(
                     tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::FABRIC_ROUTER_CONFIG),
                 false);
+            tt::Cluster::instance().l1_barrier(physical_chip_id);
         }
     }
 }

--- a/tt_fabric/control_plane.hpp
+++ b/tt_fabric/control_plane.hpp
@@ -43,6 +43,9 @@ class ControlPlane {
            chip_id_t dst_chip_id,
            chan_id_t src_chan_id) const;
 
+       std::vector<chip_id_t> get_intra_chip_neighbors(
+           mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
+
    private:
        std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
        std::vector<std::vector<chip_id_t>> logical_mesh_chip_id_to_physical_chip_id_mapping_;

--- a/tt_fabric/hw/inc/tt_fabric.h
+++ b/tt_fabric/hw/inc/tt_fabric.h
@@ -282,6 +282,11 @@ static_assert(sizeof(fvc_consumer_state_t) % 4 == 0);
 #define FVC_MODE_ROUTER 1
 #define FVC_MODE_ENDPOINT 2
 
+enum ProcessingFlags : uint8_t {
+    UCAST_DEST = 1,
+    MCAST_DEST = 2,
+    NOT_DEST = 3,
+};
 // FVC Producer holds data that needs to be forwarded to other destinations.
 // This producer receives data over ethernet from neighboring chip.
 // Data in the producer is either destined for local chip, or has to make a noc hop
@@ -297,11 +302,13 @@ typedef struct fvc_producer_state {
     uint32_t my_id;
     uint8_t chan_num;
     uint8_t packet_in_progress;
-    uint8_t packet_end_flush;
-    uint8_t pad2;
+    uint8_t packet_processing_flags;
+    uint8_t mcast_direction;
+    uint32_t mcast_router_noc_xy;
     uint32_t words_inbound;
     uint32_t words_cleared;
     uint32_t packet_words_remaining;
+    uint32_t hop_words_remaining;
     uint32_t fvc_out_rdptr;
     uint32_t buffer_size;
     uint32_t buffer_size_2x;
@@ -313,6 +320,7 @@ typedef struct fvc_producer_state {
     bool packet_corrupted;
     uint64_t packet_timestamp;
     uint64_t packet_dest;
+    uint64_t hop_dest;
     packet_header_t current_packet_header;
     uint32_t* packet_id;
     volatile uint32_t* words_received;
@@ -347,6 +355,22 @@ typedef struct fvc_producer_state {
 
         reset_words_received();
         packet_id = (uint32_t*)&current_packet_header.routing.dst_mesh_id;
+        tt::tt_fabric::chan_id_t my_chan = routing_table->intra_mesh_table.dest_entry[routing_table->my_device_id];
+        tt::tt_fabric::chan_id_t mcast_channel = 0;
+        if (routing_table->port_direction.east == my_chan) {
+            mcast_channel = routing_table->port_direction.west;
+            mcast_direction = 1;
+        } else if (routing_table->port_direction.west == my_chan) {
+            mcast_channel = routing_table->port_direction.east;
+            mcast_direction = 0;
+        } else if (routing_table->port_direction.north == my_chan) {
+            mcast_channel = routing_table->port_direction.south;
+            mcast_direction = 3;
+        } else if (routing_table->port_direction.south == my_chan) {
+            mcast_channel = routing_table->port_direction.north;
+            mcast_direction = 2;
+        }
+        mcast_router_noc_xy = eth_chan_to_noc_xy[noc_index][mcast_channel];
     }
 
     inline uint32_t inc_ptr_with_wrap(uint32_t ptr, uint32_t inc) {
@@ -463,6 +487,44 @@ typedef struct fvc_producer_state {
             (this->current_packet_header.routing.packet_size_bytes + PACKET_WORD_SIZE_BYTES - 1) >> 4;
         if (tt_fabric_is_header_valid(&current_packet_header)) {
             this->curr_packet_valid = true;
+            if (packet_is_for_local_chip()) {
+                if (packet_mcast_is_required()) {
+                    // If its mcast packet, update the hop count.
+                    // Packet arrival on this router accounts for 1 hop.
+                    // Decrement respective direction hop count and determine
+                    // whether mcast needs further hops.
+                    update_mcast_hops((packet_header_t*)next_header_ptr);
+                }
+                // After updating mcast hop counts, we check whether the mcast packet still qualifies to be
+                // an mcast packet.
+                packet_processing_flags =
+                    packet_mcast_is_active() ? ProcessingFlags::MCAST_DEST : ProcessingFlags::UCAST_DEST;
+            } else {
+                if (packet_mcast_is_active()) {
+                    // Mcast packets have dest dev/mesh id set to the device where mcast starts.
+                    // Hence packet_is_for_local_chip() returns true only for the first mcast target device.
+                    // All other devices, need to check for mcast active flag to determine if they should consume
+                    // the data or not.
+                    // Any device that receives a packet with mcast active flag set consumes the data and forwards
+                    // as well if its not the last hop of mcast group.
+
+                    // If mcast is active, update the hop count.
+                    // Decrement hop count.
+                    update_mcast_hops((packet_header_t*)next_header_ptr);
+                    // After decrementing hop count, check whether mcast is stil active.
+                    // If mcast has been deactivated here, that means this chip is the last hop for mcast packet.
+                    // If so, we service the last hop as unicast dest.
+                    // Otherwise, we handle as mcast dest, which means packet is consumed locally as well as
+                    // forwarded to next hop in mcast direction.
+                    packet_processing_flags =
+                        packet_mcast_is_active() ? ProcessingFlags::MCAST_DEST : ProcessingFlags::UCAST_DEST;
+                } else {
+                    // We are here for one of 2 reasons.
+                    // 1 - Packet is not meant for this chip.
+                    // 2 - Packet is not under active mcast.
+                    packet_processing_flags = ProcessingFlags::NOT_DEST;
+                }
+            }
         } else {
             this->packet_corrupted = true;
         }
@@ -516,7 +578,7 @@ typedef struct fvc_producer_state {
                                      ? ((uint64_t)get_next_hop_router_noc_xy() << 32) | FABRIC_ROUTER_REQ_QUEUE_START
                                      : ((uint64_t)current_packet_header.session.target_offset_h << 32) |
                                            current_packet_header.session.target_offset_l;
-            packet_dest = tt_fabric_send_pull_request(dest_addr, local_pull_request);
+            hop_dest = tt_fabric_send_pull_request(dest_addr, local_pull_request);
             if (current_packet_header.routing.flags == INLINE_FORWARD) {
                 curr_packet_valid = false;
                 flush_async_writes<fvc_mode>();
@@ -537,7 +599,7 @@ typedef struct fvc_producer_state {
                     // packet_dest is returned by tt_fabric_send_pull_request() as the address of request q entry +
                     // pull_request.words_written.
                     local_pull_request->pull_request.words_written += words_available;
-                    noc_inline_dw_write(packet_dest, local_pull_request->pull_request.words_written);
+                    noc_inline_dw_write(hop_dest, local_pull_request->pull_request.words_written);
                     packet_words_remaining -= words_available;
                 }
             } else if (curr_words_read == local_pull_request->pull_request.words_written) {
@@ -569,10 +631,176 @@ typedef struct fvc_producer_state {
 
     FORCE_INLINE bool packet_is_for_local_chip() { return my_id == *packet_id; }
 
+    inline bool packet_mcast_is_active() { return (current_packet_header.routing.flags & MCAST_ACTIVE) != 0; }
+
+    inline bool packet_mcast_is_required() { return (current_packet_header.routing.flags & MCAST_DATA) != 0; }
+
+    inline void update_mcast_hops(packet_header_t* packet_header) {
+        uint32_t hop_count = 0;
+        if (mcast_direction == 0) {
+            hop_count = current_packet_header.packet_parameters.mcast_parameters.east;
+            if (hop_count) {
+                hop_count--;
+                current_packet_header.packet_parameters.mcast_parameters.east = hop_count;
+                packet_header->packet_parameters.mcast_parameters.east = hop_count;
+            }
+        } else if (mcast_direction == 1) {
+            hop_count = current_packet_header.packet_parameters.mcast_parameters.west;
+            if (hop_count) {
+                hop_count--;
+                current_packet_header.packet_parameters.mcast_parameters.west = hop_count;
+                packet_header->packet_parameters.mcast_parameters.west = hop_count;
+            }
+        } else if (mcast_direction == 2) {
+            hop_count = current_packet_header.packet_parameters.mcast_parameters.north;
+            if (hop_count) {
+                hop_count--;
+                current_packet_header.packet_parameters.mcast_parameters.north = hop_count;
+                packet_header->packet_parameters.mcast_parameters.north = hop_count;
+            }
+        } else if (mcast_direction == 3) {
+            hop_count = current_packet_header.packet_parameters.mcast_parameters.south;
+            if (hop_count) {
+                hop_count--;
+                current_packet_header.packet_parameters.mcast_parameters.south = hop_count;
+                packet_header->packet_parameters.mcast_parameters.south = hop_count;
+            }
+        }
+        if (hop_count == 0) {
+            // on last hop clear the mcast flag bits.
+            // last hop treats packet as normal ucast async write.
+            current_packet_header.routing.flags &= ~(MCAST_ACTIVE | MCAST_DATA);
+            packet_header->routing.flags &= ~(MCAST_ACTIVE | MCAST_DATA);
+        } else {
+            current_packet_header.routing.flags |= MCAST_ACTIVE;
+            packet_header->routing.flags |= MCAST_ACTIVE;
+            // calculate new header checksum after mcast updates.
+            tt_fabric_add_header_checksum(&current_packet_header);
+            // copy new checksum to packet header in fvc buffer.
+            packet_header->packet_parameters.misc_parameters.words[0] =
+                current_packet_header.packet_parameters.misc_parameters.words[0];
+        }
+    }
+
+    template <uint8_t fvc_mode = FVC_MODE_ROUTER>
+    inline uint32_t process_mcast_packet() {
+        uint32_t words_processed = 0;
+        if (current_packet_header.session.command & ASYNC_WR) {
+            uint32_t words_available = get_num_words_available();
+            words_available = std::min(words_available, packet_words_remaining);
+            words_processed = words_available;
+            if (packet_in_progress == 0) {
+                local_pull_request->pull_request.rd_ptr = fvc_out_rdptr;
+                local_pull_request->pull_request.size = current_packet_header.routing.packet_size_bytes;
+                local_pull_request->pull_request.buffer_size = buffer_size;
+                local_pull_request->pull_request.buffer_start = xy_local_addr + buffer_start;
+                local_pull_request->pull_request.words_written = words_available;
+                local_pull_request->pull_request.words_read = 0;
+                words_cleared = 0;
+                local_pull_request->pull_request.ack_addr =
+                    xy_local_addr + (uint32_t)&local_pull_request->pull_request.words_read;
+                local_pull_request->pull_request.flags = FORWARD;
+
+                packet_words_remaining -= words_available;
+                // issue noc write to noc target of pull request.
+                // figure out next hop for mcast forwarding
+                uint64_t dest_addr = ((uint64_t)mcast_router_noc_xy << 32) | FABRIC_ROUTER_REQ_QUEUE_START;
+                hop_dest = tt_fabric_send_pull_request(dest_addr, local_pull_request);
+
+                packet_dest = ((uint64_t)current_packet_header.session.target_offset_h << 32) |
+                              current_packet_header.session.target_offset_l;
+
+                advance_out_rdptr(PACKET_HEADER_SIZE_WORDS);
+                words_available -= PACKET_HEADER_SIZE_WORDS;
+
+                uint32_t local_words_available = std::min(words_available, words_before_buffer_wrap(fvc_out_rdptr));
+                // write available data till end of input buffer
+                if (local_words_available) {
+                    // need to check local_words_available > 0 since it is possible that we only received the packet
+                    // header so far, and words_available == 0 after words_available -= PACKET_HEADER_SIZE_WORDS above.
+                    noc_async_write(
+                        get_local_buffer_read_addr(), packet_dest, local_words_available * PACKET_WORD_SIZE_BYTES);
+                    advance_out_rdptr(local_words_available);
+                    packet_dest += local_words_available * PACKET_WORD_SIZE_BYTES;
+                }
+                local_words_available = words_available - local_words_available;
+                // write remaining available data from beginning of buffer
+                if (local_words_available) {
+                    noc_async_write(
+                        get_local_buffer_read_addr(), packet_dest, local_words_available * PACKET_WORD_SIZE_BYTES);
+                    advance_out_rdptr(local_words_available);
+                    packet_dest += local_words_available * PACKET_WORD_SIZE_BYTES;
+                }
+                // subtract the header words. Remaining words are the data to be written to packet_dest.
+                // Remember to account for trailing bytes which may not be a full packet word.
+                packet_in_progress = 1;
+            } else {
+                noc_async_writes_flushed();
+                // pull_request.rd_ptr is updated by remote puller when data is read out of producer's local buffer.
+                // it is used to determine when it it safe to reclaim local buffer memory for more data.
+                uint32_t curr_words_read = local_pull_request->pull_request.words_read;
+                uint32_t words_to_clear = curr_words_read - words_cleared;
+                if (words_to_clear) {
+                    free_receiver_buffer_space<fvc_mode>(words_to_clear);
+                    words_cleared += words_to_clear;
+                }
+
+                if (packet_words_remaining) {
+                    if (words_available) {
+                        uint32_t local_words_available =
+                            std::min(words_available, words_before_buffer_wrap(fvc_out_rdptr));
+                        // write available data till end of input buffer
+                        noc_async_write(
+                            get_local_buffer_read_addr(), packet_dest, local_words_available * PACKET_WORD_SIZE_BYTES);
+                        advance_out_rdptr(local_words_available);
+                        packet_dest += local_words_available * PACKET_WORD_SIZE_BYTES;
+                        local_words_available = words_available - local_words_available;
+                        // write remaining available data from beginning of buffer
+                        if (local_words_available) {
+                            noc_async_write(
+                                get_local_buffer_read_addr(),
+                                packet_dest,
+                                local_words_available * PACKET_WORD_SIZE_BYTES);
+                            advance_out_rdptr(local_words_available);
+                            packet_dest += local_words_available * PACKET_WORD_SIZE_BYTES;
+                        }
+
+                        // hop_dest is returned by tt_fabric_send_pull_request() as the address of request q entry +
+                        // pull_request.wr_ptr.
+                        local_pull_request->pull_request.words_written += words_available;
+                        noc_inline_dw_write(hop_dest, local_pull_request->pull_request.words_written);
+                        packet_words_remaining -= words_available;
+                    }
+                } else if (curr_words_read == local_pull_request->pull_request.words_written) {
+                    // for fused command issue the atomic inc before invalidating the current packet
+                    if (current_packet_header.session.command & ATOMIC_INC) {
+                        uint64_t noc_addr =
+                            ((uint64_t)current_packet_header.packet_parameters.async_wr_atomic_parameters.noc_xy
+                             << 32) |
+                            current_packet_header.packet_parameters.async_wr_atomic_parameters.l1_offset;
+                        noc_fast_atomic_increment(
+                            noc_index,
+                            NCRISC_AT_CMD_BUF,
+                            noc_addr,
+                            NOC_UNICAST_WRITE_VC,
+                            current_packet_header.packet_parameters.async_wr_atomic_parameters.increment,
+                            31,
+                            false);
+                    }
+                    // all data has been pulled and cleared from local buffer
+                    packet_in_progress = 0;
+                    curr_packet_valid = false;
+                    packet_timestamp = get_timestamp();
+                }
+            }
+        }
+        return words_processed;
+    }
+
     template <uint8_t fvc_mode = FVC_MODE_ROUTER>
     inline uint32_t process_inbound_packet() {
         uint32_t words_processed = 0;
-        if (packet_is_for_local_chip()) {
+        if (packet_processing_flags == ProcessingFlags::UCAST_DEST) {
             if (current_packet_header.routing.flags == FORWARD) {
                 if (current_packet_header.session.command & ASYNC_WR) {
                     if (packet_in_progress == 0) {
@@ -635,6 +863,8 @@ typedef struct fvc_producer_state {
                     packet_timestamp = get_timestamp();
                 }
             }
+        } else if (packet_processing_flags == ProcessingFlags::MCAST_DEST) {
+            words_processed = process_mcast_packet();
         } else {
             pull_data_from_fvc_buffer<fvc_mode, false>();
         }
@@ -646,15 +876,6 @@ typedef struct fvc_producer_state {
         noc_async_writes_flushed();
         free_receiver_buffer_space<fvc_mode>(words_cleared);
         words_cleared = 0;
-    }
-
-    inline void check_packet_end_flush() {
-        if (packet_end_flush) {
-            flush_async_writes();
-            packet_in_progress = 0;
-            curr_packet_valid = false;
-            packet_end_flush = 0;
-        }
     }
 } fvc_producer_state_t;
 

--- a/tt_fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_fabric/hw/inc/tt_fabric_interface.h
@@ -35,7 +35,7 @@ constexpr uint32_t FVC_SYNC_THRESHOLD = 256;
 #define SOCKET_CONNECT (0x1 << 10)
 
 #define INVALID 0x0
-#define DATA 0x1
+#define MCAST_ACTIVE 0x1
 #define MCAST_DATA 0x2
 #define SYNC 0x4
 #define FORWARD 0x8
@@ -70,11 +70,11 @@ typedef struct _tt_session {
 static_assert(sizeof(tt_session) == 20);
 
 typedef struct _mcast_params {
+    uint32_t socket_id;  // Socket Id for DSocket Multicast. Ignored for ASYNC multicast.
     uint16_t east;
     uint16_t west;
     uint16_t north;
     uint16_t south;
-    uint32_t socket_id;  // Socket Id for DSocket Multicast. Ignored for ASYNC multicast.
 } mcast_params;
 
 typedef struct _socket_params {

--- a/tt_fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_fabric/hw/inc/tt_fabric_interface.h
@@ -128,10 +128,14 @@ typedef struct _packet_header {
     tt_routing routing;
 } packet_header_t;
 
-const uint32_t PACKET_HEADER_SIZE_BYTES = 48;
-const uint32_t PACKET_HEADER_SIZE_WORDS = PACKET_HEADER_SIZE_BYTES / PACKET_WORD_SIZE_BYTES;
+constexpr uint32_t PACKET_HEADER_SIZE_BYTES = 48;
+constexpr uint32_t PACKET_HEADER_SIZE_WORDS = PACKET_HEADER_SIZE_BYTES / PACKET_WORD_SIZE_BYTES;
 
 static_assert(sizeof(packet_header_t) == PACKET_HEADER_SIZE_BYTES);
+
+static_assert(offsetof(packet_header_t, routing) % 4 == 0);
+
+constexpr uint32_t packet_header_routing_offset_dwords = offsetof(packet_header_t, routing) / 4;
 
 void tt_fabric_add_header_checksum(packet_header_t* p_header) {
     uint16_t* ptr = (uint16_t*)p_header;
@@ -186,7 +190,7 @@ typedef struct _pull_request {
     uint8_t flags;  // Router command.
 } pull_request_t;
 
-const uint32_t PULL_REQ_SIZE_BYTES = 48;
+constexpr uint32_t PULL_REQ_SIZE_BYTES = 48;
 
 static_assert(sizeof(pull_request_t) == PULL_REQ_SIZE_BYTES);
 static_assert(sizeof(pull_request_t) == sizeof(packet_header_t));
@@ -197,18 +201,18 @@ typedef union _chan_request_entry {
     uint8_t bytes[48];
 } chan_request_entry_t;
 
-const uint32_t CHAN_PTR_SIZE_BYTES = 16;
+constexpr uint32_t CHAN_PTR_SIZE_BYTES = 16;
 typedef struct _chan_ptr {
     uint32_t ptr;
     uint32_t pad[3];
 } chan_ptr;
 static_assert(sizeof(chan_ptr) == CHAN_PTR_SIZE_BYTES);
 
-const uint32_t CHAN_REQ_BUF_LOG_SIZE = 4;  // must be 2^N
-const uint32_t CHAN_REQ_BUF_SIZE = 16;     // must be 2^N
-const uint32_t CHAN_REQ_BUF_SIZE_MASK = (CHAN_REQ_BUF_SIZE - 1);
-const uint32_t CHAN_REQ_BUF_PTR_MASK = ((CHAN_REQ_BUF_SIZE << 1) - 1);
-const uint32_t CHAN_REQ_BUF_SIZE_BYTES = 2 * CHAN_PTR_SIZE_BYTES + CHAN_REQ_BUF_SIZE * PULL_REQ_SIZE_BYTES;
+constexpr uint32_t CHAN_REQ_BUF_LOG_SIZE = 4;  // must be 2^N
+constexpr uint32_t CHAN_REQ_BUF_SIZE = 16;     // must be 2^N
+constexpr uint32_t CHAN_REQ_BUF_SIZE_MASK = (CHAN_REQ_BUF_SIZE - 1);
+constexpr uint32_t CHAN_REQ_BUF_PTR_MASK = ((CHAN_REQ_BUF_SIZE << 1) - 1);
+constexpr uint32_t CHAN_REQ_BUF_SIZE_BYTES = 2 * CHAN_PTR_SIZE_BYTES + CHAN_REQ_BUF_SIZE * PULL_REQ_SIZE_BYTES;
 
 typedef struct _chan_req_buf {
     chan_ptr wrptr;
@@ -236,12 +240,12 @@ static_assert(sizeof(chan_payload_ptr) == CHAN_PTR_SIZE_BYTES);
 // Each control channel message is 48 Bytes.
 // FVCC buffer is a 16 message buffer each for incoming and outgoing messages.
 // Control message capacity can be increased by increasing FVCC_BUF_SIZE.
-const uint32_t FVCC_BUF_SIZE = 16;     // must be 2^N
-const uint32_t FVCC_BUF_LOG_SIZE = 4;  // must be log2(FVCC_BUF_SIZE)
-const uint32_t FVCC_SIZE_MASK = (FVCC_BUF_SIZE - 1);
-const uint32_t FVCC_PTR_MASK = ((FVCC_BUF_SIZE << 1) - 1);
-const uint32_t FVCC_BUF_SIZE_BYTES = PULL_REQ_SIZE_BYTES * FVCC_BUF_SIZE + 2 * CHAN_PTR_SIZE_BYTES;
-const uint32_t FVCC_SYNC_BUF_SIZE_BYTES = CHAN_PTR_SIZE_BYTES * FVCC_BUF_SIZE;
+constexpr uint32_t FVCC_BUF_SIZE = 16;     // must be 2^N
+constexpr uint32_t FVCC_BUF_LOG_SIZE = 4;  // must be log2(FVCC_BUF_SIZE)
+constexpr uint32_t FVCC_SIZE_MASK = (FVCC_BUF_SIZE - 1);
+constexpr uint32_t FVCC_PTR_MASK = ((FVCC_BUF_SIZE << 1) - 1);
+constexpr uint32_t FVCC_BUF_SIZE_BYTES = PULL_REQ_SIZE_BYTES * FVCC_BUF_SIZE + 2 * CHAN_PTR_SIZE_BYTES;
+constexpr uint32_t FVCC_SYNC_BUF_SIZE_BYTES = CHAN_PTR_SIZE_BYTES * FVCC_BUF_SIZE;
 
 inline bool fvcc_buf_ptrs_empty(uint32_t wrptr, uint32_t rdptr) { return (wrptr == rdptr); }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to support 1D mcast (specifically line mcast) to enable CCLs on fabric.

### What's changed
Add support for 1D mcast on fabric and added tests.
This is specifically line mcast, where the mcast origin is the neighbour of the src device, and the direction of src to the origin is the same direction as the mcast. Generic 1D mcast where we need to route from source to an arbitrary remote mcast origin device is not supported.

Note that mcast depth specified here differs from the original proposed fabric documentation. In the documentation, depth is specified as how many hops away from the mcast origin we take for the mcast. Ex if the mcast origin is (0, 0), and we specify e_depth and s_depth as 2, then this would result in an mcast from (0, 0) to (2, 2), ie. a 3x3 rectangle will receive the data.
In this current implementation, mcast origin is included in the depth count. So with the above example, this would result in an mcast from (0, 0) to (1, 1), ie. a 2x2 rectangle.
Note that due to this behaviour, specifying a 0 depth mcast has the same behaviour as specifying a 1 depth mcast, in that only the origin node receives data.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
TG Unit: https://github.com/tenstorrent/tt-metal/actions/runs/13188779908
