### PR TITLE
[sweep] tt smi improvement

### DIFF
--- a/tests/sweep_framework/framework/tt_smi_util.py
+++ b/tests/sweep_framework/framework/tt_smi_util.py
@@ -8,30 +8,68 @@ import subprocess
 from tests.sweep_framework.framework.sweeps_logger import sweeps_logger as logger
 
 GRAYSKULL_ARGS = ["-tr", "all"]
-WORMHOLE_ARGS = ["-wr", "all"]
-
-RESET_OVERRIDE = os.getenv("TT_SMI_RESET_COMMAND")
+LEGACY_WORMHOLE_ARGS = ["-wr", "all"]
 
 
-def run_tt_smi(arch: str):
-    if RESET_OVERRIDE is not None:
-        smi_process = subprocess.run(RESET_OVERRIDE, shell=True)
+class ResetUtil:
+    def __init__(self, arch: str):
+        self.arch = arch
+        self.command = os.getenv("TT_SMI_RESET_COMMAND")
+        self.args = []
+        if arch not in ["grayskull", "wormhole_b0"]:
+            raise Exception(f"SWEEPS: Unsupported Architecture for TT-SMI Reset: {arch}")
+        if self.command is not None:
+            return
+
+        self.smi_options = [
+            "tt-smi",
+            "tt-smi-metal",
+            "/home/software/syseng/gs/tt-smi" if arch == "grayskull" else "/home/software/syseng/wh/tt-smi",
+        ]
+        for smi_option in self.smi_options:
+            executable = shutil.which(smi_option)
+            if executable is not None:
+                args = []
+                # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal).
+                # Default device 0, if needed use TT_SMI_RESET_COMMAND override.
+                if smi_option == "tt-smi-metal":
+                    args = ["-r", "0"]
+                elif arch == "grayskull":
+                    args = GRAYSKULL_ARGS
+                elif arch == "wormhole_b0":
+                    smi_process = subprocess.run([executable, "-v"], capture_output=True, text=True)
+                    smi_version = smi_process.stdout.strip()
+                    if not smi_version.startswith("3.0"):
+                        args = LEGACY_WORMHOLE_ARGS
+                    else:
+                        args = ["-r"]
+                        smi_process = subprocess.run([executable, "-g", ".reset.json"])
+                        import json
+
+                        with open(".reset.json", "r") as f:
+                            reset_json = json.load(f)
+                            card_id = reset_json["wh_link_reset"]["pci_index"]
+                            if len(card_id) < 1:
+                                raise Exception(f"SWEEPS: TT-SMI Reset Failed to Find Card ID.")
+                            args.append(str(card_id[0]))
+                        subprocess.run(["rm", "-f", ".reset.json"])
+                smi_process = subprocess.run([executable, *args])
+                if smi_process.returncode == 0:
+                    self.command = executable
+                    self.args = args
+                    break
+
+        if self.command is None:
+            raise Exception(f"SWEEPS: Unable to location tt-smi executable")
+        print(f"SWEEPS: tt-smi util initialized with command: {self.command}, args: {self.args}")
+
+    def reset(self):
+        smi_process = subprocess.run([self.command, *self.args], stdout=subprocess.DEVNULL)
         if smi_process.returncode == 0:
             logger.info("TT-SMI Reset Complete Successfully")
             return
         else:
             raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
-        return
-
-    if arch not in ["grayskull", "wormhole_b0"]:
-        raise Exception(f"SWEEPS: Unsupported Architecture for TT-SMI Reset: {arch}")
-
-    smi_options = [
-        "tt-smi",
-        "tt-smi-metal",
-        "/home/software/syseng/gs/tt-smi" if arch == "grayskull" else "/home/software/syseng/wh/tt-smi",
-    ]
-    args = GRAYSKULL_ARGS if arch == "grayskull" else WORMHOLE_ARGS
 
     # Potential implementation to use the pre-defined reset script on each CI runner. Not in use because of the time and extra functions it has. (hugepages check, etc.)
     # if os.getenv("CI") == "true":
@@ -41,18 +79,3 @@ def run_tt_smi(arch: str):
     #         return
     #     else:
     #         raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
-
-    for smi_option in smi_options:
-        executable = shutil.which(smi_option)
-        if executable is not None:
-            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal). Default device 0, if needed use TT_SMI_RESET_COMMAND override.
-            if smi_option == "tt-smi-metal":
-                args = ["-r", "0"]
-            smi_process = subprocess.run([executable, *args])
-            if smi_process.returncode == 0:
-                logger.info("TT-SMI Reset Complete Successfully")
-                return
-            else:
-                raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
-
-    raise Exception("SWEEPS: Unable to Locate TT-SMI Executable")

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -118,6 +118,7 @@ def execute_suite(test_module, test_vectors, pbar_manager, suite_name):
     p = None
     timeout = get_timeout(test_module)
     suite_pbar = pbar_manager.counter(total=len(test_vectors), desc=f"Suite: {suite_name}", leave=False)
+    reset_util = tt_smi_util.ResetUtil(ARCH)
     for test_vector in test_vectors:
         if DRY_RUN:
             print(f"Would have executed test for vector {test_vector}")
@@ -185,7 +186,7 @@ def execute_suite(test_module, test_vectors, pbar_manager, suite_name):
                 logger.warning(f"TEST TIMED OUT, Killing child process {p.pid} and running tt-smi...")
                 p.terminate()
                 p = None
-                tt_smi_util.run_tt_smi(ARCH)
+                reset_util.reset()
                 result["status"], result["exception"] = TestStatus.FAIL_CRASH_HANG, "TEST TIMED OUT (CRASH / HANG)"
                 result["e2e_perf"] = None
         result["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")


### PR DESCRIPTION
### Ticket
Link to Github Issue (n/a)


### Problem description
1. tt_smi_util tries different commands every time it's called.
2. It doesn't work with the new tt-smi binary (>=3.0), which takes a single reset option, and requires the pci id of the card.


### What's changed
Created a class `ResetUtil` which stores the tt-smi command and parameters that was detected and proved working. The subsequent calls to reset will use the same command and parameters without the trying process.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
