### PR TITLE
feat: hypot device op support

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
@@ -12,15 +12,17 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "input_shapes",
     (
+        (torch.Size([1, 1, 32, 32])),
         (torch.Size([1, 1, 64, 64])),
         (torch.Size([1, 1, 320, 384])),
         (torch.Size([1, 3, 320, 384])),
     ),
 )
 
-def test_binary_hypot_ttnn(input_shapes, device):
+def test_device_hypot_no_bcast(input_shapes, device):
+    torch.manual_seed(0)
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * (200 - 100)
-    in_data2  = torch.rand(input_shapes, dtype=torch.bfloat16) * (200 - 100)
+    in_data2 = torch.rand(input_shapes, dtype=torch.bfloat16) * (200 - 100)
 
     input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -32,3 +34,94 @@ def test_binary_hypot_ttnn(input_shapes, device):
     comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert comp_pass >= 0.9998
 
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 3, 32, 32]), torch.Size([1, 1, 1, 1])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
+    ),
+)
+
+def test_device_hypot_scalar(a_shape, b_shape, device):
+    torch.manual_seed(0)
+    in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
+    in_data2 = torch.rand(b_shape, dtype=torch.bfloat16) * (200 - 100)
+
+    input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.experimental.hypot(input_tensor_a, input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.hypot)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert comp_pass >= 0.9998
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([2, 3, 1, 4]), torch.Size([2, 3, 5, 4])), #ROW_A
+        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 1, 4])), #ROW_B
+    ),
+)
+
+def test_device_hypot_bcast_row(a_shape, b_shape, device):
+    torch.manual_seed(0)
+    in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
+    in_data2 = torch.rand(b_shape, dtype=torch.bfloat16) * (200 - 100)
+
+    input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.experimental.hypot(input_tensor_a, input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.hypot)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert comp_pass >= 0.9998
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([2, 3, 5, 1]), torch.Size([2, 3, 5, 4])), #COL_A
+        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 5, 1])), #COL_B
+    ),
+)
+
+def test_device_hypot_bcast_col(a_shape, b_shape, device):
+    torch.manual_seed(0)
+    in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
+    in_data2 = torch.rand(b_shape, dtype=torch.bfloat16) * (200 - 100)
+
+    input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.experimental.hypot(input_tensor_a, input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.hypot)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert comp_pass >= 0.9998
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([1, 1, 31, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 2, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([2, 3, 128, 1])),
+    ),
+)
+
+def test_device_hypot_invalid_bcast(a_shape, b_shape, device):
+    torch.manual_seed(0)
+    in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
+    in_data2 = torch.rand(b_shape, dtype=torch.bfloat16) * (200 - 100)
+
+    input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    with pytest.raises(RuntimeError) as e:
+        output_tensor = ttnn.experimental.hypot(input_tensor_a, input_tensor_b)
+        assert "Broadcasting rule violation" in str(e.value)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -140,25 +140,22 @@ def test_device_hypot_invalid_bcast(a_shape, b_shape, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    ([ttnn.float32]),
-)
-def test_device_hypot_sfpu_no_bcast(input_shapes, dtype, device):
+
+def test_device_hypot_sfpu_no_bcast(input_shapes, device):
     torch.manual_seed(0)
-    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(input_shapes)
-    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(input_shapes)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(input_shapes)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(input_shapes)
 
     a_tt = ttnn.from_torch(
         a_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     b_tt = ttnn.from_torch(
         b_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -183,25 +180,22 @@ def test_device_hypot_sfpu_no_bcast(input_shapes, dtype, device):
         (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    ([ttnn.float32]),
-)
-def test_device_hypot_sfpu_scalar(a_shape, b_shape, dtype, device):
+
+def test_device_hypot_sfpu_scalar(a_shape, b_shape, device):
     torch.manual_seed(0)
-    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
-    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(b_shape)
 
     a_tt = ttnn.from_torch(
         a_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     b_tt = ttnn.from_torch(
         b_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -224,25 +218,22 @@ def test_device_hypot_sfpu_scalar(a_shape, b_shape, dtype, device):
         (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 1, 4])),  # ROW_B
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    ([ttnn.float32]),
-)
-def test_device_hypot_sfpu_bcast_row(a_shape, b_shape, dtype, device):
+
+def test_device_hypot_sfpu_bcast_row(a_shape, b_shape, device):
     torch.manual_seed(0)
-    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
-    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(b_shape)
 
     a_tt = ttnn.from_torch(
         a_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     b_tt = ttnn.from_torch(
         b_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -265,25 +256,22 @@ def test_device_hypot_sfpu_bcast_row(a_shape, b_shape, dtype, device):
         (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 5, 1])),  # COL_B
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    ([ttnn.float32]),
-)
-def test_device_hypot_sfpu_bcast_col(a_shape, b_shape, dtype, device):
+
+def test_device_hypot_sfpu_bcast_col(a_shape, b_shape, device):
     torch.manual_seed(0)
-    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
-    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(b_shape)
 
     a_tt = ttnn.from_torch(
         a_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     b_tt = ttnn.from_torch(
         b_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -307,25 +295,22 @@ def test_device_hypot_sfpu_bcast_col(a_shape, b_shape, dtype, device):
         (torch.Size([5, 1, 1, 64]), torch.Size([2, 3, 128, 1])),
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    ([ttnn.float32]),
-)
-def test_device_hypot_sfpu_invalid_bcast(a_shape, b_shape, dtype, device):
+
+def test_device_hypot_sfpu_invalid_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
-    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
-    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), ttnn.float32)(b_shape)
 
     a_tt = ttnn.from_torch(
         a_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     b_tt = ttnn.from_torch(
         b_pt,
-        dtype=dtype,
+        dtype=ttnn.float32,
         device=device,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
@@ -6,8 +6,12 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range
+from models.utility_functions import torch_random
+from functools import partial
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
 
 @pytest.mark.parametrize(
     "input_shapes",
@@ -18,7 +22,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-
 def test_device_hypot_no_bcast(input_shapes, device):
     torch.manual_seed(0)
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * (200 - 100)
@@ -34,6 +37,7 @@ def test_device_hypot_no_bcast(input_shapes, device):
     comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert comp_pass >= 0.9998
 
+
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     (
@@ -43,7 +47,6 @@ def test_device_hypot_no_bcast(input_shapes, device):
         (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
     ),
 )
-
 def test_device_hypot_scalar(a_shape, b_shape, device):
     torch.manual_seed(0)
     in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
@@ -59,14 +62,14 @@ def test_device_hypot_scalar(a_shape, b_shape, device):
     comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert comp_pass >= 0.9998
 
+
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     (
-        (torch.Size([2, 3, 1, 4]), torch.Size([2, 3, 5, 4])), #ROW_A
-        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 1, 4])), #ROW_B
+        (torch.Size([2, 3, 1, 4]), torch.Size([2, 3, 5, 4])),  # ROW_A
+        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 1, 4])),  # ROW_B
     ),
 )
-
 def test_device_hypot_bcast_row(a_shape, b_shape, device):
     torch.manual_seed(0)
     in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
@@ -82,14 +85,14 @@ def test_device_hypot_bcast_row(a_shape, b_shape, device):
     comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert comp_pass >= 0.9998
 
+
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     (
-        (torch.Size([2, 3, 5, 1]), torch.Size([2, 3, 5, 4])), #COL_A
-        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 5, 1])), #COL_B
+        (torch.Size([2, 3, 5, 1]), torch.Size([2, 3, 5, 4])),  # COL_A
+        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 5, 1])),  # COL_B
     ),
 )
-
 def test_device_hypot_bcast_col(a_shape, b_shape, device):
     torch.manual_seed(0)
     in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
@@ -105,6 +108,7 @@ def test_device_hypot_bcast_col(a_shape, b_shape, device):
     comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert comp_pass >= 0.9998
 
+
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     (
@@ -113,7 +117,6 @@ def test_device_hypot_bcast_col(a_shape, b_shape, device):
         (torch.Size([5, 1, 1, 64]), torch.Size([2, 3, 128, 1])),
     ),
 )
-
 def test_device_hypot_invalid_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
     in_data1 = torch.rand(a_shape, dtype=torch.bfloat16) * (200 - 100)
