### PR TITLE
Use three arguments for distro, version, architecture

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -152,7 +152,7 @@ jobs:
     uses: ./.github/workflows/code-analysis.yaml
     secrets: inherit
     with:
-      os: ubuntu-22.04-amd64
+      version: 22.04
   tt-train-cpp-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -183,30 +183,30 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: "ubuntu-20.04-amd64"
+          - version: "20.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Debug"
             publish-artifact: false
-          - os: "ubuntu-20.04-amd64"
+          - version: "20.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "RelWithDebInfo"
             publish-artifact: false
-          - os: "ubuntu-22.04-amd64"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
-          - os: "ubuntu-22.04-amd64"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: true
-          - os: "ubuntu-22.04-amd64"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: true
     with:
-      os: ${{ matrix.config.os }}
+      version: ${{ matrix.config.version }}
       toolchain: ${{ matrix.config.toolchain }}
       build-type: ${{ matrix.config.build-type }}
       publish-artifact: ${{ matrix.config.publish-artifact }}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -12,10 +12,18 @@ on:
         type: boolean
         default: false
         description: "Build with tracy enabled"
-      os:
+      distro:
         required: false
         type: string
-        default: "ubuntu-20.04-amd64"
+        default: "ubuntu"
+      version:
+        required: false
+        type: string
+        default: "20.04"
+      architecture:
+        required: false
+        type: string
+        default: "amd64"
       toolchain:
         required: false
         type: string
@@ -47,10 +55,18 @@ on:
         type: boolean
         default: false
         description: "Build with tracy enabled"
-      os:
+      distro:
         required: false
         type: string
-        default: "ubuntu-20.04-amd64"
+        default: "ubuntu"
+      version:
+        required: false
+        type: string
+        default: "20.04"
+      architecture:
+        required: false
+        type: string
+        default: "amd64"
 
 
 jobs:
@@ -58,15 +74,18 @@ jobs:
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
-      os: ${{ inputs.os }}
+      distro: ${{ inputs.distro }}
+      version: ${{ inputs.version }}
+      architecture: ${{ inputs.architecture }}
 
   build-artifact:
-    name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.os }}"
+    name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
     timeout-minutes: 30
     env:
       SILENT: 0
       VERBOSE: 1
+      IMAGE_PARAMS: "${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}"
     runs-on:
       - build
       - in-service
@@ -95,7 +114,7 @@ jobs:
         id: generate-docker-tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: tt-metalium/${{ inputs.os }}
+          image: tt-metalium/${{ env.IMAGE_PARAMS }}
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -3,29 +3,49 @@ name: "Build tt-metal docker artifact"
 on:
   workflow_call:
     inputs:
-      os:
+      distro:
         required: false
         type: string
-        default: "ubuntu-20.04-amd64"
+        default: "ubuntu"
+      version:
+        required: false
+        type: string
+        default: "20.04"
+      architecture:
+        required: false
+        type: string
+        default: "amd64"
   workflow_dispatch:
     inputs:
-      os:
+      distro:
         required: false
         type: choice
-        default: "ubuntu-20.04-amd64"
+        default: "ubuntu"
         options:
-            - "ubuntu-20.04-amd64"
-            - "ubuntu-22.04-amd64"
+            - "ubuntu"
+      version:
+        required: false
+        type: choice
+        default: "20.04"
+        options:
+            - "20.04"
+            - "22.04"
+            - "24.04"
+      architecture:
+        required: false
+        type: choice
+        default: "amd64"
+        options:
+            - "amd64"
 jobs:
   build-docker-image:
-    name: "🐳️ Build ${{ inputs.os }} image"
+    name: "🐳️ Build ${{ inputs.distro }} {inputs.version }} image"
     timeout-minutes: 30
     env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       CONFIG: ci
       SILENT: 0
       VERBOSE: 1
-      TT_METAL_DOCKER_IMAGE: ${{ inputs.os }}
+      IMAGE_PARAMS: "${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}"
       IMAGE: tt-metalium/ubuntu-20.04-amd64
       DOCKERFILE: ubuntu-20.04-amd64
     runs-on:
@@ -55,23 +75,24 @@ jobs:
       - name: Determine docker image tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: tt-metalium/${{ inputs.os }}
