### PR TITLE
Fix non-deterministic hangs caused by MeshDevice trace replay

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -141,7 +141,8 @@ public:
     // Metal trace device capture mode
     virtual void begin_trace(const uint8_t cq_id, const uint32_t tid) = 0;
     virtual void end_trace(const uint8_t cq_id, const uint32_t tid) = 0;
-    virtual void replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) = 0;
+    virtual void replay_trace(
+        const uint8_t cq_id, const uint32_t tid, const bool block_on_device, const bool block_on_worker_thread) = 0;
     virtual void release_trace(const uint32_t tid) = 0;
 
     virtual std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -130,7 +130,11 @@ public:
     // Metal trace device capture mode
     void begin_trace(const uint8_t cq_id, const uint32_t tid) override;
     void end_trace(const uint8_t cq_id, const uint32_t tid) override;
-    void replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) override;
+    void replay_trace(
+        const uint8_t cq_id,
+        const uint32_t tid,
+        const bool block_on_device,
+        const bool block_on_worker_thread) override;
     void release_trace(const uint32_t tid) override;
     std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override { return trace_buffers_size_; }

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -139,6 +139,8 @@ public:
     // Trace APIs
     void begin_trace(const uint8_t cq_id, const uint32_t tid) override;
     void end_trace(const uint8_t cq_id, const uint32_t tid) override;
+
+    // TODO: `block_on_worker_thread` can be removed once we remove multi-threaded async dispatch
     void replay_trace(
         const uint8_t cq_id,
         const uint32_t tid,

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -139,7 +139,11 @@ public:
     // Trace APIs
     void begin_trace(const uint8_t cq_id, const uint32_t tid) override;
     void end_trace(const uint8_t cq_id, const uint32_t tid) override;
-    void replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) override;
+    void replay_trace(
+        const uint8_t cq_id,
+        const uint32_t tid,
+        const bool block_on_device,
+        const bool block_on_worker_thread) override;
     void release_trace(const uint32_t tid) override;
     std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -584,6 +584,12 @@ void MeshDevice::replay_trace(const uint8_t cq_id, const uint32_t tid, const boo
     for (auto& device : scoped_devices_->get_devices()) {
         device->replay_trace(cq_id, tid, blocking);
     }
+    // If blocking, wait until worker threads have completed
+    if (blocking) {
+        for (auto& device : scoped_devices_->get_devices()) {
+            device->synchronize();
+        }
+    }
 }
 void MeshDevice::release_trace(const uint32_t tid) {
     for (auto& device : scoped_devices_->get_devices()) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -580,12 +580,13 @@ void MeshDevice::end_trace(const uint8_t cq_id, const uint32_t tid) {
         device->end_trace(cq_id, tid);
     }
 }
-void MeshDevice::replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) {
+void MeshDevice::replay_trace(
+    const uint8_t cq_id, const uint32_t tid, const bool block_on_device, const bool block_on_worker_thread) {
     for (auto& device : scoped_devices_->get_devices()) {
-        device->replay_trace(cq_id, tid, blocking);
+        device->replay_trace(cq_id, tid, block_on_device, false /* block_on_worker_thread */);
     }
     // If blocking, wait until worker threads have completed
-    if (blocking) {
+    if (block_on_worker_thread) {
         for (auto& device : scoped_devices_->get_devices()) {
             device->synchronize();
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1326,7 +1326,7 @@ void EndTraceCapture(IDevice* device, const uint8_t cq_id, const uint32_t tid) {
 void ReplayTrace(IDevice* device, const uint8_t cq_id, const uint32_t tid, const bool blocking) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureReplayTrace, device, cq_id, tid, blocking);
-    device->replay_trace(cq_id, tid, blocking);
+    device->replay_trace(cq_id, tid, blocking /* block_on_device */, blocking /* block_on_worker_thread */);
 }
 
 void ReleaseTrace(IDevice* device, const uint32_t tid) {

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -142,7 +142,7 @@ void end_trace_capture(IDevice* device, const uint32_t tid, const QueueId cq_id)
 
 void execute_trace(IDevice* device, const uint32_t tid, const QueueId cq_id, bool blocking) {
     ZoneScoped;
-    device->replay_trace(*cq_id, tid, blocking);
+    device->replay_trace(*cq_id, tid, blocking /* block_on_device */, blocking /* block_on_worker_thread */);
 }
 
 void release_trace(IDevice* device, const uint32_t tid) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There are non-deterministic hangs with llama model tests using trace functionality. @tt-aho pointed out there are some changes in the blocking behavior that was incorrectly introduced in: https://github.com/tenstorrent/tt-metal/commit/d2ba1143ba342929b50c749f0f238468db5f9dfc

### What's changed
This change modifies the `IDevice::replay_trace` method to add more granular control over blocking behavior. Previously, we used a single boolean `blocking` to denote stalls that happen on device and stalls that happen on worker-thread. Since we've moved `push_work` API underneath the device APIs, we need this fine-grained control for orchestrating trace replay from `MeshDevice`. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13191753217
- [ ] T3000 Regression Tests: https://github.com/tenstorrent/tt-metal/actions/runs/13191607633