@@ -125,3 +128,229 @@ def test_device_hypot_invalid_bcast(a_shape, b_shape, device):
     with pytest.raises(RuntimeError) as e:
         output_tensor = ttnn.experimental.hypot(input_tensor_a, input_tensor_b)
         assert "Broadcasting rule violation" in str(e.value)
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 64, 64])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.float32]),
+)
+def test_device_hypot_sfpu_no_bcast(input_shapes, dtype, device):
+    torch.manual_seed(0)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(input_shapes)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(input_shapes)
+
+    a_tt = ttnn.from_torch(
+        a_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    b_tt = ttnn.from_torch(
+        b_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    out_tt = ttnn.experimental.hypot(a_tt, b_tt, queue_id=cq_id)
+    tt_out = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.hypot)
+    out_pt = golden_fn(a_pt, b_pt)
+    status = ttnn.pearson_correlation_coefficient(out_pt, tt_out)
+    assert status >= 0.9998
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 3, 32, 32]), torch.Size([1, 1, 1, 1])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.float32]),
+)
+def test_device_hypot_sfpu_scalar(a_shape, b_shape, dtype, device):
+    torch.manual_seed(0)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+
+    a_tt = ttnn.from_torch(
+        a_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    b_tt = ttnn.from_torch(
+        b_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    out_tt = ttnn.experimental.hypot(a_tt, b_tt, queue_id=cq_id)
+    tt_out = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.hypot)
+    out_pt = golden_fn(a_pt, b_pt)
+    status = ttnn.pearson_correlation_coefficient(out_pt, tt_out)
+    assert status >= 0.9998
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([2, 3, 1, 4]), torch.Size([2, 3, 5, 4])),  # ROW_A
+        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 1, 4])),  # ROW_B
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.float32]),
+)
+def test_device_hypot_sfpu_bcast_row(a_shape, b_shape, dtype, device):
+    torch.manual_seed(0)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+
+    a_tt = ttnn.from_torch(
+        a_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    b_tt = ttnn.from_torch(
+        b_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    out_tt = ttnn.experimental.hypot(a_tt, b_tt, queue_id=cq_id)
+    tt_out = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.hypot)
+    out_pt = golden_fn(a_pt, b_pt)
+    status = ttnn.pearson_correlation_coefficient(out_pt, tt_out)
+    assert status >= 0.9998
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([2, 3, 5, 1]), torch.Size([2, 3, 5, 4])),  # COL_A
+        (torch.Size([2, 3, 5, 4]), torch.Size([2, 3, 5, 1])),  # COL_B
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.float32]),
+)
+def test_device_hypot_sfpu_bcast_col(a_shape, b_shape, dtype, device):
+    torch.manual_seed(0)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+
+    a_tt = ttnn.from_torch(
+        a_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    b_tt = ttnn.from_torch(
+        b_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    out_tt = ttnn.experimental.hypot(a_tt, b_tt, queue_id=cq_id)
+    tt_out = ttnn.to_torch(out_tt)
+
+    golden_fn = ttnn.get_golden_function(ttnn.hypot)
+    out_pt = golden_fn(a_pt, b_pt)
+    status = ttnn.pearson_correlation_coefficient(out_pt, tt_out)
+    assert status >= 0.9998
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "a_shape, b_shape",
+    (
+        (torch.Size([1, 1, 31, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 2, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([2, 3, 128, 1])),
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    ([ttnn.float32]),
+)
+def test_device_hypot_sfpu_invalid_bcast(a_shape, b_shape, dtype, device):
+    torch.manual_seed(0)
+    a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(a_shape)
+    b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype)(b_shape)
+
+    a_tt = ttnn.from_torch(
+        a_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    b_tt = ttnn.from_torch(
+        b_pt,
+        dtype=dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    cq_id = 0
+    with pytest.raises(RuntimeError) as e:
+        output_tensor = ttnn.experimental.hypot(a_tt, b_tt, queue_id=cq_id)
+        assert "Broadcasting rule violation" in str(e.value)
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.hypot,
+    ],
+)
+def test_hypot_fp32(device, ttnn_function):
+    x_torch = torch.tensor([[2.3454653]], dtype=torch.float32)
+    y_torch = torch.tensor([[5.00030171126]], dtype=torch.float32)
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    z_torch = golden_fn(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_out = ttnn.experimental.hypot(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt_out)
+    status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
+    assert status

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hypot.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 64, 64])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+
+def test_binary_hypot_ttnn(input_shapes, device):
+    in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * (200 - 100)
+    in_data2  = torch.rand(input_shapes, dtype=torch.bfloat16) * (200 - 100)
+
+    input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.experimental.hypot(input_tensor_a, input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.hypot)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert comp_pass >= 0.9998
+

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -375,6 +375,9 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/binary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
@@ -199,7 +199,7 @@ void bind_hypot(
                const Tensor& input_tensor_b,
                const std::optional<Tensor>& output_tensor,
                const std::optional<MemoryConfig>& memory_config,
-               const uint8_t& queue_id) {
+               QueueId queue_id) -> ttnn::Tensor {
                 return self(queue_id, input_tensor_a, input_tensor_b, memory_config, output_tensor);
             },
             py::arg("input_tensor_a"),
@@ -207,89 +207,7 @@ void bind_hypot(
             py::kw_only(),
             py::arg("output_tensor") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = 0});
-}
-
-template <typename T>
-void bind_hypot(
-    py::module& module,
-    const T& operation,
-    const std::string& description,
-    const std::string& math,
-    const std::string& supported_dtype = "BFLOAT16",
-    const std::string& supported_rank = "2, 3, 4",
-    const std::string& example_tensor1 =
-        "ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)",
-    const std::string& example_tensor2 =
-        "ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)",
-    const std::string& note = "") {
-    auto doc = fmt::format(
-        R"doc(
-        {2}
-
-        .. math::
-            {3}
-
-        Args:
-            input_tensor_a (ttnn.Tensor): the input tensor.
-            input_tensor_b (ttnn.Tensor): the input tensor.
-
-        Keyword args:
-            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
-
-        Returns:
-            ttnn.Tensor: the output tensor.
-
-        Note:
-            Supported dtypes, layouts, and ranks:
-
-            .. list-table::
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-                 - Ranks
-               * - {4}
-                 - TILE
-                 - {5}
-
-            {8}
-
-        Example:
-            >>> tensor1 = {6}
-            >>> tensor2 = {7}
-            >>> output = {1}(tensor1, tensor2)
-        )doc",
-
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        description,
-        math,
-        supported_dtype,
-        supported_rank,
-        example_tensor1,
-        example_tensor2,
-        note);
-
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const T& self,
-               const Tensor& input_tensor_a,
-               const Tensor& input_tensor_b,
-               const std::optional<Tensor>& output_tensor,
-               const std::optional<MemoryConfig>& memory_config,
-               const uint8_t& queue_id) {
-                return self(queue_id, input_tensor_a, input_tensor_b, memory_config, output_tensor);
-            },
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::kw_only(),
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("queue_id") = 0});
+            py::arg("queue_id") = DefaultQueueId});
 }
 
 template <typename T>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
@@ -211,6 +211,88 @@ void bind_hypot(
 }
 
 template <typename T>
