### PR TITLE
Add support for parallelization along the width for untilize with unpadding 

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize_with_unpadding.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize_with_unpadding.py
@@ -21,13 +21,44 @@ def create_grid(x, y):
 
 
 params = [
-    pytest.param([[5, 5, 32, 32]], untilize_with_unpadding_args)
-    for untilize_with_unpadding_args in generation_funcs.gen_untilize_with_unpadding_args([[5, 5, 32, 32]])
+    pytest.param(
+        [[5, 5, 32, 32]],
+        {
+            "dtype": [ttnn.bfloat16],
+            "layout": [ttnn.TILE_LAYOUT],
+            "input_mem_config": [ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)],
+            "output_mem_config": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            "output_tensor_end": [4, 4, 31, 28],
+        },
+    )
 ]
+
 params += [
-    pytest.param([[5, 5, 64, 96]], untilize_with_unpadding_args)
-    for untilize_with_unpadding_args in generation_funcs.gen_untilize_with_unpadding_args([[5, 5, 64, 96]])
+    pytest.param(
+        [[5, 5, 64, 96]],
+        {
+            "dtype": [ttnn.bfloat16],
+            "layout": [ttnn.TILE_LAYOUT],
+            "input_mem_config": [ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)],
+            "output_mem_config": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            "output_tensor_end": [4, 4, 60, 90],
+        },
+    )
 ]
+
+params += [
+    pytest.param(
+        [[5, 5, 64, 96]],
+        {
+            "dtype": [ttnn.bfloat16],
+            "layout": [ttnn.TILE_LAYOUT],
+            "input_mem_config": [ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)],
+            "output_mem_config": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            "output_tensor_end": [4, 4, 60, 90],
+        },
+    )
+]
+
 
 params += [
     pytest.param(
@@ -35,8 +66,8 @@ params += [
         {
             "dtype": [ttnn.bfloat16],
             "layout": [ttnn.TILE_LAYOUT],
-            "input_mem_config": [ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)],
-            "output_mem_config": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            "input_mem_config": [ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)],
+            "output_mem_config": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
             "output_tensor_end": [0, 0, 119, 7299],
         },
     )

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -283,3 +283,45 @@ def test_to_layout_page_error(shape, device):
     torch_output = torch_tensor
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("shape", [[64, 7680]])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
+def test_untilize_w1(shape, input_layout, output_layout, device):
+    torch.manual_seed(0)
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
+    output_tensor = ttnn.untilize_with_unpadding(input_tensor, [36, 7667])
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(input_a[:37, :7668], output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[2, 2, 64, 6144]])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
+def test_untilize_w2(shape, input_layout, output_layout, device):
+    torch.manual_seed(0)
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
+    output_tensor = ttnn.untilize_with_unpadding(input_tensor, [1, 1, 38, 6140])
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(input_a[:, :, :39, :6141], output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[1, 1, 32, 1536]])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
+def test_untilize_w3(shape, input_layout, output_layout, device):
+    torch.manual_seed(0)
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
+    output_tensor = ttnn.untilize_with_unpadding(input_tensor, [0, 0, 31, 1535])
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(input_a[:, :, :32, :1536], output_tensor)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -299,7 +299,7 @@ def test_untilize_w1(shape, input_layout, output_layout, device):
     assert_with_pcc(input_a[:37, :7668], output_tensor)
 
 
-@pytest.mark.parametrize("shape", [[2, 2, 64, 6144]])
+@pytest.mark.parametrize("shape", [[2, 32, 6144]])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
 def test_untilize_w2(shape, input_layout, output_layout, device):
