### PR TITLE
#17682 Improve eltwise binary ng test coverage

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1238,19 +1238,50 @@ def test_binary_sharded_small_tile_row_major(a_shape, b_shape, shard_type, shard
 
 
 @pytest.mark.parametrize(
-    "a_shape, b_shape",
-    # ((torch.Size([5, 7, 2, 35]), torch.Size([5, 7, 2, 35])),),
-    ((torch.Size([1, 1, 1024, 1024]), torch.Size([1, 1, 1024, 1024])),),
-)
-@pytest.mark.parametrize(
-    "shard_type, shard_size, core_range",
+    "a_shape, b_shape, shard_type, shard_size, core_range",
     (
-        # [ttnn.ShardStrategy.HEIGHT, [64, 32], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (4, 6))})],
-        # [ttnn.ShardStrategy.WIDTH, [32, 35 * 32], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 1))})],
-        # [ttnn.ShardStrategy.BLOCK, [32, 32 * 5], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (6, 1))})],
-        [ttnn.ShardStrategy.HEIGHT, [1024, 128], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 7))})],
-        [ttnn.ShardStrategy.WIDTH, [128, 1024], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 7))})],
-        # [ttnn.ShardStrategy.BLOCK, [256, 256], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (3, 3))})],
+        [
+            torch.Size([5, 7, 2, 35]),
+            torch.Size([5, 7, 2, 35]),
+            ttnn.ShardStrategy.HEIGHT,
+            [64, 32],
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (4, 6))}),
+        ],
+        [
+            torch.Size([5, 7, 2, 35]),
+            torch.Size([5, 7, 2, 35]),
+            ttnn.ShardStrategy.WIDTH,
+            [32, 35 * 32],
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 1))}),
+        ],
+        [
+            torch.Size([5, 7, 2, 35]),
+            torch.Size([5, 7, 2, 35]),
+            ttnn.ShardStrategy.BLOCK,
+            [32, 32 * 5],
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (6, 1))}),
+        ],
+        [
+            torch.Size([1, 1, 1024, 1024]),
+            torch.Size([1, 1, 1024, 1024]),
+            ttnn.ShardStrategy.HEIGHT,
+            [1024, 128],
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 7))}),
+        ],
+        [
+            torch.Size([1, 1, 1024, 1024]),
+            torch.Size([1, 1, 1024, 1024]),
+            ttnn.ShardStrategy.WIDTH,
+            [128, 1024],
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 7))}),
+        ],
+        [
+            torch.Size([1, 1, 1024, 1024]),
+            torch.Size([1, 1, 1024, 1024]),
+            ttnn.ShardStrategy.BLOCK,
+            [256, 256],
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (3, 3))}),
+        ],
     ),
 )
 def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, device):
@@ -1269,6 +1300,7 @@ def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core
         (ttnn.DRAM_MEMORY_CONFIG, shard_config),
         (shard_config, ttnn.DRAM_MEMORY_CONFIG),
         (shard_config, shard_config),
+        (ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
     )
 
     for src_config, dst_config in input_combinations:

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1271,14 +1271,14 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
             torch.Size([1, 1, 1024, 1024]),
             ttnn.ShardStrategy.HEIGHT,
             [1024, 128],
