### PR TITLE
Tag Docker images with sha1

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: 'Docker image architecture'
     required: false
     default: tt-metalium/ubuntu-20.04-amd64
-  docker_version:
-    description: 'Specify version for the Docker image tag to use.'
+  docker_image:
+    description: 'Specify Docker image to use.'
     required: false
   docker_username:
     description: docker login username
@@ -37,11 +37,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set docker image tag
+      if: ${{ inputs.docker_image }}
+      shell: bash
+      run: |
+        echo "TT_METAL_DOCKER_IMAGE_TAG=${{ inputs.docker_image }}" >> $GITHUB_ENV
     - name: Determine docker image tag
+      if: ${{ ! inputs.docker_image }}
       uses: ./.github/actions/generate-docker-tag
       with:
         image: ${{ inputs.docker_os_arch }}
-        version: ${{ inputs.docker_version }}
     - name: Set
       shell: bash
       run: |

--- a/.github/actions/generate-docker-tag/action.yml
+++ b/.github/actions/generate-docker-tag/action.yml
@@ -2,39 +2,35 @@ name: "Run set of commands in Docker"
 description: "Run commands in docker"
 
 inputs:
-  run_args:
-    description: 'Commands to run in docker'
-    required: true
   image:
     description: 'Docker image to run commands in - follows os-arch format'
     required: false
     default: ubuntu-20.04-amd64
-  version:
-    description: 'Docker image version'
-    required: false
 runs:
   using: "composite"
   steps:
-    - name: Determine Docker Tag
+    - name: Deprecation warning
       shell: bash
       run: |
-        # If the version was provided use it, otherwise, determine what the version should be.
-        if [ "${{ inputs.version }}" != "" ]; then
-          echo "IMAGE_TAG=${{ inputs.version }}" >> $GITHUB_ENV
-        else
-          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
-            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
-          else
-            echo "IMAGE_TAG=dev-${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
-          fi
-        fi
-    - name: Determine Full Docker Image Tag
+        echo "::notice::[DEPRECATION] This action is deprecated. Please migrate to reading the Docker image from the pipeline."
+
+    - name: Checkout repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        clean: false
+
+    - name: Compute tags
+      id: tags
       shell: bash
       run: |