+void bind_hypot(
+    py::module& module,
+    const T& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& supported_rank = "2, 3, 4",
+    const std::string& example_tensor1 =
+        "ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)",
+    const std::string& example_tensor2 =
+        "ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {4}
+                 - TILE
+                 - {5}
+
+            {8}
+
+        Example:
+            >>> tensor1 = {6}
+            >>> tensor2 = {7}
+            >>> output = {1}(tensor1, tensor2)
+        )doc",
+
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        math,
+        supported_dtype,
+        supported_rank,
+        example_tensor1,
+        example_tensor2,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const T& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               const std::optional<Tensor>& output_tensor,
+               const std::optional<MemoryConfig>& memory_config,
+               const uint8_t& queue_id) {
+                return self(queue_id, input_tensor_a, input_tensor_b, memory_config, output_tensor);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+template <typename T>
 void bind_inplace_binary_ng_operation(py::module& module, T op, const std::string& docstring) {
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
@@ -6,6 +6,7 @@
 
 #include "pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/binary_ng/binary_ng.hpp"
+#include "ttnn/operations/eltwise/binary_ng/hypot/hypot.hpp"
 
 namespace ttnn::operations::binary_ng {
 namespace detail {
@@ -128,6 +129,88 @@ void bind_binary_ng_bitwise_ops(py::module& module, T op, const std::string& doc
 }
 
 template <typename T>
+void bind_hypot(
+    py::module& module,
+    const T& operation,
+    const std::string& description,
+    const std::string& math,
+    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& supported_rank = "2, 3, 4",
+    const std::string& example_tensor1 =
+        "ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)",
+    const std::string& example_tensor2 =
+        "ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)",
+    const std::string& note = "") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        .. math::
+            {3}
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the input tensor.
+            input_tensor_b (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {4}
+                 - TILE
+                 - {5}
+
+            {8}
+
+        Example:
+            >>> tensor1 = {6}
+            >>> tensor2 = {7}
+            >>> output = {1}(tensor1, tensor2)
+        )doc",
+
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        math,
+        supported_dtype,
+        supported_rank,
+        example_tensor1,
+        example_tensor2,
+        note);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const T& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               const std::optional<Tensor>& output_tensor,
+               const std::optional<MemoryConfig>& memory_config,
+               const uint8_t& queue_id) {
+                return self(queue_id, input_tensor_a, input_tensor_b, memory_config, output_tensor);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+template <typename T>
 void bind_inplace_binary_ng_operation(py::module& module, T op, const std::string& docstring) {
     bind_registered_operation(
         module,
@@ -235,5 +318,11 @@ void py_module(py::module& module) {
         module, ttnn::experimental::logaddexp_, "Binary Logaddexp In-place Operation");
     detail::bind_inplace_binary_ng_operation(
         module, ttnn::experimental::logaddexp2_, "Binary Logaddexp2 In-place Operation");
+    detail::bind_hypot(
+        module,
+        ttnn::experimental::hypot,
+        R"doc(Computes hypot :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
+        R"doc(\mathrm{output\_tensor}_i = \sqrt{(\mathrm{input\_tensor\_a}_i^2 + \mathrm{input\_tensor\_b}_i^2)})doc",
+        R"doc(BFLOAT16)doc");
 }
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -30,9 +30,9 @@ CoreRangeSet get_worker_grid(
 
 void validate_sharding(
     TensorMemoryLayout memory_layout_x,
-    const ShardSpec& shard_spec_x,
+    const tt::tt_metal::ShardSpec& shard_spec_x,
     TensorMemoryLayout memory_layout_y,
-    const ShardSpec& shard_spec_y,
+    const tt::tt_metal::ShardSpec& shard_spec_y,
     SubtileBroadcastType subtile_broadcast_type);
 
 struct BinaryNgDeviceOperation {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.cpp
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hypot_device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::binary_ng {
+
+namespace utils {
+bool is_binary_sfpu_op(DataType a, DataType b) {
+    using enum DataType;
+    return (a == FLOAT32 && b == FLOAT32);
+}
+}  // namespace utils
+
+tt::stl::hash::hash_t HypotNgDeviceOperation::operation_attributes_t::to_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        memory_config,
+        get_dtype(),
+        compute_kernel_config,
+        subtile_broadcast_type,
+        is_sfpu);
+}
+
+DataType HypotNgDeviceOperation::operation_attributes_t::get_dtype() const { return this->input_dtype; }
+
+void HypotNgDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    // We don't support sharding for now
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    TT_FATAL(
+        input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
+
+    HypotNgDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
+
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "First operand to eltwise binary must be tilized");
+
+    bool tensor_a_sharded = input_tensor_a.memory_config().is_sharded();
+    if (not tensor_a_sharded) {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "LHS operand must be either sharded or interleaved");
+    }
+
+    bool output_sharded = attributes.memory_config.is_sharded();
+    if (not output_sharded) {
+        TT_FATAL(
+            attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Output must be interleaved or sharded");
+    }
+
+    bool tensor_b_sharded = false;
+
+    if (input_tensor_b.has_value()) {
+        tensor_b_sharded = input_tensor_b->memory_config().is_sharded();
+        TT_FATAL(
+            input_tensor_a.device() == input_tensor_b->device(),
+            "Operands to eltwise binary need to be on the same device!");
+        TT_FATAL(input_tensor_b->get_layout() == Layout::TILE, "Second operand to eltwise binary must be tilized");
+
+        if (not tensor_b_sharded) {
+            TT_FATAL(
+                input_tensor_b->memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+                "RHS operand must be either sharded or interleaved");
+        }
+    }
+
+    // Validate that all shard specs match
+    if (tensor_a_sharded) {
+        if (tensor_b_sharded) {
+            validate_sharding(
+                input_tensor_a.memory_config().memory_layout,
+                *input_tensor_a.shard_spec(),
+                input_tensor_b->memory_config().memory_layout,
+                *input_tensor_b->shard_spec(),
+                attributes.subtile_broadcast_type);
+        }
+        if (output_sharded) {
+            validate_sharding(
+                input_tensor_a.memory_config().memory_layout,
+                *input_tensor_a.shard_spec(),
+                attributes.memory_config.memory_layout,
+                *attributes.memory_config.shard_spec,
+                attributes.subtile_broadcast_type);
+        }
+    } else if (tensor_b_sharded and output_sharded) {
+        validate_sharding(
+            input_tensor_b->memory_config().memory_layout,
+            *input_tensor_b->shard_spec(),
+            attributes.memory_config.memory_layout,
+            *attributes.memory_config.shard_spec,
+            attributes.subtile_broadcast_type);
+    }
+}
+
+void HypotNgDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    bool has_shard_spec = input_tensor_a.memory_config().is_sharded() ||
+                          (input_tensor_b.has_value() && input_tensor_b->memory_config().is_sharded()) ||
+                          attributes.memory_config.is_sharded();
+
+    if (output_tensor.has_value() && !has_shard_spec) {
+        compute_output_specs(attributes, tensor_args);
+    }
+
+    const auto& input_shape_a = input_tensor_a.get_logical_shape();
+    const auto input_shape_b = input_tensor_b.has_value() ? input_tensor_b->get_logical_shape() : ttnn::Shape{1, 1};
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+    for (int i = -1; i >= -larger_rank; --i) {
+        auto a_dim = (i >= -rank_a) ? input_shape_a[i] : 1;
+        auto b_dim = (i >= -rank_b) ? input_shape_b[i] : 1;
+        TT_FATAL(
+            a_dim == b_dim || a_dim == 1 || b_dim == 1,
+            "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
+            i,
+            a_dim,
+            b_dim);
+
+        if (has_shard_spec and i != -1) {
+            TT_FATAL(
+                a_dim == b_dim,
+                "Cannot broadcast sharded tensors on dims other than W, violation for rank {}, dim a: {}, dim b: {}",
+                i,
+                a_dim,
+                b_dim);
+        }
+    }
+}
+
+HypotNgDeviceOperation::spec_return_value_t HypotNgDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto input_shape_a = input_tensor_a.logical_shape();
+    const auto& tensor_b = tensor_args.input_tensor_b;
+    const auto input_shape_b = tensor_b.has_value() ? tensor_b->logical_shape() : ttnn::Shape{};
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+
+    // Broadcasting Rules Overview:
+    // - If the two tensors have different ranks, we virtually pad the smaller-rank tensor's shape
+    //   with ones on the left (i.e., higher-order dimensions) until both shapes have the same length.
+    // - For each dimension (starting from the rightmost), the sizes are compatible if:
+    //     - They are equal, or
+    //     - One of them is 1 (the dimension can be broadcast to match the other size).
+    auto compute_broadcasted_output = [rank_a, rank_b, larger_rank](const auto& shape_a, const auto& shape_b) {
+        SmallVector<uint32_t> output_shape(larger_rank, 1);
+        for (int i = -1; i >= -larger_rank; --i) {
+            auto dim_a = (i >= -rank_a) ? shape_a[i] : 1;
+            auto dim_b = (i >= -rank_b) ? shape_b[i] : 1;
+            if (dim_a != 1 && dim_b != 1) {
+                output_shape[i + larger_rank] = dim_a;
+            } else {
+                output_shape[i + larger_rank] = dim_a + dim_b - 1;
+            }
+        }
+        return ttnn::Shape(output_shape);
+    };
+
+    auto output_shape = compute_broadcasted_output(input_shape_a, input_shape_b);
+
+    if (output_tensor.has_value()) {
+        auto shape = output_tensor.value().logical_shape();
+        TT_FATAL(
+            shape == output_shape,
+            "Shape of Output tensor {} provided does not match the broadcasted output shape {}",
+            shape,
+            output_shape);
+        return output_tensor->get_tensor_spec();
+    }
+
+    if (attributes.memory_config.is_sharded()) {
+        return TensorSpec(
+            output_shape, TensorLayout(attributes.get_dtype(), PageConfig(Layout::TILE), attributes.memory_config));
+    }
+
+    return TensorSpec(
+        output_shape, TensorLayout(attributes.get_dtype(), PageConfig(Layout::TILE), attributes.memory_config));
+}
+
+HypotNgDeviceOperation::program_factory_t HypotNgDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return HypotProgramFactory{};
+}
+
+HypotNgDeviceOperation::tensor_return_value_t HypotNgDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    if (output_tensor.has_value()) {
+        return output_tensor.value();
+    }
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+}
+
+tt::stl::hash::hash_t HypotNgDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    TT_ASSERT(
+        std::holds_alternative<DeviceStorage>(input_tensor_a.get_storage()),
+        "Unexpected type {}",
+        tt::stl::get_active_type_name_in_variant(input_tensor_a.get_storage()));
+
+    if (input_tensor_b.has_value()) {
+        TT_ASSERT(
+            std::holds_alternative<DeviceStorage>(input_tensor_b->get_storage()),
+            "Unexpected type {}",
+            tt::stl::get_active_type_name_in_variant(input_tensor_b->get_storage()));
+
+        return operation::hash_operation<HypotNgDeviceOperation>(
+            attributes,
+            input_tensor_a.dtype(),
+            std::get<DeviceStorage>(input_tensor_a.storage()).memory_config(),
+            input_tensor_b->dtype(),
+            std::get<DeviceStorage>(input_tensor_b->storage()).memory_config());
+    }
+
+    return operation::hash_operation<HypotNgDeviceOperation>(
+        attributes, input_tensor_a.dtype(), std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
+}
+
+bool HypotNgDeviceOperation::skip_launch(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
+std::tuple<HypotNgDeviceOperation::operation_attributes_t, HypotNgDeviceOperation::tensor_args_t>
+HypotNgDeviceOperation::invoke(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> output_tensor) {
+    auto subtile_broadcast_type = get_subtile_broadcast_type(
+        input_tensor_a.get_logical_shape()[-2],
+        input_tensor_a.get_logical_shape()[-1],
+        input_tensor_b.get_logical_shape()[-2],
+        input_tensor_b.get_logical_shape()[-1]);
+
+    DataType dtype1 = input_tensor_a.get_dtype();
+    DataType dtype2 = input_tensor_a.get_dtype();
+    bool device_check = input_tensor_a.device()->arch() != tt::ARCH::GRAYSKULL;
+    bool is_sfpu_op = (utils::is_binary_sfpu_op(dtype1, dtype2) && device_check);
+    return {
+        operation_attributes_t{
+            std::nullopt,
+            memory_config.value_or(output_tensor.has_value() ? output_tensor->memory_config() : MemoryConfig{}),
+            input_tensor_a.get_dtype(),
+            get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor),
+            std::nullopt,
+            subtile_broadcast_type,
+            is_sfpu_op},
+        tensor_args_t{input_tensor_a, input_tensor_b, std::move(output_tensor)}};
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.hpp
@@ -9,50 +9,22 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/eltwise/binary_ng/types.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp"
+
 namespace ttnn::operations::binary_ng {
 
-enum class SubtileBroadcastType {
-    NONE,         // both tensors have equal tile dimensions (H & W)
-    SCALAR_A,     // a is a scalar (H = 1, W = 1)
-    SCALAR_B,     // b is a scalar (H = 1, W = 1)
-    ROW_A_COL_B,  // a has a single tile row, b has a single tile column
-    ROW_B_COL_A,  // b has a single tile row, a has a single tile column
-    ROW_A,        // a has a single tile row, b is full
-    ROW_B,        // b has a single tile row, a is full
-    COL_A,        // a has a single tile column, b is full
-    COL_B,        // b has a single tile column, a is full
-};
-
-SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w);
-
-CoreRangeSet get_worker_grid(
-    const Tensor& input_tensor_a, const Tensor* input_tensor_b, const std::optional<Tensor>& output_tensor);
-
-void validate_sharding(
-    TensorMemoryLayout memory_layout_x,
-    const ShardSpec& shard_spec_x,
-    TensorMemoryLayout memory_layout_y,
-    const ShardSpec& shard_spec_y,
-    SubtileBroadcastType subtile_broadcast_type);
-
-struct BinaryNgDeviceOperation {
+struct HypotNgDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct operation_attributes_t {
-        BinaryOpType binary_op_type;
-        ttnn::SmallVector<unary::UnaryWithParam> lhs_activations;
-        ttnn::SmallVector<unary::UnaryWithParam> rhs_activations;
-        ttnn::SmallVector<unary::UnaryWithParam> post_activations;
         std::optional<float> scalar;
         tt::tt_metal::MemoryConfig memory_config;
         DataType input_dtype;
-        std::optional<DataType> dtype;
         const CoreRangeSet worker_grid;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
         SubtileBroadcastType subtile_broadcast_type = SubtileBroadcastType::NONE;
         bool is_sfpu = false;
-        bool is_quant_op = false;
 
         tt::stl::hash::hash_t to_hash() const;
         DataType get_dtype() const;
@@ -64,7 +36,7 @@ struct BinaryNgDeviceOperation {
         std::optional<Tensor> output_tensor;
     };
 
-    struct ProgramFactory {
+    struct HypotProgramFactory {
         struct shared_variables_t {
             tt::tt_metal::KernelHandle reader_kernel_id;
             tt::tt_metal::KernelHandle writer_kernel_id;
@@ -85,7 +57,7 @@ struct BinaryNgDeviceOperation {
             tensor_return_value_t& output);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    using program_factory_t = std::variant<HypotProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
@@ -99,30 +71,13 @@ struct BinaryNgDeviceOperation {
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor_a_arg,
         const Tensor& input_tensor_b_arg,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
         const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations);
-
-    // tensor-scalar invocation
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a_arg,
-        float scalar,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
-        tt::stl::Span<const unary::UnaryWithParam> post_activations);
+        std::optional<Tensor> optional_output_tensor);
 };
 
 }  // namespace ttnn::operations::binary_ng
 
 namespace ttnn::prim {
-constexpr auto binary_ng =
-    ttnn::register_operation<"ttnn::prim::binary_ng", ttnn::operations::binary_ng::BinaryNgDeviceOperation>();
+constexpr auto hypot =
+    ttnn::register_operation<"ttnn::prim::hypot", ttnn::operations::binary_ng::HypotNgDeviceOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
@@ -505,9 +505,15 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
     std::string compute_hypot_kernel_filepath;
     if(kernel_config.compute_kernel == KernelName::ComputeNoBcast){
         compute_hypot_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp";
+        if(is_sfpu_op){
+            compute_hypot_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu_no_bcast.cpp";
+        }
     }
     else if(kernel_config.compute_kernel == KernelName::ComputeBcast){
-        compute_hypot_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_bcast.cpp";
+        compute_hypot_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot.cpp";
+        if(is_sfpu_op){
+            compute_hypot_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu.cpp";
+        }
     }
     else{
        TT_THROW("Unexpected KernelName encountered in hypot compute kernel !!");
@@ -559,4 +565,3 @@ void HypotNgDeviceOperation::HypotProgramFactory::override_runtime_arguments(
 }
 
 }  // namespace ttnn::operations::binary_ng
-

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
@@ -1,0 +1,552 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/work_split.hpp>
+
+#include "hypot_device_operation.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+
+
+using namespace tt::tt_metal;
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace ttnn::operations::binary_ng;
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};
+}
+
+std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
+    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t Ht, uint32_t Wt) {
+    uint32_t start_t = start_tile_id % (Ht * Wt);
+    uint32_t start_tw = start_t % Wt;
+
+    switch (broadcast_type) {
+        case SubtileBroadcastType::NONE:
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::ROW_B: return {1, 0};
+        case SubtileBroadcastType::SCALAR_A:
+        case SubtileBroadcastType::SCALAR_B: return {Ht * Wt, start_t};
+        case SubtileBroadcastType::COL_A:
+        case SubtileBroadcastType::ROW_B_COL_A:
+        case SubtileBroadcastType::COL_B:
+        case SubtileBroadcastType::ROW_A_COL_B: return {Wt, start_tw};
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+struct AllShardSpecs {
+    ShardSpec a_shard_spec;
+    ShardSpec b_shard_spec;
+    ShardSpec c_shard_spec;
+};
+
+ShardSpec adjust_to_shape(const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+    auto ret = shard_spec;
+
+    ret.shape[0] = (ret.shape[0] * to_shape[-2]) / from_shape[-2];
+    ret.shape[1] = (ret.shape[1] * to_shape[-1]) / from_shape[-1];
+
+    return ret;
+}
+
+TensorMemoryLayout get_memory_layout(const Tensor& a, const std::optional<Tensor>& b, const Tensor& c) {
+    if (a.memory_config().is_sharded()) {
+        return a.memory_config().memory_layout;
+    }
+    if (b.has_value() && b->memory_config().is_sharded()) {
+        return b->memory_config().memory_layout;
+    }
+    if (c.memory_config().is_sharded()) {
+        return c.memory_config().memory_layout;
+    }
+    return TensorMemoryLayout::INTERLEAVED;
+}
+
+std::optional<AllShardSpecs> get_shard_specs(const Tensor& a, const std::optional<Tensor>& b, const Tensor& c) {
+    bool a_sharded = a.memory_config().is_sharded();
+    bool b_sharded = b.has_value() && b->memory_config().is_sharded();
+    bool c_sharded = c.memory_config().is_sharded();
+
+    if (!a_sharded && !b_sharded && !c_sharded) {
+        return std::nullopt;
+    }
+
+    auto a_shape = a.padded_shape();
+    auto b_shape = b.has_value() ? b->padded_shape() : ttnn::Shape{1, 1};
+    auto c_shape = c.padded_shape();
+
+    ShardSpec c_shard_spec = c_sharded   ? *c.shard_spec()
+                             : a_sharded ? adjust_to_shape(*a.shard_spec(), a_shape, c_shape)
+                                         : adjust_to_shape(*b->shard_spec(), b_shape, c_shape);
+
+    return AllShardSpecs{
+        a_sharded ? *a.shard_spec() : adjust_to_shape(c_shard_spec, c_shape, a_shape),
+        b_sharded ? *b->shard_spec() : adjust_to_shape(c_shard_spec, c_shape, b_shape),
+        c_shard_spec};
+}
+
+uint32_t get_shards_per_width(const ShardSpec& shard_spec, TensorMemoryLayout memory_layout) {
+    auto num_cores = shard_spec.grid.num_cores();
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+        return 1;
+    }
+
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        return num_cores;
+    }
+
+    const auto& bbox = shard_spec.grid.bounding_box();
+    const auto& start = bbox.start_coord;
+    const auto& end = bbox.end_coord;
+    return (shard_spec.orientation == ShardOrientation::ROW_MAJOR ? end.x - start.x : end.y - start.y) + 1;
+}
+
+class ShardShapeGenerator {
+    CoreCoord end_core;
+    bool row_major;
+    std::array<uint32_t, 2> shard_shape;
+    std::array<uint32_t, 2> last_shard_shape;
+
+public:
+    ShardShapeGenerator() = default;
+
+    ShardShapeGenerator(const ShardSpec& shard_spec, const Tensor& tensor) :
+        end_core(shard_spec.grid.ranges().begin()->end_coord),
+        row_major(shard_spec.orientation == ShardOrientation::ROW_MAJOR) {
+        auto tile_height = tensor.tensor_spec().tile().get_height();
+        auto tile_width = tensor.tensor_spec().tile().get_width();
+
+        shard_shape = {
+            tt::round_up(shard_spec.shape[0], tile_height) / tile_height,
+            tt::round_up(shard_spec.shape[1], tile_width) / tile_width};
+
+        const auto [N, C, Ht, Wt] = get_shape_dims(tensor);
+        const auto unrolled_Ht = N * C * Ht;
+        last_shard_shape = {
+            shard_shape[0] - (tt::round_up(unrolled_Ht, shard_shape[0]) - unrolled_Ht),
+            shard_shape[1] - (tt::round_up(Wt, shard_shape[1]) - Wt),
+        };
+    }
+
+    std::array<uint32_t, 2> operator()(CoreCoord core) const {
+        const unsigned majorDim = row_major ? 1 : 0;
+        const unsigned minorDim = row_major ? 0 : 1;
+
+        auto current_shape = shard_shape;
+        if (core.x == end_core.x) {
+            current_shape[majorDim] = last_shard_shape[majorDim];
+        }
+        if (core.y == end_core.y) {
+            current_shape[minorDim] = last_shard_shape[minorDim];
+        }
+
+        return current_shape;
+    }
+};
+
+template <typename F>
+void set_or_update_runtime_arguments(
+    Program& program,
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    KernelHandle compute_kernel_id,
+    const HypotNgDeviceOperation::operation_attributes_t& operation_attributes,
+    const HypotNgDeviceOperation::tensor_args_t& tensor_args,
+    HypotNgDeviceOperation::tensor_return_value_t& c,
+    F handle_args) {
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+
+    const auto [aN, aC, aHt, aWt] = get_shape_dims(a);
+    const auto [bN, bC, bHt, bWt] = b.has_value() ? get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u};
+    const auto [cN, cC, cHt, cWt] = get_shape_dims(c);
+    const uint32_t cHt_unrolled = cN * cC * cHt;
+
+    bool row_major = true;
+    const auto shard_specs = get_shard_specs(a, b, c);
+    const bool has_sharding = shard_specs.has_value();
+    auto grid = has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
+
+    // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
+    // as well as having the sharded tensors (if any) start at (0, 0)
+    // This will run the original work/core distribution algorithms that are specifically for this setup, as these
+    // are faster than the generic work/core distribution algorithms that work on arbitrary CoreRangeSets
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid;
+    const auto& all_device_cores = operation_attributes.worker_grid;
+    if (all_device_cores.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (has_sharding) {
+                const auto& shard_start_coord = grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    zero_start_grid = true;
+                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                zero_start_grid = true;
+                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+    const uint32_t num_cores_total =
+        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
+
+    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores;
+    std::vector<CoreCoord> cores;
+
+    const uint32_t tile_height = c.tensor_spec().tile().get_height();
+    const uint32_t tile_width = c.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = tile_height * tile_width;
+    const uint32_t c_num_tiles = c.volume() / tile_hw;
+    uint32_t c_shard_height, c_shard_width, num_shards_per_width;
+
+    ShardShapeGenerator a_shard_shape_generator;
+    ShardShapeGenerator b_shard_shape_generator;
+    ShardShapeGenerator c_shard_shape_generator;
+
+    if (has_sharding) {
+        core_group_1 = grid;
+        a_shard_shape_generator = ShardShapeGenerator(shard_specs->a_shard_spec, a);
+        if (b.has_value()) {
+            b_shard_shape_generator = ShardShapeGenerator(shard_specs->b_shard_spec, *b);
+        }
+        c_shard_shape_generator = ShardShapeGenerator(shard_specs->c_shard_spec, c);
+        c_shard_height = shard_specs->c_shard_spec.shape[0] / tile_height;
+        c_shard_width = shard_specs->c_shard_spec.shape[1] / tile_width;
+        num_shards_per_width = get_shards_per_width(shard_specs->c_shard_spec, get_memory_layout(a, b, c));
+
+        if (zero_start_grid) {
+            auto bbox = core_group_1.bounding_box();
+            cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                compute_with_storage_grid.x,
+                compute_with_storage_grid.y,
+                row_major);
+        } else {
+            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
+        }
+    } else if (zero_start_grid) {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid, c_num_tiles, row_major);
+        cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
+    } else {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(all_device_cores, c_num_tiles, row_major);
+        cores = corerange_to_cores(all_device_cores, {}, row_major);
+    }
+
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        const auto& core = cores[i];
+
+        uint32_t a_num_tiles = 0;
+        uint32_t b_num_tiles = 0;
+        uint32_t c_num_tiles = 0;
+        if (core_group_1.contains(core)) {
+            c_num_tiles = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            c_num_tiles = num_tiles_per_core_group_2;
+        } else {
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 11>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 12>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
+            continue;
+        }
+
+        uint32_t c_start_id = 0;
+        uint32_t c_current_shard_width = 0;
+        if (has_sharding) {
+            auto c_shard_shape = c_shard_shape_generator(core);
+            c_num_tiles = c_shard_shape[0] * c_shard_shape[1];
+            c_current_shard_width = c_shard_shape[1];
+            auto a_shard_shape = a_shard_shape_generator(core);
+            a_num_tiles = a_shard_shape[0] * a_shard_shape[1];
+            c_start_id =
+                (i / num_shards_per_width) * (c_shard_height * cWt) + (i % num_shards_per_width) * c_shard_width;
+        } else {
+            c_start_id = start_tile_id;
+        }
+
+        std::array reader_runtime_args = {
+            a.buffer()->address(),
+            c_start_id,
+            a_num_tiles,
+            c_num_tiles,
+            c_current_shard_width,
+            aHt * aWt * aC * (aN > 1),
+            aHt * aWt * (aC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt};
+        handle_args(program, reader_kernel_id, core, reader_runtime_args);
+
+        if (b.has_value()) {
+            if (has_sharding) {
+                auto b_shard_shape = b_shard_shape_generator(core);
+                b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
+            }
+            std::array writer_runtime_args = {
+                b->buffer()->address(),
+                c.buffer()->address(),
+                c_start_id,
+                b_num_tiles,
+                c_num_tiles,
+                c_current_shard_width,
+                bHt * bWt * bC * (bN > 1),
+                bHt * bWt * (bC > 1),
+                cN,
+                cC,
+                cHt,
+                cWt};
+            handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+            auto [freq, counter] =
+                calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
+            std::array compute_runtime_args = {c_num_tiles, freq, counter};
+            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+        } else {
+            const auto scalar = *operation_attributes.scalar;
+            const auto packed_scalar = a.get_dtype() == DataType::FLOAT32 ? std::bit_cast<uint32_t>(scalar)
+                                       : a.get_dtype() == DataType::INT32
+                                           ? std::bit_cast<uint32_t>(static_cast<int32_t>(scalar))
+                                           : pack_two_bfloat16_into_uint32({scalar, scalar});
+            std::array writer_runtime_args = {
+                packed_scalar,
+                c.buffer()->address(),
+                c_start_id,
+                c_num_tiles,
+                c_current_shard_width,
+                cN,
+                cC,
+                cHt,
+                cWt,
+                0u,
+                0u,
+                0u};
+            handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+            std::array compute_runtime_args = {c_num_tiles, 0u, 0u};
+            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+        }
+        start_tile_id += c_num_tiles;
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::binary_ng {
+
+// Implements c = a op b
+HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOperation::HypotProgramFactory::create(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    auto is_sfpu_op = operation_attributes.is_sfpu;
+
+    auto program = CreateProgram();
+    auto* device = a.device();
+
+    const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(a, b, c);
+    const bool has_sharding = shard_specs.has_value();
+    auto tile_hw = c.tensor_spec().tile().get_tile_hw();
+    uint32_t a_num_tiles_per_shard = has_sharding ? shard_specs->a_shard_spec.numel() / tile_hw : 0;
+    uint32_t b_num_tiles_per_shard = has_sharding ? shard_specs->b_shard_spec.numel() / tile_hw : 0;
+    uint32_t c_num_tiles_per_shard = has_sharding ? shard_specs->c_shard_spec.numel() / tile_hw : 0;
+
+    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    auto b_data_format = b.has_value() ? datatype_to_dataformat_converter(b->get_dtype())
+                         : is_sfpu_op  ? datatype_to_dataformat_converter(a.get_dtype())
+                                       : DataFormat::Float16_b;
+    auto c_data_format = datatype_to_dataformat_converter(c.get_dtype());
+
+    uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
+    uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
+    uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
+
+    // we parallelize the computation across the output tiles
+    constexpr bool row_major = true;
+    const auto& all_device_cores = operation_attributes.worker_grid;
+
+    Buffer* a_buffer = a.buffer();
+    Buffer* b_buffer = b.has_value() ? b->buffer() : nullptr;
+    Buffer* c_buffer = c.buffer();
+
+    const auto op_config = is_sfpu_op;
+    std::map<std::string, std::string> compute_kernel_defines;
+    bool a_sharded = a.memory_config().is_sharded();
+    bool b_sharded = b.has_value() && b->memory_config().is_sharded();
+    bool c_sharded = c.memory_config().is_sharded();
+
+    // How many tiles to store per input CB (double buffer)
+    auto [a_cb, a_cb_handle] = create_cb(
+        tt::CBIndex::c_0,
+        program,
+        all_device_cores,
+        a_single_tile_size,
+        a_sharded ? a_num_tiles_per_shard : 2,
+        a_data_format,
+        a_sharded ? a_buffer : nullptr);
+
+         auto a_intermediate_format =  a_data_format;
+         uint32_t a_intermediate_single_tile_size = tt_metal::detail::TileSize(a_intermediate_format);
+         auto [a_cb_interim, a_cb_interim_handle] = create_cb(
+             tt::CBIndex::c_3, program, all_device_cores, a_intermediate_single_tile_size, 1, a_intermediate_format);
+
+    // If b is a scalar, we only need one tile in the CB
+    auto [b_cb, b_cb_handle] = create_cb(
+        tt::CBIndex::c_1,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_buffer == nullptr ? 1 : (b_sharded ? b_num_tiles_per_shard : 2),
+        b_data_format,
+        b_sharded ? b_buffer : nullptr);
+
+        auto b_intermediate_format = b_data_format;
+        uint32_t b_intermediate_single_tile_size = tt_metal::detail::TileSize(b_intermediate_format);
+        auto [b_cb_interim, b_cb_interim_handle] = create_cb(
+            tt::CBIndex::c_4, program, all_device_cores, b_intermediate_single_tile_size, 1, b_intermediate_format);
+
+    auto [c_cb, c_cb_handle] = create_cb(
+        tt::CBIndex::c_2,
+        program,
+        all_device_cores,
+        c_single_tile_size,
+        c_sharded ? c_num_tiles_per_shard : 2,
+        c_data_format,
+        c_sharded ? c_buffer : nullptr);
+    uint32_t a_is_dram = a_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    uint32_t b_is_dram = false;
+    uint32_t c_is_dram = c_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+
+    auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
+    std::map<std::string, std::string> dataflow_defines;
+
+    if (is_sfpu_op && a.get_dtype() == DataType::FLOAT32) {
+        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
+        dataflow_defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
+    } else if (is_sfpu_op && a.get_dtype() == DataType::INT32) {
+        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<int32_t>";
+        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val<1024, int32_t>";
+    } else {
+        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfloat16";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfloat16";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
+        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    }
+    auto reader_defines = dataflow_defines;
+    reader_defines["SRC_SHARDED"] = a_sharded ? "1" : "0";
+
+    // READER KERNEL
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp",
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding}, std::move(reader_defines)));
+
+    // WRITER KERNEL
+    auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
+    auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
+    if (b.has_value()) {
+        b_is_dram = b_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+        writer_kernel = kernel_config.writer_kernel;
+        compute_kernel = kernel_config.compute_kernel;
+    }
+    auto writer_defines = dataflow_defines;
+    writer_defines["SRC_SHARDED"] = b_sharded ? "1" : "0";
+    writer_defines["DST_SHARDED"] = c_sharded ? "1" : "0";
+
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp",
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram, has_sharding}, std::move(writer_defines)));
+
+    // COMPUTE KERNEL
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32;
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    uint32_t src0interim_cb_index = tt::CBIndex::c_3;
+    uint32_t src1interim_cb_index = tt::CBIndex::c_4;
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (is_sfpu_op) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src1_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src0interim_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src1interim_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
+
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp",
+        all_device_cores,
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .defines = std::move(compute_kernel_defines)});
+    auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        compute_kernel_id,
+        operation_attributes,
+        tensor_args,
+        c,
+        set_runtime_args);
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id}};
+}
+
+void HypotNgDeviceOperation::HypotProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& c) {
+    auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        auto& all_args = GetRuntimeArgs(program, kernel_id);
+        auto& core_args = all_args.at(core.x).at(core.y);
+        std::copy(args.begin(), args.end(), core_args.data());
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
+        cached_program.shared_variables.compute_kernel_id,
+        operation_attributes,
+        tensor_args,
+        c,
+        update_args);
+}
+
+}  // namespace ttnn::operations::binary_ng
+

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/hypot_program_factory.cpp
@@ -12,10 +12,22 @@
 using namespace tt::tt_metal;
 
 namespace {
-
 namespace CMAKE_UNIQUE_NAMESPACE {
 
 using namespace ttnn::operations::binary_ng;
+
+// For rank > 4 i.e. dims beyond NCHW will be collapsed into a single dim
+uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
+    const auto& shape = x.get_logical_shape();
+    uint32_t nD_dim = 1;
+    if (out_rank >= 5) {
+        for (int i = -5; i >= -out_rank; --i) {
+            auto dim = shape[i];
+            nD_dim *= dim;
+        }
+    }
+    return nD_dim;
+}
 
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
     const auto& shape = x.padded_shape();
@@ -112,6 +124,7 @@ uint32_t get_shards_per_width(const ShardSpec& shard_spec, TensorMemoryLayout me
 class ShardShapeGenerator {
     CoreCoord end_core;
     bool row_major;
+    TensorMemoryLayout memory_layout;
     std::array<uint32_t, 2> shard_shape;
     std::array<uint32_t, 2> last_shard_shape;
 
@@ -119,8 +132,10 @@ public:
     ShardShapeGenerator() = default;
 
     ShardShapeGenerator(const ShardSpec& shard_spec, const Tensor& tensor) :
-        end_core(shard_spec.grid.ranges().begin()->end_coord),
-        row_major(shard_spec.orientation == ShardOrientation::ROW_MAJOR) {
+        // core ranges are sorted, so the last one is indeed the last core
+        end_core(shard_spec.grid.ranges().rbegin()->end_coord),
+        row_major(shard_spec.orientation == ShardOrientation::ROW_MAJOR),
+        memory_layout(tensor.memory_config().memory_layout) {
         auto tile_height = tensor.tensor_spec().tile().get_height();
         auto tile_width = tensor.tensor_spec().tile().get_width();
 
@@ -135,19 +150,26 @@ public:
             shard_shape[1] - (tt::round_up(Wt, shard_shape[1]) - Wt),
         };
     }
-
     std::array<uint32_t, 2> operator()(CoreCoord core) const {
         const unsigned majorDim = row_major ? 1 : 0;
         const unsigned minorDim = row_major ? 0 : 1;
 
         auto current_shape = shard_shape;
-        if (core.x == end_core.x) {
+        // for uneven shard, HEIGHT, WIDTH, and BLOCK handling order should be all different in kernel
+        // only HEIGHT sharding works naturally
+        // for eltwise, it should be insignificant to process the padded tile although it is a waste
+        if (core == end_core) {
+            if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
             current_shape[majorDim] = last_shard_shape[majorDim];
-        }
-        if (core.y == end_core.y) {
             current_shape[minorDim] = last_shard_shape[minorDim];
+            } else {
+                TT_FATAL(
+                    current_shape[majorDim] == last_shard_shape[majorDim] and
+                        current_shape[minorDim] == last_shard_shape[minorDim],
+                    "no un-even shard size support memory layout {}",
+                    memory_layout);
+            }
         }
-
         return current_shape;
     }
 };
@@ -164,16 +186,21 @@ void set_or_update_runtime_arguments(
     F handle_args) {
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
+    const auto out_rank = c.logical_shape().rank();
+    auto aND = extract_nD_dims(a, out_rank);
+    auto bND = b.has_value() ? extract_nD_dims(*b, out_rank) : 1;
+    auto cND = extract_nD_dims(c, out_rank);
 
     const auto [aN, aC, aHt, aWt] = get_shape_dims(a);
     const auto [bN, bC, bHt, bWt] = b.has_value() ? get_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u};
     const auto [cN, cC, cHt, cWt] = get_shape_dims(c);
     const uint32_t cHt_unrolled = cN * cC * cHt;
 
-    bool row_major = true;
     const auto shard_specs = get_shard_specs(a, b, c);
     const bool has_sharding = shard_specs.has_value();
     auto grid = has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
+
+    const auto row_major = has_sharding ? shard_specs->a_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
 
     // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
     // as well as having the sharded tensors (if any) start at (0, 0)
@@ -182,7 +209,7 @@ void set_or_update_runtime_arguments(
     bool zero_start_grid = false;
     CoreCoord compute_with_storage_grid;
     const auto& all_device_cores = operation_attributes.worker_grid;
-    if (all_device_cores.size() == 1) {
+    if (grid.size() == 1) {
         const auto& cr = *all_device_cores.ranges().begin();
         if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
             if (has_sharding) {
@@ -260,8 +287,8 @@ void set_or_update_runtime_arguments(
         } else if (core_group_2.contains(core)) {
             c_num_tiles = num_tiles_per_core_group_2;
         } else {
-            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 11>{0});
-            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 12>{0});
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 13>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 14>{0});
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
             continue;
         }
@@ -286,12 +313,14 @@ void set_or_update_runtime_arguments(
             a_num_tiles,
             c_num_tiles,
             c_current_shard_width,
+            aHt * aWt * aC * aN * (aND > 1),
             aHt * aWt * aC * (aN > 1),
             aHt * aWt * (aC > 1),
             cN,
             cC,
             cHt,
-            cWt};
+            cWt,
+            cND};
         handle_args(program, reader_kernel_id, core, reader_runtime_args);
 
         if (b.has_value()) {
@@ -306,12 +335,14 @@ void set_or_update_runtime_arguments(
                 b_num_tiles,
                 c_num_tiles,
                 c_current_shard_width,
+                bHt * bWt * bC * bN * (bND > 1),
                 bHt * bWt * bC * (bN > 1),
                 bHt * bWt * (bC > 1),
                 cN,
                 cC,
                 cHt,
-                cWt};
+                cWt,
+                cND};
             handle_args(program, writer_kernel_id, core, writer_runtime_args);
 
             auto [freq, counter] =
@@ -334,6 +365,8 @@ void set_or_update_runtime_arguments(
                 cC,
                 cHt,
                 cWt,
+                cND,
+                0u,
                 0u,
                 0u,
                 0u};
@@ -342,6 +375,7 @@ void set_or_update_runtime_arguments(
             std::array compute_runtime_args = {c_num_tiles, 0u, 0u};
             handle_args(program, compute_kernel_id, core, compute_runtime_args);
         }
+
         start_tile_id += c_num_tiles;
     }
 }
