### PR TITLE
#17215: Add write/read APIs for TTNN tensors allocated on mesh buffer

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -5,13 +5,19 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_impl_wrapper.hpp"
 #include "ttnn_test_fixtures.hpp"
 #include <ttnn/distributed/types.hpp>
 #include <ttnn/distributed/distributed_tensor.hpp>
 
 namespace ttnn::distributed::test {
 namespace {
+
+using ::testing::FloatEq;
+using ::testing::Pointwise;
 
 using MeshTensorTest = T3kMultiDeviceFixture;
 
@@ -41,6 +47,100 @@ TEST_F(MeshTensorTest, Lifecycle) {
 
     input_tensor.deallocate();
     EXPECT_FALSE(input_tensor.is_allocated());
+}
+
+using MeshTensorDeviceTest = T3kMultiDeviceFixture;
+
+TEST_F(MeshTensorDeviceTest, ReplicateHostTensor) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    for (int i = 0; i < shape.volume(); i++) {
+        host_data[i] = i;
+    }
+
+    // Prepare host tensor to offload on device.
+    Tensor input_host_tensor_sharded = Tensor::from_vector(host_data, tensor_spec);
+    EXPECT_TRUE(input_host_tensor_sharded.storage_type() == StorageType::OWNED);
+    EXPECT_EQ(input_host_tensor_sharded.get_tensor_spec().logical_shape(), shape);
+
+    // Write host tensor to device.
+    Tensor device_tensor =
+        tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor_sharded, mesh_device_.get(), MemoryConfig{});
+    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor));
+    EXPECT_EQ(device_tensor.get_tensor_spec().logical_shape(), shape);
+
+    auto* multi_device_storage = std::get_if<tt::tt_metal::MultiDeviceStorage>(&device_tensor.get_storage());
+    ASSERT_NE(multi_device_storage, nullptr);
+    for (const auto& [_, shard_spec] : multi_device_storage->specs) {
+        EXPECT_EQ(shard_spec.logical_shape(), shape);
+    }
+    EXPECT_TRUE(std::holds_alternative<tt::tt_metal::ReplicateTensor>(multi_device_storage->strategy));
+
+    // Read the tensor back, and compare it with input data.
+    Tensor output_host_tensor = tensor_impl::to_host_mesh_tensor_wrapper(device_tensor);
+    EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    EXPECT_EQ(output_host_tensor.get_tensor_spec().logical_shape(), shape);
+
+    for (const auto& tensor : get_tensors_from_multi_device_storage(output_host_tensor)) {
+        EXPECT_EQ(tensor.get_tensor_spec().logical_shape(), shape);
+        EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
+    }
+}
+
+TEST_F(MeshTensorDeviceTest, WriteMultiDeviceHostTensor) {
+    const int num_devices = mesh_device_->num_devices();
+    ASSERT_EQ(num_devices, 8);
+    const ttnn::Shape shape{1, 8, 32, 32};
+    const ttnn::Shape shard_shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    for (int i = 0; i < shape.volume(); i++) {
+        host_data[i] = i;
+    }
+
+    // Prepare multi-device host tensor to offload on device.
+    Tensor input_host_tensor_sharded = distribute_tensor(
+        Tensor::from_vector(host_data, tensor_spec), *shard_tensor_to_mesh_mapper(*mesh_device_, /*dim=*/1));
+    EXPECT_TRUE(input_host_tensor_sharded.storage_type() == StorageType::MULTI_DEVICE_HOST);
+    EXPECT_EQ(input_host_tensor_sharded.get_tensor_spec().logical_shape(), shard_shape);
+
+    auto* multi_device_host_storage =
+        std::get_if<tt::tt_metal::MultiDeviceHostStorage>(&input_host_tensor_sharded.get_storage());
+    ASSERT_NE(multi_device_host_storage, nullptr);
+    for (const auto& shard_spec : multi_device_host_storage->specs) {
+        EXPECT_EQ(shard_spec.logical_shape(), shard_shape);
+    }
+    const auto* strategy = std::get_if<tt::tt_metal::ShardTensor>(&multi_device_host_storage->strategy);
+    ASSERT_NE(strategy, nullptr);
+    EXPECT_EQ(strategy->shard_dimension, 1);
+
+    // Write host tensor to device.
+    Tensor device_tensor =
+        tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor_sharded, mesh_device_.get(), MemoryConfig{});
+    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor));
+    EXPECT_EQ(device_tensor.get_tensor_spec().logical_shape(), shard_shape);
+
+    auto* multi_device_storage = std::get_if<tt::tt_metal::MultiDeviceStorage>(&device_tensor.get_storage());
+    ASSERT_NE(multi_device_storage, nullptr);
+    for (const auto& [_, shard_spec] : multi_device_storage->specs) {
+        EXPECT_EQ(shard_spec.logical_shape(), shard_shape);
+    }
+    const auto* device_tensor_strategy = std::get_if<tt::tt_metal::ShardTensor>(&multi_device_storage->strategy);
+    ASSERT_NE(device_tensor_strategy, nullptr);
+    EXPECT_EQ(device_tensor_strategy->shard_dimension, 1);
+
+    // Read the tensor back, and compare it with input data.
+    Tensor output_host_tensor = aggregate_tensor(
+        tensor_impl::to_host_mesh_tensor_wrapper(device_tensor), *concat_mesh_to_tensor_composer(/*dim=*/1));
+    EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::OWNED);
+    EXPECT_EQ(output_host_tensor.get_tensor_spec().logical_shape(), shape);
+
+    EXPECT_THAT(output_host_tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -31,7 +31,12 @@ void WriteShard(
     std::vector<DType>& src,
     const Coordinate& coord,
     bool blocking = false) {
-    mesh_cq.enqueue_write_shard(mesh_buffer, src.data(), coord, blocking);
+    std::vector<MeshCommandQueue::ShardDataTransfer> shard_data_transfers = {{
+        .shard_coord = coord,
+        .host_data = src.data(),
+        .region = std::nullopt,
+    }};
+    mesh_cq.enqueue_write_shards(mesh_buffer, shard_data_transfers, blocking);
 }
 
 template <typename DType>
@@ -43,7 +48,12 @@ void ReadShard(
     bool blocking = true) {
     auto shard = mesh_buffer->get_device_buffer(coord);
     dst.resize(shard->page_size() * shard->num_pages() / sizeof(DType));
-    mesh_cq.enqueue_read_shard(dst.data(), mesh_buffer, coord, blocking);
+    std::vector<MeshCommandQueue::ShardDataTransfer> shard_data_transfers = {{
+        .shard_coord = coord,
+        .host_data = dst.data(),
+        .region = std::nullopt,
+    }};
+    mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, blocking);
 }
 
 template <typename DType>

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+#include "buffer.hpp"
 #include "command_queue_interface.hpp"
 #include "mesh_buffer.hpp"
 #include "mesh_device.hpp"
