### PR TITLE
#10718: Fix produce_data workflow crash when job log not found

### DIFF
--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -34,7 +34,7 @@ download_logs_for_all_jobs() {
         job_id=$(echo "$job" | jq -r '.id')
         job_conclusion=$(echo "$job" | jq -r '.conclusion')
         echo "[info] download logs for job with id $job_id, attempt number $attempt_number"
-        gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log
+        gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || true
 
         # Only download annotations for failed jobs
         if [[ "$job_conclusion" == "failure" ]]; then


### PR DESCRIPTION
### Ticket
[10718](https://github.com/tenstorrent/tt-metal/issues/10718)

### Problem description
Crashes when job log not found
https://github.com/tenstorrent/tt-metal/actions/runs/13208296697/job/36876544774
offending job: https://github.com/tenstorrent/tt-metal/actions/runs/13204550781/job/36870214350

### What's changed
Add `|| true` after `gh api` command

### Checklist
- [x] New/Existing tests provide coverage for changes
Same workflow run on fix branch
https://github.com/tenstorrent/tt-metal/actions/runs/13208367694/job/36876767080