### PR TITLE
[TT-Train] Clip norm fix for ddp

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -155,7 +155,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N150 },
           # Disabled due to https://github.com/tenstorrent/tt-metal/issues/16012
-          # { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml
     with:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -154,7 +154,6 @@ jobs:
       matrix:
         test-group: [
           { arch: wormhole_b0, runner-label: N150 },
-          # Disabled due to https://github.com/tenstorrent/tt-metal/issues/16012
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/tt-train-post-commit.yaml

--- a/tt-train/sources/ttml/core/compute_kernel_config.cpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.cpp
@@ -20,7 +20,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::softmax() {
     config.fp32_dest_acc_en = false;
     config.math_approx_mode = false;
     config.math_fidelity = MathFidelity::HiFi4;
-    config.packer_l1_acc = false;
+    config.packer_l1_acc = true;
     return config;
 }
 

--- a/tt-train/sources/ttml/core/compute_kernel_config.cpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.cpp
@@ -20,7 +20,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::softmax() {
     config.fp32_dest_acc_en = false;
     config.math_approx_mode = false;
     config.math_fidelity = MathFidelity::HiFi4;
-    config.packer_l1_acc = true;
+    config.packer_l1_acc = false;
     return config;
 }
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -240,7 +240,7 @@ TEST_F(N300UtilsTest, DropoutDifferentSeed) {
 TEST_F(N300UtilsTest, MorehClipGradNorm) {
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
-    xt::xarray<float> xtensor = xt::ones<float>({1, 1, 1, 10});
+    xt::xarray<float> xtensor = xt::ones<float>({4, 1, 20, 5});
 
     ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
     auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer, ttnn::Layout::TILE);
@@ -257,4 +257,9 @@ TEST_F(N300UtilsTest, MorehClipGradNorm) {
     // ensure that moreh clip grad norm works without throwing a
     // bad_variant_access on n300.
     EXPECT_NO_THROW(do_it());
+    xt::xarray<float> expected_res = xt::full_like(xtensor, 0.05F);
+
+    ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
+    auto res_back = ttml::core::to_xtensor(tensor, identity_composer)[0];
+    EXPECT_TRUE(xt::allclose(expected_res, res_back, 2e-2F));
 }

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -236,3 +236,25 @@ TEST_F(N300UtilsTest, DropoutDifferentSeed) {
         EXPECT_FALSE(xt::allclose(xtensors_back[0], xtensors_back[1], /*rtol=*/1e-4, /*atol=*/1e-3));
     }
 }
+
+TEST_F(N300UtilsTest, MorehClipGradNorm) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    auto mesh_shape = device->shape();
+    xt::xarray<float> xtensor = xt::ones<float>({1, 1, 1, 10});
+
+    ttml::core::XTensorToMeshVariant<float> replicate_composer = ttml::core::ReplicateXTensorToMesh<float>(mesh_shape);
+    auto tensor = ttml::core::from_xtensor(xtensor, device, replicate_composer, ttnn::Layout::TILE);
+    auto do_it = [&tensor]() {
+        ttnn::moreh_clip_grad_norm(
+            std::vector<tt::tt_metal::Tensor>{tensor},
+            1.0F,
+            2.0F,
+            false,
+            /* total_norm */ std::nullopt,
+            /* memory_config */ std::nullopt,
+            ttml::core::ComputeKernelConfig::precise());
+    };
+    // ensure that moreh clip grad norm works without throwing a
+    // bad_variant_access on n300.
+    EXPECT_NO_THROW(do_it());
+}

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -40,6 +40,5 @@ TEST_F(ConcatOpTest, TestConcatLastDim) {
 
     auto ttnn_concat = ttnn::concat(std::vector<ttnn::Tensor>{tensor_a, tensor_b}, 3);
     auto ttnn_concat_xtensor = ttml::core::to_xtensor(ttnn_concat);
-
-    EXPECT_TRUE(xt::allclose(ttnn_concat_xtensor, expected, 5e-2F, 1e-1));
+    EXPECT_TRUE(xt::allclose(ttnn_concat_xtensor, expected, 7e-3F, 1e-6F));
 }

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <core/ttnn_all_includes.hpp>
+#include <ttnn/operations/core/compute_kernel/compute_kernel_config.hpp>
+#include <ttnn/operations/reduction/generic/generic_reductions.hpp>
+
+#include "autograd/auto_context.hpp"
+#include "core/tt_tensor_utils.hpp"
+
+class ConcatOpTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ttml::autograd::ctx().open_device();
+    }
+
+    void TearDown() override {
+        ttml::autograd::ctx().close_device();
+    }
+};
+
+// This test currently fails due to a bug in ttnn::concat. Drop the BROKEN label
+// and invert the EXPECT_FALSE when the bug is fixed.
+TEST_F(ConcatOpTest, TestConcatLastDim_BROKEN) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    device->enable_async(true);
+    auto N = 1;
+    auto C = 1;
+    auto H = 12;
+    auto W = 50;
+    auto prod = N * C * H * W;
+    xt::xarray<float> xtensor_a = xt::arange<float>(0.F, prod).reshape({N, C, H, W});
+    xt::xarray<float> xtensor_b = xt::arange<float>(prod, 2 * prod).reshape({N, C, H, W});
+
+    xt::xarray<float> expected = xt::concatenate(xt::xtuple(xtensor_a, xtensor_b), 3);
+
+    auto tensor_a = ttml::core::from_xtensor(xtensor_a, device);
+    auto tensor_b = ttml::core::from_xtensor(xtensor_b, device);
+
+    auto ttnn_concat = ttnn::concat(std::vector<ttnn::Tensor>{tensor_a, tensor_b}, 3);
+    auto ttnn_concat_xtensor = ttml::core::to_xtensor(ttnn_concat);
+
+    EXPECT_FALSE(xt::allclose(ttnn_concat_xtensor, expected));
+}

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -22,9 +22,7 @@ protected:
     }
 };
 