@@ -24,9 +26,15 @@ private:
 
     // Helper functions for reading and writing individual shards
     void write_shard_to_device(
-        std::shared_ptr<Buffer>& shard_view, const void* src, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+        std::shared_ptr<Buffer>& shard_view,
+        const void* src,
+        const BufferRegion& region,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void read_shard_from_device(
-        std::shared_ptr<Buffer>& shard_view, void* dst, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+        std::shared_ptr<Buffer>& shard_view,
+        void* dst,
+        const BufferRegion& region,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
@@ -47,7 +55,11 @@ public:
 
     // MeshBuffer Write APIs
     void enqueue_write_shard(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking);
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const void* host_data,
+        const Coordinate& coord,
+        bool blocking,
+        const std::optional<BufferRegion>& region = std::nullopt);
     void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking);
     void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking);
@@ -56,7 +68,11 @@ public:
 
     // MeshBuffer Read APIs
     void enqueue_read_shard(
-        void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);
+        void* host_data,
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const Coordinate& coord,
+        bool blocking,
+        const std::optional<BufferRegion>& region = std::nullopt);
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking);
     void enqueue_read_shards(
         const std::vector<void*>& host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, bool blocking);

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -21,20 +21,22 @@ private:
     void populate_dispatch_core_type();
     CoreCoord virtual_program_dispatch_core() const;
     CoreType dispatch_core_type() const;
+
     // Helper functions for reading and writing individual shards
     void write_shard_to_device(
         std::shared_ptr<Buffer>& shard_view, const void* src, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void read_shard_from_device(
         std::shared_ptr<Buffer>& shard_view, void* dst, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
     void read_sharded_buffer(MeshBuffer& buffer, void* dst);
     std::array<tt::tt_metal::WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> config_buffer_mgr_;
     std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed_;
-    MeshDevice* mesh_device_;
-    uint32_t id_;
+    MeshDevice* mesh_device_ = nullptr;
+    uint32_t id_ = 0;
     CoreCoord dispatch_core_;
-    CoreType dispatch_core_type_;
+    CoreType dispatch_core_type_ = CoreType::WORKER;
 
 public:
     MeshCommandQueue(MeshDevice* mesh_device, uint32_t id);
@@ -42,16 +44,23 @@ public:
     uint32_t id() const { return id_; }
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_[index]; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking);
+
     // MeshBuffer Write APIs
     void enqueue_write_shard(
-        std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking);
+        const std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking);
     void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking);
     void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking);
