### PR TITLE
Jjiang/fixed tensor creation and conversion

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -93,7 +93,7 @@ TYPED_TEST(VectorConversionTest, TensorShape) {
         auto input = arange<TypeParam>(0, static_cast<int64_t>(shape.volume()), 1);
         Tensor output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()));
 
-        EXPECT_THAT(output.get_tensor_spec().shape(), Eq(shape)) << "for shape: " << shape;
+        EXPECT_THAT(output.get_tensor_spec().logical_shape(), Eq(shape)) << "for shape: " << shape;
     }
 }
 
@@ -104,7 +104,7 @@ TYPED_TEST(VectorConversionTest, Roundtrip) {
 
         TensorSpec tensor_spec = tensor.get_tensor_spec();
 
-        EXPECT_THAT(tensor_spec.shape(), Eq(shape)) << "for shape: " << shape;
+        EXPECT_THAT(tensor_spec.logical_shape(), Eq(shape)) << "for shape: " << shape;
         EXPECT_THAT(tensor_spec.data_type(), Eq(convert_to_data_type<TypeParam>()));
 
         auto output = tensor.template to_vector<TypeParam>();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -7,8 +7,12 @@
 #include <algorithm>
 #include <cstdint>
 
+#include "assert.hpp"
+#include "buffer_constants.hpp"
+#include "shape2d.hpp"
 #include "tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp"
 #include <tt-metalium/bfloat16.hpp>
+#include <vector>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -40,6 +44,26 @@ const std::vector<ttnn::Shape>& get_shapes_for_test() {
     return *shapes;
 }
 
+TensorSpec get_tensor_spec_with_memory(
+    const ttnn::Shape& shape,
+    DataType dtype,
+    Layout layout = Layout::ROW_MAJOR,
+    TensorMemoryLayout mem_layout = TensorMemoryLayout::SINGLE_BANK) {
+    return TensorSpec(
+        shape,
+        TensorLayout(
+            dtype,
+            layout,
+            MemoryConfig{
+                .memory_layout = mem_layout,
+                .buffer_type = BufferType::DRAM,
+                .shard_spec = ShardSpec{
+                    ttnn::CoreRangeSet{ttnn::CoreRange{ttnn::CoreRange{ttnn::CoreCoord{0, 0}, ttnn::CoreCoord{4, 1}}}},
+                    {32, 64},
+                    ShardOrientation::ROW_MAJOR,
+                    ShardMode::LOGICAL}}));
+}
+
 TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype, Layout layout = Layout::ROW_MAJOR) {
     return TensorSpec(shape, TensorLayout(dtype, layout, MemoryConfig{}));
 }
@@ -64,11 +88,27 @@ class VectorConversionTest : public ::testing::Test {};
 using TestTypes = ::testing::Types<float, bfloat16, uint8_t, uint16_t, uint32_t, int32_t>;
 TYPED_TEST_SUITE(VectorConversionTest, TestTypes);
 
+TYPED_TEST(VectorConversionTest, TensorShape) {
+    for (const auto& shape : get_shapes_for_test()) {
+        auto input = arange<TypeParam>(0, static_cast<int64_t>(shape.volume()), 1);
+        Tensor output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()));
+
+        EXPECT_THAT(output.get_tensor_spec().shape(), Eq(shape)) << "for shape: " << shape;
+    }
+}
+
 TYPED_TEST(VectorConversionTest, Roundtrip) {
     for (const auto& shape : get_shapes_for_test()) {
         auto input = arange<TypeParam>(0, static_cast<int64_t>(shape.volume()), 1);
-        auto output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()))
-                          .template to_vector<TypeParam>();
+        auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()));
+
+        TensorSpec tensor_spec = tensor.get_tensor_spec();
+
+        EXPECT_THAT(tensor_spec.shape(), Eq(shape)) << "for shape: " << shape;
+        EXPECT_THAT(tensor_spec.data_type(), Eq(convert_to_data_type<TypeParam>()));
+
+        auto output = tensor.template to_vector<TypeParam>();
+
         EXPECT_THAT(output, Pointwise(Eq(), input)) << "for shape: " << shape;
     }
 }
