### PR TITLE
Slice improvements

### DIFF
--- a/models/demos/distilbert/tests/test_perf_distilbert.py
+++ b/models/demos/distilbert/tests/test_perf_distilbert.py
@@ -152,7 +152,7 @@ def test_distilbert_perf_device(batch_size, test, reset_seeds):
     margin = 0.03
     num_iterations = 1
     if is_grayskull():
-        expected_perf = 292
+        expected_perf = 57.3
     elif is_wormhole_b0():
         expected_perf = 97.0
 

--- a/models/demos/distilbert/tests/test_perf_distilbert.py
+++ b/models/demos/distilbert/tests/test_perf_distilbert.py
@@ -152,7 +152,7 @@ def test_distilbert_perf_device(batch_size, test, reset_seeds):
     margin = 0.03
     num_iterations = 1
     if is_grayskull():
-        expected_perf = 57.3
+        expected_perf = 292
     elif is_wormhole_b0():
         expected_perf = 97.0
 

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_model.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_model.py
@@ -36,7 +36,7 @@ class Emb(torch.nn.Module):
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "iterations",
-    (17,),
+    (14,),
 )
 def test_mistral_model_inference(device, iterations, use_program_cache, reset_seeds):
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_rm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_rm.py
@@ -35,6 +35,7 @@ two_chunk_dim_two_ids = [
 ]
 
 