+    void enqueue_write_shards(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer, const std::vector<const void*>& host_data, bool blocking);
+
     // MeshBuffer Read APIs
     void enqueue_read_shard(
         void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking);
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking);
+    void enqueue_read_shards(
+        const std::vector<void*>& host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, bool blocking);
+
     void finish();
     void reset_worker_state(
         bool reset_launch_msg_state,

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -53,29 +53,28 @@ public:
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_[index]; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking);
 
+    // Specifies host data to be written to or read from a MeshBuffer shard.
+    struct ShardDataTransfer {
+        Coordinate shard_coord;
+        void* host_data = nullptr;
+        std::optional<BufferRegion> region;
+    };
+
     // MeshBuffer Write APIs
-    void enqueue_write_shard(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const void* host_data,
-        const Coordinate& coord,
-        bool blocking,
-        const std::optional<BufferRegion>& region = std::nullopt);
     void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer, const void* host_data, const LogicalDeviceRange& device_range, bool blocking);
     void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking);
     void enqueue_write_shards(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer, const std::vector<const void*>& host_data, bool blocking);
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        bool blocking);
 
     // MeshBuffer Read APIs
-    void enqueue_read_shard(
-        void* host_data,
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const Coordinate& coord,
-        bool blocking,
-        const std::optional<BufferRegion>& region = std::nullopt);
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking);
     void enqueue_read_shards(
-        const std::vector<void*>& host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, bool blocking);
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        bool blocking);
 
     void finish();
     void reset_worker_state(

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -4,8 +4,10 @@
 
 #include <mesh_command_queue.hpp>
 #include <mesh_device.hpp>
+#include <optional>
 #include <tt-metalium/dispatch_settings.hpp>
 
+#include "buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_utils.hpp"
 #include "tt_metal/impl/buffers/dispatch.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
@@ -164,16 +166,21 @@ void MeshCommandQueue::finish() {
 }
 
 void MeshCommandQueue::write_shard_to_device(
-    std::shared_ptr<Buffer>& shard_view, const void* src, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    std::shared_ptr<Buffer>& shard_view,
+    const void* src,
+    const BufferRegion& region,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto device = shard_view->device();
-    BufferRegion region(0, shard_view->size());
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     buffer_dispatch::write_to_device_buffer(
         src, *shard_view, region, id_, expected_num_workers_completed_, this->dispatch_core_type(), sub_device_ids);
 }
 
 void MeshCommandQueue::read_shard_from_device(
-    std::shared_ptr<Buffer>& shard_view, void* dst, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    std::shared_ptr<Buffer>& shard_view,
+    void* dst,
+    const BufferRegion& region,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto device = shard_view->device();
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
@@ -181,7 +188,6 @@ void MeshCommandQueue::read_shard_from_device(
 
     bool exit_condition = false;
 
-    BufferRegion region(0, shard_view->size());
     if (is_sharded(shard_view->buffer_layout())) {
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
             *shard_view, id_, expected_num_workers_completed_, region);
@@ -212,9 +218,13 @@ void MeshCommandQueue::read_shard_from_device(
 }
 
 void MeshCommandQueue::enqueue_write_shard(
-    const std::shared_ptr<MeshBuffer>& mesh_buffer, const void* host_data, const Coordinate& coord, bool blocking) {
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const void* host_data,
+    const Coordinate& coord,
+    bool blocking,
+    const std::optional<BufferRegion>& region) {
     auto shard = mesh_buffer->get_device_buffer(coord);
-    this->write_shard_to_device(shard, host_data);
+    this->write_shard_to_device(shard, host_data, region.value_or(BufferRegion(0, shard->size())));
 
     if (blocking) {
         this->finish();
@@ -222,10 +232,14 @@ void MeshCommandQueue::enqueue_write_shard(
 }
 
 void MeshCommandQueue::enqueue_read_shard(
-    void* host_data, const std::shared_ptr<MeshBuffer>& mesh_buffer, const Coordinate& coord, bool blocking) {
+    void* host_data,
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const Coordinate& coord,
+    bool blocking,
+    const std::optional<BufferRegion>& region) {
     TT_FATAL(blocking, "Only blocking reads are currently supported from MeshBuffer shards.");
     auto shard = mesh_buffer->get_device_buffer(coord);
-    this->read_shard_from_device(shard, host_data);
+    this->read_shard_from_device(shard, host_data, region.value_or(BufferRegion(0, shard->size())));
 }
 
 void MeshCommandQueue::write_sharded_buffer(const MeshBuffer& buffer, const void* src) {
@@ -269,26 +283,30 @@ void MeshCommandQueue::write_sharded_buffer(const MeshBuffer& buffer, const void
                          replicated_device_y++) {
                         auto device_shard_view =
                             buffer.get_device_buffer(Coordinate(replicated_device_y, replicated_device_x));
-                        this->write_shard_to_device(device_shard_view, shard_data.data());
+                        const BufferRegion region(0, device_shard_view->size());
+                        this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                     }
                 }
             } else if (height_replicated or width_replicated) {
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     for (auto replicated_device_y = 0; replicated_device_y < num_devices_y; replicated_device_y++) {
                         auto device_shard_view = buffer.get_device_buffer(Coordinate(replicated_device_y, device_x));
-                        this->write_shard_to_device(device_shard_view, shard_data.data());
+                        const BufferRegion region(0, device_shard_view->size());
+                        this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                     }
                     device_x++;
                 } else {
                     for (auto replicated_device_x = 0; replicated_device_x < num_devices_x; replicated_device_x++) {
                         auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, replicated_device_x));
-                        this->write_shard_to_device(device_shard_view, shard_data.data());
+                        const BufferRegion region(0, device_shard_view->size());
+                        this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                     }
                     device_y++;
                 }
             } else {
                 auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, device_x));
