### PR TITLE
[skip ci] Revert "disable-pr-gate"

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -12,14 +12,14 @@ name: PR Gate
 
 on:
   workflow_dispatch:
-#  pull_request:
-#    types:
-#      - opened
-#      - reopened
-#      - synchronize
-#      - ready_for_review
-#    branches:
-#      - "main"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - "main"
 
 concurrency:
   # Use github.run_id on main branch (or any protected branch)


### PR DESCRIPTION
This reverts commit 89a06612f8a97841f05aed69d084a5973302d0ef.

### Ticket
None

### Problem description
We disabled this when we were faced with networking woes.  They have now been mitigated.

### What's changed
Re-enabled the PR Gate on PRs.

