### PR TITLE
#17731: generate gtest testcase xml and upload as artifacts during cpp/sd unit test workflows

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -87,12 +87,13 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e TT_METAL_SLOW_DISPATCH_MODE=1
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/test_results.xml
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             mkdir -p generated/test_reports
-            ${{ matrix.test-group.cmd }} --gtest_output=xml:generated/test_reports/test_results.xml
+            ${{ matrix.test-group.cmd }}
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -87,7 +87,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e TT_METAL_SLOW_DISPATCH_MODE=1
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/most_recent_tests.xml
+            -e GTEST_OUTPUT=xml:generated/test_reports
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -97,6 +97,12 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U06CXU895AP # Michael Chiou
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"
       - name: Generate system logs on failure
         uses: ./.github/actions/generate-system-logs
         if: ${{ failure() }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -91,7 +91,8 @@ jobs:
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
-            ${{ matrix.test-group.cmd }}
+            mkdir -p generated/test_reports
+            ${{ matrix.test-group.cmd }} --gtest_output=xml:generated/test_reports/test_results.xml
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -87,7 +87,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e TT_METAL_SLOW_DISPATCH_MODE=1
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports
+            -e GTEST_OUTPUT=xml:generated/test_reports/
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -87,7 +87,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e TT_METAL_SLOW_DISPATCH_MODE=1
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/test_results.xml
+            -e GTEST_OUTPUT=xml:generated/test_reports/most_recent_tests.xml
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -104,6 +104,12 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U06CXU895AP # Michael Chiou
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"
       - name: Generate system logs on failure
         uses: ./.github/actions/generate-system-logs
         if: ${{ failure() }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -98,7 +98,8 @@ jobs:
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
-            ${{ matrix.test-group.cmd }}
+            mkdir -p generated/test_reports
+            ${{ matrix.test-group.cmd }} --gtest_output=xml:generated/test_reports/test_results.xml
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -94,12 +94,13 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ inputs.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e GTEST_OUTPUT=xml:generated/test_reports/test_results.xml
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt
             pip install -e .
             mkdir -p generated/test_reports
-            ${{ matrix.test-group.cmd }} --gtest_output=xml:generated/test_reports/test_results.xml
+            ${{ matrix.test-group.cmd }}
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -94,7 +94,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ inputs.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/most_recent_tests.xml
+            -e GTEST_OUTPUT=xml:generated/test_reports
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -94,7 +94,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ inputs.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports/test_results.xml
+            -e GTEST_OUTPUT=xml:generated/test_reports/most_recent_tests.xml
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -94,7 +94,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ inputs.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GTEST_OUTPUT=xml:generated/test_reports
+            -e GTEST_OUTPUT=xml:generated/test_reports/
           run_args: |
             pip install --force-reinstall pip==21.2.4
             pip install -r tt_metal/python_env/requirements-dev.txt

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -237,4 +237,5 @@ def get_tests_from_test_report_path(test_report_path):
 
         return tests
     else:
-        raise Exception("We only support pytest junit xml outputs for now")
+        logger.warning("XML is not pytest junit format (gtest?), skipping for now")
+        return []


### PR DESCRIPTION
### Ticket
[17731
](https://github.com/tenstorrent/tt-metal/issues/17731)

### Problem description
C++ test data from cpp-unit-tests and sd-unit-tests do not get uploaded to superset since they're:

- not generating test result xml artifacts that get read in during the produce_data workflow
- running with gtest instead of pytest
- current produce_data flow only supports pytest test result format (junit test xml)


### What's changed
- Create and upload test result artifacts during cpp and sd unit test workflow

### Checklist
SD unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/13209167409
C++ tests: https://github.com/tenstorrent/tt-metal/actions/runs/13209164955
