### PR TITLE
#13385: ttnn.round direct kernel implementation

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -453,26 +453,6 @@ def test_unary_composite_rad2deg_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@skip_for_grayskull()
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-def test_unary_composite_round_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-    decimal = 1
-    output_tensor = ttnn.round(input_tensor1, decimals=decimal)
-    golden_function = ttnn.get_golden_function(ttnn.round)
-    golden_tensor = golden_function(in_data1, decimal)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from functools import partial
+from models.utility_functions import skip_for_grayskull, skip_for_blackhole, torch_random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+
+@pytest.mark.parametrize(
+    "shape",
+    (
+        torch.Size([1, 1, 32, 32]),
+        torch.Size([4, 3, 32, 32]),
+        torch.Size([2, 2, 32, 32]),
+        torch.Size([6, 4, 32, 32]),
+        torch.Size([1, 1, 320, 320]),
+        torch.Size([1, 3, 320, 64]),
+        torch.Size([1, 1, 320, 384]),
+        torch.Size([1, 3, 320, 384]),
+    ),
+)
+@pytest.mark.parametrize("decimal", [0, 1, 2])
+@pytest.mark.parametrize(
+    "dtypes",
+    [
+        (torch.float32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat16),
+    ],
+)
+@skip_for_grayskull("Requires wormhole_b0 to run")
+def test_round_new(shape, decimal, dtypes, device):
+    torch_dtype, tt_dtype = dtypes
+    torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch_dtype), tt_dtype)(
+        shape
+    )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=tt_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.round)
+    torch_output_tensor = golden_function(torch_input_tensor, decimal)
+
+    output_tensor = ttnn.round(input_tensor, decimal)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999999

--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,14 +7,14 @@ import torch
 import ttnn
 
 from functools import partial
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole, torch_random
+from models.utility_functions import skip_for_grayskull, torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 
 @pytest.mark.parametrize(
     "shape",
     (
-        torch.Size([1, 1, 32, 32]),
+        torch.Size([1, 1, 10, 10]),
         torch.Size([4, 3, 32, 32]),
         torch.Size([2, 2, 32, 32]),
         torch.Size([6, 4, 32, 32]),
@@ -24,20 +24,21 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         torch.Size([1, 3, 320, 384]),
     ),
 )
