### PR TITLE
#17167: Remove build APIs from device

### DIFF
--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
@@ -227,10 +228,14 @@ bool send_over_eth(
 
     // TODO: this should be updated to use kernel api
     uint32_t active_eth_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-    ll_api::memory const& binary_mem_send =
-        llrt::get_risc_binary(sender_device->build_firmware_target_path(active_eth_index, 0, 0));
-    ll_api::memory const& binary_mem_receive =
-        llrt::get_risc_binary(receiver_device->build_firmware_target_path(active_eth_index, 0, 0));
+    auto sender_firmware_path = BuildEnvManager::get_instance()
+                                    .get_firmware_build_state(sender_device->id(), active_eth_index, 0, 0)
+                                    .get_target_out_path("");
+    auto receiver_firmware_path = BuildEnvManager::get_instance()
+                                      .get_firmware_build_state(receiver_device->id(), active_eth_index, 0, 0)
+                                      .get_target_out_path("");
+    const ll_api::memory& binary_mem_send = llrt::get_risc_binary(sender_firmware_path);
+    const ll_api::memory& binary_mem_receive = llrt::get_risc_binary(receiver_firmware_path);
 
     for (const auto& eth_core : eth_cores) {
         llrt::write_hex_vec_to_core(

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -229,10 +229,10 @@ bool send_over_eth(
     // TODO: this should be updated to use kernel api
     uint32_t active_eth_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
     auto sender_firmware_path = BuildEnvManager::get_instance()
-                                    .get_firmware_build_state(sender_device->id(), active_eth_index, 0, 0)
+                                    .get_firmware_build_state(sender_device->build_id(), active_eth_index, 0, 0)
                                     .get_target_out_path("");
     auto receiver_firmware_path = BuildEnvManager::get_instance()
-                                      .get_firmware_build_state(receiver_device->id(), active_eth_index, 0, 0)
+                                      .get_firmware_build_state(receiver_device->build_id(), active_eth_index, 0, 0)
                                       .get_target_out_path("");
     const ll_api::memory& binary_mem_send = llrt::get_risc_binary(sender_firmware_path);
     const ll_api::memory& binary_mem_receive = llrt::get_risc_binary(receiver_firmware_path);

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include "dprint_server.hpp"
 #include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -67,7 +68,9 @@ int main(int argc, char** argv) {
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
         // Remove old compiled kernels
         static const std::string kernel_name = "test_compile_args";
-        auto binary_path_str = device->build_env().get_out_kernel_root_path() + kernel_name;
+        auto binary_path_str =
+            kernel->binaries(BuildEnvManager::get_instance().get_build_env(device->id())).get_out_kernel_root_path() +
+            kernel_name;
         std::filesystem::remove_all(binary_path_str);
 
         pass &= test_compile_args({0, 68, 0, 124}, device);

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
         // Remove old compiled kernels
         static const std::string kernel_name = "test_compile_args";
         auto binary_path_str =
-            kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env)
+            kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env)
                 .get_out_kernel_root_path() +
             kernel_name;
         std::filesystem::remove_all(binary_path_str);

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -69,7 +69,8 @@ int main(int argc, char** argv) {
         // Remove old compiled kernels
         static const std::string kernel_name = "test_compile_args";
         auto binary_path_str =
-            kernel->binaries(BuildEnvManager::get_instance().get_build_env(device->id())).get_out_kernel_root_path() +
+            kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env)
+                .get_out_kernel_root_path() +
             kernel_name;
         std::filesystem::remove_all(binary_path_str);
 

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -61,12 +61,14 @@ std::unordered_map<std::string, std::string> get_last_program_binary_path(const 
 KernelCacheStatus CompileProgramTestWrapper(IDevice* device, Program& program, bool profile_kernel = false) {
     // Check
     std::unordered_map<std::string, std::string> pre_compile_kernel_to_hash_str = get_last_program_binary_path(
-        program, BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
+        program,
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
 
     detail::CompileProgram(device, program);
 
     std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str = get_last_program_binary_path(
-        program, BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
+        program,
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
 
     KernelCacheStatus kernel_cache_status;
     for (const auto& [kernel_name, hash_str] : post_compile_kernel_to_hash_str) {
@@ -187,7 +189,8 @@ void assert_kernel_hash_matches(
 bool test_compile_program_in_loop(IDevice* device) {
     bool pass = true;
 
-    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
+    ClearKernelCache(
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
     ProgramAttributes default_attributes;
     auto program = create_program(device, default_attributes);
 
@@ -198,7 +201,7 @@ bool test_compile_program_in_loop(IDevice* device) {
         if (compile_idx == 0) {
             assert_kernel_binary_path_exists(
                 program,
-                BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
                 kernel_cache_status);
             assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
             kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
@@ -214,7 +217,8 @@ bool test_compile_program_in_loop(IDevice* device) {
 bool test_compile_program_after_clean_kernel_binary_directory(IDevice* device) {
     bool pass = true;
 
-    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
+    ClearKernelCache(
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
 
     ProgramAttributes default_attributes;
     auto program = create_program(device, default_attributes);
@@ -223,12 +227,13 @@ bool test_compile_program_after_clean_kernel_binary_directory(IDevice* device) {
 
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
 
-    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
+    ClearKernelCache(
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
     auto second_program = create_program(device, default_attributes);
     auto second_kernel_cache_status = CompileProgramTestWrapper(device, second_program);
     assert_program_cache_hit_status(second_program, /*hit_expected=*/false, second_kernel_cache_status);
@@ -282,7 +287,7 @@ std::unordered_map<std::string, std::string> compile_program_with_modified_kerne
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_cache_hit_status_for_kernel_type(program, kernel_type_to_cache_hit_status, kernel_cache_status);
     assert_hash_comparison_for_kernel_type(
@@ -306,14 +311,15 @@ bool test_compile_program_with_modified_program(IDevice* device) {
     const static std::unordered_map<tt::RISCV, bool> compute_miss_data_movement_miss = {
         {tt::RISCV::COMPUTE, false}, {tt::RISCV::BRISC, false}, {tt::RISCV::NCRISC, false}};
 
-    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
+    ClearKernelCache(
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
 
     ProgramAttributes attributes;
     auto program = create_program(device, attributes);
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -16,6 +16,7 @@
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/kernel.hpp>
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 using std::vector;
 using namespace tt;
@@ -59,13 +60,13 @@ std::unordered_map<std::string, std::string> get_last_program_binary_path(const 
 // TODO: Replace this when we have debug/test hooks (GH: #964) to inspect inside CompileProgram
 KernelCacheStatus CompileProgramTestWrapper(IDevice* device, Program& program, bool profile_kernel = false) {
     // Check
-    std::unordered_map<std::string, std::string> pre_compile_kernel_to_hash_str =
-        get_last_program_binary_path(program, device->build_env().get_out_kernel_root_path());
+    std::unordered_map<std::string, std::string> pre_compile_kernel_to_hash_str = get_last_program_binary_path(
+        program, BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
 
     detail::CompileProgram(device, program);
 
-    std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str =
-        get_last_program_binary_path(program, device->build_env().get_out_kernel_root_path());
+    std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str = get_last_program_binary_path(
+        program, BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
 
     KernelCacheStatus kernel_cache_status;
     for (const auto& [kernel_name, hash_str] : post_compile_kernel_to_hash_str) {
@@ -186,7 +187,7 @@ void assert_kernel_hash_matches(
 bool test_compile_program_in_loop(IDevice* device) {
     bool pass = true;
 
-    ClearKernelCache(device->build_env().get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
     ProgramAttributes default_attributes;
     auto program = create_program(device, default_attributes);
 
@@ -195,7 +196,10 @@ bool test_compile_program_in_loop(IDevice* device) {
     for (int compile_idx = 0; compile_idx < num_compiles; compile_idx++) {
         auto kernel_cache_status = CompileProgramTestWrapper(device, program);
         if (compile_idx == 0) {
-            assert_kernel_binary_path_exists(program, device->build_env().get_out_kernel_root_path(), kernel_cache_status);
+            assert_kernel_binary_path_exists(
+                program,
+                BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                kernel_cache_status);
             assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
             kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
         } else {
@@ -210,18 +214,21 @@ bool test_compile_program_in_loop(IDevice* device) {
 bool test_compile_program_after_clean_kernel_binary_directory(IDevice* device) {
     bool pass = true;
 
-    ClearKernelCache(device->build_env().get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
 
     ProgramAttributes default_attributes;
     auto program = create_program(device, default_attributes);
 
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
 
-    assert_kernel_binary_path_exists(program, device->build_env().get_out_kernel_root_path(), kernel_cache_status);
+    assert_kernel_binary_path_exists(
+        program,
+        BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+        kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
 
-    ClearKernelCache(device->build_env().get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
     auto second_program = create_program(device, default_attributes);
     auto second_kernel_cache_status = CompileProgramTestWrapper(device, second_program);
     assert_program_cache_hit_status(second_program, /*hit_expected=*/false, second_kernel_cache_status);
@@ -273,7 +280,10 @@ std::unordered_map<std::string, std::string> compile_program_with_modified_kerne
     const std::unordered_map<tt::RISCV, bool>& kernel_type_to_cache_hit_status) {
     auto program = create_program(device, attributes);
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
-    assert_kernel_binary_path_exists(program, device->build_env().get_out_kernel_root_path(), kernel_cache_status);
+    assert_kernel_binary_path_exists(
+        program,
+        BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+        kernel_cache_status);
     assert_cache_hit_status_for_kernel_type(program, kernel_type_to_cache_hit_status, kernel_cache_status);
     assert_hash_comparison_for_kernel_type(
         program, prev_kernel_name_to_hash, kernel_type_to_cache_hit_status, kernel_cache_status);
@@ -296,12 +306,15 @@ bool test_compile_program_with_modified_program(IDevice* device) {
     const static std::unordered_map<tt::RISCV, bool> compute_miss_data_movement_miss = {
         {tt::RISCV::COMPUTE, false}, {tt::RISCV::BRISC, false}, {tt::RISCV::NCRISC, false}};
 
-    ClearKernelCache(device->build_env().get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path());
 
     ProgramAttributes attributes;
     auto program = create_program(device, attributes);
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
-    assert_kernel_binary_path_exists(program, device->build_env().get_out_kernel_root_path(), kernel_cache_status);
+    assert_kernel_binary_path_exists(
+        program,
+        BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+        kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
 

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -62,13 +62,13 @@ KernelCacheStatus CompileProgramTestWrapper(IDevice* device, Program& program, b
     // Check
     std::unordered_map<std::string, std::string> pre_compile_kernel_to_hash_str = get_last_program_binary_path(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
 
     detail::CompileProgram(device, program);
 
     std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str = get_last_program_binary_path(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
 
     KernelCacheStatus kernel_cache_status;
     for (const auto& [kernel_name, hash_str] : post_compile_kernel_to_hash_str) {
@@ -190,7 +190,7 @@ bool test_compile_program_in_loop(IDevice* device) {
     bool pass = true;
 
     ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
     ProgramAttributes default_attributes;
     auto program = create_program(device, default_attributes);
 
@@ -201,7 +201,9 @@ bool test_compile_program_in_loop(IDevice* device) {
         if (compile_idx == 0) {
             assert_kernel_binary_path_exists(
                 program,
-                BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
+                BuildEnvManager::get_instance()
+                    .get_device_build_env(device->build_id())
+                    .build_env.get_out_kernel_root_path(),
                 kernel_cache_status);
             assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
             kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
@@ -218,7 +220,7 @@ bool test_compile_program_after_clean_kernel_binary_directory(IDevice* device) {
     bool pass = true;
 
     ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
 
     ProgramAttributes default_attributes;
     auto program = create_program(device, default_attributes);
@@ -227,13 +229,13 @@ bool test_compile_program_after_clean_kernel_binary_directory(IDevice* device) {
 
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
 
     ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
     auto second_program = create_program(device, default_attributes);
     auto second_kernel_cache_status = CompileProgramTestWrapper(device, second_program);
     assert_program_cache_hit_status(second_program, /*hit_expected=*/false, second_kernel_cache_status);
@@ -287,7 +289,7 @@ std::unordered_map<std::string, std::string> compile_program_with_modified_kerne
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_cache_hit_status_for_kernel_type(program, kernel_type_to_cache_hit_status, kernel_cache_status);
     assert_hash_comparison_for_kernel_type(
@@ -312,14 +314,14 @@ bool test_compile_program_with_modified_program(IDevice* device) {
         {tt::RISCV::COMPUTE, false}, {tt::RISCV::BRISC, false}, {tt::RISCV::NCRISC, false}};
 
     ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
 
     ProgramAttributes attributes;
     auto program = create_program(device, attributes);
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env.get_out_kernel_root_path(),
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
 
             // Run iteration to get golden
-            uint32_t mask = BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key;
+            uint32_t mask = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
             tt_metal::detail::CompileProgram(device, program);
             compute_binaries.insert({mask, compute_kernel->binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
@@ -191,7 +191,8 @@ int main(int argc, char** argv) {
                 auto& program = new_programs[i];
                 ths.emplace_back([&] {
                     for (int j = 0; j < num_compiles; j++) {
-                        uint32_t mask = BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key;
+                        uint32_t mask =
+                            BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
                         tt_metal::detail::CompileProgram(device, program);
                         uint32_t programmable_core_index =
                             hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
@@ -208,12 +209,12 @@ int main(int argc, char** argv) {
 
                         std::string kernel_name = get_latest_kernel_binary_path(
                             BuildEnvManager::get_instance()
-                                .get_device_build_env(device->id())
+                                .get_device_build_env(device->build_id())
                                 .build_env.get_out_kernel_root_path(),
                             riscv0_kernel);
                         std::string brisc_hex_path =
                             BuildEnvManager::get_instance()
-                                .get_kernel_build_state(device->id(), programmable_core_index, dm_class_idx, 0)
+                                .get_kernel_build_state(device->build_id(), programmable_core_index, dm_class_idx, 0)
                                 .get_target_out_path(kernel_name);
                         ll_api::memory const& brisc_binary =
                             llrt::get_risc_binary(brisc_hex_path, ll_api::memory::Loading::CONTIGUOUS_XIP);
@@ -222,12 +223,12 @@ int main(int argc, char** argv) {
                             "Expected saved BRISC binary to be the same as binary in persistent cache");
                         kernel_name = get_latest_kernel_binary_path(
                             BuildEnvManager::get_instance()
-                                .get_device_build_env(device->id())
+                                .get_device_build_env(device->build_id())
                                 .build_env.get_out_kernel_root_path(),
                             riscv1_kernel);
                         std::string ncrisc_hex_path =
                             BuildEnvManager::get_instance()
-                                .get_kernel_build_state(device->id(), programmable_core_index, dm_class_idx, 1)
+                                .get_kernel_build_state(device->build_id(), programmable_core_index, dm_class_idx, 1)
                                 .get_target_out_path(kernel_name);
                         auto load_type =
                             (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0)
@@ -240,7 +241,7 @@ int main(int argc, char** argv) {
                         for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
                             kernel_name = get_latest_kernel_binary_path(
                                 BuildEnvManager::get_instance()
-                                    .get_device_build_env(device->id())
+                                    .get_device_build_env(device->build_id())
                                     .build_env.get_out_kernel_root_path(),
                                 compute_kernel);
                             std::string trisc_id_str = std::to_string(trisc_id);

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -248,7 +248,7 @@ int main(int argc, char** argv) {
                             std::string trisc_hex_path =
                                 BuildEnvManager::get_instance()
                                     .get_kernel_build_state(
-                                        device->id(), programmable_core_index, compute_class_idx, trisc_id)
+                                        device->build_id(), programmable_core_index, compute_class_idx, trisc_id)
                                     .get_target_out_path(kernel_name);
                             ll_api::memory const& trisc_binary =
                                 llrt::get_risc_binary(trisc_hex_path, ll_api::memory::Loading::CONTIGUOUS_XIP);

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/hal.hpp>
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -150,7 +151,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
 
             // Run iteration to get golden
-            uint32_t mask = device->build_key();
+            uint32_t mask = BuildEnvManager::get_instance().get_build_key(device->id());
             tt_metal::detail::CompileProgram(device, program);
             compute_binaries.insert({mask, compute_kernel->binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
@@ -165,7 +166,9 @@ int main(int argc, char** argv) {
             std::vector<string> kernel_names = {"reader_unary_push_4", "writer_unary", "eltwise_copy_3m"};
             for (int i = 0; i < num_devices; i++) {
                 for (const auto& kernel_name : kernel_names) {
-                    std::filesystem::remove_all(devices[i]->build_env().get_out_kernel_root_path() + kernel_name);
+                    std::filesystem::remove_all(
+                        BuildEnvManager::get_instance().get_build_env(devices[i]->id()).get_out_kernel_root_path() +
+                        kernel_name);
                 }
             }
             tt_metal::detail::ClearKernelCache();
@@ -186,7 +189,7 @@ int main(int argc, char** argv) {
                 auto& program = new_programs[i];
                 ths.emplace_back([&] {
                     for (int j = 0; j < num_compiles; j++) {
-                        uint32_t mask = device->build_key();
+                        uint32_t mask = BuildEnvManager::get_instance().get_build_key(device->id());
                         tt_metal::detail::CompileProgram(device, program);
                         uint32_t programmable_core_index =
                             hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
@@ -201,21 +204,25 @@ int main(int argc, char** argv) {
                         TT_FATAL(riscv0_kernel->binaries(mask) == brisc_binaries.at(mask), "Error");
                         TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
-                        std::string brisc_hex_path = device->build_kernel_target_path(
-                            programmable_core_index,
-                            dm_class_idx,
-                            0,
-                            get_latest_kernel_binary_path(device->build_env().get_out_kernel_root_path(), riscv0_kernel));
+                        std::string kernel_name = get_latest_kernel_binary_path(
+                            BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                            riscv0_kernel);
+                        std::string brisc_hex_path =
+                            BuildEnvManager::get_instance()
+                                .get_kernel_build_state(device->id(), programmable_core_index, dm_class_idx, 0)
+                                .get_target_out_path(kernel_name);
                         ll_api::memory const& brisc_binary =
                             llrt::get_risc_binary(brisc_hex_path, ll_api::memory::Loading::CONTIGUOUS_XIP);
                         TT_FATAL(
                             brisc_binary == *brisc_binaries.at(mask).at(0),
                             "Expected saved BRISC binary to be the same as binary in persistent cache");
-                        std::string ncrisc_hex_path = device->build_kernel_target_path(
-                            programmable_core_index,
-                            dm_class_idx,
-                            1,
-                            get_latest_kernel_binary_path(device->build_env().get_out_kernel_root_path(), riscv1_kernel));
+                        kernel_name = get_latest_kernel_binary_path(
+                            BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                            riscv1_kernel);
+                        std::string ncrisc_hex_path =
+                            BuildEnvManager::get_instance()
+                                .get_kernel_build_state(device->id(), programmable_core_index, dm_class_idx, 1)
+                                .get_target_out_path(kernel_name);
                         auto load_type =
                             (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0)
                                 ? ll_api::memory::Loading::CONTIGUOUS
@@ -225,12 +232,15 @@ int main(int argc, char** argv) {
                             ncrisc_binary == *ncrisc_binaries.at(mask).at(0),
                             "Expected saved NCRISC binary to be the same as binary in persistent cache");
                         for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
+                            kernel_name = get_latest_kernel_binary_path(
+                                BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                                compute_kernel);
                             std::string trisc_id_str = std::to_string(trisc_id);
-                            std::string trisc_hex_path = device->build_kernel_target_path(
-                                programmable_core_index,
-                                compute_class_idx,
-                                trisc_id,
-                                get_latest_kernel_binary_path(device->build_env().get_out_kernel_root_path(), compute_kernel));
+                            std::string trisc_hex_path =
+                                BuildEnvManager::get_instance()
+                                    .get_kernel_build_state(
+                                        device->id(), programmable_core_index, compute_class_idx, trisc_id)
+                                    .get_target_out_path(kernel_name);
                             ll_api::memory const& trisc_binary =
                                 llrt::get_risc_binary(trisc_hex_path, ll_api::memory::Loading::CONTIGUOUS_XIP);
                             TT_FATAL(

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
 
             // Run iteration to get golden
-            uint32_t mask = BuildEnvManager::get_instance().get_build_key(device->id());
+            uint32_t mask = BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key;
             tt_metal::detail::CompileProgram(device, program);
             compute_binaries.insert({mask, compute_kernel->binaries(mask)});
             TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
@@ -167,7 +167,9 @@ int main(int argc, char** argv) {
             for (int i = 0; i < num_devices; i++) {
                 for (const auto& kernel_name : kernel_names) {
                     std::filesystem::remove_all(
-                        BuildEnvManager::get_instance().get_build_env(devices[i]->id()).get_out_kernel_root_path() +
+                        BuildEnvManager::get_instance()
+                            .get_device_build_env(devices[i]->id())
+                            .build_env.get_out_kernel_root_path() +
                         kernel_name);
                 }
             }
@@ -189,7 +191,7 @@ int main(int argc, char** argv) {
                 auto& program = new_programs[i];
                 ths.emplace_back([&] {
                     for (int j = 0; j < num_compiles; j++) {
-                        uint32_t mask = BuildEnvManager::get_instance().get_build_key(device->id());
+                        uint32_t mask = BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key;
                         tt_metal::detail::CompileProgram(device, program);
                         uint32_t programmable_core_index =
                             hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
@@ -205,7 +207,9 @@ int main(int argc, char** argv) {
                         TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
                         std::string kernel_name = get_latest_kernel_binary_path(
-                            BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                            BuildEnvManager::get_instance()
+                                .get_device_build_env(device->id())
+                                .build_env.get_out_kernel_root_path(),
                             riscv0_kernel);
                         std::string brisc_hex_path =
                             BuildEnvManager::get_instance()
@@ -217,7 +221,9 @@ int main(int argc, char** argv) {
                             brisc_binary == *brisc_binaries.at(mask).at(0),
                             "Expected saved BRISC binary to be the same as binary in persistent cache");
                         kernel_name = get_latest_kernel_binary_path(
-                            BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                            BuildEnvManager::get_instance()
+                                .get_device_build_env(device->id())
+                                .build_env.get_out_kernel_root_path(),
                             riscv1_kernel);
                         std::string ncrisc_hex_path =
                             BuildEnvManager::get_instance()
@@ -233,7 +239,9 @@ int main(int argc, char** argv) {
                             "Expected saved NCRISC binary to be the same as binary in persistent cache");
                         for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
                             kernel_name = get_latest_kernel_binary_path(
-                                BuildEnvManager::get_instance().get_build_env(device->id()).get_out_kernel_root_path(),
+                                BuildEnvManager::get_instance()
+                                    .get_device_build_env(device->id())
+                                    .build_env.get_out_kernel_root_path(),
                                 compute_kernel);
                             std::string trisc_id_str = std::to_string(trisc_id);
                             std::string trisc_hex_path =

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -43,7 +43,6 @@ class SubDevice;
 
 }  // namespace v0
 
-class JitBuildEnv;
 class CommandQueue;
 class TraceBuffer;
 struct TraceDescriptor;
@@ -68,8 +67,6 @@ public:
     virtual tt::ARCH arch() const = 0;
 
     virtual chip_id_t id() const = 0;
-
-    virtual uint32_t build_key() const = 0;
 
     virtual uint8_t num_hw_cqs() const = 0;
 
@@ -128,13 +125,6 @@ public:
     virtual uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const = 0;
     virtual uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const = 0;
 
-    virtual const JitBuildEnv& build_env() const = 0;
-    virtual const string build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const = 0;
-    virtual const string build_kernel_target_path(uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const = 0;
-    virtual const JitBuildState& build_firmware_state(uint32_t programmable_core, uint32_t processor_class, int i) const = 0;
-    virtual const JitBuildState& build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const = 0;
-    virtual const JitBuildStateSubset build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const = 0;
-
     virtual SystemMemoryManager& sysmem_manager() = 0;
     virtual CommandQueue& command_queue(size_t cq_id = 0) = 0;
 
@@ -155,8 +145,12 @@ public:
 
     // Checks that the given arch is on the given pci_slot and that it's responding
     // Puts device into reset
-    virtual bool initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap = {}, bool minimal = false) = 0;
-    virtual void build_firmware() = 0;
+    virtual bool initialize(
+        const uint8_t num_hw_cqs,
+        size_t l1_small_size,
+        size_t trace_region_size,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        bool minimal = false) = 0;
     virtual void reset_cores() = 0;
     virtual void initialize_and_launch_firmware() = 0;
     virtual void init_command_queue_host() = 0;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -67,6 +67,7 @@ public:
     virtual tt::ARCH arch() const = 0;
 
     virtual chip_id_t id() const = 0;
+    virtual chip_id_t build_id() const = 0;
 
     virtual uint8_t num_hw_cqs() const = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -56,6 +56,8 @@ public:
     tt::ARCH arch() const override;
 
     chip_id_t id() const override { return id_; }
+    // For a single device, build id is the same as device id
+    chip_id_t build_id() const override { return id_; }
 
     uint8_t num_hw_cqs() const override { return num_hw_cqs_; }
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -83,7 +83,6 @@ public:
     // IDevice interface implementation
     tt::ARCH arch() const override;
     MeshDeviceID id() const override;
-    uint32_t build_key() const override;
     uint8_t num_hw_cqs() const override;
     bool is_initialized() const override;
 
@@ -127,12 +126,6 @@ public:
     const std::set<CoreCoord>& storage_only_cores() const override;
     uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const override;
     uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const override;
-    const JitBuildEnv& build_env() const override;
-    const string build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const override;
-    const string build_kernel_target_path(uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const override;
-    const JitBuildState& build_firmware_state(uint32_t programmable_core, uint32_t processor_class, int i) const override;
-    const JitBuildState& build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const override;
-    const JitBuildStateSubset build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const override;
     SystemMemoryManager& sysmem_manager() override;
     CommandQueue& command_queue(size_t cq_id = 0) override;
 
@@ -151,8 +144,12 @@ public:
     bool using_fast_dispatch() const override;
 
     // Initialization APIs
-    bool initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap = {}, bool minimal = false) override;
-    void build_firmware() override;
+    bool initialize(
+        const uint8_t num_hw_cqs,
+        size_t l1_small_size,
+        size_t trace_region_size,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        bool minimal = false) override;
     void reset_cores() override;
     void initialize_and_launch_firmware() override;
     void init_command_queue_host() override;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -83,6 +83,7 @@ public:
     // IDevice interface implementation
     tt::ARCH arch() const override;
     MeshDeviceID id() const override;
+    chip_id_t build_id() const override;
     uint8_t num_hw_cqs() const override;
     bool is_initialized() const override;
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -90,12 +90,6 @@ MeshDevice::ScopedDevices::~ScopedDevices() {
 
 const std::vector<IDevice*>& MeshDevice::ScopedDevices::get_devices() const { return devices_; }
 
-uint32_t MeshDevice::build_key() const {
-    TT_FATAL(tt::tt_metal::hal.is_coordinate_virtualization_enabled(), "MeshDevice::build_key() expects coordinate virtualization to be enabled");
-    return validate_and_get_reference_value(
-        scoped_devices_->get_devices(), [](const auto& device) { return device->build_key(); });
-}
-
 uint8_t MeshDevice::num_hw_cqs() const {
     return validate_and_get_reference_value(
         scoped_devices_->get_devices(), [](const auto& device) { return device->num_hw_cqs(); });
@@ -536,28 +530,6 @@ uint32_t MeshDevice::get_noc_multicast_encoding(uint8_t noc_index, const CoreRan
     });
 }
 
-// Floating point and build environment
-const JitBuildEnv& MeshDevice::build_env() const { return reference_device()->build_env(); }
-
-// Build and firmware paths
-const string MeshDevice::build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    return reference_device()->build_firmware_target_path(programmable_core, processor_class, i);
-}
-const string MeshDevice::build_kernel_target_path(
-    uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const {
-    return reference_device()->build_kernel_target_path(programmable_core, processor_class, i, kernel_name);
-}
-const JitBuildState& MeshDevice::build_firmware_state(
-    uint32_t programmable_core, uint32_t processor_class, int i) const {
-    return reference_device()->build_firmware_state(programmable_core, processor_class, i);
-}
-const JitBuildState& MeshDevice::build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    return reference_device()->build_kernel_state(programmable_core, processor_class, i);
-}
-const JitBuildStateSubset MeshDevice::build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const {
-    return reference_device()->build_kernel_states(programmable_core, processor_class);
-}
-
 // System memory and command queue management
 SystemMemoryManager& MeshDevice::sysmem_manager() {
     TT_THROW("sysmem_manager() is not supported on MeshDevice - use individual devices instead");
@@ -636,10 +608,6 @@ bool MeshDevice::initialize(
     return true;
 }
 
-void MeshDevice::build_firmware() {
-    TT_THROW("build_firmware() is not supported on MeshDevice - use individual devices instead");
-    reference_device()->build_firmware();
-}
 void MeshDevice::reset_cores() {
     TT_THROW("reset_cores() is not supported on MeshDevice - use individual devices instead");
     reference_device()->reset_cores();

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -335,6 +335,8 @@ const MeshDeviceView& MeshDevice::get_view() const {
 }
 
 MeshDeviceID MeshDevice::id() const { return mesh_id_; }
+// For a mesh, build id is the same as the device id for the reference device
+chip_id_t MeshDevice::build_id() const { return reference_device()->id(); }
 
 bool MeshDevice::is_parent_mesh() const { return parent_mesh_.expired(); }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -35,6 +35,7 @@
 
 #include "impl/dispatch/topology.hpp"
 #include "impl/dispatch/hardware_command_queue.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 namespace tt {
 
@@ -334,130 +335,6 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
     return std::make_unique<L1BankingAllocator>(config);
 }
 
-void Device::initialize_device_kernel_defines()
-{
-    // Clear previously stored defines, in case we are running with different configuration this time.
-    // This is needed to handle the case where the number of L1 banks on GS can be changed in each run.
-    this->device_kernel_defines_.clear();
-    const size_t num_dram_banks = this->allocator()->get_num_banks(BufferType::DRAM);
-    const size_t num_l1_banks = this->allocator()->get_num_banks(BufferType::L1);
-
-    bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
-    bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);
-
-    this->device_kernel_defines_.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
-    this->device_kernel_defines_.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
-
-    if (is_dram_pow2) {
-        this->device_kernel_defines_.emplace("LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(static_cast<size_t>(log2(num_dram_banks))));
-    } else {
-        this->device_kernel_defines_.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
-    }
-    if (is_l1_pow2) {
-        this->device_kernel_defines_.emplace("LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(static_cast<size_t>(log2(num_l1_banks))));
-    } else {
-        this->device_kernel_defines_.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
-    }
-
-    // TODO (abhullar): Until we switch to virtual coordinates, we need to pass physical PCIe coordinates to device
-    //  because Blackhole PCIe endpoint is dependent on board type
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(this->id());
-    auto pcie_cores = soc_d.get_pcie_cores();
-    auto grid_size = this->grid_size();
-
-    CoreCoord pcie_core = pcie_cores.empty() ? grid_size : pcie_cores[0];
-
-    this->device_kernel_defines_.emplace("PCIE_NOC_X", std::to_string(pcie_core.x));
-    this->device_kernel_defines_.emplace("PCIE_NOC_Y", std::to_string(pcie_core.y));
-}
-
-void Device::initialize_build() {
-    ZoneScoped;
-
-    this->initialize_device_kernel_defines();
-    this->build_env_.init(this->build_key(), this->arch(), this->device_kernel_defines_);
-
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->id());
-    uint32_t dispatch_message_addr = DispatchMemMap::get(dispatch_core_type, this->num_hw_cqs_)
-                                         .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-
-    uint32_t num_build_states = hal.get_num_risc_processors();
-
-    auto init_helper = [this, dispatch_message_addr, num_build_states] (bool is_fw) -> JitBuildStateSet {
-        std::vector<std::shared_ptr<JitBuildState>> build_states;
-
-        build_states.resize(num_build_states);
-        uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
-        if (is_fw) {
-            this->build_state_indices_.resize(programmable_core_type_count);
-        }
-
-        uint32_t index = 0;
-        for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
-            HalProgrammableCoreType core_type = magic_enum::enum_value<HalProgrammableCoreType>(programmable_core);
-            uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
-            if (is_fw) {
-                this->build_state_indices_[programmable_core].resize(processor_class_count);
-            }
-            for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                auto compute_proc_class = magic_enum::enum_cast<HalProcessorClassType>(processor_class);
-                bool is_compute_processor = compute_proc_class.has_value() and compute_proc_class.value() == HalProcessorClassType::COMPUTE;
-                uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
-                if (is_fw) {
-                    this->build_state_indices_[programmable_core][processor_class] = {index, processor_types_count};
-                }
-                for (uint32_t processor_type = 0; processor_type < processor_types_count; processor_type++) {
-                    switch (core_type) {
-                        case HalProgrammableCoreType::TENSIX: {
-                            if (is_compute_processor) {
-                                build_states[index] = std::make_shared<JitBuildCompute>(
-                                    this->build_env_, JitBuiltStateConfig{.processor_id = processor_type, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-                            } else {
-                                // TODO: Make .processor_id = processor_type when brisc and ncrisc are considered one processor class
-                                build_states[index] = std::make_shared<JitBuildDataMovement>(
-                                    this->build_env_, JitBuiltStateConfig{.processor_id = processor_class, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-                            }
-                            break;
-                        }
-                        case HalProgrammableCoreType::ACTIVE_ETH: {
-                            // Cooperative means active erisc FW needs to context switch to base FW
-                            bool is_cooperative = this->arch() == ARCH::WORMHOLE_B0;
-                            build_states[index] = std::make_shared<JitBuildActiveEthernet>(
-                                this->build_env_,
-                                JitBuiltStateConfig{
-                                    .processor_id = processor_class,
-                                    .is_fw = is_fw,
-                                    .dispatch_message_addr = dispatch_message_addr,
-                                    .is_cooperative = is_cooperative});
-                            break;
-                        }
-                        case HalProgrammableCoreType::IDLE_ETH: {
-                            build_states[index] = std::make_shared<JitBuildIdleEthernet>(
-                                this->build_env_, JitBuiltStateConfig{.processor_id = processor_class, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-                            break;
-                        }
-                        default:
-                            TT_THROW("Unsupported programable core type {} to initialize build states", magic_enum::enum_name(core_type));
-                    }
-                    index++;
-                }
-            }
-        }
-
-       return build_states;
-    };
-
-    this->firmware_build_states_ = init_helper(true);
-    this->kernel_build_states_ = init_helper(false);
-}
-
-void Device::build_firmware() {
-    log_debug(tt::LogMetal, "Building base firmware for device {}", this->id_);
-    ZoneScoped;
-
-    jit_build_set(this->firmware_build_states_, nullptr);
-}
-
 void Device::initialize_device_bank_to_noc_tables(const HalProgrammableCoreType &core_type, CoreCoord virtual_core)
 {
     const uint32_t dram_to_noc_sz_in_bytes = dram_bank_to_noc_xy_.size() * sizeof(uint16_t);
@@ -492,19 +369,23 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
-                for (uint32_t riscv_id = build_idx; riscv_id < (build_idx + num_build_states); riscv_id++) {
-                    ll_api::memory const& binary_mem = llrt::get_risc_binary(
-                        firmware_build_states_[riscv_id]->get_target_out_path(""));
+                auto [build_idx, num_build_states] =
+                    BuildEnvManager::get_instance().get_build_index_and_state_count(core_type_idx, processor_class);
+                for (uint32_t riscv_id = 0; riscv_id < num_build_states; riscv_id++) {
+                    auto fw_path = BuildEnvManager::get_instance()
+                                       .get_firmware_build_state(id_, core_type_idx, processor_class, riscv_id)
+                                       .get_target_out_path("");
+                    const ll_api::memory& binary_mem = llrt::get_risc_binary(fw_path);
                     uint32_t fw_size = binary_mem.get_text_size();
-                    if (riscv_id == 1) { // TODO: clean up how brisc/ncrisc are handled
+                    if (riscv_id + build_idx == 1) {  // TODO: clean up how brisc/ncrisc are handled
                         // In this context, ncrisc_kernel_size16 is the size of the fw
                         launch_msg->kernel_config.ncrisc_kernel_size16 = (fw_size + 15) >> 4;
                     }
                     log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
 
                     if (not llrt::RunTimeOptions::get_instance().get_skip_loading_fw())  {
-                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), virtual_core, core_type_idx, processor_class, (riscv_id - build_idx));
+                        llrt::test_load_write_read_risc_binary(
+                            binary_mem, this->id(), virtual_core, core_type_idx, processor_class, riscv_id);
                     }
                 }
             }
@@ -536,13 +417,16 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
             }
             if (not llrt::RunTimeOptions::get_instance().get_skip_loading_fw()) {
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                    auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
-                    for (uint32_t eriscv_id = build_idx; eriscv_id < (build_idx + num_build_states); eriscv_id++) {
-                        ll_api::memory const& binary_mem = llrt::get_risc_binary(
-                            firmware_build_states_[eriscv_id]->get_target_out_path(""));
+                    auto num_build_states = hal.get_processor_types_count(core_type_idx, processor_class);
+                    for (uint32_t eriscv_id = 0; eriscv_id < num_build_states; eriscv_id++) {
+                        auto fw_path = BuildEnvManager::get_instance()
+                                           .get_firmware_build_state(id_, core_type_idx, processor_class, eriscv_id)
+                                           .get_target_out_path("");
+                        const ll_api::memory& binary_mem = llrt::get_risc_binary(fw_path);
                         uint32_t fw_size = binary_mem.get_text_size();
                         log_debug(LogDevice, "ERISC fw binary size: {} in bytes", fw_size);
-                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), virtual_core, core_type_idx, processor_class, (eriscv_id - build_idx));
+                        llrt::test_load_write_read_risc_binary(
+                            binary_mem, this->id(), virtual_core, core_type_idx, processor_class, eriscv_id);
                     }
                 }
             }
@@ -1030,31 +914,9 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
         update_dispatch_cores_for_multi_cq_eth_dispatch();
     }
     this->num_hw_cqs_ = num_hw_cqs;
-    constexpr uint32_t harvesting_map_bits = 12;
-    constexpr uint32_t num_hw_cq_bits = 8;
-    constexpr uint32_t dispatch_core_axis_bits = 1;
-    constexpr uint32_t dispatch_core_type_bits = 1;
-    static_assert(dispatch_core_manager::MAX_NUM_HW_CQS <= (1 << num_hw_cq_bits));
-    static_assert(static_cast<uint32_t>(DispatchCoreAxis::COUNT) <= (1 << dispatch_core_axis_bits));
-    static_assert(static_cast<uint32_t>(DispatchCoreType::COUNT) <= (1 << dispatch_core_type_bits));
-    static_assert(harvesting_map_bits + num_hw_cq_bits + dispatch_core_axis_bits + dispatch_core_type_bits <= sizeof(this->build_key_) * CHAR_BIT);
-
-    // num_hw_cqs, dispatch_core_axis, dispatch_core_type all change the number of banks, so need to be part of the
-    // build key since we have defines based on number of banks.
-    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(this->id_);
-    this->build_key_ = (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_type()) << (harvesting_map_bits + num_hw_cq_bits + dispatch_core_axis_bits)) |
-                       (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_axis()) << (harvesting_map_bits + num_hw_cq_bits)) |
-                       (static_cast<uint32_t>(num_hw_cqs_) << harvesting_map_bits);
-    if (not hal.is_coordinate_virtualization_enabled()) {
-        // Coordinate virtualization is not enabled. For a single program, its associated binaries will vary across devices with different cores harvested.
-        this->build_key_ = (this->build_key_) | tt::Cluster::instance().get_harvesting_mask(this->id());
-    } else {
-        // Coordinate Virtualization is enabled. Track only the number of harvested cores, instead of the exact harvesting configuration (this is not needed).
-        this->build_key_ = (this->build_key_) | (std::bitset<harvesting_map_bits>(tt::Cluster::instance().get_harvesting_mask(this->id())).count());
-    }
+    BuildEnvManager::get_instance().add_build_env(this->id(), this->num_hw_cqs());
     this->initialize_cluster();
     this->initialize_default_sub_device_state(l1_small_size, trace_region_size, l1_bank_remap);
-    this->initialize_build();
     this->generate_device_bank_to_noc_tables();
 
     // For minimal setup, don't initialize FW, watcher, dprint. They won't work if we're attaching to a hung chip.
@@ -1339,42 +1201,6 @@ std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const {
 
 std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(tt::stl::Span<const SubDeviceId> sub_device_ids) const {
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address(sub_device_ids);
-}
-
-std::pair<int, int> Device::build_processor_type_to_index(uint32_t programmable_core, uint32_t processor_class) const {
-    TT_ASSERT(programmable_core < this->build_state_indices_.size(),
-        "Programmable core type {} is not included in the FW or Kernel build state", programmable_core);
-    TT_ASSERT(processor_class < this->build_state_indices_[programmable_core].size(),
-        "Processor class type {} is not included in the FW or Kernel build state", processor_class);
-    return this->build_state_indices_[programmable_core][processor_class];
-}
-
-// Ideally the firmware getter would be private to the device, however, tests look for this
-const JitBuildState& Device::build_firmware_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    return *(this->firmware_build_states_[build_processor_type_to_index(programmable_core, processor_class).first + i]);
-}
-
-const JitBuildState& Device::build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    return *(this->kernel_build_states_[build_processor_type_to_index(programmable_core, processor_class).first + i]);
-}
-
-const JitBuildStateSubset Device::build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const {
-    std::pair<int, int> bptti = build_processor_type_to_index(programmable_core, processor_class);
-    JitBuildStateSubset subset = {
-        &this->kernel_build_states_[bptti.first],
-        bptti.second
-    };
-    return subset;
-}
-
-const string Device::build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const {
-    const JitBuildState& bs = build_firmware_state(programmable_core, processor_class, i);
-    return bs.get_target_out_path("");
-}
-
-const string Device::build_kernel_target_path(uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const {
-    const JitBuildState& bs = build_kernel_state(programmable_core, processor_class, i);
-    return bs.get_target_out_path(kernel_name);
 }
 
 CommandQueue& Device::command_queue(size_t cq_id) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -306,10 +306,10 @@ void DevicePool::activate_device(chip_id_t id) {
             worker_core_thread_core,
             completion_queue_reader_core);
         if (!this->firmware_built_keys.contains(
-                BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)) {
-            BuildEnvManager::get_instance().build_firmware(device->id());
+                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
+            BuildEnvManager::get_instance().build_firmware(device->build_id());
             this->firmware_built_keys.insert(
-                BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
+                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
         }
         this->devices.emplace_back(std::unique_ptr<IDevice>(device));
     } else {
@@ -317,10 +317,10 @@ void DevicePool::activate_device(chip_id_t id) {
         if (not device->is_initialized()) {
             device->initialize(num_hw_cqs, this->l1_small_size, this->trace_region_size, this->l1_bank_remap);
             if (!this->firmware_built_keys.contains(
-                    BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)) {
-                BuildEnvManager::get_instance().build_firmware(device->id());
+                    BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
+                BuildEnvManager::get_instance().build_firmware(device->build_id());
                 this->firmware_built_keys.insert(
-                    BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
+                    BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
             }
         } else {
             TT_THROW("Cannot re-initialize device {}, must first call close()", id);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -21,6 +21,7 @@
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 using namespace tt::tt_metal;
 
@@ -304,18 +305,18 @@ void DevicePool::activate_device(chip_id_t id) {
             false,
             worker_core_thread_core,
             completion_queue_reader_core);
-        if (!this->firmware_built_keys.contains(device->build_key())) {
-            device->build_firmware();
-            this->firmware_built_keys.insert(device->build_key());
+        if (!this->firmware_built_keys.contains(BuildEnvManager::get_instance().get_build_key(device->id()))) {
+            BuildEnvManager::get_instance().build_firmware(device->id());
+            this->firmware_built_keys.insert(BuildEnvManager::get_instance().get_build_key(device->id()));
         }
         this->devices.emplace_back(std::unique_ptr<IDevice>(device));
     } else {
         log_debug(tt::LogMetal, "DevicePool re-initialize device {}", id);
         if (not device->is_initialized()) {
             device->initialize(num_hw_cqs, this->l1_small_size, this->trace_region_size, this->l1_bank_remap);
-            if (!this->firmware_built_keys.contains(device->build_key())) {
-                device->build_firmware();
-                this->firmware_built_keys.insert(device->build_key());
+            if (!this->firmware_built_keys.contains(BuildEnvManager::get_instance().get_build_key(device->id()))) {
+                BuildEnvManager::get_instance().build_firmware(device->id());
+                this->firmware_built_keys.insert(BuildEnvManager::get_instance().get_build_key(device->id()));
             }
         } else {
             TT_THROW("Cannot re-initialize device {}, must first call close()", id);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -305,18 +305,22 @@ void DevicePool::activate_device(chip_id_t id) {
             false,
             worker_core_thread_core,
             completion_queue_reader_core);
-        if (!this->firmware_built_keys.contains(BuildEnvManager::get_instance().get_build_key(device->id()))) {
+        if (!this->firmware_built_keys.contains(
+                BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)) {
             BuildEnvManager::get_instance().build_firmware(device->id());
-            this->firmware_built_keys.insert(BuildEnvManager::get_instance().get_build_key(device->id()));
+            this->firmware_built_keys.insert(
+                BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
         }
         this->devices.emplace_back(std::unique_ptr<IDevice>(device));
     } else {
         log_debug(tt::LogMetal, "DevicePool re-initialize device {}", id);
         if (not device->is_initialized()) {
             device->initialize(num_hw_cqs, this->l1_small_size, this->trace_region_size, this->l1_bank_remap);
-            if (!this->firmware_built_keys.contains(BuildEnvManager::get_instance().get_build_key(device->id()))) {
+            if (!this->firmware_built_keys.contains(
+                    BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)) {
                 BuildEnvManager::get_instance().build_firmware(device->id());
-                this->firmware_built_keys.insert(BuildEnvManager::get_instance().get_build_key(device->id()));
+                this->firmware_built_keys.insert(
+                    BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
             }
         } else {
             TT_THROW("Cannot re-initialize device {}, must first call close()", id);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -436,7 +436,7 @@ void ComputeKernel::read_binaries(IDevice* device) {
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->id(), tensix_core_type, compute_class_idx, trisc_id);
+            device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
         ll_api::memory const& binary_mem = llrt::get_risc_binary(
             build_state.get_target_out_path(this->kernel_full_name_),
             ll_api::memory::Loading::CONTIGUOUS_XIP);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -318,13 +318,13 @@ bool Kernel::is_idle_eth() const {
 
 uint32_t Kernel::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
+    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
     return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
 uint32_t Kernel::get_binary_text_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
+    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
 }
 
@@ -339,33 +339,35 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 
 void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
     jit_build_genfiles_kernel_include(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     jit_build(
-        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), tensix_core_type, dm_class_idx, riscv_id),
+        BuildEnvManager::get_instance().get_kernel_build_state(
+            device->build_id(), tensix_core_type, dm_class_idx, riscv_id),
         this);
 }
 
 void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
     jit_build_genfiles_kernel_include(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
     jit_build(
-        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), erisc_core_type, dm_class_idx, erisc_id),
+        BuildEnvManager::get_instance().get_kernel_build_state(
+            device->build_id(), erisc_core_type, dm_class_idx, erisc_id),
         this);
 }
 
 void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
     jit_build_genfiles_triscs_src(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
-    JitBuildStateSubset build_states =
-        BuildEnvManager::get_instance().get_kernel_build_states(device->id(), tensix_core_type, compute_class_idx);
+    JitBuildStateSubset build_states = BuildEnvManager::get_instance().get_kernel_build_states(
+        device->build_id(), tensix_core_type, compute_class_idx);
     jit_build_subset(build_states, this);
 }
 
@@ -388,8 +390,8 @@ void DataMovementKernel::read_binaries(IDevice* device) {
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    const JitBuildState& build_state =
-        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), tensix_core_type, dm_class_idx, riscv_id);
+    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+        device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
     // TODO: from HAL
     auto load_type =
         (riscv_id == 1 && (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0)) ?
@@ -401,7 +403,7 @@ void DataMovementKernel::read_binaries(IDevice* device) {
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, binary_size);
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key, std::move(binaries));
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
 void EthernetKernel::read_binaries(IDevice* device) {
@@ -411,8 +413,8 @@ void EthernetKernel::read_binaries(IDevice* device) {
     uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
-    const JitBuildState& build_state =
-        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), erisc_core_type, dm_class_idx, erisc_id);
+    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+        device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
     int risc_id = erisc_id + (this->config_.eth_mode == Eth::IDLE ? 6 : 5); // TODO (abhullar): clean this up when llrt helpers use HAL
     // TODO: fix when active eth supports relo
     auto load_type = (this->config_.eth_mode == Eth::IDLE) ?
@@ -424,7 +426,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC {} kernel binary size: {} in bytes", erisc_id, binary_size);
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key, std::move(binaries));
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
 void ComputeKernel::read_binaries(IDevice* device) {
@@ -443,7 +445,7 @@ void ComputeKernel::read_binaries(IDevice* device) {
         log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", trisc_id + 2, binary_size);
     }
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key, std::move(binaries));
+        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
 RISCV DataMovementKernel::processor() const {
@@ -466,7 +468,7 @@ bool DataMovementKernel::configure(IDevice* device, const CoreCoord &logical_cor
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)[0];
+        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     llrt::write_binary_to_address(binary_mem, device_id, worker_core, base_address + offsets[riscv_id]);
 
@@ -477,7 +479,7 @@ bool EthernetKernel::configure(IDevice* device, const CoreCoord &logical_core, u
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
     const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)[0];
+        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
 
     if (this->config_.eth_mode == Eth::IDLE) {
         uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
@@ -500,7 +502,7 @@ bool ComputeKernel::configure(IDevice* device, const CoreCoord &logical_core, ui
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     const std::vector<const ll_api::memory*>& binaries =
-        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
+        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         llrt::write_binary_to_address(
             *binaries[trisc_id], device_id, worker_core, base_address + offsets[2 + trisc_id]);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -17,6 +17,7 @@
 #include <utils.hpp>
 #include <core_coord.hpp>
 #include "tt_metal/jit_build/genfiles.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
 namespace tt {
 
 namespace tt_metal {
@@ -317,13 +318,13 @@ bool Kernel::is_idle_eth() const {
 
 uint32_t Kernel::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(device->build_key());
+    auto iter = binaries_.find(BuildEnvManager::get_instance().get_build_key(device->id()));
     return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
 uint32_t Kernel::get_binary_text_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(device->build_key());
+    auto iter = binaries_.find(BuildEnvManager::get_instance().get_build_key(device->id()));
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
 }
 
@@ -337,26 +338,34 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 }
 
 void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
-    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
+    jit_build_genfiles_kernel_include(
+        BuildEnvManager::get_instance().get_build_env(device->id()), *this, this->kernel_src_);
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    jit_build(device->build_kernel_state(tensix_core_type, dm_class_idx, riscv_id), this);
+    jit_build(
+        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), tensix_core_type, dm_class_idx, riscv_id),
+        this);
 }
 
 void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
-    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
+    jit_build_genfiles_kernel_include(
+        BuildEnvManager::get_instance().get_build_env(device->id()), *this, this->kernel_src_);
     uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
-    jit_build(device->build_kernel_state(erisc_core_type, dm_class_idx, erisc_id), this);
+    jit_build(
+        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), erisc_core_type, dm_class_idx, erisc_id),
+        this);
 }
 
 void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
-    jit_build_genfiles_triscs_src(device->build_env(), *this, this->kernel_src_);
+    jit_build_genfiles_triscs_src(
+        BuildEnvManager::get_instance().get_build_env(device->id()), *this, this->kernel_src_);
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
-    JitBuildStateSubset build_states = device->build_kernel_states(tensix_core_type, compute_class_idx);
+    JitBuildStateSubset build_states =
+        BuildEnvManager::get_instance().get_kernel_build_states(device->id(), tensix_core_type, compute_class_idx);
     jit_build_subset(build_states, this);
 }
 
@@ -379,7 +388,8 @@ void DataMovementKernel::read_binaries(IDevice* device) {
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, dm_class_idx, riscv_id);
+    const JitBuildState& build_state =
+        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), tensix_core_type, dm_class_idx, riscv_id);
     // TODO: from HAL
     auto load_type =
         (riscv_id == 1 && (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0)) ?
@@ -390,7 +400,7 @@ void DataMovementKernel::read_binaries(IDevice* device) {
     binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, binary_size);
-    this->set_binaries(device->build_key(), std::move(binaries));
+    this->set_binaries(BuildEnvManager::get_instance().get_build_key(device->id()), std::move(binaries));
 }
 
 void EthernetKernel::read_binaries(IDevice* device) {
@@ -400,7 +410,8 @@ void EthernetKernel::read_binaries(IDevice* device) {
     uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
-    const JitBuildState &build_state = device->build_kernel_state(erisc_core_type, dm_class_idx, erisc_id);
+    const JitBuildState& build_state =
+        BuildEnvManager::get_instance().get_kernel_build_state(device->id(), erisc_core_type, dm_class_idx, erisc_id);
     int risc_id = erisc_id + (this->config_.eth_mode == Eth::IDLE ? 6 : 5); // TODO (abhullar): clean this up when llrt helpers use HAL
     // TODO: fix when active eth supports relo
     auto load_type = (this->config_.eth_mode == Eth::IDLE) ?
@@ -411,7 +422,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
     binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC {} kernel binary size: {} in bytes", erisc_id, binary_size);
-    this->set_binaries(device->build_key(), std::move(binaries));
+    this->set_binaries(BuildEnvManager::get_instance().get_build_key(device->id()), std::move(binaries));
 }
 
 void ComputeKernel::read_binaries(IDevice* device) {
@@ -420,7 +431,8 @@ void ComputeKernel::read_binaries(IDevice* device) {
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
-        const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, compute_class_idx, trisc_id);
+        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+            device->id(), tensix_core_type, compute_class_idx, trisc_id);
         ll_api::memory const& binary_mem = llrt::get_risc_binary(
             build_state.get_target_out_path(this->kernel_full_name_),
             ll_api::memory::Loading::CONTIGUOUS_XIP);
@@ -428,7 +440,7 @@ void ComputeKernel::read_binaries(IDevice* device) {
         uint32_t binary_size = binary_mem.get_packed_size();
         log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", trisc_id + 2, binary_size);
     }
-    this->set_binaries(device->build_key(), std::move(binaries));
+    this->set_binaries(BuildEnvManager::get_instance().get_build_key(device->id()), std::move(binaries));
 }
 
 RISCV DataMovementKernel::processor() const {
@@ -450,7 +462,7 @@ bool DataMovementKernel::configure(IDevice* device, const CoreCoord &logical_cor
     }
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    ll_api::memory const& binary_mem = *this->binaries(device->build_key())[0];
+    const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance().get_build_key(device->id()))[0];
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     llrt::write_binary_to_address(binary_mem, device_id, worker_core, base_address + offsets[riscv_id]);
 
@@ -460,7 +472,7 @@ bool DataMovementKernel::configure(IDevice* device, const CoreCoord &logical_cor
 bool EthernetKernel::configure(IDevice* device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const {
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
-    ll_api::memory const& binary_mem = *this->binaries(device->build_key())[0];
+    const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance().get_build_key(device->id()))[0];
 
     if (this->config_.eth_mode == Eth::IDLE) {
         uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
@@ -482,7 +494,8 @@ bool ComputeKernel::configure(IDevice* device, const CoreCoord &logical_core, ui
     }
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    std::vector<ll_api::memory const*> const& binaries = this->binaries(device->build_key());
+    const std::vector<const ll_api::memory*>& binaries =
+        this->binaries(BuildEnvManager::get_instance().get_build_key(device->id()));
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         llrt::write_binary_to_address(
             *binaries[trisc_id], device_id, worker_core, base_address + offsets[2 + trisc_id]);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -218,8 +218,8 @@ uint32_t finalize_kernel_bins(
             auto& optional_id = kg->kernel_ids[class_id];
             if (optional_id) {
                 const auto kernel = kernels.at(optional_id.value());
-                const std::vector<const ll_api::memory*>& binaries =
-                    kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
+                const std::vector<const ll_api::memory*>& binaries = kernel->binaries(
+                    BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
                     hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -219,7 +219,7 @@ uint32_t finalize_kernel_bins(
             if (optional_id) {
                 const auto kernel = kernels.at(optional_id.value());
                 const std::vector<const ll_api::memory*>& binaries =
-                    kernel->binaries(BuildEnvManager::get_instance().get_build_key(device->id()));
+                    kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
                     hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
 
 namespace tt::tt_metal {
 namespace program_dispatch {
@@ -217,7 +218,8 @@ uint32_t finalize_kernel_bins(
             auto& optional_id = kg->kernel_ids[class_id];
             if (optional_id) {
                 const auto kernel = kernels.at(optional_id.value());
-                const std::vector<const ll_api::memory*>& binaries = kernel->binaries(device->build_key());
+                const std::vector<const ll_api::memory*>& binaries =
+                    kernel->binaries(BuildEnvManager::get_instance().get_build_key(device->id()));
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
                     hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -42,7 +42,8 @@ void GenerateBinaries(IDevice* device, JitBuildOptions &build_options, const std
     //const std::string tracyPrefix = "GenerateBinaries_";
     //ZoneName((tracyPrefix + build_options.name).c_str(), build_options.name.length() + tracyPrefix.length());
     try {
-        jit_build_genfiles_descriptors(BuildEnvManager::get_instance().get_build_env(device->id()), build_options);
+        jit_build_genfiles_descriptors(
+            BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env, build_options);
         kernel->generate_binaries(device, build_options);
     } catch (std::runtime_error &ex) {
         TT_THROW("Failed to generate binaries for {} {}", kernel->name(), ex.what());
@@ -1115,7 +1116,8 @@ void detail::Program_::populate_dispatch_data(IDevice* device) {
             } else {
                 sub_kernels = {kernel->processor()};
             }
-            const auto& binaries = kernel->binaries(BuildEnvManager::get_instance().get_build_key(device->id()));
+            const auto& binaries =
+                kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
             std::vector<uint32_t> dst_base_addrs;
             std::vector<uint32_t> page_offsets;
             std::vector<uint32_t> lengths;
@@ -1308,7 +1310,7 @@ void Program::populate_dispatch_data(IDevice* device) { pimpl_->populate_dispatc
 
 void Program::generate_dispatch_commands(IDevice* device) {
     bool is_cached = this->is_cached();
-    uint64_t command_hash = BuildEnvManager::get_instance().get_build_key(device->id());
+    uint64_t command_hash = BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key;
     if (not hal.is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the command hash, to always assert on programs being reused across devices.
@@ -1334,7 +1336,7 @@ void Program::allocate_kernel_bin_buf_on_device(IDevice* device) { pimpl_->alloc
 
 void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
     //ZoneScoped;
-    if (compiled_.contains(BuildEnvManager::get_instance().get_build_key(device->id()))) {
+    if (compiled_.contains(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key)) {
         return;
     }
     // Clear the determined sub_device_ids when we compile the program for the first time
@@ -1394,7 +1396,8 @@ void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
             validate_kernel_placement(kernel);
             launch_build_step(
                 [kernel, device, this] {
-                    JitBuildOptions build_options(BuildEnvManager::get_instance().get_build_env(device->id()));
+                    JitBuildOptions build_options(
+                        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_env);
                     kernel->set_build_options(build_options);
                     if (this->compiled_.empty()) {
                         this->set_remote_circular_buffer_init(kernel);
@@ -1405,7 +1408,7 @@ void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
                     auto kernel_hash = KernelCompileHash(
                         kernel,
                         build_options,
-                        BuildEnvManager::get_instance().get_build_key(device->id()),
+                        BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key,
                         device->get_device_kernel_defines_hash());
                     std::string kernel_path_suffix = kernel->name() + "/" + std::to_string(kernel_hash) + "/";
                     kernel->set_full_name(kernel_path_suffix);
@@ -1451,7 +1454,7 @@ void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
     if (detail::MemoryReporter::enabled()) {
         detail::MemoryReporter::inst().flush_program_memory_usage(get_id(), device);
     }
-    compiled_.insert(BuildEnvManager::get_instance().get_build_key(device->id()));
+    compiled_.insert(BuildEnvManager::get_instance().get_device_build_env(device->id()).build_key);
 }
 
 void Program::compile(IDevice* device, bool fd_bootloader_mode) { pimpl_->compile(device, fd_bootloader_mode); }

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(JIT_BUILD_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/build.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/build_env_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/genfiles.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel_args.cpp

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -24,8 +24,6 @@ BuildEnvManager::BuildEnvManager() {
     }
 }
 
-BuildEnvManager::~BuildEnvManager() {}
-
 std::map<std::string, std::string> initialize_device_kernel_defines(chip_id_t device_id, uint8_t num_hw_cqs) {
     std::map<std::string, std::string> device_kernel_defines;
 
@@ -227,7 +225,7 @@ const JitBuildState& BuildEnvManager::get_kernel_build_state(
     return *device_id_to_kernel_build_states_[device_id][state_idx];
 }
 
-const JitBuildStateSubset BuildEnvManager::get_kernel_build_states(
+JitBuildStateSubset BuildEnvManager::get_kernel_build_states(
     chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class) {
     TT_ASSERT(
         device_id_to_kernel_build_states_.count(device_id) != 0,

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -199,6 +199,7 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t device_id,
 }
 
 void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
+    const std::lock_guard<std::mutex> lock(this->lock);
     uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
 
@@ -211,6 +212,7 @@ void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
 }
 
 const DeviceBuildEnv& BuildEnvManager::get_device_build_env(chip_id_t device_id) {
+    const std::lock_guard<std::mutex> lock(this->lock);
     TT_ASSERT(device_id_to_build_env_.count(device_id) != 0, "Couldn't find build env for device {}.", device_id);
     return device_id_to_build_env_[device_id];
 }
@@ -237,6 +239,7 @@ JitBuildStateSubset BuildEnvManager::get_kernel_build_states(
 
 std::pair<int, int> BuildEnvManager::get_build_index_and_state_count(
     uint32_t programmable_core, uint32_t processor_class) {
+    const std::lock_guard<std::mutex> lock(this->lock);
     TT_ASSERT(
         programmable_core < build_state_indices_.size(),
         "Programmable core type {} is not included in the FW or Kernel build state",

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -34,8 +34,17 @@ std::map<std::string, std::string> initialize_device_kernel_defines(chip_id_t de
     // # of L1 banks needs to match allocator. For L1BankingAllocator this is the # of storage cores. TODO: when
     // allocator is pulled out of device, use it to get that info here.
     const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
-    const size_t num_l1_banks = tt::get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config).size() +
-                                tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config).size();
+    const size_t num_compute_and_storage_cores =
+        tt::get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config).size();
+    const size_t num_storage_only_cores =
+        tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config).size();
+    size_t num_banks_per_storage_core = 0;
+    if (num_storage_only_cores > 0) {
+        num_banks_per_storage_core =
+            static_cast<size_t>(soc_d.worker_l1_size) /
+            tt::get_storage_core_bank_size(device_id, num_hw_cqs, dispatch_core_config).value();
+    }
+    const size_t num_l1_banks = num_compute_and_storage_cores + num_storage_only_cores * num_banks_per_storage_core;
 
     bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
     bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "build_env_manager.hpp"
+#include <tt_cluster.hpp>
+#include <command_queue_interface.hpp>
+
+namespace tt::tt_metal {
+
+BuildEnvManager::BuildEnvManager() {
+    // Initialize build_state_indices_
+    uint32_t index = 0;
+    uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
+    build_state_indices_.resize(programmable_core_type_count);
+    for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
+        uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
+        build_state_indices_[programmable_core].resize(processor_class_count);
+        for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
+            uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
+            build_state_indices_[programmable_core][processor_class] = {index, processor_types_count};
+            index += processor_types_count;
+        }
+    }
+}
+
+BuildEnvManager::~BuildEnvManager() {}
+
+std::map<std::string, std::string> initialize_device_kernel_defines(chip_id_t device_id, uint8_t num_hw_cqs) {
+    std::map<std::string, std::string> device_kernel_defines;
+
+    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device_id);
+    const size_t num_dram_banks = static_cast<size_t>(soc_d.get_num_dram_views());
+    // # of L1 banks needs to match allocator. For L1BankingAllocator this is the # of storage cores. TODO: when
+    // allocator is pulled out of device, use it to get that info here.
+    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
+    const size_t num_l1_banks = tt::get_logical_compute_cores(device_id, num_hw_cqs, dispatch_core_config).size() +
+                                tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config).size();
+
+    bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
+    bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);
+
+    device_kernel_defines.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
+    device_kernel_defines.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
+
+    if (is_dram_pow2) {
+        device_kernel_defines.emplace(
+            "LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(static_cast<size_t>(log2(num_dram_banks))));
+    } else {
+        device_kernel_defines.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
+    }
+    if (is_l1_pow2) {
+        device_kernel_defines.emplace(
+            "LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(static_cast<size_t>(log2(num_l1_banks))));
+    } else {
+        device_kernel_defines.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
+    }
+
+    // TODO (abhullar): Until we switch to virtual coordinates, we need to pass physical PCIe coordinates to device
+    //  because Blackhole PCIe endpoint is dependent on board type
+    auto pcie_cores = soc_d.get_pcie_cores();
+    CoreCoord pcie_core = pcie_cores.empty() ? soc_d.grid_size : pcie_cores[0];
+
+    device_kernel_defines.emplace("PCIE_NOC_X", std::to_string(pcie_core.x));
+    device_kernel_defines.emplace("PCIE_NOC_Y", std::to_string(pcie_core.y));
+
+    return device_kernel_defines;
+}
+
+uint32_t compute_build_key(chip_id_t device_id, uint8_t num_hw_cqs) {
+    uint32_t build_key = 0;
+    constexpr uint32_t harvesting_map_bits = 12;
+    constexpr uint32_t num_hw_cq_bits = 8;
+    constexpr uint32_t dispatch_core_axis_bits = 1;
+    constexpr uint32_t dispatch_core_type_bits = 1;
+    static_assert(dispatch_core_manager::MAX_NUM_HW_CQS <= (1 << num_hw_cq_bits));
+    static_assert(static_cast<uint32_t>(DispatchCoreAxis::COUNT) <= (1 << dispatch_core_axis_bits));
+    static_assert(static_cast<uint32_t>(DispatchCoreType::COUNT) <= (1 << dispatch_core_type_bits));
+    static_assert(
+        harvesting_map_bits + num_hw_cq_bits + dispatch_core_axis_bits + dispatch_core_type_bits <=
+        sizeof(build_key) * CHAR_BIT);
+
+    // num_hw_cqs, dispatch_core_axis, dispatch_core_type all change the number of banks, so need to be part of the
+    // build key since we have defines based on number of banks.
+    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
+    build_key = (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_type())
+                 << (harvesting_map_bits + num_hw_cq_bits + dispatch_core_axis_bits)) |
+                (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_axis())
+                 << (harvesting_map_bits + num_hw_cq_bits)) |
+                (static_cast<uint32_t>(num_hw_cqs) << harvesting_map_bits);
+    if (not hal.is_coordinate_virtualization_enabled()) {
+        // Coordinate virtualization is not enabled. For a single program, its associated binaries will vary across
+        // devices with different cores harvested.
+        build_key |= tt::Cluster::instance().get_harvesting_mask(device_id);
+    } else {
+        // Coordinate Virtualization is enabled. Track only the number of harvested cores, instead of the exact
+        // harvesting configuration (this is not needed).
+        build_key |= (std::bitset<harvesting_map_bits>(tt::Cluster::instance().get_harvesting_mask(device_id)).count());
+    }
+    return build_key;
+}
+
+JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t device_id, uint8_t num_hw_cqs, bool is_fw) {
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device_id);
+    uint32_t dispatch_message_addr = DispatchMemMap::get(dispatch_core_type, num_hw_cqs)
+                                         .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
+
+    uint32_t num_build_states = hal.get_num_risc_processors();
+    std::vector<std::shared_ptr<JitBuildState>> build_states;
+    build_states.resize(num_build_states);
+
+    uint32_t index = 0;
+    uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
+    for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
+        HalProgrammableCoreType core_type = magic_enum::enum_value<HalProgrammableCoreType>(programmable_core);
+        uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
+        for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
+            auto compute_proc_class = magic_enum::enum_cast<HalProcessorClassType>(processor_class);
+            bool is_compute_processor =
+                compute_proc_class.has_value() and compute_proc_class.value() == HalProcessorClassType::COMPUTE;
+            uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
+            for (uint32_t processor_type = 0; processor_type < processor_types_count; processor_type++) {
+                switch (core_type) {
+                    case HalProgrammableCoreType::TENSIX: {
+                        if (is_compute_processor) {
+                            build_states[index] = std::make_shared<JitBuildCompute>(
+                                build_env,
+                                JitBuiltStateConfig{
+                                    .processor_id = processor_type,
+                                    .is_fw = is_fw,
+                                    .dispatch_message_addr = dispatch_message_addr});
+                        } else {
+                            // TODO: Make .processor_id = processor_type when brisc and ncrisc are considered one
+                            // processor class
+                            build_states[index] = std::make_shared<JitBuildDataMovement>(
+                                build_env,
+                                JitBuiltStateConfig{
+                                    .processor_id = processor_class,
+                                    .is_fw = is_fw,
+                                    .dispatch_message_addr = dispatch_message_addr});
+                        }
+                        break;
+                    }
+                    case HalProgrammableCoreType::ACTIVE_ETH: {
+                        // Cooperative means active erisc FW needs to context switch to base FW
+                        bool is_cooperative = tt::Cluster::instance().arch() == ARCH::WORMHOLE_B0;
+                        build_states[index] = std::make_shared<JitBuildActiveEthernet>(
+                            build_env,
+                            JitBuiltStateConfig{
+                                .processor_id = processor_class,
+                                .is_fw = is_fw,
+                                .dispatch_message_addr = dispatch_message_addr,
+                                .is_cooperative = is_cooperative});
+                        break;
+                    }
+                    case HalProgrammableCoreType::IDLE_ETH: {
+                        build_states[index] = std::make_shared<JitBuildIdleEthernet>(
+                            build_env,
+                            JitBuiltStateConfig{
+                                .processor_id = processor_class,
+                                .is_fw = is_fw,
+                                .dispatch_message_addr = dispatch_message_addr});
+                        break;
+                    }
+                    default:
+                        TT_THROW(
+                            "Unsupported programable core type {} to initialize build states",
+                            magic_enum::enum_name(core_type));
+                }
+                index++;
+            }
+        }
+    }
+
+    return build_states;
+}
+
+void BuildEnvManager::add_build_env(chip_id_t device_id, uint8_t num_hw_cqs) {
+    uint32_t build_key = compute_build_key(device_id, num_hw_cqs);
+    device_id_to_build_key_[device_id] = build_key;
+
+    auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
+    device_id_to_build_env_[device_id].init(build_key, tt::Cluster::instance().arch(), device_kernel_defines);
+
+    device_id_to_firmware_build_states_[device_id] =
+        create_build_state(device_id_to_build_env_[device_id], device_id, num_hw_cqs, true);
+    device_id_to_kernel_build_states_[device_id] =
+        create_build_state(device_id_to_build_env_[device_id], device_id, num_hw_cqs, false);
+}
+
+const JitBuildEnv& BuildEnvManager::get_build_env(chip_id_t device_id) {
+    TT_ASSERT(device_id_to_build_env_.count(device_id) != 0, "Couldn't find build env for device {}.", device_id);
+    return device_id_to_build_env_[device_id];
+}
+
+uint32_t BuildEnvManager::get_build_key(chip_id_t device_id) {
+    TT_ASSERT(device_id_to_build_key_.count(device_id) != 0, "Couldn't find build key for device {}.", device_id);
+    return device_id_to_build_key_[device_id];
+}
+
+const JitBuildState& BuildEnvManager::get_firmware_build_state(
+    chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id) {
+    TT_ASSERT(
+        device_id_to_firmware_build_states_.count(device_id) != 0,
+        "Couldn't find firmware build state for device {}.",
+        device_id);
+    uint32_t state_idx = get_build_index_and_state_count(programmable_core, processor_class).first + processor_id;
+    return *device_id_to_firmware_build_states_[device_id][state_idx];
+}
+
+const JitBuildState& BuildEnvManager::get_kernel_build_state(
+    chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id) {
+    TT_ASSERT(
+        device_id_to_kernel_build_states_.count(device_id) != 0,
+        "Couldn't find kernel build state for device {}.",
+        device_id);
+    uint32_t state_idx = get_build_index_and_state_count(programmable_core, processor_class).first + processor_id;
+    return *device_id_to_kernel_build_states_[device_id][state_idx];
+}
+
+const JitBuildStateSubset BuildEnvManager::get_kernel_build_states(
+    chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class) {
+    TT_ASSERT(
+        device_id_to_kernel_build_states_.count(device_id) != 0,
+        "Couldn't find kernel build state for device {}.",
+        device_id);
+    std::pair<int, int> b_id_and_count = get_build_index_and_state_count(programmable_core, processor_class);
+    JitBuildStateSubset subset = {
+        &device_id_to_kernel_build_states_[device_id][b_id_and_count.first], b_id_and_count.second};
+    return subset;
+}
+
+std::pair<int, int> BuildEnvManager::get_build_index_and_state_count(
+    uint32_t programmable_core, uint32_t processor_class) {
+    TT_ASSERT(
+        programmable_core < build_state_indices_.size(),
+        "Programmable core type {} is not included in the FW or Kernel build state",
+        programmable_core);
+    TT_ASSERT(
+        processor_class < build_state_indices_[programmable_core].size(),
+        "Processor class type {} is not included in the FW or Kernel build state",
+        processor_class);
+    return build_state_indices_[programmable_core][processor_class];
+}
+
+void BuildEnvManager::build_firmware(chip_id_t device_id) {
+    TT_ASSERT(
+        device_id_to_firmware_build_states_.count(device_id) != 0,
+        "Couldn't find firmware build state for device {}.",
+        device_id);
+    log_debug(tt::LogMetal, "Building base firmware for device {}", device_id);
+    ZoneScoped;
+
+    jit_build_set(device_id_to_firmware_build_states_[device_id], nullptr);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -29,7 +29,7 @@ public:
         chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id);
     const JitBuildState& get_kernel_build_state(
         chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id);
-    const JitBuildStateSubset get_kernel_build_states(
+    JitBuildStateSubset get_kernel_build_states(
         chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class);
 
     void build_firmware(chip_id_t device_id);
@@ -40,7 +40,7 @@ public:
 
 private:
     BuildEnvManager();
-    ~BuildEnvManager();
+    ~BuildEnvManager() = default;
 
     std::unordered_map<chip_id_t, JitBuildEnv> device_id_to_build_env_;
     std::unordered_map<chip_id_t, uint32_t> device_id_to_build_key_;

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -58,6 +58,7 @@ private:
     // A device-agnostic mapping from programmable_core_type and processor_class to unique index + processor_type_count.
     // TODO: processor_type_count can be looked up in the hal, do we need this in here?
     ProgCoreMapping build_state_indices_;
+    std::mutex lock;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "build.hpp"
+
+namespace tt::tt_metal {
+
+// Singleton class to generate and hold build environments, build keys, and build states.
+class BuildEnvManager {
+public:
+    BuildEnvManager(const BuildEnvManager&) = delete;
+    BuildEnvManager& operator=(const BuildEnvManager&) = delete;
+    static BuildEnvManager& get_instance() {
+        static BuildEnvManager instance;
+        return instance;
+    }
+
+    // Add a new build environment for the corresponding device id and num_hw_cqs. Also generates the build key and
+    // build states.
+    void add_build_env(chip_id_t device_id, uint8_t num_hw_cqs);
+
+    // Getter functions for build envs/keys/states
+    const JitBuildEnv& get_build_env(chip_id_t device_id);
+    uint32_t get_build_key(chip_id_t device_id);
+    const JitBuildState& get_firmware_build_state(
+        chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id);
+    const JitBuildState& get_kernel_build_state(
+        chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id);
+    const JitBuildStateSubset get_kernel_build_states(
+        chip_id_t device_id, uint32_t programmable_core, uint32_t processor_class);
+
+    void build_firmware(chip_id_t device_id);
+
+    // Helper function to get the unique build id and number of states for a given programmable_core and
+    // processor_class.
+    std::pair<int, int> get_build_index_and_state_count(uint32_t programmable_core, uint32_t processor_class);
+
+private:
+    BuildEnvManager();
+    ~BuildEnvManager();
+
+    std::unordered_map<chip_id_t, JitBuildEnv> device_id_to_build_env_;
+    std::unordered_map<chip_id_t, uint32_t> device_id_to_build_key_;
+    std::unordered_map<chip_id_t, JitBuildStateSet> device_id_to_firmware_build_states_;
+    std::unordered_map<chip_id_t, JitBuildStateSet> device_id_to_kernel_build_states_;
+
+    // A device-agnostic mapping from programmable_core_type and processor_class to unique index + processor_type_count.
+    // TODO: processor_type_count can be looked up in the hal, do we need this in here?
+    std::vector<std::vector<std::pair<int, int>>> build_state_indices_;
+};
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17167

### Problem description
Build env/key/states were owned by device, but the only true dependency they have on it is the device ID. Want to pull them out and remove the build-related APIs from Device.

### What's changed
Move build env/key/state management to a separate BuildEnvManager class. In the near future I'm imagining that we can move more build-related things out of Program/Kernel into this class as well.

Due to BH not yet supporting virtual coords, and I'm told some GS has harvesting and doesn't support virtual coords, we can't break the dependency on device ID just yet. But when we can, it should be just a simple change in the BuildEnvManager class + its users.

### Checklist
Post-Commit: https://github.com/tenstorrent/tt-metal/actions/runs/13245393881
T3K (same failures as [main](https://github.com/tenstorrent/tt-metal/actions/runs/13214171698)): https://github.com/tenstorrent/tt-metal/actions/runs/13237414367
BH: https://github.com/tenstorrent/tt-metal/actions/runs/13245423992