### PR TITLE
#0: Add missing flush in send_chunk_from_address

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
@@ -54,7 +54,9 @@ template<ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode = ttnn::ccl::EDM_IO_BLOCK
 FORCE_INLINE void send_chunk_from_address(
     const uint32_t& local_l1_address, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
     noc_async_write(local_l1_address, remote_l1_write_addr, page_size * num_pages);
-    if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING) {
+    if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING) {
+        noc_async_writes_flushed();
+    } else if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING) {
         noc_async_write_barrier();
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`send_chunk_from_address` takes in a blocking mode enum, but it only handles when set to BLOCKING, not FLUSH_BLOCKING.

### What's changed
Add case for adding noc_async_writes_flushed when FLUSH_BLOCKING is set.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
