### PR TITLE
Run the entire build job in a container

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -209,14 +209,15 @@ jobs:
 
       - name: 'Tar files'
         if: ${{ inputs.publish-artifact }}
-        run: tar -cvhf ttm_any.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train data runtime
+        run: tar -cvhf /work/ttm_any.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train data runtime
 
       - name: ☁️ Upload tarball
         if: ${{ inputs.publish-artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: TTMetal_build_any${{ (inputs.tracy && '_profiler') || '' }}
-          path: ttm_any.tar
+          path: /work/ttm_any.tar
+          if-no-files-found: error
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -205,7 +205,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: eager-dist-${{ inputs.distro }}-${{ inputs.version }}-any
-          path: dist/
+          path: /work/dist/
+          if-no-files-found: error
 
       - name: 'Tar files'
         if: ${{ inputs.publish-artifact }}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -104,13 +104,29 @@ jobs:
     name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
     timeout-minutes: 30
-    env:
-      SILENT: 0
-      VERBOSE: 1
-      IMAGE_PARAMS: "${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}"
     runs-on:
       - build
       - in-service
+    container:
+      image: ${{ needs.build-docker-image.outputs.ci-build-tag }}
+      env:
+        CCACHE_TEMPDIR: /tmp/ccache
+        CARGO_HOME: /tmp/.cargo
+        TT_FROM_PRECOMPILED_DIR: /work
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /home/ubuntu/.ccache-ci:/github/home/.ccache # HOME is hardcoded for no clear reason: https://github.com/actions/runner/issues/863
+        - /mnt/MLPerf/ccache:/mnt/MLPerf/ccache
+      # Group 1457 is for the shared ccache drive
+      # tmpfs is for efficiency
+      options: >
+        --group-add 1457
+        --tmpfs /tmp
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+
     steps:
       - name: Verify ccache availability
         shell: bash
@@ -119,92 +135,96 @@ jobs:
             echo "::error title=ccache-mlperf-not-mounted::NFS drive is not mounted; build machine not properly provisioned."
             exit 1
           fi
-          if [ ! -d "$HOME/.ccache-ci" ]; then
+          if [ ! -d "$HOME/.ccache" ]; then
             echo "::error title=ccache-not-provisioned::Ccache is not properly provisioned."
             exit 1
           fi
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-          echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
-          echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
-      - name: Update submodules
-        run: |
-          git submodule update --init --recursive
-      - name: Docker login
-        uses: docker/login-action@v3
+
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
         with:
-          registry: https://ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull docker image
-        run: docker pull ${{ needs.build-docker-image.outputs.ci-build-tag }}
-      - name: Build tt-metal and libs
-        uses: tenstorrent/docker-run-action@v5
-        with:
-          image: ${{ needs.build-docker-image.outputs.ci-build-tag }}
-          options: |
-            --rm
-            --tmpfs /tmp
-            -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
-            --group-add 1457
-            -v ${{ github.workspace }}:${{ github.workspace }}
-            -v /etc/passwd:/etc/passwd:ro
-            -v /etc/shadow:/etc/shadow:ro
-            -v /etc/bashrc:/etc/bashrc:ro
-            -v /home/ubuntu/.ccache-ci:/home/ubuntu/.ccache
-            -v /mnt/MLPerf/ccache:/mnt/MLPerf/ccache
-            -e CARGO_HOME=${{ github.workspace }}/.cargo
-            -e TT_FROM_PRECOMPILED_DIR=${{ github.workspace }}
-            -w ${{ github.workspace }}
-          run: |
-            set -eu # basic shell hygiene
+          submodules: recursive
+          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
 
-            # /tmp is a tmpfs; more efficient than persisted storage
-            mkdir -p /tmp/ccache
-            export CCACHE_TEMPDIR=/tmp/ccache
+      - name: Sanity check
+        run: |
+          set -eu # basic shell hygiene
+          if find . -maxdepth 1 -type d -name 'build*' -print -quit | grep -q .; then
+            echo "!!! ALERT !!! This should never happen, but does explain an issue we've been hunting. Please send a link to this job to Metal Infra.  kthxbye."
+            exit 42
+          fi
 
-            # Zero out the stats so we can see how we did this build
-            # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
-            ccache -z
+      - name: Create ccache tmpdir
+        run: |
+          mkdir -p /tmp/ccache
 
-            args_fixme=$([ "${{ inputs.skip-tt-train }}" = "true" ] && echo "--build-metal-tests --build-ttnn-tests --build-programming-examples" || echo "--build-all")
-            echo "Args: ${args_fixme}"
-            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --toolchain-path ${{ inputs.toolchain }} ${args_fixme} --enable-ccache"
-            echo "Build tracy: ${{ inputs.tracy }}"
-            if [ "${{ inputs.tracy }}" = "true" ]; then
-              build_command="$build_command --enable-profiler"
-            fi
+      - name: Prepare ccache summary
+        run: |
+          # Zero out the stats so we can see how we did this build
+          # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
+          ccache -z
 
-            [ -n "$(find . -maxdepth 1 -type d -name 'build*' -print -quit)" ] &&
-              { echo "!!! ALERT !!! This should never happen, but does explain an issue we've been hunting. Please send a link to this job to Metal Infra.  kthxbye."; exit 1; }
+      - name: 🔧 CMake configure
+        run: |
+          set -eu # basic shell hygiene
 
-            nice -n 19 $build_command
+          args_fixme=$([ "${{ inputs.skip-tt-train }}" = "true" ] && echo "--build-metal-tests --build-ttnn-tests --build-programming-examples" || echo "--build-all")
+          echo "Args: ${args_fixme}"
+          build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --toolchain-path ${{ inputs.toolchain }} ${args_fixme} --enable-ccache --configure-only"
+          echo "Build tracy: ${{ inputs.tracy }}"
+          if [ "${{ inputs.tracy }}" = "true" ]; then
+            build_command="$build_command --enable-profiler"
+          fi
 
-            echo "Build wheel: ${{ inputs.build-wheel }}"
-            if [ "${{ inputs.build-wheel }}" = "true" ]; then
-              nice -n 19 python3 -m build
-            fi
-            ccache -s > build/ccache.stats
-      - name: Upload distribution as artifact
+          nice -n 19 $build_command
+
+      - name: 🛠️ Compile
+        run: |
+          # --target install is for the tarball that should get replaced by proper packaging later
+          nice -19 cmake --build build --target install
+
+      - name: 📦 Package
+        if: false # Packaging coming later
+        run: |
+          nice -19 cmake --build $build_dir --target package
+
+      - name: 🐍 Build wheel
+        if: ${{ inputs.build-wheel }}
+        run: |
+          nice -n 19 python3 -m build
+
+      - name: Publish ccache summary
+        run: |
+          echo '## CCache Summary' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          ccache -s >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: ☁️ Upload wheel
         if: ${{ inputs.build-wheel }}
         uses: actions/upload-artifact@v4
         with:
           name: eager-dist-${{ inputs.distro }}-${{ inputs.version }}-any
           path: dist/
-      - name: Publish Ccache summary
-        run: |
-          echo '## CCache Summary' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat build/ccache.stats >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - name: 'Tar files'
         if: ${{ inputs.publish-artifact }}
         run: tar -cvhf ttm_any.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train data runtime
-      - name: 'Upload Artifact'
+
+      - name: ☁️ Upload tarball
         if: ${{ inputs.publish-artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: TTMetal_build_any${{ (inputs.tracy && '_profiler') || '' }}
           path: ttm_any.tar
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # We are forced to checkout the repo into a subdir of the host's workdir; this pollutes the host
+          # with root-owned files.  Be sure to clean up after ourselves in case we're on a non-ephemeral runner.
+          echo "pre rm"
+          ls -al /__w/tt-metal/tt-metal
+          rm -rf /__w/tt-metal/tt-metal/docker-job
+          echo "post rm"
+          ls -al /__w/tt-metal/tt-metal

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -34,6 +34,7 @@ show_help() {
     echo "  --c-compiler-path                Set path to C++ compiler."
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
+    echo "  --configure-only                 Only configure the project, do not build."
 }
 
 clean() {
@@ -65,6 +66,7 @@ cxx_compiler_path=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+configure_only="OFF"
 
 declare -a cmake_args
 
@@ -99,6 +101,7 @@ cxx-compiler-path:
 c-compiler-path:
 ttnn-shared-sub-libs
 toolchain-path:
+configure-only
 "
 
 # Flatten LONGOPTIONS into a comma-separated string for getopt
@@ -156,6 +159,8 @@ while true; do
             build_all="ON";;
         --ttnn-shared-sub-libs)
             ttnn_shared_sub_libs="ON";;
+        --configure-only)
+            configure_only="ON";;
         --disable-unity-builds)
 	    unity_builds="OFF";;
         --disable-light-metal-trace)
@@ -343,5 +348,7 @@ echo "INFO: Running: cmake "${cmake_args[@]}""
 cmake "${cmake_args[@]}"
 
 # Build libraries and cpp tests
-echo "INFO: Building Project"
-cmake --build $build_dir --target install
+if [ "$configure_only" = "OFF" ]; then
+    echo "INFO: Building Project"
+    cmake --build $build_dir --target install
+fi


### PR DESCRIPTION
### Ticket
#17633

### Problem description
* Data analysis: Most of the heavy lifting is all inside one step (CMake configure, which includes downloads; the compile/link; and (soon) packaging).  We need to break it apart so we can see which area needs optimizing.
* Readability: having all the docker magic at a step level breaks the flow of reading "Do A, then B, thenC"

### What's changed
Pivoted from running most steps on the host, and then running one step in a container to running the entire batch of steps in a container.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13170396426)

