### PR TITLE
[tt-train] Fix timing of grad sync and clipping in NanoGPT in the presence of grad accumulation

### DIFF
--- a/tt-train/configs/training_shakespear_nanogpt.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt.yaml
@@ -11,7 +11,6 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
-  use_ddp: false
   transformer_config:
     num_heads: 6
     embedding_dim: 384

--- a/tt-train/configs/training_shakespear_nanogpt.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt.yaml
@@ -11,6 +11,7 @@ training_config:
   use_kahan_summation: false
   use_clip_grad_norm: false
   clip_grad_norm_max_norm: 1.0
+  use_ddp: false
   transformer_config:
     num_heads: 6
     embedding_dim: 384

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -333,6 +333,7 @@ struct TrainingConfig {
     std::string scheduler_type = "identity";
     bool use_clip_grad_norm = false;
     float clip_grad_norm_max_norm = 1.0F;
+    bool use_ddp = false;
     ttml::models::gpt2::TransformerConfig transformer_config;
 };
 
@@ -356,6 +357,7 @@ TrainingConfig parse_config(const YAML::Node &yaml_config) {
     config.tokenizer_type = training_config["tokenizer_type"].as<std::string>(config.tokenizer_type);
     config.scheduler_type = training_config["scheduler_type"].as<std::string>(config.scheduler_type);
     config.use_clip_grad_norm = training_config["use_clip_grad_norm"].as<bool>(config.use_clip_grad_norm);
+    config.use_ddp = training_config["use_ddp"].as<bool>(config.use_ddp);
     config.clip_grad_norm_max_norm =
         training_config["clip_grad_norm_max_norm"].as<float>(config.clip_grad_norm_max_norm);
 
@@ -377,13 +379,17 @@ int main(int argc, char **argv) {
     bool is_eval = false;
     bool add_time_to_name = true;
     bool enable_wandb = true;
-    bool ddp = false;
     app.add_option("-c,--config", config_name, "Yaml Config name")->default_val(config_name);
     app.add_option("-e,--eval", is_eval, "Is evaluation")->default_val(is_eval);
     app.add_option("-t,--add_time_to_name", add_time_to_name, "Add time to run name")->default_val(add_time_to_name);
     app.add_option("-w,--wandb", enable_wandb, "Enable wandb logging")->default_val(enable_wandb);
-    app.add_option("-d,--ddp", ddp, "Enable DDP")->default_val(ddp);
     CLI11_PARSE(app, argc, argv);
+
+    auto yaml_config = YAML::LoadFile(config_name);
+    TrainingConfig config = parse_config(yaml_config);
+    EvalConfig eval_config = parse_eval_config(yaml_config);
+
+    bool ddp = config.use_ddp;
 
     initialize_device(ddp);
 
@@ -394,10 +400,6 @@ int main(int argc, char **argv) {
             return -1;
         }
     }
-
-    auto yaml_config = YAML::LoadFile(config_name);
-    TrainingConfig config = parse_config(yaml_config);
-    EvalConfig eval_config = parse_eval_config(yaml_config);
 
     if (enable_wandb) {
         wandbcpp::init({.project = config.project_name, .name = generate_run_name(config, add_time_to_name)});
@@ -424,6 +426,7 @@ int main(int argc, char **argv) {
             {"scheduler_type", config.scheduler_type},
             {"using_clip_grad_norm", config.use_clip_grad_norm},
             {"clip_grad_norm_max_norm", config.clip_grad_norm_max_norm},
+            {"use_ddp", config.use_ddp},
         });
     }
 

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -635,14 +635,13 @@ int main(int argc, char **argv) {
             auto samples = features->get_value().get_logical_shape()[0];
             gradient_accumulator_helper.update(loss_float, samples);
 
-            // synchronize gradients for multi-device case, no-op if single device
-            auto parameters = model->parameters();
-            ttml::core::distributed::synchronize_parameters(parameters);
-            if (config.use_clip_grad_norm) {
-                ttml::core::clip_grad_norm(parameters, config.clip_grad_norm_max_norm);
-            }
-
             if (gradient_accumulator_helper.should_step()) {
+                // synchronize gradients for multi-device case, no-op if single device
+                auto parameters = model->parameters();
+                ttml::core::distributed::synchronize_parameters(parameters);
+                if (config.use_clip_grad_norm) {
+                    ttml::core::clip_grad_norm(parameters, config.clip_grad_norm_max_norm);
+                }
                 optimizer->step();
                 scheduler->step();
                 auto global_step = optimizer->get_steps();

--- a/tt-train/sources/ttml/core/clip_grad_norm.cpp
+++ b/tt-train/sources/ttml/core/clip_grad_norm.cpp
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <core/clip_grad_norm.hpp>
-#include <core/compute_kernel_config.hpp>
 #include <core/ttnn_all_includes.hpp>
-#include <serialization/serializable.hpp>
+#include "core/clip_grad_norm.hpp"
+#include "core/compute_kernel_config.hpp"
+#include "serialization/serializable.hpp"
 
 namespace ttml::core {
 


### PR DESCRIPTION
### Ticket
#17568

### What's changed
- Sync and clip grads only just before an optimizer step.
- Fix include style for internal headers.
- Bonus (can relocate to another PR if desired): Makes DDP a yaml config option for NanoGPT

### Checklist
- [x] ttml tests pass
- [x] NanoGPT demo trains as expected
