### PR TITLE
Split header and implementation for dispatch_core_manager.hpp

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_core_manager.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_manager.hpp
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <list>
+#include <unordered_map>
+#include <vector>
+
 #include "core_descriptor.hpp"
 #include "core_coord.hpp"
-#include <list>
 #include "dispatch_core_common.hpp"
 
 namespace tt::tt_metal {
@@ -49,20 +52,9 @@ class dispatch_core_manager {
 
     //TODO: this should probably be in command_queue_interface.hpp, but it's here for now due to circular dependency
     static constexpr uint8_t MAX_NUM_HW_CQS = 2;
-    static void initialize(const DispatchCoreConfig &dispatch_core_config, uint8_t num_hw_cqs) noexcept {
-        log_debug(tt::LogMetal, "DevicePool initialize");
-        if (_inst == nullptr) {
-            static dispatch_core_manager dispatch_core_manager(dispatch_core_config, num_hw_cqs);
-            _inst = &dispatch_core_manager;
-        } else if (_inst->dispatch_core_config_by_device[0] != dispatch_core_config or num_hw_cqs != _inst->num_hw_cqs) {
-            _inst->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs);
-        }
-    }
+    static void initialize(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) noexcept;
 
-    static dispatch_core_manager &instance() {
-        TT_ASSERT(_inst != nullptr, "Trying to get dispatch_core_manager without initializing it");
-        return *_inst;
-    }
+    static dispatch_core_manager& instance();
 
     /// @brief Gets the location of the kernel desginated to read from the issue queue region from a particular command queue
     ///         Each command queue has an issue queue where host enqueues commands. This core relays to the dispatcher core to interpret and launch
@@ -71,26 +63,9 @@ class dispatch_core_manager {
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the issue queue interface
-    const tt_cxy_pair &prefetcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.prefetcher.has_value()) {
-            return assignment.prefetcher.value();
-        }
-        // Issue queue interface is on the MMIO device
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-        CoreCoord issue_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
-        assignment.prefetcher = tt_cxy_pair(mmio_device_id, issue_queue_coord.x, issue_queue_coord.y);
-        log_dispatch_assignment("Prefetcher", assignment.prefetcher.value(), device_id, channel, cq_id);
-        return assignment.prefetcher.value();
-    }
+    const tt_cxy_pair& prefetcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_prefetcher_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.prefetcher.has_value()) {
-            return true;
-        }
-        return false;
-    }
+    bool is_prefetcher_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated to interface with prefetcher kernel running on mmio device.
     ///         Prefetcher kernel on mmio device relays commands to prefetcher_d running on remote device.
@@ -98,50 +73,18 @@ class dispatch_core_manager {
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the issue queue interface
-    const tt_cxy_pair &prefetcher_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.prefetcher_d.has_value()) {
-            return assignment.prefetcher_d.value();
-        }
-        CoreCoord prefetch_d_coord = this->get_next_available_dispatch_core(device_id);
-        assignment.prefetcher_d = tt_cxy_pair(device_id, prefetch_d_coord.x, prefetch_d_coord.y);
-        log_dispatch_assignment("Prefetcher D", assignment.prefetcher_d.value(), device_id, channel, cq_id);
-        return assignment.prefetcher_d.value();
-    }
+    const tt_cxy_pair& prefetcher_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_prefetcher_d_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.prefetcher_d.has_value()) {
-            return true;
-        }
-        return false;
-    }
+    bool is_prefetcher_d_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated for multiplexing issue queue traffic to tunneler.
     /// @param device_id ID of the device that a fast dispatch command targets
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the mux core
-    const tt_cxy_pair &mux_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.mux.has_value()) {
-            return assignment.mux.value();
-        }
-        // Mux interface is on the MMIO device
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-        CoreCoord mux_coord = this->get_next_available_dispatch_core(mmio_device_id);
-        assignment.mux = tt_cxy_pair(mmio_device_id, mux_coord.x, mux_coord.y);
-        log_dispatch_assignment("Mux", assignment.mux.value(), device_id, channel, cq_id);
-        return assignment.mux.value();
-    }
+    const tt_cxy_pair& mux_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_mux_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.mux.has_value()) {
-            return true;
-        }
-        return false;
-    }
+    bool is_mux_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated for multiplexing traffic back towards mmio chip.
     /// @param device_id ID of the device that a fast dispatch command targets
