### PR TITLE
Uniquely identify this job so we can enforce it

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -33,7 +33,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-artifact:
+  pr-gate-build:
+    name: Build
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     uses: ./.github/workflows/build-artifact.yaml
     with:


### PR DESCRIPTION
### Ticket
None

### Problem description
The PR Gate is not acting as a Gate.
GH needs a Job Name to enforce passing.  I sense a maintenance nightmare in our midst.

### What's changed
Gave this job a unique ID.  I expect we'll need some soak time before we can requirement; I don't know if GH will handle legacy branches with grace.
