### PR TITLE
Update EDM Fabric flow control between sender and receiver channels over Ethernet to use stream registers and eth reg write

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -26,14 +26,10 @@ FORCE_INLINE void line_sync(
     mcast_fwd_packet_header->to_atomic_inc();
     mcast_bwd_packet_header->to_atomic_inc();
 
-    DPRINT << "sync_noc_x = " << (uint32_t)sync_noc_x << ", sync_noc_y = " << (uint32_t)sync_noc_y
-           << ", sync_bank_addr = " << (uint32_t)sync_bank_addr << ", sync_val = " << (uint32_t)sync_val << "\n";
     if (fabric_connection.has_forward_connection()) {
         mcast_fwd_packet_header->to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader{
             sync_bank_addr, 1, 128, static_cast<uint8_t>(sync_noc_x), static_cast<uint8_t>(sync_noc_y)});
-        DPRINT << "EDMF WAIT\n";
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        DPRINT << "\tDone\n";
         fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
             (uint32_t)mcast_fwd_packet_header, sizeof(tt::fabric::PacketHeader));
     }
@@ -41,9 +37,7 @@ FORCE_INLINE void line_sync(
     if (fabric_connection.has_backward_connection()) {
         mcast_bwd_packet_header->to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader{
             sync_bank_addr, 1, 128, static_cast<uint8_t>(sync_noc_x), static_cast<uint8_t>(sync_noc_y)});
-        DPRINT << "EDMB WAIT\n";
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-        DPRINT << "\tDone\n";
         fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
             (uint32_t)mcast_bwd_packet_header, sizeof(tt::fabric::PacketHeader));
     }
@@ -96,19 +90,6 @@ void kernel_main() {
     const size_t finish_sync_val = 3 * total_workers_per_sync;
 
     fabric_connection.open();
-
-    if (fabric_connection.has_forward_connection()) {
-        DPRINT << "FWD Start wrptr = " << (uint32_t)*fabric_connection.get_forward_connection().buffer_slot_wrptr_ptr
-               << "\n";
-        DPRINT << "FWD Start rdptr = "
-               << (uint32_t)*fabric_connection.get_forward_connection().from_remote_buffer_slot_rdptr_ptr << "\n";
-    }
-    if (fabric_connection.has_backward_connection()) {
-        DPRINT << "BWD Start wrptr = " << (uint32_t)*fabric_connection.get_backward_connection().buffer_slot_wrptr_ptr
-               << "\n";
-        DPRINT << "BWD Start rdptr = "
-               << (uint32_t)*fabric_connection.get_backward_connection().from_remote_buffer_slot_rdptr_ptr << "\n";
-    }
 
     cb_reserve_back(source_l1_cb_index, 1);
     cb_reserve_back(packet_header_cb, packet_header_size_in_headers);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -2977,10 +2977,6 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     using namespace ttnn::ccl;
     TT_FATAL(num_devices_with_workers <= line_size, "num_devices_with_workers must be less than or equal to num_links");
 
-    // if (params.line_sync) {
-    //     TT_FATAL(num_op_invocations == 1, "Performance reporting only supported for 1 invocation per test");
-    // }
-
     auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
 
     // static constexpr size_t source_l1_buffer_address = 1000000;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -224,12 +224,15 @@ std::tuple<std::shared_ptr<Buffer>, std::vector<uint32_t>> build_input_buffer(
     return {local_input_buffer, inputs};
 }
 
