### PR TITLE
[TT-Train] fp32 turned off for softmax

### DIFF
--- a/tt-train/sources/ttml/core/compute_kernel_config.cpp
+++ b/tt-train/sources/ttml/core/compute_kernel_config.cpp
@@ -17,7 +17,7 @@ ttnn::WormholeComputeKernelConfig ComputeKernelConfig::precise() {
 
 ttnn::WormholeComputeKernelConfig ComputeKernelConfig::softmax() {
     ttnn::WormholeComputeKernelConfig config;
-    config.fp32_dest_acc_en = true;
+    config.fp32_dest_acc_en = false;
     config.math_approx_mode = false;
     config.math_fidelity = MathFidelity::HiFi4;
     config.packer_l1_acc = true;

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -72,7 +72,7 @@ autograd::TensorPtr log_softmax_moreh(const autograd::TensorPtr& tensor, int dim
         ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOp::LOGSOFTMAX,
         ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOpParallelizationStrategy::NONE,
         /* output_mem_config */ std::nullopt,
-        /* compute_kernel_config */ core::ComputeKernelConfig::precise());
+        /* compute_kernel_config */ core::ComputeKernelConfig::softmax());
     auto out = autograd::create_tensor(log_softmax);
 
     autograd::GradFunction grad = [tensor, out, dim]() {


### PR DESCRIPTION
### Problem description
fp32_dest doesn't work for softmax and log_softmax.
Training is exloding.

### What's changed
Disabled it for both ops.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13189909685
- [x] New/Existing tests provide coverage for changes
