### PR TITLE
BH post commit profiler regression

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -168,10 +168,21 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-  profiler-regression:
+  run-profiler-regression:
     needs: build-artifact-profiler
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: grayskull, runner-label: E150 },
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
+    with:
+      arch: ${{ matrix.test-group.arch}}
+      runner-label: ${{ matrix.test-group.runner-label}}
   build-docs:
     needs: build-artifact
     uses: ./.github/workflows/docs-latest-public.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -15,6 +15,15 @@ on:
           required: true
           type: string
           default: 'BH'
+      build-type:
+        required: false
+        default: Release
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - CI
   schedule:
     - cron: "0 */2 * * *"
   # Pause this since not enough runners to support every commit to main
@@ -37,13 +46,28 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
+      build-type: ${{ inputs.build-type || 'Release' }}
       version: "22.04"
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      tracy: true
+      version: "20.04"
   build-wheels:
     needs: build-artifact
     uses: ./.github/workflows/_build-wheels-impl.yaml
     with:
       os: "ubuntu-22.04"
       from-precompiled: true
+  run-profiler-regression:
+    needs: build-artifact-profiler
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit
+    with:
+      arch: "blackhole"
+      runner-label: ${{ inputs.runner-label || 'BH' }}
   umd-unit-tests:
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -12,5 +12,16 @@ jobs:
     secrets: inherit
   run-profiler-regression:
     needs: build-artifact-profiler
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: grayskull, runner-label: E150 },
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
+    with:
+      arch: ${{ matrix.test-group.arch}}
+      runner-label: ${{ matrix.test-group.runner-label}}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -2,6 +2,46 @@ name: "[internal] metal - Run profiler regression impl"
 
 on:
   workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 35
+      os:
+        required: false
+        type: string
+        default: "ubuntu-20.04"
+  workflow_dispatch:
+    inputs:
+      arch:
+        required: true
+        type: choice
+        options:
+          - grayskull
+          - wormhole_b0
+          - blackhole
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - E150
+          - N150
+          - N300
+          - BH
+      timeout:
+        required: false
+        type: number
+        default: 35
+      os:
+        required: false
+        type: string
+        default: "ubuntu-20.04"
 
 jobs:
   profiler-regression:
@@ -9,21 +49,14 @@ jobs:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
-      matrix:
-        runner-info: [
-          # E150
-          {arch: grayskull, runs-on: ["cloud-virtual-machine", "E150", "in-service"], name: E150},
-          # N150
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N150", "in-service"], name: N150},
-          # N300
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N300", "in-service"], name: N300},
-        ]
     env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
-      ARCH_NAME: ${{ matrix.runner-info.arch }}
+      ARCH_NAME: ${{ inputs.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ matrix.runner-info.runs-on }}
+    runs-on:
+      - ${{ inputs.runner-label }}
+      - cloud-virtual-machine
+      - in-service
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - name: Set up dynamic env vars for build
@@ -36,7 +69,7 @@ jobs:
         run: tar -xvf ttm_any.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run profiler regression tests
-        timeout-minutes: 30
+        timeout-minutes: ${{ inputs.timeout }}
         run: |
           ./tests/scripts/run_profiler_regressions.sh
       - uses: ./.github/actions/slack-report

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -21,7 +21,7 @@ from tt_metal.tools.profiler.common import (
     clear_profiler_runtime_artifacts,
 )
 
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import skip_for_grayskull, skip_for_blackhole
 
 PROG_EXMP_DIR = "programming_examples/profiler"
 
@@ -82,6 +82,7 @@ def test_multi_op():
     REF_COUNT_DICT = {
         "grayskull": [108 * OP_COUNT * RUN_COUNT, 88 * OP_COUNT * RUN_COUNT],
         "wormhole_b0": [72 * OP_COUNT * RUN_COUNT, 64 * OP_COUNT * RUN_COUNT, 56 * OP_COUNT * RUN_COUNT],
+        "blackhole": [130 * OP_COUNT * RUN_COUNT, 120 * OP_COUNT * RUN_COUNT, 110 * OP_COUNT * RUN_COUNT],
     }
 
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
@@ -152,6 +153,11 @@ def test_full_buffer():
             64 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
             56 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
         ],
+        "blackhole": [
+            130 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
+            120 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
+            110 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
+        ],
     }
 
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
@@ -189,6 +195,10 @@ def test_dispatch_cores():
             "Tensix CQ Dispatch": 16,
             "Tensix CQ Prefetch": 25,
         },
+        "blackhole": {
+            "Tensix CQ Dispatch": 16,
+            "Tensix CQ Prefetch": 25,
+        },
     }
 
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
@@ -216,6 +226,7 @@ def test_dispatch_cores():
     os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
 
 
+@skip_for_blackhole()
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
@@ -297,20 +308,29 @@ def test_timestamped_events():
     OP_COUNT = 2
     RISC_COUNT = 5
     ZONE_COUNT = 100
-    ERISC_COUNTS = [0, 1, 5]
-    TENSIX_COUNTS = [72, 64, 56]
+    WH_ERISC_COUNTS = [0, 1, 5]
+    WH_TENSIX_COUNTS = [72, 64, 56]
+    BH_ERISC_COUNTS = [0, 1, 5]
+    BH_TENSIX_COUNTS = [130, 120, 110]
 
-    COMBO_COUNTS = []
-    for T in TENSIX_COUNTS:
-        for E in ERISC_COUNTS:
-            COMBO_COUNTS.append((T, E))
+    WH_COMBO_COUNTS = []
+    for T in WH_TENSIX_COUNTS:
+        for E in WH_ERISC_COUNTS:
+            WH_COMBO_COUNTS.append((T, E))
+
+    BH_COMBO_COUNTS = []
+    for T in BH_TENSIX_COUNTS:
+        for E in BH_ERISC_COUNTS:
+            BH_COMBO_COUNTS.append((T, E))
 
     REF_COUNT_DICT = {
         "grayskull": [108 * OP_COUNT * RISC_COUNT * ZONE_COUNT, 88 * OP_COUNT * RISC_COUNT * ZONE_COUNT],
-        "wormhole_b0": [(T * RISC_COUNT + E) * OP_COUNT * ZONE_COUNT for T, E in COMBO_COUNTS],
+        "wormhole_b0": [(T * RISC_COUNT + E) * OP_COUNT * ZONE_COUNT for T, E in WH_COMBO_COUNTS],
+        "blackhole": [(T * RISC_COUNT + E) * OP_COUNT * ZONE_COUNT for T, E in BH_COMBO_COUNTS],
     }
     REF_ERISC_COUNT = {
-        "wormhole_b0": [C * OP_COUNT * ZONE_COUNT for C in ERISC_COUNTS],
+        "wormhole_b0": [C * OP_COUNT * ZONE_COUNT for C in WH_ERISC_COUNTS],
+        "blackhole": [C * OP_COUNT * ZONE_COUNT for C in BH_ERISC_COUNTS],
     }
 
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17080

### Problem description
BH post commit doesn't test profiler runs on BH

### What's changed
Make run_profiler_regression ready for integrating into BH post_commit. 
NOTE: The test will be integrated into BH post commit in separate PR.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13159837986/job/36725734945)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/13160710474)
- [x] [ Single profiler regression post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13160198648) 
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13160201671)