@@ -149,92 +92,33 @@ class dispatch_core_manager {
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the mux_d core
 
-    const tt_cxy_pair &mux_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.mux_d.has_value()) {
-            return assignment.mux_d.value();
-        }
-        // mux_d is on remote device
-        CoreCoord mux_d_coord = this->get_next_available_dispatch_core(device_id);
-        assignment.mux_d = tt_cxy_pair(device_id, mux_d_coord.x, mux_d_coord.y);
-        log_dispatch_assignment("Mux D", assignment.mux_d.value(), device_id, channel, cq_id);
-        return assignment.mux_d.value();
-    }
+    const tt_cxy_pair& mux_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated for demultiplexing traffic to completion queues.
     /// @param device_id ID of the device that a fast dispatch command targets
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the mux core
-    const tt_cxy_pair &demux_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.demux.has_value()) {
-            return assignment.demux.value();
-        }
-        // demux interface is on the MMIO device
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-        CoreCoord demux_coord = this->get_next_available_dispatch_core(mmio_device_id);
-        assignment.demux = tt_cxy_pair(mmio_device_id, demux_coord.x, demux_coord.y);
-        log_dispatch_assignment("Demux", assignment.demux.value(), device_id, channel, cq_id);
-        return assignment.demux.value();
-    }
+    const tt_cxy_pair& demux_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_demux_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.demux.has_value()) {
-            return true;
-        }
-        return false;
-    }
+    bool is_demux_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated for demultiplexing traffic on remote chip.
     /// @param device_id ID of the device that a fast dispatch command targets
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the demux_d core
-    const tt_cxy_pair &demux_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.demux_d.has_value()) {
-            return assignment.demux_d.value();
-        }
-        // demux_d is on remote device
-        CoreCoord demux_d_coord = this->get_next_available_dispatch_core(device_id);
-        assignment.demux_d = tt_cxy_pair(device_id, demux_d_coord.x, demux_d_coord.y);
-        log_dispatch_assignment("Demux D", assignment.demux_d.value(), device_id, channel, cq_id);
-        return assignment.demux_d.value();
-    }
+    const tt_cxy_pair& demux_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated for tunneling over ethernet.
     /// @param device_id ID of the device that a fast dispatch command targets
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the ethernet tunnel core
-    const tt_cxy_pair &tunneler_core(chip_id_t upstream_device_id, chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.tunneler.has_value()) {
-            return assignment.tunneler.value();
-        }
+    const tt_cxy_pair& tunneler_core(
+        chip_id_t upstream_device_id, chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-        auto[us_core, ds_core] = tt::Cluster::instance().get_eth_tunnel_core(upstream_device_id, device_id, EthRouterMode::BI_DIR_TUNNELING);
-
-        assignment.tunneler = us_core;
-        assignment.tunneler_d = ds_core;
-
-        log_dispatch_assignment("Tunneler Remote", assignment.tunneler.value(), device_id, channel, cq_id, true);
-        log_dispatch_assignment("Tunneler Local", assignment.tunneler_d.value(), device_id, channel, cq_id, true);
-        return assignment.tunneler.value();
-    }
-
-    const tt_cxy_pair &us_tunneler_core_local(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.tunneler_d.has_value()) {
-            return assignment.tunneler_d.value();
-        }
-        TT_ASSERT(false, "Device {} has no allocation for Local Upstream Tunneler Core.", device_id);
-        assignment.tunneler_d = tt_cxy_pair(0, 0, 0);
-        return assignment.tunneler_d.value();
-    }
-
+    const tt_cxy_pair& us_tunneler_core_local(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel desginated to write to the completion queue region for a particular command queue
     ///         Each command queue has one completion queue
@@ -244,174 +128,62 @@ class dispatch_core_manager {
     /// @param channel assigned to the command queue
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the completion queue interface
-    const tt_cxy_pair &completion_queue_writer_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.completion_queue_writer.has_value()) {
-            return assignment.completion_queue_writer.value();
-        }
-        // Completion queue interface is on the MMIO device
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-        CoreCoord completion_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
-        assignment.completion_queue_writer = tt_cxy_pair(mmio_device_id, completion_queue_coord.x, completion_queue_coord.y);
-        TT_ASSERT(not assignment.dispatcher.has_value(), "Command dispatcher core {} must match completion queue interface core for MMIO device {}", assignment.dispatcher.value().str(), device_id);
-        assignment.dispatcher = assignment.completion_queue_writer;
-        log_dispatch_assignment("Completion Queue Writer", assignment.completion_queue_writer.value(), device_id, channel, cq_id);
-        return assignment.completion_queue_writer.value();
-    }
+    const tt_cxy_pair& completion_queue_writer_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_completion_queue_writer_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.completion_queue_writer.has_value()) {
-            return true;
-        }
-        return false;
-    }
+    bool is_completion_queue_writer_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel designated to relay fast dispatch commands to worker cores from a particular command queue
     /// @param device_id ID of the device that should be running the command
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the dispatcher core
-    const tt_cxy_pair &dispatcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.dispatcher.has_value()) {
-            return assignment.dispatcher.value();
-        }
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-        CoreCoord dispatcher_coord = this->get_next_available_dispatch_core(mmio_device_id);
-        assignment.dispatcher = tt_cxy_pair(mmio_device_id, dispatcher_coord.x, dispatcher_coord.y);
-        TT_ASSERT(not assignment.completion_queue_writer.has_value(), "Command dispatcher core must match completion queue interface core for MMIO device {}", device_id);
-        assignment.completion_queue_writer = assignment.dispatcher;
-        log_dispatch_assignment("Dispatcher", assignment.dispatcher.value(), device_id, channel, cq_id);
-        return assignment.dispatcher.value();
-    }
+    const tt_cxy_pair& dispatcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_dispatcher_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.dispatcher.has_value()) {
-            return true;
-        }
-        return false;
-    }
+    bool is_dispatcher_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    bool is_dispatcher_s_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        return assignment.dispatcher_s.has_value();
-    }
+    bool is_dispatcher_s_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
     /// @brief Gets the location of the kernel designated to relay fast dispatch commands to worker cores from a particular command queue
     /// @param device_id ID of the device that should be running the command
     /// @param channel assigned to the command queue where commands are enqueued
     /// @param cq_id ID of the command queue within the channel
     /// @return tt_cxy_pair logical location (chip + core coordinate) of the dispatcher_d core
