### PR TITLE
#17134: Add SD down block unit test

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -12,10 +12,6 @@ from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_p
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_basic_transformer_block import basic_transformer_block
 from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
-    pre_process_input,
-    post_process_output,
-)
 from models.utility_functions import (
     skip_for_grayskull,
 )

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from diffusers import StableDiffusionPipeline
+import os
+import ttnn
+import pytest
+
+from models.utility_functions import torch_random
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import (
+    skip_for_grayskull,
+)
+
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downblock_2d_new_conv import downblock2d
+from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    get_default_compute_config,
+    preprocess_and_push_input_to_device,
+    post_process_output_and_move_to_host,
+)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("hidden_states, shard_end_core, shard_shape", [([2, 1280, 8, 8], (7, 3), (32, 160))])
+@pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
+def test_downblock_512x512(reset_seeds, device, hidden_states, shard_end_core, shard_shape, temb):
+    # Initialize PyTorch component
+    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    torch_down_block = pipe.unet.down_blocks[3]
+
+    # Initialize ttnn component
+    reader_patterns_cache = {}
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
+    )
+    parameters = parameters.down_blocks[3]
+    N, _, H, W = hidden_states
+    compute_kernel_config = get_default_compute_config(device)
+
+    ttnn_down_block = downblock2d(device, parameters, reader_patterns_cache, N, H, W, compute_kernel_config)
+
+    # Prepare inputs
+    in_channels = hidden_states[1]
+    out_channels = in_channels
+    temb_channels = 1280
+    input_shape = hidden_states
+    hidden_states = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    temb = torch_random(temb, -0.1, 0.1, dtype=torch.float32)
+
+    # Run PyTorch component
+    torch_output, torch_residuals = torch_down_block(hidden_states, temb.squeeze(0).squeeze(0))
+
+    # Prepare inputs for ttnn component
+    hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    temb = temb.permute(2, 0, 1, 3)
+    temb = ttnn.from_torch(temb, ttnn.bfloat16)
+    temb = ttnn.to_layout(temb, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    temb = ttnn.to_device(temb, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    # Run ttnn component
+    output, residuals = ttnn_down_block(
+        temb,
+        hidden_states,
+        in_channels,
+        out_channels,
+        temb_channels,
+        num_layers=2,
+        resnet_eps=1e-5,
+        resnet_act_fn="silu",
+    )
+
+    # Compare outputs
+    output = post_process_output_and_move_to_host(output, N, H, W, out_channels)
+    assert_with_pcc(torch_output, output, 0.97)
+
+    for torch_residual, residual in zip(torch_residuals, residuals):
+        residual = post_process_output_and_move_to_host(residual, N, H, W, out_channels)
+        assert_with_pcc(torch_residual, residual, 0.97)

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -19,7 +19,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upblock_2d_new_co
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
-    post_process_output,
+    post_process_output_and_move_to_host,
     weight_to_bfp8,
 )
 
@@ -100,6 +100,6 @@ def test_upblock_512x512(reset_seeds, device, res_hidden_states_tuple, hidden_st
         upsample_size=None,
     )
 
-    op = post_process_output(device, op, N, H * 2, W * 2, in_channels)
-    op = ttnn.to_torch(op)
+    op = post_process_output_and_move_to_host(op, N, H * 2, W * 2, in_channels)
+
     assert_with_pcc(torch_output, op, 0.95)

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -18,7 +18,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 from models.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     pre_process_input,
-    post_process_output,
+    post_process_output_and_move_to_host,
 )
 
 
@@ -80,7 +80,6 @@ def test_upsample2d_512x512(device, scale_factor, batch_size, in_channels, input
         in_channels,
         out_channels,
     )
-    tt_up = post_process_output(device, tt_up, batch_size, input_height * 2, input_width * 2, in_channels)
-    torch_up = ttnn.to_torch(tt_up)
+    torch_up = post_process_output_and_move_to_host(tt_up, batch_size, input_height * 2, input_width * 2, in_channels)
 
     assert_with_pcc(torch_output, torch_up, 0.99)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -11,13 +11,13 @@ import os
 import torch
 from typing import Optional, Dict
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
-    pre_process_input,
-    post_process_output,
     permute_conv_parameters,
     weight_to_bfp8,
-    dealloc_input,
 )
-from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import conv_cache
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    conv_cache,
+    get_default_compute_config,
+)
 from loguru import logger
 
 
@@ -721,13 +721,7 @@ class resnetBlock2D:
             transpose_shards=False,
             reshard_if_not_optimal=False,
         )
-        compute_config = ttnn.init_device_compute_kernel_config(
-            self.device.arch(),
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=False,
-        )
+        compute_config = get_default_compute_config(self.device)
         if self.conv2_config_override and "act_block_h" in self.conv2_config_override:
             conv_config.act_block_h_override = self.conv2_config_override["act_block_h"]
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -38,6 +38,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     pad_group_norm_weight,
     pre_process_input,
     conv_cache,
+    get_default_compute_config,
 )
 
 fp32_accum = True
@@ -389,13 +390,7 @@ class UNet2DConditionModel:
             transpose_shards=False,
             reshard_if_not_optimal=True,
         )
-        compute_config = ttnn.init_device_compute_kernel_config(
-            self.device.arch(),
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=False,
-        )
+        compute_config = get_default_compute_config(self.device)
 
         conv_kwargs = {
             "in_channels": in_channels,
@@ -681,13 +676,7 @@ class UNet2DConditionModel:
             transpose_shards=False,
             reshard_if_not_optimal=True,
         )
-        compute_config = ttnn.init_device_compute_kernel_config(
-            self.device.arch(),
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=False,
-        )
+        compute_config = get_default_compute_config(self.device)
 
         conv_kwargs_1 = {
             "in_channels": self.conv_out_in_channels,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_2d_new_conv.py
@@ -12,10 +12,10 @@ from models.utility_functions import (
 
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_upsample_nearest_2d import upsample_nearest2d
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
-    run_ttnn_conv_with_pre_and_post_tensor_formatting,
     conv_cache,
 )
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    get_default_compute_config,
     permute_conv_parameters,
 )
 from loguru import logger
@@ -97,13 +97,7 @@ class upsample2d:
             transpose_shards=False,
             reshard_if_not_optimal=False,  # Reshard has error : 1616 Bytes unique+common runtime args targeting kernel reshard_reader on (x=0,y=0) are too large. Cannot be written as they will run into memory region reserved for result. Max allowable size is 1024 Bytes
         )
-        compute_config = ttnn.init_device_compute_kernel_config(
-            self.device.arch(),
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=False,
-        )
+        compute_config = get_default_compute_config(self.device)
         if self.conv_config_override and "act_block_h" in self.conv_config_override:
             conv_config.act_block_h_override = self.conv_config_override["act_block_h"]
 


### PR DESCRIPTION
### Ticket
#17134

### Problem description
Add test for Stable Diffusion down block component.

### What's changed
Aside from the new test, couple of utility functions were cleaned up, and the tests using them were updated accordingly.

### Affected pipelines

- (Single card) Nightly ttnn and models: https://github.com/tenstorrent/tt-metal/actions/runs/13181031283
- (Single card) Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/13195955457
- (Single card) Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/13183526000
