### PR TITLE
[tt-train] Add cargo to init_repo for tt-train

### DIFF
--- a/tt-train/init_repo.sh
+++ b/tt-train/init_repo.sh
@@ -12,6 +12,6 @@ pre-commit install
 chmod +x init_tt_metal.sh
 source ./init_tt_metal.sh
 
-sudo apt-get install python3-dev python3-numpy
+sudo apt-get install python3-dev python3-numpy cargo
 pip install wandb
 pip install numpy


### PR DESCRIPTION
### Ticket
n/a

### Problem description
cargo is a transitive dependency of tt-train (due to inclusion of a tokenizer crate). Currently tt-train build fails when it's not already installed. 

### What's changed
- adds cargo to the tt-train dependency setup script to avoid confusing build failures when it's absent

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes


