### PR TITLE
#0: Fix Llama3 RoPE eager test regression

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -106,7 +106,9 @@ class PytorchLlamaRotaryModel(torch.nn.Module):
 
 
 def compute_gather_cos_sin(dhead, end, position_ids):
-    cos, sin = precompute_freqs(dhead, end, theta=10000.0, use_scaled=False)  # Using reference defaults
+    cos, sin = precompute_freqs(
+        dhead, end, theta=10000.0, scale_factor=None, orig_context_len=131072
+    )  # Using reference defaults (no scaling)
     position_id_expanded = position_ids.unsqueeze(1).expand(-1, cos.shape[-1])
     cos = cos.gather(0, position_id_expanded)
     sin = sin.gather(0, position_id_expanded)
@@ -178,8 +180,10 @@ def run_test_rotary_embedding_llama(
         # inp: [seq_len, batch, n_heads, head_dim]
 
         if fuse_qk:
-            # Set up rope with 2 * batch size (for fused qk)
-            rope_setup_decode = TtLlamaRotarySetup(device, batch * 2, head_dim, max_seq_len)
+            # Set up rope with 2 * batch size (for fused qk) (no scaling)
+            rope_setup_decode = TtLlamaRotarySetup(
+                device, batch * 2, head_dim, max_seq_len, rope_theta=10000, scale_factor=None, orig_context_len=131072
+            )
             tt_model.transformation_mat = rope_setup_decode.transformation_mat
             cos, sin = rope_setup_decode.get_rot_mats(position_ids.repeat(2))
 
@@ -217,8 +221,11 @@ def run_test_rotary_embedding_llama(
             input_mem_configs = [q_input_mem_config, k_input_mem_config]
 
         else:
-            # Set up rope with batch size
-            rope_setup_decode = TtLlamaRotarySetup(device, batch, head_dim, max_seq_len)
+            # Set up rope with batch size (no scaling)
+            rope_setup_decode = TtLlamaRotarySetup(
+                device, batch, head_dim, max_seq_len, rope_theta=10000, scale_factor=None, orig_context_len=131072
+            )
+
             tt_model.transformation_mat = rope_setup_decode.transformation_mat
             cos, sin = rope_setup_decode.get_rot_mats(position_ids)
 


### PR DESCRIPTION
Fixes a regression in one of the eager tests related to Llama3 Rope.

FIY @skhorasganiTT @yieldthought @bkeith-TT 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13204906185)