+          image: tt-metalium/${{ env.IMAGE_PARAMS }}
       - name: Build Docker image and push to GHCR
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}
-          file: dockerfile/${{ inputs.os }}.Dockerfile
+          file: dockerfile/${{ env.IMAGE_PARAMS }}.Dockerfile
           push: true
           tags: ${{ env.TT_METAL_DOCKER_IMAGE_TAG}}
+          build-args: UBUNTU_VERSION=${{ inputs.version }}
           cache-from: type=registry,ref=${{ env.TT_METAL_REF_IMAGE_TAG }}
           cache-to: type=inline
           pull: true
       - name: Tag Docker main image as current image
         if: steps.changed-files-specific.outputs.any_changed != 'true'
         run: |
-          docker pull ghcr.io/${{ github.repository }}/tt-metalium/${{ env.TT_METAL_DOCKER_IMAGE }}:latest
-          docker tag ghcr.io/${{ github.repository }}/tt-metalium/${{ env.TT_METAL_DOCKER_IMAGE }}:latest ${{ env.TT_METAL_DOCKER_IMAGE_TAG}}
+          docker pull ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_PARAMS }}:latest
+          docker tag ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_PARAMS }}:latest ${{ env.TT_METAL_DOCKER_IMAGE_TAG}}
       - name: Push Docker image to GitHub Container Registry
         run: |
           docker push ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -19,30 +19,30 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: "ubuntu-20.04-amd64"
+          - version: "20.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Debug"
             publish-artifact: false
-          - os: "ubuntu-20.04-amd64"
+          - version: "20.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "RelWithDebInfo"
             publish-artifact: false
-          - os: "ubuntu-22.04-amd64"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
-          - os: "ubuntu-22.04-amd64"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: true
-          - os: "ubuntu-22.04-amd64"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: true
     with:
-      os: ${{ matrix.config.os }}
+      os: ${{ matrix.config.version }}
       toolchain: ${{ matrix.config.toolchain }}
       build-type: ${{ matrix.config.build-type }}
       publish-artifact: ${{ matrix.config.publish-artifact }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -51,6 +51,7 @@ jobs:
     needs: build-docker-image
     env:
       ARCH_NAME: wormhole_b0
+      IMAGE_PARAMS: "${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}"
     runs-on:
       - build
       - in-service
@@ -75,7 +76,7 @@ jobs:
         id: generate-docker-tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: tt-metalium/${{ inputs.os }}
+          image: tt-metalium/${{ env.IMAGE_PARAMS }}
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -3,20 +3,36 @@ name: "Code analysis"
 on:
   workflow_call:
     inputs:
-      os:
+      distro:
         required: false
         type: string
-        default: "ubuntu-22.04-amd64"
+        default: "ubuntu"
+      version:
+        required: false
+        type: string
+        default: "20.04"
+      architecture:
+        required: false
+        type: string
+        default: "amd64"
       full-scan:
         required: false
         type: boolean
         default: false
   workflow_dispatch:
     inputs:
-      os:
+      distro:
         required: false
         type: string
-        default: "ubuntu-22.04-amd64"
+        default: "ubuntu"
+      version:
+        required: false
+        type: string
+        default: "20.04"
+      architecture:
+        required: false
+        type: string
+        default: "amd64"
       full-scan:
         required: false
         type: boolean
@@ -27,7 +43,9 @@ jobs:
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
-      os: ${{ inputs.os }}
+      distro: ${{ inputs.distro }}
+      version: ${{ inputs.version }}
+      architecture: ${{ inputs.architecture }}
 
   clang-tidy:
     needs: build-docker-image

--- a/.github/workflows/cpp-ttnn-project.yaml
+++ b/.github/workflows/cpp-ttnn-project.yaml
@@ -10,7 +10,9 @@ jobs:
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
-      os: ubuntu-22.04-amd64
+      distro: "ubuntu"
+      version: "22.04"
+      architecture: "amd64"
 
   ttnn-project:
     needs: build-docker-image


### PR DESCRIPTION
### Problem description
For some reason we merged OS distribution, OS version, and CPU architecture into a single argument.
This reduces our flexibility, and would require us to do string split in github workflows whenever we need substrings.
We also weren't passing in our Dockerfile's build-arg (allowing default to be used)

### What's changed
Switch to three inputs for build-artifact.yaml and build-docker-artifact.yaml

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13119004964)
