### PR TITLE
EDM Packet Header Optimization: Simplify packet size storage and access (+other misc low-level optimizations)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -140,8 +140,8 @@ void kernel_main() {
             noc_async_write(source_l1_buffer_address, dest_addr, packet_payload_size_bytes);
             if (fabric_connection.has_forward_connection()) {
                 DeviceZoneScopedN("WR-FWD");
-                mcast_fwd_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{
-                    noc0_dest_addr, packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader)});
+                mcast_fwd_packet_header->to_noc_unicast_write(
+                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
                 {
                     DeviceZoneScopedN("WR-FWD-WAIT");
                     fabric_connection.get_forward_connection().wait_for_empty_write_slot();
@@ -155,8 +155,8 @@ void kernel_main() {
 
             if (fabric_connection.has_backward_connection()) {
                 DeviceZoneScopedN("WR-BWD");
-                mcast_bwd_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{
-                    noc0_dest_addr, packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader)});
+                mcast_bwd_packet_header->to_noc_unicast_write(
+                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
                 {
                     DeviceZoneScopedN("WR-BWD-WAIT");
                     fabric_connection.get_backward_connection().wait_for_empty_write_slot();
@@ -179,7 +179,7 @@ void kernel_main() {
         DeviceZoneScopedN("UNICAST-WRITE");
         auto& fabric_conn =
             unicast_is_fwd ? fabric_connection.get_forward_connection() : fabric_connection.get_backward_connection();
-        unicast_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr, packet_payload_size_bytes});
+        unicast_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
         fabric_conn.wait_for_empty_write_slot();
         fabric_conn.send_payload_without_header_non_blocking_from_address(
             source_l1_buffer_address, packet_payload_size_bytes);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -122,20 +122,18 @@ void kernel_main() {
 
         // bit of a hack to extract X/Y
         const auto dest_noc_address = get_noc_addr(p, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
-        const size_t packet_size = page_size + sizeof(tt::fabric::PacketHeader);
+        const size_t packet_size = page_size;
         auto packet_addr = get_read_ptr(cb_id_in0);
         auto& packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(packet_addr);
         if constexpr (mcast_mode) {
             packet_header
                 .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
-                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                    dest_noc_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
-            packet_header.reserved2 = 0x1111;  // debug only
+                .to_noc_unicast_write(
+                    tt::fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         } else {
             packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
-                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                    dest_noc_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
-            packet_header.reserved2 = 0x1111;  // debug only
+                .to_noc_unicast_write(
+                    tt::fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         }
 
         sender.send_payload_blocking_from_address(packet_addr, packet_size);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
@@ -59,12 +59,10 @@ auto forward_to_fabric_from_cb(
     if constexpr (mcast_mode) {
         packet_header
             .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_address}, (pages_to_send * page_size));
     } else {
         packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_address}, (pages_to_send * page_size));
     }
 
     uint64_t buffer_address = sender.edm_buffer_addr + (*sender.buffer_index_ptr * (sender.buffer_size_bytes + sizeof(eth_channel_sync_t)));

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
@@ -33,8 +33,9 @@ bool terminate_fabric_endpoints_farthest_to_nearest (
             reinterpret_cast<volatile uint32_t*>(a_packet_header_addr)[sizeof(tt::fabric::PacketHeader) >> 2] = tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE;
             sender.wait_for_empty_write_slot();
             packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{static_cast<uint8_t>(distance)})
-                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                    termination_sig_noc_addr, sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t)});
+                .to_noc_unicast_write(
+                    tt::fabric::NocUnicastCommandHeader{termination_sig_noc_addr},
+                    sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t));
             sender.send_payload_blocking_from_address(a_packet_header_addr, packet_header.get_payload_size_including_header());
             noc_async_writes_flushed();
         }

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -464,6 +464,17 @@ def test_all_gather(
             None,
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
+        (
+            4,
+            [1, 4, 32, 1280],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
     ],
 )
 @pytest.mark.parametrize("num_links", [1])

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -469,7 +469,7 @@ def test_all_gather(
             [1, 4, 32, 1280],
             3,
             ttnn.TILE_LAYOUT,
-            (32, 128),
+            (32, 320),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
             None,
             None,

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -96,6 +96,12 @@ void eth_write_remote_reg(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
     eth_txq_reg_write(q_num, ETH_TXQ_REMOTE_REG_DATA, val);
     eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_REG);
 }
