### PR TITLE
#0: Rename  overloads `Tensor::to` to `Tensor::to_layout` / `Tensor::to_device`

### DIFF
--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -230,7 +230,7 @@ void test_bert() {
     auto attention_mask =
         ttnn::random::uniform(
             bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({batch_size, 1, TILE_HEIGHT, sequence_size}), Layout::TILE)
-            .to(device, l1_memory_config);
+            .to_device(device, l1_memory_config);
 
     auto parameters = Parameters{};
     for (auto encoder_index = 0; encoder_index < num_encoders; encoder_index++) {
@@ -238,74 +238,74 @@ void test_bert() {
             fmt::format("fused_qkv_weight_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, hidden_size, hidden_size * 3}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("fused_qkv_bias_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, hidden_size * 3}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("selfout_weight_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, hidden_size, hidden_size}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("selfout_bias_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, hidden_size}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("attention_layernorm_weight_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), Layout::ROW_MAJOR)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("attention_layernorm_bias_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), Layout::ROW_MAJOR)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("ff1_weight_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, hidden_size, intermediate_size}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("ff1_bias_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, intermediate_size}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("ff2_weight_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, intermediate_size, hidden_size}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("ff2_bias_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, hidden_size}), Layout::TILE)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("feedforward_layernorm_weight_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), Layout::ROW_MAJOR)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
         parameters.emplace(
             fmt::format("feedforward_layernorm_bias_{}", encoder_index),
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), Layout::ROW_MAJOR)
-                .to(device, dram_memory_config));
+                .to_device(device, dram_memory_config));
     };
     parameters.emplace(
         "qa_head_weight",
         ttnn::random::uniform(
             bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, hidden_size, TILE_WIDTH}), Layout::TILE)
-            .to(device, dram_memory_config));
+            .to_device(device, dram_memory_config));
     parameters.emplace(
         "qa_head_bias",
         ttnn::reshape(
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), Layout::TILE)
-                .to(device, dram_memory_config),
+                .to_device(device, dram_memory_config),
             ttnn::Shape({1, 1, 1, TILE_WIDTH})));
 
     auto run_bert = [&]() {
@@ -314,7 +314,7 @@ void test_bert() {
         auto hidden_states =
             ttnn::random::uniform(
                 bfloat16(-1.0f), bfloat16(1.0f), ttnn::Shape({batch_size, 1, sequence_size, hidden_size}), Layout::TILE)
-                .to(device, l1_memory_config);
+                .to_device(device, l1_memory_config);
         for (auto encoder_index = 0; encoder_index < num_encoders; encoder_index++) {
             hidden_states = encoder(std::move(hidden_states), attention_mask, parameters, encoder_index, head_size);
         }

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
                         throw std::runtime_error("Unsupported Dim!");
                     }
 
-                    Tensor a = ttnn::random::random(input_shape_a).to(Layout::TILE).to(device);
+                    Tensor a = ttnn::random::random(input_shape_a).to_layout(Layout::TILE).to_device(device);
                     Tensor b = ttnn::zeros(
                         ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), DataType::BFLOAT16, Layout::TILE, *device);
 
@@ -67,28 +67,28 @@ int main(int argc, char** argv) {
             }
 
             {
-                Tensor a = ttnn::random::random(Shape({1, 1, 32, 4544})).to(Layout::TILE).to(device);
+                Tensor a = ttnn::random::random(Shape({1, 1, 32, 4544})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 4544}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::H);
                 Tensor d = c.cpu();
             }
 
             {
-                Tensor a = ttnn::random::random(Shape({1, 1, 32, 4544})).to(Layout::TILE).to(device);
+                Tensor a = ttnn::random::random(Shape({1, 1, 32, 4544})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 4544}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::ADD, ttnn::BcastOpDim::H);
                 Tensor d = c.cpu();
             }
 
             {
-                Tensor a = ttnn::random::random(Shape({1, 71, 32, 32})).to(Layout::TILE).to(device);
+                Tensor a = ttnn::random::random(Shape({1, 71, 32, 32})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 32}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
                 Tensor d = c.cpu();
             }
 
             {
-                Tensor a = ttnn::random::random(Shape({1, 71, 32, 64})).to(Layout::TILE).to(device);
+                Tensor a = ttnn::random::random(Shape({1, 71, 32, 64})).to_layout(Layout::TILE).to_device(device);
                 Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 32}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
                 Tensor d = c.cpu();

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
         ttnn::Shape shapeb1({1, 1, Kt * TILE_HEIGHT, Nt * TILE_WIDTH});
 
         // Allocates a DRAM buffer on device populated with values specified by initialize
-        Tensor a = ttnn::random::random(shapea).to(Layout::TILE).to(device);
+        Tensor a = ttnn::random::random(shapea).to_layout(Layout::TILE).to_device(device);
         Tensor b = ttnn::zeros(shapeb, DataType::BFLOAT16, Layout::TILE, *device);
         Tensor b1 = ttnn::zeros(shapeb1, DataType::BFLOAT16, Layout::TILE, *device);
 

