### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Docs

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles.rst
@@ -3,5 +3,5 @@ add_tiles
 
 
 .. doxygenfunction:: add_tiles_init_nof()
-.. doxygenfunction:: add_tiles_init(uint32_t icb0 = 0, uint32_t icb1 = 1, bool acc_to_dest = false)
+.. doxygenfunction:: add_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false)
 .. doxygenfunction:: add_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles_bcast.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles_bcast.rst
@@ -1,6 +1,6 @@
 add_tiles_bcast
 ===============
 
-.. doxygenfunction:: add_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
-.. doxygenfunction:: add_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
+.. doxygenfunction:: add_bcast_cols_init_short(uint32_t icb0, uint32_t icb1)
+.. doxygenfunction:: add_bcast_rows_init_short(uint32_t icb0, uint32_t icb1)
 .. doxygenfunction:: add_tiles_bcast(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/matmul_block.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/matmul_block.rst
@@ -1,7 +1,7 @@
 matmul_block
 ============
 
-.. doxygenfunction:: mm_block_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16, const uint32_t transpose=0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1)
-.. doxygenfunction:: mm_block_init_short(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, const uint32_t transpose=0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1)
-.. doxygenfunction:: mm_block_init_short_with_dt(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t old_in1_cb_id=2, const uint32_t transpose=0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1)
+.. doxygenfunction:: mm_block_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, const uint32_t transpose=0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1)
+.. doxygenfunction:: mm_block_init_short(uint32_t in0_cb_id, uint32_t in1_cb_id, const uint32_t transpose=0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1)
+.. doxygenfunction:: mm_block_init_short_with_dt(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t old_in1_cb_id, const uint32_t transpose=0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1)
 .. doxygenfunction:: matmul_block(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t in0_tile_index, uint32_t in1_tile_index, uint32_t idst, const uint32_t transpose, uint32_t ct_dim, uint32_t rt_dim, uint32_t kt_dim)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/matmul_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/matmul_tiles.rst
@@ -1,7 +1,7 @@
 matmul_tiles
 ============
 
-.. doxygenfunction:: mm_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16, const uint32_t transpose=0)
-.. doxygenfunction:: mm_init_short_with_dt(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t c_in_old_srca = 2, const uint32_t transpose=0)
-.. doxygenfunction:: mm_init_short(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, const uint32_t transpose=0)
+.. doxygenfunction:: mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, const uint32_t transpose=0)
+.. doxygenfunction:: mm_init_short_with_dt(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t c_in_old_srca, const uint32_t transpose=0)
+.. doxygenfunction:: mm_init_short(uint32_t in0_cb_id, uint32_t in1_cb_id, const uint32_t transpose=0)
 .. doxygenfunction:: matmul_tiles(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t in0_tile_index, uint32_t in1_tile_index, uint32_t idst, const uint32_t transpose)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/move_copy_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/move_copy_tile.rst
@@ -3,5 +3,5 @@ move_copy_tile
 
 
 .. doxygenfunction:: copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cbid, uint32_t transpose = 0)
-.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid = 0, uint32_t transpose = 0)
+.. doxygenfunction:: copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transpose = 0)
 .. doxygenfunction:: copy_tile_init(uint32_t cbid)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles.rst
@@ -2,5 +2,5 @@ mul_tiles
 =========
 
 .. doxygenfunction:: mul_tiles_init_f()
-.. doxygenfunction:: mul_tiles_init(uint32_t icb0 = 0, uint32_t icb1 = 1)
+.. doxygenfunction:: mul_tiles_init(uint32_t icb0, uint32_t icb1)
 .. doxygenfunction:: mul_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles_bcast.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles_bcast.rst
@@ -1,8 +1,8 @@
 mul_tiles_bcast
 ===============
 
-.. doxygenfunction:: mul_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
-.. doxygenfunction:: mul_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
+.. doxygenfunction:: mul_bcast_cols_init_short(uint32_t icb0, uint32_t icb1)
+.. doxygenfunction:: mul_bcast_rows_init_short(uint32_t icb0, uint32_t icb1)
 .. doxygenfunction:: mul_tiles_bcast(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)
-.. doxygenfunction:: mul_tiles_bcast_scalar_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
+.. doxygenfunction:: mul_tiles_bcast_scalar_init_short(uint32_t icb0, uint32_t icb1)
 .. doxygenfunction:: mul_tiles_bcast_scalar(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles.rst
@@ -2,5 +2,5 @@ sub_tiles
 =========
 
 .. doxygenfunction:: sub_tiles_init_nof()
-.. doxygenfunction:: sub_tiles_init(uint32_t icb0 = 0, uint32_t icb1 = 1, bool acc_to_dest = false)
+.. doxygenfunction:: sub_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false)
 .. doxygenfunction:: sub_tiles( uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles_bcast.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles_bcast.rst
@@ -2,5 +2,5 @@ sub_tiles_bcast
 ===============
 
 
-.. doxygenfunction:: sub_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
+.. doxygenfunction:: sub_bcast_cols_init_short(uint32_t icb0, uint32_t icb1)
 .. doxygenfunction:: sub_tiles_bcast(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/transpose_wh_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/transpose_wh_tile.rst
@@ -1,5 +1,5 @@
 transpose_wh_tile
 =================
 
-.. doxygenfunction:: transpose_wh_init(uint32_t icb, uint32_t ocb = 16)
+.. doxygenfunction:: transpose_wh_init(uint32_t icb, uint32_t ocb)
 .. doxygenfunction:: transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the documentation (.rst files) for compute kernel APIs.

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files.

This PR assumes changes from [this PR](https://github.com/tenstorrent/tt-metal/pull/16571) and will be merged once that is merged.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [x] [Doc build test](https://github.com/tenstorrent/tt-metal/actions/runs/13145490034)

