### PR TITLE
[UMD] Change logical to translated mapping to new API

### DIFF
--- a/tt_metal/api/tt-metalium/tt_cluster.hpp
+++ b/tt_metal/api/tt-metalium/tt_cluster.hpp
@@ -242,8 +242,11 @@ class Cluster {
     bool is_worker_core(const CoreCoord &core, chip_id_t chip_id) const;
     bool is_ethernet_core(const CoreCoord &core, chip_id_t chip_id) const;
     CoreCoord get_logical_ethernet_core_from_virtual(chip_id_t chip, CoreCoord core) const;
-    const std::unordered_map<int, int>& get_worker_logical_to_virtual_x(chip_id_t chip_id) const { return this->worker_logical_to_virtual_x_.at(this->get_board_type(chip_id)); };
-    const std::unordered_map<int, int>& get_worker_logical_to_virtual_y(chip_id_t chip_id) const { return this->worker_logical_to_virtual_y_.at(this->get_board_type(chip_id)); };
+
+    // These two functions should be removed in favor of direct translation.
+    const std::unordered_map<int, int> get_worker_logical_to_virtual_x(chip_id_t chip_id) const;
+    const std::unordered_map<int, int> get_worker_logical_to_virtual_y(chip_id_t chip_id) const;
+
     const std::unordered_map<CoreCoord, int32_t>& get_virtual_routing_to_profiler_flat_id(chip_id_t chip_id) const;
    private:
     Cluster();
@@ -262,7 +265,6 @@ class Cluster {
         const std::unordered_map<chip_id_t, tt_SocDescriptor> &input,
         const std::unordered_map<chip_id_t, uint32_t> &per_chip_id_harvesting_masks);
     void generate_virtual_to_umd_coord_mapping();
-    void generate_logical_to_virtual_coord_mapping();
     void generate_virtual_to_profiler_flat_id_mapping();
 
     // Reserves ethernet cores in cluster for tunneling
@@ -295,9 +297,6 @@ class Cluster {
     std::unordered_map<tt_cxy_pair, tt_cxy_pair> virtual_to_umd_coord_mapping_;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> virtual_worker_cores_;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> virtual_eth_cores_;
-    std::unordered_map<BoardType, std::unordered_map<int, int>> worker_logical_to_virtual_x_;
-    std::unordered_map<BoardType, std::unordered_map<int, int>> worker_logical_to_virtual_y_;
-    std::unordered_map<BoardType, std::unordered_map<CoreCoord, CoreCoord>> eth_logical_to_virtual_;
     std::unordered_map<BoardType, std::unordered_map<CoreCoord, int32_t>> virtual_routing_to_profiler_flat_id_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -390,6 +390,11 @@ CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
         return soc_desc.get_physical_dram_core_from_logical(logical_coord);
     }
 
+    // TBD: Remove when all WORKER are rewritten to TENSIX
+    if (core_type == CoreType::WORKER) {
+        core_type = CoreType::TENSIX;
+    }
+
     tt::umd::CoreCoord translated_coord =
         soc_desc.translate_coord_to({logical_coord, core_type, CoordSystem::LOGICAL}, CoordSystem::TRANSLATED);
     return {translated_coord.x, translated_coord.y};

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -385,6 +385,11 @@ const std::unordered_set<CoreCoord>& Cluster::get_virtual_eth_cores(chip_id_t ch
 
 CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
     chip_id_t chip_id, CoreCoord logical_coord, const CoreType& core_type) const {
+    // Keeping the old behavior, although UMD does define translation for other cores as well.
+    if (core_type != CoreType::WORKER && core_type != CoreType::DRAM && core_type != CoreType::ETH) {
+        TT_THROW("Undefined conversion for core type.");
+    }
+
     auto& soc_desc = this->get_soc_desc(chip_id);
     if (core_type == CoreType::DRAM) {
         return soc_desc.get_physical_dram_core_from_logical(logical_coord);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -198,7 +198,6 @@ void Cluster::initialize_device_drivers() {
     tt_device_params default_params;
     this->start_driver(default_params);
     this->generate_virtual_to_umd_coord_mapping();
-    this->generate_logical_to_virtual_coord_mapping();
     this->generate_virtual_to_profiler_flat_id_mapping();
 }
 
@@ -347,39 +346,6 @@ void Cluster::generate_virtual_to_umd_coord_mapping() {
     }
 }
 
-void Cluster::generate_logical_to_virtual_coord_mapping() {
-    for (auto chip_id : this->cluster_desc_->get_all_chips()) {
-        auto board_type = this->get_board_type(chip_id);
-        if (this->worker_logical_to_virtual_x_.find(board_type) != this->worker_logical_to_virtual_x_.end()) {
-            continue;
-        }
-        auto& soc_desc = this->get_soc_desc(chip_id);
-        this->worker_logical_to_virtual_x_.insert({board_type, {}});
-        this->worker_logical_to_virtual_y_.insert({board_type, {}});
-        this->eth_logical_to_virtual_.insert({board_type, {}});
-        for (auto x_coords : soc_desc.worker_log_to_routing_x) {
-            CoreCoord phys_core = soc_desc.get_physical_tensix_core_from_logical(CoreCoord(x_coords.first, 0));
-            CoreCoord virtual_coords = this->get_virtual_coordinate_from_physical_coordinates(chip_id, phys_core);
-            this->worker_logical_to_virtual_x_.at(board_type).insert({x_coords.first, virtual_coords.x});
-        }
-        for (auto y_coords : soc_desc.worker_log_to_routing_y) {
-            CoreCoord phys_core = soc_desc.get_physical_tensix_core_from_logical(CoreCoord(0, y_coords.first));
-            CoreCoord virtual_coords = this->get_virtual_coordinate_from_physical_coordinates(chip_id, phys_core);
-            this->worker_logical_to_virtual_y_.at(board_type).insert({y_coords.first, virtual_coords.y});
-        }
-        for (std::size_t log_eth_core_y = 0; log_eth_core_y < soc_desc.get_cores(CoreType::ETH).size();
-             log_eth_core_y++) {
-            CoreCoord logical_eth_core = {0, log_eth_core_y};
-            tt::umd::CoreCoord phys_eth_core =
-                soc_desc.translate_coord_to(soc_desc.get_eth_core_for_channel(log_eth_core_y), CoordSystem::PHYSICAL);
-            CoreCoord virtual_coords =
-                this->get_virtual_coordinate_from_physical_coordinates(chip_id, {phys_eth_core.x, phys_eth_core.y});
-            this->eth_logical_to_virtual_.at(board_type).insert({logical_eth_core, virtual_coords});
-        }
-    }
-
-}
-
 void Cluster::generate_virtual_to_profiler_flat_id_mapping() {
 #if defined(TRACY_ENABLE)
     for (auto chip_id : this->cluster_desc_->get_all_chips()) {
@@ -417,15 +383,16 @@ const std::unordered_set<CoreCoord>& Cluster::get_virtual_eth_cores(chip_id_t ch
     return this->virtual_eth_cores_.at(chip_id);
 }
 
-CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(chip_id_t chip_id, CoreCoord logical_coord, const CoreType& core_type) const {
-    auto board_type = this->get_board_type(chip_id);
-    if (core_type == CoreType::WORKER) {
-        return CoreCoord(this->worker_logical_to_virtual_x_.at(board_type).at(logical_coord.x), this->worker_logical_to_virtual_y_.at(board_type).at(logical_coord.y));
-    } else if (core_type == CoreType::ETH) {
-        return this->eth_logical_to_virtual_.at(board_type).at(logical_coord);
-    }
+CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
+    chip_id_t chip_id, CoreCoord logical_coord, const CoreType& core_type) const {
     auto& soc_desc = this->get_soc_desc(chip_id);
-    return soc_desc.get_physical_core_from_logical_core(logical_coord, core_type);
+    if (core_type == CoreType::DRAM) {
+        return soc_desc.get_physical_dram_core_from_logical(logical_coord);
+    }
+
+    tt::umd::CoreCoord translated_coord =
+        soc_desc.translate_coord_to(logical_coord, CoordSystem::LOGICAL, CoordSystem::TRANSLATED);
+    return {translated_coord.x, translated_coord.y};
 }
 
 tt_cxy_pair Cluster::get_virtual_coordinate_from_logical_coordinates(tt_cxy_pair logical_coordinate, const CoreType& core_type) const {
@@ -456,6 +423,26 @@ CoreCoord Cluster::get_logical_ethernet_core_from_virtual(chip_id_t chip, CoreCo
     tt::umd::CoreCoord logical_core =
         get_soc_desc(chip).translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
     return {logical_core.x, logical_core.y};
+}
+
+const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_x(chip_id_t chip_id) const {
+    std::unordered_map<int, int> worker_logical_to_virtual_x;
+    const auto& soc_desc = tt::Cluster::instance().get_soc_desc(chip_id);
+    for (const tt::umd::CoreCoord& logical_core : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::LOGICAL)) {
+        tt::umd::CoreCoord translated_core = soc_desc.translate_coord_to(logical_core, CoordSystem::TRANSLATED);
+        worker_logical_to_virtual_x[logical_core.x] = translated_core.x;
+    }
+    return worker_logical_to_virtual_x;
+}
+
+const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(chip_id_t chip_id) const {
+    std::unordered_map<int, int> worker_logical_to_virtual_y;
+    const auto& soc_desc = tt::Cluster::instance().get_soc_desc(chip_id);
+    for (const tt::umd::CoreCoord& logical_core : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::LOGICAL)) {
+        tt::umd::CoreCoord translated_core = soc_desc.translate_coord_to(logical_core, CoordSystem::TRANSLATED);
+        worker_logical_to_virtual_y[logical_core.y] = translated_core.y;
+    }
+    return worker_logical_to_virtual_y;
 }
 
 uint32_t Cluster::get_harvested_rows(chip_id_t chip) const {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -391,7 +391,7 @@ CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
     }
 
     tt::umd::CoreCoord translated_coord =
-        soc_desc.translate_coord_to(logical_coord, CoordSystem::LOGICAL, CoordSystem::TRANSLATED);
+        soc_desc.translate_coord_to({logical_coord, core_type, CoordSystem::LOGICAL}, CoordSystem::TRANSLATED);
     return {translated_coord.x, translated_coord.y};
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -391,12 +391,13 @@ CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
     }
 
     // TBD: Remove when all WORKER are rewritten to TENSIX
-    if (core_type == CoreType::WORKER) {
-        core_type = CoreType::TENSIX;
+    CoreType core_type_to_use = core_type;
+    if (core_type_to_use == CoreType::WORKER) {
+        core_type_to_use = CoreType::TENSIX;
     }
 
     tt::umd::CoreCoord translated_coord =
-        soc_desc.translate_coord_to({logical_coord, core_type, CoordSystem::LOGICAL}, CoordSystem::TRANSLATED);
+        soc_desc.translate_coord_to({logical_coord, core_type_to_use, CoordSystem::LOGICAL}, CoordSystem::TRANSLATED);
     return {translated_coord.x, translated_coord.y};
 }
 


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/17002

### Problem description
Alter some APIs and remove some usages.

### What's changed
- Remove worker_logical_to_virtual_x_ and worker_logical_to_virtual_y_
- Change get_virtual_coordinate_from_logical_coordinates so that it uses new api for tensix and eth, and same path for DRAM
- Implement get_worker_logical_to_virtual_x and get_worker_logical_to_virtual_y, which should be removed once but is out of scope for this PR. However. remove the usage of old API through them.

### Testing
I've added new code directly to generate_logical_to_virtual_coord_mapping, and verified that old vs new mappings are the same, before removing that code. I've verified it matches what we return by translate_coord_to from LOGICAL to TRANSLATED coords. I did this on wormhole only

### Checklist
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13204500386 https://github.com/tenstorrent/tt-metal/actions/runs/13208231490
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197582366
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197585051
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/13197587167
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197589587
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197591287
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197592965
- [ ] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197595178
- [x] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197597328
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13197599629
