### PR TITLE
These deps are required for TT-Train

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -43,7 +43,6 @@ RUN mkdir -p /tmp/cba \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     bc \
-    cargo \
     clang-tidy-17 \
     curl \
     dialog \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -89,8 +89,10 @@ ub_buildtime_packages()
      git \
      python3-dev \
      pkg-config \
+     cargo \
      cmake \
      ninja-build \
+     libboost-dev \
      libhwloc-dev \
      libc++-17-dev \
      libc++abi-17-dev \


### PR DESCRIPTION
### Ticket
None

### Problem description
These deps are needed when building TT-Train

### What's changed
Added additional dependencies identified that tokenizers-cpp requires to build.

