### PR TITLE
[Fabric] Test code updates and minor fixes

### DIFF
--- a/tt_fabric/hw/inc/tt_fabric.h
+++ b/tt_fabric/hw/inc/tt_fabric.h
@@ -1423,7 +1423,7 @@ inline uint64_t tt_fabric_send_pull_request(uint64_t dest_addr, volatile local_p
 }
 
 inline void tt_fabric_init() {
-    uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc_index, 0, NOC_NODE_ID);
+    uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc_index, 0, NOC_CFG(NOC_ID_LOGICAL));
     uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
     uint32_t my_y = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
     xy_local_addr = NOC_XY_ADDR(my_x, my_y, 0);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17573)

### Problem description
The test code selects worker cores at random for running traffic b/w chips. This could impact benchmarking as the performance could be impacted by the physical distance of the cores from the routers.

### What's changed
- The test code will now consistently pick the optimum worker cores for any given router. This will minimize any variations in the performance numbers because of worker core selection.
- New options:
  - Benchmark mode (```--benchmark```): Bundles together all the settings and configurations needed to run perf benchmarks.
  - Packet size in KB (```--packet_size_kb```)
- Removed options:
  - Max packet size in words (```--max_packet_size_words```): Use ```--packet_size_kb``` instead.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13146015390)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
