### PR TITLE
#0: Remove large shapes from single device trace tests to cut down APC time

### DIFF
--- a/tests/ttnn/unit_tests/test_single_device_trace.py
+++ b/tests/ttnn/unit_tests/test_single_device_trace.py
@@ -11,7 +11,7 @@ from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 512, 512), (1, 3, 32, 32)])
+@pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 32, 32)])
 @pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
@@ -71,7 +71,7 @@ def test_single_device_single_trace(device, shape, enable_async, blocking):
     device.enable_async(False)
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)])
+@pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32)])
 @pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Trace tests run with large shapes on CI across multiple configurations, making them data-movement bound, which slows down APC.
- We don't need to test large shapes in APC anymore, given that this is a stable feature and we have T3K stress tests.

### What's changed
Remove large shapes from APC Trace suite.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