--- a/tests/tt_eager/ops/test_conv_prepare_weights_and_biases.cpp
+++ b/tests/tt_eager/ops/test_conv_prepare_weights_and_biases.cpp
@@ -463,7 +463,7 @@ static void test_convert_conv_bias_tensor_to_tiled_layout_block_sharded() {
     tt::log_info(tt::LogTest, "Running {}", __func__);
     for (auto i = 0; i < bias_tensor_shape.size(); i++) {
         auto input_tensor =
-            ttnn::random::random(Shape(bias_tensor_shape[i]), DataType::BFLOAT16).to(Layout::ROW_MAJOR).cpu();
+            ttnn::random::random(Shape(bias_tensor_shape[i]), DataType::BFLOAT16).to_layout(Layout::ROW_MAJOR).cpu();
         auto input_buffer = owned_buffer::get_as<bfloat16>(input_tensor);
         auto output_tensor = ttnn::operations::conv::convert_conv_bias_tensor_to_tiled_layout_block_sharded(
             input_tensor, shards[i], DataType::BFLOAT16);

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -39,10 +39,11 @@ bool run_test(const ttnn::Shape& shape, const DeviceFunction& device_function, I
     auto input_tensor_b = ttnn::random::random(shape, DataType::BFLOAT16);
 
     auto host_output = HostFunction(input_tensor_a, input_tensor_b);
-    auto device_output =
-        device_function(input_tensor_a.to(Layout::TILE).to(device), input_tensor_b.to(Layout::TILE).to(device))
-            .cpu()
-            .to(Layout::ROW_MAJOR);
+    auto device_output = device_function(
+                             input_tensor_a.to_layout(Layout::TILE).to_device(device),
+                             input_tensor_b.to_layout(Layout::TILE).to_device(device))
+                             .cpu()
+                             .to_layout(Layout::ROW_MAJOR);
 
     return ttnn::allclose<bfloat16>(host_output, device_output, args...);
 }
@@ -111,8 +112,9 @@ int main() {
     run_binary_ops();
 
     // Allocate a tensor to show that the addresses aren't cached
-    auto input_tensor =
-        ttnn::random::uniform(bfloat16(0.0f), bfloat16(0.0f), Shape({1, 1, 32, 32})).to(Layout::TILE).to(device);
+    auto input_tensor = ttnn::random::uniform(bfloat16(0.0f), bfloat16(0.0f), Shape({1, 1, 32, 32}))
+                            .to_layout(Layout::TILE)
+                            .to_device(device);
 
     run_binary_ops();
 

--- a/tests/tt_eager/ops/test_fold_op.cpp
+++ b/tests/tt_eager/ops/test_fold_op.cpp
@@ -16,7 +16,7 @@ using namespace tt::tt_metal;
 using namespace constants;
 
 void run_fold(IDevice* device, const ttnn::Shape& shape) {
-    Tensor input_tensor = ttnn::random::random(shape).to(Layout::ROW_MAJOR).to(device);
+    Tensor input_tensor = ttnn::random::random(shape).to_layout(Layout::ROW_MAJOR).to_device(device);
     uint32_t stride_h = 2;
     uint32_t stride_w = 2;
     uint8_t queue_id = 0;

--- a/tests/tt_eager/ops/test_layernorm_op.cpp
+++ b/tests/tt_eager/ops/test_layernorm_op.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
         int device_id = 0;
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
         ttnn::Shape shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
-        Tensor a = ttnn::random::random(shape).to(Layout::TILE).to(device);
+        Tensor a = ttnn::random::random(shape).to_layout(Layout::TILE).to_device(device);
         Tensor c = ttnn::layer_norm(a, 1e-4f);
         Tensor d = c.cpu();
         Tensor host_a = a.cpu();  // Move tensor a to host to validate

--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -381,9 +381,9 @@ int main() {
         ttnn::Shape filter_tensor_shape({config.window_hw.first, config.window_hw.second});
 
         Tensor input_padded_tensor =
-            ttnn::random::random(input_tensor_shape, DataType::BFLOAT16).to(Layout::ROW_MAJOR).cpu();
+            ttnn::random::random(input_tensor_shape, DataType::BFLOAT16).to_layout(Layout::ROW_MAJOR).cpu();
         Tensor filter_tensor =
-            ttnn::random::random(filter_tensor_shape, DataType::BFLOAT16).to(Layout::ROW_MAJOR).cpu();
+            ttnn::random::random(filter_tensor_shape, DataType::BFLOAT16).to_layout(Layout::ROW_MAJOR).cpu();
         auto input_padded_tensor_buf = owned_buffer::get_as<bfloat16>(input_padded_tensor);
         auto filter_tensor_buf = owned_buffer::get_as<bfloat16>(filter_tensor);
 

--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -16,7 +16,7 @@ using namespace tt::tt_metal;
 using namespace constants;
 
 void run_softmax(IDevice* device, const ttnn::Shape& shape) {
-    Tensor input_tensor = ttnn::random::random(shape).to(Layout::TILE).to(device);
+    Tensor input_tensor = ttnn::random::random(shape).to_layout(Layout::TILE).to_device(device);
     Tensor device_output_tensor = ttnn::softmax_in_place(input_tensor);
     Tensor output_tensor = device_output_tensor.cpu();
 }

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -61,8 +61,8 @@ TEST_F(DispatchFixture, TestTensorOwnershipSanity) {
             host_tensor.get_storage());
         // Send tensor to device, read it back and copy it to empty tensor initialized by main thread
         Tensor reshaped_tensor = ttnn::experimental::view(host_tensor, ttnn::Shape{1, 1, 32, 128});
-        auto device_tensor = reshaped_tensor.to(Layout::TILE).to(device);
-        auto thread_local_tensor = device_tensor.cpu().to(Layout::ROW_MAJOR);
+        auto device_tensor = reshaped_tensor.to_layout(Layout::TILE).to_device(device);
+        auto thread_local_tensor = device_tensor.cpu().to_layout(Layout::ROW_MAJOR);
         readback_tensor.set_storage(thread_local_tensor.get_storage());
         readback_tensor.set_tensor_spec(thread_local_tensor.get_tensor_spec());
         readback_tensor.tensor_attributes->metadata_populated = true;
@@ -292,8 +292,8 @@ TEST_F(DispatchFixture, TestTensorAsyncDataMovement) {
                 host_tensor.get_storage());
 
             Tensor reshaped_tensor = ttnn::experimental::view(host_tensor, ttnn::Shape{1, 1, 32, tensor_stop / 32});
-            auto device_tensor = reshaped_tensor.to(Layout::TILE).to(device);
-            auto thread_local_tensor = device_tensor.cpu().to(Layout::ROW_MAJOR);
+            auto device_tensor = reshaped_tensor.to_layout(Layout::TILE).to_device(device);
+            auto thread_local_tensor = device_tensor.cpu().to_layout(Layout::ROW_MAJOR);
             log_info(LogTest, "Worker populating empty host readback_tensor");
             readback_tensor.set_storage(thread_local_tensor.get_storage());
             readback_tensor.set_tensor_spec(thread_local_tensor.get_tensor_spec());

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -22,14 +22,14 @@ bool test_tensor_copy_semantics(IDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     // host tensor to host tensor copy constructor
-    Tensor host_a = ttnn::random::random(single_tile_shape).to(Layout::TILE);
+    Tensor host_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     Tensor host_a_copy = host_a;
     auto host_a_data = owned_buffer::get_as<bfloat16>(host_a);
     auto host_a_copy_data = owned_buffer::get_as<bfloat16>(host_a_copy);
     pass &= host_a_data == host_a_copy_data;
 
     // dev tensor to dev tensor copy constructor
-    Tensor dev_a = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device);
+    Tensor dev_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device);
     Tensor dev_a_copy = dev_a;
     auto dev_a_on_host = dev_a.cpu();
     auto dev_a_copy_on_host = dev_a_copy.cpu();
@@ -40,15 +40,15 @@ bool test_tensor_copy_semantics(IDevice* device) {
     // host tensor updated with host tensor copy assignment
     Tensor host_c = ttnn::experimental::view(
                         ttnn::arange(/*start=*/0, /*stop=*/single_tile_shape.volume(), /*step=*/1), single_tile_shape)
-                        .to(Layout::TILE);
-    Tensor host_c_copy = ttnn::random::random(single_tile_shape).to(Layout::TILE);
+                        .to_layout(Layout::TILE);
+    Tensor host_c_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     host_c_copy = host_c;
     auto host_c_data = owned_buffer::get_as<bfloat16>(host_c);
     auto host_c_copy_data = owned_buffer::get_as<bfloat16>(host_c_copy);
     pass &= host_c_data == host_c_copy_data;
 
     // host tensor updated with dev tensor copy assignment
-    Tensor host_d_copy = ttnn::random::random(single_tile_shape).to(Layout::TILE);
+    Tensor host_d_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     host_d_copy = dev_a;
     pass &= (host_d_copy.storage_type() == StorageType::DEVICE);
     auto host_d_copy_on_host = host_d_copy.cpu();
@@ -57,7 +57,7 @@ bool test_tensor_copy_semantics(IDevice* device) {
 
     // dev tensor updated with host tensor copy assignment
     Tensor host_e = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE);
-    Tensor dev_e_copy = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device);
+    Tensor dev_e_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device);
     dev_e_copy = host_e;
     pass &= (dev_e_copy.storage_type() == StorageType::OWNED);
     auto host_e_data = owned_buffer::get_as<bfloat16>(host_e);
@@ -92,7 +92,8 @@ bool test_tensor_move_semantics(IDevice* device) {
     pass &= host_a_copy_data == bfloat_data;
 
     // dev tensor to dev tensor move constructor
-    Tensor dev_a = Tensor(OwnedStorage{bfloat_data}, single_tile_shape, DataType::BFLOAT16, Layout::TILE).to(device);
+    Tensor dev_a =
+        Tensor(OwnedStorage{bfloat_data}, single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
     auto og_buffer_a = dev_a.buffer();
     Tensor dev_a_copy = std::move(dev_a);
     pass &= dev_a_copy.buffer() == og_buffer_a;
@@ -122,7 +123,7 @@ bool test_tensor_move_semantics(IDevice* device) {
     auto bfloat_data_four = owned_buffer::get_as<bfloat16>(random_tensor_four);
     Tensor host_e = Tensor(random_tensor_four.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE);
     Tensor dev_e_copy =
-        Tensor(host_c_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to(device);
+        Tensor(host_c_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
     dev_e_copy = std::move(host_e);
     pass &= (dev_e_copy.storage_type() == StorageType::OWNED);
     auto dev_e_copy_data = owned_buffer::get_as<bfloat16>(dev_e_copy);
@@ -132,9 +133,9 @@ bool test_tensor_move_semantics(IDevice* device) {
     auto random_tensor_five = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
     auto bfloat_data_five = owned_buffer::get_as<bfloat16>(random_tensor_five);
     Tensor dev_b =
-        Tensor(random_tensor_four.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to(device);
+        Tensor(random_tensor_four.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
     Tensor dev_b_copy =
-        Tensor(dev_e_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to(device);
+        Tensor(dev_e_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
     dev_b_copy = std::move(dev_b);
     pass &= (dev_b_copy.storage_type() == StorageType::DEVICE);
     auto dev_b_copy_on_host = dev_b_copy.cpu();
@@ -154,32 +155,32 @@ bool test_tensor_deallocate_semantics(IDevice* device) {
         MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1};
 
     // dev tensor allocate, deallocate, reallocate same address DRAM
-    Tensor dev_a = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, dram_mem_config);
+    Tensor dev_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     uint32_t address_a = dev_a.buffer()->address();
     dev_a.deallocate();
-    Tensor dev_b = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, dram_mem_config);
+    Tensor dev_b = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     uint32_t address_b = dev_b.buffer()->address();
     pass &= address_a == address_b;
 
     // dev tensor allocate, allocate, deallocate, reallocate same address DRAM
-    Tensor dev_c = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, dram_mem_config);
+    Tensor dev_c = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     dev_b.deallocate();
-    Tensor dev_d = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, dram_mem_config);
+    Tensor dev_d = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     uint32_t address_d = dev_d.buffer()->address();
     pass &= address_b == address_d;
 
     // dev tensor allocate, deallocate, reallocate same address L1
-    Tensor dev_e = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, l1_mem_config);
+    Tensor dev_e = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     uint32_t address_e = dev_e.buffer()->address();
     dev_e.deallocate();
-    Tensor dev_f = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, l1_mem_config);
+    Tensor dev_f = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     uint32_t address_f = dev_f.buffer()->address();
     pass &= address_e == address_f;
 
     // dev tensor allocate, allocate, deallocate, reallocate same address DRAM
-    Tensor dev_g = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, l1_mem_config);
+    Tensor dev_g = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     dev_f.deallocate();
-    Tensor dev_h = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, l1_mem_config);
+    Tensor dev_h = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     uint32_t address_h = dev_h.buffer()->address();
     pass &= address_f == address_h;
 
@@ -196,7 +197,7 @@ bool test_tensor_deallocate_and_close_device(IDevice* device) {
         MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1};
 
     // dev tensor allocate, deallocate, reallocate same address DRAM
-    Tensor dev_a = ttnn::random::random(single_tile_shape).to(Layout::TILE).to(device, dram_mem_config);
+    Tensor dev_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     uint32_t address_a = dev_a.buffer()->address();
     pass &= tt_metal::CloseDevice(device);
     dev_a.deallocate();

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -21,8 +21,8 @@ bool test_single_tile_single_dram_bank_loopback(IDevice* device) {
     bool pass = true;
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
-    Tensor host_a = ttnn::random::random(single_tile_shape).to(Layout::TILE);
-    Tensor device_a = host_a.to(device);
+    Tensor host_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
+    Tensor device_a = host_a.to_device(device);
     Tensor loopbacked_a = device_a.cpu();
     auto host_a_data = owned_buffer::get_as<bfloat16>(host_a);
     auto loopbacked_a_data = owned_buffer::get_as<bfloat16>(loopbacked_a);
@@ -35,8 +35,8 @@ bool test_multi_tile_multi_dram_bank_loopback(IDevice* device) {
     bool pass = true;
     ttnn::Shape multi_tile_shape({1, 1, 4 * TILE_HEIGHT, 3 * TILE_WIDTH});
 
-    Tensor host_a = ttnn::random::random(multi_tile_shape).to(Layout::TILE);
-    Tensor device_a = host_a.to(device);
+    Tensor host_a = ttnn::random::random(multi_tile_shape).to_layout(Layout::TILE);
+    Tensor device_a = host_a.to_device(device);
     Tensor loopbacked_a = device_a.cpu();
     auto host_a_data = owned_buffer::get_as<bfloat16>(host_a);
     auto loopbacked_a_data = owned_buffer::get_as<bfloat16>(loopbacked_a);

--- a/tests/tt_eager/tensors/test_ranks.cpp
+++ b/tests/tt_eager/tensors/test_ranks.cpp
@@ -25,8 +25,8 @@ bool test_2d_tensor(IDevice* device) {
     ttnn::Shape shape({30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 2;
 
     return pass;
@@ -38,8 +38,8 @@ bool test_3d_tensor(IDevice* device) {
     ttnn::Shape shape({3, 30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 3;
 
     return pass;
@@ -51,8 +51,8 @@ bool test_4d_tensor(IDevice* device) {
     ttnn::Shape shape({2, 3, 30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 4;
 
     return pass;
@@ -64,8 +64,8 @@ bool test_5d_tensor(IDevice* device) {
     ttnn::Shape shape({2, 2, 3, 30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 5;
 
     return pass;
@@ -77,8 +77,8 @@ bool test_6d_tensor(IDevice* device) {
     ttnn::Shape shape({2, 2, 2, 3, 30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 6;
 
     return pass;
@@ -90,8 +90,8 @@ bool test_7d_tensor(IDevice* device) {
     ttnn::Shape shape({2, 2, 2, 2, 3, 30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 7;
 
     return pass;
@@ -103,8 +103,8 @@ bool test_8d_tensor(IDevice* device) {
     ttnn::Shape shape({2, 2, 2, 2, 2, 3, 30, 30});
     Tensor tensor = ttnn::random::random(shape);
     tensor = tensor.pad_to_tile(0.0f);
-    tensor = tensor.to(Layout::TILE);
-    tensor = tensor.to(device);
+    tensor = tensor.to_layout(Layout::TILE);
+    tensor = tensor.to_device(device);
     pass &= tensor.get_logical_shape().rank() == 8;
 
     return pass;

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -28,14 +28,14 @@
 07: a_cpu = np.array([[1,2,3,4],[5,6,7,8]], dtype=np.bfloat16)
 08:
 09: // define tensors on the device with CPU tensors
-10: a_dev = torch.from_numpy(a_cpu).to(device)
+10: a_dev = torch.from_numpy(a_cpu).to_device(device)
 11:
 12: c_dev = torch.sqrt(a_dev)
 13:
 14: print(c_dev[1][0])
 15:
 16: d_cpu = np.array([[11,12,13,14],[15,16,17,18]])
-17: d_dev = d_cpu.to(device)
+17: d_dev = d_cpu.to_device(device)
 18:
 19: e_dev = c_dev + d_dev
 20: print(e_dev)
@@ -105,7 +105,7 @@ void test_raw_host_memory_pointer() {
     /* Sanity Check End */
 
     /*  Run and Print Start   */
-    Tensor a_dev = a_cpu.to(device);
+    Tensor a_dev = a_cpu.to_device(device);
 
     Tensor c_dev = ttnn::sqrt(a_dev);
 

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -54,7 +54,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
 
     std::thread t0([&]() {
         for (int j = 0; j < 100; j++) {
-            Tensor t0_tensor = t0_host_tensor.to(device, mem_cfg, t0_io_cq);
+            Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
             EXPECT_TRUE(is_tensor_on_device(t0_tensor));
             EXPECT_THAT(t0_tensor.to_vector<float>(), Pointwise(FloatEq(), t0_host_data));
         }
@@ -62,7 +62,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
 
     std::thread t1([&]() {
         for (int j = 0; j < 100; j++) {
-            Tensor t1_tensor = t1_host_tensor.to(device, mem_cfg, t1_io_cq);
+            Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
             EXPECT_TRUE(is_tensor_on_device(t1_tensor));
             EXPECT_THAT(t1_tensor.to_vector<float>(), Pointwise(FloatEq(), t1_host_data));
         }

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -81,7 +81,7 @@ int main() {
         // processing
         tt::tt_metal::Layout::TILE);
     // Once created, the tensor "on host" and we must move it to the device to perform operations on it
-    x = x.to(device);
+    x = x.to_device(device);
 
     // Print the tensor to see what it looks like
     std::cout << "Tensot x:\n";

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -66,7 +66,7 @@ template <class T = float>
 template <class T = float>
 auto to_xtensor(const tt::tt_metal::Tensor& tensor, const MeshToXTensorVariant<T>& composer) {
     auto cpu_tensor = tensor.cpu();
-    cpu_tensor = cpu_tensor.to(Layout::ROW_MAJOR);
+    cpu_tensor = cpu_tensor.to_layout(Layout::ROW_MAJOR);
     auto cpu_tensors = ttnn::distributed::get_device_tensors(cpu_tensor);
     std::vector<xt::xarray<T>> res;
     res.reserve(cpu_tensors.size());

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
@@ -190,7 +190,7 @@ Tensor distribute_tensor(
     std::vector<Tensor> tensors = mapper.map(tensor);
     Tensor output = aggregate_as_tensor(tensors, mapper.config());
     if (mesh_device.has_value()) {
-        return output.to(&(mesh_device->get()));
+        return output.to_device(&(mesh_device->get()));
     }
     return output;
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -69,7 +69,7 @@ Tensor create_tensor_from_owned_buffer(
         if (output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B) {
             auto tensor =
                 Tensor(std::move(OwnedStorage{std::move(buf)}), output_shape, DataType::FLOAT32, Layout::ROW_MAJOR)
-                    .to(Layout::TILE);
+                    .to_layout(Layout::TILE);
             auto output_float_data = owned_buffer::get_as<float>(tensor).get();
             auto output_packed_data =
                 output_dtype == DataType::BFLOAT8_B
@@ -85,7 +85,7 @@ Tensor create_tensor_from_owned_buffer(
             "Unsupported output datatype");
     }
     auto rm_tensor = Tensor(std::move(OwnedStorage{std::move(buf)}), output_shape, output_dtype, Layout::ROW_MAJOR);
-    return rm_tensor.to(Layout::TILE);
+    return rm_tensor.to_layout(Layout::TILE);
 }
 
 template <typename T>

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -53,10 +53,10 @@ ttnn::Tensor to_device(
     const ttnn::Tensor& tensor, IDevice* device, const std::optional<MemoryConfig>& memory_config, uint8_t cq_id) {
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
     if (mem_config.is_sharded() and (device->arch() == tt::ARCH::BLACKHOLE)) {
-        auto interleaved_tensor = tensor.to(device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
+        auto interleaved_tensor = tensor.to_device(device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
         return ttnn::interleaved_to_sharded(ttnn::DefaultQueueId, interleaved_tensor, mem_config, std::nullopt);
     } else {
-        return tensor.to(device, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG), cq_id);
+        return tensor.to_device(device, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG), cq_id);
     }
 }
 
@@ -68,10 +68,10 @@ ttnn::Tensor to_device(
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
     // Currently no direct sharded write support in BLACKHOLE due to alignment issue
     if (mem_config.is_sharded() and (mesh_device->arch() == tt::ARCH::BLACKHOLE)) {
-        auto interleaved_tensor = tensor.to(mesh_device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
+        auto interleaved_tensor = tensor.to_device(mesh_device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
         return ttnn::interleaved_to_sharded(ttnn::DefaultQueueId, interleaved_tensor, mem_config, std::nullopt);
     } else {
-        return tensor.to(mesh_device, mem_config, cq_id);
+        return tensor.to_device(mesh_device, mem_config, cq_id);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
@@ -144,27 +144,27 @@ inline Tensor create_tensor_from_buffer(
         case DataType::UINT16: {
             auto data = cast<uint16_t, T>(input_buffer);
             return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to(input_layout);
+                .to_layout(input_layout);
         }
         case DataType::INT32: {
             auto data = cast<int32_t, T>(input_buffer);
             return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to(input_layout);
+                .to_layout(input_layout);
         }
         case DataType::UINT32: {
             auto data = cast<uint32_t, T>(input_buffer);
             return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to(input_layout);
+                .to_layout(input_layout);
         }
         case DataType::FLOAT32: {
             auto data = cast<float, T>(input_buffer);
             return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to(input_layout);
+                .to_layout(input_layout);
         }
         case DataType::BFLOAT16: {
             auto data = cast<::bfloat16, T>(input_buffer);
             return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to(input_layout);
+                .to_layout(input_layout);
         }
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
@@ -176,7 +176,7 @@ inline Tensor create_tensor_from_buffer(
                               padded_shape,
                               DataType::FLOAT32,
                               Layout::ROW_MAJOR)
-                              .to(Layout::TILE);
+                              .to_layout(Layout::TILE);
             auto output_float_data = tt::tt_metal::owned_buffer::get_as<float>(tensor).get();
             auto output_packed_data =
                 dtype == DataType::BFLOAT8_B
@@ -244,7 +244,7 @@ struct ToDtype {
             return input_tensor;
         }
 
-        auto row_major_input_tensor = input_tensor.to(ttnn::ROW_MAJOR_LAYOUT);
+        auto row_major_input_tensor = input_tensor.to_layout(ttnn::ROW_MAJOR_LAYOUT);
         auto intermediate_tensor = distributed::is_multi_device_tensor(row_major_input_tensor)
                                        ? transform(row_major_input_tensor, detail::convert_to_cpp_supported_dtype)
                                        : detail::convert_to_cpp_supported_dtype(row_major_input_tensor);

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -194,9 +194,9 @@ Tensor to_layout_impl(
     } else {
         TT_ASSERT(not dtype.has_value(), "dtype cannot be specified when converting layout on host!");
         if (not requires_padding_change(tensor, layout)) {
-            return device ? tensor.to(layout, device) : tensor.to(layout);
+            return device ? tensor.to_layout(layout, device) : tensor.to_layout(layout);
         } else if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-            tensor = device ? tensor.to(layout, device) : tensor.to(layout);
+            tensor = device ? tensor.to_layout(layout, device) : tensor.to_layout(layout);
             tensor = tensor.unpad_from_tile(tensor.get_logical_shape());
             return ttnn::reshape(tensor, ttnn::Shape{output_shape});
         } else if (layout == ttnn::TILE_LAYOUT) {
@@ -205,7 +205,7 @@ Tensor to_layout_impl(
                 padded_input_start.push_back(0);
             }
             tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), 0);
-            tensor = device ? tensor.to(layout, device) : tensor.to(layout);
+            tensor = device ? tensor.to_layout(layout, device) : tensor.to_layout(layout);
             return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
         } else {
             TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -99,9 +99,9 @@ static Tensor arange_impl(
     auto output =
         Tensor(
             OwnedStorage{owned_buffer}, ttnn::Shape{1, 1, 1, static_cast<uint32_t>(size)}, data_type, Layout::ROW_MAJOR)
-            .to(layout);
+            .to_layout(layout);
     if (device.has_value()) {
-        output = output.to(device->get_devices(), output_mem_config);
+        output = output.to_device(device->get_devices(), output_mem_config);
     }
     return output;
 }
@@ -125,7 +125,7 @@ static Tensor full_impl(
     if (!optional_output_tensor.has_value()) {
         auto output = Tensor(OwnedStorage{owned_buffer}, shape, data_type, layout);
         if (!devices.empty()) {
-            output = output.to(devices, output_mem_config);
+            output = output.to_device(devices, output_mem_config);
         }
         return output;
     } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/data_transfer/data_transfer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_transfer/data_transfer.cpp
@@ -27,7 +27,7 @@ Tensor DataTransferToDeviceOperation::invoke(
         return {input_tensor};
     }
 
-    return input_tensor.to(device, memory_config);
+    return input_tensor.to_device(device, memory_config);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -46,7 +46,8 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
             ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
             DataType::BFLOAT16,
             Layout::ROW_MAJOR)
-            .to(device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1});
+            .to_device(
+                device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1});
     auto pad_value_const_tensor_addr = pad_value_const_tensor.buffer()->address();
 
     Buffer* src0_buffer = a.buffer();
@@ -477,7 +478,8 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
             ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
             DataType::BFLOAT16,
             Layout::ROW_MAJOR)
-            .to(device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1});
+            .to_device(
+                device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1});
     auto pad_value_const_tensor_addr = pad_value_const_tensor.buffer()->address();
 
     // uint32_t ntiles_h = output_tensor_shape[0] * output_tensor_shape[1] * output_tensor_shape[2] / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -48,9 +48,9 @@ static Tensor manual_insertion(
                 logical_shape,
                 TensorLayout::fromPaddedShape(
                     DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-            .to(Layout::ROW_MAJOR);
+            .to_layout(Layout::ROW_MAJOR);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -75,10 +75,10 @@ std::vector<Tensor> split_dim_n_chunks_rm(
             output_chunk = output_chunk.pad_to_tile(0.0);
         }
 
-        output_chunk = output_chunk.to(layout);
+        output_chunk = output_chunk.to_layout(layout);
 
         if (device) {
-            output_chunk = output_chunk.to(*device);
+            output_chunk = output_chunk.to_device(*device);
         }
 
         output_tensors.push_back(output_chunk);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1886,8 +1886,8 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
             if (updated_grad.storage_type() != StorageType::DEVICE &&
                 updated_grad.storage_type() != StorageType::MULTI_DEVICE) {
                 Tensor pad_updated_grad = updated_grad.pad_to_tile(1.0f);
-                pad_updated_grad = pad_updated_grad.to(Layout::TILE);
-                updated_grad = pad_updated_grad.to(input.device());
+                pad_updated_grad = pad_updated_grad.to_layout(Layout::TILE);
+                updated_grad = pad_updated_grad.to_device(input.device());
             }
         } else if (dim == 2 || dim == -2) {
             ttnn::SmallVector<int64_t> after_permute_dims = {0, 2, 1, 3};

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -129,7 +129,7 @@ Tensor AutoFormat::format_input_tensor(
     // Host side conversions
     if (pad_input) {
         if (formatted_input.get_layout() != Layout::ROW_MAJOR) {
-            formatted_input = formatted_input.to(Layout::ROW_MAJOR);
+            formatted_input = formatted_input.to_layout(Layout::ROW_MAJOR);
             convert_layout = formatted_input.get_layout() != target_layout;
         }
         formatted_input = ttnn::pad(
@@ -140,7 +140,7 @@ Tensor AutoFormat::format_input_tensor(
     }
 
     if (convert_layout) {
-        formatted_input = formatted_input.to(target_layout);
+        formatted_input = formatted_input.to_layout(target_layout);
     }
 
     return AutoFormat::move_tensor_to_device(formatted_input, device, mem_config);
@@ -225,7 +225,7 @@ Tensor AutoFormat::format_output_tensor(
     if (unpad_output) {
         // Requires RM for unpad
         if (formatted_output.get_layout() != Layout::ROW_MAJOR) {
-            formatted_output = formatted_output.to(Layout::ROW_MAJOR);
+            formatted_output = formatted_output.to_layout(Layout::ROW_MAJOR);
             convert_layout = formatted_output.get_layout() != target_layout;
         }
         auto begins = std::array<uint32_t, 4>({0, 0, 0, 0});
@@ -238,10 +238,10 @@ Tensor AutoFormat::format_output_tensor(
         // Default to RM layout if we can't match the formatted_input layout
         if (target_layout == Layout::TILE && !AutoFormat::legal_tile_shape(formatted_output.get_padded_shape())) {
             if (formatted_output.get_layout() != Layout::ROW_MAJOR) {
-                formatted_output = formatted_output.to(Layout::ROW_MAJOR);
+                formatted_output = formatted_output.to_layout(Layout::ROW_MAJOR);
             }
         } else {
-            formatted_output = formatted_output.to(target_layout);
+            formatted_output = formatted_output.to_layout(target_layout);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -68,7 +68,7 @@ Tensor ArgmaxOperation::invoke(
                             output_memory_config);
                         max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
                     }
-                    tindex = tindex.to(input_a.device());
+                    tindex = tindex.to_device(input_a.device());
                     max_val.deallocate();
                     Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
                     Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
@@ -119,7 +119,7 @@ Tensor ArgmaxOperation::invoke(
                             input_a.device(),
                             output_memory_config);
                     }
-                    tindex = tindex.to(input_a.device());
+                    tindex = tindex.to_device(input_a.device());
                     Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
                     cmp_results.deallocate();
                     Tensor midx = full_like(max_indices, size);

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -66,9 +66,9 @@ static Tensor index_trilu(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -108,9 +108,9 @@ static Tensor index_width(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -150,9 +150,9 @@ static Tensor index_height(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -191,9 +191,9 @@ static Tensor index_all(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -227,9 +227,9 @@ static Tensor mask_padded_input(
             }  // dim H
         }  // dim C
     }  // dim N
-    auto output = Tensor(OwnedStorage{owned_buffer}, padded_shape, data_type, Layout::ROW_MAJOR).to(layout);
+    auto output = Tensor(OwnedStorage{owned_buffer}, padded_shape, data_type, Layout::ROW_MAJOR).to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -270,9 +270,9 @@ static Tensor fill_first_val_into_tensor(
                               MemoryConfig{},
                               input_tensor.get_logical_shape(),
                               input_tensor.get_padded_shape())))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -329,9 +329,9 @@ static Tensor prod_result_computation_GS(
                               MemoryConfig{},
                               input_tensor.get_logical_shape(),
                               input_tensor.get_padded_shape())))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -392,9 +392,9 @@ static Tensor prod_result_computation_WH_B0(
                               MemoryConfig{},
                               input_tensor.get_logical_shape(),
                               input_tensor.get_padded_shape())))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -434,9 +434,9 @@ static Tensor index_channel(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -475,9 +475,9 @@ static Tensor index_batch(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -514,9 +514,9 @@ static Tensor manual_insertion(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
                               data_type, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape)))
-                      .to(layout);
+                      .to_layout(layout);
     if (device != nullptr) {
-        output = output.to(device, output_mem_config);
+        output = output.to_device(device, output_mem_config);
     }
     return output;
 }
@@ -578,7 +578,7 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
         }
     }
 
-    return Tensor(OwnedStorage{owned_buffer}, spec).to(layout);
+    return Tensor(OwnedStorage{owned_buffer}, spec).to_layout(layout);
 }
 
 static Tensor random(

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -241,7 +241,7 @@ operation::ProgramWithCallbacks upsample_multi_core(
                                                : shard_spec.orientation;
     ShardSpec config_shard_spec(input.shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
     MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
-    auto config_tensor_device = config_tensor.to(device, memory_config);
+    auto config_tensor_device = config_tensor.to_device(device, memory_config);
 
     tt::DataFormat config_df = tt::DataFormat::RawUInt16;
     auto config_buffer = config_tensor_device.device_buffer();

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -689,7 +689,7 @@ Tensor move_config_tensor_to_device(
                          : ShardOrientation::ROW_MAJOR;
     ShardSpec shard_spec(p_config.grid, shard_shape, config_shard_orientation);
     MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, shard_spec};
-    return config_tensor.to(device, memory_config);
+    return config_tensor.to_device(device, memory_config);
 }
 
 std::string SlidingWindowConfig::to_string() const {

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -353,7 +353,7 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
                 TensorLayout::fromPaddedShape(
                     data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
         if (device != nullptr) {
-            tensor = tensor.to(device, memory_config);
+            tensor = tensor.to_device(device, memory_config);
         } else if (has_memory_config) {
             tt::log_warning("Memory config is ignored when loading the tensor because device is not provided");
         }
@@ -377,7 +377,7 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
                 TensorLayout::fromPaddedShape(
                     data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
         if (device != nullptr) {
-            tensor = tensor.to(device);
+            tensor = tensor.to_device(device);
         }
         return tensor;
     }

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -174,24 +174,24 @@ public:
     template <typename T>
     std::vector<T> to_vector() const;
 
-    Tensor to(
+    Tensor to_device(
         IDevice* target_device,
         const MemoryConfig& mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
         uint8_t cq_id = ttnn::DefaultQueueId) const;
 
-    Tensor to(
+    Tensor to_device(
         distributed::MeshDevice* mesh_device,
         const MemoryConfig& mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
         uint8_t cq_id = ttnn::DefaultQueueId) const;
 
-    Tensor to(
+    Tensor to_device(
         const std::vector<IDevice*>& workers,
         const MemoryConfig& mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
         uint8_t cq_id = ttnn::DefaultQueueId) const;
 
-    Tensor to(Layout target_layout, IDevice* worker = nullptr) const;
+    Tensor to_layout(Layout target_layout, IDevice* worker = nullptr) const;
 
-    Tensor to(Layout target_layout, distributed::MeshDevice* mesh_device) const;
+    Tensor to_layout(Layout target_layout, distributed::MeshDevice* mesh_device) const;
 
     Tensor pad(const ttnn::Shape& output_padded_shape, const ttnn::Shape& input_tensor_start, float pad_value) const;
 

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -27,7 +27,8 @@
 
 namespace tt::tt_metal::tensor_ops {
 
-Tensor tensor_to(const Tensor& input_tensor, IDevice* target_device, const MemoryConfig& mem_config, uint8_t cq_id) {
+Tensor tensor_to_device(
+    const Tensor& input_tensor, IDevice* target_device, const MemoryConfig& mem_config, uint8_t cq_id) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_device, mem_config);
     // Tensor can be using borrowed storage. If so, when running in async mode, copy this tensor to owned storage.
@@ -63,7 +64,7 @@ Tensor tensor_to(const Tensor& input_tensor, IDevice* target_device, const Memor
     return device_tensor;
 }
 
-Tensor tensor_to(
+Tensor tensor_to_device(
     const Tensor& input_tensor, const std::vector<IDevice*>& workers, const MemoryConfig& mem_config, uint8_t cq_id) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to", input_tensor, workers, mem_config);
@@ -141,7 +142,7 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, uint8_t cq_id) {
     return host_tensor;
 }
 
-Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, IDevice* worker) {
+Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_layout, worker);
     // Only push layout conversion to worker if running in async mode
@@ -173,7 +174,7 @@ Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, IDevice* work
     return output;
 }
 
-Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
+Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_layout, mesh_device);
     if (mesh_device) {

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -20,14 +20,15 @@ class IDevice;
 
 namespace tt::tt_metal::tensor_ops {
 
-Tensor tensor_to(const Tensor& input_tensor, IDevice* target_device, const MemoryConfig& mem_config, uint8_t cq_id);
+Tensor tensor_to_device(
+    const Tensor& input_tensor, IDevice* target_device, const MemoryConfig& mem_config, uint8_t cq_id);
 
-Tensor tensor_to(
+Tensor tensor_to_device(
     const Tensor& input_tensor, const std::vector<IDevice*>& workers, const MemoryConfig& mem_config, uint8_t cq_id);
 
-Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
+Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
 
-Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
+Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
 
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, uint8_t cq_id);
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The overloads `Tensor::to` are confusing, especially the one that accepts both layout and device:

https://github.com/tenstorrent/tt-metal/blob/6aaf8384daff2472a8ef077fb39e83b054fbca43/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp#L196-L201

### What's changed
Rename  overloads `Tensor::to` to `Tensor::to_layout` / `Tensor::to_device`.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13161454707) - same failures as on [main](https://github.com/tenstorrent/tt-metal/actions/runs/13158578337).
