### PR TITLE
Add new buckets for common infra errors

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -95,6 +95,12 @@ jobs:
           echo "attempt-number=$attempt_number" >> "$GITHUB_OUTPUT"
 
           echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/tenstorrent/tt-metal/actions/runs/$run_id/attempts/$attempt_number"
+      - name: Get API rate limit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "[Info] Grabbing API rate limit status"
+          gh api rate_limit
       - name: Output auxiliary values
         env:
           GH_TOKEN: ${{ github.token }}

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -97,6 +97,8 @@ def get_job_failure_signature_(github_job, failure_description) -> Optional[Unio
         "lost communication with the server": str(InfraErrorV1.RUNNER_COMM_FAILURE),
         "runner has received a shutdown signal": str(InfraErrorV1.RUNNER_SHUTDOWN_FAILURE),
         "No space left on device": str(InfraErrorV1.DISK_SPACE_FAILURE),
+        "API rate limit exceeded": str(InfraErrorV1.API_RATE_LIMIT_FAILURE),
+        "Tenstorrent cards seem to be in use": str(InfraErrorV1.RUNNER_CARD_IN_USE_FAILURE),
     }
 
     # Check the mapping dictionary for specific failure signature types

--- a/infra/data_collection/models.py
+++ b/infra/data_collection/models.py
@@ -9,3 +9,5 @@ class InfraErrorV1(enum.Enum):
     DISK_SPACE_FAILURE = enum.auto()
     RUNNER_COMM_FAILURE = enum.auto()
     RUNNER_SHUTDOWN_FAILURE = enum.auto()
+    API_RATE_LIMIT_FAILURE = enum.auto()
+    RUNNER_CARD_IN_USE_FAILURE = enum.auto()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to track how often we're seeing API/github rate limit related failures.

### What's changed
Added new signatures for common errors to expose and track them in separate buckets
1. API rate limit e.g. https://github.com/tenstorrent/tt-metal/actions/runs/13150957065/job/36698360349
2. Cards in use e.g. https://github.com/tenstorrent/tt-metal/actions/runs/13147257366/job/36688135811

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
