### PR TITLE
#17246: Fixing invalid test in ccl

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
@@ -1959,24 +1959,29 @@ def test_all_gather_fp32(  # https://github.com/tenstorrent/tt-metal/issues/9686
         ttnn.bfloat16,
     ],
 )
-@pytest.mark.parametrize(
-    "tensor_mem_layout",
-    [
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-    ],
-)
 @pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
-    "input_shape, input_shard_shape,shard_grid",
+    "input_shape, input_shard_shape,shard_grid,tensor_mem_layout",
     (
         # LLama
         (
             (4, 1, 256, 32),
             (32, 32),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            (1, 1, 64, 1024),
+            (64, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            (4, 1, 256, 64),
+            (256, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ),
     ),
 )


### PR DESCRIPTION
### Ticket
#17246 

### Problem description
The input sharding configuration for the tiny tile test was invalid for width and block sharding. Changed the shapes in width and block to abide by the requirements.
### What's changed
Modify the pytest so tensor memory layout is tied to shape and setting the shape and shard shape based on the test being run

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
