### PR TITLE
Add more async slots for dispatch

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -230,8 +230,8 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [17, 12, 3902],
-        "Ethernet CQ Prefetch": [18, 1954],
+        "Ethernet CQ Dispatch": [17, 12, 3899],
+        "Ethernet CQ Prefetch": [18, 1951],
     }
     os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
     devicesData = run_device_profiler_test(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -160,7 +160,7 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     string expected = fmt::format(
         "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. Current kernel: {}.",
         device->id(),
-        (riscv_type == DebugErisc) ? "ethnet" : "worker",
+        (riscv_type == DebugErisc) ? "active ethnet" : "worker",
         logical_core.x,
         logical_core.y,
         virtual_core.x,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -171,7 +171,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 "bytes from local L1[{:#08x}] to Unknown core w/ virtual coords {} [addr=0x{:08x}] (NOC target "
                 "address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
                 device->id(),
-                (is_eth_core) ? "ethnet" : "worker",
+                (is_eth_core) ? "active ethnet" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -188,7 +188,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
-                (is_eth_core) ? "ethnet" : "worker",
+                (is_eth_core) ? "active ethnet" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -207,7 +207,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
-                (is_eth_core) ? "ethnet" : "worker",
+                (is_eth_core) ? "active ethnet" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -225,7 +225,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 "bytes from local L1[{:#08x}] to Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (NOC target "
                 "overwrites mailboxes).",
                 device->id(),
-                (is_eth_core) ? "ethnet" : "worker",
+                (is_eth_core) ? "active ethnet" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,
@@ -243,7 +243,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
                 "bytes to local L1[{:#08x}] from Tensix core w/ virtual coords {} L1[addr=0x{:08x}] (Local L1 "
                 "overwrites mailboxes).",
                 device->id(),
-                (is_eth_core) ? "ethnet" : "worker",
+                (is_eth_core) ? "active ethnet" : "worker",
                 core.x,
                 core.y,
                 virtual_core.x,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -159,8 +159,9 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
                     k_id_s = "";
                 }
                 expected = fmt::format(
-                    "Device {} ethnet core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},   X,   X,   X  ",
+                    "Device {} {} ethnet core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},   X,   X,   X  ",
                     device->id(),
+                    is_active ? "active" : "idle",
                     logical_core.x,
                     logical_core.y,
                     virtual_core.x,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
@@ -3,6 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 void kernel_main() {
+#if NOP_COUNT
+    for (int i = 0; i < ITERATIONS; i++) {
+#pragma GCC unroll 4096
+        for (int j = 0; j < NOP_COUNT; j++) {
+            asm("nop");
+        }
+    }
+#else
 #ifdef PAGE_SIZE
     uint32_t page_size = PAGE_SIZE;
 #else
@@ -58,6 +66,7 @@ void kernel_main() {
     noc_async_write_barrier();
 #else
     noc_async_read_barrier();
+#endif
 #endif
 #endif
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_pgm_dispatch.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_pgm_dispatch.sh
@@ -208,7 +208,34 @@ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} 
  build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 4096 -x $max_x -y $max_y -kg 8 $trace_option $eth_dispatch_option
  build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 8192 -x $max_x -y $max_y -kg 8 $trace_option $eth_dispatch_option
 
- # Same as above, but w/ 1 slow kernel and 4 fast "shadow kernels" (test worker RB queuing)
+ # Run kernels w/ a fixed runtime.  Diff between expected time and actual time is unhidden dispatch cost
+ echo "###" kernel groups w/ 4 shadow kernels
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 256 -rs 10000 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 512 -rs 10000 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 1024 -rs 10000 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 2048 -rs 10000 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 4096 -rs 10000 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 8192 -rs 10000 $trace_option $eth_dispatch_option
+
+ # Same as above but w/o ncrisc to measure ncrisc init cost
+ echo "###" kernel groups w/ 4 shadow kernels
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 256 -rs 10000 -n $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 512 -rs 10000 -n $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 1024 -rs 10000 -n $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 2048 -rs 10000 -n $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 4096 -rs 10000 -n $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 8192 -rs 10000 -n $trace_option $eth_dispatch_option
+
+ # Same as above but with 32 CBs to measure CB init cost
+ echo "###" kernel groups w/ 4 shadow kernels
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 256 -rs 10000 -n -c 32 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 512 -rs 10000 -n -c 32 $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 1024 -rs 10000 -n -c 32  $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 2048 -rs 10000 -n -c 32  $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 4096 -rs 10000 -n -c 32  $trace_option $eth_dispatch_option
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 8192 -rs 10000 -n -c 32  $trace_option $eth_dispatch_option
+
+ # Like earlier tests w/ kernel groups, but w/ 1 slow kernel and 4 fast "shadow kernels" (test worker RB queuing)
  echo "###" kernel groups w/ 4 shadow kernels
  build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 256 -x $max_x -y $max_y -kg $max_x -rs 40000 -nf 4 $trace_option $eth_dispatch_option
  build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -s 512 -x $max_x -y $max_y -kg $max_x -rs 40000 -nf 4 $trace_option $eth_dispatch_option

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_pgm_dispatch_0.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_pgm_dispatch_0.sh
@@ -1,0 +1,77 @@
+#/bin/bash
+
+if [ "$ARCH_NAME" = "grayskull" ]; then
+    echo "Configured core range for grayskull"
+    max_x="11"
+    max_y="8"
+elif [ "$ARCH_NAME" = "wormhole_b0" ]; then
+    echo "Configured core range for wormhole_b0"
+    max_x="7"
+    max_y="6"
+elif [ "$ARCH_NAME" = "blackhole" ]; then
+    echo "Configured core range for blackhole"
+    max_x="12"
+    max_y="9"
+else
+    echo "Unknown arch: $ARCH_NAME"
+    exit 1
+fi
+
+# Initialize the string variable
+trace_option=""
+eth_dispatch_option=""
+
+# Parse command line arguments
+for arg in "$@"; do
+    case $arg in
+        --trace)
+            trace_option="-tr"
+            shift
+            ;;
+        --eth)
+            eth_dispatch_option="-de"
+            shift
+            ;;
+        *)
+            # Handle other arguments if necessary
+            ;;
+    esac
+done
+
+set -x
+
+# skips ncrisc to reduce uncovered kernel init time on WH
+function shadow_test() {
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 256 -x $max_x -y $max_y -rs 40000 $trace_option $eth_dispatch_option $@
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 2048 -x $max_x -y $max_y -rs 40000 $trace_option $eth_dispatch_option $@
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 8192 -x $max_x -y $max_y -rs 40000 $trace_option $eth_dispatch_option $@
+
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 256 -x $max_x -y $max_y -rs 40000 -a 1 $trace_option $eth_dispatch_option $@
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 2048 -x $max_x -y $max_y -rs 40000 -a 1 $trace_option $eth_dispatch_option $@
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 8192 -x $max_x -y $max_y -rs 40000 -a 1 $trace_option $eth_dispatch_option $@
+
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 256 -x $max_x -y $max_y -kg $max_x -rs 40000 -a 1 $trace_option $eth_dispatch_option $@
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 2048 -x $max_x -y $max_y -kg $max_x -rs 40000 -a 1 $trace_option $eth_dispatch_option $@
+ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_${ARCH_NAME} --custom -w 5000 -n -s 8192 -x $max_x -y $max_y -kg $max_x -rs 40000 -a 1 $trace_option $eth_dispatch_option $@
+}
+
+# Test w/ n shadow kernels
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 0
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 1
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 2
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 3
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 4
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 5
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 6
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 7
+echo "###" kernel groups w/ 4 shadow kernels
+  shadow_test -nf 8
+echo "###" done

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -49,6 +49,7 @@ bool hammer_pcie_g = false;
 bool hammer_pcie_type_g = false;
 bool test_write = false;
 bool linked = false;
