### PR TITLE
#0: Fix T3000 unit tests and suppress chatty logs

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -23,9 +23,9 @@ run_t3000_ttmetal_tests() {
   ./build/test/tt_metal/unit_tests_debug_tools_${ARCH_NAME} --gtest_filter="DPrintFixture.*:WatcherFixture.*" ; fail+=$?
 
   # Programming examples
-  ./build/test/tt_metal/programming_examples/distributed/distributed_program_dispatch
-  ./build/test/tt_metal/programming_examples/distributed/distributed_buffer_rw
-  ./build/test/tt_metal/programming_examples/distributed/distributed_eltwise_add
+  ./build/programming_examples/distributed/distributed_program_dispatch
+  ./build/programming_examples/distributed/distributed_buffer_rw
+  ./build/programming_examples/distributed/distributed_eltwise_add
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -1013,9 +1013,9 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferForL1) 
     const std::vector<ShardedSubBufferStressTestConfig>& configs =
         local_test_functions::generate_sharded_sub_buffer_test_configs(max_buffer_size);
     for (IDevice* device : devices_) {
-        tt::log_info("Running on Device {}", device->id());
+        tt::log_debug("Running on Device {}", device->id());
         for (const ShardedSubBufferStressTestConfig& config : configs) {
-            tt::log_info(
+            tt::log_debug(
                 tt::LogTest,
                 "Device: {} buffer_size: {} page_size: {} region_offset: {} region_size: {} shard_shape: [{}, {}] "
                 "page_shape: [{}, {}] tensor2d_shape: [{}, {}] layout: {} orientation: {} cores: {}",


### PR DESCRIPTION
### Ticket
None

### Problem description
- T3000 unit test suite erroring out because of incorrect binary path for programming examples
- Hard to read CI log because of chatty `log_info` message

### What's changed
- Corrected binary path
- `log_info` -> `log_debug`

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13125172071
- [x] T3000 unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/13125162183
