### PR TITLE
Fix outdated call to `ttnn.open_device` in ttnn tutorial notebooks

### DIFF
--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -89,7 +89,13 @@ void py_device_module_types(py::module& m_device) {
 
     py::class_<tt::tt_metal::DispatchCoreConfig>(
         m_device, "DispatchCoreConfig", "Class representing dispatch core configuration.")
-        .def(py::init<>(), "Default constructor initializing type to WORKER and axis to ROW.")
+        .def(
+            py::init<>(),
+            "Default constructor initializing type to WORKER and axis to default value on platform architecture.")
+        .def(
+            py::init<tt::tt_metal::DispatchCoreType>(),
+            "Constructor with specified dispatch core type and default axis on platform architecture.",
+            py::arg("type"))
         .def(
             py::init<tt::tt_metal::DispatchCoreType, tt::tt_metal::DispatchCoreAxis>(),
             "Constructor with specified dispatch core type and axis.",

--- a/ttnn/tutorials/003.ipynb
+++ b/ttnn/tutorials/003.ipynb
@@ -123,7 +123,7 @@
     "dispatch_core_type = ttnn.device.DispatchCoreType.ETH\n",
     "if \"grayskull\" in os.environ.get(\"ARCH_NAME\"):\n",
     "    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER\n",
-    "device = ttnn.open_device(device_id=device_id, l1_small_size=8192, dispatch_core_type=dispatch_core_type)"
+    "device = ttnn.open_device(device_id=device_id, l1_small_size=8192, dispatch_core_config=ttnn.device.DispatchCoreConfig(dispatch_core_type))"
    ]
   },
   {

--- a/ttnn/tutorials/004.ipynb
+++ b/ttnn/tutorials/004.ipynb
@@ -814,7 +814,7 @@
     "dispatch_core_type = ttnn.device.DispatchCoreType.ETH\n",
     "if \"grayskull\" in os.environ.get(\"ARCH_NAME\"):\n",
     "    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER\n",
-    "device = ttnn.open_device(device_id=0, l1_small_size=8192, dispatch_core_type=dispatch_core_type)"
+    "device = ttnn.open_device(device_id=0, l1_small_size=8192, dispatch_core_config=ttnn.device.DispatchCoreConfig(dispatch_core_type))"
    ]
   },
   {


### PR DESCRIPTION
### Ticket
#17500

### Problem description
I tracked the code to [here](https://github.com/tenstorrent/tt-metal/blob/e106618f7cecdb42fd8bf4148cb610d1e1bc98e0/ttnn/cpp/ttnn/device.hpp#L19) and [here](https://github.com/tenstorrent/tt-metal/blob/e106618f7cecdb42fd8bf4148cb610d1e1bc98e0/tt_metal/api/tt-metalium/dispatch_core_common.hpp#L57). It seems the fix should be simply:
```python
device = ttnn.open_device(device_id=device_id, l1_small_size=8192, dispatch_core_config=ttnn.device.DispatchCoreConfig(dispatch_core_type)) # dispatch_core_type == ttnn.device.DispatchCoreType.ETH because I am running on wormhole
```
However, I encountered this error message when running with the above fix:
```
Exception has occurred: TypeError
__init__(): incompatible constructor arguments. The following argument types are supported:
    1. ttnn._ttnn.device.DispatchCoreConfig()
    2. ttnn._ttnn.device.DispatchCoreConfig(type: ttnn._ttnn.device.DispatchCoreType, axis: ttnn._ttnn.device.DispatchCoreAxis)
```
This error tells me that maybe the constructor that I was looking for -- `DispatchCoreConfig(DispatchCoreType type) : type_(type), axis_(get_default_axis()) {}`  -- is not bound to python. This is confirmed by [this code](https://github.com/tenstorrent/tt-metal/blob/c7825a1e62fe6d6bdee4dd0fabafbfe6146aee7b/ttnn/cpp/pybind11/device.cpp#L90).

### What's changed
The solution is to simply add the missing python binding for the constructor of `DispatchCoreConfig` that accepts just an instance of `DispatchCoreType` as argument.

I also updated the tutorial notebooks and verified that they run as expected with the changes in this PR.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13118687959)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
