### PR TITLE
Fix undefined QueueId in ttnn events

### DIFF
--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024-2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include <memory>
+#include "ttnn/common/queue_id.hpp"
 #include "ttnn/distributed/types.hpp"
 
 #include "tt-metalium/device.hpp"


### PR DESCRIPTION
### Ticket
None

### Problem description
`QueueId` is undefined in `ttnn/cpp/ttnn/events.cpp/hpp`.

### What's changed
Include the appropriate header for `QueueId`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)