+FORCE_INLINE
+void eth_write_remote_reg_no_txq_check(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
+    eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, reg_addr);
+    eth_txq_reg_write(q_num, ETH_TXQ_REMOTE_REG_DATA, val);
+    eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_REG);
+}
 
 void check_and_context_switch() {
     uint32_t start_time = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/global_semaphore.hpp>
 #include "cpp/ttnn/global_semaphore.hpp"
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 namespace ttnn::global_semaphore {
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
@@ -33,8 +33,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     pkt_hdr->reserved2 = my_chip_id;
 #endif
 
-    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
+    pkt_hdr->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr}, payload_size_bytes);
 
     switch (current_cmd_header.dest_type) {
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: {

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_utils.hpp
@@ -118,9 +118,7 @@ void mcast_contig_pages_to_noc_address(
         pkt_hdr
             .to_chip_multicast(
                 tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(forward_direction_num_hops)})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_addr,
-                packet_send_size_bytes});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_addr}, packet_send_size_bytes);
         forward_fabric_sender.wait_for_empty_write_slot();
         forward_fabric_sender.send_payload_flush_blocking_from_address(l1_read_addr, packet_send_size_bytes);
     }
@@ -131,9 +129,7 @@ void mcast_contig_pages_to_noc_address(
         pkt_hdr
             .to_chip_multicast(
                 tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(backward_direction_num_hops)})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_addr,
-                packet_send_size_bytes});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_addr}, packet_send_size_bytes);
         backward_fabric_sender.wait_for_empty_write_slot();
         backward_fabric_sender.send_payload_non_blocking_from_address(l1_read_addr, packet_send_size_bytes);
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
@@ -19,13 +19,13 @@ enum TerminationSignal : uint32_t {
     IMMEDIATELY_TERMINATE = 2
 };
 
-
-// 2 bits
+// 3 bits
 enum NocSendType : uint8_t {
     NOC_UNICAST_WRITE = 0,
-    NOC_MULTICAST_WRITE = 1,
-    NOC_UNICAST_ATOMIC_INC = 2,
-    NOC_MULTICAST_ATOMIC_INC = 3
+    NOC_UNICAST_INLINE_WRITE = 1,
+    NOC_MULTICAST_WRITE = 2,
+    NOC_UNICAST_ATOMIC_INC = 3,
+    NOC_MULTICAST_ATOMIC_INC = 4
 };
 // How to send the payload across the cluster
 // 1 bit
@@ -33,7 +33,6 @@ enum ChipSendType : uint8_t {
     CHIP_UNICAST = 0,
     CHIP_MULTICAST = 1,
 };