+@pytest.mark.skip("Replaced in https://github.com/tenstorrent/tt-metal/pull/17461")
 @pytest.mark.parametrize(
     "in_mem_config",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
@@ -19,6 +19,7 @@ import pytest
 import os
 
 
+@pytest.mark.skip("Replaced in https://github.com/tenstorrent/tt-metal/pull/17461")
 @pytest.mark.parametrize(
     "in_mem_config",
     (

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -777,6 +777,7 @@ def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
     (
         ([3234, 4], [0, 2], [3234, 4], [1, 1]),
         ([196, 196, 2], [0, 0, 1], [196, 196, 2], [1, 1, 1]),
+        ([1, 23, 40], [0, 0, 39], [1, 23, 40], [1, 1, 1]),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -416,8 +416,6 @@ def test_slice_negative_ends(layout, dim, ends, device):
     ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
 
     if dim == 3:
-        if layout == ttnn.ROW_MAJOR_LAYOUT and ends == -32:
-            pytest.skip("Page size will become 0 and we don't handle transforming pages to second last dimension")
         torch_output = torch_input[:, :, :, 0:ends]
         ttnn_output = ttnn_input[:, :, :, 0:ends]
     elif dim == 2:
@@ -454,8 +452,6 @@ def test_slice_bert(input_shape, input_start, input_ends, layout, device):
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
     else:
-        if (input_ends[-1] - input_start[-1]) % 2 != 0:
-            pytest.skip("Cannot slice the last dimension to 1 in row major layout")
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
 
@@ -504,8 +500,6 @@ def test_ttnn_slice_bert(input_shape, input_start, input_ends, layout, memory_co
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
     else:
-        if (input_ends[-1] - input_start[-1]) % 2 != 0:
-            pytest.skip("Cannot slice the last dimension to 1 in row major layout")
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
 
@@ -581,8 +575,6 @@ def test_ttnn_slice_optimized_shapes(input_shape, input_start, input_ends, layou
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
     else:
-        if (input_ends[-1] - input_start[-1]) % 2:
-            pytest.skip("Cannot slice the last dimension to 1 in row major layout")
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
 
@@ -624,8 +616,6 @@ def test_ttnn_slice_5d(input_shape, input_start, input_ends, layout, memory_conf
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
     else:
-        if (input_ends[-1] - input_start[-1]) % 2:
-            pytest.skip("Cannot slice the last dimension to 1 in row major layout")
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
 
@@ -659,13 +649,9 @@ def test_ttnn_slice_5d(input_shape, input_start, input_ends, layout, memory_conf
 )
 def test_slice_5d(input_shape, input_start, input_ends, input_stride, layout, device):
     if layout == ttnn.TILE_LAYOUT:
-        if input_stride != (1, 1, 1, 1, 1):
-            pytest.skip("Cannot untilize 5D tensor")
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
     else:
-        if (input_ends[-1] - input_start[-1]) % 2:
-            pytest.skip("Cannot slice the last dimension to 1 in row major layout")
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
 
@@ -758,7 +744,6 @@ def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, dev
     ),
 )
 def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
-    pytest.skip("These tests are known to fail")
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
 
     slice_obj = slice(start, end, step)

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -468,6 +468,17 @@ def test_slice_bert(input_shape, input_start, input_ends, layout, device):
             input_start[2] : input_ends[2],
             input_start[3] : input_ends[3],
         ]
+    elif len(input_shape) == 3:
+        torch_output = torch_input[
+            input_start[0] : input_ends[0],
+            input_start[1] : input_ends[1],
+            input_start[2] : input_ends[2],
+        ]
+        ttnn_output = ttnn_input[
+            input_start[0] : input_ends[0],
+            input_start[1] : input_ends[1],
+            input_start[2] : input_ends[2],
+        ]
     elif len(input_shape) == 2:
         torch_output = torch_input[input_start[0] : input_ends[0], input_start[1] : input_ends[1]]
         ttnn_output = ttnn_input[input_start[0] : input_ends[0], input_start[1] : input_ends[1]]
@@ -759,6 +770,71 @@ def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
     ttnn_output_tensor = ttnn.from_device(ttnn_output).to_torch_with_logical_shape()
 
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_start, input_ends, input_stride",
+    (([3234, 4], [0, 2], [3234, 4], [1, 1]),),
+)
+@pytest.mark.parametrize(
+    "layout",
+    (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+)
+def test_slice_adversarial_flexible(input_shape, input_start, input_ends, input_stride, layout, device):
+    if layout == ttnn.TILE_LAYOUT:
+        torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+    else:
+        torch_input = torch.randn(input_shape, dtype=torch.float32)
+        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+    if len(input_shape) == 5:
+        torch_output = torch_input[
+            input_start[0] : input_ends[0] : input_stride[0],
+            input_start[1] : input_ends[1] : input_stride[1],
+            input_start[2] : input_ends[2] : input_stride[2],
+            input_start[3] : input_ends[3] : input_stride[3],
+            input_start[4] : input_ends[4] : input_stride[4],
+        ]
+        ttnn_output = ttnn_input[
+            input_start[0] : input_ends[0] : input_stride[0],
+            input_start[1] : input_ends[1] : input_stride[1],
+            input_start[2] : input_ends[2] : input_stride[2],
+            input_start[3] : input_ends[3] : input_stride[3],
+            input_start[4] : input_ends[4] : input_stride[4],
+        ]
+    elif len(input_shape) == 4:
+        torch_output = torch_input[
+            input_start[0] : input_ends[0] : input_stride[0],
+            input_start[1] : input_ends[1] : input_stride[1],
+            input_start[2] : input_ends[2] : input_stride[2],
+            input_start[3] : input_ends[3] : input_stride[3],
+        ]
+        ttnn_output = ttnn_input[
+            input_start[0] : input_ends[0] : input_stride[0],
+            input_start[1] : input_ends[1] : input_stride[1],
+            input_start[2] : input_ends[2] : input_stride[2],
+            input_start[3] : input_ends[3] : input_stride[3],
+        ]
+    elif len(input_shape) == 3:
+        torch_output = torch_input[
+            input_start[0] : input_ends[0] : input_stride[0],
+            input_start[1] : input_ends[1] : input_stride[1],
+            input_start[2] : input_ends[2] : input_stride[2],
+        ]
+        ttnn_output = ttnn_input[
+            input_start[0] : input_ends[0] : input_stride[0],
+            input_start[1] : input_ends[1] : input_stride[1],
+            input_start[2] : input_ends[2] : input_stride[2],
+        ]
+    elif len(input_shape) == 2:
+        torch_output = torch_input[input_start[0] : input_ends[0], input_start[1] : input_ends[1]]
+        ttnn_output = ttnn_input[input_start[0] : input_ends[0], input_start[1] : input_ends[1]]
+    elif len(input_shape) == 1:
+        torch_output = torch_input[input_start[0] : input_ends[0]]
+        ttnn_output = ttnn_input[input_start[0] : input_ends[0]]
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_output, ttnn_output, 0.99)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -774,19 +774,32 @@ def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
 
 @pytest.mark.parametrize(
     "input_shape, input_start, input_ends, input_stride",
-    (([3234, 4], [0, 2], [3234, 4], [1, 1]),),
+    (
+        ([3234, 4], [0, 2], [3234, 4], [1, 1]),
+        ([196, 196, 2], [0, 0, 1], [196, 196, 2], [1, 1, 1]),
+    ),
 )
 @pytest.mark.parametrize(
     "layout",
     (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
 )
-def test_slice_adversarial_flexible(input_shape, input_start, input_ends, input_stride, layout, device):
+@pytest.mark.parametrize(
+    "input_memory_config",
+    (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+)
+def test_slice_adversarial_flexible(
+    input_shape, input_start, input_ends, input_stride, layout, input_memory_config, device
+):
     if layout == ttnn.TILE_LAYOUT:
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
-        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+        ttnn_input = ttnn.from_torch(
+            torch_input, device=device, dtype=ttnn.bfloat16, memory_config=input_memory_config, layout=layout
+        )
     else:
         torch_input = torch.randn(input_shape, dtype=torch.float32)
-        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+        ttnn_input = ttnn.from_torch(
+            torch_input, device=device, dtype=ttnn.bfloat16, memory_config=input_memory_config, layout=layout
+        )
 
     if len(input_shape) == 5:
         torch_output = torch_input[

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -787,6 +787,7 @@ def test_slice_adversarial_flexible(input_shape, input_start, input_ends, input_
     else:
         torch_input = torch.randn(input_shape, dtype=torch.float32)
         ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+
     if len(input_shape) == 5:
         torch_output = torch_input[
             input_start[0] : input_ends[0] : input_stride[0],

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -746,35 +746,11 @@ def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, dev
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
 
 
-@pytest.mark.skip("#15796 1D tiled support is not available as of yet")
-@pytest.mark.parametrize(
-    "input_shape, dim, start, end, step, layout",
-    (([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),),  # Difference in expected shape as it's a 1D tensor
-)
-def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
-    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
-
-    slice_obj = slice(start, end, step)
-
-    # Prepare indices for slicing in the specified dimension
-    indices = [slice(None)] * len(input_shape)  # By default, select all elements along every dimension
-    indices[dim] = slice_obj  # Apply slicing to the target dimension
-    indices = tuple(indices)
-
-    # Apply slicing to the input_tensor
-    torch_output_tensor = torch_input[indices]
-
-    ttnn_tensor = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=ttnn.bfloat16)
-    ttnn_output = ttnn_tensor[indices]
-
-    ttnn_output_tensor = ttnn.from_device(ttnn_output).to_torch_with_logical_shape()
-
-    assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
-
-
 @pytest.mark.parametrize(
     "input_shape, input_start, input_ends, input_stride",
     (
+        ([3], [0, 0], [-1, -1], [1, 1]),
+        ([1, 7], [0, 0], [-1, -1], [1, 1]),
         ([3234, 4], [0, 2], [3234, 4], [1, 1]),
         ([196, 196, 2], [0, 0, 1], [196, 196, 2], [1, 1, 1]),
         ([1, 23, 40], [0, 0, 39], [1, 23, 40], [1, 1, 1]),
@@ -788,7 +764,7 @@ def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
     "input_memory_config",
     (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
 )
-def test_slice_adversarial_flexible(
+def test_slice_pytorch2_former_failures(
     input_shape, input_start, input_ends, input_stride, layout, input_memory_config, device
 ):
     if layout == ttnn.TILE_LAYOUT:

--- a/tests/ttnn/unit_tests/test_getitem.py
+++ b/tests/ttnn/unit_tests/test_getitem.py
@@ -76,16 +76,6 @@ def test_getitem_2d(device, height, width, input_layout, on_device):
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
-def test_getitem_scalar_output():
-    torch_input_tensor = torch.rand((16, 32), dtype=torch.bfloat16)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor)
-
-    with pytest.raises(RuntimeError) as e:
-        input_tensor[0, 0]
-    assert "Host tensor slice cannot return a scalar or empty tensor" in str(e.value)
-
-
 @pytest.mark.parametrize("batch_sizes", [(), (1, 1)])
 @pytest.mark.parametrize("height", [32, 64])
 @pytest.mark.parametrize("width", [32, 96])

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1197,8 +1197,8 @@ void pytensor_module(py::module& m_tensor) {
         .def(
             "unpad",
             [](const Tensor& self,
-               const std::array<uint32_t, 4>& output_tensor_start,
-               const std::array<uint32_t, 4>& output_tensor_end) {
+               const ttnn::SmallVector<uint32_t>& output_tensor_start,
+               const ttnn::SmallVector<uint32_t>& output_tensor_end) {
                 return self.unpad(ttnn::Shape(output_tensor_start), ttnn::Shape(output_tensor_end));
             },
             R"doc(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -16,8 +16,6 @@
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include "cpp/ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
-// #include "cpp/ttnn/operations/data_movement/slice/slice.hpp"
-// #include "cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp"
 #include "cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp"
 
 #include <ranges>

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -16,8 +16,9 @@
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include "cpp/ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
-#include "cpp/ttnn/operations/data_movement/slice/slice.hpp"
-#include "cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp"
+// #include "cpp/ttnn/operations/data_movement/slice/slice.hpp"
+// #include "cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp"
+#include "cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp"
 
 #include <ranges>
 #include <utility>
@@ -109,31 +110,15 @@ MassagedConcat build_untilize_rm_retilize_concat(
                     TT_FATAL(
                         input_tensor.get_layout() == ttnn::TILE_LAYOUT,
                         "ttnn.concat: expected all input tensors to be in tile layout");
-                    auto untilized_tensor = ttnn::untilize(input_tensor);
-                    // untilized, so now we have a padded rm tensor. we slice to
-                    // remove the padding.
-                    const auto& input_shape = input_tensor.get_logical_shape();
-                    std::vector<uint32_t> begins_vec(input_shape.rank(), 0);
-                    tt::stl::Span<const uint32_t> begins = begins_vec;
-                    tt::stl::Span<const uint32_t> ends = input_shape.view();
-                    std::vector<uint32_t> steps_vec(input_shape.rank(), 1);
-                    tt::stl::Span<const uint32_t> steps = steps_vec;
 
-                    // we now perform a padding-oblivious slice to remove the
-                    // tile padding.
-                    // FIXME: change this to a legit slice call once
-                    // padding-oblivious entry point is uplifted to the slice
-                    // op.
-                    untilized_tensor = tt::tt_metal::operation::run(
-                        SliceDeviceOperation{
-                            ttnn::Shape(begins), ttnn::Shape(ends), ttnn::Shape(steps), output_memory_config},
-                        {untilized_tensor},
-                        {},
-                        {std::nullopt},
-                        queue_id)[0];
-
-                    untilized_tensor = ttnn::reshape(untilized_tensor, input_tensor.get_logical_shape());
-                    return untilized_tensor;
+                    ttnn::SmallVector<uint32_t> end_indices(
+                        input_tensor.get_logical_shape().cbegin(), input_tensor.get_logical_shape().cend());
+                    std::for_each(end_indices.begin(), end_indices.end(), [](auto& x) {
+                        if (x > 0) {
+                            --x;
+                        }
+                    });
+                    return ttnn::untilize_with_unpadding(input_tensor, ttnn::Shape(end_indices), output_memory_config);
                 });
             return std::make_tuple(itensors, dim, groups);
         },

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -21,6 +22,8 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t misalignment = get_compile_time_arg_val(1);
+    uint32_t read_size = unpadded_stick_size + misalignment;
 
     const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
 
@@ -35,7 +38,13 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
             uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-            noc_async_read(src_noc_addr, src_buffer_l1_addr, unpadded_stick_size);
+
+            noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+            if constexpr (misalignment != 0) {
+                noc_async_read_barrier();
+                tt::data_movement::common::tt_memmove<false, false, false, 0>(
+                    src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
+            }
             src_buffer_l1_addr += stick_size_offset;
             src_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -38,7 +38,6 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
             uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-
             noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
             if constexpr (misalignment != 0) {
                 noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
@@ -38,7 +38,8 @@ void kernel_main() {
     uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
     volatile tt_l1_ptr uint16_t* in_stick = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_buffer_l1_addr);
 
-    uint32_t index[dims - 1];  // To hold current index in each of the first dims-1 dimensions
+    uint32_t index[dims];  // To hold current index in each of the first dims-1 dimensions
+    index[dims - 1] = 0;   // Initialize the last index to 0
     for (uint32_t i = 0; i < dims - 1; i++) {
         index[i] = starts[i];  // Initialize the index with the start values
     }
@@ -68,16 +69,19 @@ void kernel_main() {
             out_stick_id++;
         }
         cb_push_back(cb_id_out0, 1);
-
-        // Increment the indices for the first dims-1 dimensions
-        for (int32_t i = dims - 2; i >= 0; i--) {  // Start from the last of the first dims-1
-            index[i] += strides[i];
-            if (index[i] < ends[i]) {
-                break;  // Successfully incremented this dimension, no carry over
-            } else {
-                index[i] = starts[i];  // Reset this dimension and carry over to the next
-                if (i == 0) {
-                    done = true;  // If the first dimension is reset, we've completed all iterations
+        if constexpr (dims == 1) {
+            break;  // If there's only one dimension, we're done
+        } else {
+            // Increment the indices for the first dims-1 dimensions
+            for (int32_t i = dims - 2; i >= 0; i--) {  // Start from the last of the first dims-1
+                index[i] += strides[i];
+                if (index[i] < ends[i]) {
+                    break;  // Successfully incremented this dimension, no carry over
+                } else {
+                    index[i] = starts[i];  // Reset this dimension and carry over to the next
+                    if (i == 0) {
+                        done = true;  // If the first dimension is reset, we've completed all iterations
+                    }
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -94,7 +94,7 @@ void SliceDeviceOperation::validate_with_output_tensors(
         TT_FATAL(this->slice_start[i] <= this->slice_end[i], "Error");
     }
     if (!output_tensors.empty() && output_tensors[0].has_value()) {
-        const auto output_shape_required = compute_output_specs(input_tensors)[0].logical_shape();
+        const auto output_shape_required = compute_output_specs(input_tensors)[0].padded_shape();
         const auto& out_tensor = output_tensors[0].value();
         TT_FATAL(
             out_tensor.get_padded_shape() == output_shape_required,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -73,11 +73,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, ALIGNMENT);
     uint32_t start_addr = input_tensor.buffer()->address();
-    if (misalignment == 0) {
-        start_addr += begins_bytes;
-    }
     std::vector<uint32_t> common_reader_kernel_args = {
-        start_addr,
+        start_addr + begins_bytes - misalignment,  // read from nearest aligned address
         padded_row_size_bytes,
         unpadded_row_size_bytes,
         unpadded_row_size_bytes_offset,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -204,7 +204,10 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     uint32_t begins_bytes = output_tensor_start[-1] * a.element_size();
     uint32_t misalignment = begins_bytes % SRC_BUFFER_ALIGNMENT;
 
-    uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, ALIGNMENT) + misalignment;
+    if (misalignment != 0) {
+        ALIGNMENT *= 2;
+    }
+    uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, ALIGNMENT);
 
     uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                          : num_sticks_per_core_group_2;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -35,28 +35,28 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     auto input_shape = input_tensor.get_logical_shape();
     auto output_shape = output_tensor.get_logical_shape();
 
-    uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
-    uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
+    uint32_t input_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+    uint32_t output_row_size_bytes = output_shape[-1] * input_tensor.element_size();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-    std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
-    std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
 
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
 
     // TODO: Remove first element of these arrays and update kernel accordingly
     // This currently just matches tile version where we iterate over the row as well
-    num_unpadded_sticks_per_dim[0] = 1;
-    num_padded_sticks_per_dim[0] = 0;
+    num_output_sticks_per_dim[0] = 1;
+    num_input_sticks_per_dim[0] = 0;
     accumulated_total_per_dim[0] = 1;
 
     for (int32_t i = 1; i < num_dims; i++) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_output_dim = output_shape[-(i + 1)];
         uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_sticks_per_dim[i] = num_unpadded_dim;
-        num_padded_sticks_per_dim[i] = num_padded_dim;
+        uint32_t num_input_dim = (num_total_dim - num_output_dim) * accumulated_total_per_dim[i - 1];
+        num_output_sticks_per_dim[i] = num_output_dim;
+        num_input_sticks_per_dim[i] = num_input_dim;
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
 
@@ -71,22 +71,22 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
     uint32_t misalignment = begins_bytes % SRC_BUFFER_ALIGNMENT;
 
-    uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, ALIGNMENT);
+    uint32_t output_row_size_bytes_offset = tt::round_up(output_row_size_bytes, ALIGNMENT);
     uint32_t start_addr = input_tensor.buffer()->address();
     std::vector<uint32_t> common_reader_kernel_args = {
         start_addr + begins_bytes - misalignment,  // read from nearest aligned address
-        padded_row_size_bytes,
-        unpadded_row_size_bytes,
-        unpadded_row_size_bytes_offset,
+        input_row_size_bytes,
+        output_row_size_bytes,
+        output_row_size_bytes_offset,
         num_dims,
         0,
         0,
         0,
         0};
     common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
+        common_reader_kernel_args.end(), num_output_sticks_per_dim.begin(), num_output_sticks_per_dim.end());
     common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
+        common_reader_kernel_args.end(), num_input_sticks_per_dim.begin(), num_input_sticks_per_dim.end());
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
 
@@ -108,22 +108,22 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         if (num_sticks_per_core != 0) {
             auto num_sticks_per_core_pad32 = num_sticks_per_core + (32 - num_sticks_per_core % 32) % 32;
             num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
-                num_sticks_per_core_pad32, unpadded_row_size_bytes_offset, max_read_size);
+                num_sticks_per_core_pad32, output_row_size_bytes_offset, max_read_size);
             num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
         }
 
-        id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
-        uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
+        id_per_dim[0] = num_sticks_written % num_output_sticks_per_dim[0];
+        uint32_t output_written = num_sticks_written / num_output_sticks_per_dim[0];
         uint32_t start_id = id_per_dim[0] + start_offset;
 
         for (uint32_t j = 1; j < num_dims; j++) {
-            id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
+            id_per_dim[j] = output_written % num_output_sticks_per_dim[j];
+            output_written = output_written / num_output_sticks_per_dim[j];
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
         }
         std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
         //
-        uint32_t addr_offset = 5;  // input buffer addr, padded_row_size_bytes, unpadded_row_size_bytes, num_dims
+        uint32_t addr_offset = 5;  // input buffer addr, input_row_size_bytes, output_row_size_bytes, num_dims
         reader_kernel_args[addr_offset++] = start_id;
         reader_kernel_args[addr_offset++] = num_sticks_per_core;
         reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
@@ -132,8 +132,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         std::vector<uint32_t> writer_kernel_args = {
             output_buffer->address(),
-            unpadded_row_size_bytes,
-            unpadded_row_size_bytes_offset,
+            output_row_size_bytes,
+            output_row_size_bytes_offset,
             num_sticks_per_core,
             num_sticks_per_core_read,
             num_read_per_barrier,
@@ -155,7 +155,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    uint32_t num_unpadded_sticks = output.volume() / output.get_logical_shape()[-1];
+    uint32_t num_output_sticks = output.volume() / output.get_logical_shape()[-1];
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -164,14 +164,14 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
     uint32_t num_cores_total = num_cores_x * num_cores_y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_sticks);
 
     tt::tt_metal::Buffer* src0_buffer = a.buffer();
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
-    uint32_t padded_row_size_bytes = a.get_logical_shape()[-1] * a.element_size();
-    uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+    uint32_t input_row_size_bytes = a.get_logical_shape()[-1] * a.element_size();
+    uint32_t output_row_size_bytes = output_shape[-1] * a.element_size();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -179,8 +179,8 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
 
-    uint32_t src_stick_size = padded_row_size_bytes;
-    uint32_t dst_stick_size = unpadded_row_size_bytes;
+    uint32_t src_stick_size = input_row_size_bytes;
+    uint32_t dst_stick_size = output_row_size_bytes;
 
     uint32_t src0_cb_index = 0;
     uint32_t max_read_size = 4096;
@@ -200,7 +200,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     if (misalignment != 0) {
         ALIGNMENT *= 2;
     }
-    uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, ALIGNMENT);
+    uint32_t cb_page_size = tt::round_up(output_row_size_bytes, ALIGNMENT);
 
     uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                          : num_sticks_per_core_group_2;
@@ -265,7 +265,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
             uint32_t num_cores_x = compute_with_storage_grid_size.x;
             uint32_t num_cores_y = compute_with_storage_grid_size.y;
             uint32_t num_cores_total = num_cores_x * num_cores_y;
-            uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_logical_shape()[-1];
+            uint32_t num_output_sticks = dst_tensor.volume() / dst_tensor.get_logical_shape()[-1];
             auto
                 [num_cores,
                  all_cores,
@@ -273,7 +273,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
                  core_group_2,
                  num_sticks_per_core_group_1,
                  num_sticks_per_core_group_2] =
-                    tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+                    tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_sticks);
 
             const auto tensor_start =
                 static_cast<const ttnn::operations::data_movement::SliceDeviceOperation*>(operation)->slice_start;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -147,11 +147,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 
 operation::ProgramWithCallbacks slice_rm_multi_core(
-    const Tensor& a, 
-    Tensor& output, 
-    const ttnn::Shape& output_tensor_start, 
-    const ttnn::Shape& output_tensor_end) {
-
+    const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
     const ttnn::Shape output_shape = output.get_logical_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
@@ -440,7 +436,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     tt::tt_metal::IDevice* device = input_tensor.device();
 
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_logical_shape();
+    auto input_shape = input_tensor.get_padded_shape();
     auto output_shape = output_tensor.get_logical_shape();
 
     uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
@@ -575,10 +571,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 
 operation::ProgramWithCallbacks slice_rm_multi_core_sharded(
-    const Tensor& a, 
-    Tensor& output, 
-    const ttnn::Shape& output_tensor_start, 
-    const ttnn::Shape& output_tensor_end) {
+    const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
     const ttnn::Shape output_shape = output.get_logical_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
@@ -725,15 +718,15 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     std::vector<uint32_t>& accumulated_total_per_dim) {
     const auto input_buffer = input_tensor.buffer();
     const auto output_buffer = output_tensor.buffer();
-    const auto& input_shape = input_tensor.get_logical_shape();
-    const auto& output_shape = output_tensor.get_logical_shape();
+    const auto& input_shape = input_tensor.get_padded_shape();
+    const auto& output_shape = output_tensor.get_padded_shape();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
-    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_unpadded_Xt = std::max(static_cast<std::uint32_t>(1), output_shape[-1] / TILE_WIDTH);
     uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
     uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
-    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_unpadded_Yt = std::max(static_cast<std::uint32_t>(1), output_shape[-2] / TILE_HEIGHT);
     uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
     uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -583,7 +583,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core_sharded(
     uint32_t num_unpadded_sticks = output.volume() / output.get_logical_shape()[-1];
 
     // stick sizes
-    uint32_t W_padded = a.get_logical_shape()[-1];
+    uint32_t W_padded = a.get_padded_shape()[-1];
     uint32_t W_unpadded = output.get_logical_shape()[-1];
     auto stick_size_padded = W_padded * a.element_size();
     auto stick_size_unpadded = W_unpadded * output.element_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -31,8 +31,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_padded_shape();
-    auto output_shape = output_tensor.get_padded_shape();
+    auto input_shape = input_tensor.get_logical_shape();
+    auto output_shape = output_tensor.get_logical_shape();
 
     uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
@@ -59,7 +59,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
 
-    uint32_t unpadded_row_size_bytes_offset = output_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM
+    uint32_t unpadded_row_size_bytes_offset = (output_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ||
+                                               input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM)
                                                   ? tt::round_up(unpadded_row_size_bytes, TILE_WIDTH)
                                                   : tt::round_up(unpadded_row_size_bytes, TILE_WIDTH / 2);
 
@@ -137,15 +138,19 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 
 operation::ProgramWithCallbacks slice_rm_multi_core(
-    const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    const ttnn::Shape output_shape = output.get_padded_shape();
+    const Tensor& a, 
+    Tensor& output, 
+    const ttnn::Shape& output_tensor_start, 
+    const ttnn::Shape& output_tensor_end) {
+
+    const ttnn::Shape output_shape = output.get_logical_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    uint32_t num_unpadded_sticks = output.volume() / output.get_padded_shape()[-1];
+    uint32_t num_unpadded_sticks = output.volume() / output.get_logical_shape()[-1];
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -160,7 +165,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
-    uint32_t padded_row_size_bytes = a.get_padded_shape()[-1] * a.element_size();
+    uint32_t padded_row_size_bytes = a.get_logical_shape()[-1] * a.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
@@ -175,8 +180,9 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     uint32_t src0_cb_index = 0;
     uint32_t max_read_size = 4096;
-    uint32_t cb_page_size = dst_is_dram ? tt::round_up(unpadded_row_size_bytes, TILE_WIDTH)
-                                        : tt::round_up(unpadded_row_size_bytes, TILE_WIDTH / 2);
+    uint32_t cb_page_size = (dst_is_dram || src0_is_dram) ? tt::round_up(unpadded_row_size_bytes, TILE_WIDTH)
+                                                          : tt::round_up(unpadded_row_size_bytes, TILE_WIDTH / 2);
+
     uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                          : num_sticks_per_core_group_2;
     uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
@@ -239,7 +245,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
             uint32_t num_cores_x = compute_with_storage_grid_size.x;
             uint32_t num_cores_y = compute_with_storage_grid_size.y;
             uint32_t num_cores_total = num_cores_x * num_cores_y;
-            uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_padded_shape()[-1];
+            uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_logical_shape()[-1];
             auto
                 [num_cores,
                  all_cores,
@@ -285,8 +291,8 @@ operation::ProgramWithCallbacks slice_rm_strided_single_core_n_dims(
     // TODO: multi core implementation - work division is not trivial as we need to determine the N/C/H/W start and end
     // points for each split, and base that off stride
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
-    const auto output_shape = output.get_padded_shape();
-    const auto input_shape = a.get_padded_shape();
+    const auto output_shape = output.get_logical_shape();
+    const auto input_shape = a.get_logical_shape();
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
     uint32_t src_is_dram = a.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
@@ -318,9 +324,7 @@ operation::ProgramWithCallbacks slice_rm_strided_single_core_n_dims(
             src_is_dram,
             (uint32_t)page_size_input,
             (uint32_t)input_shape.rank(),
-        }
-
-                                               ));
+        }));
 
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -412,8 +416,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     tt::tt_metal::IDevice* device = input_tensor.device();
 
     auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_padded_shape();
-    auto output_shape = output_tensor.get_padded_shape();
+    auto input_shape = input_tensor.get_logical_shape();
+    auto output_shape = output_tensor.get_logical_shape();
 
     uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
@@ -547,16 +551,19 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 
 operation::ProgramWithCallbacks slice_rm_multi_core_sharded(
-    const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    const ttnn::Shape output_shape = output.get_padded_shape();
+    const Tensor& a, 
+    Tensor& output, 
+    const ttnn::Shape& output_tensor_start, 
+    const ttnn::Shape& output_tensor_end) {
+    const ttnn::Shape output_shape = output.get_logical_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::IDevice* device = a.device();
 
-    uint32_t num_padded_sticks = a.volume() / a.get_padded_shape()[-1];
-    uint32_t num_unpadded_sticks = output.volume() / output.get_padded_shape()[-1];
+    uint32_t num_padded_sticks = a.volume() / a.get_logical_shape()[-1];
+    uint32_t num_unpadded_sticks = output.volume() / output.get_logical_shape()[-1];
 
     // stick sizes
     uint32_t W_padded = a.get_logical_shape()[-1];
@@ -694,8 +701,8 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     std::vector<uint32_t>& accumulated_total_per_dim) {
     const auto input_buffer = input_tensor.buffer();
     const auto output_buffer = output_tensor.buffer();
-    const auto& input_shape = input_tensor.get_padded_shape();
-    const auto& output_shape = output_tensor.get_padded_shape();
+    const auto& input_shape = input_tensor.get_logical_shape();
+    const auto& output_shape = output_tensor.get_logical_shape();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
@@ -823,7 +830,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
 
 operation::ProgramWithCallbacks slice_tile_multi_core(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    const auto output_shape = output.get_padded_shape();
+    const auto output_shape = output.get_logical_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -856,7 +863,7 @@ operation::ProgramWithCallbacks slice_tile_multi_core(
             .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(a.get_padded_shape().rank());
+    std::uint32_t num_dims = static_cast<std::uint32_t>(a.get_logical_shape().rank());
 
     // Reader compile-time args
     // Data is 32 byte aligned

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -107,7 +107,7 @@ ttnn::Tensor SliceOperation::invoke(
             aligned_ends &= slice_aligned_to_tile(modified_ends) || (modified_ends[input_rank - 1] == input_shape[-1] &&
                                                                      modified_ends[input_rank - 2] == input_shape[-2]);
         }
-        rm_only = !no_step || !aligned_begins || !aligned_ends || one_dimensional;
+        rm_only = !no_step || !aligned_begins || !aligned_ends || one_dimensional || input_tensor.is_sharded();
         if (rm_only) {
             if (!no_step) {
                 TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -27,6 +27,18 @@ ttnn::Tensor SliceOperation::invoke(
 
     const auto& input_shape = input_tensor.get_logical_shape();
     uint32_t input_rank = input_shape.rank();
+    auto input_layout = input_tensor.get_layout();
+    if (input_rank < 2) {
+        TT_FATAL(input_layout == Layout::ROW_MAJOR, "Slice is not supported for non-row-major tensors with rank < 2");
+    }
+    TT_FATAL(
+        input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
+    TT_FATAL(begins.size() == ends.size(), "Start {} and end {} must have the same size", begins.size(), ends.size());
+    TT_FATAL(
+        step.size() == begins.size(),
+        "Step {} must have the same size as start {} and end",
+        step.size(),
+        begins.size());
 
     bool no_step = std::ranges::all_of(step, [](uint32_t s) { return s == 1; });
     bool starts_zero = std::ranges::all_of(begins, [](uint32_t s) { return s == 0; });
@@ -38,59 +50,58 @@ ttnn::Tensor SliceOperation::invoke(
         }
     }
 
-    if (no_step && starts_zero && ends_max) {
+    const auto& tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
+
+    auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
+                                                            : memory_config_arg.value_or(input_tensor.memory_config());
+
+    auto ret_adjustment([&](const ttnn::Tensor& input_tensor) {
         if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value()
-                                     ? optional_output_tensor.value().memory_config()
-                                     : memory_config_arg.value_or(input_tensor.memory_config());
-            return ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            auto tensor = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            tensor = ttnn::to_layout(tensor, input_layout, std::nullopt, std::nullopt, (IDevice*)nullptr);
+            return tensor;
         }
         return input_tensor;
+    });
+
+    // No-op check
+    if (no_step && starts_zero && ends_max) {
+        return ret_adjustment(input_tensor);
     }
-
-    TT_FATAL(
-        input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
-    TT_FATAL(begins.size() == ends.size(), "Start {} and end {} must have the same size", begins.size(), ends.size());
-    TT_FATAL(
-        step.size() == begins.size(),
-        "Step {} must have the same size as start {} and end",
-        step.size(),
-        begins.size());
-
-    bool rm_only = !no_step && input_tensor.get_layout() == Layout::TILE;
-    Tensor input = input_tensor;
-    if (rm_only) {
-        TT_FATAL(input.get_dtype() == DataType::BFLOAT16, "Strided slice is not supported for BFLOAT8 tensors");
-        input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-    }
-
-    // Unsqueeze tensor to 4D if necessary
-    if (input_rank < 4) {
-        input = ttnn::unsqueeze_to_4D(input);
-    }
-
-    auto padded_shape = input.get_padded_shape();
-    size_t adjusted_rank = padded_shape.rank();  // Now adjusted to 4 after unsqueeze
 
     // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
-    ttnn::SmallVector<uint32_t> modified_begins(adjusted_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_ends(padded_shape.cbegin(), padded_shape.cend());
-    ttnn::SmallVector<uint32_t> modified_step(adjusted_rank, 1);
-
-    size_t rank_diff = adjusted_rank - input_rank;
+    ttnn::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttnn::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttnn::SmallVector<uint32_t> modified_step(input_rank, 1);
 
     // Wrap indices and adjust begins, ends, and step
     for (size_t i = 0; i < begins.size(); ++i) {
-        size_t idx = i + rank_diff;
-
         if constexpr (std::is_signed_v<T>) {
-            modified_begins[idx] = wrap_index(begins[i], input_shape[i]);
-            modified_ends[idx] = wrap_index(ends[i], input_shape[i]);
-            modified_step[idx] = static_cast<uint32_t>(step[i]);
+            modified_begins[i] = wrap_index(begins[i], input_shape[i]);
+            modified_ends[i] = wrap_index(ends[i], input_shape[i]);
+            modified_step[i] = static_cast<uint32_t>(step[i]);
         } else {
-            modified_begins[idx] = begins[i];
-            modified_ends[idx] = ends[i];
-            modified_step[idx] = step[i];
+            modified_begins[i] = begins[i];
+            modified_ends[i] = ends[i];
+            modified_step[i] = step[i];
+        }
+    }
+
+    bool unaligned_begins = false;
+    bool unaligned_ends = false;
+    bool rm_only = false;
+
+    Tensor input = input_tensor;
+    if (input_tensor.get_layout() == Layout::TILE) {
+        unaligned_begins |= (modified_begins[input_rank - 2] % tile_shape[0] != 0) ||
+                            (modified_begins[input_rank - 1] % tile_shape[1] != 0);
+        // TODO: if only the ends are unaligned, we can use fill_pad to pad the tensor
+        unaligned_ends |= (modified_ends[input_rank - 2] % tile_shape[0] != 0) ||
+                          (modified_ends[input_rank - 1] % tile_shape[1] != 0);
+        rm_only = !no_step || unaligned_begins || unaligned_ends;
+        if (rm_only) {
+            TT_FATAL(input.get_dtype() == DataType::BFLOAT16, "Strided slice is not supported for BFLOAT8 tensors");
+            input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config, (IDevice*)nullptr);
         }
     }
 
@@ -113,13 +124,14 @@ ttnn::Tensor SliceOperation::invoke(
 
     // Compute actual and padded shapes for the original input rank
     for (size_t i = 0; i < input_rank; ++i) {
-        size_t idx = i + rank_diff;
         TT_FATAL(
-            modified_ends[idx] >= modified_begins[idx],
-            "End {} must be greater than or equal to start {}",
-            modified_ends[idx],
-            modified_begins[idx]);
-        auto val = output_dim_i(idx, modified_ends);
+            modified_begins[i] <= modified_ends[i],
+            "Invalid slice operation: begin[{}] must be less than or equal to end[{}], but got {} > {}",
+            i,
+            i,
+            modified_begins[i],
+            modified_ends[i]);
+        auto val = output_dim_i(i, modified_ends);
         if (val == 0) {
             empty = true;
         }
@@ -131,8 +143,7 @@ ttnn::Tensor SliceOperation::invoke(
 
     if (empty) {
         TT_FATAL(
-            input_tensor.storage_type() == StorageType::DEVICE,
-            "Host tensor slice cannot return a scalar or empty tensor");
+            input.storage_type() == StorageType::DEVICE, "Host tensor slice cannot return a scalar or empty tensor");
         return ttnn::empty(
             actual_shape,
             input_tensor.dtype(),
@@ -209,7 +220,7 @@ ttnn::Tensor SliceOperation::invoke(
     tt::stl::Span<const T> step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor) {
-    return SliceOperation::invoke<T>(ttnn::DefaultQueueId, input_tensor, begins, ends, step, memory_config_arg);
+    return SliceOperation::invoke<T>(ttnn::DefaultQueueId, input_tensor, begins, ends, step, memory_config_arg, optional_output_tensor);
 }
 
 // Specialization for uint32_t and N=4
@@ -343,7 +354,8 @@ ttnn::Tensor SliceOperation::invoke(
     tt::stl::Span<const T> start(output_tensor_start.begin(), output_tensor_start.end());
     tt::stl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
     tt::stl::Span<const T> step_vec(step.begin(), step.end());
-    return SliceOperation::invoke<T>(queue_id, input_tensor, start, end, step_vec, memory_config_arg);
+    return SliceOperation::invoke<T>(
+        queue_id, input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor);
 }
 
 template <typename T, std::size_t N>
@@ -355,7 +367,13 @@ ttnn::Tensor SliceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor) {
     return SliceOperation::invoke<T, N>(
-        ttnn::DefaultQueueId, input_tensor, output_tensor_start, output_tensor_end, step, memory_config_arg);
+        ttnn::DefaultQueueId,
+        input_tensor,
+        output_tensor_start,
+        output_tensor_end,
+        step,
+        memory_config_arg,
+        optional_output_tensor);
 }
 
 template ttnn::Tensor SliceOperation::invoke<int>(
@@ -393,10 +411,36 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     const std::optional<Tensor>& optional_output_tensor);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
+    uint8_t queue_id,
     const ttnn::Tensor& input_tensor,
     const std::array<uint32_t, 4>& output_tensor_start,
     const std::array<uint32_t, 4>& output_tensor_end,
     const std::array<uint32_t, 4>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor);
+
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 4>& output_tensor_start,
+    const std::array<uint32_t, 4>& output_tensor_end,
+    const std::array<uint32_t, 4>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor);
+
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
+    uint8_t queue_id,
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 3>& output_tensor_start,
+    const std::array<uint32_t, 3>& output_tensor_end,
+    const std::array<uint32_t, 3>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor);
+
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 3>& output_tensor_start,
+    const std::array<uint32_t, 3>& output_tensor_end,
+    const std::array<uint32_t, 3>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -88,21 +88,24 @@ ttnn::Tensor SliceOperation::invoke(
         }
     }
 
-    bool unaligned_begins = false;
-    bool unaligned_ends = false;
+    bool aligned_begins = true;
+    bool aligned_ends = true;
     bool rm_only = false;
     bool one_dimensional = input_rank == 1;
 
     Tensor input = input_tensor;
     if (input_tensor.get_layout() == Layout::TILE) {
         if (!one_dimensional) {
-            unaligned_begins |= (modified_begins[input_rank - 2] % tile_shape[0] != 0) ||
-                                (modified_begins[input_rank - 1] % tile_shape[1] != 0);
+            auto slice_aligned_to_tile = [&tile_shape, &input_rank](const auto& v) -> bool {
+                return (v[input_rank - 2] % tile_shape[0] == 0) && (v[input_rank - 1] % tile_shape[1] == 0);
+            };
+
+            aligned_begins &= slice_aligned_to_tile(modified_begins);
             // TODO: if only the ends are unaligned, we can use fill_pad to pad the tensor
-            unaligned_ends |= (modified_ends[input_rank - 2] % tile_shape[0] != 0) ||
-                              (modified_ends[input_rank - 1] % tile_shape[1] != 0);
+            aligned_ends &= slice_aligned_to_tile(modified_ends) || (modified_ends[input_rank - 1] == input_shape[-1] &&
+                                                                     modified_ends[input_rank - 2] == input_shape[-2]);
         }
-        rm_only = !no_step || unaligned_begins || unaligned_ends || one_dimensional;
+        rm_only = !no_step || !aligned_begins || !aligned_ends || one_dimensional;
         if (rm_only) {
             TT_FATAL(input.get_dtype() == DataType::BFLOAT16, "Strided slice is not supported for BFLOAT8 tensors");
             input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config, (IDevice*)nullptr);
@@ -113,17 +116,8 @@ ttnn::Tensor SliceOperation::invoke(
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
-    ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
-    if (input.layout() == Layout::TILE) {
-        padded_ends[adjusted_rank - 2] = std::max(
-            tt::round_up(padded_ends[adjusted_rank - 2], tt::constants::TILE_HEIGHT), tt::constants::TILE_HEIGHT);
-        padded_ends[adjusted_rank - 1] = std::max(
-            tt::round_up(padded_ends[adjusted_rank - 1], tt::constants::TILE_WIDTH), tt::constants::TILE_WIDTH);
-    }
-
-    ttnn::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
+    ttnn::SmallVector<uint32_t> actual_shape_vec;
     actual_shape_vec.reserve(input_rank);
-    final_padded_shape_vec.reserve(input_rank);
     bool empty = false;
 
     // Compute actual and padded shapes for the original input rank
@@ -140,10 +134,8 @@ ttnn::Tensor SliceOperation::invoke(
             empty = true;
         }
         actual_shape_vec.push_back(val);
-        final_padded_shape_vec.push_back(std::max(output_dim_i(idx, padded_ends), static_cast<uint32_t>(1)));
     }
     ttnn::Shape actual_shape(actual_shape_vec);
-    ttnn::Shape final_padded_shape(final_padded_shape_vec);
 
     if (empty) {
         TT_FATAL(
@@ -154,18 +146,6 @@ ttnn::Tensor SliceOperation::invoke(
             input_tensor.layout(),
             input_tensor.device(),
             memory_config_arg.value_or(input_tensor.memory_config()));
-    }
-
-    // Early exit if slice is a no-op
-    if (final_padded_shape == input.get_padded_shape() && no_step) {
-        if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value()
-                                     ? optional_output_tensor.value().memory_config()
-                                     : memory_config_arg.value_or(input_tensor.memory_config());
-            auto res = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
-            return ttnn::reshape(res, actual_shape, final_padded_shape);
-        }
-        return ttnn::reshape(input_tensor, actual_shape, final_padded_shape);
     }
 
     auto res = tt::tt_metal::operation::operation::run(
@@ -193,124 +173,6 @@ ttnn::Tensor SliceOperation::invoke(
     return SliceOperation::invoke<T>(ttnn::DefaultQueueId, input_tensor, begins, ends, step, memory_config_arg, optional_output_tensor);
 }
 
-// Specialization for uint32_t and N=4
-template <>
-ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
-    QueueId queue_id,
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 4>& begins,
-    const std::array<uint32_t, 4>& ends,
-    const std::array<uint32_t, 4>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor) {
-    const auto& padded_input_shape = input_tensor.get_padded_shape();
-    TT_FATAL(padded_input_shape.rank() == 4, "Input tensor must have rank 4");
-
-    bool no_step = step[0] == 1 && step[1] == 1 && step[2] == 1 && step[3] == 1;
-    bool starts_zero = begins[0] == 0 && begins[1] == 0 && begins[2] == 0 && begins[3] == 0;
-    bool ends_max = ends[0] == padded_input_shape[0] && ends[1] == padded_input_shape[1] &&
-                    ends[2] == padded_input_shape[2] && ends[3] == padded_input_shape[3];
-
-    if (no_step && starts_zero && ends_max) {
-        if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value()
-                                     ? optional_output_tensor.value().memory_config()
-                                     : memory_config_arg.value_or(input_tensor.memory_config());
-            return ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
-        }
-        return input_tensor;
-    }
-    bool rm_only = !no_step && input_tensor.get_layout() == Layout::TILE;
-    ttnn::Tensor input = input_tensor;
-    if (rm_only) {
-        input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-    }
-
-    const bool tiled = input.get_layout() == Layout::TILE;
-    bool on_device = input.storage_type() == StorageType::DEVICE;
-
-    std::array<uint32_t, 4> actual_shape_vec;
-    std::array<uint32_t, 4> padded_shape_vec;
-    const std::array<uint32_t, 4> padded_ends =
-        tiled ? std::array<uint32_t, 4>(
-                    {ends[0],
-                     ends[1],
-                     std::max(tt::round_up(ends[2], tt::constants::TILE_HEIGHT), tt::constants::TILE_HEIGHT),
-                     std::max(tt::round_up(ends[3], tt::constants::TILE_WIDTH), tt::constants::TILE_WIDTH)})
-              : ends;
-    bool empty = false;
-    for (int i = 0; i < 4; ++i) {
-        TT_FATAL(ends[i] >= begins[i], "End {} must be greater than or equal to start {}", ends[i], begins[i]);
-        uint32_t offset = step[i] - begins[i] - 1;
-        uint32_t dim_size = (ends[i] + offset) / step[i];
-        empty |= dim_size == 0;
-        actual_shape_vec[i] = dim_size;
-        padded_shape_vec[i] = std::max((padded_ends[i] + offset) / step[i], 1u);
-    }
-    ttnn::Shape actual_shape(actual_shape_vec);
-    ttnn::Shape padded_shape(padded_shape_vec);
-
-    if (empty) {
-        TT_FATAL(on_device, "Host tensor slice cannot return a scalar or empty tensor");
-        auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
-                                                                : memory_config_arg.value_or(input.memory_config());
-        return ttnn::empty(actual_shape, input.dtype(), input_tensor.layout(), input.device(), memory_config);
-    }
-
-    // Early exit if slice is a no-op
-    if (padded_shape == padded_input_shape && no_step) {
-        if (input.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
-                                                                    : memory_config_arg.value_or(input.memory_config());
-            auto res = ttnn::to_memory_config(input, memory_config, std::nullopt);
-            return ttnn::reshape(res, actual_shape, padded_shape);
-        }
-        return ttnn::reshape(input, actual_shape, padded_shape);  // change to view
-    }
-
-    if (on_device) {
-        auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
-                                                                : memory_config_arg.value_or(input.memory_config());
-
-        // Check for in-place unpad optimization
-        if (input.is_sharded() && input.memory_config() == memory_config && padded_input_shape.rank() > 1) {
-            TT_FATAL(no_step, "Sharded tensor slice implementation does not support striding");
-            bool in_place_unpad = true;
-            for (int i = 0; i < 2; ++i) {
-                in_place_unpad &= begins[i] == 0 && ends[i] == 1 && padded_input_shape[i] == 1;
-            }
-            in_place_unpad &=
-                begins[2] == 0 && tt::div_up(ends[2], input.shard_spec().value().shape[0]) ==
-                                      tt::div_up(padded_input_shape[2], input.shard_spec().value().shape[0]);
-            in_place_unpad &= begins[3] == 0 && ends[3] == padded_input_shape[3];
-            if (in_place_unpad) {
-                return ttnn::reshape(input, actual_shape, padded_shape);
-            }
-        }
-
-        input = tt::tt_metal::operation::run(
-            SliceDeviceOperation{ttnn::Shape(begins), ttnn::Shape(padded_ends), ttnn::Shape(step), memory_config},
-            {input},
-            {},
-            {optional_output_tensor},
-            queue_id)[0];
-        input = ttnn::reshape(input, actual_shape, padded_shape);
-        return rm_only ? ttnn::to_layout(input, input.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr)
-                       : input;
-    }
-
-    TT_FATAL(no_step, "Host tensor slice does not support strides");
-
-    if (input.get_padded_shape() == actual_shape) {
-        return input;
-    } else {
-        auto input_4d_rm = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-        auto output_4d = input_4d_rm.unpad(ttnn::Shape(begins), ttnn::Shape(ends));
-        auto output_4d_rm =
-            ttnn::to_layout(output_4d, input.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr);
-        return ttnn::reshape(output_4d_rm, actual_shape, padded_shape);
-    }
-}
 
 template <typename T, std::size_t N>
 ttnn::Tensor SliceOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -153,17 +153,15 @@ ttnn::Tensor SliceOperation::invoke(
             memory_config_arg.value_or(input_tensor.memory_config()));
     }
 
-    auto res = tt::tt_metal::operation::operation::run(
-                   SliceDeviceOperation{
-                       ttnn::Shape(modified_begins),
-                       ttnn::Shape(modified_ends),
-                       ttnn::Shape(modified_step),
-                       memory_config},
-                   {input},
-                   {},
-                   {optional_output_tensor},
-                   queue_id)
-                   .at(0);
+    auto res =
+        tt::tt_metal::operation::run(
+            SliceDeviceOperation{
+                ttnn::Shape(modified_begins), ttnn::Shape(modified_ends), ttnn::Shape(modified_step), memory_config},
+            {input},
+            {},
+            {optional_output_tensor},
+            queue_id)
+            .at(0);
     return ret_adjustment(res);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -27,9 +27,10 @@ ttnn::Tensor SliceOperation::invoke(
 
     const auto& input_shape = input_tensor.get_logical_shape();
     uint32_t input_rank = input_shape.rank();
+
     auto input_layout = input_tensor.get_layout();
-    if (input_rank < 2) {
-        TT_FATAL(input_layout == Layout::ROW_MAJOR, "Slice is not supported for non-row-major tensors with rank < 2");
+    if (input_rank == 0) {
+        return input_tensor;
     }
     TT_FATAL(
         input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
@@ -90,15 +91,18 @@ ttnn::Tensor SliceOperation::invoke(
     bool unaligned_begins = false;
     bool unaligned_ends = false;
     bool rm_only = false;
+    bool one_dimensional = input_rank == 1;
 
     Tensor input = input_tensor;
     if (input_tensor.get_layout() == Layout::TILE) {
-        unaligned_begins |= (modified_begins[input_rank - 2] % tile_shape[0] != 0) ||
-                            (modified_begins[input_rank - 1] % tile_shape[1] != 0);
-        // TODO: if only the ends are unaligned, we can use fill_pad to pad the tensor
-        unaligned_ends |= (modified_ends[input_rank - 2] % tile_shape[0] != 0) ||
-                          (modified_ends[input_rank - 1] % tile_shape[1] != 0);
-        rm_only = !no_step || unaligned_begins || unaligned_ends;
+        if (!one_dimensional) {
+            unaligned_begins |= (modified_begins[input_rank - 2] % tile_shape[0] != 0) ||
+                                (modified_begins[input_rank - 1] % tile_shape[1] != 0);
+            // TODO: if only the ends are unaligned, we can use fill_pad to pad the tensor
+            unaligned_ends |= (modified_ends[input_rank - 2] % tile_shape[0] != 0) ||
+                              (modified_ends[input_rank - 1] % tile_shape[1] != 0);
+        }
+        rm_only = !no_step || unaligned_begins || unaligned_ends || one_dimensional;
         if (rm_only) {
             TT_FATAL(input.get_dtype() == DataType::BFLOAT16, "Strided slice is not supported for BFLOAT8 tensors");
             input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config, (IDevice*)nullptr);
@@ -164,52 +168,18 @@ ttnn::Tensor SliceOperation::invoke(
         return ttnn::reshape(input_tensor, actual_shape, final_padded_shape);
     }
 
-    if (input_tensor.storage_type() != StorageType::DEVICE) {
-        TT_FATAL(no_step, "Host tensor slice does not support strides");
-        if (input_tensor.get_padded_shape() == actual_shape) {
-            return input_tensor;
-        } else {
-            input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-            input = input.unpad(ttnn::Shape(modified_begins), ttnn::Shape(modified_ends));
-            input = ttnn::to_layout(input, input_tensor.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr);
-            return ttnn::reshape(input, actual_shape, final_padded_shape);
-        }
-    } else {
-        const auto& input_tensor_shape = input.get_padded_shape();
-        auto memory_config = optional_output_tensor.has_value()
-                                 ? optional_output_tensor.value().memory_config()
-                                 : memory_config_arg.value_or(input_tensor.memory_config());
-
-        if (input.is_sharded() && input.memory_config() == memory_config && input_tensor_shape.rank() > 1) {
-            TT_FATAL(no_step, "Sharded tensor slice implementation does not support striding");
-            uint32_t i;
-            bool in_place_unpad = true;
-            for (i = 0; i < input_tensor_shape.rank() - 2; ++i) {
-                in_place_unpad &= modified_begins[i] == 0 && modified_ends[i] == 1 && input_tensor_shape[i] == 1;
-            }
-            in_place_unpad &=
-                modified_begins[i] == 0 && tt::div_up(modified_ends[i], input.shard_spec().value().shape[0]) ==
-                                               tt::div_up(input_tensor_shape[i], input.shard_spec().value().shape[0]);
-            i++;
-            in_place_unpad &= modified_begins[i] == 0 && modified_ends[i] == input_tensor_shape[i];
-            if (in_place_unpad) {
-                return ttnn::reshape(input_tensor, actual_shape, final_padded_shape);
-            }
-        }
-
-        auto res =
-            tt::tt_metal::operation::run(
-                SliceDeviceOperation{
-                    ttnn::Shape(modified_begins), ttnn::Shape(padded_ends), ttnn::Shape(modified_step), memory_config},
-                {input},
-                {},
-                {optional_output_tensor},
-                queue_id)
-                .at(0);
-        res = ttnn::reshape(res, actual_shape, final_padded_shape);
-        return rm_only ? ttnn::to_layout(res, input_tensor.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr)
-                       : res;
-    }
+    auto res = tt::tt_metal::operation::operation::run(
+                   SliceDeviceOperation{
+                       ttnn::Shape(modified_begins),
+                       ttnn::Shape(modified_ends),
+                       ttnn::Shape(modified_step),
+                       memory_config},
+                   {input},
+                   {},
+                   {optional_output_tensor},
+                   queue_id)
+                   .at(0);
+    return ret_adjustment(res);
 }
 
 template <typename T>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -507,7 +507,10 @@ std::vector<std::optional<Tensor>> ExecuteBackwardConcat::invoke(
     if (are_required_outputs[0]) {
         ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         ttnn::SmallVector<uint32_t> end_index = {
-            input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
+            input.get_logical_shape()[0],
+            input.get_logical_shape()[1],
+            input.get_logical_shape()[2],
+            input.get_logical_shape()[3]};
         ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
         ttnn::slice(queue_id, grad, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
@@ -525,7 +528,10 @@ std::vector<std::optional<Tensor>> ExecuteBackwardConcat::invoke(
             start_index_2 = {0, 0, 0, input.padded_shape()[3]};
         }
         ttnn::SmallVector<uint32_t> end_index_2 = {
-            grad.padded_shape()[0], grad.padded_shape()[1], grad.padded_shape()[2], grad.padded_shape()[3]};
+            grad.get_logical_shape()[0],
+            grad.get_logical_shape()[1],
+            grad.get_logical_shape()[2],
+            grad.get_logical_shape()[3]};
         ttnn::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
         ttnn::slice(queue_id, grad, start_index_2, end_index_2, step_2, std::nullopt, other_grad);
         grad_tensor[1] = other_grad;

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -31,7 +31,7 @@ def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
     """
 
     # Gather some basic info
-    input_rank = len(input_tensor.logical_shape)
+    input_rank = len(input_tensor.shape)
     shape = input_tensor.shape  # Or input_tensor.logical_shape, depending on your library's conventions
 
     # 1) Normalize slices into a tuple.

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -105,14 +105,6 @@ def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
             # We mimic Python negative slicing for start/stop
             start, stop, step = s.start, s.stop, s.step
 
-            # handle negative starts
-            if start is not None and start < 0:
-                start = start + shape[dim_idx]
-
-            # handle negative stops
-            if stop is not None and stop < 0:
-                stop = stop + shape[dim_idx]
-
             # default values
             if start is None:
                 start = 0

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -26,7 +26,7 @@ def _golden_function(input_tensor: ttnn.Tensor, slices):
     golden_function=_golden_function,
 )
 def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
-    input_rank = len(input_tensor.shape)
+    input_rank = len(input_tensor.logical_shape)
 
     if isinstance(slices, int):
         slices = (slice(None, slices, None),)
@@ -66,7 +66,6 @@ def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
     slice_start = [_slice.start if _slice.start is not None else 0 for _slice in slices]
     slice_end = [_slice.stop if _slice.stop is not None else input_tensor.shape[i] for i, _slice in enumerate(slices)]
     slice_step = [_slice.step if _slice.step is not None else 1 for _slice in slices]
-
     output = ttnn.slice(input_tensor, slice_start, slice_end, slice_step)
 
     return output


### PR DESCRIPTION
### Ticket
#17351 
#16966 

### Problem description
A few bugs/missing features/bad practices in slice:

- Python style list splicing slices do not work when we want to slice off a single dimension eg) tensor[0, :::]
- When begins is unaligned for row major slice, we get PCC errors
- 1D row major strided slice gets a hang
- Host side fall back to unpad when the tensor is on host
- No support for non-tile aligned begins/ends for tiled slice

### What's changed

- Add Python style list splicing for single dimensions
- Fix row major slice on unaligned begins
- Add support for 1D strided RM slice
- Remove host side code
- Fallback to RM slice when tiled slice has unaligned begins/ends
- Use `ttnn::untilize_with_unpadding` in `ttnn::concat` instead of `ttnn::slice` to deal with unpadding
- Switch to logical sizes in `ttnn::bw_concat`
- Unit test coverage for Mistral slices
- Tweak to Mistral attention to solve some correctness issues, and Mistral test to deal with the changes.

Sweep tests at 100% pass. Results: 
[slice_forge_sweeps.csv](https://github.com/user-attachments/files/18677884/slice_forge_sweeps.csv)
[slice_rm_pytorch_sweep.csv](https://github.com/user-attachments/files/18677885/slice_rm_pytorch_sweep.csv)
[slice_tiled_pytorch2_sweep.csv](https://github.com/user-attachments/files/18677886/slice_tiled_pytorch2_sweep.csv)


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. [Submitted](https://github.com/tenstorrent/tt-metal/actions/runs/13318848581)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [Submitted](https://github.com/tenstorrent/tt-metal/actions/runs/13532735803)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