@@ -79,6 +119,23 @@ TYPED_TEST(VectorConversionTest, InvalidSize) {
 
     ASSERT_NE(input.size(), shape.volume());
     EXPECT_ANY_THROW(Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>())));
+}
+
+TYPED_TEST(VectorConversionTest, OddshapeRoundtripTilizedLayout) {
+    ttnn::Shape shape{1, 40, 3, 121};
+
+    auto input = arange<TypeParam>(0, shape.volume(), 1);
+
+    auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE));
+
+    ASSERT_NE(tensor.tensor_spec().padded_shape(), tensor.tensor_spec().logical_shape());
+
+    EXPECT_THAT(tensor.tensor_spec().logical_shape(), ShapeIs(1, 40, 3, 121));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(1, 40, 32, 128));
+
+    auto output = tensor.template to_vector<TypeParam>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
 }
 
 TYPED_TEST(VectorConversionTest, RoundtripTilezedLayout) {
@@ -186,5 +243,141 @@ TEST_F(DeviceVectorConversionTest, RoundtripWithMemoryConfig) {
     EXPECT_THAT(output.to_vector<float>(), Pointwise(Eq(), input));
 }
 
+// TODO: simplify into two layered class TYPED_TEST_P
+class ShardVectorConversionTest : public ::testing::TestWithParam<TensorMemoryLayout> {};
+
+TEST_P(ShardVectorConversionTest, UInt32RoundtripRowMajShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input = arange<uint32_t>(0, shape.volume(), 1);
+
+    auto tensor =
+        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::UINT32, Layout::ROW_MAJOR, GetParam()));
+
+    auto output = tensor.template to_vector<uint32_t>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TEST_P(ShardVectorConversionTest, UInt32RoundtripTilizedShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input = arange<uint32_t>(0, shape.volume(), 1);
+
+    auto tensor =
+        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::UINT32, Layout::TILE, GetParam()));
+
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(121, 128));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
+
+    auto output = tensor.template to_vector<uint32_t>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TEST_P(ShardVectorConversionTest, FloatRoundtripRowMajShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    auto tensor = Tensor::from_vector(
+        input, get_tensor_spec_with_memory(shape, DataType::FLOAT32, Layout::ROW_MAJOR, GetParam()));
+
+    auto output = tensor.template to_vector<float>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TEST_P(ShardVectorConversionTest, FloatRoundtripTilizedShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    auto tensor =
+        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::FLOAT32, Layout::TILE, GetParam()));
+
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(121, 128));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
+
+    auto output = tensor.template to_vector<float>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TEST_P(ShardVectorConversionTest, Bfloat16RoundtripRowMajShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input_bf16 = arange<bfloat16>(0, static_cast<int64_t>(shape.volume()), 1);
+
+    std::vector<float> input_ft;
+    input_ft.reserve(input_bf16.size());
+    std::transform(
+        input_bf16.begin(), input_bf16.end(), std::back_inserter(input_ft), [](bfloat16 bf) { return bf.to_float(); });
+
+    auto tensor_bf = Tensor::from_vector(
+        input_ft, get_tensor_spec_with_memory(shape, DataType::BFLOAT16, Layout::ROW_MAJOR, GetParam()));
+
+    auto output_ft = tensor_bf.to_vector<float>();
+
+    EXPECT_THAT(output_ft, Pointwise(Eq(), input_ft));
+}
+
+TEST_P(ShardVectorConversionTest, Bfloat16RoundtripTilizedShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input_bf16 = arange<bfloat16>(0, static_cast<int64_t>(shape.volume()), 1);
+
+    std::vector<float> input_ft;
+    input_ft.reserve(input_bf16.size());
+    std::transform(
+        input_bf16.begin(), input_bf16.end(), std::back_inserter(input_ft), [](bfloat16 bf) { return bf.to_float(); });
+
+    auto tensor_bf =
+        Tensor::from_vector(input_ft, get_tensor_spec_with_memory(shape, DataType::BFLOAT16, Layout::TILE, GetParam()));
+
+    EXPECT_THAT(tensor_bf.get_logical_shape(), ShapeIs(121, 128));
+    EXPECT_THAT(tensor_bf.get_padded_shape(), ShapeIs(128, 128));
+
+    auto output_ft = tensor_bf.to_vector<float>();
+
+    EXPECT_THAT(output_ft, Pointwise(FloatNear(4.0f), input_ft));
+}
+
+TEST_P(ShardVectorConversionTest, BlockfloatRoundtripRowMajShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input = arange<float>(0, shape.volume(), 1, 32);
+
+    auto tensor =
+        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::BFLOAT8_B, Layout::TILE, GetParam()));
+
+    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
+}
+
+TEST_P(ShardVectorConversionTest, BlockfloatRoundtripTilizedShardMapping) {
+    ttnn::Shape shape{121, 128};
+
+    auto input = arange<float>(0, shape.volume(), 1, 32);
+
+    auto tensor =
+        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::BFLOAT8_B, Layout::TILE, GetParam()));
+
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(121, 128));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
+
+    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ShardVectorConversionTests,
+    ShardVectorConversionTest,
+    ::testing::Values(
+        TensorMemoryLayout::INTERLEAVED,
+        TensorMemoryLayout::SINGLE_BANK,
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        TensorMemoryLayout::WIDTH_SHARDED,
+        TensorMemoryLayout::BLOCK_SHARDED));
+
 }  // namespace