-
 
 struct UnicastRoutingCommandHeader {
     uint8_t distance_in_hops;
@@ -52,11 +51,10 @@ static_assert(sizeof(RoutingFields) == sizeof(UnicastRoutingCommandHeader), "Rou
 
 struct NocUnicastCommandHeader {
     uint64_t noc_address;
-    uint32_t size;
-    // ignores header size
-    inline uint32_t get_payload_only_size() const {
-        return size;
-    }
+};
+struct NocUnicastInlineWriteCommandHeader {
+    uint64_t noc_address;
+    uint32_t value;
 };
 struct NocUnicastAtomicIncCommandHeader {
     NocUnicastAtomicIncCommandHeader(uint64_t noc_address, uint16_t val, uint16_t wrap)
@@ -68,16 +66,10 @@ struct NocUnicastAtomicIncCommandHeader {
 };
 struct NocMulticastCommandHeader {
     uint32_t address;
-    uint32_t size;
     uint8_t noc_x_start;
     uint8_t noc_y_start;
     uint8_t mcast_rect_size_x;
     uint8_t mcast_rect_size_y;
-
-    // ignores header size
-    inline uint32_t get_payload_only_size() const {
-        return size;
-    }
 };
 struct NocMulticastAtomicIncCommandHeader {
     uint32_t address;
@@ -88,12 +80,14 @@ struct NocMulticastAtomicIncCommandHeader {
     uint8_t size_x;
     uint8_t size_y;
 };
-static_assert(sizeof(NocUnicastCommandHeader) == 16, "NocUnicastCommandHeader size is not 1 byte");
-static_assert(sizeof(NocMulticastCommandHeader) == 12, "NocMulticastCommandHeader size is not 1 byte");
+static_assert(sizeof(NocUnicastCommandHeader) == 8, "NocUnicastCommandHeader size is not 1 byte");
+static_assert(sizeof(NocMulticastCommandHeader) == 8, "NocMulticastCommandHeader size is not 1 byte");
+static_assert(sizeof(NocUnicastInlineWriteCommandHeader) == 16, "NocMulticastCommandHeader size is not 1 byte");
 static_assert(sizeof(NocUnicastAtomicIncCommandHeader) == 16, "NocUnicastCommandHeader size is not 1 byte");
 static_assert(sizeof(NocMulticastAtomicIncCommandHeader) == 12, "NocAtomicIncCommandHeader size is not 1 byte");
 union NocCommandFields{
     NocUnicastCommandHeader unicast_write;
+    NocUnicastInlineWriteCommandHeader unicast_inline_write;
     NocMulticastCommandHeader mcast_write;
     NocUnicastAtomicIncCommandHeader unicast_seminc;
     NocMulticastAtomicIncCommandHeader mcast_seminc;
@@ -106,16 +100,16 @@ struct PacketHeader {
     //   -> unicast_write, mcast_write, unicast_seminc, mcast_seminc
     // For now, kept it separate so I could do reads which would be handled differently
     // but for our purposes we shouldn't need read so we should be able to omit the support
-    NocSendType noc_send_type : 2;
+    NocSendType noc_send_type : 3;
     ChipSendType chip_send_type : 1;
-    uint8_t reserved : 1;
+
     // Used only by the EDM sender and receiver channels. Populated by EDM sender channel to
     // indicate to the receiver channel what channel was the source of this packet. Reserved
     // otherwise.
     uint8_t src_ch_id : 4;
 
     RoutingFields routing_fields;
-    uint16_t reserved2; // can be tagged with src device for debug
+    uint16_t payload_size_bytes; // excludes header size
     NocCommandFields command_fields; // size = 16B due to uint64_t alignment
 
     // Sort of hack to work-around DRAM read alignment issues that must be 32B aligned
@@ -134,23 +128,9 @@ struct PacketHeader {
     inline void set_routing_fields(RoutingFields &fields) { this->routing_fields = fields; }
     inline void set_command_fields(NocCommandFields &fields) { this->command_fields = fields; }
 
+    // Returns size of payload in bytes - TODO: convert to words (4B)
     size_t get_payload_size_excluding_header() volatile const {
-        switch(this->noc_send_type) {
-            case NOC_UNICAST_WRITE: {
-                return this->command_fields.unicast_write.size - sizeof(PacketHeader);
-            } break;
-            case NOC_MULTICAST_WRITE: {
-                return this->command_fields.mcast_write.size - sizeof(PacketHeader);
-            } break;
-            case NOC_UNICAST_ATOMIC_INC:
-            case NOC_MULTICAST_ATOMIC_INC:
-                return 0;
-            default:
-            #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-                ASSERT(false);
-            #endif
-                return 0;
-        };
+        return this->payload_size_bytes;
     }
     inline size_t get_payload_size_including_header() volatile const {
         return get_payload_size_excluding_header() + sizeof(PacketHeader);
@@ -167,26 +147,36 @@ struct PacketHeader {
         return *this;
     }
 
-    inline PacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header) {
+    inline PacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) {
         this->noc_send_type = NOC_UNICAST_WRITE;
         this->command_fields.unicast_write = noc_unicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
         return *this;
     }
-    inline PacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header) {
+    inline PacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write = noc_unicast_command_header;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline PacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
         this->noc_send_type = NOC_MULTICAST_WRITE;
         this->command_fields.mcast_write = noc_multicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
         return *this;
     }
     inline PacketHeader &to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) {
         this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
         this->command_fields.unicast_seminc = noc_unicast_atomic_inc_command_header;
+        this->payload_size_bytes = 0;
         return *this;
     }
-    inline PacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header) {
+    inline PacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
         #if defined(KERNEL_BUILD) || defined(FW_BUILD)
         ASSERT(false);
         while (1) {};
         #endif
+        this->payload_size_bytes = payload_size_bytes;
         return *this;
     }
 
@@ -201,20 +191,27 @@ struct PacketHeader {
         this->routing_fields.chip_mcast.start_distance_in_hops = chip_multicast_command_header.start_distance_in_hops;
         return this;
     }
-    inline volatile PacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header) volatile {
+    inline volatile PacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) volatile {
         this->noc_send_type = NOC_UNICAST_WRITE;
         this->command_fields.unicast_write.noc_address = noc_unicast_command_header.noc_address;
-        this->command_fields.unicast_write.size = noc_unicast_command_header.size;
+        this->payload_size_bytes = payload_size_bytes;
 
         return this;
     }
-    inline volatile PacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header) volatile {
+    inline volatile PacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) volatile {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write.noc_address = noc_unicast_command_header.noc_address;
+        this->command_fields.unicast_inline_write.value = noc_unicast_command_header.value;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline volatile PacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) volatile {
         this->noc_send_type = NOC_MULTICAST_WRITE;
         this->command_fields.mcast_write.mcast_rect_size_x = noc_multicast_command_header.mcast_rect_size_x;
         this->command_fields.mcast_write.mcast_rect_size_y = noc_multicast_command_header.mcast_rect_size_y;
         this->command_fields.mcast_write.noc_x_start = noc_multicast_command_header.noc_x_start;
         this->command_fields.mcast_write.noc_y_start = noc_multicast_command_header.noc_y_start;
-        this->command_fields.mcast_write.size = noc_multicast_command_header.size;
+        this->payload_size_bytes = payload_size_bytes;
         this->command_fields.mcast_write.address = noc_multicast_command_header.address;
 
         return this;
@@ -225,11 +222,12 @@ struct PacketHeader {
         this->command_fields.unicast_seminc.noc_address = noc_unicast_atomic_inc_command_header.noc_address;
         this->command_fields.unicast_seminc.val = noc_unicast_atomic_inc_command_header.val;
         this->command_fields.unicast_seminc.wrap = noc_unicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = 0;
 
         return this;
     }
     inline volatile PacketHeader *to_noc_multicast_atomic_inc(
-        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header) volatile {
+        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) volatile {
         this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
         this->command_fields.mcast_seminc.address = noc_multicast_atomic_inc_command_header.address;
         this->command_fields.mcast_seminc.noc_x_start = noc_multicast_atomic_inc_command_header.noc_x_start;
@@ -238,6 +236,7 @@ struct PacketHeader {
         this->command_fields.mcast_seminc.size_y = noc_multicast_atomic_inc_command_header.size_y;
         this->command_fields.mcast_seminc.val = noc_multicast_atomic_inc_command_header.val;
         this->command_fields.mcast_seminc.wrap = noc_multicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = payload_size_bytes;
 
         return this;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -780,8 +780,6 @@ void run_receiver_channel_step(
     bool unflushed_writes = !wr_flush_ptr.is_caught_up_to(wr_sent_ptr);
     if (unflushed_writes) {
         auto receiver_buffer_index = wr_flush_ptr.get_buffer_index();
-        // Temporary patch for instability. Issue was not caught due to what appears to be a bug in CI
-        // not running all tests. Issue tracked here: https://github.com/tenstorrent/tt-metal/issues/17702
         bool next_trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
         if (next_trid_flushed) {
             local_receiver_channel.eth_clear_sender_channel_ack(receiver_buffer_index);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -20,11 +20,8 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
     const size_t payload_l1_address = l1_read_addr;
 
-    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr_forward->to_noc_unicast_write(
-        tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
-    pkt_hdr_backward->to_noc_unicast_write(
-        tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
+    pkt_hdr_forward->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr}, payload_size_bytes);
+    pkt_hdr_backward->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr}, payload_size_bytes);
 
     noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
     if (fabric_connection.has_forward_connection()) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17686

### What's changed
Several low-level optimizations in EDM fabric:

- Simplify packet size storage and access
  - promote to "top-level" of packet to remove conditionality previously needed to get size info from packet
  - NOTE: packet size now specifies PAYLOAD SIZE ONLY!!! The header size must be implicitly added by fabric.
    - net this is still fine because we had to previous subtract header size when writing out to noc.

- Migrate `eth_send_packet` calls to new version that takes size in bytes. 
  - This version avoids a number of shift operations that were present in the previously used version.
  
- Add and using new eth write remote reg (`eth_write_remote_reg_no_txq_check`) that doesn't have conditional context switch in body of function

Extra functionality: Added `NOC_UNICAST_INLINE_WRITE` eth packet command type to address a regression as a result of the above change (if the command type wasn't added)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13206241810
- [ ] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13206245905
- [ ] TG:https://github.com/tenstorrent/tt-metal/actions/runs/13206243531
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
