### PR TITLE
Replacing L1 base address increment instructions with CFGSHIFTMASK

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -451,6 +451,10 @@ def test_matmul_in1_dram_sharded_with_mm_chain(
     )
 
 
+@pytest.mark.skipif(
+    is_blackhole(),
+    reason="Skipping to accommodate changes in #4: Replacing L1 base address increment instructions with CFGSHIFTMASK",
+)
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(
     "fp32_acc_mode",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -451,10 +451,6 @@ def test_matmul_in1_dram_sharded_with_mm_chain(
     )
 
 
-@pytest.mark.skipif(
-    is_blackhole(),
-    reason="Skipping to accommodate changes in #4: Replacing L1 base address increment instructions with CFGSHIFTMASK",
-)
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(
     "fp32_acc_mode",

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -84,17 +84,20 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    _llk_unpack_AB_matmul_init_(
-        transpose,
-        ct_dim,
-        rt_dim,
-        kt_dim,
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        unpA_num_faces,
-        unpB_num_faces,
-        partial_face_a,
-        partial_face_b);
+    {
+        DeviceZoneScopedN("UNPACK MATMUL INIT");
+        _llk_unpack_AB_matmul_init_(
+            transpose,
+            ct_dim,
+            rt_dim,
+            kt_dim,
+            unpA_face_r_dim,
+            unpB_face_r_dim,
+            unpA_num_faces,
+            unpB_num_faces,
+            partial_face_a,
+            partial_face_b);
+    }
 }
 
 inline void llk_unpack_AB_matmul(
@@ -126,19 +129,22 @@ inline void llk_unpack_AB_matmul(
     std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
 
     WAYPOINT("UPMW");
-    _llk_unpack_AB_matmul_(
-        base_address_a,
-        base_address_b,
-        tile_index_a,
-        tile_index_b,
-        tile_size_a,
-        tile_size_b,
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        partial_face_a,
-        partial_face_b,
-        ct_dim,
-        rt_dim,
-        kt_dim);
+    {
+        DeviceZoneScopedN("UNPACK MATMUL");
+        _llk_unpack_AB_matmul_(
+            base_address_a,
+            base_address_b,
+            tile_index_a,
+            tile_index_b,
+            tile_size_a,
+            tile_size_b,
+            unpA_face_r_dim,
+            unpB_face_r_dim,
+            partial_face_a,
+            partial_face_b,
+            ct_dim,
+            rt_dim,
+            kt_dim);
+    }
     WAYPOINT("UPMD");
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -84,20 +84,17 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
-    {
-        DeviceZoneScopedN("UNPACK MATMUL INIT");
-        _llk_unpack_AB_matmul_init_(
-            transpose,
-            ct_dim,
-            rt_dim,
-            kt_dim,
-            unpA_face_r_dim,
-            unpB_face_r_dim,
-            unpA_num_faces,
-            unpB_num_faces,
-            partial_face_a,
-            partial_face_b);
-    }
+    _llk_unpack_AB_matmul_init_(
+        transpose,
+        ct_dim,
+        rt_dim,
+        kt_dim,
+        unpA_face_r_dim,
+        unpB_face_r_dim,
+        unpA_num_faces,
+        unpB_num_faces,
+        partial_face_a,
+        partial_face_b);
 }
 
 inline void llk_unpack_AB_matmul(
@@ -129,22 +126,19 @@ inline void llk_unpack_AB_matmul(
     std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
 
     WAYPOINT("UPMW");
-    {
-        DeviceZoneScopedN("UNPACK MATMUL");
-        _llk_unpack_AB_matmul_(
-            base_address_a,
-            base_address_b,
-            tile_index_a,
-            tile_index_b,
-            tile_size_a,
-            tile_size_b,
-            unpA_face_r_dim,
-            unpB_face_r_dim,
-            partial_face_a,
-            partial_face_b,
-            ct_dim,
-            rt_dim,
-            kt_dim);
-    }
+    _llk_unpack_AB_matmul_(
+        base_address_a,
+        base_address_b,
+        tile_index_a,
+        tile_index_b,
+        tile_size_a,
+        tile_size_b,
+        unpA_face_r_dim,
+        unpB_face_r_dim,
+        partial_face_a,
+        partial_face_b,
+        ct_dim,
+        rt_dim,
+        kt_dim);
     WAYPOINT("UPMD");
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -401,9 +401,6 @@ void MAIN {
                     pack_untilize_uninit(mm_partials_cb_id);
                 }
                 if constexpr (batch > 1 || num_blocks_w_dim > 1 || num_blocks_h_dim > 1) {
-                    // reconfigure init for matmul
-                    mm_block_init_short(
-                        in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef FUSE_BIAS
                     // reconfigure unpacker df for src A and src B
                     reconfig_data_format(mm_partials_cb_id, in1_cb_id, bias_cb_id, in0_cb_id);
@@ -411,6 +408,9 @@ void MAIN {
                     // reconfigure unpacker df for src A
                     reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
 #endif
+                    // reconfigure init for matmul
+                    mm_block_init_short(
+                        in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
                 }
             }
         }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-llk-bh/issues/4)

### Problem description
Blackhole has new `CFGSHIFTMASK` that can update addresses for the unpacker instructions inside the mop/replay buffers. If an operation is unpacker bound, then using this instruction should increase performance.

### What's changed
Replaced L1 base address increment code that uses cfg read/write and tdma gpr operations with the new `CFGSHIFTMASK` instruction in the unpack AB matmul llk api. This replacement saves 6 instructions in the mop replay buffer. No notable performance improvements.

Only affects BH and addresses an issue in BH third party repo.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13399863311)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13399865409) (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
