### PR TITLE
#0: fix golden functions for conv and matmul

### DIFF
--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -243,6 +243,8 @@ def _golden_function(
     groups: int = 1,
     bias_tensor=None,
     conv_config: Conv2dConfig = None,
+    return_output_dim=False,
+    return_weights_and_bias=False,
     **_,
 ):
     import torch
@@ -270,7 +272,10 @@ def _golden_function(
     N, C, H, W = output_tensor.shape
     output_tensor = output_tensor.permute(0, 2, 3, 1).reshape(1, 1, N * H * W, C)  # N, C, H, W -> 1, 1, NHW, C
 
-    return [output_tensor]
+    if return_output_dim or return_weights_and_bias:
+        return [output_tensor]
+
+    return output_tensor
 
 
 ttnn.attach_golden_function(

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -17,7 +17,9 @@ MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig = (
 )
 
 
-def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
+def _golden_function(
+    input_tensor_a, input_tensor_b, transpose_a=False, transpose_b=False, *, bias=None, activation=None, **kwargs
+):
     import torch
 
     if transpose_a:


### PR DESCRIPTION
Fix golden functions for:
- matmul - arguments used in the function were picked up with the kwargs; function was broken
- conv2d - new parameters define whether we return Tensor only or Tensor with some metadata; before, we would get the error if we expect only Tensor as the output

All post-commit:  https://github.com/tenstorrent/tt-metal/actions/runs/13162283663