-        echo "TT_METAL_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
-        echo "TT_METAL_REF_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest" >> $GITHUB_ENV
-    - name: Output Docker Image Tag
-      shell: bash
-      run: |
-        echo "IMAGE_TAG=${{ env.IMAGE_TAG }}"
-        echo "TT_METAL_DOCKER_IMAGE_TAG=${{ env.TT_METAL_DOCKER_IMAGE_TAG}}"
+        BUILD_TAG=$(cat \
+          dockerfile/*.Dockerfile \
+          scripts/docker/install_test_deps.sh \
+          scripts/docker/requirements* \
+          tt_metal/python_env/requirements-dev.txt \
+          docs/requirements-docs.txt \
+          tests/sweep_framework/requirements-sweeps.txt \
+          | sha1sum | cut -d' ' -f1)
+        echo "BUILD_TAG=$BUILD_TAG" >> $GITHUB_ENV
+        echo "TT_METAL_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:${BUILD_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -42,6 +42,13 @@ on:
         required: false
         type: boolean
         default: false
+    outputs:
+      docker-image-ci-build-tag:
+        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+        value: ${{ jobs.build-docker-image.outputs.ci-build-tag }}
+      #docker-image-ci-test-tag:
+      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+      #  value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
 
 
   workflow_dispatch:
@@ -67,6 +74,11 @@ on:
         required: false
         type: string
         default: "amd64"
+      toolchain:
+        required: false
+        type: string
+        default: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+        description: "Toolchain file to use for build"
 
 
 jobs:
@@ -110,11 +122,6 @@ jobs:
       - name: Update submodules
         run: |
           git submodule update --init --recursive
-      - name: Generate docker tag
-        id: generate-docker-tag
-        uses: ./.github/actions/generate-docker-tag
-        with:
-          image: tt-metalium/${{ env.IMAGE_PARAMS }}
       - name: Docker login
         uses: docker/login-action@v3
         with:
@@ -122,11 +129,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull docker image
-        run: docker pull ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
+        run: docker pull ${{ needs.build-docker-image.outputs.ci-build-tag }}
       - name: Build tt-metal and libs
         uses: tenstorrent/docker-run-action@v5
         with:
-          image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
+          image: ${{ needs.build-docker-image.outputs.ci-build-tag }}
           options: |
             --rm
             --tmpfs /tmp

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -43,10 +43,10 @@ on:
         type: boolean
         default: false
     outputs:
-      docker-image-ci-build-tag:
+      ci-build-docker-image:
         description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
         value: ${{ jobs.build-docker-image.outputs.ci-build-tag }}
-      #docker-image-ci-test-tag:
+      #ci-test-docker-image:
       #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
       #  value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
 

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -15,6 +15,13 @@ on:
         required: false
         type: string
         default: "amd64"
+    outputs:
+      ci-build-tag:
+        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+        value: ${{ jobs.check-docker-images.outputs.ci-build-tag }}
+      #ci-test-tag:
+      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+      #  value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
   workflow_dispatch:
     inputs:
       distro:
@@ -37,62 +44,76 @@ on:
         default: "amd64"
         options:
             - "amd64"
+
+env:
+  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}
+
 jobs:
+  check-docker-images:
+    runs-on: ubuntu-latest
+    outputs:
+      ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
+      ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
+      # ci-test-exists: ${{ steps.images.outputs.ci-test-exists }}
+      # ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Compute tags
+        id: tags
+        run: |
+          BUILD_TAG=$(cat \
+            dockerfile/*.Dockerfile \
+            scripts/docker/install_test_deps.sh \
+            scripts/docker/requirements* \
+            tt_metal/python_env/requirements-dev.txt \
+            docs/requirements-docs.txt \
+            tests/sweep_framework/requirements-sweeps.txt \
+            | sha1sum | cut -d' ' -f1)
+          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${BUILD_TAG}" >> $GITHUB_OUTPUT
+
+          # TODO: When we have multiple Docker images, do something like this:
+          # TEST_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
+          # echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${TEST_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Query images exist
+        id: images
+        run: |
+          if docker manifest inspect ${{ steps.tags.outputs.ci-build-tag }} > /dev/null 2>&1; then
+            echo "${{ steps.tags.outputs.ci-build-tag }} exists"
+            echo "ci-build-exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "${{ steps.tags.outputs.ci-build-tag }} does not exist"
+            echo "ci-build-exists=false" >> $GITHUB_OUTPUT
+          fi
+
+
   build-docker-image:
     name: "🐳️ Build ${{ inputs.distro }} ${{inputs.version }} image"
+    needs: check-docker-images
+    if: needs.check-docker-images.outputs.ci-build-exists != 'true'
     timeout-minutes: 30
-    env:
-      CONFIG: ci
-      SILENT: 0
-      VERBOSE: 1
-      IMAGE_PARAMS: "${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}"
-      IMAGE: tt-metalium/ubuntu-20.04-amd64
-      DOCKERFILE: ubuntu-20.04-amd64
     runs-on:
       - build-docker
       - in-service
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-        with:
-          fetch-depth: 0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: https://ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get all test, doc and src files that have changed
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v45
-        with:
-          files: |
-              dockerfile/**.Dockerfile
-              scripts/docker/install_test_deps.sh
-              scripts/docker/requirements*
-              pyproject.toml
-              tt_metal/python_env/requirements-dev.txt
-          base_sha: 'main'
-      - name: Determine docker image tag
-        uses: ./.github/actions/generate-docker-tag
-        with:
-          image: tt-metalium/${{ env.IMAGE_PARAMS }}
       - name: Build Docker image and push to GHCR
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}
-          file: dockerfile/${{ env.IMAGE_PARAMS }}.Dockerfile
+          file: dockerfile/${{ env.IMAGE_NAME }}.Dockerfile
           push: true
-          tags: ${{ env.TT_METAL_DOCKER_IMAGE_TAG}}
+          tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
           build-args: UBUNTU_VERSION=${{ inputs.version }}
-          cache-from: type=registry,ref=${{ env.TT_METAL_REF_IMAGE_TAG }}
           cache-to: type=inline
           pull: true
-      - name: Tag Docker main image as current image
-        if: steps.changed-files-specific.outputs.any_changed != 'true'
-        run: |
-          docker pull ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_PARAMS }}:latest
-          docker tag ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_PARAMS }}:latest ${{ env.TT_METAL_DOCKER_IMAGE_TAG}}
-      - name: Push Docker image to GitHub Container Registry
-        run: |
-          docker push ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -67,6 +67,8 @@ jobs:
             echo "::error title=ccache-not-provisioned::Ccache is not properly provisioned."
             exit 1
           fi
+      - name: Check out repo
+        uses: actions/checkout@v4
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -192,6 +192,7 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
+      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
   release-docs:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -186,6 +186,7 @@ jobs:
           fail_on_unmatched_files: true
   create-docker-release-image:
     needs: [
+      build-artifact,
       create-tag,
       create-and-upload-draft-release
     ]

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -22,5 +22,6 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
+      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       version: dev-${GITHUB_REF_NAME//\//-}
       is_major_version: false

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -18,7 +18,7 @@ jobs:
       os: ${{ matrix.os }}
       from-precompiled: true
   publish-release-image:
-    needs: build-wheels
+    needs: [ build-wheels, build-artifact ]
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -85,8 +85,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-release
-          docker_version: ${{ inputs.version }}
+          image: ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release:${{ inputs.version }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           run_args: |
             ${{ matrix.test_group.cmd }}

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -3,6 +3,10 @@ name: "[internal] Create and Publish Release Docker Image"
 on:
   workflow_call:
     inputs:
+      base-image:
+        description: "Base image to build on top of"
+        required: true
+        type: string
       version:
         required: true
         type: string
@@ -51,7 +55,7 @@ jobs:
           push: true
           build-args: |
             WHEEL_FILENAME=${{ env.WHEEL_FILENAME }}
-            BASE_IMAGE_NAME=tt-metalium/${{ matrix.os }}-amd64
+            BASE_IMAGE=${{ inputs.base-image }}
           tags: ${{ env.TAG_NAME }}
           context: .
           file: dockerfile/release.Dockerfile
@@ -85,7 +89,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          image: ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release:${{ inputs.version }}
+          docker_image: ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release:${{ inputs.version }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           run_args: |
             ${{ matrix.test_group.cmd }}

--- a/dockerfile/release.Dockerfile
+++ b/dockerfile/release.Dockerfile
@@ -1,9 +1,9 @@
-ARG BASE_IMAGE_NAME=tt-metalium/ubuntu-20.04-amd64
+ARG BASE_IMAGE=ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64:latest
 #
 # Currently the release image uses the base image which is also the build image.
 # However, in the future, we could point a true base image that is a base for both releases and builds.
 # This work is described in https://github.com/tenstorrent/tt-metal/issues/11974
-FROM ghcr.io/tenstorrent/tt-metal/$BASE_IMAGE_NAME
+FROM $BASE_IMAGE
 
 ARG WHEEL_FILENAME
 ADD $WHEEL_FILENAME $WHEEL_FILENAME


### PR DESCRIPTION
### Ticket
#17464

### Problem description
Our current tagging of Docker images has a few problems:
1. Not versioned - we may pick up the wrong image
2. May be regenerated needlessly
3. Wastes gh api calls, which are limited
4. Unable to be used at the job scope
(more details in the ticket)

### What's changed
* Docker images are tagged according to the SHA1 of the inputs.
* Determination of whether a new image needs to be rebuilt is now done on a Cloud image and consumes only 8-10s as opposed to the previous 20-40s, not to mention the wait time for a docker-build runner to become available.
* Identification of whether a new image must be rebuilt is done without any GH API calls.  Only a shallow clone of the repo is required.
* The job produces `outputs` for the image tags such that downstream jobs may reference it and run within a container at the job scope.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13148557130)
- [x] [Python Wheel Release Image succeeds](https://github.com/tenstorrent/tt-metal/actions/runs/13148270334)
