### PR TITLE
fixed 3 link all gather sdpa specialized shape and added workaround for nd pcc

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -78,7 +78,9 @@ def get_core_range_set(output_core_grid):
 @pytest.mark.parametrize(
     "num_devices, num_links",
     [
+        (4, 3),
         (4, 2),
+        (4, 1),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -30,7 +30,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
         fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
             l1_read_addr, payload_size_bytes);
-        fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
             (uint32_t)pkt_hdr_forward, sizeof(tt::fabric::PacketHeader));
     }
 
@@ -38,7 +38,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
             l1_read_addr, payload_size_bytes);
-        fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
+        fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
             (uint32_t)pkt_hdr_backward, sizeof(tt::fabric::PacketHeader));
     }
 


### PR DESCRIPTION
### Ticket
This PR fixes the issue for 3 link all gather for AllGather after SDPA specialized shape and workaround the nd pcc bug (#17671) due to `send_payload_flush_non_blocking_from_address` by changing it to blocking.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13185497056) CI passes