+uint32_t nop_count_g = 0;
 
 void init(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
@@ -88,6 +89,7 @@ void init(int argc, char** argv) {
         log_info(LogTest, " -hp: hammer hugepage PCIe memory while executing (for PCIe test)");
         log_info(LogTest, " -hpt:hammer hugepage PCIe hammer type: 0:32bit writes 1:128bit non-temporal writes");
         log_info(LogTest, "  -psrta: pass page size as a runtime argument (default compile time define)");
+        log_info(LogTest, " -nop: time loop of <n> nops");
         exit(0);
     }
 
@@ -110,6 +112,8 @@ void init(int argc, char** argv) {
     page_size_g = test_args::get_command_option_uint32(input_args, "-p", DEFAULT_PAGE_SIZE);
     page_size_as_runtime_arg_g = test_args::has_command_option(input_args, "-psrta");
     read_one_packet_g = test_args::has_command_option(input_args, "-o");
+    nop_count_g = test_args::get_command_option_uint32(input_args, "-nop", 0);
+
     if (read_one_packet_g && page_size_g > 8192) {
         log_info(LogTest, "Page size must be <= 8K for read_one_packet\n");
         exit(-1);
@@ -270,7 +274,9 @@ int main(int argc, char** argv) {
             {"LINKED", std::to_string(linked)},
             {"NUM_MCAST_DESTS", std::to_string(num_mcast_dests)},
             {"MCAST_NOC_END_ADDR_X", std::to_string(mcast_noc_addr_end_x)},
-            {"MCAST_NOC_END_ADDR_Y", std::to_string(mcast_noc_addr_end_y)}};
+            {"MCAST_NOC_END_ADDR_Y", std::to_string(mcast_noc_addr_end_y)},
+            {"NOP_COUNT", std::to_string(nop_count_g)},
+        };
         if (!page_size_as_runtime_arg_g) {
             defines.insert(std::pair<string, string>("PAGE_SIZE", std::to_string(page_size_g)));
         }

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -329,7 +329,7 @@ struct core_info_msg_t {
     volatile uint8_t pad[25];
 };
 
-constexpr uint32_t launch_msg_buffer_num_entries = 4;
+constexpr uint32_t launch_msg_buffer_num_entries = 8;
 struct mailboxes_t {
     struct ncrisc_halt_msg_t ncrisc_halt;
     struct slave_sync_msg_t slave_sync;

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -68,7 +68,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12256
+#define MEM_MAILBOX_SIZE 12640
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 
@@ -125,7 +125,7 @@
 // TODO: reduce this when mailbox sizes are core type aware for some members (eg watcher/dprint)
 // TODO: also, move into gap above in the reserved area
 #define MEM_IERISC_MAILBOX_BASE (MEM_IERISC_RESERVED1 + MEM_IERISC_RESERVED1_SIZE)
-#define MEM_IERISC_MAILBOX_SIZE 3344
+#define MEM_IERISC_MAILBOX_SIZE 3728
 #define MEM_IERISC_MAILBOX_END (MEM_IERISC_MAILBOX_BASE + MEM_IERISC_MAILBOX_SIZE)
 #define MEM_IERISC_FIRMWARE_BASE (MEM_IERISC_MAILBOX_END)
 #define MEM_SLAVE_IERISC_FIRMWARE_BASE (MEM_IERISC_FIRMWARE_BASE + MEM_IERISC_FIRMWARE_SIZE)

--- a/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
@@ -43,7 +43,7 @@ struct address_map {
     static constexpr uint32_t MEM_ERISC_RESERVED1_SIZE = 1024;
 
     static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = MEM_ERISC_RESERVED1 + MEM_ERISC_RESERVED1_SIZE;
-    static constexpr std::uint32_t ERISC_MEM_MAILBOX_SIZE = 3344;
+    static constexpr std::uint32_t ERISC_MEM_MAILBOX_SIZE = 3728;
     static constexpr std::uint32_t ERISC_MEM_MAILBOX_END = ERISC_MEM_MAILBOX_BASE + ERISC_MEM_MAILBOX_SIZE;
 
     static constexpr std::int32_t FIRMWARE_BASE = ERISC_MEM_MAILBOX_END;

--- a/tt_metal/hw/inc/grayskull/dev_mem_map.h
+++ b/tt_metal/hw/inc/grayskull/dev_mem_map.h
@@ -71,7 +71,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12256
+#define MEM_MAILBOX_SIZE 12640
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS MEM_MAILBOX_BASE + 4
 #define MEM_SLAVE_RUN_MAILBOX_ADDRESS MEM_MAILBOX_BASE + 8

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -72,7 +72,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12256
+#define MEM_MAILBOX_SIZE 12640
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS MEM_MAILBOX_BASE + 4
 #define MEM_SLAVE_RUN_MAILBOX_ADDRESS MEM_MAILBOX_BASE + 8
@@ -136,7 +136,7 @@
 // TODO: reduce this when mailbox sizes are core type aware for some members (eg watcher/dprint)
 // TODO: also, move into gap above in the reserved area
 #define MEM_IERISC_MAILBOX_BASE (MEM_IERISC_RESERVED2 + MEM_IERISC_RESERVED2_SIZE)
-#define MEM_IERISC_MAILBOX_SIZE 3232
+#define MEM_IERISC_MAILBOX_SIZE 3616
 #define MEM_IERISC_MAILBOX_END (MEM_IERISC_MAILBOX_BASE + MEM_IERISC_MAILBOX_SIZE)
 #define MEM_IERISC_FIRMWARE_BASE MEM_IERISC_MAILBOX_END
 #define MEM_IERISC_MAP_END (MEM_IERISC_FIRMWARE_BASE + MEM_IERISC_FIRMWARE_SIZE)

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -58,7 +58,7 @@ struct address_map {
 
     static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
 
-    static constexpr std::uint32_t ERISC_MEM_MAILBOX_SIZE = 3232;
+    static constexpr std::uint32_t ERISC_MEM_MAILBOX_SIZE = 3616;
     static constexpr std::uint32_t ERISC_MEM_MAILBOX_END = ERISC_MEM_MAILBOX_BASE + ERISC_MEM_MAILBOX_SIZE;
     static constexpr std::int32_t ERISC_L1_KERNEL_CONFIG_BASE = ERISC_MEM_MAILBOX_END;
     static constexpr std::int32_t FABRIC_ROUTER_CONFIG_BASE =

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -311,7 +311,7 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     virtual_core.type = logical_core.type;
 
     // Print device id, core coords (logical)
-    string core_type = is_eth_core ? "ethnet" : "worker";
+    string core_type = is_eth_core ? (is_active_eth_core ? "active ethnet" : "idle ethnet") : "worker";
     string core_coord_str = fmt::format(
         "core(x={:2},y={:2}) virtual(x={:2},y={:2})",
         logical_core.coord.x,
@@ -343,6 +343,13 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     // For more accurate reporting of launch messages and running kernel ids, dump data from the previous valid
     // program (one entry before), if the current program is invalid (enables == 0)
     uint32_t launch_msg_read_ptr = mbox_data->launch_msg_rd_ptr;
+    if (launch_msg_read_ptr > launch_msg_buffer_num_entries) {
+        TT_THROW(
+            "Watcher read invalid launch_msg_read_ptr on {}: read {}, max valid {}!",
+            core_str,
+            launch_msg_read_ptr,
+            launch_msg_buffer_num_entries);
+    }
     if (mbox_data->launch[launch_msg_read_ptr].kernel_config.enables == 0) {
         launch_msg_read_ptr = (launch_msg_read_ptr - 1 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
     }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1513,6 +1513,9 @@ void reserve_space_in_kernel_config_buffer(
             dispatch_md.stall_first = false;
             dispatch_md.stall_before_program = true;
         }
+
+        // TODO: config_buffer_mgr is stateful so code below restores original reservation state
+        // pull state out of the config_buffer_mgr
         reservation = config_buffer_mgr.reserve(program_config_sizes);
     }
 
@@ -1527,6 +1530,10 @@ void reserve_space_in_kernel_config_buffer(
     }
     config_buffer_mgr.alloc(expected_num_workers_completed + num_program_workers);
 
+    // TODO.  This code is needlessly complex due to enqueue program and
+    // binary writing being intertwined.  Separate out writing kernel
+    // binaries into program compile/finalize.  The sync below is confusing
+    // and not needed (just need a barrier on DRAM write)
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Insert a stall before writing any program configs when binaries are in flight
         dispatch_md.stall_first = true;


### PR DESCRIPTION
### Ticket
#15221 

### Problem description
Running a slow kernel followed by multiple fast kernels was showing less async overlap than expected.  The launch message buffer was sized to 4 entries.  1 entry is required by watcher (to handle cores with no work to do).  1 entry is consumed by the currently running kernel.  That left only 2 to queue work into the future which isn't very many for some models (eg, resnet).

### What's changed
Grew the buffer to 8 entries.  Improved watcher to better trap an error found during development.  Added a set of tests to generate shadow kernel data.

Note that there are still some unexpected/not understood results for follow-on work.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