+
 }  // namespace ttnn

--- a/tests/ttnn/unit_tests/tensor/test_python_tensor_conversion
+++ b/tests/ttnn/unit_tests/tensor/test_python_tensor_conversion
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pathlib
+import pytest
+
+
+import torch
+
+
+import ttnn
+
+
+@pytest.mark.parametrize("size", [64])
+@pytest.mark.parametrize("mode", [ttnn.graph.RunMode.NO_DISPATCH, ttnn.graph.RunMode.NORMAL])
+@pytest.mark.parametrize("dtype", [torch.int32, torch.float, torch.bfloat16, torch.uint8])
+def test_convert_python_tensor(device, size, mode, dtype):
+    torch.manual_seed(0)
+
+    # weird hack necessary for pytorch typechecking...
+    test = torch.tensor([1], dtype=dtype)
+    if torch.is_floating_point(test):
+        torch_input_tensor = torch.rand((size,), dtype=dtype)
+    else:
+        torch_input_tensor = torch.randint(0, 256, (size,), dtype=dtype)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(input_tensor, torch_rank=1)
+
+    assert torch.equal(output_tensor, torch_input_tensor)
+
+
+@pytest.mark.parametrize("size", [64])
+@pytest.mark.parametrize("mode", [ttnn.graph.RunMode.NO_DISPATCH, ttnn.graph.RunMode.NORMAL])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b])
+def test_convert_python_tensor_bfp_b(device, size, mode, dtype):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((size,), dtype=torch.float)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=(dtype))
+    output_tensor = ttnn.to_torch(input_tensor, torch_rank=1)
+    # assert torch.equal(output_tensor,torch_input_tensor)
+    assert output_tensor.storage_type() != ttnn.StorageType.BORROWED


### PR DESCRIPTION
Change create_tt_tensor_from_py_data to use from_vector - fixed branch (https://github.com/tenstorrent/tt-metal/pull/17389)
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16837

### Problem description
Fixed the rebase error causing main to break
Duplicate bespoke code in pytensor.cpp for bfloat handling, should
probably use the tensor.cpp version for better maintainability.

### What's changed
Changed shape to logical_shape in test_vector_conversion.cpp which fixes the build error.
Call from_vector within pytensor.cpp instead of directly doing bfloat
packing in pytensor.cpp, clean up from_span and
create_owned_tensor_from_row_major_data helper method in tensor.cpp, add
test cases to cover the new path.

### Checklist
- [X] Post commit CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/13038902373
- [X] Blackhole Post commit (if applicable)
- [X] Model regression CI testing passes (if applicable)
- [X] Device performance regression CI testing passes (if applicable)
- [X] **(For models and ops writers)** Full [new
models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml)
tests passes
- [X] New/Existing tests provide coverage for changes:
tt-metal/tests/ttnn/unit_tests/test_convert_python_tensor.py added,
ttnn/unit_tests in general