### PR TITLE
Add per core kernel stats and first start to last start

### DIFF
--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -24,6 +24,28 @@ class default_setup(metaclass=MergeMetaclass):
     ]
 
     timerAnalysis = {
+        "device_kernel_first_to_last_start": {
+            "across": "ops",
+            "type": "op_first_last",
+            "start": {
+                "core": "ANY",
+                "risc": "ANY",
+                "zone_phase": "ZONE_START",
+                "zone_name": [f"{risc}-KERNEL" for risc in riscTypes],
+            },
+            "end": {
+                "core": "ANY",
+                "risc": "ANY",
+                "zone_phase": "ZONE_START",
+                "zone_name": [f"{risc}-KERNEL" for risc in riscTypes],
+            },
+        },
+        "device_kernel_duration_per_core": {
+            "across": "ops",
+            "type": "op_core_first_last",
+            "start": {"core": "ANY", "risc": "ANY", "zone_name": [f"{risc}-KERNEL" for risc in riscTypes]},
+            "end": {"core": "ANY", "risc": "ANY", "zone_name": [f"{risc}-KERNEL" for risc in riscTypes]},
+        },
         "device_fw_duration": {
             "across": "ops",
             "type": "op_first_last",

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -53,6 +53,10 @@ OPS_CSV_HEADER = [
     "OP TO OP LATENCY [ns]",
     "DEVICE FW DURATION [ns]",
     "DEVICE KERNEL DURATION [ns]",
+    "DEVICE KERNEL DURATION PER CORE MIN [ns]",
+    "DEVICE KERNEL DURATION PER CORE MAX [ns]",
+    "DEVICE KERNEL DURATION PER CORE AVG [ns]",
+    "DEVICE KERNEL FIRST TO LAST START [ns]",
     "DEVICE BRISC KERNEL DURATION [ns]",
     "DEVICE NCRISC KERNEL DURATION [ns]",
     "DEVICE TRISC0 KERNEL DURATION [ns]",
@@ -349,10 +353,11 @@ def append_device_data(ops, traceReplays, logFolder):
                             cores.add(core)
                 deviceOp["core_usage"] = {"count": len(cores), "cores": [str(core) for core in cores]}
                 deviceOp["device_time"] = {
-                    analysis: data["series"] for analysis, data in deviceOpTime["analysis"].items()
+                    analysis: {"series": data["series"], "stats": data["stats"]}
+                    for analysis, data in deviceOpTime["analysis"].items()
                 }
                 for analysis, data in deviceOp["device_time"].items():
-                    for sample in data:
+                    for sample in data["series"]:
                         sample["duration_ns"] = sample["duration_cycles"] * 1000 / freq
             traceOps = {}
 
@@ -422,7 +427,8 @@ def get_device_data_generate_report(
                             cores.add(core)
                 deviceOp["core_usage"] = {"count": len(cores), "cores": [str(core) for core in cores]}
                 deviceOp["device_time"] = {
-                    analysis: data["series"] for analysis, data in deviceOpTime["analysis"].items()
+                    analysis: {"series": data["series"], "stats": data["stats"]}
+                    for analysis, data in deviceOpTime["analysis"].items()
                 }
 
                 if "run_host_id" in timeID.keys():
@@ -430,15 +436,26 @@ def get_device_data_generate_report(
                 else:
                     deviceOp["global_call_count"] = i
                 for analysis, data in deviceOp["device_time"].items():
-                    for sample in data:
+                    for sample in data["series"]:
                         sample["duration_ns"] = sample["duration_cycles"] * 1000 / freq
                 deviceOps[device].append(deviceOp)
 
                 rowDict = {csv_header_format("global_call_count"): deviceOp["global_call_count"]}
-                for analysis, analysisData in deviceOp["device_time"].items():
-                    headerField = f"{csv_header_format(analysis)} [ns]"
-                    assert len(analysisData) == 1, "Unexpected device data format"
-                    rowDict[headerField] = f"{analysisData[0]['duration_ns']:.0f}"
+                for analysis, data in deviceOp["device_time"].items():
+                    analysisData = data["series"]
+                    analysisStats = data["stats"]
+                    if "core" in analysis:
+                        assert len(analysisData) >= 1, "Unexpected device data format"
+                        headerField = f"{csv_header_format(analysis)} MIN [ns]"
+                        rowDict[headerField] = f"{analysisStats['Min']:.0f}"
+                        headerField = f"{csv_header_format(analysis)} MAX [ns]"
+                        rowDict[headerField] = f"{analysisStats['Max']:.0f}"
+                        headerField = f"{csv_header_format(analysis)} AVG [ns]"
+                        rowDict[headerField] = f"{analysisStats['Average']:.0f}"
+                    else:
+                        headerField = f"{csv_header_format(analysis)} [ns]"
+                        assert len(analysisData) == 1, "Unexpected device data format"
+                        rowDict[headerField] = f"{analysisData[0]['duration_ns']:.0f}"
                     if analysis == "device_fw_duration":
                         rowDict["DEVICE FW START CYCLE"] = analysisData[0]["start_cycle"]
                         rowDict["DEVICE FW END CYCLE"] = analysisData[0]["end_cycle"]
@@ -646,10 +663,21 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                 if "device_time" in opData.keys():
                     assert "device_id" in opData.keys(), "Op has device data without device_id"
                     deviceID = opData["device_id"]
-                    for analysis, analysisData in opData["device_time"].items():
-                        headerField = f"{csv_header_format(analysis)} [ns]"
-                        assert len(analysisData) == 1, "Unexpected device data format"
-                        rowDict[headerField] = f"{analysisData[0]['duration_ns']:.0f}"
+                    for analysis, data in opData["device_time"].items():
+                        analysisData = data["series"]
+                        analysisStats = data["stats"]
+                        if "core" in analysis:
+                            assert len(analysisData) >= 1, "Unexpected device data format"
+                            headerField = f"{csv_header_format(analysis)} MIN [ns]"
+                            rowDict[headerField] = f"{analysisStats['Min']:.0f}"
+                            headerField = f"{csv_header_format(analysis)} MAX [ns]"
+                            rowDict[headerField] = f"{analysisStats['Max']:.0f}"
+                            headerField = f"{csv_header_format(analysis)} AVG [ns]"
+                            rowDict[headerField] = f"{analysisStats['Average']:.0f}"
+                        else:
+                            headerField = f"{csv_header_format(analysis)} [ns]"
+                            assert len(analysisData) == 1, "Unexpected device data format"
+                            rowDict[headerField] = f"{analysisData[0]['duration_ns']:.0f}"
                         if analysis == "device_fw_duration":
                             rowDict["DEVICE FW START CYCLE"] = analysisData[0]["start_cycle"]
                             rowDict["DEVICE FW END CYCLE"] = analysisData[0]["end_cycle"]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17473

### Problem description
Due to kernel preloading and other dispatch async behaviours, per core stats are added to better represent dispatch overhead in perf report

### What's changed
provide per core kernel performance stats and also first kernel start to last kernel start times.  

### Checklist
- [x] [Profiler regression post commit ](https://github.com/tenstorrent/tt-metal/actions/runs/13159262282)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/13157677010/job/36718696832) GS was tested locally as CI BM was broken at the time of testing. 
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/13159277413)

Added 
<img width="1327" alt="Screenshot 2025-02-05 at 10 33 14 AM" src="https://github.com/user-attachments/assets/6e1fef73-f576-4692-8e08-a0f8ec0f7034" />

[ops_perf_results.csv](https://github.com/user-attachments/files/18674823/ops_perf_results.csv)
