### PR TITLE
#17134: Add remaining SD unit tests

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from diffusers import StableDiffusionPipeline
+import pytest
+import torch
+import ttnn
+
+from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_mid_block_2d_cross_attn_new_conv import (
+    unet_mid_block_2d_cross_attn,
+)
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    get_default_compute_config,
+    preprocess_and_push_input_to_device,
+    post_process_output_and_move_to_host,
+)
+from models.utility_functions import skip_for_grayskull, torch_random
+from ttnn.model_preprocessing import preprocess_model_parameters
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "hidden_states, shard_end_core, shard_shape",
+    [
+        ([2, 1280, 8, 8], (7, 3), (32, 160)),
+    ],
+)
+@pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
+def test_cross_attention_midblock_512x512(reset_seeds, device, hidden_states, shard_end_core, shard_shape, temb):
+    # Initialize PyTorch component
+    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    torch_midblock = unet.mid_block
+
+    # Initialize ttnn component
+    reader_patterns_cache = {}
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
+    )
+    parameters = parameters.mid_block
+    N, _, H, W = hidden_states
+    compute_kernel_config = get_default_compute_config(device)
+
+    ttnn_midblock = unet_mid_block_2d_cross_attn(
+        device, parameters, reader_patterns_cache, N, H, W, compute_kernel_config
+    )
+
+    # Prepare inputs
+    in_channels = hidden_states[1]
+    out_channels = in_channels
+    temb_channels = 1280
+    input_shape = hidden_states
+    hidden_states = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    temb = torch_random(temb, -0.1, 0.1, dtype=torch.float32)
+
+    encoder_hidden_states_shape = [1, 2, 77, 768]
+    encoder_hidden_states = torch.randn(encoder_hidden_states_shape)
+
+    # Run PyTorch component
+    torch_output = torch_midblock(hidden_states, temb.squeeze(0).squeeze(0), encoder_hidden_states.squeeze(0))
+
+    # Prepare inputs for ttnn component
+    hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    temb = temb.permute(2, 0, 1, 3)
+    temb = ttnn.from_torch(temb, ttnn.bfloat16)
+    temb = ttnn.to_layout(temb, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    temb = ttnn.to_device(temb, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    encoder_hidden_states = torch.nn.functional.pad(encoder_hidden_states, (0, 0, 0, 19))
+    encoder_hidden_states = ttnn.from_torch(
+        encoder_hidden_states, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    # Run ttnn component
+    output = ttnn_midblock(
+        hidden_states=hidden_states,
+        temb=temb,
+        encoder_hidden_states=encoder_hidden_states,
+        attention_mask=None,
+        cross_attention_kwargs=None,
+        in_channels=in_channels,
+        temb_channels=temb_channels,
+        resnet_eps=1e-5,
+        resnet_act_fn="silu",
+        attn_num_head_channels=8,
+        config=unet.config,
+    )
+
+    # Compare outputs
+    output = post_process_output_and_move_to_host(output, N, H, W, out_channels)
+    assert_with_pcc(torch_output, output, 0.97)

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from diffusers import StableDiffusionPipeline
+import os
+import ttnn
+import pytest
+
+from models.utility_functions import torch_random
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import (
+    skip_for_grayskull,
+)
+
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downsample_2d_new_conv import downsample_2d
+from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    get_default_compute_config,
+    preprocess_and_push_input_to_device,
+    post_process_output_and_move_to_host,
+)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "block_index, hidden_states, shard_end_core, shard_shape",
+    [
+        (0, [2, 320, 64, 64], (4, 7), (1024, 64)),
+        (1, [2, 640, 32, 32], (4, 7), (256, 128)),
+        (2, [2, 1280, 16, 16], (7, 7), (64, 160)),
+    ],
+)
+def test_downblock_512x512(reset_seeds, device, block_index, hidden_states, shard_end_core, shard_shape):
+    # Initialize PyTorch component
+    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    torch_downsample = pipe.unet.down_blocks[block_index].downsamplers[0]
+
+    # Initialize ttnn component
+    reader_patterns_cache = {}
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
+    )
+    parameters = parameters.down_blocks[block_index].downsamplers[0]
+    N, _, H, W = hidden_states
+    compute_kernel_config = get_default_compute_config(device)
+
+    ttnn_downsample = downsample_2d(device, parameters, reader_patterns_cache, N, H, W, compute_kernel_config)
+
+    # Prepare inputs
+    in_channels = hidden_states[1]
+    out_channels = in_channels
+    input_shape = hidden_states
+    hidden_states = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+
+    # Run PyTorch component
+    torch_output = torch_downsample(hidden_states)
+
+    # Prepare inputs for ttnn component
+    hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    # Run ttnn component
+    output = ttnn_downsample(
+        in_channels=out_channels,
+        out_channels=out_channels,
+        hidden_states=hidden_states,
+        use_conv=True,
+    )
+
+    # Compare outputs
+    output = post_process_output_and_move_to_host(output, N, H // 2, W // 2, out_channels)
+    assert_with_pcc(torch_output, output, 0.99)

--- a/tests/nightly/single_card/stable_diffusion/test_cross_attn_midblock_2d.py
+++ b/tests/nightly/single_card/stable_diffusion/test_cross_attn_midblock_2d.py
@@ -1,0 +1,1 @@
+../../../../models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py

--- a/tests/nightly/single_card/stable_diffusion/test_downsample_2d.py
+++ b/tests/nightly/single_card/stable_diffusion/test_downsample_2d.py
@@ -1,0 +1,1 @@
+../../../../models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py


### PR DESCRIPTION
### Ticket
#17134 

### What's changed
Add remaining component tests - downsample 2d and cross attention mid block

### Pipelines
(Single card) Nightly models and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/13207751805