-    const tt_cxy_pair &dispatcher_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.dispatcher_d.has_value()) {
-            return assignment.dispatcher_d.value();
-        }
-        CoreCoord dispatcher_d_coord = this->get_next_available_dispatch_core(device_id);
-        assignment.dispatcher_d = tt_cxy_pair(device_id, dispatcher_d_coord.x, dispatcher_d_coord.y);
-        log_dispatch_assignment("Dispatcher D", assignment.dispatcher_d.value(), device_id, channel, cq_id);
-        return assignment.dispatcher_d.value();
-    }
+    const tt_cxy_pair& dispatcher_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    const tt_cxy_pair &dispatcher_s_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
-        dispatch_core_placement_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
-        if (assignment.dispatcher_s.has_value()) {
-            return assignment.dispatcher_s.value();
-        }
-        CoreCoord dispatcher_s_coord;
-        if (this->get_dispatch_core_type(device_id) == CoreType::WORKER) {
-            chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-            if (mmio_device_id == device_id) {
-                // dispatch_s is on the same tensix core as dispatch_hd
-                dispatcher_s_coord = this->dispatcher_core(device_id, channel, cq_id);
-            } else {
-                // dispatch_s is on the same tensix as dispatch_d
-                dispatcher_s_coord = this->dispatcher_d_core(device_id, channel, cq_id);
-            }
-        } else {
-            dispatcher_s_coord = this->get_next_available_dispatch_core(device_id);
-        }
-        assignment.dispatcher_s = tt_cxy_pair(device_id, dispatcher_s_coord.x, dispatcher_s_coord.y);
-        log_dispatch_assignment("Dispatcher S", assignment.dispatcher_s.value(), device_id, channel, cq_id);
-        return assignment.dispatcher_s.value();
-    }
+    const tt_cxy_pair& dispatcher_s_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id);
 
