### PR TITLE
Removed workaround for blackhole alignment

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
@@ -173,15 +173,8 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     log_debug(tt::LogOp, "out_stick_nbytes = {}", out_stick_nbytes);
     log_debug(tt::LogOp, "input_tensor.buffer()->alignment() = {}", input_tensor.buffer()->alignment());
 
-    uint32_t input_buffer_alignment = input_tensor.buffer()->alignment();
-    if (device->arch() == tt::ARCH::BLACKHOLE) {
-        // FIXME: Remove this workaround once the alignment is fixed in the allocator:
-        // https://github.com/tenstorrent/tt-metal/pull/13762, ticket:
-        // https://github.com/tenstorrent/tt-metal/issues/13609
-        input_buffer_alignment = 32;  // this is a workaround for the issue mentioned above
-    }
-    if (out_stick_nbytes % input_buffer_alignment != 0) {
-        aligned_input_nstick_nbytes = tt::round_up(out_stick_nbytes, input_buffer_alignment);
+    if (out_stick_nbytes % input_tensor.buffer()->alignment() != 0) {
+        aligned_input_nstick_nbytes = tt::round_up(out_stick_nbytes, input_tensor.buffer()->alignment());
     }
     // reader kernel
     std::vector<uint32_t> reader_ct_args = {


### PR DESCRIPTION
### Ticket
Issue: #17226 

### What's changed
As https://github.com/tenstorrent/tt-metal/pull/17122 is merged, allocator uses L1 and DRAM specific alignments, not max of these 2, so this workaround can be removed. This also resolves the 8 PCC errors in the Blackhole Conv2D unit tests (sticks in these cases were 16B aligned, but with the workaround, they were overridden to 32B, which caused reading from invalid source addresses in halo op). With this change, tests will have a 100% pass rate.