@@ -356,6 +390,7 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
     using namespace tt;
     using namespace tt::tt_metal;
+
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
     auto is_sfpu_op = operation_attributes.is_sfpu;
@@ -365,23 +400,24 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
 
     const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(a, b, c);
     const bool has_sharding = shard_specs.has_value();
+
     auto tile_hw = c.tensor_spec().tile().get_tile_hw();
     uint32_t a_num_tiles_per_shard = has_sharding ? shard_specs->a_shard_spec.numel() / tile_hw : 0;
     uint32_t b_num_tiles_per_shard = has_sharding ? shard_specs->b_shard_spec.numel() / tile_hw : 0;
     uint32_t c_num_tiles_per_shard = has_sharding ? shard_specs->c_shard_spec.numel() / tile_hw : 0;
 
-    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
-    auto b_data_format = b.has_value() ? datatype_to_dataformat_converter(b->get_dtype())
-                         : is_sfpu_op  ? datatype_to_dataformat_converter(a.get_dtype())
-                                       : DataFormat::Float16_b;
-    auto c_data_format = datatype_to_dataformat_converter(c.get_dtype());
+    const auto a_dtype = a.get_dtype();
+    // Always pass the more accurate fp32 when the quantization scale is passed as a scalar
+    const auto b_dtype = b->get_dtype();
+    const auto a_data_format = datatype_to_dataformat_converter(a_dtype);
+    const auto b_data_format = datatype_to_dataformat_converter(b_dtype);
+    const auto c_data_format = datatype_to_dataformat_converter(c.get_dtype());
 
     uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
     uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
     uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
 
     // we parallelize the computation across the output tiles