-                this->write_shard_to_device(device_shard_view, shard_data.data());
+                const BufferRegion region(0, device_shard_view->size());
+                this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     if (++device_x == num_devices_x) {
                         device_x = 0;
@@ -328,7 +346,9 @@ void MeshCommandQueue::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
     for (std::size_t shard_y = 0; shard_y < num_shards_y; shard_y++) {
         for (std::size_t shard_x = 0; shard_x < num_shards_x; shard_x++) {
             auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, device_x));
-            this->read_shard_from_device(device_shard_view, shard_data.data());
+            const BufferRegion region(0, device_shard_view->size());
+            this->read_shard_from_device(device_shard_view, shard_data.data(), region);
+
             uint32_t write_offset = shard_x * single_write_size + shard_y * stride_size_bytes * shard_shape.height();
             uint32_t size_to_write = total_write_size_per_shard;
             uint32_t local_offset = 0;
@@ -363,7 +383,8 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
             for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y + 1;
                  logical_y++) {
                 auto device_shard_view = buffer.get_device_buffer(Coordinate(logical_y, logical_x));
-                this->write_shard_to_device(device_shard_view, host_data);
+                const BufferRegion region(0, device_shard_view->size());
+                this->write_shard_to_device(device_shard_view, host_data, region);
             }
         }
     } else {
@@ -389,28 +410,30 @@ void MeshCommandQueue::enqueue_read_mesh_buffer(
 
 void MeshCommandQueue::enqueue_write_shards(
     const std::shared_ptr<MeshBuffer>& buffer, const std::vector<const void*>& host_data, bool blocking) {
-    // Note: this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
+    // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     const auto [num_rows, num_cols] = buffer->device()->shape();
     TT_FATAL(host_data.size() == num_rows * num_cols, "Expected number of shards to match the number of devices.");
     for (std::size_t shard_y = 0; shard_y < num_rows; ++shard_y) {
         for (std::size_t shard_x = 0; shard_x < num_cols; ++shard_x) {
             auto device_shard_view = buffer->get_device_buffer(Coordinate(shard_y, shard_x));
-            write_shard_to_device(device_shard_view, host_data[shard_y * num_cols + shard_x]);
+            const BufferRegion region(0, device_shard_view->size());
+            write_shard_to_device(device_shard_view, host_data[shard_y * num_cols + shard_x], region);
         }
     }
 }
 
 void MeshCommandQueue::enqueue_read_shards(
     const std::vector<void*>& host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
-    // Note: this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
+    // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     const auto [num_rows, num_cols] = buffer->device()->shape();
     TT_FATAL(host_data.size() == num_rows * num_cols, "Expected number of shards to match the number of devices.");
     for (std::size_t shard_y = 0; shard_y < num_rows; ++shard_y) {
         for (std::size_t shard_x = 0; shard_x < num_cols; ++shard_x) {
             auto device_shard_view = buffer->get_device_buffer(Coordinate(shard_y, shard_x));
-            read_shard_from_device(device_shard_view, host_data[shard_y * num_cols + shard_x]);
+            const BufferRegion region(0, device_shard_view->size());
+            read_shard_from_device(device_shard_view, host_data[shard_y * num_cols + shard_x], region);
         }
     }
 }

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -389,6 +389,8 @@ void MeshCommandQueue::enqueue_read_mesh_buffer(
 
 void MeshCommandQueue::enqueue_write_shards(
     const std::shared_ptr<MeshBuffer>& buffer, const std::vector<const void*>& host_data, bool blocking) {
+    // Note: this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
+    // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     const auto [num_rows, num_cols] = buffer->device()->shape();
     TT_FATAL(host_data.size() == num_rows * num_cols, "Expected number of shards to match the number of devices.");
     for (std::size_t shard_y = 0; shard_y < num_rows; ++shard_y) {
@@ -401,6 +403,8 @@ void MeshCommandQueue::enqueue_write_shards(
 
 void MeshCommandQueue::enqueue_read_shards(
     const std::vector<void*>& host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
+    // Note: this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
+    // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     const auto [num_rows, num_cols] = buffer->device()->shape();
     TT_FATAL(host_data.size() == num_rows * num_cols, "Expected number of shards to match the number of devices.");
     for (std::size_t shard_y = 0; shard_y < num_rows; ++shard_y) {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -211,6 +211,11 @@ bool is_multi_device_tensor(const Tensor& tensor) {
            tensor.storage_type() == StorageType::MULTI_DEVICE_HOST;
 }
 
+bool is_mesh_buffer_tensor(const Tensor& tensor) {
+    auto* multi_device_storage = std::get_if<MultiDeviceStorage>(&tensor.get_storage());
+    return multi_device_storage != nullptr && multi_device_storage->mesh_buffer != nullptr;
+}
+
 std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_device_tensor) {
     std::vector<ttnn::Tensor> tensors;
     if (multi_device_tensor.storage_type() == StorageType::MULTI_DEVICE) {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -115,8 +115,7 @@ Tensor aggregate_as_tensor(
                     shard_tile.get_width());
             }
         }
-        auto storage =
-            MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), specs, /*mesh_buffer_=*/nullptr};
+        auto storage = MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), specs};
         return Tensor(std::move(storage), reference_shard.get_tensor_spec());
     }
 }
@@ -268,7 +267,7 @@ Tensor create_multi_device_tensor(
             specs.insert({device_id, tensor.get_tensor_spec()});
         }
         return Tensor{
-            MultiDeviceStorage{strategy, ordered_device_ids, device_buffers, specs, /*mesh_buffer_=*/nullptr},
+            MultiDeviceStorage{strategy, ordered_device_ids, device_buffers, specs},
             TensorSpec(
                 tensors.at(0).get_logical_shape(),
                 TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -115,7 +115,8 @@ Tensor aggregate_as_tensor(
                     shard_tile.get_width());
             }
         }
-        auto storage = MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), specs};
+        auto storage =
+            MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), specs, /*mesh_buffer=*/nullptr};
         return Tensor(std::move(storage), reference_shard.get_tensor_spec());
     }
 }
