### PR TITLE
[Fabric] Add controller kernel to sync the producers

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/common/kernel_utils.hpp"
+// clang-format on
+
+void kernel_main() {
+    uint32_t rt_args_idx = 0;
+    uint32_t time_seed = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t num_tx_workers = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t tx_signal_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t host_signal_address = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t num_mcast_dests = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t mcast_encoding = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+
+    // wait for sync from tx kernels
+    while (*(volatile tt_l1_ptr uint32_t*)tx_signal_addr != num_tx_workers);
+
+    // wait for signal from host
+    // this is needed to know that all the routers are up and running on all the chips
+    while (*(volatile tt_l1_ptr uint32_t*)host_signal_address == 0);
+
+    tt_l1_ptr uint32_t* mcast_sem = reinterpret_cast<tt_l1_ptr uint32_t*>(0x100000);
+    *mcast_sem = 1;
+
+    // do a noc multicast to tx kernels
+    uint64_t mcast_dest_addr = get_noc_addr_helper(mcast_encoding, tx_signal_addr);
+    noc_async_write_multicast_one_packet((uint32_t)mcast_sem, mcast_dest_addr, sizeof(uint32_t), num_mcast_dests);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
@@ -17,7 +17,6 @@ using namespace tt::tt_fabric;
 uint32_t src_endpoint_id;
 // constexpr uint32_t src_endpoint_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(1);
-static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
 constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(2);
 
 constexpr uint32_t data_buffer_start_addr = get_compile_time_arg_val(3);
@@ -83,10 +82,27 @@ uint32_t rx_addr_hi;
 uint32_t gk_interface_addr_l;
 uint32_t gk_interface_addr_h;
 
+uint32_t controller_noc_offset;
+
 // flag to check if need to zero out notification addr
 bool reset_notif_addr = true;
 
 uint32_t time_seed;
+
+inline void notify_traffic_controller() {
+    // send semaphore increment to traffic controller kernel on this device.
+    uint64_t dest_addr = get_noc_addr_helper(controller_noc_offset, signal_address);
+    noc_fast_atomic_increment<DM_DYNAMIC_NOC>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        dest_addr,
+        NOC_UNICAST_WRITE_VC,
+        1,
+        31,
+        false,
+        false,
+        MEM_NOC_ATOMIC_RET_VAL_ADDR);
+}
 
 // generates packets with random size and payload on the input sideß
 inline bool test_buffer_handler_async_wr() {
@@ -363,6 +379,7 @@ void kernel_main() {
     time_seed = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     src_endpoint_id = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    controller_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t router_x = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t router_y = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     dest_device = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -421,9 +438,13 @@ void kernel_main() {
         max_packet_size_mask = (max_packet_size_mask << 1) + 1;
     }
 
-    // wait till test sends start signal. This is set by test
-    // once tt_fabric kernels have been launched on all the test devices.
-    while (*(tt_l1_ptr volatile uint32_t*)signal_address == 0);
+    // notify the controller kernel that this worker is ready to proceed
+    notify_traffic_controller();
+
+    // wait till controllrer sends start signal. This is set by controller
+    // once tt_fabric kernels have been launched on all the test devices and
+    // all the tx workers are ready on this chip
+    while (*(volatile tt_l1_ptr uint32_t*)signal_address == 0);
 
     test_results[PQ_TEST_MISC_INDEX] = 0xff000001;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -18,7 +18,6 @@ using namespace tt::tt_fabric;
 uint32_t src_endpoint_id;
 // constexpr uint32_t src_endpoint_id = get_compile_time_arg_val(0);
 constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(1);
-static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
 constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(2);
 
 constexpr uint32_t data_buffer_start_addr = get_compile_time_arg_val(3);
@@ -70,8 +69,23 @@ uint32_t target_address;
 uint32_t noc_offset;
 uint32_t gk_interface_addr_l;
 uint32_t gk_interface_addr_h;
-
+uint32_t controller_noc_offset;
 uint32_t time_seed;
+
+inline void notify_traffic_controller() {
+    // send semaphore increment to traffic controller kernel on this device.
+    uint64_t dest_addr = get_noc_addr_helper(controller_noc_offset, signal_address);
+    noc_fast_atomic_increment<DM_DYNAMIC_NOC>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        dest_addr,
+        NOC_UNICAST_WRITE_VC,
+        1,
+        31,
+        false,
+        false,
+        MEM_NOC_ATOMIC_RET_VAL_ADDR);
+}
 
 void kernel_main() {
     tt_fabric_init();
@@ -80,13 +94,19 @@ void kernel_main() {
     time_seed = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     src_endpoint_id = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    controller_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t router_x = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t router_y = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     dest_device = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t rx_buf_size = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     gk_interface_addr_l = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     gk_interface_addr_h = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
-    target_address = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+
+    if constexpr (ASYNC_WR & test_command) {
+        base_target_address = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    }
+
+    target_address = base_target_address;
 
     // Read in the routing table
     uint64_t router_config_addr =
@@ -125,8 +145,12 @@ void kernel_main() {
     // make sure fabric node gatekeeper is available.
     fabric_endpoint_init();
 
+    // notify the controller kernel that this worker is ready to proceed
+    notify_traffic_controller();
+
     // wait till test sends start signal. This is set by test
-    // once tt_fabric kernels have been launched on all the test devices.
+    // once tt_fabric kernels have been launched on all the test devices and
+    // all tx workers are ready to send data
     while (*(volatile tt_l1_ptr uint32_t*)signal_address == 0);
 
     uint64_t start_timestamp = get_timestamp();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17573)

### Problem description
Currently the producer kernels wait for the signal from host to start transmitting packets. This could cause the workers to transmit the packets in non-overlapping time frames thus impacting perf calculations. This could get as worse as the workers running serially because of fabric not allowing context switch for the slow dispatch commands to go through.

### What's changed
Add a new controller kernel that now synchronizes all the producers on the same chip. This kernel now waits for the signal from the host and then noc mcasts the notification to the worker kernels, thus reducing the skew to the order of 10s of cycles. This kernel can be extended to setup other handshakes in the future as well.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13168201035)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