-    constexpr bool row_major = true;
     const auto& all_device_cores = operation_attributes.worker_grid;
 
     Buffer* a_buffer = a.buffer();
@@ -432,30 +468,15 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
         c_sharded ? c_num_tiles_per_shard : 2,
         c_data_format,
         c_sharded ? c_buffer : nullptr);
+
     uint32_t a_is_dram = a_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     uint32_t b_is_dram = false;
     uint32_t c_is_dram = c_buffer->buffer_type() == tt_metal::BufferType::DRAM;
 
     auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
-    std::map<std::string, std::string> dataflow_defines;
 
-    if (is_sfpu_op && a.get_dtype() == DataType::FLOAT32) {
-        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
-        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
-        dataflow_defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
-    } else if (is_sfpu_op && a.get_dtype() == DataType::INT32) {
-        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
-        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<int32_t>";
-        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val<1024, int32_t>";
-    } else {
-        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfloat16";
-        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfloat16";
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
-        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
-    }
-    auto reader_defines = dataflow_defines;
+    // READER KERNEL
+    auto reader_defines = make_dataflow_defines(a_dtype, is_sfpu_op);
     reader_defines["SRC_SHARDED"] = a_sharded ? "1" : "0";
 
     // READER KERNEL
@@ -473,7 +494,7 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
         writer_kernel = kernel_config.writer_kernel;
         compute_kernel = kernel_config.compute_kernel;
     }
