### PR TITLE
optimize edm fabric packet header structure

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -8,7 +8,7 @@
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp"
-
+#include "ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
 struct unicast_mode {
     uint8_t distance;
 };
@@ -122,31 +122,19 @@ void kernel_main() {
 
         // bit of a hack to extract X/Y
         const auto dest_noc_address = get_noc_addr(p, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
-        const size_t dest_addr = dest_noc_address & 0xFFFFFFFF;
-        const size_t dest_noc_x = (dest_noc_address >> NOC_ADDR_LOCAL_BITS) & ((1 << NOC_ADDR_NODE_ID_BITS) - 1);
-        const size_t dest_noc_y =
-            (dest_noc_address >> (NOC_ADDR_LOCAL_BITS + NOC_ADDR_NODE_ID_BITS)) & ((1 << NOC_ADDR_NODE_ID_BITS) - 1);
         const size_t packet_size = page_size + sizeof(tt::fabric::PacketHeader);
-
         auto packet_addr = get_read_ptr(cb_id_in0);
         auto& packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(packet_addr);
         if constexpr (mcast_mode) {
-            packet_header.to_write()
+            packet_header
                 .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
-                .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                    dest_addr,
-                    (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader),
-                    static_cast<uint8_t>(dest_noc_x),
-                    static_cast<uint8_t>(dest_noc_y)});
+                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                    dest_noc_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
             packet_header.reserved2 = 0x1111;  // debug only
         } else {
-            packet_header.to_write()
-                .to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
-                .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                    dest_addr,
-                    (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader),
-                    static_cast<uint8_t>(dest_noc_x),
-                    static_cast<uint8_t>(dest_noc_y)});
+            packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
+                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                    dest_noc_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
             packet_header.reserved2 = 0x1111;  // debug only
         }
 
@@ -160,10 +148,11 @@ void kernel_main() {
 
         auto& packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(a_packet_header_addr);
         ASSERT(*last_message_semaphore_address == 0);
-        packet_header.to_atomic_inc();
+        uint64_t last_message_semaphore_noc0_addr =
+            safe_get_noc_addr(my_x[0], my_y[0], (uint32_t)last_message_semaphore_address, 0);
         packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{2});
-        packet_header.to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader(
-            reinterpret_cast<size_t>(last_message_semaphore_address), 1, 32, my_x[0], my_y[0]));
+        packet_header.to_noc_unicast_atomic_inc(
+            tt::fabric::NocUnicastAtomicIncCommandHeader(last_message_semaphore_noc0_addr, 1, 32));
 
         sender.send_payload_blocking_from_address(
             a_packet_header_addr, packet_header.get_payload_size_including_header());

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
@@ -51,28 +51,20 @@ auto forward_to_fabric_from_cb(
     sender.wait_for_empty_write_slot();
 
     // bit of a hack to extract X/Y
-    const auto dest_noc_address = get_noc_addr(current_page, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
-    const auto [dest_worker_noc, dest_addr] = get_noc_address_components(dest_noc_address);
+    const auto noc0_dest_address = get_noc_addr(current_page, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
     const size_t packet_size = page_size + sizeof(tt::fabric::PacketHeader);
 
     auto packet_addr = get_read_ptr(cb_id);
     auto &packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(packet_addr);
     if constexpr (mcast_mode) {
-        packet_header.to_write()
+        packet_header
             .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
-            .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                dest_addr,
-                (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader),
-                static_cast<uint8_t>(dest_worker_noc.x),
-                static_cast<uint8_t>(dest_worker_noc.y)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                noc0_dest_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
     } else {
-        packet_header.to_write()
-            .to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
-            .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                dest_addr,
-                (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader),
-                static_cast<uint8_t>(dest_worker_noc.x),
-                static_cast<uint8_t>(dest_worker_noc.y)});
+        packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                noc0_dest_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
     }
 
     uint64_t buffer_address = sender.edm_buffer_addr + (*sender.buffer_index_ptr * (sender.buffer_size_bytes + sizeof(eth_channel_sync_t)));
@@ -196,15 +188,10 @@ void kernel_main() {
     ASSERT(*last_message_semaphore_address == 0);
     packet_header.reserved = 0xE;
     packet_header.reserved2 = 0xFFFF;
-    packet_header.to_atomic_inc();
+    uint64_t last_message_sem_noc_addr = get_noc_addr(my_x[0], my_y[0], last_message_semaphore_address);
     packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{kLoopbackNumHopsToMyChip});
-    packet_header.to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader(
-            reinterpret_cast<size_t>(last_message_semaphore_address),
-            1,
-            32,
-            my_x[0],
-            my_y[0]
-        ));
+    packet_header.to_noc_unicast_atomic_inc(
+        tt::fabric::NocUnicastAtomicIncCommandHeader(last_message_sem_noc_addr, 1, 32));
 
     sender.send_payload_blocking_from_address(a_packet_header_addr, packet_header.get_payload_size_including_header());
 

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
@@ -23,20 +23,18 @@ bool terminate_fabric_endpoints_farthest_to_nearest (
             closed = true;
             sender.close();
         }
