### PR TITLE
#17768: Float32 support for Inference mode in Batch Norm

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -18,12 +18,15 @@ def data_gen_with_range_batch_norm(
     device,
     is_input=False,
     required_grad=False,
+    testing_dtype="bfloat16",
 ):
     assert high > low, "Incorrect range provided"
     torch.manual_seed(213919)
     channels = input_shapes[1]
     size = input_shapes if is_input else channels
-    pt_tensor = torch.rand(size, requires_grad=required_grad).bfloat16() * (high - low) + low
+    torch_dtype = getattr(torch, testing_dtype)
+    ttnn_dtype = getattr(ttnn, testing_dtype)
+    pt_tensor = torch.rand(size, requires_grad=required_grad, dtype=torch_dtype) * (high - low) + low
     reshaped_tensor = pt_tensor
     if not is_input:
         reshaped_tensor = pt_tensor.view(1, channels, 1, 1)
@@ -31,7 +34,7 @@ def data_gen_with_range_batch_norm(
         reshaped_tensor,
         device=device,
         layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.bfloat16,
+        dtype=ttnn_dtype,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     return pt_tensor, tt_tensor

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -73,8 +73,11 @@ void set_or_update_runtime_arguments(
         }
 
         uint32_t cHtWt = cHt * cWt;
-        class bfloat16 bfloat_scalar_eps(eps);
-        uint32_t packed_scalar_eps = pack_two_bfloat16_into_uint32({bfloat_scalar_eps, bfloat_scalar_eps});
+        const auto scalar = eps;
+        const auto packed_scalar_eps = input_tensor.get_dtype() == DataType::FLOAT32
+                                           ? std::bit_cast<uint32_t>(scalar)
+                                           : pack_two_bfloat16_into_uint32({scalar, scalar});
+
         std::array reader_runtime_args = {
             packed_scalar_eps,
             input_tensor.buffer()->address(),
@@ -218,38 +221,83 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     const auto e_is_dram = weight_has_value and weight_tensor->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
     const auto f_is_dram = bias_has_value and bias_tensor->buffer()->buffer_type() == tt_metal::BufferType::DRAM;
 
+    std::map<std::string, std::string> dataflow_defines;  // Currently support only for fp32, bf16
+    if (input_tensor.get_dtype() == DataType::FLOAT32) {
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
+        dataflow_defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
+    } else {
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
+        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    }
+
     // READER KERNEL
+    auto reader_defines = dataflow_defines;
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp",
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig({a_is_dram}));
+        tt_metal::ReaderDataMovementConfig({a_is_dram}, std::move(reader_defines)));
 
     // WRITER KERNEL
+    auto writer_defines = dataflow_defines;
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp",
         all_device_cores,
-        tt_metal::WriterDataMovementConfig({
-            b_is_dram,
-            c_is_dram,
-            d_is_dram,
-            e_is_dram,
-            f_is_dram,
-            static_cast<uint32_t>(weight_has_value),
-            static_cast<uint32_t>(bias_has_value),
-        }));
+        tt_metal::WriterDataMovementConfig(
+            {
+                b_is_dram,
+                c_is_dram,
+                d_is_dram,
+                e_is_dram,
+                f_is_dram,
+                static_cast<uint32_t>(weight_has_value),
+                static_cast<uint32_t>(bias_has_value),
+            },
+            std::move(writer_defines)));
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
                             c_data_format == tt::DataFormat::Float32;
+
+    uint32_t src_input_cb_index = tt::CBIndex::c_0;
+    uint32_t src_batch_mean_cb_index = tt::CBIndex::c_1;
+    uint32_t src_batch_var_cb_index = tt::CBIndex::c_3;
+    uint32_t src_eps_cb_index = tt::CBIndex::c_4;
+    uint32_t src_temp_den_cb_index = tt::CBIndex::c_5;
+    uint32_t src_temp_num_cb_index = tt::CBIndex::c_6;
+    uint32_t src_weight_cb_index = tt::CBIndex::c_16;
+    uint32_t src_temp_1_cb_index = tt::CBIndex::c_17;
+    uint32_t src_bias_cb_index = tt::CBIndex::c_18;
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        for (const auto cb_index :
+             {src_input_cb_index,
+              src_batch_mean_cb_index,
+              src_batch_var_cb_index,
+              src_temp_num_cb_index,
+              src_temp_den_cb_index,
+              src_eps_cb_index,
+              src_weight_cb_index,
+              src_temp_1_cb_index,
+              src_bias_cb_index}) {
+            unpack_to_dest_mode[cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        }
+    }
+
     std::vector<uint32_t> compute_kernel_args = {
         static_cast<uint32_t>(weight_has_value), static_cast<uint32_t>(bias_has_value)};
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp",
+        fmt::format(
+            "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_{}.cpp",
+            fp32_dest_acc_en ? "sfpu_kernel" : "kernel"),
         all_device_cores,
