### PR TITLE
[Old-llama70b-vLLM] Remove 2x4 device assertion since t3k mesh now opens with 1x8

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -42,9 +42,6 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
             llama_version=llama_version,
         )
 
-        mesh_rows = t3k_mesh_device.shape.num_rows
-        mesh_cols = t3k_mesh_device.shape.num_cols
-        assert mesh_rows == 2 and mesh_cols == 4, f"Invalid mesh device shape: {mesh_rows}x{mesh_cols}"
         check_mesh_device(t3k_mesh_device, model_config)
 
         # initialize arg classes


### PR DESCRIPTION

### Ticket
N/A

### Problem description
- t3k_mesh_device now opens with 1x8 and old-llama-70b vLLM generator was asserting for 2x4

### What's changed
- Removed outdated assert

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