@@ -267,7 +268,7 @@ Tensor create_multi_device_tensor(
             specs.insert({device_id, tensor.get_tensor_spec()});
         }
         return Tensor{
-            MultiDeviceStorage{strategy, ordered_device_ids, device_buffers, specs},
+            MultiDeviceStorage{strategy, ordered_device_ids, device_buffers, specs, /*mesh_buffer=*/nullptr},
             TensorSpec(
                 tensors.at(0).get_logical_shape(),
                 TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -45,6 +45,10 @@ Tensor get_device_tensor(const Tensor& multi_device_tensor, const int device_id)
 // Returns true has MultiDeviceHost/MultiDevice Storage
 bool is_multi_device_tensor(const Tensor& tensor);
 
+// Returns true if tensor has MultiDevice storage type and is allocated on a mesh buffer.
+// TODO: remove when the infrastructure uniformly works with mesh buffer backed tensors.
+bool is_mesh_buffer_tensor(const Tensor& tensor);
+
 // Given a multi-device tensor and a device, returns a list of per-device tensors.
 std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_device_tensor);
 

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -16,4 +16,32 @@ std::vector<std::shared_ptr<Buffer>> MultiDeviceStorage::get_buffers() const {
     return buf_vec;
 }
 
+MultiDeviceStorage::MultiDeviceStorage(
+    const DistributedTensorConfig& strategy_,
+    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_,
+    const TensorSpec& tensor_spec) :
+    strategy(strategy_),
+    mesh_buffer(mesh_buffer_)  //
+{
+    // In the long term, this code won't exist: no interactions will be made with individual Buffers, and instead the
+    // APIs will use MeshBuffer directly. MeshBuffer will also guarantee that all shards have the same tensor spec.
+    //
+    // For now, this code ensures MeshBuffer backed tensors are compatible with the rest of the ops infra.
+    const auto [num_rows, num_cols] = mesh_buffer->device()->shape();
+
+    ordered_device_ids.reserve(num_rows * num_cols);
+    buffers.reserve(num_rows * num_cols);
+    specs.reserve(num_rows * num_cols);
+
+    for (int row = 0; row < num_rows; ++row) {
+        for (int col = 0; col < num_cols; ++col) {
+            auto buffer = mesh_buffer->get_device_buffer(distributed::Coordinate{row, col});
+            const int device_id = buffer->device()->id();
+            ordered_device_ids.push_back(device_id);
+            buffers.emplace(device_id, std::move(buffer));
+            specs.emplace(device_id, tensor_spec);
+        }
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -17,14 +17,13 @@ std::vector<std::shared_ptr<Buffer>> MultiDeviceStorage::get_buffers() const {
 }
 
 MultiDeviceStorage::MultiDeviceStorage(
-    const DistributedTensorConfig& strategy_,
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_,
-    const TensorSpec& tensor_spec) :
-    strategy(strategy_),
+    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_, const TensorSpec& tensor_spec) :
+    strategy(ReplicateTensor{}),
     mesh_buffer(mesh_buffer_)  //
 {
-    // In the long term, this code won't exist: no interactions will be made with individual Buffers, and instead the
-    // APIs will use MeshBuffer directly. MeshBuffer will also guarantee that all shards have the same tensor spec.
+    // TODO: #17215 - In the long term, this code won't exist: no interactions will be made with individual Buffers, and
+    // instead the APIs will use MeshBuffer directly. MeshBuffer will also guarantee that all shards have the same
+    // tensor spec.
     //
     // For now, this code ensures MeshBuffer backed tensors are compatible with the rest of the ops infra.
     const auto [num_rows, num_cols] = mesh_buffer->device()->shape();

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -243,17 +243,22 @@ struct MultiDeviceStorage {
         swap(first.mesh_buffer, second.mesh_buffer);
     }
 
+    // Constructs a multi-device tensor backed by a collection of heterogeneous single-device buffers.
     MultiDeviceStorage(
         DistributedTensorConfig strategy_,
         std::vector<int> ordered_device_ids_,
         std::unordered_map<int, std::shared_ptr<Buffer>> buffers_,
-        std::unordered_map<int, TensorSpec> specs_,
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_) :
+        std::unordered_map<int, TensorSpec> specs_) :
         strategy(std::move(strategy_)),
         ordered_device_ids(std::move(ordered_device_ids_)),
         buffers(std::move(buffers_)),
-        specs(std::move(specs_)),
-        mesh_buffer(std::move(mesh_buffer_)) {}
+        specs(std::move(specs_)) {}
+
+    // Constructs a multi-device tensor backed by mesh buffer.
+    MultiDeviceStorage(
+        const DistributedTensorConfig& strategy_,
+        const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_,
+        const TensorSpec& tensor_spec);
 
     MultiDeviceStorage(MultiDeviceStorage&& other) { swap(*this, other); }
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 
@@ -248,17 +249,16 @@ struct MultiDeviceStorage {
         DistributedTensorConfig strategy_,
         std::vector<int> ordered_device_ids_,
         std::unordered_map<int, std::shared_ptr<Buffer>> buffers_,
-        std::unordered_map<int, TensorSpec> specs_) :
+        std::unordered_map<int, TensorSpec> specs_,
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_) :
         strategy(std::move(strategy_)),
         ordered_device_ids(std::move(ordered_device_ids_)),
         buffers(std::move(buffers_)),
-        specs(std::move(specs_)) {}
+        specs(std::move(specs_)),
+        mesh_buffer(std::move(mesh_buffer_)) {}
 
-    // Constructs a multi-device tensor backed by mesh buffer.
-    MultiDeviceStorage(
-        const DistributedTensorConfig& strategy_,
-        const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_,
-        const TensorSpec& tensor_spec);
+    // Constructs a replicated multi-device tensor backed by mesh buffer.
+    MultiDeviceStorage(const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_, const TensorSpec& tensor_spec);
 
     MultiDeviceStorage(MultiDeviceStorage&& other) { swap(*this, other); }
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -379,6 +379,9 @@ struct MultiDeviceStorage {
 using Storage = std::variant<OwnedStorage, DeviceStorage, BorrowedStorage, MultiDeviceHostStorage, MultiDeviceStorage>;
 
 template <typename T>
+concept OwnedOrBorrowedStorage = std::is_same_v<T, OwnedStorage> || std::is_same_v<T, BorrowedStorage>;
+
+template <typename T>
 constexpr void raise_unsupported_storage() {
     static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported Storage");
 }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -1016,7 +1016,7 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
     TT_FATAL(
         tt::tt_metal::detail::InMainThread(), "Allocation of a tensor on mesh must be called from the main thread");
     auto mesh_buffer = tensor_impl::allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
-    MultiDeviceStorage multi_device_storage(ReplicateTensor{}, std::move(mesh_buffer), tensor_spec);
+    MultiDeviceStorage multi_device_storage(std::move(mesh_buffer), tensor_spec);
     return Tensor(std::move(multi_device_storage), tensor_spec);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -1016,29 +1016,7 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
     TT_FATAL(
         tt::tt_metal::detail::InMainThread(), "Allocation of a tensor on mesh must be called from the main thread");
     auto mesh_buffer = tensor_impl::allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
-
-    const auto [num_rows, num_cols] = mesh_device->shape();
-    std::vector<int> ordered_device_ids;
-    std::unordered_map<int, std::shared_ptr<Buffer>> buffers;
-    std::unordered_map<int, TensorSpec> specs;
-
-    ordered_device_ids.reserve(num_rows * num_cols);
-    buffers.reserve(num_rows * num_cols);
-    specs.reserve(num_rows * num_cols);
-
-    for (int row = 0; row < num_rows; ++row) {
-        for (int col = 0; col < num_cols; ++col) {
-            auto buffer = mesh_buffer->get_device_buffer(distributed::Coordinate{row, col});
-            const int device_id = buffer->device()->id();
-            ordered_device_ids.push_back(device_id);
-            buffers.emplace(device_id, std::move(buffer));
-            specs.emplace(device_id, tensor_spec);
-        }
-    }
-
-    MultiDeviceStorage multi_device_storage(
-        ReplicateTensor{}, std::move(ordered_device_ids), std::move(buffers), std::move(specs), std::move(mesh_buffer));
-
+    MultiDeviceStorage multi_device_storage(ReplicateTensor{}, std::move(mesh_buffer), tensor_spec);
     return Tensor(std::move(multi_device_storage), tensor_spec);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -190,6 +190,10 @@ inline void read_data_from_device_buffer(std::shared_ptr<Buffer> device_buffer, 
 template <typename T>
 Tensor to_host(const Tensor& tensor, bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId);
 
+// TODO: #17215 - This will eventually subsume `to_host`, when "mesh buffer" backed tensors become the default.
+template <typename T>
+Tensor to_host_from_mesh_tensor(const Tensor& tensor, bool blocking = true);
+
 template <typename T>
 Tensor to_device(
     const Tensor& tensor,

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -205,7 +205,7 @@ Tensor to_device(
 // TODO: #17215 - This will eventually subsume `to_device`, when "mesh buffer" backed tensors become the default.
 template <typename T>
 Tensor to_device_mesh_tensor(
-    const Tensor& tensor, distributed::MeshDevice* target_device, const MemoryConfig& memory_config);
+    const Tensor& tensor, distributed::MeshDevice* mesh_device, const MemoryConfig& memory_config);
 
 // ======================================================================================
 //                                  .to_layout()

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/bfloat4.hpp>
 #include <tt-metalium/bfloat8.hpp>
+#include "tt-metalium/mesh_device.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -173,18 +174,18 @@ std::shared_ptr<distributed::MeshBuffer> allocate_mesh_buffer_on_device(
     distributed::MeshDevice* mesh_device, const TensorSpec& tensor_spec);
 
 template <typename T>
-inline void read_data_from_device_buffer(
+void read_data_from_device_buffer(
     CommandQueue& cq, std::shared_ptr<Buffer> device_buffer, void* host_buffer_data, bool blocking) {
     EnqueueReadBuffer(cq, device_buffer, host_buffer_data, blocking);
 }
 
 template <typename T>
-inline void read_data_from_device_buffer(std::shared_ptr<Buffer> device_buffer, std::vector<T>& host_buffer) {
+void read_data_from_device_buffer(std::shared_ptr<Buffer> device_buffer, std::vector<T>& host_buffer) {
     ::tt::tt_metal::detail::ReadFromBuffer(device_buffer, host_buffer);
 }
 
 // ======================================================================================
-//                                         .to()
+//                                         .to_host() and .to_device()
 // ======================================================================================
 
 template <typename T>
@@ -192,7 +193,7 @@ Tensor to_host(const Tensor& tensor, bool blocking = true, uint8_t cq_id = ttnn:
 
 // TODO: #17215 - This will eventually subsume `to_host`, when "mesh buffer" backed tensors become the default.
 template <typename T>
-Tensor to_host_from_mesh_tensor(const Tensor& tensor, bool blocking = true);
+Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking = true);
 
 template <typename T>
 Tensor to_device(
@@ -200,6 +201,15 @@ Tensor to_device(
     IDevice* target_device,
     const MemoryConfig& memory_config,
     uint8_t cq_id = ttnn::DefaultQueueId);
+
+// TODO: #17215 - This will eventually subsume `to_device`, when "mesh buffer" backed tensors become the default.
+template <typename T>
+Tensor to_device_mesh_tensor(
+    const Tensor& tensor, distributed::MeshDevice* target_device, const MemoryConfig& memory_config);
+
+// ======================================================================================
+//                                  .to_layout()
+// ======================================================================================
 
 template <typename T>
 Tensor to_layout(const Tensor& tensor, Layout target_layout);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
@@ -38,6 +38,7 @@ inline size_t packed_buffer_size_bytes_wrapper(DataType dtype, size_t volume_unp
 }
 
 WRAP_FUNCTION(to_host)
+WRAP_FUNCTION(to_host_from_mesh_tensor)
 WRAP_FUNCTION(extract_shard)
 WRAP_FUNCTION(to_device)
 WRAP_FUNCTION(to_layout)

--- a/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
@@ -38,9 +38,10 @@ inline size_t packed_buffer_size_bytes_wrapper(DataType dtype, size_t volume_unp
 }
 
 WRAP_FUNCTION(to_host)
-WRAP_FUNCTION(to_host_from_mesh_tensor)
+WRAP_FUNCTION(to_host_mesh_tensor)
 WRAP_FUNCTION(extract_shard)
 WRAP_FUNCTION(to_device)
+WRAP_FUNCTION(to_device_mesh_tensor)
 WRAP_FUNCTION(to_layout)
 WRAP_FUNCTION(pad)
 WRAP_FUNCTION(unpad)

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -100,13 +100,6 @@ Tensor tensor_to(
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, uint8_t cq_id) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::cpu", input_tensor, blocking);
-    if (ttnn::distributed::is_mesh_buffer_tensor(input_tensor)) {
-        Tensor host_tensor = tensor_impl::to_host_from_mesh_tensor_wrapper(input_tensor, blocking);
-        host_tensor = tt::tt_metal::set_tensor_id(host_tensor);
-        GraphTracker::instance().track_function_end(host_tensor);
-        return host_tensor;
-    }
-
     auto workers = input_tensor.get_workers(blocking);
     if (not workers.size()) {
         // Tensor is on host and does not have a worker group.

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -100,6 +100,13 @@ Tensor tensor_to(
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, uint8_t cq_id) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::cpu", input_tensor, blocking);
+    if (ttnn::distributed::is_mesh_buffer_tensor(input_tensor)) {
+        Tensor host_tensor = tensor_impl::to_host_from_mesh_tensor_wrapper(input_tensor, blocking);
+        host_tensor = tt::tt_metal::set_tensor_id(host_tensor);
+        GraphTracker::instance().track_function_end(host_tensor);
+        return host_tensor;
+    }
+
     auto workers = input_tensor.get_workers(blocking);
     if (not workers.size()) {
         // Tensor is on host and does not have a worker group.


### PR DESCRIPTION
### Ticket
#17215

### Problem description
Tensors allocated on mesh buffer (aka "mesh tensors") need write and read APIs exposed to TTNN.

### What's changed
* Extended mesh CQ interface to read / write shards, to accommodate TTNN multi-device sharding APIs.
  * The future work includes parallelizing the per-device dispatches internally, within Metal.
* Add `to_device_mesh_tensor` and `to_host_mesh_tensor` that will be the main API used in TTNN to read/write the mesh buffer tensors.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13167605541)
- [X] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13167605541)
- [X] New/Existing tests provide coverage for changes
