### PR TITLE
#16364: split prefetch dependent config

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -18,8 +18,7 @@ typedef struct dispatch_static_config {
     std::optional<uint32_t> my_downstream_cb_sem_id;
 
     std::optional<uint32_t> split_dispatch_page_preamble_size;  // 14
-    std::optional<uint32_t> split_prefetch;
-    std::optional<uint32_t> prefetch_h_max_credits;
+    std::optional<uint32_t> prefetch_h_max_credits;             // Used if split_prefetch is true
 
     std::optional<uint32_t> packed_write_max_unicast_sub_cmds;  // 19
     std::optional<uint32_t> dispatch_s_sync_sem_base_addr;
@@ -50,8 +49,9 @@ typedef struct dispatch_dependent_config {
     std::optional<uint32_t> downstream_cb_size;    // Dependent
     std::optional<uint32_t> downstream_cb_sem_id;  // Dependant
 
-    std::optional<uint32_t> prefetch_h_noc_xy;                     // Dependent
-    std::optional<uint32_t> prefetch_h_local_downstream_sem_addr;  // Dependent
+    std::optional<uint32_t> split_prefetch;                        // If upstream is NOT a prefetch_HD
+    std::optional<uint32_t> prefetch_h_noc_xy;                     // Dependent. Used if split_prefetch is true
+    std::optional<uint32_t> prefetch_h_local_downstream_sem_addr;  // Dependent. Used if split_prefetch is true
 } dispatch_dependent_config_t;
 
 class DispatchKernel : public FDKernel {


### PR DESCRIPTION
Split prefetch depends on up/downstream prefetcher

### Ticket
#16364

### Problem description
Dispatcher split_prefetch compile arg is hardcoded. It needs to be dynamic based on if the up/downstream prefetcher is HD or not. Some experimental cases like `test_prefetcher` needs this

### What's changed
Move `split_prefetch` into dispatcher `dependent_config_t`

### Checklist
TGG: https://github.com/tenstorrent/tt-metal/actions/runs/13131888170
All Post Commit: https://github.com/tenstorrent/tt-metal/actions/runs/13131884104
T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13131891540/job/36638838359
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