-    auto writer_defines = dataflow_defines;
+    auto writer_defines = make_dataflow_defines(b_dtype, is_sfpu_op);
     writer_defines["SRC_SHARDED"] = b_sharded ? "1" : "0";
     writer_defines["DST_SHARDED"] = c_sharded ? "1" : "0";
 
@@ -493,6 +514,7 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
     uint32_t src1interim_cb_index = tt::CBIndex::c_4;
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+
     if (is_sfpu_op) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
         unpack_to_dest_mode[src1_cb_index] = UnpackToDestMode::UnpackToDestFp32;
@@ -502,6 +524,7 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
 
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
 
+    const uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
     std::string compute_hypot_kernel_filepath;
     if(kernel_config.compute_kernel == KernelName::ComputeNoBcast){
         compute_hypot_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp";
@@ -525,7 +548,9 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
         tt_metal::ComputeConfig{
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .compile_args = {num_tiles_per_cycle},
             .defines = std::move(compute_kernel_defines)});
+
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
     };
@@ -539,6 +564,7 @@ HypotNgDeviceOperation::HypotProgramFactory::cached_program_t HypotNgDeviceOpera
         tensor_args,
         c,
         set_runtime_args);
+
     return {std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id}};
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot.cpp
@@ -147,4 +147,3 @@ void MAIN {
     }
 }
 }// namespace NAMESPACE