-    CoreType get_dispatch_core_type(chip_id_t device_id) {
-        return this->dispatch_core_config_by_device[device_id].get_core_type();
-    }
+    CoreType get_dispatch_core_type(chip_id_t device_id);
 
-    DispatchCoreConfig get_dispatch_core_config(chip_id_t device_id) {
-        return this->dispatch_core_config_by_device[device_id];
-    }
+    DispatchCoreConfig get_dispatch_core_config(chip_id_t device_id);
 
-    void add_dispatch_core_to_device(chip_id_t device_id, const CoreCoord& core) {
-        // TODO: remove this API, we should read the core descriptor once, should not have backdoors like this to add cores
-        auto& dispatch_cores = available_dispatch_cores_by_device.at(device_id);
-        if (std::find(dispatch_cores.begin(), dispatch_cores.end(), core) == dispatch_cores.end()) {
-            dispatch_cores.push_back(core);
-        }
-    }
+    // TODO: remove this API, we should read the core descriptor once, should not have backdoors like this to add cores
+    void add_dispatch_core_to_device(chip_id_t device_id, const CoreCoord& core);
 
-    std::vector<CoreCoord> get_all_logical_dispatch_cores(chip_id_t device_id) {
-        return tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, this->dispatch_core_config_by_device[device_id]);
-    }
-   private:
+    std::vector<CoreCoord> get_all_logical_dispatch_cores(chip_id_t device_id);
+
+private:
     /// @brief dispatch_core_manager constructor initializes a list of cores per device that are designated for any dispatch functionality
     ///         This list contains dispatch cores that have not been assigned to a particular dispatch function
     /// @param num_hw_cqs is used to get the correct collection of dispatch cores for a particular device
     /// @param dispatch_core_config specfies the core type that is designated for dispatch functionality
-    dispatch_core_manager(const DispatchCoreConfig &dispatch_core_config, uint8_t num_hw_cqs) {
-        this->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs);
-    }
-
+    dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
 
     /// @brief reset_dispatch_core_manager initializes vector of cores per device for dispatch kernels
     /// @param dispatch_core_config specfies the core type for dispatch kernels
-    void reset_dispatch_core_manager(const DispatchCoreConfig &dispatch_core_config, uint8_t num_hw_cqs) {
-        this->dispatch_core_assignments.clear();
-        this->available_dispatch_cores_by_device.clear();
-        this->dispatch_core_config_by_device.clear();
-        for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
-            std::list<CoreCoord> &logical_dispatch_cores = this->available_dispatch_cores_by_device[device_id];
-            for (const CoreCoord &logical_dispatch_core :
-                 tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, dispatch_core_config)) {
-                logical_dispatch_cores.push_back(logical_dispatch_core);
-            }
-
-            this->dispatch_core_config_by_device[device_id] = dispatch_core_config;
-            this->num_hw_cqs = num_hw_cqs;
-        }
-    }
+    void reset_dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
 
     /// @brief getting any available dispatch core for a device
     /// @param device_id
     /// @return
-    CoreCoord get_next_available_dispatch_core(chip_id_t device_id) {
-        if (this->available_dispatch_cores_by_device.find(device_id) == this->available_dispatch_cores_by_device.end()) {
-            TT_THROW("Invalid device ID to assign dispatch cores {}", device_id);
-        }
-        if (this->available_dispatch_cores_by_device.at(device_id).empty()) {
-            TT_THROW("No more available dispatch cores on device {} to assign. Expand dispatch cores specified in core descriptor YAML", device_id);
-        }
-        CoreCoord avail_dispatch_core = this->available_dispatch_cores_by_device.at(device_id).front();
-        this->available_dispatch_cores_by_device.at(device_id).pop_front();
-        return avail_dispatch_core;
-    }
+    CoreCoord get_next_available_dispatch_core(chip_id_t device_id);
 