@@ -307,10 +307,10 @@ def test_untilize_w2(shape, input_layout, output_layout, device):
     input_a = torch.randn(shape, dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
-    output_tensor = ttnn.untilize_with_unpadding(input_tensor, [1, 1, 38, 6140])
+    output_tensor = ttnn.untilize_with_unpadding(input_tensor, [1, 30, 6140])
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(input_a[:, :, :39, :6141], output_tensor)
+    assert_with_pcc(input_a[:, :31, :6141], output_tensor)
 
 
 @pytest.mark.parametrize("shape", [[1, 1, 32, 1536]])
@@ -325,3 +325,17 @@ def test_untilize_w3(shape, input_layout, output_layout, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(input_a[:, :, :32, :1536], output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[1, 1, 32, 10912]])
+@pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
+def test_untilize_w4(shape, input_layout, output_layout, device):
+    torch.manual_seed(0)
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=input_layout, dtype=ttnn.bfloat16)
+    output_tensor = ttnn.untilize_with_unpadding(input_tensor, [0, 0, 0, 10911])
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(input_a[:, :, :1, :10912], output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp
@@ -12,76 +12,15 @@ void MAIN {
     uint32_t third_dim = get_compile_time_arg_val(2);
     untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 
-    // UNPACK(( DPRINT << "Block count=" << uint32_t(per_core_block_cnt) << " tile count=" << per_core_block_tile_cnt <<
-    // ENDL() ));
-
-    // UNPACK (( DPRINT <<  "per_core_block_cnt: " << per_core_block_cnt << ENDL()));
-    // UNPACK (( DPRINT <<  "per_core_block_tile_cnt: " << per_core_block_tile_cnt << ENDL()));
-    // UNPACK (( DPRINT <<  "third_dim: " << third_dim << ENDL()));
-
+    uint32_t onetile = 1;
     for (uint32_t b = 0; b < per_core_block_cnt * per_core_block_tile_cnt * third_dim; ++b) {
-        cb_wait_front(tt::CBIndex::c_0, 1);
-        cb_reserve_back(tt::CBIndex::c_16, 1);
+        cb_wait_front(tt::CBIndex::c_0, onetile);
+        cb_reserve_back(tt::CBIndex::c_16, onetile);
 
-        // for (int32_t r = 0; r < 32; ++r) {
-        // SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        //     UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_0, 0, sr, false, false) << ENDL() ));
-        // }
+        untilize_block(tt::CBIndex::c_0, onetile, tt::CBIndex::c_16);
 
-        untilize_block(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
-
-        // UNPACK (( DPRINT <<  "AFTER UNTILIZE BLOCK " << ENDL()));
-        // for (int32_t r = 0; r < 32; ++r) {
-        // SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        //     UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_16, 0, sr) << ENDL() ));
-        // }
-
-        cb_push_back(tt::CBIndex::c_16, 1);
-        cb_pop_front(tt::CBIndex::c_0, 1);
+        cb_push_back(tt::CBIndex::c_16, onetile);
+        cb_pop_front(tt::CBIndex::c_0, onetile);
     }
 }
 }  // namespace NAMESPACE
-
-/*
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
-// SPDX-License-Identifier: Apache-2.0
-
-#include <cstdint>
-
-#include "compute_kernel_api/untilize.h"
-#include "compute_kernel_api/pack_untilize.h"
-
-namespace NAMESPACE {
-void MAIN {
-    constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
-    constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
-    uint32_t third_dim = get_compile_time_arg_val(2);
-
-    pack_untilize_init<1>(tt::CBIndex::c_0, tt::CBIndex::c_16);
-
-    for (uint32_t b = 0; b < per_core_block_cnt * per_core_block_tile_cnt * third_dim ; ++b) {
-        cb_wait_front(tt::CBIndex::c_0, 1);
-        cb_reserve_back(tt::CBIndex::c_16, 1);
-
-        //for (int32_t r = 0; r < 32; ++r) {
-        //SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        //    UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_0, 0, sr, false, false) << ENDL() ));
-        //}
-
-        pack_untilize_block<1>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
-
-        //for (int32_t r = 0; r < 32; ++r) {
-        //SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        //    UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_16, 0, sr) << ENDL() ));
-        //}
-
-        cb_push_back(tt::CBIndex::c_16, 1);
-        cb_pop_front(tt::CBIndex::c_0, 1);
-    }
-
-    pack_untilize_uninit(tt::CBIndex::c_16);
-}
-}  // namespace NAMESPACE
-
-*/

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/untilize.h"
+#include "debug/dprint.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    uint32_t third_dim = get_compile_time_arg_val(2);
+    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    // UNPACK(( DPRINT << "Block count=" << uint32_t(per_core_block_cnt) << " tile count=" << per_core_block_tile_cnt <<
+    // ENDL() ));
+
+    // UNPACK (( DPRINT <<  "per_core_block_cnt: " << per_core_block_cnt << ENDL()));
+    // UNPACK (( DPRINT <<  "per_core_block_tile_cnt: " << per_core_block_tile_cnt << ENDL()));
+    // UNPACK (( DPRINT <<  "third_dim: " << third_dim << ENDL()));
+
+    for (uint32_t b = 0; b < per_core_block_cnt * per_core_block_tile_cnt * third_dim; ++b) {
+        cb_wait_front(tt::CBIndex::c_0, 1);
+        cb_reserve_back(tt::CBIndex::c_16, 1);
+
+        // for (int32_t r = 0; r < 32; ++r) {
+        // SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
+        //     UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_0, 0, sr, false, false) << ENDL() ));
+        // }
+
+        untilize_block(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
+
+        // UNPACK (( DPRINT <<  "AFTER UNTILIZE BLOCK " << ENDL()));
+        // for (int32_t r = 0; r < 32; ++r) {
+        // SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
+        //     UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_16, 0, sr) << ENDL() ));
+        // }
+
+        cb_push_back(tt::CBIndex::c_16, 1);
+        cb_pop_front(tt::CBIndex::c_0, 1);
+    }
+}
+}  // namespace NAMESPACE
+
+/*
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/untilize.h"
+#include "compute_kernel_api/pack_untilize.h"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    uint32_t third_dim = get_compile_time_arg_val(2);
+
+    pack_untilize_init<1>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    for (uint32_t b = 0; b < per_core_block_cnt * per_core_block_tile_cnt * third_dim ; ++b) {
+        cb_wait_front(tt::CBIndex::c_0, 1);
+        cb_reserve_back(tt::CBIndex::c_16, 1);
+
+        //for (int32_t r = 0; r < 32; ++r) {
+        //SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
+        //    UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_0, 0, sr, false, false) << ENDL() ));
+        //}
+
+        pack_untilize_block<1>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
+
+        //for (int32_t r = 0; r < 32; ++r) {
+        //SliceRange sr = SliceRange{.h0 = (uint8_t)r, .h1 = (uint8_t)(r+1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
+        //    UNPACK(( DPRINT  << TSLICE(tt::CBIndex::c_16, 0, sr) << ENDL() ));
+        //}
+
+        cb_push_back(tt::CBIndex::c_16, 1);
+        cb_pop_front(tt::CBIndex::c_0, 1);
+    }
+
+    pack_untilize_uninit(tt::CBIndex::c_16);
+}
+}  // namespace NAMESPACE
+
+*/

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
@@ -52,20 +52,14 @@ void kernel_main() {
                 write_size = width_size - padded_size;
             }
 