-static void build_and_enqueue(const std::vector<IDevice*>& devices, std::vector<Program>& programs) {
+static void build_and_enqueue(
+    const std::vector<IDevice*>& devices, std::vector<Program>& programs, bool enqueue_only = false) {
     TT_FATAL(
         devices.size() == programs.size(),
         "Number of devices must match number of programs when calling build_and_enqueue in test");
-    for (size_t i = 0; i < devices.size(); i++) {
-        tt::tt_metal::detail::CompileProgram(devices[i], programs[i]);
+    if (!enqueue_only) {
+        for (size_t i = 0; i < devices.size(); i++) {
+            tt::tt_metal::detail::CompileProgram(devices[i], programs[i]);
+        }
     }
     for (size_t i = 0; i < devices.size(); i++) {
         tt_metal::EnqueueProgram(devices[i]->command_queue(), programs[i], false);
@@ -2946,7 +2949,7 @@ TEST(CclAsyncOp, DISABLED_AllGather_PersistentFabric_Dim3_Links2_Shape1_1_32_819
 struct WriteThroughputStabilityTestWithPersistentFabricParams {
     size_t line_size = 4;
     size_t num_devices_with_workers = 0;
-    bool line_sync = false;
+    bool line_sync = true;
 };
 
 void RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -2974,9 +2977,9 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     using namespace ttnn::ccl;
     TT_FATAL(num_devices_with_workers <= line_size, "num_devices_with_workers must be less than or equal to num_links");
 
-    if (params.line_sync) {
-        TT_FATAL(num_op_invocations == 1, "Performance reporting only supported for 1 invocation per test");
-    }
+    // if (params.line_sync) {
+    //     TT_FATAL(num_op_invocations == 1, "Performance reporting only supported for 1 invocation per test");
+    // }
 
     auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
 
@@ -3040,15 +3043,22 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
             [dest_bank_addr](const auto& buffer) { return buffer->address() == dest_bank_addr; }),
         "Test setup error: all destination buffers must have the same bank address across devices");
 
-    auto global_semaphores = ttnn::global_semaphore::create_global_semaphore_with_same_address(
-        test_fixture.mesh_device_.get(),
-        devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
-        0,                             // initial value
-        tt::tt_metal::BufferType::L1,  // buffer type
-        1000                           // attempts
-    );
-    auto global_semaphore_addr =
-        ttnn::global_semaphore::get_global_semaphore_address(global_semaphores.global_semaphores.at(0));
+    std::vector<tt::tt_metal::DeviceAddr> global_semaphore_addrs;
+    global_semaphore_addrs.reserve(line_size + 1);
+    std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> global_semaphore_handles;
+    for (size_t i = 0; i < line_size * 4; i++) {
+        auto global_semaphores = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+            test_fixture.mesh_device_.get(),
+            devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+            0,                             // initial value
+            tt::tt_metal::BufferType::L1,  // buffer type
+            1000                           // attempts
+        );
+        global_semaphore_handles.push_back(global_semaphores);
+        auto global_semaphore_addr =
+            ttnn::global_semaphore::get_global_semaphore_address(global_semaphores.global_semaphores.at(0));
+        global_semaphore_addrs.push_back(global_semaphore_addr);
+    }
 
     std::vector<IDevice*> worker_devices;
     for (size_t i = 0; i < num_devices_with_workers; i++) {
@@ -3062,6 +3072,8 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
         "instead.",
         line_size,
         worker_devices.size());
+    std::vector<KernelHandle> worker_kernel_ids;
+    std::vector<size_t> per_device_global_sem_addr_rt_arg;
     for (size_t i = 0; i < num_devices_with_workers; i++) {
         const size_t line_index = i;
         auto& program = programs[i];
@@ -3113,6 +3125,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
             "tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp",
             worker_cores,
             tt_metal::WriterDataMovementConfig(worker_ct_args));
+        worker_kernel_ids.push_back(worker_kernel_id);
         for (size_t l = 0; l < num_links; l++) {
             auto worker_core = worker_cores_vec[l];
             auto build_connection_args = [&local_device_fabric_handle, device, &program, &worker_core](
@@ -3160,8 +3173,12 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
             if (params.line_sync) {
                 rt_args.push_back(sync_core_noc_x);
                 rt_args.push_back(sync_core_noc_y);
-                rt_args.push_back(global_semaphore_addr);
-                rt_args.push_back(num_links * num_devices_with_workers /*line_size*/);
+                if (l == 0) {
+                    per_device_global_sem_addr_rt_arg.push_back(rt_args.size());
+                }
+                TT_FATAL(global_semaphore_addrs.at(0) != -1, "Invalid test setup. Global semaphore address is -1");
+                rt_args.push_back(global_semaphore_addrs.at(0));
+                rt_args.push_back(num_links * num_devices_with_workers);
             }
 
             tt_metal::SetRuntimeArgs(program, worker_kernel_id, worker_core, rt_args);
@@ -3170,7 +3187,19 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
 
     for (size_t i = 0; i < num_op_invocations; i++) {
         log_info(tt::LogTest, "Iteration: {}", i);
-        build_and_enqueue(worker_devices, programs);
+        if (i != 0 && params.line_sync) {
+            for (size_t k = 0; k < worker_kernel_ids.size(); k++) {
+                auto& worker_rt_args_by_core = GetRuntimeArgs(programs[k], worker_kernel_ids[k]);
+                auto global_sem_addr_rt_arg_idx = per_device_global_sem_addr_rt_arg[k];
+                for (size_t l = 0; l < num_links; l++) {
+                    auto& worker_rt_args = worker_rt_args_by_core[worker_cores_vec[l].x][worker_cores_vec[l].y];
+                    worker_rt_args.at(global_sem_addr_rt_arg_idx) =
+                        global_semaphore_addrs[i % global_semaphore_addrs.size()];
+                }
+            }
+        }
+
+        build_and_enqueue(worker_devices, programs, i != 0);
 
         log_info(tt::LogTest, "Waiting for Op finish on all devices");
         wait_for_worker_subdevice_program_completion(worker_devices, subdevice_managers);
@@ -3180,7 +3209,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     TT_FATAL(fabric_programs->size() == devices.size(), "Expected fabric programs size to be same as devices size");
     log_info(tt::LogTest, "Fabric teardown");
     persistent_fabric_teardown_sequence(
-        devices, subdevice_managers, fabric_handle.value(), tt::fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+        devices, subdevice_managers, fabric_handle.value(), tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE);
 
     log_info(tt::LogTest, "Waiting for teardown completion");
     for (IDevice* d : devices) {
@@ -3204,7 +3233,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
     const size_t num_unicasts = 2;
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     params.line_size = 2;
@@ -3217,9 +3246,66 @@ TEST(EdmFabric, BasicMcastThroughputTest_SingleMcast) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_2Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+// hangs with DPRINT
+TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_2Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_SingleWorker_4Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 4;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+// First to hang - maybe somethign to do with merging traffic
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_TwoWorkers_4Device) {
+    const size_t num_mcasts = 9;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 4;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 2;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
@@ -3228,9 +3314,23 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap) {
     const size_t num_unicasts = 0;
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_SingleWorker_2Device) {
+    const size_t num_mcasts = 10;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const size_t line_size = 2;
+    const bool line_sync = false;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_size = line_size;
+    params.line_sync = line_sync;
+    params.num_devices_with_workers = 1;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
@@ -3240,7 +3340,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap_2Devic
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
     const size_t line_size = 2;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
@@ -3252,7 +3352,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderOneElemWrap_ReceiverNoWrap) {
     const size_t num_unicasts = 0;
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -3264,7 +3364,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_2D
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
     const size_t line_size = 2;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = line_size;
     params.line_sync = line_sync;
@@ -3276,7 +3376,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled) {
     const size_t num_unicasts = 0;
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -3287,7 +3387,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwoWrap_ReceiverOneWrap) {
     const size_t num_unicasts = 0;
     const size_t num_links = 1;
     const size_t num_op_invocations = 1;
-    const bool line_sync = false;
+    const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -3376,7 +3476,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SenderTwiceFilled_ReceiverOnceFilled_Li
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFourTImesFilled_ReceiverTwiceFilled_2Device_1Worker) {
     const size_t num_mcasts = 36;
     const size_t num_unicasts = 0;
     const size_t num_links = 1;
@@ -3461,7 +3561,7 @@ TEST(EdmFabric, BasicMcastThroughputTest_SmallPerf1) {
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 
-TEST(EdmFabric, BasicMcastThroughputTest_0) {
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_0) {
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
@@ -3469,16 +3569,20 @@ TEST(EdmFabric, BasicMcastThroughputTest_0) {
     const bool line_sync = false;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_size = 2;
+    params.line_sync = line_sync;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-TEST(EdmFabric, BasicMcastThroughputTest_1) {
+TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_1) {
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
     const bool line_sync = false;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_2) {
     const size_t num_mcasts = 50000;
@@ -3493,7 +3597,11 @@ TEST(EdmFabric, BasicMcastThroughputTest_3) {
     const size_t num_unicasts = 2;
     const size_t num_links = 2;
     const size_t num_op_invocations = 1;
-    RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
 TEST(EdmFabric, BasicMcastThroughputTest_4) {
     const size_t num_mcasts = 800000;
@@ -3550,7 +3658,6 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_10) {
     const size_t num_op_invocations = 50;
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-// DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
     const size_t num_mcasts = 100;
     const size_t num_unicasts = 2;
@@ -3558,7 +3665,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_6_Short) {
     const size_t num_op_invocations = 100;
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-// DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
     const size_t num_mcasts = 1000;
     const size_t num_unicasts = 2;
@@ -3566,7 +3672,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_7_Short) {
     const size_t num_op_invocations = 50;
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-// DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
     const size_t num_mcasts = 50000;
     const size_t num_unicasts = 2;
@@ -3574,7 +3679,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_8_Short) {
     const size_t num_op_invocations = 20;
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-// DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;
@@ -3582,7 +3686,6 @@ TEST(EdmFabric, BasicMcastThroughputTest_9_Short) {
     const size_t num_op_invocations = 10;
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
-// DISABLED due to long runtime
 TEST(EdmFabric, BasicMcastThroughputTest_10_Short) {
     const size_t num_mcasts = 800000;
     const size_t num_unicasts = 2;

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -446,7 +446,7 @@ def test_all_gather(
 @pytest.mark.parametrize("num_iters", [8])
 @pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_sharded(
-    pcie_mesh_device,
+    t3k_mesh_device,
     num_devices,
     output_shape,
     dim,
@@ -461,8 +461,11 @@ def test_all_gather_sharded(
     shard_grid,
     tensor_mem_layout,
 ):
+    if num_links > 1:
+        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
+
     run_all_gather_impl(
-        pcie_mesh_device,
+        t3k_mesh_device,
         num_devices,
         output_shape,
         dim,

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -528,7 +528,6 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
             case ttnn::ccl::cmd::CclCommandDestType::CHIP_MULTICAST: {
                 const auto& mcast_args = cmd_ctx.current_cmd_header.get_multicast_dest_args();
                 if (cmd_ctx.fabric_connection.has_forward_connection()) {
-                    DeviceZoneScopedN("SEND-FWD");
                     cmd_ctx.fabric_connection.get_forward_connection().wait_for_empty_write_slot();
                     pkt_hdr->to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{
                         1, static_cast<uint8_t>(mcast_args.num_targets_forward_direction)});
@@ -538,7 +537,6 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
 
                 // Write the mcast packet (backward)
                 if (cmd_ctx.fabric_connection.has_backward_connection()) {
-                    DeviceZoneScopedN("SEND-BWD");
                     pkt_hdr->to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{
                         1, static_cast<uint8_t>(mcast_args.num_targets_backward_direction)});
                     cmd_ctx.fabric_connection.get_backward_connection().wait_for_empty_write_slot();

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -528,6 +528,7 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
             case ttnn::ccl::cmd::CclCommandDestType::CHIP_MULTICAST: {
                 const auto& mcast_args = cmd_ctx.current_cmd_header.get_multicast_dest_args();
                 if (cmd_ctx.fabric_connection.has_forward_connection()) {
+                    DeviceZoneScopedN("SEND-FWD");
                     cmd_ctx.fabric_connection.get_forward_connection().wait_for_empty_write_slot();
                     pkt_hdr->to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{
                         1, static_cast<uint8_t>(mcast_args.num_targets_forward_direction)});
@@ -537,6 +538,7 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
 
                 // Write the mcast packet (backward)
                 if (cmd_ctx.fabric_connection.has_backward_connection()) {
+                    DeviceZoneScopedN("SEND-BWD");
                     pkt_hdr->to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{
                         1, static_cast<uint8_t>(mcast_args.num_targets_backward_direction)});
                     cmd_ctx.fabric_connection.get_backward_connection().wait_for_empty_write_slot();

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -243,7 +243,7 @@ private:
 
     FORCE_INLINE void update_edm_buffer_slot_wrptr() {
         uint64_t const noc_sem_addr = get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr);
-
+        DPRINT << "Tell EDM of packet\n";
         noc_inline_dw_write(noc_sem_addr, *this->buffer_slot_wrptr_ptr);
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -243,7 +243,6 @@ private:
 
     FORCE_INLINE void update_edm_buffer_slot_wrptr() {
         uint64_t const noc_sem_addr = get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr);
-        DPRINT << "Tell EDM of packet\n";
         noc_inline_dw_write(noc_sem_addr, *this->buffer_slot_wrptr_ptr);
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
@@ -118,7 +118,7 @@ struct PacketHeader {
     CommandType command_type : 2;
     ChipSendType chip_send_type : 1;
     NocSendType noc_send_type : 1;
-    uint8_t reserved : 4;
+    uint8_t src_ch_id : 4;
 
     RoutingFields routing_fields;
     uint16_t reserved2; // can be tagged with src device for debug
@@ -261,6 +261,7 @@ struct PacketHeader {
 
         return this;
     }
+    inline void set_src_ch_id(uint8_t ch_id) volatile { this->src_ch_id = ch_id; }
 };
 
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -17,7 +17,6 @@
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 
 #include "noc_overlay_parameters.h"
-// #include "tt_metal/hw/inc/wormhole/stream_interface.h"
 
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_counters.hpp"
 
@@ -293,9 +292,6 @@ void remote_update_ptr_val(uint32_t stream_id, int32_t val) {
 template <uint32_t stream_id>
 void init_ptr_val(int32_t val) {
     NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, val);
-    // static constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX);
-    // *reinterpret_cast<volatile uint32_t*>(addr) = val;
-
 }
 
 constexpr std::array<uint32_t, 2> to_sender_packets_acked_streams = {{

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -16,6 +16,9 @@
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 
+#include "noc_overlay_parameters.h"
+// #include "tt_metal/hw/inc/wormhole/stream_interface.h"
+
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_counters.hpp"
 
 
@@ -166,39 +169,6 @@ Packets 0, 2, and 3 are smaller than the full buffer size, while packet 1 is the
   buf 0           buf 1           buf 2           buf 3
 
 
-A detail of the channel structure is omitted from the above diagram, namely the EDM <-> EDM flow control region for each buffer.
-Each buffer really looks something like this:
-
-
-             &header->  |----------------| channel_base_address
-                        |    header      |
-            &payload->  |----------------|
-                        |                |
-                        |    payload     |
-                        |                |
-       &channel_sync->  |----------------|
-                        |  channel_sync  |  // This is new
-                        ------------------
-
-The "channel_sync" is an `eth_channel_sync_t` and is internal to the EDM implementation and is used to indicate packet
-transmission state between sender and receiver EDMs.
-
-The protocol for its use is:
-1) Sender updates the field indicating new data:
-   - set `bytes_sent` to a non-zero value indicating new data
-   - clear `receiver_ack` to 0
-   - set `src_id` to the sender channel id so the receiver knows who the sender was (and where the ack should go)
-2) Sender sends this channel sync to the corresponding location in the receiver channel (either in the same transmission
-   as the packet or separately)
-3) Receiver sees that `bytes_sent` is non-zero, indicating a new packet. It sends back an acknowledgement (first level):
-   - set `receiver_ack` to non-zero
-   *NOTE* IMPORTANT: To avoid a race, the receiver must be sure to send its channel_sync_t from a different address it uses
-   as for the second level acknowledgement
-   3b) When sender receives an ack, it understands it can overwrite its local copy of the packet with new data
-4) After receiver properly writes out its packet, it sends a second level acknowledgement, indicating it can receive new
-   data into this specific buffer index:
-   - clear the bytes_sent and receiver_ack fields and send back the `channel_sync` to the sender
-
 
 
 ## Sending Packets
@@ -215,6 +185,22 @@ Sending a packet is done as follows:
 The flow control protocol between EDM channels is built on a rd/wr ptr based protocol where pointers are
 to buffer slots within the channel (as opposed so something else like byte or word offset). Ptrs are
 free to advance independently from each other as long as there is no overflow or underflow.
+
+The flow control is implemented through the use of several stream registers: one per conceptual pointer being tracked.
+In total there are 5 such counters:
+1) to receiver channel packets sent
+  - Incremented by sender (via eth_reg_write) by the number of buffer slots written. In practice, this means it is
+    incremented once per packet
+2) to sender 0 packets acked
+  - Incremented by receiver for every new packet from channel 0 that it sees
+3) to sender 1 packets acked
+  - Incremented by receiver for every new packet from channel 1 that it sees
+4) to sender 0 packets completed
+  - Incremented by receiver for every packet from channel 0 that it completes processing for
+5) to sender 1 packets completed
+  - Incremented by receiver for every packet from channel 1 that it completes processing for
+
+See calls to `increment_local_update_ptr_val`, `remote_update_ptr_val`, `init_ptr_val` for more on implementation.
 
 ### Sender Channel Flow Control
 Both sender channels share the same flow control view into the receiver channel. This is because both channels
@@ -256,6 +242,71 @@ write to the same receiver channel.
 ////////////////////////////////////////////////
 // Data structures, types, enums, and constants
 ////////////////////////////////////////////////
+
+
+// senders update this stream
+static constexpr uint32_t to_receiver_pkts_sent_id = 0;
+// receivers updates the reg on this stream
+static constexpr uint32_t to_sender_0_pkts_acked_id = 1;
+// receivers updates the reg on this stream
+static constexpr uint32_t to_sender_1_pkts_acked_id = 2;
+// receivers updates the reg on this stream
+static constexpr uint32_t to_sender_0_pkts_completed_id = 3;
+// receivers updates the reg on this stream
+static constexpr uint32_t to_sender_1_pkts_completed_id = 4;
+
+// This will be an atomic register read to the register
+template <uint32_t stream_id>
+int32_t get_ptr_val() {
+    return NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    return *reinterpret_cast<volatile uint32_t*>(addr);
+}
+int32_t get_ptr_val(uint8_t stream_id) {
+    return NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    const uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    return *reinterpret_cast<volatile uint32_t*>(addr);
+}
+
+// Writing to this register will leverage the built-in stream hardware which will automatically perform an atomic increment
+// on the register. This can save precious erisc cycles by offloading a lot of pointer manipulation.
+// Additionally, these registers are accessible via eth_reg_write calls which can be used to write a value,
+// inline the eth command (without requiring source L1)
+template <uint32_t stream_id>
+void increment_local_update_ptr_val(int32_t val) {
+    NOC_STREAM_WRITE_REG_FIELD(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX, REMOTE_DEST_BUF_WORDS_FREE_INC, val);
+}
+void increment_local_update_ptr_val(uint8_t stream_id, int32_t val) {
+    NOC_STREAM_WRITE_REG_FIELD(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX, REMOTE_DEST_BUF_WORDS_FREE_INC, val);
+}
+
+template <uint32_t stream_id>
+void remote_update_ptr_val(int32_t val) {
+    constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
+    eth_write_remote_reg(addr, val << REMOTE_DEST_BUF_WORDS_FREE_INC);
+}
+void remote_update_ptr_val(uint32_t stream_id, int32_t val) {
+    const uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
+    eth_write_remote_reg(addr, val << REMOTE_DEST_BUF_WORDS_FREE_INC);
+}
+
+template <uint32_t stream_id>
+void init_ptr_val(int32_t val) {
+    NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, val);
+    // static constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX);
+    // *reinterpret_cast<volatile uint32_t*>(addr) = val;
+
+}
+
+constexpr std::array<uint32_t, 2> to_sender_packets_acked_streams = {{
+    to_sender_0_pkts_acked_id,
+    to_sender_1_pkts_acked_id
+}};
+
+constexpr std::array<uint32_t, 2> to_sender_packets_completed_streams = {{
+    to_sender_0_pkts_completed_id,
+    to_sender_1_pkts_completed_id
+}};
 
 /*
  * Tracks receiver channel pointers (from sender side)
@@ -376,6 +427,7 @@ static constexpr size_t num_messages_to_move_ctor_value = 1;
 static constexpr size_t receiver_channel_id = NUM_SENDER_CHANNELS;
 static constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 
+
 /////////////////////////////////////////////
 //   SENDER SIDE HELPERS
 /////////////////////////////////////////////
@@ -402,18 +454,14 @@ void send_next_data(
     tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS> &sender_buffer_channel,
     tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS> &sender_worker_interface,
     OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &outbound_to_receiver_channel_pointers,
-    tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &receiver_buffer_channel) {
+    tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &receiver_buffer_channel,
+    uint8_t sender_channel_index) {
 
     auto &remote_receiver_wrptr = outbound_to_receiver_channel_pointers.wrptr;
     auto &local_sender_wrptr = sender_worker_interface.local_wrptr;
     auto local_sender_wrptr_buffer_index = local_sender_wrptr.get_buffer_index();
 
     ASSERT(!eth_txq_is_busy());
-    ASSERT(
-        reinterpret_cast<size_t>(sender_buffer_channel.get_bytes_sent_address(local_sender_wrptr_buffer_index)) ==
-        (reinterpret_cast<size_t>(sender_buffer_channel.get_buffer_address(local_sender_wrptr_buffer_index)) +
-         reinterpret_cast<size_t>(sender_buffer_channel.get_max_eth_payload_size()) -
-         (uint32_t)sizeof(eth_channel_sync_t)));
 
     // TODO: TUNING - experiment with only conditionally breaking the transfer up into multiple packets if we are
     //       a certain threshold less than full packet
@@ -421,11 +469,13 @@ void send_next_data(
     //       compare
     //       NOTE: if we always send full packet, then we don't need the second branch below dedicated for
     //             channel sync
-    ASSERT(tt::fabric::is_valid(*const_cast<tt::fabric::PacketHeader *>(reinterpret_cast<volatile tt::fabric::PacketHeader *>(sender_buffer_channel.get_buffer_address(local_sender_wrptr_buffer_index)))));
-    const size_t payload_size = sender_buffer_channel.get_payload_plus_channel_sync_size(local_sender_wrptr_buffer_index);
-    *sender_buffer_channel.get_bytes_sent_address(local_sender_wrptr_buffer_index) = payload_size;
-    *sender_buffer_channel.get_bytes_acked_address(local_sender_wrptr_buffer_index) = 0;
-    *sender_buffer_channel.get_src_id_address(local_sender_wrptr_buffer_index) = sender_buffer_channel.get_id();
+    auto volatile *pkt_header =
+        reinterpret_cast<volatile tt::fabric::PacketHeader *>(sender_buffer_channel.get_buffer_address(local_sender_wrptr_buffer_index));
+    ASSERT(tt::fabric::is_valid(*const_cast<tt::fabric::PacketHeader *>(pkt_header)));
+    size_t payload_size = 0;
+    payload_size = pkt_header->get_payload_size_including_header();
+    pkt_header->src_ch_id = sender_channel_index;
+
     ASSERT(*sender_buffer_channel.get_src_id_address(local_sender_wrptr_buffer_index) < 2);
 
     auto src_addr = sender_buffer_channel.get_buffer_address(local_sender_wrptr_buffer_index);
@@ -437,20 +487,13 @@ void send_next_data(
         payload_size,
         payload_size >> ETH_BYTES_TO_WORDS_SHIFT);
 
-    bool sent_payload_and_channel_sync_in_one_shot =
-        payload_size == sender_buffer_channel.get_max_eth_payload_size();
-    if (!sent_payload_and_channel_sync_in_one_shot) {
-        // We weren't able to send the channel_sync_t in one shot with the payload so we need to send a second
-        // packet
-        // TODO: TUNING - consider busy waiting for a maximum amount of time
-        while (eth_txq_is_busy()) {}
-        send_channel_sync(
-            sender_buffer_channel, local_sender_wrptr, receiver_buffer_channel, remote_receiver_wrptr);
-    }
 
     // Note: We can only advance to the next buffer index if we have fully completed the send (both the payload and sync
     // messages)
     local_sender_wrptr.increment();
+    // update the remote reg
+    static constexpr uint32_t words_to_forward = 1;
+    remote_update_ptr_val<to_receiver_pkts_sent_id>(words_to_forward);
     remote_receiver_wrptr.increment();
 }
 
@@ -476,38 +519,10 @@ void receiver_send_received_ack(
     // Set the acknowledgement bits. We have a different location than the
 
     auto receiver_buffer_index = receiver_channel_ptr.get_buffer_index();
-    const auto src_id = *local_receiver_buffer_channel.get_src_id_address(receiver_buffer_index);
-    auto &sender_ackptr = remote_eth_sender_ackptrs[src_id];
-
     ASSERT(src_id < NUM_SENDER_CHANNELS);
-    const size_t local_ack_channel_sync_src_addr =
-        local_receiver_buffer_channel.get_eth_transaction_ack_word_addr() + (src_id * sizeof(eth_channel_sync_t));
-    reinterpret_cast<volatile eth_channel_sync_t *>(local_ack_channel_sync_src_addr)->bytes_sent = 1; // *local_receiver_buffer_channel.get_bytes_sent_address();
-    reinterpret_cast<volatile eth_channel_sync_t *>(local_ack_channel_sync_src_addr)->receiver_ack = 1;
-    reinterpret_cast<volatile eth_channel_sync_t *>(local_ack_channel_sync_src_addr)->src_id = src_id;
-    reinterpret_cast<volatile eth_channel_sync_t *>(local_ack_channel_sync_src_addr)->reserved_2 = 0xc0ffee2;
-
-    auto &sender_buffer_channel = remote_sender_channels[src_id];
-    auto sender_ackptr_buffer_index = sender_ackptr.get_buffer_index();
-    ASSERT(src_id < NUM_SENDER_CHANNELS);
-    ASSERT(
-        reinterpret_cast<size_t>(sender_buffer_channel.get_bytes_sent_address(sender_ackptr_buffer_index)) ==
-        reinterpret_cast<size_t>(sender_buffer_channel.get_buffer_address(sender_ackptr_buffer_index)) +
-            reinterpret_cast<size_t>(sender_buffer_channel.get_max_eth_payload_size()) -
-            sizeof(eth_channel_sync_t));
-    // Make sure we don't alias the erisc_info eth_channel_sync_t
-    ASSERT(
-        reinterpret_cast<volatile eth_channel_sync_t *>(local_receiver_buffer_channel.get_bytes_sent_address(receiver_buffer_index))
-            ->bytes_sent != 0);
-    ASSERT(
-        reinterpret_cast<volatile eth_channel_sync_t *>(local_receiver_buffer_channel.get_bytes_sent_address(receiver_buffer_index))
-            ->receiver_ack == 0);
-    ASSERT(!eth_txq_is_busy());
-    internal_::eth_send_packet_unsafe(
-        0,
-        local_ack_channel_sync_src_addr >> 4,
-        ((uint32_t)(sender_buffer_channel.get_bytes_sent_address(sender_ackptr_buffer_index))) >> 4,
-        1);
+    auto volatile *pkt_header = reinterpret_cast<volatile tt::fabric::PacketHeader *>(local_receiver_buffer_channel.get_buffer_address(receiver_buffer_index));
+    const auto src_id = pkt_header->src_ch_id;
+    remote_update_ptr_val(to_sender_packets_acked_streams[src_id], 1);
 }
 
 // MUST CHECK !is_eth_txq_busy() before calling
@@ -519,25 +534,13 @@ FORCE_INLINE void receiver_send_completion_ack(
     tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &local_receiver_buffer_channel) {
 
     auto receiver_buffer_index = receiver_channel_ptr.get_buffer_index();
-    volatile auto local_bytes_sent_addr = local_receiver_buffer_channel.get_bytes_sent_address(receiver_buffer_index);
-    volatile auto local_src_id_ptr = local_receiver_buffer_channel.get_src_id_address(receiver_buffer_index);
-    *(local_bytes_sent_addr) = 0;
-    *(local_receiver_buffer_channel.get_bytes_acked_address(receiver_buffer_index)) = 0;
 
-    auto src_sender_channel = *local_src_id_ptr;
-    auto &remote_sender_channel = remote_sender_channels[src_sender_channel];
-    auto &remote_sender_completion_ptr = remote_eth_sender_completion_ptrs[src_sender_channel];
-
-    ASSERT(src_sender_channel < NUM_SENDER_CHANNELS);
-    ASSERT(!eth_txq_is_busy());
-
-    internal_::eth_send_packet_unsafe(
-        0,
-        (uint32_t)(local_bytes_sent_addr) >> 4,
-        (uint32_t)(remote_sender_channel.get_bytes_sent_address(remote_sender_completion_ptr.get_buffer_index())) >> 4,
-        1);
-
+    ASSERT(src_id < NUM_SENDER_CHANNELS);
+    auto volatile *pkt_header = reinterpret_cast<volatile tt::fabric::PacketHeader *>(local_receiver_buffer_channel.get_buffer_address(receiver_buffer_index));
+    const auto src_id = pkt_header->src_ch_id;
+    remote_update_ptr_val(to_sender_packets_completed_streams[src_id], 1);
     receiver_channel_ptr.increment();
+    auto &remote_sender_completion_ptr = remote_eth_sender_completion_ptrs[src_id];
     remote_sender_completion_ptr.increment();
 }
 
@@ -547,6 +550,7 @@ PacketLocalForwardType get_packet_local_forward_type(const volatile tt::fabric::
     const bool packet_needs_forwarding = packet_must_be_forwarded_to_next_chip(packet_header);
     PacketLocalForwardType forward_type =
         static_cast<PacketLocalForwardType>(packet_needs_forwarding << 1 | local_chip_is_packet_destination);
+    DPRINT << "Forward type: " << (uint32_t)forward_type << "\n";
     return forward_type;
 }
 
@@ -605,7 +609,6 @@ bool run_sender_channel_step(
     tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &remote_receiver_channel,
     volatile tt::fabric::EdmFabricSenderChannelCounters* sender_channel_counters,
     PacketHeaderRecorder &packet_header_recorder,
-    bool graceful_termination_mode,
     bool &channel_connection_established,
     uint8_t sender_channel_index) {
     bool did_something = false;
@@ -613,81 +616,60 @@ bool run_sender_channel_step(
     // If the receiver has space, and we have one or more packets unsent from producer, then send one
     // TODO: convert to loop to send multiple packets back to back (or support sending multiple packets in one shot)
     //       when moving to stream regs to manage rd/wr ptrs
+    // TODO: update to be stream reg based. Initialize to space available and simply check for non-zero
     bool receiver_has_space_for_packet = outbound_to_receiver_channel_pointers.has_space_for_packet();
     if (receiver_has_space_for_packet && !eth_txq_is_busy()) {
         bool has_unsent_packet = local_sender_channel_worker_interface.has_unsent_payload();
         if (has_unsent_packet) {
             bool sender_backpressured_from_sender_side = !(local_sender_channel_worker_interface.local_rdptr.distance_behind(local_sender_channel_worker_interface.local_wrptr) < SENDER_NUM_BUFFERS);
             if (!sender_backpressured_from_sender_side) {
-                ASSERT(local_sender_channel.eth_is_receiver_channel_send_done(local_sender_channel_worker_interface.local_wrptr.get_buffer_index()));
                 did_something = true;
                 auto packet_header = reinterpret_cast<tt::fabric::PacketHeader*>(local_sender_channel.get_buffer_address(local_sender_channel_worker_interface.local_wrptr.get_buffer_index()));
-                tt::fabric::validate(*packet_header);
                 if constexpr (enable_packet_header_recording) {
+                    tt::fabric::validate(*packet_header);
                     packet_header_recorder.record_packet_header(packet_header);
                 }
+                print_pkt_header(packet_header);
                 send_next_data(
                     local_sender_channel,
                     local_sender_channel_worker_interface,
                     outbound_to_receiver_channel_pointers,
-                    remote_receiver_channel);
+                    remote_receiver_channel,
+                    sender_channel_index);
+                DPRINT << "\tSent\n";
             }
         }
     }
 
-    bool has_unacknowledged_eth_packets = outbound_to_receiver_channel_pointers.has_unacknowledged_or_incomplete_eth_packets();
-    if (has_unacknowledged_eth_packets) {
-        {
-            auto& sender_ackptr = local_sender_channel_worker_interface.local_ackptr;
-            auto old_ackptr = sender_ackptr;
-            // Only check for acks first
-            bool check_next = !local_sender_channel_worker_interface.all_eth_packets_acked();
-            while (check_next) {
-                // TODO: change how ack is represented so we can check both at once without
-                //       having to worry about races (i.e. right now we don't have monotonicity
-                //       but if we did we could safely (check ack || completed))
-                tt::fabric::BufferIndex rd_buffer_index = sender_ackptr.get_buffer_index();
-
-                bool acked_or_completed = local_sender_channel.eth_is_acked_or_completed(rd_buffer_index);
-                if (acked_or_completed) {
-                    local_sender_channel.eth_clear_sender_channel_ack(rd_buffer_index);
-                    sender_ackptr.increment();
-                    local_sender_channel_worker_interface.propagate_ackptr_to_connection_info();
-                    did_something = true;
-                    outbound_to_receiver_channel_pointers.ack_ptr.increment();
-                }
-                check_next = acked_or_completed && !local_sender_channel_worker_interface.all_eth_packets_acked();
-            }
-
-            bool advanced = old_ackptr.get_ptr() != sender_ackptr.get_ptr();
-            if (advanced && channel_connection_established) {
-                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr();
-            }
-        }
-
-        {
-            // stupid implementation but keeps things simple to bootstrap
-            auto& sender_rdptr = local_sender_channel_worker_interface.local_rdptr;
-            bool check_next = !local_sender_channel_worker_interface.all_eth_packets_completed();
-            while (check_next) {
-                bool completed = local_sender_channel.eth_is_receiver_channel_send_done(sender_rdptr.get_buffer_index());
-                if (completed) {
-                    did_something = true;
-                    if (local_sender_channel_worker_interface.local_ackptr.get_ptr() == sender_rdptr.get_ptr()) {
-                        // If ackptr is also here, then we need to increment it too
-                        outbound_to_receiver_channel_pointers.ack_ptr.increment();
-                        local_sender_channel_worker_interface.propagate_ackptr_to_connection_info();
-                        if (channel_connection_established) {
-                            local_sender_channel_worker_interface.update_worker_copy_of_read_ptr();
-                        }
-                    }
-                    outbound_to_receiver_channel_pointers.completion_ptr.increment();
-                    sender_rdptr.increment();
-                }
-                check_next = completed && !local_sender_channel_worker_interface.all_eth_packets_completed();
-            }
-        }
+    // Process COMPLETIONs from receiver
+    int32_t completions_since_last_check = get_ptr_val(to_sender_packets_completed_streams[sender_channel_index]);
+    if (completions_since_last_check > 0) {
+        auto& sender_rdptr = local_sender_channel_worker_interface.local_rdptr;
+        DPRINT << "EDMS got " << (uint32_t)completions_since_last_check << " completions since last check. Incrementing.\n";
+        outbound_to_receiver_channel_pointers.completion_ptr.increment_n(completions_since_last_check);
+        sender_rdptr.increment_n(completions_since_last_check);
+        DPRINT << "\tnew sendptr: " << (uint32_t)sender_rdptr.get_ptr() << "\n";
+        increment_local_update_ptr_val(to_sender_packets_completed_streams[sender_channel_index], -completions_since_last_check);
+        DPRINT << "\tnew sendptr (compl) after decrement: " << (uint32_t)get_ptr_val(to_sender_packets_completed_streams[sender_channel_index]) << "\n";
     }
+
+    // Process ACKs from receiver
+    // ACKs are processed second to avoid any sort of races. If we process acks second,
+    // we are guaranteed to see equal to or greater the number of acks than completions
+    auto acks_since_last_check = get_ptr_val(to_sender_packets_acked_streams[sender_channel_index]);
+
+    auto& sender_ackptr = local_sender_channel_worker_interface.local_ackptr;
+    if (acks_since_last_check > 0) {
+        sender_ackptr.increment_n(acks_since_last_check);
+        DPRINT << "EDMS got " << (uint32_t)acks_since_last_check << " acks since last check. Incrementing.\n";
+        if (channel_connection_established) {
+            local_sender_channel_worker_interface.update_worker_copy_of_read_ptr();
+        }
+        increment_local_update_ptr_val(to_sender_packets_acked_streams[sender_channel_index], -acks_since_last_check);
+        DPRINT << "\tnew sender ackptr after decrement: " << (uint32_t)get_ptr_val(to_sender_packets_acked_streams[sender_channel_index]) << "\n";
+    }
+    did_something = did_something || (completions_since_last_check + acks_since_last_check) > 0;
+
 
     if (!channel_connection_established) {
         // Can get rid of one of these two checks if we duplicate the logic above here in the function
@@ -729,14 +711,14 @@ void run_receiver_channel_step(
     PacketHeaderRecorder &packet_header_recorder,
     ReceiverState *const receiver_state_out) {
 
-    // Optimization:
-    //  1. Let wrptr advance ahead of ackptr
     auto &ack_ptr = receiver_channel_pointers.ack_ptr;
-    auto ack_ptr_buffer_index = ack_ptr.get_buffer_index();
-    bool packet_received = local_receiver_channel.eth_bytes_are_available_on_channel(ack_ptr_buffer_index) &&
-        receiver_channel_pointers.completion_ptr.distance_behind(ack_ptr) < RECEIVER_NUM_BUFFERS;
+    auto pkts_received_since_last_check = get_ptr_val<to_receiver_pkts_sent_id>();
+    bool pkts_received = pkts_received_since_last_check > 0;
     bool can_send_over_eth = !eth_txq_is_busy();
-    if (packet_received && can_send_over_eth) {
+    ASSERT(receiver_channel_pointers.completion_ptr.distance_behind(ack_ptr) < RECEIVER_NUM_BUFFERS);
+    if (pkts_received && can_send_over_eth) {
+        // currently only support processing one packet at a time, so we only decrement by 1
+        increment_local_update_ptr_val<to_receiver_pkts_sent_id>(-1);
         receiver_send_received_ack(
             remote_eth_sender_wrptrs,
             remote_sender_channnels,
@@ -750,9 +732,11 @@ void run_receiver_channel_step(
     if (unwritten_packets) {
         auto receiver_buffer_index = wr_sent_ptr.get_buffer_index();
         volatile auto packet_header = local_receiver_channel.get_packet_header(receiver_buffer_index);
+        print_pkt_header(packet_header);
         bool can_send_to_all_local_chip_receivers =
             can_forward_packet_completely(packet_header, downstream_edm_interface);
         if (can_send_to_all_local_chip_receivers) {
+            DPRINT << "EDMR Forwarding packet\n";
             receiver_forward_packet(packet_header, downstream_edm_interface);
             wr_sent_ptr.increment();
         }
@@ -761,8 +745,10 @@ void run_receiver_channel_step(
     auto &wr_flush_ptr = receiver_channel_pointers.wr_flush_ptr;
     bool unflushed_writes = !wr_flush_ptr.is_caught_up_to(wr_sent_ptr);
     if (unflushed_writes) {
+        DPRINT << "Unflushed writes\n";
         bool writes_flushed = ncrisc_noc_nonposted_writes_sent(noc_index);
         if (writes_flushed) {
+            DPRINT << "EDMR packet write flushed\n";
             auto receiver_buffer_index = wr_flush_ptr.get_buffer_index();
             local_receiver_channel.eth_clear_sender_channel_ack(receiver_buffer_index);
             wr_flush_ptr.increment();
@@ -772,8 +758,10 @@ void run_receiver_channel_step(
     auto &completion_ptr = receiver_channel_pointers.completion_ptr;
     bool unsent_completions = !completion_ptr.is_caught_up_to(wr_flush_ptr);
     if (unsent_completions) {
+        DPRINT << "Unsent completions\n";
         bool can_send_without_blocking = !eth_txq_is_busy();
         if (can_send_without_blocking) {
+            DPRINT << "EDMR sending completion ack\n";
             // completion ptr incremented in callee
             receiver_send_completion_ack(
                 remote_eth_sender_wrptrs,
@@ -800,17 +788,22 @@ FORCE_INLINE bool got_termination_signal(volatile tt::fabric::TerminationSignal 
 template <size_t RECEIVER_NUM_BUFFERS, size_t SENDER_NUM_BUFFERS, size_t NUM_SENDER_CHANNELS>
 bool all_channels_drained(tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &local_receiver_channel,
                           std::array<tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &local_sender_channels,
-                          std::array<tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &local_sender_channel_worker_interfaces) {
+                          std::array<tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &local_sender_channel_worker_interfaces,
+                          ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &receiver_channel_pointers) {
 
     bool eth_buffers_drained =
-        !local_sender_channel_worker_interfaces[0].has_unacked_sends() &&
-        !local_sender_channel_worker_interfaces[1].has_unacked_sends() &&
-        local_receiver_channel.all_buffers_drained();
+        local_sender_channel_worker_interfaces[0].all_eth_packets_completed() &&
+        local_sender_channel_worker_interfaces[1].all_eth_packets_completed() &&
+        !local_sender_channel_worker_interfaces[0].has_unsent_payload() &&
+        !local_sender_channel_worker_interfaces[1].has_unsent_payload() &&
+        receiver_channel_pointers.completion_ptr.is_caught_up_to(receiver_channel_pointers.ack_ptr) &&
+        get_ptr_val<to_receiver_pkts_sent_id>() == 0 &&
+        get_ptr_val<to_sender_0_pkts_acked_id>() == 0 &&
+        get_ptr_val<to_sender_1_pkts_acked_id>() == 0 &&
+        get_ptr_val<to_sender_0_pkts_completed_id>() == 0 &&
+        get_ptr_val<to_sender_1_pkts_completed_id>() == 0;
 
-    bool sender0_has_unsent_packets = local_sender_channel_worker_interfaces[0].has_unsent_payload();
-    bool sender1_has_unsent_packets = local_sender_channel_worker_interfaces[1].has_unsent_payload();
-
-    return eth_buffers_drained && !sender0_has_unsent_packets && !sender1_has_unsent_packets;
+    return eth_buffers_drained;
 }
 
 /*
@@ -856,7 +849,7 @@ void run_fabric_edm_main_loop(
         if (got_graceful_termination) {
             DPRINT << "EDM Graceful termination\n";
             bool all_drained = all_channels_drained<RECEIVER_NUM_BUFFERS, SENDER_NUM_BUFFERS, NUM_SENDER_CHANNELS>(
-                local_receiver_channel, local_sender_channels, local_sender_channel_worker_interfaces);
+                local_receiver_channel, local_sender_channels, local_sender_channel_worker_interfaces, receiver_channel_pointers);
 
             if (all_drained) {
                 return;
@@ -875,7 +868,6 @@ void run_fabric_edm_main_loop(
             remote_receiver_channel,
             sender_channel_counters_ptrs[sender_channel_index],
             sender_channel_packet_recorders[sender_channel_index],
-            got_graceful_termination,
             channel_connection_established[sender_channel_index],
             sender_channel_index);
 
@@ -909,6 +901,15 @@ void kernel_main() {
     static constexpr size_t handshake_addr = get_compile_time_arg_val(2);
     *reinterpret_cast<volatile uint32_t*>(handshake_addr) = 0;
     auto eth_transaction_ack_word_addr = handshake_addr + sizeof(eth_channel_sync_t);
+
+    // Initialize stream register state for credit management across the Ethernet link.
+    // We make sure to do this before we handshake to guarantee that the registers are
+    // initialized before the other side has any possibility of modifying them.
+    init_ptr_val<to_receiver_pkts_sent_id>(0);
+    init_ptr_val<to_sender_0_pkts_acked_id>(0);
+    init_ptr_val<to_sender_1_pkts_acked_id>(0);
+    init_ptr_val<to_sender_0_pkts_completed_id>(0);
+    init_ptr_val<to_sender_1_pkts_completed_id>(0);
 
     static constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
     if constexpr (is_handshake_sender) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -11,6 +11,7 @@
 #include "debug/dprint.h"
 #include "dataflow_api.h"
 #include "tt_metal/hw/inc/ethernet/tunneling.h"
+#include "tt_metal/hw/inc/utils/utils.h"
 #include "risc_attribs.h"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"
@@ -42,7 +43,7 @@ using BufferPtr = NamedType<uint8_t, struct BufferPtrType>;
 template <size_t LIMIT, typename T>
 auto wrap_increment(T val) -> T {
     static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
-    constexpr bool is_pow2 = (LIMIT & (LIMIT - 1)) == 0;
+    constexpr bool is_pow2 = is_power_of_2(LIMIT);
     if constexpr (LIMIT == 1) {
         return val;
     } else if constexpr (LIMIT == 2) {
@@ -56,7 +57,7 @@ auto wrap_increment(T val) -> T {
 template <size_t LIMIT, typename T>
 auto wrap_increment_n(T val, uint8_t increment) -> T {
     static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
-    constexpr bool is_pow2 = (LIMIT & (LIMIT - 1)) == 0;
+    constexpr bool is_pow2 = is_power_of_2(LIMIT);
     if constexpr (LIMIT == 1) {
         return val;
     } else if constexpr (LIMIT == 2) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17430

### Problem description
Flow control between sender and receiver channels is currently done by embedding the information within the channel buffer directly. As a result several tradeoffs are introduced:
- Fixed max packet size
- Tradeoff decision to send larger packet with garbage data or send two packets for flow control
- Numerous additional arithmetic calculations to determine offsets in the channel buffer to find next `channel_syncs` (the embedded memory containing flow control info per packet).

### What's changed
Make use of stream registers to track credit exchange between sender/receiver in EDM fabric. These stream registers can be written two and have an atomic increment feature on write. This includes all write type (local and from eth_reg_write). This saves us lots of calculations that were previously spent on computing offsets into channel buffers for reading of channel syncs.

The flow control is implemented through the use of several stream registers: one per conceptual pointer being tracked.
In total there are 5 such pointers (registers) in use:
1) to receiver channel packets sent
  - Incremented by sender (via eth_reg_write) by the number of buffer slots written. In practice, this means it is
    incremented once per packet
2) to sender 0 packets acked
  - Incremented by receiver for every new packet from channel 0 that it sees
3) to sender 1 packets acked
  - Incremented by receiver for every new packet from channel 1 that it sees
4) to sender 0 packets completed
  - Incremented by receiver for every packet from channel 0 that it completes processing for
5) to sender 1 packets completed
  - Incremented by receiver for every packet from channel 1 that it completes processing for

All updates to the remote copy of the pointer are performed through the eth_reg_write API, which enables the caller to embed the payload in the command submitted to the eth tx command queue.

### Note on Source Channel Identification
The receiver channel needs to know who sent each given packet so it can correctly direct acks to the right producer sender channel. The new implementation here is to require the sender channel to write their channel ID to the new sender channel field in the packet header. This field is only used by the sender and receiver channel and is otherwise reserved. The receiver reads this part of the header to understand which of the above ack/completion registers to `eth_reg_write` to. 

### Future Work
Future work will include further evaluation for other places in the kernel that can make use of this register (but for other streams) if it saves additional calculations. Every cycle saved by Erisc directly leads to lower latency and higher throughput.

Additionally, with this new flow-control mechanism, the EDM fabric can be migrated to word based credits rather than buffer slots.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/13150055685
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13150059668
  - t3k nightly was failing due to regression on main which shows up on certain machines (has to do with device boot order)
    - Two unknowingly conflicting changes merged around the same time
    - Last commit to PR recovers passing behaviour to t3k nightly and pipeline is here: https://github.com/tenstorrent/tt-metal/actions/runs/13168041775
- [x] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13150062428
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) - N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