-    void log_dispatch_assignment(std::string name, tt_cxy_pair &cxy, chip_id_t device_id, uint16_t channel, uint8_t cq_id, bool force_ethernet = false) {
-        log_debug(
-            tt::LogMetal,
-            "Allocated {} Core: {}({}) for Device {} Channel {} CQ ID {}",
-            name,
-            cxy.str(),
-            tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(cxy, force_ethernet? CoreType::ETH : get_dispatch_core_type(cxy.chip)).str(),
-            device_id,
-            channel,
-            cq_id);
-    }
-
+    void log_dispatch_assignment(
+        std::string name,
+        tt_cxy_pair& cxy,
+        chip_id_t device_id,
+        uint16_t channel,
+        uint8_t cq_id,
+        bool force_ethernet = false);
 
     // {device ID : {channel (hugepage) : {cq_id : dispatch assignment}}}
     // Each device has an assigned hugepage at a specific channel that holds (up to 2) hardware command queues (represented by cq_id)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -25,6 +25,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/host_runtime_commands.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_query_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_core_common.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_core_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/hardware_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/launch_message_ring_buffer_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -159,8 +159,6 @@ void bind_current_thread_to_free_cores(const std::unordered_set<uint32_t>& free_
 }  // namespace device_cpu_allocator
 
 DevicePool* DevicePool::_inst = nullptr;
-// Should probably add a dispatch_core_manager.cpp and move this there
-tt_metal::dispatch_core_manager* tt_metal::dispatch_core_manager::_inst = nullptr;
 
 void DevicePool::init_profiler_devices() const {
 #if defined(TRACY_ENABLE)

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -25,7 +25,7 @@ void dispatch_core_manager::initialize(const DispatchCoreConfig& dispatch_core_c
     }
 }
 