-            // Read from DRAM to tmp buffer
-
             noc_async_write(l1_read_addr, dst_noc_addr + start_id + mul * size_per_row_per_block, write_size);
 
-            // Block before copying data from tmp to cb buffer
             noc_async_write_barrier();
 
-            // pushing one tile at a time because the current LLK tilize implementation doesn't support tilizing more
-            // than one tile per column at the same time this needs to be fixed
             if (k > 0 && (k % tile_width == 0)) {
                 cb_pop_front(cb_id_out0, onetile * has_rows);
                 cb_wait_front(cb_id_out0, onetile * has_rows);
             }
-            // increment by the unpadded size only
             l1_read_addr += width_size;
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_out0 = 16;
+
+    const uint32_t total_num_rows = get_compile_time_arg_val(3);
+    const uint32_t ncores = get_compile_time_arg_val(4);
+    const uint32_t third_dim = get_compile_time_arg_val(5);
+    const uint32_t tile_width = get_compile_time_arg_val(6);
+    /*
+    DPRINT << "total_num_rows: " << total_num_rows << ENDL();
+    DPRINT << "ncores: " << ncores << ENDL();
+    DPRINT << "third dim: " << third_dim <<ENDL();
+    DPRINT << "tile_width: " << tile_width <<ENDL();
+    */
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t unpadded_X_size = get_arg_val<uint32_t>(1);
+    const uint32_t core_number = get_arg_val<uint32_t>(2);
+
+    // DPRINT << "dst_addr: " << dst_addr <<ENDL();
+    // DPRINT << "unpadded_X_size: " << unpadded_X_size << ENDL();
+    // DPRINT << "core_number: " << core_number <<ENDL();
+
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(0) == 1;
+
+#define stick_size_is_pow2 get_compile_time_arg_val(1) == 1
+#if (stick_size_is_pow2)
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(2);
+    const InterleavedPow2AddrGen<dst0_is_dram> s = {
+        .bank_base_address = dst_addr, .log_base_2_of_page_size = log_base_2_of_page_size};
+#else
+    const InterleavedAddrGen<dst0_is_dram> s = {.bank_base_address = dst_addr, .page_size = unpadded_X_size};
+#endif
+
+    auto write_block = [&](uint32_t num_rows,
+                           uint32_t mul,
+                           uint32_t size_per_row_per_block,
+                           uint32_t start_id,
+                           uint32_t width_size,
+                           uint32_t size_2d) {
+        uint32_t onetile = 1;
+        bool has_rows = (num_rows) > 0;
+
+        cb_wait_front(cb_id_out0, onetile * has_rows);
+        uint32_t l1_read_addr = get_write_ptr(cb_id_out0);
+        uint32_t original_addr = get_write_ptr(cb_id_out0);
+
+        // DPRINT << "l1_read_addr: " << l1_read_addr << ENDL();
+        // DPRINT << "has_rows: " << uint32_t(has_rows) <<ENDL();
+
+        for (uint32_t k = 0; k < num_rows; k++) {
+            // DPRINT << "k: " << k << ENDL();
+            uint64_t dst_noc_addr = get_noc_addr(size_2d + k, s);
+            // DPRINT << "dst_noc_addr: " << dst_noc_addr <<ENDL();
+
+            uint32_t total_size = mul * size_per_row_per_block + start_id + width_size;
+            uint32_t padded_size = total_size - unpadded_X_size;
+            uint32_t write_size = width_size;
+            // DPRINT << "total_size: " << total_size << ENDL();
+            // DPRINT << "padded_size: " << padded_size << ENDL();
+            // DPRINT << "write_size: " << write_size <<ENDL();
+            if (mul == ncores - 1 && padded_size > 0) {
+                write_size = width_size - padded_size;
+                // DPRINT << "write_size: " << write_size <<ENDL();
+            }
+
+            // Read from DRAM to tmp buffer
+
+            // DPRINT << "WRITING AT: " <<  dst_noc_addr + start_id + mul * size_per_row_per_block << ENDL();
+            // DPRINT << "WRITING : " << write_size << " BYTES " << ENDL();
+            noc_async_write(l1_read_addr, dst_noc_addr + start_id + mul * size_per_row_per_block, write_size);
+
+            // Block before copying data from tmp to cb buffer
+            noc_async_write_barrier();
+
+            // pushing one tile at a time because the current LLK tilize implementation doesn't support tilizing more
+            // than one tile per column at the same time this needs to be fixed
+            if (k > 0 && (k % tile_width == 0)) {
+                // DPRINT << "K >0 && K %32 ==0" <<ENDL();
+                // auto* ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(original_addr);
+                // for (uint32_t i0 = 0; i0 < 1024; i0 = i0+1) {
+                //     DPRINT << "IN THE WRITER VALUE AT i0 = " << (uint32_t)i0 <<  " is: " << BF16((uint16_t)ptr0[i0])
+                //     << ENDL();
+                // }
+                cb_pop_front(cb_id_out0, onetile * has_rows);
+                cb_wait_front(cb_id_out0, onetile * has_rows);
+                // original_addr = l1_read_addr + width_size;
+            }
+            // increment by the unpadded size only
+            l1_read_addr += width_size;
+        }
+
+        // DPRINT << "before last pop" <<ENDL();
+        // auto* ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(original_addr);
+        // for (uint32_t i0 = 0; i0 < 1024; i0 = i0+1) {
+        //     DPRINT << "IN THE WRITER VALUE AT i0 = " << (uint32_t)i0 <<  " is: " << BF16((uint16_t)ptr0[i0])
+        //     << ENDL();
+        // }
+        cb_pop_front(cb_id_out0, onetile * has_rows);
+    };
+
+    const uint32_t size_per_row_per_block = get_arg_val<uint32_t>(3);
+    const uint32_t blocks_per_core = get_arg_val<uint32_t>(4);
+    const uint32_t width_size = get_arg_val<uint32_t>(5);
+    // DPRINT << "size_per_row_per_block: " << size_per_row_per_block << ENDL();
+    // DPRINT << "blocks_per_core: " << blocks_per_core << ENDL();
+    // DPRINT << "width_size: " << width_size <<ENDL();
+
+    uint32_t size_2d = 0;
+    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        uint32_t start_id = 0;
+        // DPRINT << "FOR DIM = :" << dim3 <<ENDL();
+        for (uint32_t b = 0; b < blocks_per_core; b++) {
+            // DPRINT << "for block b =" << b << ENDL();
+            write_block(total_num_rows, core_number, size_per_row_per_block, start_id, width_size, size_2d);
+            start_id += width_size;
+            // DPRINT << "start id: " << start_id <<ENDL();
+        }
+        size_2d += total_num_rows;
+        // DPRINT << "size_2d: " << size_2d <<ENDL();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
@@ -13,19 +13,10 @@ void kernel_main() {
     const uint32_t ncores = get_compile_time_arg_val(4);
     const uint32_t third_dim = get_compile_time_arg_val(5);
     const uint32_t tile_width = get_compile_time_arg_val(6);
-    /*
-    DPRINT << "total_num_rows: " << total_num_rows << ENDL();
-    DPRINT << "ncores: " << ncores << ENDL();
-    DPRINT << "third dim: " << third_dim <<ENDL();
-    DPRINT << "tile_width: " << tile_width <<ENDL();
-    */
+
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t unpadded_X_size = get_arg_val<uint32_t>(1);
     const uint32_t core_number = get_arg_val<uint32_t>(2);
-
-    // DPRINT << "dst_addr: " << dst_addr <<ENDL();
-    // DPRINT << "unpadded_X_size: " << unpadded_X_size << ENDL();
-    // DPRINT << "core_number: " << core_number <<ENDL();
 
     constexpr bool dst0_is_dram = get_compile_time_arg_val(0) == 1;
 
@@ -49,31 +40,20 @@ void kernel_main() {
 
         cb_wait_front(cb_id_out0, onetile * has_rows);
         uint32_t l1_read_addr = get_write_ptr(cb_id_out0);
-        uint32_t original_addr = get_write_ptr(cb_id_out0);
-
-        // DPRINT << "l1_read_addr: " << l1_read_addr << ENDL();
-        // DPRINT << "has_rows: " << uint32_t(has_rows) <<ENDL();
 
         for (uint32_t k = 0; k < num_rows; k++) {
-            // DPRINT << "k: " << k << ENDL();
             uint64_t dst_noc_addr = get_noc_addr(size_2d + k, s);
-            // DPRINT << "dst_noc_addr: " << dst_noc_addr <<ENDL();
 
             uint32_t total_size = mul * size_per_row_per_block + start_id + width_size;
             uint32_t padded_size = total_size - unpadded_X_size;
             uint32_t write_size = width_size;
-            // DPRINT << "total_size: " << total_size << ENDL();
-            // DPRINT << "padded_size: " << padded_size << ENDL();
-            // DPRINT << "write_size: " << write_size <<ENDL();
+
             if (mul == ncores - 1 && padded_size > 0) {
                 write_size = width_size - padded_size;
-                // DPRINT << "write_size: " << write_size <<ENDL();
             }
 
             // Read from DRAM to tmp buffer
 
-            // DPRINT << "WRITING AT: " <<  dst_noc_addr + start_id + mul * size_per_row_per_block << ENDL();
-            // DPRINT << "WRITING : " << write_size << " BYTES " << ENDL();
             noc_async_write(l1_read_addr, dst_noc_addr + start_id + mul * size_per_row_per_block, write_size);
 
             // Block before copying data from tmp to cb buffer
@@ -82,47 +62,27 @@ void kernel_main() {
             // pushing one tile at a time because the current LLK tilize implementation doesn't support tilizing more
             // than one tile per column at the same time this needs to be fixed
             if (k > 0 && (k % tile_width == 0)) {
-                // DPRINT << "K >0 && K %32 ==0" <<ENDL();
-                // auto* ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(original_addr);
-                // for (uint32_t i0 = 0; i0 < 1024; i0 = i0+1) {
-                //     DPRINT << "IN THE WRITER VALUE AT i0 = " << (uint32_t)i0 <<  " is: " << BF16((uint16_t)ptr0[i0])
-                //     << ENDL();
-                // }
                 cb_pop_front(cb_id_out0, onetile * has_rows);
                 cb_wait_front(cb_id_out0, onetile * has_rows);
-                // original_addr = l1_read_addr + width_size;
             }
             // increment by the unpadded size only
             l1_read_addr += width_size;
         }
 
-        // DPRINT << "before last pop" <<ENDL();
-        // auto* ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(original_addr);
-        // for (uint32_t i0 = 0; i0 < 1024; i0 = i0+1) {
-        //     DPRINT << "IN THE WRITER VALUE AT i0 = " << (uint32_t)i0 <<  " is: " << BF16((uint16_t)ptr0[i0])
-        //     << ENDL();
-        // }
         cb_pop_front(cb_id_out0, onetile * has_rows);
     };
 
     const uint32_t size_per_row_per_block = get_arg_val<uint32_t>(3);
     const uint32_t blocks_per_core = get_arg_val<uint32_t>(4);
     const uint32_t width_size = get_arg_val<uint32_t>(5);
-    // DPRINT << "size_per_row_per_block: " << size_per_row_per_block << ENDL();
-    // DPRINT << "blocks_per_core: " << blocks_per_core << ENDL();
-    // DPRINT << "width_size: " << width_size <<ENDL();
 
     uint32_t size_2d = 0;
     for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
         uint32_t start_id = 0;
-        // DPRINT << "FOR DIM = :" << dim3 <<ENDL();
         for (uint32_t b = 0; b < blocks_per_core; b++) {
-            // DPRINT << "for block b =" << b << ENDL();
             write_block(total_num_rows, core_number, size_per_row_per_block, start_id, width_size, size_2d);
             start_id += width_size;
-            // DPRINT << "start id: " << start_id <<ENDL();
         }
         size_2d += total_num_rows;
-        // DPRINT << "size_2d: " << size_2d <<ENDL();
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -221,7 +221,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleav
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();
 
-    uint32_t num_blocks = input_shape[-1] == 0 ? 0 : input_shape[-1] / TILE_WIDTH;
+    uint32_t num_blocks = input_shape[-1] / TILE_WIDTH;
     uint32_t num_tiles_per_row = a.get_padded_shape()[-1] / TILE_WIDTH;
     uint32_t num_tiles_per_col = a.get_padded_shape()[-2] / TILE_HEIGHT;
 
@@ -248,7 +248,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleav
 
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // reader
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -410,7 +410,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    // reader
+    /** reader
+     */
 
     uint32_t src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
 
@@ -420,7 +421,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
         all_cores,
         ReaderDataMovementConfig({src0_is_dram}));
 
-    // writer
+    /** writer
+     */
 
     uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     uint32_t stick_size = unpadded_row_size_bytes;
@@ -439,7 +441,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
              (std::uint32_t)(
                  input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32)}));
 
