### PR TITLE
#0: Fix failing Llama TG tests by preserving old behavior for ShardTensor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -258,6 +258,7 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
         **updated_device_params,
         offset=ttnn.MeshOffset(0, 1),
     )
+    mesh_device.reshape(ttnn.MeshShape(1, 4))
 
     logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
     yield mesh_device

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -153,7 +153,6 @@ std::vector<IDevice*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_
                 [&](const ShardTensor2D& s) {
                     return mesh_device.get_view().get_devices(MeshShape{s.shard_mesh.y, s.shard_mesh.x});
                 },
-                [&](const ShardTensor& s) { return get_workers_for_tensor(mesh_device.get_view().get_line_devices()); },
                 [&](const auto&) { return get_workers_for_tensor(mesh_device.get_devices()); }},
             host_storage.strategy);
     } else if (std::holds_alternative<MultiDeviceStorage>(tensor.get_storage())) {


### PR DESCRIPTION
### Problem description
Previously, when we had a MxN MeshDevice, a mesh_mapper of `ShardTensorToMesh` would behave differently based on whether `mesh_type` passed into the MeshDevice was `MeshType::RowMajor`, `MeshType::Ring`.

With the removal of `MeshType` from MeshDevice specification, this changed the default behavior for users constructing a MeshDevice with default `mesh_type=MeshType::RowMajor`. This change now preserves the old behavior so that shards are distributed in row-major instead of a ring

### What's changed
- Preserve old behavior of distributing tensor shards for devices to be row-major when `mesh_mapper=ShardTensorToMesh` is specified on a `MxN` MeshDevice.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13190618726
- [x] TG Regressions: https://github.com/tenstorrent/tt-metal/actions/runs/13192782758
- [x] T3000 Regression: https://github.com/tenstorrent/tt-metal/actions/runs/13195073649