-

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_bcast.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/sqrt.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start) {
+
+    using namespace ckernel;
+    constexpr uint32_t onetile = 1;
+
+    #if BCAST_INPUT
+    #define CB_PRE_BCAST cb_pre_rhs
+    #define CB_POST_BCAST cb_post_rhs
+    #define CB_PRE_OTHER cb_pre_lhs
+    #define CB_POST_OTHER cb_post_lhs
+    #else
+    #define CB_PRE_BCAST cb_pre_lhs
+    #define CB_POST_BCAST cb_post_lhs
+    #define CB_PRE_OTHER cb_pre_rhs
+    #define CB_POST_OTHER cb_post_rhs
+    #endif
+
+    reconfig_data_format_srca(CB_POST_BCAST, CB_PRE_BCAST);
+    pack_reconfig_data_format(cb_out, CB_POST_BCAST);
+
+    cb_wait_front(CB_PRE_BCAST, onetile);
+    cb_reserve_back(CB_POST_BCAST, onetile);
+
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile_to_dst_init_short(CB_PRE_BCAST);
+        copy_tile(CB_PRE_BCAST, i, i);
+        square_tile_init();
+        square_tile(i);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < onetile; ++i) {
+        pack_tile(i, CB_POST_BCAST);
+    }
+    tile_regs_release();
+
+    cb_pop_front(CB_PRE_BCAST, onetile);
+    cb_push_back(CB_POST_BCAST, onetile);
+
+    reconfig_data_format_srca(CB_PRE_BCAST, CB_POST_BCAST);
+    pack_reconfig_data_format(CB_POST_BCAST, cb_out);
+
+    cb_wait_front(CB_POST_BCAST, onetile);
+
+    // Compute on other cb (no-bcast reqd)
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        reconfig_data_format_srca(CB_POST_OTHER, CB_PRE_OTHER);
+        pack_reconfig_data_format(cb_out, CB_POST_OTHER);
+
+        cb_wait_front(CB_PRE_OTHER, onetile);
+        cb_reserve_back(CB_POST_OTHER, onetile);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile_to_dst_init_short(CB_PRE_OTHER);
+            copy_tile(CB_PRE_OTHER, i, i);
+            square_tile_init();
+            square_tile(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i, CB_POST_OTHER);
+        }
+        tile_regs_release();
+
+        cb_pop_front(CB_PRE_OTHER, onetile);
+        cb_push_back(CB_POST_OTHER, onetile);
+
+        reconfig_data_format_srca(CB_PRE_OTHER, CB_POST_OTHER);
+        pack_reconfig_data_format(CB_POST_OTHER, cb_out);
+
+        cb_wait_front(CB_POST_OTHER, onetile);
+        cb_reserve_back(cb_out, onetile);
+
+        tile_regs_acquire();
+        add_tiles_init(cb_post_lhs, cb_post_rhs);
+        add_tiles(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        sqrt_tile_init();
+        sqrt_tile(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(CB_POST_OTHER, onetile);
+    }
+    cb_pop_front(CB_POST_BCAST, onetile);
+}
+
+void MAIN {
+
+    using namespace ckernel;
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_input_a = tt::CBIndex::c_0;
+    constexpr auto cb_input_b = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_a_inter = tt::CBIndex::c_3;  // intermediate cb for a^2
+    constexpr auto cb_b_inter = tt::CBIndex::c_4;  // intermediate cb for b^2
+
+    constexpr uint32_t onetile = 1;
+    binary_op_init_common(cb_a_inter, cb_b_inter, cb_out);
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(cb_input_a, cb_a_inter, cb_input_b, cb_b_inter, cb_out, tile_freq, tile_start);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(cb_input_a, cb_a_inter, cb_input_b, cb_b_inter, cb_out, remaining_iterations, tile_start);
+    }
+}
+}// namespace NAMESPACE
+

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_no_bcast.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/sqrt.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+
+    using namespace ckernel;
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_input_a = tt::CBIndex::c_0;
+    constexpr auto cb_input_b = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_a_inter = tt::CBIndex::c_3;  // intermediate cb for a^2
+    constexpr auto cb_b_inter = tt::CBIndex::c_4;  // intermediate cb for b^2
+
+    constexpr uint32_t onetile = 1;
+    binary_op_init_common(cb_a_inter, cb_b_inter, cb_out);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+
+        // for a^2
+        reconfig_data_format_srca(cb_a_inter, cb_input_a);
+        pack_reconfig_data_format(cb_out, cb_a_inter);
+
+        cb_wait_front(cb_input_a, onetile);
+        cb_reserve_back(cb_a_inter, onetile);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile_to_dst_init_short(cb_input_a);
+            copy_tile(cb_input_a, i, i);  // cb to DST
+            square_tile_init();
+            square_tile(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i, cb_a_inter);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_input_a, onetile);
+        cb_push_back(cb_a_inter, onetile);
+
+        reconfig_data_format_srca(/*old*/ cb_input_a, /*new*/ cb_a_inter);
+        pack_reconfig_data_format(/*old*/ cb_a_inter, /*new*/ cb_out);
+
+        // wait input a^2 tile
+        cb_wait_front(cb_a_inter, onetile);
+
+        // for b^2
+        reconfig_data_format_srca(cb_a_inter, cb_input_b);
+        pack_reconfig_data_format(cb_out, cb_b_inter);
+
+        cb_wait_front(cb_input_b, onetile);
+        cb_reserve_back(cb_b_inter, onetile);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile_to_dst_init_short(cb_input_b);
+            copy_tile(cb_input_b, i, i);
+            square_tile_init();
+            square_tile(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i, cb_b_inter);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_input_b, onetile);
+        cb_push_back(cb_b_inter, onetile);
+
+        reconfig_data_format_srca(/*old*/ cb_input_b, /*new*/ cb_a_inter);
+        pack_reconfig_data_format(/*old*/ cb_b_inter, /*new*/ cb_out);
+
+        // wait input b^2 tile
+        cb_wait_front(cb_b_inter, onetile);
+        // reserve out tile
+        cb_reserve_back(cb_out, onetile);
+
+        add_tiles_init(cb_a_inter, cb_b_inter);
+
+        tile_regs_acquire();
+        add_tiles(cb_a_inter, cb_b_inter, 0, 0, 0);
+        sqrt_tile_init();
+        sqrt_tile(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_a_inter, onetile);
+        cb_pop_front(cb_b_inter, onetile);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sqrt.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start) {
+    using namespace ckernel;
+    constexpr uint32_t onetile = 1;
+
+    #if BCAST_INPUT
+    #define CB_PRE_BCAST cb_pre_rhs
+    #define CB_POST_BCAST cb_post_rhs
+    #define CB_PRE_OTHER cb_pre_lhs
+    #define CB_POST_OTHER cb_post_lhs
+    #else
+    #define CB_PRE_BCAST cb_pre_lhs
+    #define CB_POST_BCAST cb_post_lhs
+    #define CB_PRE_OTHER cb_pre_rhs
+    #define CB_POST_OTHER cb_post_rhs
+    #endif
+
+    reconfig_data_format_srca(CB_POST_BCAST, CB_PRE_BCAST);
+    pack_reconfig_data_format(cb_out, CB_POST_BCAST);
+
+    cb_wait_front(CB_PRE_BCAST, onetile);
+    cb_reserve_back(CB_POST_BCAST, onetile);
+
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile_to_dst_init_short(CB_PRE_BCAST);
+        copy_tile(CB_PRE_BCAST, i, i);
+        square_tile_init();
+        square_tile(i);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < onetile; ++i) {
+        pack_tile(i, CB_POST_BCAST);
+    }
+    tile_regs_release();
+
+    cb_pop_front(CB_PRE_BCAST, onetile);
+    cb_push_back(CB_POST_BCAST, onetile);
+
+    reconfig_data_format_srca(CB_PRE_BCAST, CB_POST_BCAST);
+    pack_reconfig_data_format(CB_POST_BCAST, cb_out);
+
+    cb_wait_front(CB_POST_BCAST, onetile);
+
+    // Compute on other cb (no-bcast reqd)
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        reconfig_data_format_srca(CB_POST_OTHER, CB_PRE_OTHER);
+        pack_reconfig_data_format(cb_out, CB_POST_OTHER);
+
+        cb_wait_front(CB_PRE_OTHER, onetile);
+        cb_reserve_back(CB_POST_OTHER, onetile);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile_to_dst_init_short(CB_PRE_OTHER);
+            copy_tile(CB_PRE_OTHER, i, i);
+            square_tile_init();
+            square_tile(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i, CB_POST_OTHER);
+        }
+        tile_regs_release();
+
+        cb_pop_front(CB_PRE_OTHER, onetile);
+        cb_push_back(CB_POST_OTHER, onetile);
+
+        reconfig_data_format_srca(CB_PRE_OTHER, CB_POST_OTHER);
+        pack_reconfig_data_format(CB_POST_OTHER, cb_out);
+
+        cb_wait_front(CB_POST_OTHER, onetile);
+        cb_reserve_back(cb_out, onetile);
+
+        add_binary_tile_init();
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_post_lhs, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_post_rhs, i, i * 2 + 1);
+            add_binary_tile(i * 2, i * 2 + 1);
+            sqrt_tile_init();
+            sqrt_tile(i * 2);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(CB_POST_OTHER, onetile);
+    }
+    cb_pop_front(CB_POST_BCAST, onetile);
+}
+
+void MAIN {
+
+    using namespace ckernel;
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_input_a = tt::CBIndex::c_0;
+    constexpr auto cb_input_b = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_a_inter = tt::CBIndex::c_3;  // intermediate cb for a^2
+    constexpr auto cb_b_inter = tt::CBIndex::c_4;  // intermediate cb for b^2
+
+    constexpr uint32_t onetile = 1;
+    unary_op_init_common(cb_a_inter, cb_out);
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(cb_input_a, cb_a_inter, cb_input_b, cb_b_inter, cb_out, tile_freq, tile_start);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(cb_input_a, cb_a_inter, cb_input_b, cb_b_inter, cb_out, remaining_iterations, tile_start);
+    }
+}
+}// namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -110,9 +110,12 @@ ALWI void process_tile(
             add_binary_tile(i * 2, i * 2 + 1);
             sqrt_tile_init();
             sqrt_tile(i * 2);
-            tile_regs_commit();
+        }
+        tile_regs_commit();
 
-            tile_regs_wait();
+        tile_regs_wait();
+
+        for (uint32_t i = 0; i < onetile; ++i) {
             pack_tile(i * 2, cb_out);
         }
         tile_regs_release();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu_no_bcast.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sqrt.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+