+        uint64_t termination_sig_noc_addr = get_noc_addr(edm_noc_x, edm_noc_y, termination_addr);
         if (distance == 0) {
-            noc_inline_dw_write(get_noc_addr(edm_noc_x, edm_noc_y, termination_addr), tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE);
+            noc_inline_dw_write(
+                get_noc_addr(edm_noc_x, edm_noc_y, termination_addr),
+                tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE);
         } else {
             auto &packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(a_packet_header_addr);
             reinterpret_cast<volatile uint32_t*>(a_packet_header_addr)[sizeof(tt::fabric::PacketHeader) >> 2] = tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE;
             sender.wait_for_empty_write_slot();
-            packet_header.to_write()
-                .to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{static_cast<uint8_t>(distance)})
-                .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                    termination_addr,
-                    sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t),
-                    static_cast<uint8_t>(edm_noc_x),
-                    static_cast<uint8_t>(edm_noc_y)
-                });
+            packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{static_cast<uint8_t>(distance)})
+                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                    termination_sig_noc_addr, sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t)});
             sender.send_payload_blocking_from_address(a_packet_header_addr, packet_header.get_payload_size_including_header());
             noc_async_writes_flushed();
         }

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -51,8 +51,8 @@ def run_with_trace(
     output_tensor_mesh = ttnn.experimental.reduce_scatter_async(
         input_tensor_mesh,
         dim=dim,
-        from_remote_multi_device_global_semaphore=from_remote_semaphore_handles,
-        to_remote_multi_device_global_semaphore=to_remote_semaphore_handles,
+        from_remote_multi_device_global_semaphore=from_remote_semaphore_handles[0],
+        to_remote_multi_device_global_semaphore=to_remote_semaphore_handles[0],
         math_op=math_op,
         num_links=num_links,
         memory_config=output_mem_config,
@@ -69,8 +69,10 @@ def run_with_trace(
         output_tensor_mesh = ttnn.experimental.reduce_scatter_async(
             input_tensor_mesh,
             dim=dim,
-            from_remote_multi_device_global_semaphore=from_remote_semaphore_handles,
-            to_remote_multi_device_global_semaphore=to_remote_semaphore_handles,
+            from_remote_multi_device_global_semaphore=from_remote_semaphore_handles[
+                i % len(from_remote_semaphore_handles)
+            ],
+            to_remote_multi_device_global_semaphore=to_remote_semaphore_handles[i % len(to_remote_semaphore_handles)],
             math_op=math_op,
             num_links=num_links,
             memory_config=output_mem_config,
@@ -168,16 +170,12 @@ def run_reduce_scatter_test(
     mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    from_remote_semaphore_handles = create_global_semaphore_with_same_address(
-        mesh_device,
-        ccl_sub_device_crs,
-        0,  # , search_max=True
-    )
-    to_remote_semaphore_handles = create_global_semaphore_with_same_address(
-        mesh_device,
-        ccl_sub_device_crs,
-        0,  # , search_max=True
-    )
+    from_remote_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+    to_remote_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
     mesh_device.set_sub_device_stall_group([worker_sub_device_id])
     debug = False
 
@@ -237,8 +235,12 @@ def run_reduce_scatter_test(
             output_tensor_mesh = ttnn.experimental.reduce_scatter_async(
                 input_tensor_mesh,
                 dim=dim,
-                from_remote_multi_device_global_semaphore=from_remote_semaphore_handles,
-                to_remote_multi_device_global_semaphore=to_remote_semaphore_handles,
+                from_remote_multi_device_global_semaphore=from_remote_semaphore_handles[
+                    i % len(from_remote_semaphore_handles)
+                ],
+                to_remote_multi_device_global_semaphore=to_remote_semaphore_handles[
+                    i % len(to_remote_semaphore_handles)
+                ],
                 math_op=math_op,
                 num_links=num_links,
                 memory_config=output_mem_config,
@@ -246,9 +248,9 @@ def run_reduce_scatter_test(
                 subdevice_id=worker_sub_device_id,
             )
 
-        logger.info(f"Waiting for op to finish all iterations")
-        ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
-        logger.info(f"Done iterations")
+            logger.info(f"Waiting for op to finish all iterations")
+            ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done iterations")
 
     # Compute golden
     # TODO: Make it model how reduce scatter actually works for numerical correctness/ordering

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
@@ -26,7 +26,6 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     FabricConnectionManager& fabric_connection,
     size_t& l1_read_addr,
     uint32_t payload_size_bytes) {
-    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
     const size_t payload_l1_address = l1_read_addr;
 
     auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
@@ -35,8 +34,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
 #endif
 
     size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+    pkt_hdr->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
 
     switch (current_cmd_header.dest_type) {
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: {

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp
@@ -7,6 +7,7 @@
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 
 #include "dataflow_api.h"
+#include "noc_nonblocking_api.h"
 #include <cstdint>
 
 // NOTE: This will eventually be updated with an official API
@@ -16,15 +17,16 @@ FORCE_INLINE bool is_using_noc_coords(uint16_t noc_x, uint16_t noc_y) {
     return noc_x < VIRTUAL_COORDS_START_X && noc_y < VIRTUAL_COORDS_START_Y;
 }
 
-FORCE_INLINE uint64_t safe_get_noc_addr(uint8_t dest_noc_x, uint8_t dest_noc_y, uint32_t dest_bank_addr) {
+FORCE_INLINE uint64_t
+safe_get_noc_addr(uint8_t dest_noc_x, uint8_t dest_noc_y, uint32_t dest_bank_addr, uint8_t noc_id = noc_index) {
     bool using_noc_coords = is_using_noc_coords(dest_noc_x, dest_noc_y);
     uint8_t noc_x = dest_noc_x;
     uint8_t noc_y = dest_noc_y;
     if (using_noc_coords) {
-        noc_x = NOC_X_PHYS_COORD(dest_noc_x);
-        noc_y = NOC_Y_PHYS_COORD(dest_noc_y);
+        noc_x = NOC_0_X_PHYS_COORD(noc_id, noc_size_x, dest_noc_x);
+        noc_y = NOC_0_Y_PHYS_COORD(noc_id, noc_size_y, dest_noc_y);
     }
-    return get_noc_addr(noc_x, noc_y, dest_bank_addr);
+    return get_noc_addr(noc_x, noc_y, dest_bank_addr, noc_id);
 }
 // TODO: COMMONIZE WITH THE ONE IN `ccl_send_writer.cpp`
 FORCE_INLINE std::pair<ttnn::ccl::WorkerXY, uint32_t> get_noc_address_components(uint64_t noc_addr) {

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -125,7 +125,7 @@ template <
     tt::tt_metal::BufferType buffer_type,
     tt::tt_metal::Layout page_layout,
     typename ShardingInfoType>
-FORCE_INLINE auto build_source_address_generator(
+auto build_source_address_generator(
     std::size_t& arg_idx,
     address_t tensor_address,
     std::size_t page_size,
@@ -208,7 +208,7 @@ void update_ccl_command(
 
 template <typename Addrgen>
 struct command_context_t final {
-    FORCE_INLINE command_context_t(
+    command_context_t(
         FabricConnectionManager& fabric_connection,
         Addrgen& addrgen,
         uint16_t num_commands,
@@ -269,7 +269,7 @@ struct command_context_t final {
 
     FORCE_INLINE bool current_command_active() const { return populated; }
 
-    FORCE_INLINE void fetch_next_command() {
+    void fetch_next_command() {
         populated = true;
 
         this->current_cmd_header = ttnn::ccl::cmd::CclCommandHeader::from_uint32(get_arg_val<uint32_t>(arg_idx++));
@@ -416,7 +416,7 @@ void update_ccl_command(
 }
 
 template <typename Addrgen>
-FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrgen>& cmd_ctx) {
+void try_advance_inline_write_or_atomic_inc(command_context_t<Addrgen>& cmd_ctx) {
     const size_t value = cmd_ctx.cmd_specific_ctx.inline_value_ctx.value;
     const size_t dest_bank_addr = cmd_ctx.dest_addr_info.address;
     bool is_remote_atomic_inc_over_fabric = cmd_ctx.command_requires_fabric();
@@ -432,31 +432,23 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
                                     ? my_y[0]
                                     : cmd_ctx.core_desc_info.core_desc_args.noc_unicast.y;
 
+    bool write_local = !is_remote_atomic_inc_over_fabric;
     if (is_remote_atomic_inc_over_fabric) {
         ASSERT(cmd_ctx.core_desc_type == ttnn::ccl::cmd::CclCommandCoreDescriptorType::NOC_XY);
-        // For now, we won't skip if we are waiting for space from fabric
-        // since we assume the other command stream will need to wait anyways
-        bool can_write_into_fabric = true;
-        if (!can_write_into_fabric) {
-            return;
-        }
 
         ASSERT(cmd_ctx.packet_header_buffer_addr != 0);
         auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(cmd_ctx.packet_header_buffer_addr);
-        if (cmd_ctx.current_cmd_header.code == ttnn::ccl::cmd::CclCommandCode::ATOMIC_INC) {
-            pkt_hdr->to_atomic_inc();
-        } else {
-            pkt_hdr->to_write();
-        }
 #ifdef DEBUG_PRINT_ENABLED
         pkt_hdr->reserved2 = my_chip_id;
 #endif
-        pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
-            dest_bank_addr,
-            static_cast<uint16_t>(value),
-            32,
-            static_cast<uint8_t>(dest_noc0_x),
-            static_cast<uint8_t>(dest_noc0_y)});
+        uint64_t dest_noc_addr_for_pkt = safe_get_noc_addr(dest_noc0_x, dest_noc0_y, dest_bank_addr, 0);
+        if (cmd_ctx.current_cmd_header.code == ttnn::ccl::cmd::CclCommandCode::ATOMIC_INC) {
+            pkt_hdr->to_noc_unicast_atomic_inc(
+                tt::fabric::NocUnicastAtomicIncCommandHeader{dest_noc_addr_for_pkt, static_cast<uint16_t>(value), 32});
+        } else {
+            pkt_hdr->to_noc_unicast_write(
+                tt::fabric::NocUnicastCommandHeader{dest_noc_addr_for_pkt, static_cast<uint16_t>(value)});
+        }
 
         switch (cmd_ctx.current_cmd_header.dest_type) {
             case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: {
@@ -471,11 +463,12 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
                     cmd_ctx.packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
             } break;
             case ttnn::ccl::cmd::CclCommandDestType::CHIP_MULTICAST: {
+                write_local = true;
                 const auto& mcast_args = cmd_ctx.current_cmd_header.get_multicast_dest_args();
                 if (cmd_ctx.fabric_connection.has_forward_connection()) {
-                    cmd_ctx.fabric_connection.get_forward_connection().wait_for_empty_write_slot();
                     pkt_hdr->to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{
                         1, static_cast<uint8_t>(mcast_args.num_targets_forward_direction)});
+                    cmd_ctx.fabric_connection.get_forward_connection().wait_for_empty_write_slot();
                     cmd_ctx.fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
                         cmd_ctx.packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
                 }
@@ -489,13 +482,6 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
                         cmd_ctx.packet_header_buffer_addr, sizeof(tt::fabric::PacketHeader));
                 }
 
-                uint64_t dest_noc_addr = safe_get_noc_addr(dest_noc0_x, dest_noc0_y, dest_bank_addr);
-                if (cmd_ctx.current_cmd_header.code == ttnn::ccl::cmd::CclCommandCode::ATOMIC_INC) {
-                    noc_semaphore_inc(dest_noc_addr, value);
-                } else if (cmd_ctx.current_cmd_header.code == ttnn::ccl::cmd::CclCommandCode::RAW_INLINE_WRITE_BYTES) {
-                    noc_inline_dw_write(dest_noc_addr, value);
-                }
-
             } break;
 
             default: {
@@ -503,8 +489,9 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
             } break;
         };
 
-    } else {
-        const uint64_t dest_noc_addr = get_noc_addr(dest_noc0_x, dest_noc0_y, dest_bank_addr);
+    }
+    if (write_local) {
+        uint64_t dest_noc_addr = get_noc_addr(dest_noc0_x, dest_noc0_y, dest_bank_addr);
         if (cmd_ctx.current_cmd_header.code == ttnn::ccl::cmd::CclCommandCode::ATOMIC_INC) {
             noc_semaphore_inc(dest_noc_addr, value);
         } else if (cmd_ctx.current_cmd_header.code == ttnn::ccl::cmd::CclCommandCode::RAW_INLINE_WRITE_BYTES) {
@@ -515,7 +502,7 @@ FORCE_INLINE void try_advance_inline_write_or_atomic_inc(command_context_t<Addrg
 
 #ifndef NO_TENSOR_MODE
 template <tt::tt_metal::TensorMemoryLayout TENSOR_LAYOUT, tt::tt_metal::Layout MEM_LAYOUT, typename Addrgen>
-FORCE_INLINE void try_advance_read_tensor_to_cb(command_context_t<Addrgen>& cmd_ctx) {
+void try_advance_read_tensor_to_cb(command_context_t<Addrgen>& cmd_ctx) {
     if (!cb_pages_reservable_at_back(cmd_ctx.cb_id, cmd_ctx.packet_size_in_pages)) {
         return;
     }
@@ -566,14 +553,13 @@ FORCE_INLINE void try_advance_read_tensor_to_cb(command_context_t<Addrgen>& cmd_
 }
 #endif
 
-FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
+void write_and_advance_local_read_address_for_fabric_write(
     uint64_t noc0_dest_noc_addr,
     size_t packet_header_buffer_addr,
     const ttnn::ccl::cmd::CclCommandHeader& current_cmd_header,
     FabricConnectionManager& fabric_connection,
     size_t& l1_read_addr,
     uint32_t payload_size_bytes) {
-    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
     const size_t payload_l1_address = l1_read_addr;
 
     auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
@@ -582,8 +568,8 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
 #endif
 
     size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+    pkt_hdr->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+        noc0_dest_noc_addr, packet_send_size_bytes});
 
     switch (current_cmd_header.dest_type) {
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: {
@@ -592,13 +578,16 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
                                                                   : fabric_connection.get_backward_connection();
 
             pkt_hdr->to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{unicast_args.distance_in_hops});
+
             fabric_conn.wait_for_empty_write_slot();
             fabric_conn.send_payload_without_header_non_blocking_from_address(l1_read_addr, payload_size_bytes);
             fabric_conn.send_payload_flush_blocking_from_address((uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
         } break;
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_MULTICAST: {
+            const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
+            uint64_t dest_noc_addr = safe_get_noc_addr(static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y), dest_addr);
             noc_async_write(
-                payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
+                payload_l1_address, dest_noc_addr, payload_size_bytes);
             const auto& mcast_args = current_cmd_header.get_multicast_dest_args();
             if (fabric_connection.has_forward_connection()) {
                 pkt_hdr->to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{
@@ -670,7 +659,7 @@ FORCE_INLINE void write_payload_then_advance_read_address(
 // based on command type so we can avoid the perf overhead of the branching that would otherwise
 // be required.
 template <tt::tt_metal::TensorMemoryLayout TENSOR_LAYOUT, tt::tt_metal::Layout MEM_LAYOUT, typename Addrgen>
-FORCE_INLINE void try_advance_write_tensor_from_cb(command_context_t<Addrgen>& cmd_ctx) {
+void try_advance_write_tensor_from_cb(command_context_t<Addrgen>& cmd_ctx) {
     if (!cb_pages_available_at_front(cmd_ctx.cb_id, cmd_ctx.packet_size_in_pages)) {
         return;
     }
@@ -748,7 +737,7 @@ FORCE_INLINE static ttnn::ccl::cmd::noc_transfer_info advance_to_next_noc_transa
     return noc_transfer_info;
 }
 
-FORCE_INLINE static void try_advance_noc_read_burst(
+static void try_advance_noc_read_burst(
     noc_transfer_burst_context& noc_burst_ctx, uint32_t cb_id, uint32_t packet_size_in_pages, arg_idx_t& arg_idx) {
     if (!cb_pages_reservable_at_back(cb_id, packet_size_in_pages)) {
         return;
@@ -805,7 +794,7 @@ static void try_advance_noc_write_burst(
 }
 
 template <tt::tt_metal::TensorMemoryLayout TENSOR_LAYOUT, tt::tt_metal::Layout MEM_LAYOUT, typename Addrgen>
-FORCE_INLINE void try_advance(command_context_t<Addrgen>& cmd_ctx) {
+void try_advance(command_context_t<Addrgen>& cmd_ctx) {
     switch (cmd_ctx.current_cmd_header.code) {
         case ttnn::ccl::cmd::CclCommandCode::STREAM_TENSOR_TO_EDM:  // STREAM TENSOR TO CB
 #ifndef NO_TENSOR_MODE

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_utils.hpp
@@ -84,7 +84,7 @@ std::pair<WorkerXY, uint32_t> get_noc_address_components(uint64_t noc_addr) {
 //------------------------------------------------------------------------------
 
 void mcast_contig_pages_to_noc_address(
-    uint64_t noc_addr,
+    uint64_t noc0_dest_addr,
     size_t l1_read_addr,
     size_t contig_pages_advanced,
     size_t payload_page_size,
@@ -95,12 +95,17 @@ void mcast_contig_pages_to_noc_address(
     size_t forward_direction_num_hops,
     size_t backward_direction_num_hops) {
     const size_t payload_size_bytes = contig_pages_advanced * payload_page_size;
-    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc_addr);
+    const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_addr);
     const size_t payload_l1_address = l1_read_addr + sizeof(tt::fabric::PacketHeader);
 
     // Local chip write
     noc_async_write(
-        payload_l1_address, get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr, noc_index), payload_size_bytes);
+        payload_l1_address,
+        // We are writing out from local core so we need to normalize to our noc
+        // if the target is a virtual coord this is actually redundant but for DRAM
+        // coords it is necessary
+        get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr, noc_index),
+        payload_size_bytes);
     size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
 
     // Forward fabric connection
@@ -110,14 +115,12 @@ void mcast_contig_pages_to_noc_address(
             "sizeof(sizeof(tt::fabric::PacketHeader)) is not a power of two which violates the below assertion");
 
         auto& pkt_hdr = *reinterpret_cast<tt::fabric::PacketHeader*>(l1_read_addr);
-        pkt_hdr.to_write()
+        pkt_hdr
             .to_chip_multicast(
                 tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(forward_direction_num_hops)})
-            .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                dest_addr,
-                packet_send_size_bytes,
-                static_cast<uint8_t>(dest_noc_xy.x),
-                static_cast<uint8_t>(dest_noc_xy.y)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                noc0_dest_addr,
+                packet_send_size_bytes});
         forward_fabric_sender.wait_for_empty_write_slot();
         forward_fabric_sender.send_payload_flush_blocking_from_address(l1_read_addr, packet_send_size_bytes);
     }
@@ -125,14 +128,12 @@ void mcast_contig_pages_to_noc_address(
     // Backward fabric connection
     if (has_backward_fabric_connection) {
         auto& pkt_hdr = *reinterpret_cast<tt::fabric::PacketHeader*>(l1_read_addr);
-        pkt_hdr.to_write()
+        pkt_hdr
             .to_chip_multicast(
                 tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(backward_direction_num_hops)})
-            .to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-                dest_addr,
-                packet_send_size_bytes,
-                static_cast<uint8_t>(dest_noc_xy.x),
-                static_cast<uint8_t>(dest_noc_xy.y)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
+                noc0_dest_addr,
+                packet_send_size_bytes});
         backward_fabric_sender.wait_for_empty_write_slot();
         backward_fabric_sender.send_payload_non_blocking_from_address(l1_read_addr, packet_send_size_bytes);
     }
@@ -170,7 +171,7 @@ void mcast_payload_chunk_to_output_tensor_address(
         contig_pages_advanced = std::min<size_t>(contig_pages, n_pages);
 
         mcast_contig_pages_to_noc_address(
-            noc_addr,
+            noc0_dest_addr,
             l1_read_addr,
             contig_pages_advanced,
             payload_page_size,
@@ -294,7 +295,7 @@ void mcast_sync_signal_to_addr(
         ASSERT((pkt_addr & (sizeof(tt::fabric::PacketHeader) - 1)) == 0);
 
         auto& pkt_hdr = *reinterpret_cast<tt::fabric::PacketHeader*>(pkt_addr);
-        pkt_hdr.to_atomic_inc()
+        pkt_hdr
             .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(directional_num_hops)})
             .to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
                 remote_sem_l1_addr,

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp
@@ -9,13 +9,9 @@
 
 namespace tt::fabric {
 
-FORCE_INLINE void validate(PacketHeader const& packet_header) {
-    ASSERT(packet_header.command_type == CommandType::WRITE || packet_header.command_type == CommandType::ATOMIC_INC);
-    ASSERT(packet_header.chip_send_type < 2);
-    ASSERT(packet_header.noc_send_type < 2);
-}
+FORCE_INLINE void validate(const PacketHeader& packet_header) { ASSERT(packet_header.chip_send_type < 2); }
 FORCE_INLINE bool is_valid(PacketHeader const& packet_header) {
-    return (packet_header.command_type < 2) && (packet_header.chip_send_type < 2) && (packet_header.noc_send_type < 2);
+    return (packet_header.chip_send_type < 2) && (packet_header.noc_send_type < 2);
 }
 
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -150,14 +150,13 @@ void kernel_main() {
     }
 
     // 2. mcast output ready semaphore
+    uint64_t out_ready_sem_noc_addr_in_pkt =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
     auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_seminc);
-    pkt_hdr->to_atomic_inc();
     pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
-        out_ready_sem_bank_addr,
+        out_ready_sem_noc_addr_in_pkt,
         static_cast<uint16_t>(1),  // increment 1
-        32,
-        static_cast<uint8_t>(out_ready_sem_noc0_x),
-        static_cast<uint8_t>(out_ready_sem_noc0_y)});
+        32});
     // Write the mcast packet (forward)
     if (fabric_connection.has_forward_connection()) {
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
@@ -159,13 +159,12 @@ void kernel_main() {
 
     // 2. mcast output ready semaphore
     auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_seminc);
-    pkt_hdr->to_atomic_inc();
+    uint64_t out_ready_sem_noc_addr_in_pkt =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
     pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
-        out_ready_sem_bank_addr,
+        out_ready_sem_noc_addr_in_pkt,
         static_cast<uint16_t>(1),  // increment 1
-        32,
-        static_cast<uint8_t>(out_ready_sem_noc0_x),
-        static_cast<uint8_t>(out_ready_sem_noc0_y)});
+        32});
     // Write the mcast packet (forward)
     if (fabric_connection.has_forward_connection()) {
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/buffer_constants.hpp>
 #include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
 #include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
 #include <cstdint>
 #include <utility>
 
@@ -20,10 +21,10 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     const size_t payload_l1_address = l1_read_addr;
 
     size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr_forward->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
-    pkt_hdr_backward->to_write()->to_noc_unicast(tt::fabric::NocUnicastCommandHeader{
-        dest_addr, packet_send_size_bytes, static_cast<uint8_t>(dest_noc_xy.x), static_cast<uint8_t>(dest_noc_xy.y)});
+    pkt_hdr_forward->to_noc_unicast_write(
+        tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
+    pkt_hdr_backward->to_noc_unicast_write(
+        tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
 
     noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
     if (fabric_connection.has_forward_connection()) {


### PR DESCRIPTION
flatten the command and noc command type field to a single field to simplify header processing; lowers burden on workers and eriscs.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/17429

### Problem description
The packet header added an unnecessary additional level of nesting by having a field for write vs atomic and a separate one for noc_unicast vs noc_multicast. This leads to inefficiencies in kernels processing or inspecting headers because it means they often require nested checks. Additionally, it forces an additional call on the worker when setting up the packet header.

### What's changed
Flattened/merged these two packet fields to remove nesting code in EDM fabric and workers.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13189525899
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13189597206
  - after rebase: https://github.com/tenstorrent/tt-metal/actions/runs/13193935020 
- [x] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13189617879
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