-static dispatch_core_manager& dispatch_core_manager::instance() {
+dispatch_core_manager& dispatch_core_manager::instance() {
     TT_ASSERT(dispatch_core_manager::_inst != nullptr, "Trying to get dispatch_core_manager without initializing it");
     return *dispatch_core_manager::_inst;
 }
@@ -318,12 +318,7 @@ CoreCoord dispatch_core_manager::get_next_available_dispatch_core(chip_id_t devi
 }
 
 void dispatch_core_manager::log_dispatch_assignment(
-    std::string name,
-    tt_cxy_pair& cxy,
-    chip_id_t device_id,
-    uint16_t channel,
-    uint8_t cq_id,
-    bool force_ethernet = false) {
+    std::string name, tt_cxy_pair& cxy, chip_id_t device_id, uint16_t channel, uint8_t cq_id, bool force_ethernet) {
     log_debug(
         tt::LogMetal,
         "Allocated {} Core: {}({}) for Device {} Channel {} CQ ID {}",

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dispatch_core_manager.hpp"
+
+#include "core_descriptor.hpp"
+#include "core_coord.hpp"
+#include <list>
+#include "dispatch_core_common.hpp"
+
+#include "tt_cluster.hpp"
+
+namespace tt::tt_metal {
+
+dispatch_core_manager* dispatch_core_manager::_inst = nullptr;
+
+void dispatch_core_manager::initialize(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) noexcept {
+    log_debug(tt::LogMetal, "DevicePool initialize");
+    if (_inst == nullptr) {
+        static dispatch_core_manager dispatch_core_manager(dispatch_core_config, num_hw_cqs);
+        _inst = &dispatch_core_manager;
+    } else if (_inst->dispatch_core_config_by_device[0] != dispatch_core_config or num_hw_cqs != _inst->num_hw_cqs) {
+        _inst->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs);
+    }
+}
+
+static dispatch_core_manager::dispatch_core_manager& instance() {
+    TT_ASSERT(_inst != nullptr, "Trying to get dispatch_core_manager without initializing it");
+    return *_inst;
+}
+
+const tt_cxy_pair& dispatch_core_manager::prefetcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.prefetcher.has_value()) {
+        return assignment.prefetcher.value();
+    }
+    // Issue queue interface is on the MMIO device
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    CoreCoord issue_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
+    assignment.prefetcher = tt_cxy_pair(mmio_device_id, issue_queue_coord.x, issue_queue_coord.y);
+    log_dispatch_assignment("Prefetcher", assignment.prefetcher.value(), device_id, channel, cq_id);
+    return assignment.prefetcher.value();
+}
+
+bool dispatch_core_manager::is_prefetcher_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.prefetcher.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+const tt_cxy_pair& dispatch_core_manager::prefetcher_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.prefetcher_d.has_value()) {
+        return assignment.prefetcher_d.value();
+    }
+    CoreCoord prefetch_d_coord = this->get_next_available_dispatch_core(device_id);
+    assignment.prefetcher_d = tt_cxy_pair(device_id, prefetch_d_coord.x, prefetch_d_coord.y);
+    log_dispatch_assignment("Prefetcher D", assignment.prefetcher_d.value(), device_id, channel, cq_id);
+    return assignment.prefetcher_d.value();
+}
+
+bool dispatch_core_manager::is_prefetcher_d_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.prefetcher_d.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+const tt_cxy_pair& dispatch_core_manager::mux_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.mux.has_value()) {
+        return assignment.mux.value();
+    }
+    // Mux interface is on the MMIO device
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    CoreCoord mux_coord = this->get_next_available_dispatch_core(mmio_device_id);
+    assignment.mux = tt_cxy_pair(mmio_device_id, mux_coord.x, mux_coord.y);
+    log_dispatch_assignment("Mux", assignment.mux.value(), device_id, channel, cq_id);
+    return assignment.mux.value();
+}
+
+bool dispatch_core_manager::is_mux_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.mux.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+const tt_cxy_pair& dispatch_core_manager::mux_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.mux_d.has_value()) {
+        return assignment.mux_d.value();
+    }
+    // mux_d is on remote device
+    CoreCoord mux_d_coord = this->get_next_available_dispatch_core(device_id);
+    assignment.mux_d = tt_cxy_pair(device_id, mux_d_coord.x, mux_d_coord.y);
+    log_dispatch_assignment("Mux D", assignment.mux_d.value(), device_id, channel, cq_id);
+    return assignment.mux_d.value();
+}
+
+const tt_cxy_pair& dispatch_core_manager::demux_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.demux.has_value()) {
+        return assignment.demux.value();
+    }
+    // demux interface is on the MMIO device
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    CoreCoord demux_coord = this->get_next_available_dispatch_core(mmio_device_id);
+    assignment.demux = tt_cxy_pair(mmio_device_id, demux_coord.x, demux_coord.y);
+    log_dispatch_assignment("Demux", assignment.demux.value(), device_id, channel, cq_id);
+    return assignment.demux.value();
+}
+
+bool dispatch_core_manager::is_demux_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.demux.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+const tt_cxy_pair& dispatch_core_manager::demux_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.demux_d.has_value()) {
+        return assignment.demux_d.value();
+    }
+    // demux_d is on remote device
+    CoreCoord demux_d_coord = this->get_next_available_dispatch_core(device_id);
+    assignment.demux_d = tt_cxy_pair(device_id, demux_d_coord.x, demux_d_coord.y);
+    log_dispatch_assignment("Demux D", assignment.demux_d.value(), device_id, channel, cq_id);
+    return assignment.demux_d.value();
+}
+
+const tt_cxy_pair& dispatch_core_manager::tunneler_core(
+    chip_id_t upstream_device_id, chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.tunneler.has_value()) {
+        return assignment.tunneler.value();
+    }
+
+    auto [us_core, ds_core] =
+        tt::Cluster::instance().get_eth_tunnel_core(upstream_device_id, device_id, EthRouterMode::BI_DIR_TUNNELING);
+
+    assignment.tunneler = us_core;
+    assignment.tunneler_d = ds_core;
+
+    log_dispatch_assignment("Tunneler Remote", assignment.tunneler.value(), device_id, channel, cq_id, true);
+    log_dispatch_assignment("Tunneler Local", assignment.tunneler_d.value(), device_id, channel, cq_id, true);
+    return assignment.tunneler.value();
+}
+
+const tt_cxy_pair& dispatch_core_manager::us_tunneler_core_local(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.tunneler_d.has_value()) {
+        return assignment.tunneler_d.value();
+    }
+    TT_ASSERT(false, "Device {} has no allocation for Local Upstream Tunneler Core.", device_id);
+    assignment.tunneler_d = tt_cxy_pair(0, 0, 0);
+    return assignment.tunneler_d.value();
+}
+
+const tt_cxy_pair& dispatch_core_manager::completion_queue_writer_core(
+    chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.completion_queue_writer.has_value()) {
+        return assignment.completion_queue_writer.value();
+    }
+    // Completion queue interface is on the MMIO device
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    CoreCoord completion_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
+    assignment.completion_queue_writer =
+        tt_cxy_pair(mmio_device_id, completion_queue_coord.x, completion_queue_coord.y);
+    TT_ASSERT(
+        not assignment.dispatcher.has_value(),
+        "Command dispatcher core {} must match completion queue interface core for MMIO device {}",
+        assignment.dispatcher.value().str(),
+        device_id);
+    assignment.dispatcher = assignment.completion_queue_writer;
+    log_dispatch_assignment(
+        "Completion Queue Writer", assignment.completion_queue_writer.value(), device_id, channel, cq_id);
+    return assignment.completion_queue_writer.value();
+}
+
+bool dispatch_core_manager::is_completion_queue_writer_core_allocated(
+    chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.completion_queue_writer.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+const tt_cxy_pair& dispatch_core_manager::dispatcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.dispatcher.has_value()) {
+        return assignment.dispatcher.value();
+    }
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    CoreCoord dispatcher_coord = this->get_next_available_dispatch_core(mmio_device_id);
+    assignment.dispatcher = tt_cxy_pair(mmio_device_id, dispatcher_coord.x, dispatcher_coord.y);
+    TT_ASSERT(
+        not assignment.completion_queue_writer.has_value(),
+        "Command dispatcher core must match completion queue interface core for MMIO device {}",
+        device_id);
+    assignment.completion_queue_writer = assignment.dispatcher;
+    log_dispatch_assignment("Dispatcher", assignment.dispatcher.value(), device_id, channel, cq_id);
+    return assignment.dispatcher.value();
+}
+
+bool dispatch_core_manager::is_dispatcher_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.dispatcher.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+bool dispatch_core_manager::is_dispatcher_s_core_allocated(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    return assignment.dispatcher_s.has_value();
+}
+
+const tt_cxy_pair& dispatch_core_manager::dispatcher_d_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.dispatcher_d.has_value()) {
+        return assignment.dispatcher_d.value();
+    }
+    CoreCoord dispatcher_d_coord = this->get_next_available_dispatch_core(device_id);
+    assignment.dispatcher_d = tt_cxy_pair(device_id, dispatcher_d_coord.x, dispatcher_d_coord.y);
+    log_dispatch_assignment("Dispatcher D", assignment.dispatcher_d.value(), device_id, channel, cq_id);
+    return assignment.dispatcher_d.value();
+}
+
+const tt_cxy_pair& dispatch_core_manager::dispatcher_s_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+    dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+    if (assignment.dispatcher_s.has_value()) {
+        return assignment.dispatcher_s.value();
+    }
+    CoreCoord dispatcher_s_coord;
+    if (this->get_dispatch_core_type(device_id) == CoreType::WORKER) {
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        if (mmio_device_id == device_id) {
+            // dispatch_s is on the same tensix core as dispatch_hd
+            dispatcher_s_coord = this->dispatcher_core(device_id, channel, cq_id);
+        } else {
+            // dispatch_s is on the same tensix as dispatch_d
+            dispatcher_s_coord = this->dispatcher_d_core(device_id, channel, cq_id);
+        }
+    } else {
+        dispatcher_s_coord = this->get_next_available_dispatch_core(device_id);
+    }
+    assignment.dispatcher_s = tt_cxy_pair(device_id, dispatcher_s_coord.x, dispatcher_s_coord.y);
+    log_dispatch_assignment("Dispatcher S", assignment.dispatcher_s.value(), device_id, channel, cq_id);
+    return assignment.dispatcher_s.value();
+}
+
+CoreType dispatch_core_manager::get_dispatch_core_type(chip_id_t device_id) {
+    return this->dispatch_core_config_by_device[device_id].get_core_type();
+}
+
+DispatchCoreConfig dispatch_core_manager::get_dispatch_core_config(chip_id_t device_id) {
+    return this->dispatch_core_config_by_device[device_id];
+}
+
+void dispatch_core_manager::add_dispatch_core_to_device(chip_id_t device_id, const CoreCoord& core) {
+    // TODO: remove this API, we should read the core descriptor once, should not have backdoors like this to add cores
+    auto& dispatch_cores = available_dispatch_cores_by_device.at(device_id);
+    if (std::find(dispatch_cores.begin(), dispatch_cores.end(), core) == dispatch_cores.end()) {
+        dispatch_cores.push_back(core);
+    }
+}
+
+std::vector<CoreCoord> dispatch_core_manager::get_all_logical_dispatch_cores(chip_id_t device_id) {
+    return tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, this->dispatch_core_config_by_device[device_id]);
+}
+
+// private methods
+
+dispatch_core_manager::dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
+    this->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs);
+}
+
+void dispatch_core_manager::reset_dispatch_core_manager(
+    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
+    this->dispatch_core_assignments.clear();
+    this->available_dispatch_cores_by_device.clear();
+    this->dispatch_core_config_by_device.clear();
+    for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
+        std::list<CoreCoord>& logical_dispatch_cores = this->available_dispatch_cores_by_device[device_id];
+        for (const CoreCoord& logical_dispatch_core :
+             tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, dispatch_core_config)) {
+            logical_dispatch_cores.push_back(logical_dispatch_core);
+        }
+
+        this->dispatch_core_config_by_device[device_id] = dispatch_core_config;
+        this->num_hw_cqs = num_hw_cqs;
+    }
+}
+
+CoreCoord dispatch_core_manager::get_next_available_dispatch_core(chip_id_t device_id) {
+    if (this->available_dispatch_cores_by_device.find(device_id) == this->available_dispatch_cores_by_device.end()) {
+        TT_THROW("Invalid device ID to assign dispatch cores {}", device_id);
+    }
+    if (this->available_dispatch_cores_by_device.at(device_id).empty()) {
+        TT_THROW(
+            "No more available dispatch cores on device {} to assign. Expand dispatch cores specified in core "
+            "descriptor YAML",
+            device_id);
+    }
+    CoreCoord avail_dispatch_core = this->available_dispatch_cores_by_device.at(device_id).front();
+    this->available_dispatch_cores_by_device.at(device_id).pop_front();
+    return avail_dispatch_core;
+}
+
+void dispatch_core_manager::log_dispatch_assignment(
+    std::string name,
+    tt_cxy_pair& cxy,
+    chip_id_t device_id,
+    uint16_t channel,
+    uint8_t cq_id,
+    bool force_ethernet = false) {
+    log_debug(
+        tt::LogMetal,
+        "Allocated {} Core: {}({}) for Device {} Channel {} CQ ID {}",
+        name,
+        cxy.str(),
+        tt::Cluster::instance()
+            .get_virtual_coordinate_from_logical_coordinates(
+                cxy, force_ethernet ? CoreType::ETH : get_dispatch_core_type(cxy.chip))
+            .str(),
+        device_id,
+        channel,
+        cq_id);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -25,9 +25,9 @@ void dispatch_core_manager::initialize(const DispatchCoreConfig& dispatch_core_c
     }
 }
 
-static dispatch_core_manager::dispatch_core_manager& instance() {
-    TT_ASSERT(_inst != nullptr, "Trying to get dispatch_core_manager without initializing it");
-    return *_inst;
+static dispatch_core_manager& dispatch_core_manager::instance() {
+    TT_ASSERT(dispatch_core_manager::_inst != nullptr, "Trying to get dispatch_core_manager without initializing it");
+    return *dispatch_core_manager::_inst;
 }
 
 const tt_cxy_pair& dispatch_core_manager::prefetcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -4,6 +4,8 @@
 
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
+#include "tt_cluster.hpp"
+
 namespace {
 
 tt::tt_metal::DispatchCoreConfig dispatch_core_config() {

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <dispatch_core_manager.hpp>
-#include <tt-metalium/tt_cluster.hpp>
 
 namespace tt::tt_metal {
 


### PR DESCRIPTION
# Problem description
I am trying to move tt_cluster.hpp out of the public api folder.
Trouble is many other public files include it.
It is going to be a multiple PR situation to isolate it.

### What's changed
Split dispatch_core_manager.hpp into header and implementation, so that the inclusion of tt_cluster.hpp can happen on the C++ side.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13170267214) CI passes
