### PR TITLE
#0: skip credit handshake when no words have been received.

### DIFF
--- a/tt_fabric/hw/inc/tt_fabric.h
+++ b/tt_fabric/hw/inc/tt_fabric.h
@@ -380,6 +380,9 @@ typedef struct fvc_producer_state {
     FORCE_INLINE uint32_t get_num_words_available() {
         if constexpr (fvc_mode == FVC_MODE_ROUTER) {
             uint32_t new_words = *words_received;
+            if (new_words == 0) {
+                return words_inbound;
+            }
             *words_received_local_update = (-new_words) << REMOTE_DEST_BUF_WORDS_FREE_INC;
             words_inbound += new_words;
             uint32_t temp = inbound_wrptr.ptr + new_words;


### PR DESCRIPTION
Currently when checking for words received over ethernet, fabric kernel still does all the motions and words cleared handshakes even if 0 words have been received.
This is burning cycles sending functionally redundant information.
Changing code to return immediately if words received == 0.
