### PR TITLE
#16364: update DispatchMemMap address calculation

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -177,6 +177,8 @@ public:
     uint32_t tunneling_buffer_size_;
     uint32_t tunneling_buffer_pages_;  // tunneling_buffer_size_ / PREFETCH_D_BUFFER_LOG_PAGE_SIZE
 
+    uint32_t kernel_debug_status_enable_{0};  // How much space reserved for debug status. 0 means disabled.
+
     CoreType core_type_;  // Which core this settings is for
 
     bool operator==(const DispatchSettings& other) const {
@@ -275,6 +277,12 @@ public:
         this->dispatch_message_ = DISPATCH_MESSAGE_ENTRIES * l1_alignment;
         this->other_ptrs_size = l1_alignment;
 
+        return *this;
+    }
+
+    // Trivial setter for enabling dispatch kernel debug status
+    DispatchSettings& kernel_debug_status_enable(uint32_t size) {
+        this->kernel_debug_status_enable_ = size;
         return *this;
     }
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -174,8 +174,9 @@ void DispatchKernel::GenerateDependentConfigs() {
         auto prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0]);
         TT_ASSERT(prefetch_kernel);
         dependent_config_.upstream_logical_core = prefetch_kernel->GetLogicalCore();
-        dependent_config_.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
-        dependent_config_.upstream_sync_sem = prefetch_kernel->GetStaticConfig().downstream_sync_sem_id;
+        dependent_config_.upstream_dispatch_cb_sem_id =
+            prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id.value();
+        dependent_config_.upstream_sync_sem = prefetch_kernel->GetStaticConfig().downstream_sync_sem_id.value();
 
         if (prefetch_kernel->GetStaticConfig().is_h_variant.value() &&
             prefetch_kernel->GetStaticConfig().is_d_variant.value()) {
@@ -228,7 +229,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         dependent_config_.prefetch_h_noc_xy = tt::tt_metal::hal.noc_xy_encoding(
             prefetch_h_kernel->GetVirtualCore().x, prefetch_h_kernel->GetVirtualCore().y);
         dependent_config_.prefetch_h_local_downstream_sem_addr =
-            prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id;
+            prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id.value();
         dependent_config_.downstream_cb_base = 0;    // Unused
         dependent_config_.downstream_cb_size = 0;    // Unused
         dependent_config_.downstream_cb_sem_id = 0;  // Unused
@@ -238,8 +239,9 @@ void DispatchKernel::GenerateDependentConfigs() {
         auto prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0]);
         TT_ASSERT(prefetch_kernel);
         dependent_config_.upstream_logical_core = prefetch_kernel->GetLogicalCore();
-        dependent_config_.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
-        dependent_config_.upstream_sync_sem = prefetch_kernel->GetStaticConfig().downstream_sync_sem_id;
+        dependent_config_.upstream_dispatch_cb_sem_id =
+            prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id.value();
+        dependent_config_.upstream_sync_sem = prefetch_kernel->GetStaticConfig().downstream_sync_sem_id.value();
 
         if (prefetch_kernel->GetStaticConfig().is_h_variant.value() &&
             prefetch_kernel->GetStaticConfig().is_d_variant.value()) {


### PR DESCRIPTION
### Ticket
#16364

### Problem description
While updating `test_prefetcher` I noticed that `cmddat_q_base_` will overlap with `dispatch_buffer_base_` if the cmddat size is bigger than the dispatch log page size. It happens because `cmddat_q_base_` and `dispatch_buffer_base_` are "allocated" from the same starting address `prefetch_dispatch_unreserved_base`.

### What's changed

- Prefetch kernels to use `prefetch_buffer_base` instead of `dispatch_buffer_base`
- Use `tt::align` to align the addresses
- Add a `kernel_debug_status_enable` option in `DispatchSettings`. This is used for test prefetcher.

NOTE:
L1 Layout for each kernel
// Prefetcher: prefetch_buffer_base() | cmddat_q_base() | scratch_db_base()
// Dispatcher: dispatch_buffer_base()
// MUX/DEMUX/etc: Kernel Debug Status | dispatch_buffer_base()

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
