### PR TITLE
[skip ci] Fix invoking the workflow manually

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: "amd64"
+      toolchain:
+        required: false
+        type: string
+        default: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+        description: "Toolchain file to use for build"
 
 
 jobs:


### PR DESCRIPTION
### Ticket
None

### Problem description
An input is missing when we enter via workflow_dispatch (read: trigger it manually).

### What's changed
Defined the missing input.

