### PR TITLE
#0: Fix ordering of devices after reshape applied on MeshDevice

### DIFF
--- a/tests/ttnn/distributed/test_distributed_reshape.cpp
+++ b/tests/ttnn/distributed/test_distributed_reshape.cpp
@@ -83,7 +83,7 @@ TEST_P(MeshReshapeTest, TestReshapeBetweenConfigurations) {
     EXPECT_EQ(mesh->num_rows(), old_shape.num_rows);
     EXPECT_EQ(mesh->num_cols(), old_shape.num_cols);
 
-    auto original_order = get_physical_device_ids(*mesh);
+    auto original_order = mesh->get_device_ids();
 
     // Attempt reshape
     mesh->reshape({new_shape.num_rows, new_shape.num_cols});
@@ -93,7 +93,7 @@ TEST_P(MeshReshapeTest, TestReshapeBetweenConfigurations) {
     EXPECT_EQ(mesh->num_cols(), new_shape.num_cols);
 
     // Verify device ordering is preserved
-    EXPECT_EQ(get_physical_device_ids(*mesh), original_order);
+    EXPECT_EQ(mesh->get_device_ids(), original_order);
 }
 
 // Generate all possible combinations of shapes from kMeshShapes
@@ -121,35 +121,34 @@ TEST_F(T3000ReshapeTest, InvalidReshapeDimensions) {
     EXPECT_EQ(mesh->num_cols(), 8);
 }
 
-TEST_F(T3000ReshapeTest, From1x8To2x4) {
+TEST_F(T3000ReshapeTest, From1x8To2x4ThenBackTo1x8) {
     auto mesh = ttnn::distributed::open_mesh_device(
         {1, 8}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
 
     EXPECT_EQ(mesh->num_rows(), 1);
     EXPECT_EQ(mesh->num_cols(), 8);
-    auto original_order = get_physical_device_ids(*mesh);
-
-    mesh->reshape({2, 4});
-    EXPECT_EQ(mesh->num_rows(), 2);
-    EXPECT_EQ(mesh->num_cols(), 4);
-    auto new_order = get_physical_device_ids(*mesh);
-    EXPECT_EQ(original_order, new_order);
-}
-
-TEST_F(T3000ReshapeTest, OnRingTopology) {
-    auto mesh = ttnn::distributed::open_mesh_device(
-        {1, 8}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
-
-    EXPECT_EQ(mesh->num_rows(), 1);
-    EXPECT_EQ(mesh->num_cols(), 8);
-    auto original_order = get_physical_device_ids(*mesh);
+    auto original_order = mesh->get_device_ids();
 
     mesh->reshape({2, 4});
 
     EXPECT_EQ(mesh->num_rows(), 2);
     EXPECT_EQ(mesh->num_cols(), 4);
-    auto new_order = get_physical_device_ids(*mesh);
-    EXPECT_EQ(original_order, new_order);
+    std::vector<chip_id_t> expected_physical_device_id_order = {
+        original_order[0],
+        original_order[1],
+        original_order[2],
+        original_order[3],
+        original_order[7],
+        original_order[6],
+        original_order[5],
+        original_order[4],
+    };
+
+    auto new_order = mesh->get_device_ids();
+    EXPECT_EQ(new_order, expected_physical_device_id_order);
+
+    mesh->reshape({1, 8});
+    EXPECT_EQ(mesh->get_device_ids(), original_order);
 }
 
 TEST_F(T3000ReshapeTest, InvalidTotalDeviceCount) {
@@ -163,26 +162,6 @@ TEST_F(T3000ReshapeTest, InvalidTotalDeviceCount) {
     // Verify original shape is preserved after failed reshapes
     EXPECT_EQ(mesh->num_rows(), 1);
     EXPECT_EQ(mesh->num_cols(), 8);
-}
-
-TEST_F(T3000ReshapeTest, MultipleReshapes) {
-    auto mesh = ttnn::distributed::open_mesh_device(
-        {1, 8}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
-
-    auto original_order = get_physical_device_ids(*mesh);
-
-    // Test multiple reshapes
-    mesh->reshape({2, 4});  // 1x8 -> 2x4
-    auto order1 = get_physical_device_ids(*mesh);
-    EXPECT_EQ(order1, original_order);
-
-    mesh->reshape({4, 2});  // 2x4 -> 4x2
-    auto order2 = get_physical_device_ids(*mesh);
-    EXPECT_EQ(order2, original_order);
-
-    mesh->reshape({1, 8});  // 4x2 -> 1x8 (back to original)
-    auto final_order = get_physical_device_ids(*mesh);
-    EXPECT_EQ(final_order, original_order);
 }
 
 TEST_F(T3000ReshapeTest, RingPreservation) {
@@ -239,7 +218,7 @@ TEST_F(T3000ReshapeTest, From1x4To2x2Valid) {
     mesh->reshape({2, 2});
     EXPECT_EQ(mesh->num_rows(), 2);
     EXPECT_EQ(mesh->num_cols(), 2);
-    auto new_layout = get_physical_device_ids(*mesh);
+    auto new_layout = mesh->get_device_ids();
     for (auto physical_device_id : physical_device_ids) {
         EXPECT_TRUE(std::find(new_layout.begin(), new_layout.end(), physical_device_id) != new_layout.end());
     }
@@ -249,27 +228,21 @@ TEST_F(T3000ReshapeTest, From2x2To1x4) {
     auto mesh = ttnn::distributed::open_mesh_device(
         {2, 2}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
 
-    std::vector<chip_id_t> original_layout;
-    for (size_t i = 0; i < mesh->num_rows(); ++i) {
-        for (size_t j = 0; j < mesh->num_cols(); ++j) {
-            auto id = mesh->get_device(i, j)->id();
-            original_layout.push_back(id);
-        }
-    }
+    auto mesh_2x2_device_ids = mesh->get_device_ids();
 
     mesh->reshape({1, 4});
     EXPECT_EQ(mesh->num_rows(), 1);
     EXPECT_EQ(mesh->num_cols(), 4);
 
-    std::vector<chip_id_t> new_layout;
-    for (size_t i = 0; i < mesh->num_rows(); ++i) {
-        for (size_t j = 0; j < mesh->num_cols(); ++j) {
-            auto id = mesh->get_device(i, j)->id();
-            new_layout.push_back(id);
-        }
-    }
+    auto mesh_1x4_device_ids = mesh->get_device_ids();
+    std::vector<chip_id_t> expected_1x4_device_ids = {
+        mesh_2x2_device_ids[0],
+        mesh_2x2_device_ids[1],
+        mesh_2x2_device_ids[3],
+        mesh_2x2_device_ids[2],
+    };
 
-    EXPECT_EQ(new_layout, original_layout);
+    EXPECT_EQ(mesh_1x4_device_ids, expected_1x4_device_ids);
 }
 
 }  // namespace ttnn::distributed::test

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -64,6 +64,9 @@ private:
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;
 
+    // Returns the devices in row-major order for the new mesh shape
+    std::vector<IDevice*> get_row_major_devices(const MeshShape& new_shape) const;
+
 public:
     MeshDevice(
         std::shared_ptr<ScopedDevices> mesh_handle,

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -252,11 +252,23 @@ size_t MeshDevice::num_cols() const { return mesh_shape_.num_cols; }
 
 MeshShape MeshDevice::shape() const { return mesh_shape_; }
 
-void MeshDevice::reshape(const MeshShape& new_shape) {
-    TT_FATAL(
-        new_shape.num_rows * new_shape.num_cols == this->num_devices(),
-        "New shape must have the same number of devices as current shape");
-
+std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_shape) const {
+    // MeshDeviceView requires devices to be provided as a 1D array in row-major order for the target mesh shape.
+    // The physical connectivity between devices must be preserved when reshaping.
+    //
+    // Example:
+    // Given 4 devices physically connected in a 2x2 grid like this:
+    //   [0]--[1]
+    //    |    |
+    //   [3]--[2]
+    //
+    // For a 1x4 mesh shape:
+    // - Devices must form a line: 0->1->2->3
+    // - Row-major order will be: [0,1,2,3]
+    //
+    // For a 2x2 mesh shape:
+    // - Preserves original 2x2 physical connectivity
+    // - Row-major order will be: [0,1,3,2]
     std::unordered_map<chip_id_t, size_t> physical_device_id_to_linearized_index;
     for (size_t i = 0; i < this->num_devices(); i++) {
         physical_device_id_to_linearized_index[this->get_devices()[i]->id()] = i;
@@ -264,6 +276,7 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
 
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
     // However, going from a Line mesh to an MxN mesh is not always possible.
+    std::vector<IDevice*> new_device_order;
     if (new_shape.num_rows != 1 and new_shape.num_cols != 1) {
         auto new_physical_device_ids =
             SystemMesh::instance().request_available_devices(
@@ -285,10 +298,22 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
                     this->num_cols());
             }
         }
+        for (size_t i = 0; i < new_physical_device_ids.size(); i++) {
+            new_device_order.push_back(this->get_device(new_physical_device_ids[i]));
+        }
+    } else {
+        new_device_order = view_->get_line_devices();
     }
+    return new_device_order;
+}
+
+void MeshDevice::reshape(const MeshShape& new_shape) {
+    TT_FATAL(
+        new_shape.num_rows * new_shape.num_cols == this->num_devices(),
+        "New shape must have the same number of devices as current shape");
 
     mesh_shape_ = new_shape;
-    view_ = std::make_unique<MeshDeviceView>(scoped_devices_->get_devices(), mesh_shape_);
+    view_ = std::make_unique<MeshDeviceView>(this->get_row_major_devices(new_shape), new_shape);
 }
 
 bool MeshDevice::close() {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Reported by TT-Forge team working when trying to use CCL Line All-Gather after reshaping MeshDevice. Error complains that Device[i-1] not connected to Device[i].

### What's changed
- MeshDevice supports changing the logical shape over the collection of its devices. This change updates MeshDevice::reshape to correctly maintain physical device connectivity after reshape.
- Refactored test cases in test_distributed_reshape.cpp to validate device order preservation
- Added a simple end-to-end test case for reproducing the original issue. Reshape followed by CCL line-all-gather.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13176791976
- [x] T3000 Regressions: https://github.com/tenstorrent/tt-metal/actions/runs/13176798221
- [x] New/Existing tests provide coverage for changes
