### PR TITLE
#0: Fix NCRISC delay

### DIFF
--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -35,7 +35,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
     DeviceZoneScopedMainChildN("NCRISC-KERNEL");
 #ifdef KERNEL_RUN_TIME
     uint64_t end_time = c_tensix_core::read_wall_clock() + KERNEL_RUN_TIME;
-    while (c_tensix_core::read_wall_clock() < KERNEL_RUN_TIME);
+    while (c_tensix_core::read_wall_clock() < end_time);
 #endif
 #else
     extern uint32_t __kernel_init_local_l1_base[];


### PR DESCRIPTION
### What's changed
The current KERNEL_RUN_TIME code was ignoring end_time and instead delaying an arbitrary amount. Instead match the code for other kernels and wait for the correct amount of time.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