-@pytest.mark.parametrize("decimal", [0, 1, 2])
+@pytest.mark.parametrize("decimal", range(-6, 7))
 @pytest.mark.parametrize(
     "dtypes",
     [
-        (torch.float32, ttnn.float32),
         (torch.bfloat16, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
 @skip_for_grayskull("Requires wormhole_b0 to run")
-def test_round_new(shape, decimal, dtypes, device):
+def test_round_new(shape, dtypes, decimal, device):
     torch_dtype, tt_dtype = dtypes
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch_dtype), tt_dtype)(
         shape
     )
+
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
         dtype=tt_dtype,
@@ -45,10 +46,11 @@ def test_round_new(shape, decimal, dtypes, device):
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-
+    torch_input_tensor = ttnn.to_torch(input_tensor)
     golden_function = ttnn.get_golden_function(ttnn.round)
     torch_output_tensor = golden_function(torch_input_tensor, decimal)
 
     output_tensor = ttnn.round(input_tensor, decimal)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999999
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -14,6 +14,7 @@
 #include "llk_math_eltwise_unary_sfpu_max.h"
 #include "llk_math_eltwise_unary_sfpu_power.h"
 #include "llk_math_eltwise_unary_sfpu_rsqrt.h"
+#include "llk_math_eltwise_unary_sfpu_round.h"
 #include "llk_math_eltwise_unary_sfpu_sigmoid.h"
 #include "llk_math_eltwise_unary_sfpu_sign.h"
 #include "llk_math_eltwise_unary_sfpu_signbit.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,28 +15,41 @@ namespace ckernel::sfpu {
 inline vInt float_to_int31(vFloat v) {
     vInt q = float_to_int16(v * 0x1p-15f, 0);
     vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
-    return (q << 15) + r;
+    v_if(r < 0) {
+        r = setsgn(r, 0);
+        q = (q << 15) - r;
+    }
+    v_else { q = (q << 15) + r; }
+    v_endif return q;
 }
 
 inline vFloat round_even(vFloat v) {
-    v_if(sfpi::abs(v) < 0x1p30f) { v = int32_to_float(float_to_int31(v), 0); }
+    vFloat result;
+    v_if(sfpi::abs(v) < 0x1p30f) {
+        result = int32_to_float(float_to_int31(v), 0);
+        v_if(sfpi::abs(v - result) == 0.5F) {
+            vInt res = float_to_int16(result);
+            res = res & 0x7FFE;
+            result = int32_to_float(res);
+        }
+        v_endif;
+    }
     v_endif;
-    return v;
+    return result;
 }
+
+inline constexpr float TABLE[] = {
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F,
+    1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F,
+    1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,
+    1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,
+    1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,
+    1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+};
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 void calculate_round(const int decimals) {
     const auto exp10i = [](int n) {
-        const float TABLE[] = {
-            1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F,
-            1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F,
-            1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F,
-            1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,
-            1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,
-            1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,  1e25F,  1e26F,
-            1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
-        };
-
         if (n > 38) {
             return 1.0F / 0.0F;
         }
@@ -53,14 +66,8 @@ void calculate_round(const int decimals) {
 
     for (int _ = 0; _ < ITERATIONS; ++_) {
         vFloat v = dst_reg[0];
-        vFloat result = inverse * round_even(v * coeff);
-        v_if(coeff == 1.0F && sfpi::abs(v - result) == 0.5F) {
-            vInt res = float_to_int16(result);
-            res = res & 0x7FFE;
-            result = int32_to_float(res);
-            result = setsgn(result, v);
-        }
-        v_endif;
+        vFloat result = inverse * round_even(sfpi::abs(v) * coeff);
+        result = setsgn(result, v);
         dst_reg[0] = result;
         ++dst_reg;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel::sfpu {
+
+inline vInt float_to_int31(vFloat v) {
+    vInt q = float_to_int16(v * 0x1p-15f, 0);
+    vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
+    return (q << 15) + r;
+}
+
+inline vFloat round_even(vFloat v) {
+    v_if(sfpi::abs(v) < 0x1p30f) { v = int32_to_float(float_to_int31(v), 0); }
+    v_endif;
+    return v;
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+void calculate_round(const int decimals) {
+    const auto exp10i = [](int n) {
+        const float TABLE[] = {
+            1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F,
+            1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F,
+            1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F,
+            1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,
+            1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,
+            1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,  1e25F,  1e26F,
+            1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+        };
+
+        if (n > 38) {
+            return 1.0F / 0.0F;
+        }
+
+        if (n < -45) {
+            return 0.0F;
+        }
+
+        return TABLE[n + 45];
+    };
+
+    const vFloat coeff = exp10i(decimals);
+    const vFloat inverse = exp10i(-decimals);
+
+    for (int _ = 0; _ < ITERATIONS; ++_) {
+        vFloat v = dst_reg[0];
+        vFloat result = inverse * round_even(v * coeff);
+        v_if(coeff == 1.0F && sfpi::abs(v - result) == 0.5F) {
+            vInt res = float_to_int16(result);
+            res = res & 0x7FFE;
+            result = int32_to_float(res);
+        }
+        v_endif;
+        dst_reg[0] = result;
+        ++dst_reg;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -58,6 +58,7 @@ void calculate_round(const int decimals) {
             vInt res = float_to_int16(result);
             res = res & 0x7FFE;
             result = int32_to_float(res);
+            result = setsgn(result, v);
         }
         v_endif;
         dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_round.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_round_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::round, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_round(uint dst_index, int decimals, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_round<APPROXIMATE>, dst_index, vector_mode, decimals);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -91,4 +91,5 @@ enum SfpuType {
     cumsum,
     fill,
     prelu,
+    round,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -20,6 +20,7 @@
 #include "llk_math_eltwise_unary_sfpu_signbit.h"
 #include "llk_math_eltwise_unary_sfpu_floor.h"
 #include "llk_math_eltwise_unary_sfpu_ceil.h"
+#include "llk_math_eltwise_unary_sfpu_round.h"
 #include "llk_math_eltwise_unary_sfpu_silu.h"
 #include "llk_math_eltwise_unary_sfpu_square.h"
 #include "llk_math_eltwise_unary_sfpu_tanh.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,28 +15,41 @@ namespace ckernel::sfpu {
 inline vInt float_to_int31(vFloat v) {
     vInt q = float_to_int16(v * 0x1p-15f, 0);
     vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
-    return (q << 15) + r;
+    v_if(r < 0) {
+        r = setsgn(r, 0);
+        q = (q << 15) - r;
+    }
+    v_else { q = (q << 15) + r; }
+    v_endif return q;
 }
 
 inline vFloat round_even(vFloat v) {
-    v_if(sfpi::abs(v) < 0x1p30f) { v = int32_to_float(float_to_int31(v), 0); }
+    vFloat result;
+    v_if(sfpi::abs(v) < 0x1p30f) {
+        result = int32_to_float(float_to_int31(v), 0);
+        v_if(sfpi::abs(v - result) == 0.5F) {
+            vInt res = float_to_int16(result);
+            res = res & 0x7FFE;
+            result = int32_to_float(res);
+        }
+        v_endif;
+    }
     v_endif;
-    return v;
+    return result;
 }
+
+inline constexpr float TABLE[] = {
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F,
+    1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F,
+    1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,
+    1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,
+    1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,
+    1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+};
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 void calculate_round(const int decimals) {
     const auto exp10i = [](int n) {
-        const float TABLE[] = {
-            1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F,
-            1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F,
-            1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F,
-            1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,
-            1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,
-            1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,  1e25F,  1e26F,
-            1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
-        };
-
         if (n > 38) {
             return 1.0F / 0.0F;
         }
@@ -53,14 +66,8 @@ void calculate_round(const int decimals) {
 
     for (int _ = 0; _ < ITERATIONS; ++_) {
         vFloat v = dst_reg[0];
-        vFloat result = inverse * round_even(v * coeff);
-        v_if(coeff == 1.0F && sfpi::abs(v - result) == 0.5F) {
-            vInt res = float_to_int16(result);
-            res = res & 0x7FFE;
-            result = int32_to_float(res);
-            result = setsgn(result, v);
-        }
-        v_endif;
+        vFloat result = inverse * round_even(sfpi::abs(v) * coeff);
+        result = setsgn(result, v);
         dst_reg[0] = result;
         ++dst_reg;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel::sfpu {
+
+inline vInt float_to_int31(vFloat v) {
+    vInt q = float_to_int16(v * 0x1p-15f, 0);
+    vInt r = float_to_int16(v - int32_to_float(q, 0) * 0x1p15f, 0);
+    return (q << 15) + r;
+}
+
+inline vFloat round_even(vFloat v) {
+    v_if(sfpi::abs(v) < 0x1p30f) { v = int32_to_float(float_to_int31(v), 0); }
+    v_endif;
+    return v;
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+void calculate_round(const int decimals) {
+    const auto exp10i = [](int n) {
+        const float TABLE[] = {
+            1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F,
+            1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F, 1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F,
+            1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F, 1e-11F, 1e-10F,
+            1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,
+            1e3F,   1e4F,   1e5F,   1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,
+            1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,  1e23F,  1e24F,  1e25F,  1e26F,
+            1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+        };
+
+        if (n > 38) {
+            return 1.0F / 0.0F;
+        }
+
+        if (n < -45) {
+            return 0.0F;
+        }
+
+        return TABLE[n + 45];
+    };
+
+    const vFloat coeff = exp10i(decimals);
+    const vFloat inverse = exp10i(-decimals);
+
+    for (int _ = 0; _ < ITERATIONS; ++_) {
+        vFloat v = dst_reg[0];
+        vFloat result = inverse * round_even(v * coeff);
+        v_if(coeff == 1.0F && sfpi::abs(v - result) == 0.5F) {
+            vInt res = float_to_int16(result);
+            res = res & 0x7FFE;
+            result = int32_to_float(res);
+        }
+        v_endif;
+        dst_reg[0] = result;
+        ++dst_reg;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -58,6 +58,7 @@ void calculate_round(const int decimals) {
             vInt res = float_to_int16(result);
             res = res & 0x7FFE;
             result = int32_to_float(res);
+            result = setsgn(result, v);
         }
         v_endif;
         dst_reg[0] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_round.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_round.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_round_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::round, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_round(uint dst_index, int decimals, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_round<APPROXIMATE>, dst_index, vector_mode, decimals);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -91,5 +91,6 @@ enum SfpuType {
     unused,
     reshuffle_rows,
     cumsum,
-    fill
+    fill,
+    round,
 };

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/round.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/round.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,21 +20,21 @@ namespace ckernel {
  */
 ALWI void round_tile_init() { MATH((llk_math_eltwise_unary_sfpu_round_init<APPROX>())); }
 
+// clang-format off
 /**
- * Performs round operation on each row of a tile.
+ * Performs element-wise computation of the round operation on each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
  *
  * Return value: None
  *
- * | Argument        | Description                                                                | Type     | Valid
- * Range                                           | Required |
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to modify the sign bit of     | uint32_t | Must be
- * less than the size of the DST register buffer | True     | | decimals        | The number of decimal places to round
- * to.                                  | int32_t  |                                                       | True     |
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | decimals        | The number of decimal places to round to.                                  | uint32_t |                                                       | True     |
  */
+// clang-format on
 ALWI void round_tile(uint32_t idst, int32_t decimals) {
     MATH((llk_math_eltwise_unary_sfpu_round<APPROX>(idst, decimals)));
 }

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/round.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/round.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_round.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void round_tile_init() { MATH((llk_math_eltwise_unary_sfpu_round_init<APPROX>())); }
+
+/**
+ * Performs round operation on each row of a tile.
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid
+ * Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to modify the sign bit of     | uint32_t | Must be
+ * less than the size of the DST register buffer | True     | | decimals        | The number of decimal places to round
+ * to.                                  | int32_t  |                                                       | True     |
+ */
+ALWI void round_tile(uint32_t idst, int32_t decimals) {
+    MATH((llk_math_eltwise_unary_sfpu_round<APPROX>(idst, decimals)));
+}
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -96,6 +96,10 @@
 #include "compute_kernel_api/eltwise_unary/floor.h"
 #endif
 
+#if SFPU_OP_ROUND_INCLUDE
+#include "compute_kernel_api/eltwise_unary/round.h"
+#endif
+
 #if SFPU_OP_LEFT_SHIFT_INCLUDE
 #include "compute_kernel_api/eltwise_unary/left_shift.h"
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -84,6 +84,7 @@ enum class UnaryOpType {
     FLOOR_FLOAT32,
     CEIL,
     CEIL_FLOAT32,
+    ROUND,
     LEFT_SHIFT,
     REMAINDER,
     FMOD,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -64,6 +64,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::REMAINDER: return "SFPU_OP_REMAINDER_INCLUDE";
         case UnaryOpType::FMOD: return "SFPU_OP_FMOD_INCLUDE";
         case UnaryOpType::FILL: return "SFPU_OP_FILL_INCLUDE";
+        case UnaryOpType::ROUND: return "SFPU_OP_ROUND_INCLUDE";
         default: return "SFPU_OP_COMPUTE_KERNEL_API_INCLUDE";
     };
 }
@@ -77,6 +78,9 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::FILL:
             op_init_and_name = {
                 "fill_tile_init();", fmt::format("fill_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            break;
+        case UnaryOpType::ROUND:
+            op_init_and_name = {"round_tile_init();", fmt::format("round_tile({}, {});", idst, (int)param0)};
             break;
         case UnaryOpType::RELU_MAX:
             op_init_and_name = {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -63,6 +63,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::REMAINDER:
         case UnaryOpType::FILL:
+        case UnaryOpType::ROUND:
         case UnaryOpType::PRELU_SFPU:
         case UnaryOpType::FMOD: return true;
         default: return false;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -44,7 +44,6 @@ enum class UnaryCompositeOpType {
     POW,
     TRIL,
     TRIU,
-    ROUND,
     POLYGAMMA,
     HARDSHRINK,
     SOFTSHRINK,
@@ -100,7 +99,6 @@ Tensor _geglu(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
 Tensor _swiglu(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
 Tensor _tril(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _triu(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-Tensor _round(const Tensor&, int32_t decimal = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _polygamma(const Tensor&, int32_t, const std::optional<MemoryConfig>&);
 Tensor _hardshrink(
     const Tensor& a, float lambd = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
@@ -273,13 +271,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::TRIU> {
     static Tensor handle(const Tensor& t1, int32_t param1, const std::optional<MemoryConfig>& mem_cfg) {
         return _triu(t1, param1, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::ROUND> {
-    static Tensor handle(const Tensor& t1, int32_t param1, const std::optional<MemoryConfig>& mem_cfg) {
-        return _round(t1, param1, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -21,6 +21,7 @@ void validate_supported_arch_dtype(
         case UnaryOpType::REMAINDER:
         case UnaryOpType::FLOOR:
         case UnaryOpType::CEIL:
+        case UnaryOpType::ROUND:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::RIGHT_SHIFT:
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -289,6 +289,7 @@ Tensor ExecuteUnaryWithIntegerParameter<unary_op_type, T>::invoke(
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::POWER, uint32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::LEFT_SHIFT, int32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::RIGHT_SHIFT, int32_t>;
+template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::ROUND, int32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_AND, int32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_OR, int32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_XOR, int32_t>;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -269,6 +269,7 @@ REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(ne_unary, UNARY_NE);
 
 // Unaries with integer parameter
 REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(power, POWER, uint32_t);
+REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(round, ROUND, int32_t);
 
 // Other unaries
 constexpr auto identity =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -281,9 +281,6 @@ constexpr auto tril = ttnn::register_operation_with_auto_launch_op<
 constexpr auto triu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::triu",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::TRIU>>();
-constexpr auto round = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::round",
-    operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::ROUND>>();
 constexpr auto polygamma = ttnn::register_operation_with_auto_launch_op<
     "ttnn::polygamma",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::POLYGAMMA>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -562,7 +562,7 @@ void bind_unary_operation_with_int_parameter(
                const int parameter,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
-               const uint8_t& queue_id) {
+               QueueId queue_id) {
                 return self(queue_id, input_tensor, parameter, memory_config, output_tensor);
             },
             py::arg("input_tensor"),
@@ -570,7 +570,7 @@ void bind_unary_operation_with_int_parameter(
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = 0});
+            py::arg("queue_id") = DefaultQueueId});
 }
 
 template <typename unary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -494,6 +494,84 @@ void bind_unary_operation_with_float_parameter(
             py::arg("queue_id") = DefaultQueueId});
 }
 
+template <typename unary_operation_t>
+void bind_unary_operation_with_int_parameter(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name,
+    const std::string& parameter_doc,
+    const std::string& info_doc,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        Applies {0} to :attr:`input_tensor` element-wise with {2}.
+
+        {4}
+
+        .. math::
+            \mathrm{{output\_tensor}}_i = \verb|{0}|(\mathrm{{input\_tensor}}_i, \verb|{2}|)
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            {2} (int): {3}.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {5}
+                 - TILE
+                 - 2, 3, 4
+
+            {6}
+
+        Example:
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> {2} = 3
+            >>> output = {1}(tensor, {2})
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        parameter_name,
+        parameter_doc,
+        info_doc,
+        supported_dtype,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const Tensor& input_tensor,
+               const int parameter,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const uint8_t& queue_id) {
+                return self(queue_id, input_tensor, parameter, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg(parameter_name.c_str()),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
 
 template <typename unary_operation_t>
 void bind_unary_operation_with_dim_parameter(
@@ -1740,11 +1818,11 @@ void py_module(py::module& module) {
         "diagonal", "diagonal value", 0,
         R"doc(Performs triu function on :attr:`input_tensor`, :attr:`diagonal`.)doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
-    detail::bind_unary_composite_int_with_default(
+    detail::bind_unary_operation_with_int_parameter(
         module,
         ttnn::round,
-        "decimals", "decimals value", 0,
-        R"doc(Performs round function on :attr:`input_tensor`, :attr:`decimals`.)doc",
+        "decimals", "no. of decimal places to round off to",
+        R"doc(Round the input tensor to `decimals` decimal places.)doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc",
         R"doc(Not supported on Grayskull.)doc");
     detail::bind_unary_composite_int(


### PR DESCRIPTION
### Ticket
#13385 

### Problem description
ttnn.round is currently implemented as a combination of ttnn.floor, ttnn.add, etc. This op can be implemented as a kernel op. #13851 has laid the groundwork for this issue to which I have added a few modifications.

### What's changed
- Write a kernel function for ttnn.round that directly calls casting instructions.
- Replace current implementation with the kernel function.

### Performance
Old Kernel Duration: 15884448 ns
New Kernel Duration: 529442 ns
Performance Gain: 15355006 ns

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13804112732) - PASSED
- [x] [Blackhole Post commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13715306217) - PASSED
- [x] [(Single-card) Tests for new models ](https://github.com/tenstorrent/tt-metal/actions/runs/13804123199) - same as main
- [x] New/Existing tests provide coverage for changes
