### PR TITLE
produce_data workflow: only call gh api for the current attempt and not attempts before it

### DIFF
--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -29,7 +29,7 @@ download_logs_for_all_jobs() {
     local workflow_run_id=$2
     local attempt_number=$3
 
-    echo "[info] Downloading logs for job with id $job_id for attempt $attempt_number"
+    echo "[info] Downloading logs for workflow with id $workflow_run_id for attempt $attempt_number"
     gh api /repos/$repo/actions/runs/$workflow_run_id/attempts/$attempt_number/jobs --paginate | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
         job_id=$(echo "$job" | jq -r '.id')
         job_conclusion=$(echo "$job" | jq -r '.conclusion')


### PR DESCRIPTION
### Ticket
...

### Problem description
Current produce data flow calls gh api for all previous attempts of a pipeline run, wasting api calls on jobs that were already uploaded and are not being analyzed.
E.g. https://github.com/tenstorrent/tt-metal/actions/runs/13181486938 `run_id=13167920775 attempt_number=3`
```
[info] downloading logs for job with id  for all attempts up to 3
[Info] Downloading for attempt 1
[info] download logs for job with id 36752327012, attempt number 1
[...]
[info] download logs for job with id 36792589705, attempt number 3
```
The [python data script ](https://github.com/tenstorrent/tt-metal/blob/7689f433dfe5cdd55fbadf24940421bc4a713610/infra/data_collection/cicd.py#L61) only looks at the current `attempt_number`'s jobs for analysis; in a 3-retry-attempt APC pipeline run, 1200 api calls are made, of which only 600 are used

`attempt_number 1`: 200 api calls made, 200 consumed, 0 wasted
`attempt_number 2`: 400 api calls made, 200 consumed, 200 wasted
`attempt_number 3`: 600 api calls made, 200 consumed, 400 wasted

### What's changed
Remove the for-loop iterating over previous attempts of the same pipeline run when downloading for job log data from `gh api`.

### Checklist
- [x] New/Existing tests provide coverage for changes
https://github.com/tenstorrent/tt-metal/actions/runs/13182347381
