### PR TITLE
[skip ci] Reduce number of builds per APC job

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -183,23 +183,10 @@ jobs:
     strategy:
       matrix:
         config:
-          - version: "20.04"
+          - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Debug"
             publish-artifact: false
-          - version: "20.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "RelWithDebInfo"
-            publish-artifact: false
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "Release"
-            publish-artifact: false
-          - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-            build-type: "Release"
-            publish-artifact: false
-            skip-tt-train: true
           - version: "22.04"
             toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"


### PR DESCRIPTION
### Problem description
Builders are in high demand.
We will move off of Ubuntu 20.04 in the next month or so.
22.04 Release builds are stressed by clang-tidy workflow (pretty sure)

### What's changed
Reduce extra builds to 22.04 clang Debug, and 22.04 gcc Release

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13209215226) CI passes