-// This test currently fails due to a bug in ttnn::concat. Drop the BROKEN label
-// and invert the EXPECT_FALSE when the bug is fixed.
-TEST_F(ConcatOpTest, TestConcatLastDim_BROKEN) {
+TEST_F(ConcatOpTest, TestConcatLastDim) {
     auto* device = &ttml::autograd::ctx().get_device();
     device->enable_async(true);
     auto N = 1;
@@ -43,5 +41,5 @@ TEST_F(ConcatOpTest, TestConcatLastDim_BROKEN) {
     auto ttnn_concat = ttnn::concat(std::vector<ttnn::Tensor>{tensor_a, tensor_b}, 3);
     auto ttnn_concat_xtensor = ttml::core::to_xtensor(ttnn_concat);
 
-    EXPECT_FALSE(xt::allclose(ttnn_concat_xtensor, expected));
+    EXPECT_TRUE(xt::allclose(ttnn_concat_xtensor, expected, 5e-2F, 1e-1));
 }

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -108,6 +108,9 @@ auto map_launch_op_args_to_execute_on_worker_thread_args(
                        &optional_output_tensor_index,
                        &optional_output_tensors](auto&& arg) {
         using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, std::vector<Tensor>>) {
+            return input_tensors;
+        }
         if constexpr (std::is_same_v<T, Tensor>) {
             return input_tensors.at(input_tensor_index++);
         } else if constexpr (std::is_same_v<T, std::optional<const Tensor>>) {
@@ -307,9 +310,22 @@ private:
 
         using execute_on_worker_thread_return_t = decltype(operation_t::invoke(args...));
 
-        const Tensors input_tensors = detail::extract_args_to_vector<ttnn::Tensor>(args...);
+        Tensors ten_input_tensors = detail::extract_args_to_vector<ttnn::Tensor>(args...);
         const OptionalConstTensors optional_input_tensors =
             detail::extract_args_to_vector<std::optional<const ttnn::Tensor>>(args...);
+        std::vector<std::vector<ttnn::Tensor>> vec_input_tensors =
+            detail::extract_args_to_vector<std::vector<ttnn::Tensor>>(args...);
+        if (ten_input_tensors.size() > 0 && vec_input_tensors.size() > 0) {
+            TT_THROW("Only one of input_tensors or vec_input_tensors can be specified.
+            It means in the invoke function you have both Tensor and std::vector<Tensor> as inoput parameters");
+        }
+        if (ten_input_tensors.size() == 0 && vec_input_tensors.size() > 2) {
+            TT_THROW(
+                "You have more than one std::vector<Tensor> input parameters in the invoke. Only one vector is "
+                "allowed");
+        }
+
+        auto& input_tensors = ten_input_tensors.size() > 0 ? ten_input_tensors : vec_input_tensors[0];
 
         auto output_tensors = detail::create_async_output_tensors<operation_t, execute_on_worker_thread_return_t>(
             input_tensors, optional_input_tensors, args...);

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -315,19 +315,19 @@ private:
             detail::extract_args_to_vector<std::optional<const ttnn::Tensor>>(args...);
         std::vector<std::vector<ttnn::Tensor>> vec_input_tensors =
             detail::extract_args_to_vector<std::vector<ttnn::Tensor>>(args...);
-        if (single_input_tensor.size() > 0 && vec_input_tensors.size() > 0) {
+        if (!(single_input_tensor.empty() || vec_input_tensors.empty())) {
             TT_THROW(
                 "Only one of single_input_tensor or vec_input_tensors can be specified."
                 "Ensure that your invoke function does not have both Tensor and std::vector<Tensor> as input "
                 "parameters");
         }
-        if (single_input_tensor.size() == 0 && vec_input_tensors.size() > 1) {
+        if (single_input_tensor.empty() && vec_input_tensors.size() > 1) {
             TT_THROW(
                 "You have more than one std::vector<Tensor> input parameters in the invoke. Only one vector is "
                 "allowed");
         }
 
-        auto& input_tensors = vec_input_tensors.size() > 0 ? vec_input_tensors[0] : single_input_tensor;
+        auto& input_tensors = !vec_input_tensors.empty() ? vec_input_tensors[0] : single_input_tensor;
 
         auto output_tensors = detail::create_async_output_tensors<operation_t, execute_on_worker_thread_return_t>(
             input_tensors, optional_input_tensors, args...);

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -321,7 +321,7 @@ private:
                 "Ensure that your invoke function does not have both Tensor and std::vector<Tensor> as input "
                 "parameters");
         }
-        if (single_input_tensor.size() == 0 && vec_input_tensors.size() > 2) {
+        if (single_input_tensor.size() == 0 && vec_input_tensors.size() > 1) {
             TT_THROW(
                 "You have more than one std::vector<Tensor> input parameters in the invoke. Only one vector is "
                 "allowed");

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -310,23 +310,24 @@ private:
 
         using execute_on_worker_thread_return_t = decltype(operation_t::invoke(args...));
 
-        Tensors ten_input_tensors = detail::extract_args_to_vector<ttnn::Tensor>(args...);
+        Tensors single_input_tensor = detail::extract_args_to_vector<ttnn::Tensor>(args...);
         const OptionalConstTensors optional_input_tensors =
             detail::extract_args_to_vector<std::optional<const ttnn::Tensor>>(args...);
         std::vector<std::vector<ttnn::Tensor>> vec_input_tensors =
             detail::extract_args_to_vector<std::vector<ttnn::Tensor>>(args...);
-        if (ten_input_tensors.size() > 0 && vec_input_tensors.size() > 0) {
+        if (single_input_tensor.size() > 0 && vec_input_tensors.size() > 0) {
             TT_THROW(
-                "Only one of input_tensors or vec_input_tensors can be specified."
-                "It means in the invoke function you have both Tensor and std::vector<Tensor> as inoput parameters");
+                "Only one of single_input_tensor or vec_input_tensors can be specified."
+                "Ensure that your invoke function does not have both Tensor and std::vector<Tensor> as input "
+                "parameters");
         }
-        if (ten_input_tensors.size() == 0 && vec_input_tensors.size() > 2) {
+        if (single_input_tensor.size() == 0 && vec_input_tensors.size() > 2) {
             TT_THROW(
                 "You have more than one std::vector<Tensor> input parameters in the invoke. Only one vector is "
                 "allowed");
         }
 
-        auto& input_tensors = vec_input_tensors.size() > 0 ? vec_input_tensors[0] : ten_input_tensors;
+        auto& input_tensors = vec_input_tensors.size() > 0 ? vec_input_tensors[0] : single_input_tensor;
 
         auto output_tensors = detail::create_async_output_tensors<operation_t, execute_on_worker_thread_return_t>(
             input_tensors, optional_input_tensors, args...);

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -325,7 +325,7 @@ private:
                 "allowed");
         }
 
-        auto& input_tensors = ten_input_tensors.size() > 0 ? ten_input_tensors : vec_input_tensors[0];
+        auto& input_tensors = vec_input_tensors.size() > 0 ? vec_input_tensors[0] : ten_input_tensors;
 
         auto output_tensors = detail::create_async_output_tensors<operation_t, execute_on_worker_thread_return_t>(
             input_tensors, optional_input_tensors, args...);

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -316,8 +316,9 @@ private:
         std::vector<std::vector<ttnn::Tensor>> vec_input_tensors =
             detail::extract_args_to_vector<std::vector<ttnn::Tensor>>(args...);
         if (ten_input_tensors.size() > 0 && vec_input_tensors.size() > 0) {
-            TT_THROW("Only one of input_tensors or vec_input_tensors can be specified.
-            It means in the invoke function you have both Tensor and std::vector<Tensor> as inoput parameters");
+            TT_THROW(
+                "Only one of input_tensors or vec_input_tensors can be specified."
+                "It means in the invoke function you have both Tensor and std::vector<Tensor> as inoput parameters");
         }
         if (ten_input_tensors.size() == 0 && vec_input_tensors.size() > 2) {
             TT_THROW(

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -159,9 +159,6 @@ MassagedConcat build_untilize_rm_retilize_concat(
                          const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> ttnn::Tensor {
             std::vector<ttnn::Tensor> itensors(tensors);
             auto res = concat_impl(itensors, dim, groups, output_memory_config);
-            for (auto& tensor : itensors) {
-                tensor.deallocate();
-            }
             return res;
         }});
 }
@@ -323,9 +320,6 @@ ttnn::Tensor ConcatOperation::invoke(
 
     std::vector<ttnn::Tensor> itensors(input_tensors);
     auto res = massaged_concat(itensors, dim, groups);
-    for (auto& tensor : itensors) {
-        tensor.deallocate();
-    }
     return res;
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.cpp
@@ -6,12 +6,19 @@
 
 namespace ttnn::operations::moreh::moreh_getitem {
 Tensor MorehGetItem::invoke(
-    const Tensor& input,
+    const std::optional<const Tensor>& input,
     const std::vector<Tensor>& index_tensors,
     const ttnn::SmallVector<uint32_t>& index_dims,
     const std::optional<Tensor>& output,
     // const CoreRange core_range,
     const std::optional<MemoryConfig>& memory_config) {
-    return ttnn::prim::moreh_getitem(input, index_tensors, index_dims, output, memory_config);
+    if (!input.has_value()) {
+        // FIXME: This is a hack to work around limitations in the decorator
+        // infra which requires either an input tensor or a vector of input
+        // tensors but not both; wrapping the input tensor in an optional allows
+        // us to work around this without rewriting half of the runtime.
+        TT_THROW("Input tensor is required for moreh_getitem operation.");
+    }
+    return ttnn::prim::moreh_getitem(input.value(), index_tensors, index_dims, output, memory_config);
 }
 }  // namespace ttnn::operations::moreh::moreh_getitem

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.hpp
@@ -10,7 +10,7 @@
 namespace ttnn::operations::moreh::moreh_getitem {
 struct MorehGetItem {
     static Tensor invoke(
-        const Tensor& input,
+        const std::optional<const Tensor>& input,
         const std::vector<Tensor>& index_tensors,
         const ttnn::SmallVector<uint32_t>& index_dims,
         const std::optional<Tensor>& output,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
clip grad norm takes std::vector<Tensor> but infra doesn't support it for sharding in the multidevice case.

### What's changed
Add multidevice support for std::vector<Tensor>.
Also added additional checks.
So any op with std::vector<Tensor> as input didn't work as expected for n300.
We found 3 ops:
1) concat
- fix triggered another issue. We accidentally deallocated input tensors in the op.
2) moreh_clip_grad
- didn't require any fixes because it takes only std::vector
3) moreh_get_item.
 - current infra cannot see aa difference between tensor and vector of tensors because it puts everything into the vector and it is hard to take it back in the right order without a huge changes to the decorators. Thats why we updated  first parameter to be the optional<const Tensor>.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13444739840
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