-    // compute
+    /** compute
+     */
 
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -206,6 +206,173 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
     return {std::move(program), override_runtime_args_callback};
 }
 
+operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_col_interleaved(
+    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    const auto& input_shape = a.get_padded_shape();
+    const auto& output_shape = output.get_padded_shape();
+    // printf("output shape:\n");
+    // std::cout << output_shape << std::endl;
+
+    IDevice* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+
+    // uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.volume() / input_shape[-1] / TILE_HEIGHT;
+    uint32_t num_blocks = input_shape[-1] == 0 ? 0 : input_shape[-1] / TILE_WIDTH;
+    uint32_t num_tiles_per_row = a.get_padded_shape()[-1] / TILE_WIDTH;
+    uint32_t num_tiles_per_col = a.get_padded_shape()[-2] / TILE_HEIGHT;
+
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        ttnn::split_blocks_for_tilize(grid_size, num_blocks);
+
+    bool has_cliff = core_range_cliff.size() > 0;
+
+    uint32_t padded_row_size_bytes;
+    uint32_t unpadded_row_size_bytes;
+
+    if (a.get_dtype() == DataType::BFLOAT8_B) {
+        padded_row_size_bytes = input_shape[-1] * output.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * output.element_size();
+    } else {
+        padded_row_size_bytes = input_shape[-1] * a.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+    }
+
+    create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_col, input_cb_data_format);
+    create_cb(tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_tiles_per_col, output_cb_data_format);
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // reader
+
+    uint32_t src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
+    uint32_t num_tiles_2d = a.get_padded_shape()[-1] * a.get_padded_shape()[-2] / TILE_HW;
+    // printf("a.get_padded_shape()[-1]: %u\n", a.get_padded_shape()[-1]);
+    // printf("a.get_padded_shape()[-2]: %u\n", a.get_padded_shape()[-2]);
+    // printf("TILE_HW: %u\n", TILE_HW);
+    // printf("num_tiles_2d: %u\n", num_tiles_2d);
+
+    auto log_shape = output.get_logical_shape();
+    uint32_t third_dim = 1;
+    if (log_shape.rank() == 3) {
+        third_dim = log_shape[-3];
+    } else if (log_shape.rank() >= 4) {
+        third_dim = log_shape[-3] * log_shape[-4];
+    }
+
+    KernelHandle unary_reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp",
+        all_cores,
+        ReaderDataMovementConfig({src0_is_dram, num_tiles_2d, third_dim, nblocks_per_core}));
+
+    // writer
+
+    uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    uint32_t stick_size = unpadded_row_size_bytes;
+    uint32_t stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (std::uint32_t)std::log2(stick_size) : 0;
+
+    uint32_t total_num_rows = output.get_logical_shape()[-2];
+    // printf("total_num_rows: %u\n", total_num_rows);
+
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+        "writer_unary_stick_layout_col_multicore.cpp",
+        all_cores,
+        WriterDataMovementConfig(
+            {out_is_dram, stick_size_is_power_of_two, log2_stick_size, total_num_rows, ncores, third_dim, TILE_WIDTH}));
+
+    // compute
+
+    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp");
+    // if (num_tiles_per_row > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.get_dtype() == DataType::UINT16) {
+    //     compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
+    // }
+
+    if (core_range.size() > 0) {
+        auto tilize_kernel_id = CreateKernel(
+            program,
+            compute_kernel,
+            core_range,
+            ComputeConfig{
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = {nblocks_per_core, num_tiles_per_col, third_dim}});
+    }
+    if (has_cliff) {
+        auto tilize_cliff_kernel_id = CreateKernel(
+            program,
+            compute_kernel,
+            core_range_cliff,
+            ComputeConfig{
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = {nblocks_per_core_cliff, num_tiles_per_col, third_dim}});
+    }
+
+    // RUNTIME ARGS
+    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    uint32_t number_blocks_per_core;
+    for (uint32_t i = 0; i < ncores; ++i) {
+        const auto& core = cores[i];
+
+        if (has_cliff && i == ncores - 1) {
+            number_blocks_per_core = nblocks_per_core_cliff;
+        } else {
+            number_blocks_per_core = nblocks_per_core;
+        }
+        uint32_t size_per_row_per_block = nblocks_per_core * TILE_WIDTH * a.element_size();
+
+        //  writer runtime args
+        std::vector<uint32_t> writer_rt_args = {
+            dst_buffer->address(),
+            unpadded_row_size_bytes,
+            i,
+            size_per_row_per_block,
+            number_blocks_per_core,
+            TILE_WIDTH * a.element_size(),
+        };
+
+        // reader runtime args
+        const std::array reader_rt_args = {src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core};
+        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+    }
+
+    auto override_runtime_args_callback =
+        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
+            const Program& program,
+            const std::vector<Buffer*>& input_buffers,
+            const std::vector<Buffer*>& output_buffers) {
+            auto src_buffer = input_buffers.at(0);
+            auto dst_buffer = output_buffers.at(0);
+
+            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+
+            for (const auto& core : cores) {
+                {
+                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                    runtime_args[0] = src_buffer->address();
+                }
+                {
+                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                    runtime_args[0] = dst_buffer->address();
+                }
+            }
+        };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
 operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
     tt::tt_metal::Program program{};