-            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 7))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 0))}),
         ],
         [
             torch.Size([1, 1, 1024, 1024]),
             torch.Size([1, 1, 1024, 1024]),
             ttnn.ShardStrategy.WIDTH,
             [128, 1024],
-            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (0, 7))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 0))}),
         ],
         [
             torch.Size([1, 1, 1024, 1024]),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -319,27 +319,6 @@ def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_confi
 
 
 @pytest.mark.parametrize(
-    "a, b, c_golden",
-    [
-        ([1, 2], [3], [4, 5]),
-        ([1], [2, 3], [3, 4]),
-        ([1, 2], [3, 4], [4, 6]),
-    ],
-)
-def test_binary_invalid_layout(device, a, b, c_golden):
-    a = torch.BFloat16Tensor(a)
-    b = torch.BFloat16Tensor(b)
-    assert torch.add(a, b).tolist() == c_golden
-
-    ttnn_a = ttnn.from_torch(a, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    ttnn_b = ttnn.from_torch(b, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-
-    with pytest.raises(RuntimeError):
-        cq_id = 0
-        ttnn_c = ttnn.experimental.add(ttnn_a, ttnn_b, queue_id=cq_id)
-
-
-@pytest.mark.parametrize(
     "a_shape, b_shape",
     [
         [[2, 4, 12, 64, 64], [12, 1, 1]],

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -155,10 +155,21 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& output_tensor = tensor_args.output_tensor;
 
-    TT_FATAL(input_tensor_a.get_logical_shape().rank() <= 4, "Tensor a does not support rank >= 5");
+    auto nd_support = [](const auto& shape) {
+        bool valid = true;
+        for (int i = -5; i >= -shape.rank(); --i) {
+            if (shape[i] != 1) {
+                valid = false;
+                break;
+            }
+        }
+        return valid;
+    };
+
+    TT_FATAL(nd_support(input_tensor_a.get_logical_shape()), "Tensor a does not support 5D or more");
 
     if (input_tensor_b.has_value()) {
-        TT_FATAL(input_tensor_b->get_logical_shape().rank() <= 4, "Tensor b does not support rank >= 5");
+        TT_FATAL(nd_support(input_tensor_b->get_logical_shape()), "Tensor b does not support 5D or more");
     }
 
     TT_FATAL(
@@ -253,8 +264,6 @@ void BinaryNgDeviceOperation::validate_on_program_cache_hit(
     const int rank_b = input_shape_b.rank();
     const int larger_rank = std::max(rank_a, rank_b);
 
-    TT_FATAL(larger_rank <= 4, "Broadcasting currently only supporting ranks <= 4");
-
     for (int i = -1; i >= -larger_rank; --i) {
         auto a_dim = (i >= -rank_a) ? input_shape_a[i] : 1;
         auto b_dim = (i >= -rank_b) ? input_shape_b[i] : 1;
@@ -265,10 +274,20 @@ void BinaryNgDeviceOperation::validate_on_program_cache_hit(
             a_dim,
             b_dim);
 
+        if (i <= -5) {
+            TT_FATAL(
+                a_dim == 1 && b_dim == 1,
+                "Broadcasting rule violation for 5D {}, dim a: {}, dim b: {}",
+                i,
+                a_dim,
+                b_dim);
+        }
+
         if (has_shard_spec and i != -1) {
             TT_FATAL(
                 a_dim == b_dim,
-                "Cannot broadcast sharded tensors on dims other than W, violation for rank {}, dim a: {}, dim b: {}",
+                "Cannot broadcast sharded tensors on dims other than W, violation for rank {}, dim a: {}, dim b: "
+                "{}",
                 i,
                 a_dim,
                 b_dim);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -155,6 +155,12 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& output_tensor = tensor_args.output_tensor;
 
+    TT_FATAL(input_tensor_a.get_logical_shape().rank() <= 4, "Tensor a does not support rank >= 5");
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(input_tensor_b->get_logical_shape().rank() <= 4, "Tensor b does not support rank >= 5");
+    }
+
     TT_FATAL(
         input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
 
@@ -246,6 +252,9 @@ void BinaryNgDeviceOperation::validate_on_program_cache_hit(
     const int rank_a = input_shape_a.rank();
     const int rank_b = input_shape_b.rank();
     const int larger_rank = std::max(rank_a, rank_b);
+
+    TT_FATAL(larger_rank <= 4, "Broadcasting currently only supporting ranks <= 4");
+
     for (int i = -1; i >= -larger_rank; --i) {
         auto a_dim = (i >= -rank_a) ? input_shape_a[i] : 1;
         auto b_dim = (i >= -rank_b) ? input_shape_b[i] : 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -45,8 +45,7 @@ struct AllShardSpecs {
     ShardSpec c_shard_spec;
 };
 
-ShardSpec adjust_to_shape(
-    const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+ShardSpec adjust_to_shape(const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
     auto ret = shard_spec;
 
     ret.shape[0] = (ret.shape[0] * to_shape[-2]) / from_shape[-2];
@@ -180,7 +179,7 @@ void set_or_update_runtime_arguments(
     bool zero_start_grid = false;
     CoreCoord compute_with_storage_grid;
     const auto& all_device_cores = operation_attributes.worker_grid;
-    if (all_device_cores.size() == 1) {
+    if (grid.size() == 1) {
         const auto& cr = *all_device_cores.ranges().begin();
         if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
             if (has_sharding) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -167,10 +167,12 @@ void set_or_update_runtime_arguments(
     const auto [cN, cC, cHt, cWt] = get_shape_dims(c);
     const uint32_t cHt_unrolled = cN * cC * cHt;
 
-    bool row_major = true;
     const auto shard_specs = get_shard_specs(a, b, c);
     const bool has_sharding = shard_specs.has_value();
     auto grid = has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
+
+    bool row_major =
+        has_sharding ? shard_specs->a_shard_spec.orientation == ShardOrientation::ROW_MAJOR ? true : false : true;
 
     // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
     // as well as having the sharded tensors (if any) start at (0, 0)
@@ -383,7 +385,6 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
 
     // we parallelize the computation across the output tiles
-    constexpr bool row_major = true;
     const auto& all_device_cores = operation_attributes.worker_grid;
 
     Buffer* a_buffer = a.buffer();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17682)

### Problem description
Improve test coverage, and negative testing. 

### What's changed
Fixed bug to support sharding col_major, more than one CoreRange for core grid, 5D/ND sad path checking, and various test cases for binary and sharding.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
