### PR TITLE
[tt-train] Add patch command in CPM

### DIFF
--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -88,12 +88,13 @@ CPMAddPackage(NAME taskflow GITHUB_REPOSITORY taskflow/taskflow GIT_TAG v3.7.0 O
 
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_cli11.cmake)
 
+# gersemi: off
 CPMAddPackage(
     NAME msgpack
     GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git
     GIT_TAG cpp-6.1.0
-    PATCHES
-        msgpack.patch
+    PATCH_COMMAND
+        patch --dry-run -p1 -R < ${CMAKE_CURRENT_LIST_DIR}/msgpack.patch || patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/msgpack.patch
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "MSGPACK_BUILD_EXAMPLES OFF"
@@ -112,8 +113,9 @@ CPMAddPackage(
     NAME tokenizers-cpp
     GITHUB_REPOSITORY mlc-ai/tokenizers-cpp
     GIT_TAG 5de6f656c06da557d4f0fb1ca611b16d6e9ff11d
-    PATCHES
-        tokenizers-cpp.patch
+    PATCH_COMMAND
+        patch --dry-run -p1 -R < ${CMAKE_CURRENT_LIST_DIR}/tokenizers-cpp.patch || patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/tokenizers-cpp.patch
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
 )
+# gersemi: on


### PR DESCRIPTION
### Problem description
After switching from Release to Debug (or Debug to Release), build command results in error.

### What's changed
Add patch command for two CPM packages of interest to properly apply or ignore patch if needed.

Thanks @dmakoviichuk-tt for finding the fix. 