@@ -223,6 +390,11 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
 
     uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.volume() / input_shape[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = a.get_padded_shape()[-1] / TILE_WIDTH;
+
+    uint32_t num_tiles_per_col = output.get_padded_shape()[-2] / TILE_HEIGHT;
+    if (num_tiles_per_row > num_tiles_per_col) {
+        return untilize_with_unpadding_multi_core_col_interleaved(a, output, use_pack_untilize, fp32_dest_acc_en);
+    }
 
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(grid_size, num_blocks);
@@ -247,8 +419,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    /** reader
-     */
+    // reader
+
     uint32_t src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
 
     KernelHandle unary_reader_kernel_id = CreateKernel(
@@ -257,8 +429,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
         all_cores,
         ReaderDataMovementConfig({src0_is_dram}));
 
-    /** writer
-     */
+    // writer
+
     uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     uint32_t stick_size = unpadded_row_size_bytes;
     uint32_t stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
@@ -276,8 +448,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
              (std::uint32_t)(
                  input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32)}));
 
-    /** compute
-     */
+    // compute
+
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
     if (num_tiles_per_row > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize || a.get_dtype() == DataType::UINT16) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp
@@ -11,19 +11,11 @@ void kernel_main() {
     uint32_t tiles_per_row = get_arg_val<uint32_t>(2);
     uint32_t num_blocks = get_arg_val<uint32_t>(3);
 
-    DPRINT << "src_addr: " << src_addr << ENDL();
-    DPRINT << "core_number: " << core_number << ENDL();
-    DPRINT << "tiles_per_row: " << tiles_per_row << ENDL();
-    DPRINT << "num_blocks: " << num_blocks << ENDL();
     constexpr uint32_t cb_id_in0 = 0;
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t num_tiles_per_2d = get_compile_time_arg_val(1);
     const uint32_t third_dim = get_compile_time_arg_val(2);
     const uint32_t number_blocks_per_core = get_compile_time_arg_val(3);
-
-    DPRINT << "num_tiles_per_2d: " << num_tiles_per_2d << ENDL();
-    DPRINT << "third_dim: " << third_dim << ENDL();
-    DPRINT << "number_blocks_per_core: " << number_blocks_per_core << ENDL();
 
 #ifdef OUT_SHARDED
     cb_wait_front(cb_id_in0, onetile);
@@ -47,26 +39,15 @@ void kernel_main() {
 #else
     uint32_t end_id = num_tiles_per_2d;
     for (uint32_t dim = 0; dim < third_dim; dim++) {
-        DPRINT << "FOR DIM =" << dim << ENDL();
         for (uint32_t k = 0; k < num_blocks; k++) {
-            DPRINT << "for k = : " << k << ENDL();
-            DPRINT << "start i is: " << num_tiles_per_2d * dim + number_blocks_per_core * core_number << ENDL();
-            DPRINT << "end i is:" << end_id + num_tiles_per_2d * dim << ENDL();
-            DPRINT << "increment i by :" << tiles_per_row << ENDL();
             for (uint32_t i = num_tiles_per_2d * dim + number_blocks_per_core * core_number;
                  i < end_id + num_tiles_per_2d * dim;
                  i = i + tiles_per_row) {
 #endif
-                DPRINT << "Reading for i=: " << i << ENDL();
                 cb_reserve_back(cb_id_in0, onetile);
                 uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
                 noc_async_read_tile(i + k, s, l1_write_addr);
 
-                auto* ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
-                for (uint32_t i0 = 0; i0 < 1024; i0 = i0 + 1) {
-                    DPRINT << "IN THE WRITER VALUE AT i0 = " << (uint32_t)i0 << " is: " << BF16((uint16_t)ptr0[i0])
-                           << ENDL();
-                }
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp
@@ -1,0 +1,76 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t core_number = get_arg_val<uint32_t>(1);
+    uint32_t tiles_per_row = get_arg_val<uint32_t>(2);
+    uint32_t num_blocks = get_arg_val<uint32_t>(3);
+
+    DPRINT << "src_addr: " << src_addr << ENDL();
+    DPRINT << "core_number: " << core_number << ENDL();
+    DPRINT << "tiles_per_row: " << tiles_per_row << ENDL();
+    DPRINT << "num_blocks: " << num_blocks << ENDL();
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t num_tiles_per_2d = get_compile_time_arg_val(1);
+    const uint32_t third_dim = get_compile_time_arg_val(2);
+    const uint32_t number_blocks_per_core = get_compile_time_arg_val(3);
+
+    DPRINT << "num_tiles_per_2d: " << num_tiles_per_2d << ENDL();
+    DPRINT << "third_dim: " << third_dim << ENDL();
+    DPRINT << "number_blocks_per_core: " << number_blocks_per_core << ENDL();
+
+#ifdef OUT_SHARDED
+    cb_wait_front(cb_id_in0, onetile);
+#else
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+#ifdef BACKWARDS
+    uint32_t end_id = -num_tiles_per_2d;
+    for (uint32_t dim = 0; dim > -third_dim; dim--) {
+        for (uint32_t k = 0; k > -num_blocks; k--) {
+            for (uint32_t i = num_tiles_per_2d * dim - number_blocks_per_core * core_number;
+                 i > end_id + num_tiles_per_2d * dim;
+                 i = i - tiles_per_row) {
+#else
+    uint32_t end_id = num_tiles_per_2d;
+    for (uint32_t dim = 0; dim < third_dim; dim++) {
+        DPRINT << "FOR DIM =" << dim << ENDL();
+        for (uint32_t k = 0; k < num_blocks; k++) {
+            DPRINT << "for k = : " << k << ENDL();
+            DPRINT << "start i is: " << num_tiles_per_2d * dim + number_blocks_per_core * core_number << ENDL();
+            DPRINT << "end i is:" << end_id + num_tiles_per_2d * dim << ENDL();
+            DPRINT << "increment i by :" << tiles_per_row << ENDL();
+            for (uint32_t i = num_tiles_per_2d * dim + number_blocks_per_core * core_number;
+                 i < end_id + num_tiles_per_2d * dim;
+                 i = i + tiles_per_row) {
+#endif
+                DPRINT << "Reading for i=: " << i << ENDL();
+                cb_reserve_back(cb_id_in0, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+                noc_async_read_tile(i + k, s, l1_write_addr);
+
+                auto* ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
+                for (uint32_t i0 = 0; i0 < 1024; i0 = i0 + 1) {
+                    DPRINT << "IN THE WRITER VALUE AT i0 = " << (uint32_t)i0 << " is: " << BF16((uint16_t)ptr0[i0])
+                           << ENDL();
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_id_in0, onetile);
+            }
+        }
+    }
+#endif
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/17537

### Problem description
Currently, the untilize with unpadding implementation supports parallelization only along the height dimension. This affects perf for wide tensors, as they are mapped to a limited number of cores.

### What's changed
In this PR, we introduce support for parallelizing the untiling operation along the width dimension, similar to tilize with padding. The operation executes the parallelization over the dimension with the larger number of tiles.
In future versions: 
	- we want the operation to support the parallelization along both dimensions simultaneously
	- we want the compute kernel to support the processing of an entire column block at once instead of one tile at a time

For the tests added in test_to_layout.py, the kernel duration of the previous implementation is around 1.8 to 24.8 times larger than the current implementation  

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13121055787
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
