### PR TITLE
 #17623: Delete artifact when one of the steps fails.

### DIFF
--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -82,4 +82,4 @@ jobs:
         uses: geekyeggo/delete-artifact@v5
         continue-on-error: true
         with:
-            name: gh_pages
+            name: github-pages

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -73,3 +73,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         id: deployment
         uses: actions/deploy-pages@v4.0.4
+      - name: Delete artifact if deployment failed
+        # When the deployment API call fails, the artifacts are not cleaned up correctly
+        # and the next attempt (!) run will cause an error.
+        # See more:
+        # https://github.com/tenstorrent/tt-metal/issues/17623
+        if: ${{ failure() }}
+        uses: geekyeggo/delete-artifact@v5
+        failOnError: false
+        with:
+            name: gh_pages

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -80,6 +80,6 @@ jobs:
         # https://github.com/tenstorrent/tt-metal/issues/17623
         if: ${{ failure() }}
         uses: geekyeggo/delete-artifact@v5
-        failOnError: false
+        continue-on-error: true
         with:
             name: gh_pages


### PR DESCRIPTION
### Ticket
#17623 

### Problem description

This issue occurs when Github pages Deployment API calls runs into a problem such as here:
https://github.com/tenstorrent/tt-metal/actions/runs/13175864122/job/36775283617
or here
https://github.com/tenstorrent/tt-metal/actions/runs/13161274904/job/36730654968

```
Run actions/deploy-pages@v4.0.4
Fetching artifact metadata for "github-pages" in this workflow run
Found 4 artifact(s)
Creating Pages deployment with payload:
{
	"artifact_id": 2546345450,
	"pages_build_version": "cac10882de94b1e44e2f86864ebcaf8507889e8c",
	"oidc_token": "***"
}
Error: Creating Pages deployment failed
Error: HttpError: We couldn't respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists.
    at /home/runner/work/_actions/actions/deploy-pages/v4.0.4/node_modules/@octokit/request/dist-node/index.js:1[24](https://github.com/tenstorrent/tt-metal/actions/runs/13175864122/job/36775283617#step:14:25):1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4.0.4/src/internal/api-client.js:1[25](https://github.com/tenstorrent/tt-metal/actions/runs/13175864122/job/36775283617#step:14:26):1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4.0.4/src/internal/deployment.js:74:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4.0.4/src/index.js:[30](https://github.com/tenstorrent/tt-metal/actions/runs/13175864122/job/36775283617#step:14:31):1)
Error: Error: Failed to create deployment (status: 504) with build version cac10882de94b1e44e2f86864ebcaf8507889e8c. Server error, is githubstatus.com reporting a Pages outage? Please re-run the deployment at a later time.
```

All subsequent **attempt** runs will experience the following error likely due to failure of Github API to clean up the artifacts.

```
Error: Fetching artifact metadata failed. Is githubstatus.com reporting issues with API requests, Pages, or Actions? Please re-run the deployment at a later time.
Error: Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
    at getArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v4.0.4/src/internal/api-client.js:89:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4.0.4/src/internal/deployment.js:66:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4.0.4/src/index.js:[30](https://github.com/tenstorrent/tt-metal/actions/runs/13175864122/job/36796833931#step:14:31):1)
Error: Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

### What's changed

Added the additional step to delete the artifact upon one of the steps failing. This should clean up the artifact in cases where the deployment fails.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