+    using namespace ckernel;
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_input_a = tt::CBIndex::c_0;
+    constexpr auto cb_input_b = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_a_inter = tt::CBIndex::c_3;  // intermediate cb for a^2
+    constexpr auto cb_b_inter = tt::CBIndex::c_4;  // intermediate cb for b^2
+
+    constexpr uint32_t onetile = 1;
+    unary_op_init_common(cb_a_inter, cb_out);
+    //binary_op_init_common(cb_a_inter, cb_b_inter, cb_out);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+
+        // for a^2
+        reconfig_data_format_srca(cb_a_inter, cb_input_a);
+        pack_reconfig_data_format(cb_out, cb_a_inter);
+
+        cb_wait_front(cb_input_a, onetile);
+        cb_reserve_back(cb_a_inter, onetile);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile_to_dst_init_short(cb_input_a);
+            copy_tile(cb_input_a, i, i);  // cb to DST
+            square_tile_init();
+            square_tile(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i, cb_a_inter);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_input_a, onetile);
+        cb_push_back(cb_a_inter, onetile);
+
+        reconfig_data_format_srca(/*old*/ cb_input_a, /*new*/ cb_a_inter);
+        pack_reconfig_data_format(/*old*/ cb_a_inter, /*new*/ cb_out);
+
+        // wait input a^2 tile
+        cb_wait_front(cb_a_inter, onetile);
+
+        // for b^2
+        reconfig_data_format_srca(cb_a_inter, cb_input_b);
+        pack_reconfig_data_format(cb_out, cb_b_inter);
+
+        cb_wait_front(cb_input_b, onetile);
+        cb_reserve_back(cb_b_inter, onetile);
+
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile_to_dst_init_short(cb_input_b);
+            copy_tile(cb_input_b, i, i);
+            square_tile_init();
+            square_tile(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i, cb_b_inter);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_input_b, onetile);
+        cb_push_back(cb_b_inter, onetile);
+
+        reconfig_data_format_srca(/*old*/ cb_input_b, /*new*/ cb_a_inter);
+        pack_reconfig_data_format(/*old*/ cb_b_inter, /*new*/ cb_out);
+
+        // wait input b^2 tile
+        cb_wait_front(cb_b_inter, onetile);
+        // reserve out tile
+        cb_reserve_back(cb_out, onetile);
+
+        add_binary_tile_init();
+
+        tile_regs_acquire();
+
+        // copy cb_a_inter at even idx
+        copy_tile_to_dst_init_short_with_dt(cb_b_inter, cb_a_inter);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_a_inter, i, i * 2);
+        }
+
+        //copy cb_b_inter at odd idx
+        copy_tile_to_dst_init_short_with_dt(cb_a_inter, cb_b_inter);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_b_inter, i, i * 2 + 1);
+            add_binary_tile(i * 2, i * 2 + 1);
+            sqrt_tile_init();
+            sqrt_tile(i * 2);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_a_inter, onetile);
+        cb_pop_front(cb_b_inter, onetile);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/device/kernels/compute/eltwise_hypot_sfpu_no_bcast.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -26,7 +26,6 @@ void MAIN {
 
     constexpr uint32_t onetile = 1;
     unary_op_init_common(cb_a_inter, cb_out);
-    //binary_op_init_common(cb_a_inter, cb_b_inter, cb_out);
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
 
@@ -111,9 +110,12 @@ void MAIN {
             add_binary_tile(i * 2, i * 2 + 1);
             sqrt_tile_init();
             sqrt_tile(i * 2);
-            tile_regs_commit();
+        }
+        tile_regs_commit();
 
-            tile_regs_wait();
+        tile_regs_wait();
+
+        for (uint32_t i = 0; i < onetile; ++i) {
             pack_tile(i * 2, cb_out);
         }
         tile_regs_release();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
@@ -1,5 +1,5 @@
 
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +19,7 @@ inline bool needs_typecast_to_bfloat16(const Tensor& input) {
 }
 
 Tensor Hypot::invoke(
-    uint8_t queue_id,
+    QueueId queue_id,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
@@ -1,0 +1,48 @@
+
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hypot.hpp"
+#include "ttnn/operations/eltwise/binary_ng/hypot/device/hypot_device_operation.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+namespace utils {
+inline Tensor typecast_to(DataType dtype, const Tensor& input) {
+    return input.get_dtype() == dtype ? input : ttnn::typecast(input, dtype);
+}
+
+inline bool needs_typecast_to_bfloat16(const Tensor& input) {
+    return (input.get_dtype() == DataType::BFLOAT8_B || input.get_dtype() == DataType::BFLOAT4_B);
+}
+}
+
+Tensor Hypot::invoke(
+    uint8_t queue_id,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+
+    bool typecast_a = utils::needs_typecast_to_bfloat16(input_tensor_a);
+    bool typecast_b = utils::needs_typecast_to_bfloat16(input_tensor_b);
+    Tensor input_a = typecast_a ? utils::typecast_to(DataType::BFLOAT16, input_tensor_a) : input_tensor_a;
+    Tensor input_b = typecast_b ? utils::typecast_to(DataType::BFLOAT16, input_tensor_b) : input_tensor_b;
+    return ttnn::prim::hypot(
+        queue_id,
+        input_a,
+        input_b,
+        memory_config,
+        optional_output_tensor);
+}
+
+Tensor Hypot::invoke(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return invoke(DefaultQueueId, input_tensor_a, input_tensor_b, memory_config, optional_output_tensor);
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.cpp
@@ -27,14 +27,52 @@ Tensor Hypot::invoke(
 
     bool typecast_a = utils::needs_typecast_to_bfloat16(input_tensor_a);
     bool typecast_b = utils::needs_typecast_to_bfloat16(input_tensor_b);
-    Tensor input_a = typecast_a ? utils::typecast_to(DataType::BFLOAT16, input_tensor_a) : input_tensor_a;
-    Tensor input_b = typecast_b ? utils::typecast_to(DataType::BFLOAT16, input_tensor_b) : input_tensor_b;
-    return ttnn::prim::hypot(
-        queue_id,
-        input_a,
-        input_b,
-        memory_config,
-        optional_output_tensor);
+    const bool output_preallocated = optional_output_tensor.has_value();
+
+    // RM is never BFLOAT8 or BFLOAT4 so we can assume it goes in here.
+    if (!typecast_a && !typecast_b) {
+        bool input_a_rm = input_tensor_a.get_layout() == Layout::ROW_MAJOR;
+        bool input_b_rm = input_tensor_b.get_layout() == Layout::ROW_MAJOR;
+        Tensor input_a =
+            input_a_rm ? ttnn::to_layout(input_tensor_a, Layout::TILE, std::nullopt, std::nullopt, (IDevice*)nullptr)
+                        : input_tensor_a;
+        Tensor input_b =
+            input_b_rm ? ttnn::to_layout(input_tensor_b, Layout::TILE, std::nullopt, std::nullopt, (IDevice*)nullptr)
+                        : input_tensor_b;
+
+        if (input_a_rm && input_b_rm) {
+            // we don't support to_layout with optional output tensor
+            TT_FATAL(
+                !output_preallocated,
+                "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
+        }
+
+        Tensor result = prim::hypot(
+            queue_id,
+            input_a,
+            input_b,
+            memory_config,
+            optional_output_tensor);
+
+        // if both inputs are in row major, convert the output to row major
+        // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
+        // since it leads to better perf
+        if (input_a_rm && input_b_rm) {
+            result = ttnn::to_layout(result, Layout::ROW_MAJOR, std::nullopt, memory_config, (IDevice*)nullptr);
+        }
+
+        return result;
+    }
+    else{
+        Tensor input_a = typecast_a ? utils::typecast_to(DataType::BFLOAT16, input_tensor_a) : input_tensor_a;
+        Tensor input_b = typecast_b ? utils::typecast_to(DataType::BFLOAT16, input_tensor_b) : input_tensor_b;
+        return ttnn::prim::hypot(
+            queue_id,
+            input_a,
+            input_b,
+            memory_config,
+            optional_output_tensor);
+    }
 }
 
 Tensor Hypot::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.hpp
@@ -1,5 +1,5 @@
 
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ namespace ttnn::operations::binary_ng {
 
 struct Hypot {
     static Tensor invoke(
-        uint8_t queue_id,
+        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/hypot/hypot.hpp
@@ -1,0 +1,36 @@
+
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/eltwise/binary_ng/types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+struct Hypot {
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output_tensor = std::nullopt);
+};
+
+}  // namespace ttnn::operations::binary_ng
+
+namespace ttnn::experimental {
+
+constexpr auto hypot =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::experimental::hypot", ttnn::operations::binary_ng::Hypot>();
+}  // namespace ttnn::experimental


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
ttnn.hypot is implemented as a composite op.

### What's changed
Implemented hypot as a device op in ttnn.experimental.hypot under binary_ng module.
Current implementation is implemented for bfloat16 and float32 dtypes and supports the following versions:

1. No Bcast support
2. Bcast support
3. Float32 support

### Performance Metrics
The project is built with option "--enable-profiler" to collect the performance metrics.
Parameters compared: DEVICE KERNEL DURATION [ns].
Performance of ttnn.hypot(composite (benchmark)) is compared with ttnn.experimental.hypot(device op) for following cases:-

1. No Broadcast version
   - Input Tensor shapes [1, 1, 4096, 4096]
   - Analysis: DEVICE KERNEL DURATION [ns]: 42.10% faster than benchmark. (829206ns vs 1432223ns) 

2. Row Broadcast version (H-bcast)
   - Input Tensor A shape [1, 4096, 1, 4096]
   - Input Tensor B shape [1, 4096, 5, 4096]
   - Analysis: DEVICE KERNEL DURATION [ns]: 87.44% faster than benchmark. (68665605ns vs 546665142ns) 

3. Col Broadcast version (W-bcast)
   - Input Tensor A shape [4096, 1, 4096, 1]
   - Input Tensor B shape [4096, 1, 4096, 5]
   - Analysis: DEVICE KERNEL DURATION [ns]:  81.23% faster than benchmark. (102774029ns vs 547484468ns) 

4. N Broadcast version
   - Input Tensor A shape [5, 4096, 4096, 1]
   - Input Tensor B shape [1, 4096, 4096, 1]
   - Analysis: DEVICE KERNEL DURATION [ns]:  65.16% faster than benchmark. (4240512ns vs 12171596ns) 

5. C Broadcast version
   - Input Tensor shapes [1, 1, 4096, 4096]
   - Input Tensor B shape [4096, 1, 4096, 5]
   - Analysis: DEVICE KERNEL DURATION [ns]: 65.38%  faster than benchmark. (4215040ns vs 12174878ns)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