-        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .compile_args = compute_kernel_args});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+
+#include <cstdint>
+
+namespace NAMESPACE {
+
+ALWI void batchnorm_bcast_tiles(
+    uint32_t cb_bcast,
+    uint32_t cb_other,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t cb_batch_var,
+    uint32_t cb_eps,
+    uint32_t cb_den,
+    uint32_t cb_num,
+    uint32_t cb_weight,
+    uint32_t cb_bias,
+    uint32_t cb_tmp_1,
+    uint32_t cb_output_0,
+    uint32_t weight_has,
+    uint32_t bias_has) {
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    uint32_t weight_has_value = weight_has;
+    uint32_t bias_has_value = bias_has;
+    auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
+    auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
+
+    // input - batch_mean
+    cb_wait_front(cb_bcast, onetile);
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        cb_wait_front(cb_other, onetile);
+
+        cb_reserve_back(cb_num, onetile);
+
+        sub_binary_tile_init();
+        tile_regs_acquire();
+        tile_regs_wait();
+        copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_other);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_other, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_other, cb_bcast);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_bcast, i, i * 2 + 1);
+            sub_binary_tile(i * 2, i * 2 + 1);
+            tile_regs_commit();
+            pack_tile(i * 2, cb_num);
+        }
+        tile_regs_release();
+        cb_push_back(cb_num, onetile);
+        cb_pop_front(cb_other, onetile);
+    }
+    cb_pop_front(cb_bcast, onetile);
+
+    // 1/(sqrt(batch_var + eps))
+    cb_reserve_back(cb_den, onetile);
+    cb_wait_front(cb_batch_var, onetile);
+    cb_wait_front(cb_eps, onetile);
+
+    add_binary_tile_init();
+    rsqrt_tile_init();
+    copy_tile_to_dst_init_short_with_dt(cb_eps, cb_batch_var);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile(cb_batch_var, i, i * 2);
+    }
+    copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_eps);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile(cb_eps, i, i * 2 + 1);
+
+        add_binary_tile(i * 2, i * 2 + 1);
+        rsqrt_tile(i * 2);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(i * 2, cb_den);
+    }
+    tile_regs_release();
+
+    cb_push_back(cb_den, onetile);
+    cb_pop_front(cb_batch_var, onetile);
+    cb_pop_front(cb_eps, onetile);
+
+    // (input - batch_mean)/(sqrt(batch_var + eps)) = result
+    cb_wait_front(cb_den, onetile);
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        cb_wait_front(cb_num, onetile);
+
+        cb_reserve_back(cb_affine_or_out, onetile);
+
+        mul_binary_tile_init();
+        tile_regs_acquire();
+        tile_regs_wait();
+        copy_tile_to_dst_init_short_with_dt(cb_den, cb_num);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_num, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_num, cb_den);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_den, i, i * 2 + 1);
+            mul_binary_tile(i * 2, i * 2 + 1);
+            tile_regs_commit();
+            pack_tile(i * 2, cb_affine_or_out);
+        }
+        tile_regs_release();
+        cb_push_back(cb_affine_or_out, onetile);
+        cb_pop_front(cb_num, onetile);
+    }
+    cb_pop_front(cb_den, onetile);
+
+    if (weight_has_value) {  // result = result * weight
+        cb_wait_front(cb_weight, onetile);
+        for (uint32_t j = tile_start; j < freq; ++j) {
+            cb_wait_front(cb_affine_or_out, onetile);
+
+            cb_reserve_back(cb_scaled_output, onetile);
+
+            mul_binary_tile_init();
+            tile_regs_acquire();
+            tile_regs_wait();
+            copy_tile_to_dst_init_short_with_dt(cb_weight, cb_affine_or_out);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_affine_or_out, i, i * 2);
+            }
+            copy_tile_to_dst_init_short_with_dt(cb_affine_or_out, cb_weight);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_weight, i, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1);
+                tile_regs_commit();
+                pack_tile(i * 2, cb_scaled_output);
+            }
+            tile_regs_release();
+            cb_push_back(cb_scaled_output, onetile);
+            cb_pop_front(cb_affine_or_out, onetile);
+        }
+        cb_pop_front(cb_weight, onetile);
+    }
+
+    if (bias_has_value) {  // result = result + bias
+        cb_wait_front(cb_bias, onetile);
+        for (uint32_t j = tile_start; j < freq; ++j) {
+            cb_wait_front(cb_tmp_1, onetile);
+
+            cb_reserve_back(cb_output_0, onetile);
+
+            add_binary_tile_init();
+            tile_regs_acquire();
+            tile_regs_wait();
+            copy_tile_to_dst_init_short_with_dt(cb_bias, cb_tmp_1);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_tmp_1, i, i * 2);
+            }
+            copy_tile_to_dst_init_short_with_dt(cb_tmp_1, cb_bias);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_bias, i, i * 2 + 1);
+                add_binary_tile(i * 2, i * 2 + 1);
+                tile_regs_commit();
+                pack_tile(i * 2, cb_output_0);
+            }
+            tile_regs_release();
+            cb_push_back(cb_output_0, onetile);
+            cb_pop_front(cb_tmp_1, onetile);
+        }
+        cb_pop_front(cb_bias, onetile);
+    }
+}
+
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+    constexpr uint32_t weight_has_value = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t bias_has_value = get_compile_time_arg_val(1) == 1;
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_input = tt::CBIndex::c_0;       // input
+    constexpr auto cb_batch_mean = tt::CBIndex::c_1;  // batch_mean
+    constexpr auto cb_output_0 =
+        tt::CBIndex::c_2;  // output -- > [(input - batch_mean)/(sqrt(batch_var + eps))] * weight
+    constexpr auto cb_batch_var = tt::CBIndex::c_3;  // batch_var
+    constexpr auto cb_eps = tt::CBIndex::c_4;        // eps
+    constexpr auto cb_den = tt::CBIndex::c_5;        // 1/(sqrt(batch_var + eps))
+    constexpr auto cb_num = tt::CBIndex::c_6;        // input - batch_mean
+    constexpr auto cb_weight = tt::CBIndex::c_16;    // weight tensor
+    constexpr auto cb_tmp_1 = tt::CBIndex::c_17;     // (input - batch_mean)/(sqrt(batch_var + eps))
+    constexpr auto cb_bias = tt::CBIndex::c_18;      // bias tensor
+
+    auto cb_bcast = cb_batch_mean;
+    auto cb_other = cb_input;
+
+    unary_op_init_common(cb_other, cb_output_0);
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        batchnorm_bcast_tiles(
+            cb_bcast,
+            cb_other,
+            tile_freq,
+            tile_start,
+            cb_batch_var,
+            cb_eps,
+            cb_den,
+            cb_num,
+            cb_weight,
+            cb_bias,
+            cb_tmp_1,
+            cb_output_0,
+            weight_has_value,
+            bias_has_value);
+    }
+    if (remaining_iterations > 0) {
+        batchnorm_bcast_tiles(
+            cb_bcast,
+            cb_other,
+            remaining_iterations,
+            tile_start,
+            cb_batch_var,
+            cb_eps,
+            cb_den,
+            cb_num,
+            cb_weight,
+            cb_bias,
+            cb_tmp_1,
+            cb_output_0,
+            weight_has_value,
+            bias_has_value);
+    }
+
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -37,8 +37,18 @@ void kernel_main() {
 
     constexpr auto cb_id_eps = tt::CBIndex::c_4;
 
+    union {
+        float f;
+        uint32_t u;
+    } scalar;
+    scalar.u = eps;
     cb_reserve_back(cb_id_eps, onetile);
-    fill_with_val_bfloat16(cb_id_eps, eps);
+#ifdef FILL_WITH_VALUE_FLOAT
+    FILL_WITH_VALUE_FLOAT(cb_id_eps, scalar.f);
+#endif
+#ifdef FILL_WITH_VALUE
+    FILL_WITH_VALUE(cb_id_eps, eps);
+#endif
     cb_push_back(cb_id_eps, onetile);
 
     // Input tile offset

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -89,7 +89,7 @@ void kernel_main() {
             uint32_t l1_write_addr = get_write_ptr(cb_id_src);
             noc_async_read_tile(tile_offset, src, l1_write_addr);
             noc_async_read_barrier();
-            fill_tile_with_first_element_bfloat16(cb_id_src);
+            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
             cb_push_back(cb_id_src, onetile);
 
             // read a tile from batch variance
@@ -97,7 +97,7 @@ void kernel_main() {
             uint32_t l1_batch_var_write_addr = get_write_ptr(cb_id_batch_var);
             noc_async_read_tile(tile_offset, batch_var, l1_batch_var_write_addr);
             noc_async_read_barrier();
-            fill_tile_with_first_element_bfloat16(cb_id_batch_var);
+            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_batch_var);
             cb_push_back(cb_id_batch_var, onetile);
 
             if constexpr (weight_has_value) {  // read a tile from weight tensor
@@ -105,7 +105,7 @@ void kernel_main() {
                 uint32_t l1_weight_write_addr = get_write_ptr(cb_id_weight);
                 noc_async_read_tile(tile_offset, weight, l1_weight_write_addr);
                 noc_async_read_barrier();
-                fill_tile_with_first_element_bfloat16(cb_id_weight);
+                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_weight);
                 cb_push_back(cb_id_weight, onetile);
             }
 
@@ -114,7 +114,7 @@ void kernel_main() {
                 uint32_t l1_bias_write_addr = get_write_ptr(cb_id_bias);
                 noc_async_read_tile(tile_offset, bias, l1_bias_write_addr);
                 noc_async_read_barrier();
-                fill_tile_with_first_element_bfloat16(cb_id_bias);
+                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_bias);
                 cb_push_back(cb_id_bias, onetile);
             }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17768

### Problem description
To Provide Fp32 support for Inference mode of BN

### What's changed
Support provided for fp32 data type for inference mode of BN

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13217558701)
- [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13157671059)
- [x] [(Single-card) Tests for new models](https://github.com/tenstorrent/tt-metal/actions/runs/13217560775) - Passed as in main
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/13217560090) - Passed as in main
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/13217559606)
- [x] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/13217559245) - Passed as in main

