### PR TITLE
#15496 Change Tensor serialization to serialize TensorSpec with flatbuffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-narrowing>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-non-template-friend>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-error=non-template-friend>"
-    "$<$<CXX_COMPILER_ID:GNU>:-Wno-error=unused-result>"
     "$<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>"
     "$<$<BOOL:${ENABLE_MSAN}>:-fsanitize=memory>"
     "$<$<BOOL:${ENABLE_TSAN}>:-fsanitize=thread>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-narrowing>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-non-template-friend>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-error=non-template-friend>"
+    "$<$<CXX_COMPILER_ID:GNU>:-Wno-error=unused-result>"
     "$<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>"
     "$<$<BOOL:${ENABLE_MSAN}>:-fsanitize=memory>"
     "$<$<BOOL:${ENABLE_TSAN}>:-fsanitize=thread>"

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -674,10 +674,20 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated)
 
+message(
+    "BIN DIR "
+    ${CMAKE_BINARY_DIR}
+)
 set(TTNN_PUBLIC_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR} # ${PROJECT_SOURCE_DIR}/ttnn
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated # symlink to tt_eager; should become native folder once merge complete
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers
+    ${CMAKE_BINARY_DIR}/tt_metal/impl/flatbuffers
+)
+message(
+    "TTNN_PUBLIC_INCLUDE_DIRS "
+    ${TTNN_PUBLIC_INCLUDE_DIRS}
 )
 set(TTNN_PUBLIC_LINK_LIBRARIES
     metal_common_libs
@@ -686,6 +696,7 @@ set(TTNN_PUBLIC_LINK_LIBRARIES
     xtensor
     xtensor-blas
     xtl
+    FlatBuffers::FlatBuffers
 )
 set(TTNN_PUBLIC_LINK_DIRS "")
 
@@ -805,6 +816,27 @@ endforeach(
     SUBLIBRARY_PATH
     ${TTNN_SUBLIBRARIES}
 )
+
+set(FBS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs)
+message(
+    "ROOT DIR "
+    ${CMAKE_SOURCE_DIR}
+)
+get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
+set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/${FBS_FILE_NAME}_generated.h")
+add_custom_command(
+    OUTPUT
+        ${FBS_GENERATED_HEADER}
+    COMMAND
+        flatc --cpp --scoped-enums -I "${CMAKE_SOURCE_DIR}/tt_metal/impl/" -o "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/"
+        ${FBS_FILE}
+    DEPENDS
+        flatc
+        ${FBS_FILE}
+    COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
+    VERBATIM
+)
+list(APPEND TENSOR_SRCS ${FBS_GENERATED_HEADER})
 
 add_ttnn_sublibrary(ttnn_tensor ${TENSOR_SRCS})
 add_ttnn_sublibrary(ttnn_ccl ${CCL_TTNN_SRCS})

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -674,20 +674,11 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated)
 
-message(
-    "BIN DIR "
-    ${CMAKE_BINARY_DIR}
-)
 set(TTNN_PUBLIC_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR} # ${PROJECT_SOURCE_DIR}/ttnn
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated # symlink to tt_eager; should become native folder once merge complete
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers
-    ${CMAKE_BINARY_DIR}/tt_metal/impl/flatbuffers
-)
-message(
-    "TTNN_PUBLIC_INCLUDE_DIRS "
-    ${TTNN_PUBLIC_INCLUDE_DIRS}
 )
 set(TTNN_PUBLIC_LINK_LIBRARIES
     metal_common_libs
@@ -816,27 +807,6 @@ endforeach(
     SUBLIBRARY_PATH
     ${TTNN_SUBLIBRARIES}
 )
-
-set(FBS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs)
-message(
-    "ROOT DIR "
-    ${CMAKE_SOURCE_DIR}
-)
-get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
-set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/${FBS_FILE_NAME}_generated.h")
-add_custom_command(
-    OUTPUT
-        ${FBS_GENERATED_HEADER}
-    COMMAND
-        flatc --cpp --scoped-enums -I "${CMAKE_SOURCE_DIR}/tt_metal/impl/" -o "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/"
-        ${FBS_FILE}
-    DEPENDS
-        flatc
-        ${FBS_FILE}
-    COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
-    VERBATIM
-)
-list(APPEND TENSOR_SRCS ${FBS_GENERATED_HEADER})
 
 add_ttnn_sublibrary(ttnn_tensor ${TENSOR_SRCS})
 add_ttnn_sublibrary(ttnn_ccl ${CCL_TTNN_SRCS})

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -808,6 +808,8 @@ endforeach(
     ${TTNN_SUBLIBRARIES}
 )
 
+GENERATE_FBS_HEADER(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs)
+list(APPEND TENSOR_SRCS ${FBS_GENERATED_HEADER_FILE})
 add_ttnn_sublibrary(ttnn_tensor ${TENSOR_SRCS})
 add_ttnn_sublibrary(ttnn_ccl ${CCL_TTNN_SRCS})
 add_ttnn_sublibrary(ttnn_ccl_exp ${CCL_EXPERIMENTAL_TTNN_SRCS})

--- a/ttnn/cpp/ttnn/tensor/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/tensor/CMakeLists.txt
@@ -18,22 +18,3 @@ set(TENSOR_SRCS
     CACHE INTERNAL
     "Tensor sources to reuse in ttnn build"
 )
-
-set(FBS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/tensor_types.fbs)
-get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
-message(
-    "CURRENT BIN DIR "
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
-set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/${FBS_FILE_NAME}_generated.h")
-add_custom_command(
-    OUTPUT
-        ${FBS_GENERATED_HEADER}
-    COMMAND
-        flatc --cpp --scoped-enums -o "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/" ${FBS_FILE}
-    DEPENDS
-        flatc
-        ${FBS_FILE}
-    COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
-)
-list(APPEND TENSOR_SRCS ${FBS_GENERATED_HEADER})

--- a/ttnn/cpp/ttnn/tensor/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/tensor/CMakeLists.txt
@@ -13,6 +13,8 @@ set(TENSOR_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/layout/page_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layout/tensor_layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/xtensor/partition.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/tensor_types_to_flatbuffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/tensor_types_from_flatbuffer.cpp
     CACHE INTERNAL
     "Tensor sources to reuse in ttnn build"
 )

--- a/ttnn/cpp/ttnn/tensor/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/tensor/CMakeLists.txt
@@ -18,3 +18,22 @@ set(TENSOR_SRCS
     CACHE INTERNAL
     "Tensor sources to reuse in ttnn build"
 )
+
+set(FBS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/flatbuffer/tensor_types.fbs)
+get_filename_component(FBS_FILE_NAME ${FBS_FILE} NAME_WLE)
+message(
+    "CURRENT BIN DIR "
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+set(FBS_GENERATED_HEADER "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/${FBS_FILE_NAME}_generated.h")
+add_custom_command(
+    OUTPUT
+        ${FBS_GENERATED_HEADER}
+    COMMAND
+        flatc --cpp --scoped-enums -o "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/" ${FBS_FILE}
+    DEPENDS
+        flatc
+        ${FBS_FILE}
+    COMMENT "Generating FlatBuffers header ${FBS_GENERATED_HEADER}"
+)
+list(APPEND TENSOR_SRCS ${FBS_GENERATED_HEADER})

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs
@@ -100,5 +100,5 @@ table TensorSpec {
     tensor_layout: TensorLayout;
 }
 
-root_type MemoryConfig;
+//root_type MemoryConfig;
 root_type TensorSpec;

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs
@@ -1,0 +1,104 @@
+namespace ttnn.flatbuffer;
+
+table CoreCoord {
+    x: int;
+    y: int;
+}
+
+table CoreRange {
+    start: CoreCoord;
+    end: CoreCoord;
+}
+
+table CoreRangeSet {
+    ranges: [CoreRange];
+}
+
+table Tile {
+    tile_shape_h: uint32;
+    tile_shape_w: uint32;
+    transpose_tile: bool;
+}
+
+enum TensorMemoryLayout: ushort {
+    Interleaved = 0,
+    SingleBank = 1,
+    HeightSharded = 2,
+    WidthSharded = 3,
+    BlockSharded = 4,
+}
+
+enum BufferType: ushort {
+    DRAM = 0,
+    L1 = 1,
+    SystemMemory = 2,
+    L1Small = 3,
+    Trace = 4,
+}
+
+enum ShardOrientation : ubyte {
+    RowMajor = 0,
+    ColMajor = 1,
+}
+
+enum ShardMode : ubyte {
+    Physical,
+    Logical,
+}
+
+table ShardShape {
+    height: uint32;
+    width: uint32;
+}
+
+table ShardSpec {
+    grid: CoreRangeSet;
+    shape_h: uint32;
+    shape_w: uint32;
+    orientation: ShardOrientation;
+    shard_mode: ShardMode;
+    physical_shard_shape: ShardShape;
+}
+
+enum DataType : ubyte {
+    BFloat16 = 0,
+    Float32 = 1,
+    UInt32 = 2,
+    BFloat8B = 3,
+    BFloat4B = 4,
+    UInt8 = 5,
+    UInt16 = 6,
+    Int32 = 7,
+    Invalid = 8
+}
+
+table RowMajorPageConfig {}
+table TilePageConfig {
+    tile: Tile;
+}
+
+union PageConfig {
+    row_major: RowMajorPageConfig,
+    tile: TilePageConfig,
+}
+
+table MemoryConfig {
+    memory_layout: TensorMemoryLayout;
+    buffer_type: BufferType;
+    shard_spec: ShardSpec;
+}
+
+table TensorLayout {
+    data_type: DataType;
+    page_config: PageConfig;
+    memory_config: MemoryConfig;
+    alignment: [uint32];
+}
+
+table TensorSpec {
+    shape: [uint32];
+    tensor_layout: TensorLayout;
+}
+
+root_type MemoryConfig;
+root_type TensorSpec;

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types.fbs
@@ -100,5 +100,4 @@ table TensorSpec {
     tensor_layout: TensorLayout;
 }
 
-//root_type MemoryConfig;
 root_type TensorSpec;

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.cpp
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor_types_from_flatbuffer.hpp"
+
+namespace ttnn {
+
+BufferType from_flatbuffer(flatbuffer::BufferType type) {
+    switch (type) {
+        case flatbuffer::BufferType::DRAM: return BufferType::DRAM;
+        case flatbuffer::BufferType::L1: return BufferType::L1;
+        case flatbuffer::BufferType::SystemMemory: return BufferType::SYSTEM_MEMORY;
+        case flatbuffer::BufferType::L1Small: return BufferType::L1_SMALL;
+        case flatbuffer::BufferType::Trace: return BufferType::TRACE;
+    }
+    TT_THROW("Unsupported BufferType from flatbuffer.");
+}
+
+TensorMemoryLayout from_flatbuffer(flatbuffer::TensorMemoryLayout layout) {
+    switch (layout) {
+        case flatbuffer::TensorMemoryLayout::Interleaved: return TensorMemoryLayout::INTERLEAVED;
+        case flatbuffer::TensorMemoryLayout::SingleBank: return TensorMemoryLayout::SINGLE_BANK;
+        case flatbuffer::TensorMemoryLayout::HeightSharded: return TensorMemoryLayout::HEIGHT_SHARDED;
+        case flatbuffer::TensorMemoryLayout::WidthSharded: return TensorMemoryLayout::WIDTH_SHARDED;
+        case flatbuffer::TensorMemoryLayout::BlockSharded: return TensorMemoryLayout::BLOCK_SHARDED;
+    }
+    TT_THROW("Unsupported TensorMemoryLayout from flatbuffer.");
+}
+
+DataType from_flatbuffer(flatbuffer::DataType type) {
+    switch (type) {
+        case flatbuffer::DataType::BFloat16: return DataType::BFLOAT16;
+        case flatbuffer::DataType::Float32: return DataType::FLOAT32;
+        case flatbuffer::DataType::UInt32: return DataType::UINT32;
+        case flatbuffer::DataType::BFloat8B: return DataType::BFLOAT8_B;
+        case flatbuffer::DataType::BFloat4B: return DataType::BFLOAT4_B;
+        case flatbuffer::DataType::UInt8: return DataType::UINT8;
+        case flatbuffer::DataType::UInt16: return DataType::UINT16;
+        case flatbuffer::DataType::Int32: return DataType::INT32;
+        case flatbuffer::DataType::Invalid: return DataType::INVALID;
+    }
+    TT_THROW("Unsupported DataType from flatbuffer.");
+}
+
+MemoryConfig from_flatbuffer(const flatbuffer::MemoryConfig* config) {
+    return MemoryConfig{
+        from_flatbuffer(config->memory_layout()),
+        from_flatbuffer(config->buffer_type()),
+        from_flatbuffer(config->shard_spec()),
+    };
+}
+
+ShardOrientation from_flatbuffer(flatbuffer::ShardOrientation orientation) {
+    switch (orientation) {
+        case flatbuffer::ShardOrientation::RowMajor: return ShardOrientation::ROW_MAJOR;
+        case flatbuffer::ShardOrientation::ColMajor: return ShardOrientation::COL_MAJOR;
+    }
+    TT_THROW("Unsupported ShardOrientation from flatbuffer.");
+}
+
+ShardMode from_flatbuffer(flatbuffer::ShardMode mode) {
+    switch (mode) {
+        case flatbuffer::ShardMode::Physical: return ShardMode::PHYSICAL;
+        case flatbuffer::ShardMode::Logical: return ShardMode::LOGICAL;
+    }
+    TT_THROW("Unsupported ShardMode from flatbuffer.");
+}
+
+ShardSpec from_flatbuffer(const flatbuffer::ShardSpec* spec) {
+    CoreRangeSet grid = from_flatbuffer(spec->grid());
+    std::array<uint32_t, 2> shape = {spec->shape_h(), spec->shape_w()};
+    ShardOrientation orientation = from_flatbuffer(spec->orientation());
+    ShardMode mode = from_flatbuffer(spec->shard_mode());
+    if (const auto* fb_shard_shape = spec->physical_shard_shape()) {
+        std::array<uint32_t, 2> physical_shard_shape = {fb_shard_shape->height(), fb_shard_shape->width()};
+        return ShardSpec(grid, shape, physical_shard_shape, orientation);
+    }
+    return ShardSpec(grid, shape, orientation, mode);
+}
+
+CoreCoord from_flatbuffer(const flatbuffer::CoreCoord* core_coord) {
+    return CoreCoord{core_coord->x(), core_coord->y()};
+}
+
+CoreRange from_flatbuffer(const flatbuffer::CoreRange* core_range) {
+    return CoreRange{
+        {core_range->start()->x(), core_range->start()->y()}, {core_range->end()->x(), core_range->end()->y()}};
+}
+
+CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
+    std::vector<CoreRange> ranges;
+    for (const auto* range : *core_range_set->ranges()) {
+        ranges.emplace_back(
+            CoreCoord{range->start()->x(), range->start()->y()}, CoreCoord{range->end()->x(), range->end()->y()});
+    }
+    return CoreRangeSet{ranges};
+}
+
+TensorLayout from_flatbuffer(const flatbuffer::TensorLayout* layout) {
+    PageConfig page_config = [&] {
+        switch (layout->page_config_type()) {
+            case flatbuffer::PageConfig::row_major: return PageConfig(Layout::ROW_MAJOR);
+            case flatbuffer::PageConfig::tile: {
+                const auto* tile_page_config = layout->page_config_as_tile();
+                const auto* flat_tile = tile_page_config->tile();
+                Tile tile(
+                    std::array{flat_tile->tile_shape_h(), flat_tile->tile_shape_w()}, flat_tile->transpose_tile());
+                return PageConfig(Layout::TILE, tile);
+            }
+            default: TT_THROW("Unsupported PageConfig type from flatbuffer.");
+        }
+    }();
+
+    return TensorLayout::restore_from_serialized(
+        from_flatbuffer(layout->data_type()),
+        page_config,
+        from_flatbuffer(layout->memory_config()),
+        Alignment(SmallVector<uint32_t>(layout->alignment()->cbegin(), layout->alignment()->cend())));
+}
+
+TensorSpec from_flatbuffer(const flatbuffer::TensorSpec* spec) {
+    return TensorSpec(
+        Shape(SmallVector<uint32_t>(spec->shape()->cbegin(), spec->shape()->cend())),
+        from_flatbuffer(spec->tensor_layout()));
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.cpp
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.cpp
@@ -44,10 +44,14 @@ DataType from_flatbuffer(flatbuffer::DataType type) {
 }
 
 MemoryConfig from_flatbuffer(const flatbuffer::MemoryConfig* config) {
+    std::optional<ShardSpec> shard_spec;
+    if (config->shard_spec()) {
+        shard_spec = from_flatbuffer(config->shard_spec());
+    }
     return MemoryConfig{
         from_flatbuffer(config->memory_layout()),
         from_flatbuffer(config->buffer_type()),
-        from_flatbuffer(config->shard_spec()),
+        shard_spec,
     };
 }
 

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.hpp
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tensor_types_generated.h"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+
+namespace ttnn {
+
+BufferType from_flatbuffer(flatbuffer::BufferType type);
+TensorMemoryLayout from_flatbuffer(flatbuffer::TensorMemoryLayout layout);
+DataType from_flatbuffer(flatbuffer::DataType type);
+ShardOrientation from_flatbuffer(flatbuffer::ShardOrientation orientation);
+ShardMode from_flatbuffer(flatbuffer::ShardMode mode);
+CoreCoord from_flatbuffer(const flatbuffer::CoreCoord* fb_coord);
+CoreRange from_flatbuffer(const flatbuffer::CoreRange* fb_coord);
+CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* fb_coord);
+ShardSpec from_flatbuffer(const flatbuffer::ShardSpec* spec);
+MemoryConfig from_flatbuffer(const flatbuffer::MemoryConfig* config);
+TensorLayout from_flatbuffer(const flatbuffer::TensorLayout* layout);
+TensorSpec from_flatbuffer(const flatbuffer::TensorSpec* spec);
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_to_flatbuffer.cpp
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_to_flatbuffer.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor_types_to_flatbuffer.hpp"
+
+namespace ttnn {
+
+flatbuffer::ShardOrientation to_flatbuffer(ShardOrientation orientation) {
+    switch (orientation) {
+        case ShardOrientation::ROW_MAJOR: return flatbuffer::ShardOrientation::RowMajor;
+        case ShardOrientation::COL_MAJOR: return flatbuffer::ShardOrientation::ColMajor;
+    }
+    TT_THROW("Unsupported ShardOrientation to flatbuffer.");
+}
+
+flatbuffer::ShardMode to_flatbuffer(ShardMode shard_mode) {
+    switch (shard_mode) {
+        case ShardMode::LOGICAL: return flatbuffer::ShardMode::Logical;
+        case ShardMode::PHYSICAL: return flatbuffer::ShardMode::Physical;
+    }
+    TT_THROW("Unsupported ShardMode to flatbuffer.");
+}
+
+flatbuffers::Offset<flatbuffer::ShardSpec> to_flatbuffer(
+    const ShardSpec& spec, flatbuffers::FlatBufferBuilder& builder) {
+    flatbuffers::Offset<flatbuffer::ShardShape> physical_shard_shape = 0;
+    if (spec.physical_shard_shape.has_value()) {
+        const auto& phys_shape = *spec.physical_shard_shape;
+        physical_shard_shape = flatbuffer::CreateShardShape(builder, phys_shape[0], phys_shape[1]);
+    }
+    return flatbuffer::CreateShardSpec(
+        builder,
+        to_flatbuffer(builder, spec.grid),
+        spec.shape[0],
+        spec.shape[1],
+        to_flatbuffer(spec.orientation),
+        to_flatbuffer(spec.mode),
+        physical_shard_shape);
+}
+
+flatbuffers::Offset<flatbuffer::CoreCoord> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreCoord& core_coord) {
+    return flatbuffer::CreateCoreCoord(builder, core_coord.x, core_coord.y);
+}
+
+flatbuffers::Offset<flatbuffer::CoreRange> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreRange& core_range) {
+    auto start = flatbuffer::CreateCoreCoord(builder, core_range.start_coord.x, core_range.start_coord.y);
+    auto end = flatbuffer::CreateCoreCoord(builder, core_range.end_coord.x, core_range.end_coord.y);
+    return flatbuffer::CreateCoreRange(builder, start, end);
+}
+
+flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreRangeSet& core_range_set) {
+    std::vector<flatbuffers::Offset<flatbuffer::CoreRange>> range_offsets;
+    for (const auto& range : core_range_set.ranges()) {
+        auto start = flatbuffer::CreateCoreCoord(builder, range.start_coord.x, range.start_coord.y);
+        auto end = flatbuffer::CreateCoreCoord(builder, range.end_coord.x, range.end_coord.y);
+        range_offsets.push_back(flatbuffer::CreateCoreRange(builder, start, end));
+    }
+    auto ranges_vector = builder.CreateVector(range_offsets);
+    return flatbuffer::CreateCoreRangeSet(builder, ranges_vector);
+}
+
+flatbuffer::TensorMemoryLayout to_flatbuffer(TensorMemoryLayout layout) {
+    switch (layout) {
+        case TensorMemoryLayout::INTERLEAVED: return flatbuffer::TensorMemoryLayout::Interleaved;
+        case TensorMemoryLayout::SINGLE_BANK: return flatbuffer::TensorMemoryLayout::SingleBank;
+        case TensorMemoryLayout::HEIGHT_SHARDED: return flatbuffer::TensorMemoryLayout::HeightSharded;
+        case TensorMemoryLayout::WIDTH_SHARDED: return flatbuffer::TensorMemoryLayout::WidthSharded;
+        case TensorMemoryLayout::BLOCK_SHARDED: return flatbuffer::TensorMemoryLayout::BlockSharded;
+    }
+    TT_THROW("Unsupported TensorMemoryLayout to flatbuffer.");
+}
+
+flatbuffer::BufferType to_flatbuffer(BufferType type) {
+    switch (type) {
+        case BufferType::DRAM: return flatbuffer::BufferType::DRAM;
+        case BufferType::L1: return flatbuffer::BufferType::L1;
+        case BufferType::SYSTEM_MEMORY: return flatbuffer::BufferType::SystemMemory;
+        case BufferType::L1_SMALL: return flatbuffer::BufferType::L1Small;
+        case BufferType::TRACE: return flatbuffer::BufferType::Trace;
+    }
+    TT_THROW("Unsupported BufferType to flatbuffer.");
+}
+
+flatbuffer::DataType to_flatbuffer(DataType type) {
+    switch (type) {
+        case DataType::BFLOAT16: return flatbuffer::DataType::BFloat16;
+        case DataType::FLOAT32: return flatbuffer::DataType::Float32;
+        case DataType::UINT32: return flatbuffer::DataType::UInt32;
+        case DataType::BFLOAT8_B: return flatbuffer::DataType::BFloat8B;
+        case DataType::BFLOAT4_B: return flatbuffer::DataType::BFloat4B;
+        case DataType::UINT8: return flatbuffer::DataType::UInt8;
+        case DataType::UINT16: return flatbuffer::DataType::UInt16;
+        case DataType::INT32: return flatbuffer::DataType::Int32;
+        case DataType::INVALID: return flatbuffer::DataType::Invalid;
+    }
+    TT_THROW("Unsupported DataType to flatbuffer.");
+}
+
+flatbuffers::Offset<flatbuffer::MemoryConfig> to_flatbuffer(
+    const MemoryConfig& config, flatbuffers::FlatBufferBuilder& builder) {
+    flatbuffers::Offset<flatbuffer::ShardSpec> shard_spec = 0;
+    if (config.shard_spec.has_value()) {
+        shard_spec = to_flatbuffer(*config.shard_spec, builder);
+    }
+    return flatbuffer::CreateMemoryConfig(
+        builder, to_flatbuffer(config.memory_layout), to_flatbuffer(config.buffer_type), shard_spec);
+}
+
+flatbuffers::Offset<flatbuffer::TensorLayout> to_flatbuffer(
+    const TensorLayout& layout, flatbuffers::FlatBufferBuilder& builder) {
+    const auto& alignment = layout.get_alignment();
+    auto flat_alignment = builder.CreateVector(alignment.view().data(), alignment.size());
+    auto page_config = layout.get_page_config();
+    if (page_config.get_layout() == Layout::TILE) {
+        auto tile = page_config.get_tile();
+        auto flat_tile =
+            flatbuffer::CreateTile(builder, tile.get_height(), tile.get_width(), tile.get_transpose_of_faces());
+        return flatbuffer::CreateTensorLayout(
+            builder,
+            to_flatbuffer(layout.get_data_type()),
+            flatbuffer::PageConfig::tile,
+            flatbuffer::CreateTilePageConfig(builder, flat_tile).Union(),
+            to_flatbuffer(layout.get_memory_config(), builder),
+            flat_alignment);
+    } else if (page_config.get_layout() == Layout::ROW_MAJOR) {
+        return flatbuffer::CreateTensorLayout(
+            builder,
+            to_flatbuffer(layout.get_data_type()),
+            flatbuffer::PageConfig::row_major,
+            flatbuffer::CreateRowMajorPageConfig(builder).Union(),
+            to_flatbuffer(layout.get_memory_config(), builder),
+            flat_alignment);
+    }
+    TT_THROW("Unsupported PageConfig type to flatbuffer.");
+}
+
+flatbuffers::Offset<flatbuffer::TensorSpec> to_flatbuffer(
+    const TensorSpec& spec, flatbuffers::FlatBufferBuilder& builder) {
+    const auto& shape = spec.logical_shape();
+    auto flat_shape = builder.CreateVector(shape.view().data(), shape.rank());
+    return flatbuffer::CreateTensorSpec(builder, flat_shape, to_flatbuffer(spec.tensor_layout(), builder));
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_to_flatbuffer.hpp
+++ b/ttnn/cpp/ttnn/tensor/flatbuffer/tensor_types_to_flatbuffer.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tensor_types_generated.h"
+
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+
+namespace ttnn {
+
+flatbuffers::Offset<flatbuffer::CoreCoord> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreCoord& core_coord);
+flatbuffers::Offset<flatbuffer::CoreRange> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreRange& core_range);
+flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreRangeSet& core_range_set);
+
+flatbuffer::ShardOrientation to_flatbuffer(ShardOrientation orientation);
+flatbuffer::ShardMode to_flatbuffer(ShardMode shard_mode);
+flatbuffers::Offset<flatbuffer::ShardSpec> to_flatbuffer(
+    const ShardSpec& spec, flatbuffers::FlatBufferBuilder& builder);
+
+flatbuffer::TensorMemoryLayout to_flatbuffer(TensorMemoryLayout layout);
+flatbuffer::BufferType to_flatbuffer(BufferType type);
+flatbuffer::DataType to_flatbuffer(DataType type);
+
+flatbuffers::Offset<flatbuffer::MemoryConfig> to_flatbuffer(
+    const MemoryConfig& config, flatbuffers::FlatBufferBuilder& builder);
+flatbuffers::Offset<flatbuffer::TensorLayout> to_flatbuffer(
+    const TensorLayout& layout, flatbuffers::FlatBufferBuilder& builder);
+flatbuffers::Offset<flatbuffer::TensorSpec> to_flatbuffer(
+    const TensorSpec& spec, flatbuffers::FlatBufferBuilder& builder);
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
@@ -138,6 +138,11 @@ TensorLayout TensorLayout::fromPaddedShape(
         CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(logical_shape, padded_shape, page_config, memory_config));
 }
 
+TensorLayout TensorLayout::restore_from_serialized(
+    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
+    return TensorLayout(dtype, page_config, memory_config, alignment);
+}
+
 void TensorLayout::initialize_alignment() {
     auto default_alignment = page_config_.create_default_alignment(dtype_, memory_config_);
     if (alignment_.empty()) {

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
@@ -82,6 +82,9 @@ public:
         return std::forward_as_tuple(dtype_, page_config_, memory_config_, alignment_);
     }
 
+    static TensorLayout restore_from_serialized(
+        DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
+
 private:
     // Private to not expose alignment parameter to the public API
     TensorLayout(

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -73,115 +73,119 @@ struct LegacyShape {
     }
 };
 
-static constexpr std::size_t SENTINEL_VALUE = std::numeric_limits<std::size_t>::max();
+static constexpr uint64_t SENTINEL_VALUE = std::numeric_limits<uint64_t>::max();
 
-void dump_tensor_spec(const TensorSpec& tensor_spec, std::ostream& output_stream) {
+void dump_tensor_spec(const TensorSpec& tensor_spec, FILE* output_file) {
     flatbuffers::FlatBufferBuilder builder;
     auto flat_spec = ttnn::to_flatbuffer(tensor_spec, builder);
     builder.Finish(flat_spec);
     uint64_t buffer_size = builder.GetSize();
-    output_stream.write(reinterpret_cast<const char*>(&buffer_size), sizeof(uint64_t));
-    output_stream.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), sizeof(buffer_size));
+    fwrite(&buffer_size, sizeof(buffer_size), 1, output_file);
+    fwrite(builder.GetBufferPointer(), buffer_size, 1, output_file);
 }
 
-TensorSpec load_tensor_spec(std::istream& input_stream) {
+TensorSpec load_tensor_spec(FILE* input_file) {
     uint64_t bin_size = 0;
-    input_stream.read(reinterpret_cast<char*>(&bin_size), sizeof(uint64_t));
-    std::vector<char> bin(bin_size);
-    input_stream.read(&bin[0], bin_size);
-    auto spec = flatbuffers::GetRoot<ttnn::flatbuffer::TensorSpec>(bin.data());
+    fread(&bin_size, sizeof(bin_size), 1, input_file);
+    std::vector<uint8_t> bin(bin_size);
+    fread(bin.data(), bin_size, 1, input_file);
+    flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(bin.data()), bin_size);
+    if (!ttnn::flatbuffer::VerifyTensorSpecBuffer(verifier)) {
+        std::cout << "tensor spec verification failed2" << std::endl;
+    }
+    auto spec = ttnn::flatbuffer::GetTensorSpec(bin.data());
     return ttnn::from_flatbuffer(spec);
 }
 
-void dump_owned_storage(std::ofstream& output_stream, const OwnedStorage& storage) {
+void dump_owned_storage(FILE* output_file, const OwnedStorage& storage) {
     std::visit(
-        [&output_stream]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
+        [output_file]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
             const auto buffer = owned_buffer::get_as<T>(generic_buffer);
-            auto size = buffer.size();
-            output_stream.write(reinterpret_cast<const char*>(&size), sizeof(size));
-            output_stream.write(reinterpret_cast<const char*>(buffer.begin()), sizeof(T) * size);
+            uint64_t size = buffer.size();
+            fwrite(&size, sizeof(size), 1, output_file);
+            fwrite(buffer.data(), sizeof(T) * size, 1, output_file);
         },
         storage.buffer);
 }
 
-void dump_borrowed_storage(std::ofstream& output_stream, const BorrowedStorage& storage) {
+void dump_borrowed_storage(FILE* output_file, const BorrowedStorage& storage) {
     std::visit(
-        [&output_stream]<typename T>(const borrowed_buffer::Buffer<T>& generic_buffer) {
+        [output_file]<typename T>(const borrowed_buffer::Buffer<T>& generic_buffer) {
             const auto buffer = borrowed_buffer::get_as<T>(generic_buffer);
-            auto size = buffer.size();
-            output_stream.write(reinterpret_cast<const char*>(&size), sizeof(size));
-            output_stream.write(reinterpret_cast<const char*>(buffer.begin()), sizeof(T) * size);
+            uint64_t size = buffer.size();
+            fwrite(&size, sizeof(size), 1, output_file);
+            fwrite(buffer.data(), sizeof(T) * size, 1, output_file);
         },
         storage.buffer);
 }
 
 void dump_multi_device_host_storage(
-    std::ofstream& output_stream, const MultiDeviceHostStorage& storage, const DistributedTensorConfig& strategy) {
-    std::size_t num_buffers = storage.num_buffers();
-    output_stream.write(reinterpret_cast<const char*>(&num_buffers), sizeof(std::size_t));
+    FILE* output_file, const MultiDeviceHostStorage& storage, const DistributedTensorConfig& strategy) {
+    uint64_t num_buffers = storage.num_buffers();
+    fwrite(&num_buffers, sizeof(num_buffers), 1, output_file);
 
     // Use the user-specified strategy which defines how it gets distributed when mapped onto multi-device
-    output_stream.write(reinterpret_cast<const char*>(&strategy), sizeof(DistributedTensorConfig));
+    fwrite(&strategy, sizeof(strategy), 1, output_file);
 
     if (std::holds_alternative<ReplicateTensor>(strategy)) {
         std::visit(
-            [&output_stream]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
+            [output_file]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
                 const auto buffer = owned_buffer::get_as<T>(generic_buffer);
-                auto size = buffer.size();
-                output_stream.write(reinterpret_cast<const char*>(&size), sizeof(size));
-                output_stream.write(reinterpret_cast<const char*>(buffer.begin()), sizeof(T) * size);
+                uint64_t size = buffer.size();
+                fwrite(&size, sizeof(size), 1, output_file);
+                fwrite(buffer.begin(), sizeof(T) * size, 1, output_file);
             },
             storage.get_buffer(0));
         auto spec = storage.specs.at(0);
-        dump_tensor_spec(spec, output_stream);
+        dump_tensor_spec(spec, output_file);
     } else {
         for (int i = 0; i < num_buffers; i++) {
             std::visit(
-                [&output_stream]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
+                [output_file]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
                     const auto buffer = owned_buffer::get_as<T>(generic_buffer);
-                    auto size = buffer.size();
-                    output_stream.write(reinterpret_cast<const char*>(&size), sizeof(size));
-                    output_stream.write(reinterpret_cast<const char*>(buffer.begin()), sizeof(T) * size);
+                    uint64_t size = buffer.size();
+                    fwrite(&size, sizeof(size), 1, output_file);
+                    fwrite(buffer.begin(), sizeof(T) * size, 1, output_file);
                 },
                 storage.get_buffer(i));
         }
         for (const auto& spec : storage.specs) {
-            dump_tensor_spec(spec, output_stream);
+            dump_tensor_spec(spec, output_file);
         }
     }
 }
 
 template <typename T>
-OwnedStorage load_owned_storage(std::ifstream& input_stream) {
-    std::size_t size = 0;
-    input_stream.read(reinterpret_cast<char*>(&size), sizeof(std::size_t));
+OwnedStorage load_owned_storage(FILE* input_file) {
+    uint64_t size = 0;
+    fread(&size, sizeof(size), 1, input_file);
     auto buffer = owned_buffer::create<T>(size);
-    input_stream.read(reinterpret_cast<char*>(buffer.begin()), sizeof(T) * size);
+    fread(buffer.begin(), sizeof(T) * size, 1, input_file);
     return {buffer};
 }
 
 template <typename T>
 MultiDeviceHostStorage load_multi_device_host_storage(
-    std::ifstream& input_stream, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
-    std::size_t num_buffers = 0;
+    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
+    uint64_t num_buffers = 0;
     DistributedTensorConfig strategy;
-    input_stream.read(reinterpret_cast<char*>(&num_buffers), sizeof(std::size_t));
-    input_stream.read(reinterpret_cast<char*>(&strategy), sizeof(DistributedTensorConfig));
+    fread(&num_buffers, sizeof(num_buffers), 1, input_file);
+    fread(&strategy, sizeof(strategy), 1, input_file);
 
     std::vector<OwnedBuffer> buffers;
     std::vector<ttnn::TensorSpec> specs;
     if (std::holds_alternative<ReplicateTensor>(strategy)) {
-        std::size_t size = 0;
-        input_stream.read(reinterpret_cast<char*>(&size), sizeof(std::size_t));
+        uint64_t size = 0;
+        fread(&size, sizeof(size), 1, input_file);
         auto buffer = owned_buffer::create<T>(size);
-        input_stream.read(reinterpret_cast<char*>(buffer.begin()), sizeof(T) * size);
+        fread(buffer.begin(), sizeof(T) * size, 1, input_file);
         buffers.push_back(buffer);
         auto spec = [&] {
             if (version_id >= 5) {
-                return load_tensor_spec(input_stream);
+                return load_tensor_spec(input_file);
             }
             auto shape = LegacyShape{};
-            input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
+            fread(&shape, sizeof(shape), 1, input_file);
             return TensorSpec(
                 shape.logical_shape(),
                 TensorLayout::fromPaddedShape(
@@ -196,20 +200,18 @@ MultiDeviceHostStorage load_multi_device_host_storage(
 
     } else {
         for (std::size_t i = 0; i < num_buffers; ++i) {
-            std::size_t size = 0;
-            input_stream.read(reinterpret_cast<char*>(&size), sizeof(std::size_t));
-
+            uint64_t size = 0;
+            fread(&size, sizeof(size), 1, input_file);
             auto buffer = owned_buffer::create<T>(size);
-            input_stream.read(reinterpret_cast<char*>(buffer.begin()), sizeof(T) * size);
-
+            fread(buffer.begin(), sizeof(T) * size, 1, input_file);
             buffers.push_back(std::move(buffer));
         }
         for (std::size_t i = 0; i < num_buffers; ++i) {
             if (version_id >= 5) {
-                specs.push_back(load_tensor_spec(input_stream));
+                specs.push_back(load_tensor_spec(input_file));
             } else {
                 auto shape = LegacyShape{};
-                input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
+                fread(&shape, sizeof(shape), 1, input_file);
                 TensorSpec spec(
                     shape.logical_shape(),
                     TensorLayout::fromPaddedShape(
@@ -222,44 +224,44 @@ MultiDeviceHostStorage load_multi_device_host_storage(
     return {strategy, buffers, specs};
 }
 
-OwnedStorage load_owned_storage(std::ifstream& input_stream, DataType data_type) {
+OwnedStorage load_owned_storage(FILE* input_file, DataType data_type) {
     if (data_type == DataType::UINT32 or data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
         using T = std::uint32_t;
-        return load_owned_storage<T>(input_stream);
+        return load_owned_storage<T>(input_file);
     } else if (data_type == DataType::INT32) {
         using T = std::int32_t;
-        return load_owned_storage<T>(input_stream);
+        return load_owned_storage<T>(input_file);
     } else if (data_type == DataType::UINT8) {
         using T = std::uint8_t;
-        return load_owned_storage<T>(input_stream);
+        return load_owned_storage<T>(input_file);
     } else if (data_type == DataType::UINT16) {
         using T = std::uint16_t;
-        return load_owned_storage<T>(input_stream);
+        return load_owned_storage<T>(input_file);
     } else if (data_type == DataType::FLOAT32) {
         using T = float;
-        return load_owned_storage<T>(input_stream);
+        return load_owned_storage<T>(input_file);
     } else if (data_type == DataType::BFLOAT16) {
         using T = bfloat16;
-        return load_owned_storage<T>(input_stream);
+        return load_owned_storage<T>(input_file);
     } else {
         TT_THROW("Unsupported DataType");
     }
 }
 
 MultiDeviceHostStorage load_multi_device_host_storage(
-    std::ifstream& input_stream, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
+    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
     if (data_type == DataType::UINT32 or data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
         using T = std::uint32_t;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
     } else if (data_type == DataType::UINT16) {
         using T = std::uint16_t;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
     } else if (data_type == DataType::FLOAT32) {
         using T = float;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
     } else if (data_type == DataType::BFLOAT16) {
         using T = bfloat16;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
     } else {
         TT_THROW("Unsupported DataType");
     }
@@ -267,20 +269,15 @@ MultiDeviceHostStorage load_multi_device_host_storage(
 
 template <typename T>
 Storage load_storage(
-    std::ifstream& input_stream,
-    DataType data_type,
-    Layout layout,
-    StorageType storage_type,
-    T device,
-    uint8_t version_id) {
+    FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, T device, uint8_t version_id) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::MULTI_DEVICE) {
         if constexpr (std::is_same_v<T, MeshDevice*>) {
-            return load_multi_device_host_storage(input_stream, data_type, layout, device, version_id);
+            return load_multi_device_host_storage(input_file, data_type, layout, device, version_id);
         } else {
             TT_THROW("MeshDevice is required for MULTI_DEVICE_HOST storage");
         }
     } else {
-        return load_owned_storage(input_stream, data_type);
+        return load_owned_storage(input_file, data_type);
     }
 }
 
@@ -288,18 +285,19 @@ Storage load_storage(
 
 void dump_tensor(
     const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy) {
-    std::ofstream output_stream(file_name, std::ios::out | std::ios::binary);
-    if (not output_stream) {
+    std::cout << "Dumping tensor " << file_name << std::endl;
+    FILE* output_file = fopen(file_name.c_str(), "wb");
+    if (not output_file) {
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));
     }
 
-    output_stream.write(reinterpret_cast<const char*>(&SENTINEL_VALUE), sizeof(std::size_t));
-    output_stream.write(reinterpret_cast<const char*>(&VERSION_ID), sizeof(std::uint8_t));
+    fwrite(&SENTINEL_VALUE, sizeof(SENTINEL_VALUE), 1, output_file);
+    fwrite(&VERSION_ID, sizeof(VERSION_ID), 1, output_file);
 
-    dump_tensor_spec(tensor.get_tensor_spec(), output_stream);
+    dump_tensor_spec(tensor.get_tensor_spec(), output_file);
 
     auto storage_type = tensor.storage_type();
-    output_stream.write(reinterpret_cast<const char*>(&storage_type), sizeof(StorageType));
+    fwrite(&storage_type, sizeof(storage_type), 1, output_file);
 
     bool is_on_device = is_tensor_on_device_or_multidevice(tensor);
     Tensor tensor_to_dump = tensor;
@@ -308,49 +306,51 @@ void dump_tensor(
     }
 
     std::visit(
-        [&output_stream, &strategy](const auto& storage) {
+        [output_file, &strategy](const auto& storage) {
             using StorageType = std::decay_t<decltype(storage)>;
             if constexpr (std::is_same_v<StorageType, OwnedStorage>) {
-                dump_owned_storage(output_stream, storage);
+                dump_owned_storage(output_file, storage);
             } else if constexpr (std::is_same_v<StorageType, BorrowedStorage>) {
-                dump_borrowed_storage(output_stream, storage);
+                dump_borrowed_storage(output_file, storage);
             } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
                 TT_THROW("Device storage isn't supported");
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {
                 TT_THROW("Device storage isn't supported");
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
                 auto distribute_config = get_distributed_tensor_config(strategy);
-                dump_multi_device_host_storage(output_stream, storage, distribute_config);
+                dump_multi_device_host_storage(output_file, storage, distribute_config);
             } else {
                 raise_unsupported_storage<StorageType>();
             }
         },
         tensor_to_dump.get_storage());
+
+    fclose(output_file);
 }
 
 template <typename T>
-Tensor load_tensor_helper_legacy_impl(std::ifstream& input_stream, T device, uint8_t version_id) {
+Tensor load_tensor_helper_legacy_impl(FILE* input_file, T device, uint8_t version_id) {
     auto shape = LegacyShape{};
     DataType data_type;
     Layout layout;
     StorageType storage_type;
-    input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
-    input_stream.read(reinterpret_cast<char*>(&data_type), sizeof(DataType));
-    input_stream.read(reinterpret_cast<char*>(&layout), sizeof(Layout));
-    input_stream.read(reinterpret_cast<char*>(&storage_type), sizeof(StorageType));
+    fread(&shape, sizeof(shape), 1, input_file);
+    fread(&data_type, sizeof(data_type), 1, input_file);
+    fread(&layout, sizeof(layout), 1, input_file);
+    fread(&storage_type, sizeof(storage_type), 1, input_file);
 
     bool has_memory_config = false;
     MemoryConfig memory_config =
         MemoryConfig{.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::DRAM};
 
     if (version_id >= 2) {
-        input_stream.read(reinterpret_cast<char*>(&has_memory_config), sizeof(bool));
+        fread(&has_memory_config, sizeof(has_memory_config), 1, input_file);
         if (has_memory_config) {
-            memory_config = tt::tt_metal::load_memory_config(input_stream);
+            memory_config = tt::tt_metal::load_memory_config(input_file);
         }
     }
 
-    auto storage = load_storage(input_stream, data_type, layout, storage_type, device, version_id);
+    auto storage = load_storage(input_file, data_type, layout, storage_type, device, version_id);
 
     auto tensor = Tensor(
         std::move(storage),
@@ -363,19 +363,20 @@ Tensor load_tensor_helper_legacy_impl(std::ifstream& input_stream, T device, uin
     } else if (has_memory_config) {
         tt::log_warning("Memory config is ignored when loading the tensor because device is not provided");
     }
+    fclose(input_file);
     return tensor;
 }
 
 template <typename T>
-Tensor load_tensor_helper_very_legacy_impl(std::ifstream& input_stream, T device) {
+Tensor load_tensor_helper_very_legacy_impl(FILE* input_file, T device) {
     auto shape = LegacyShape{};
     DataType data_type;
     Layout layout;
-    input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
-    input_stream.read(reinterpret_cast<char*>(&data_type), sizeof(DataType));
-    input_stream.read(reinterpret_cast<char*>(&layout), sizeof(Layout));
+    fread(&shape, sizeof(shape), 1, input_file);
+    fread(&data_type, sizeof(data_type), 1, input_file);
+    fread(&layout, sizeof(layout), 1, input_file);
 
-    auto storage = load_owned_storage(input_stream, data_type);
+    auto storage = load_owned_storage(input_file, data_type);
     auto tensor = Tensor(
         std::move(storage),
         TensorSpec(
@@ -390,37 +391,39 @@ Tensor load_tensor_helper_very_legacy_impl(std::ifstream& input_stream, T device
 
 template <typename T>
 Tensor load_tensor_helper(const std::string& file_name, T device) {
-    std::ifstream input_stream(file_name, std::ios::in | std::ios::binary);
-    if (not input_stream) {
+    std::cout << "Loading tensor " << file_name << std::endl;
+    FILE* input_file = fopen(file_name.c_str(), "rb");
+    if (not input_file) {
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));
     }
 
     std::size_t read_sentinel;
-    input_stream.read(reinterpret_cast<char*>(&read_sentinel), sizeof(read_sentinel));
+    fread(&read_sentinel, sizeof(read_sentinel), 1, input_file);
     if (read_sentinel != SENTINEL_VALUE) {
-        input_stream.seekg(0, std::ios::beg);
-        return load_tensor_helper_very_legacy_impl(input_stream, device);
+        fseek(input_file, 0, SEEK_SET);
+        return load_tensor_helper_very_legacy_impl(input_file, device);
     }
 
     std::uint8_t version_id;
-    input_stream.read(reinterpret_cast<char*>(&version_id), sizeof(version_id));
+    fread(&version_id, sizeof(version_id), 1, input_file);
     if (version_id > VERSION_ID) {
         throw std::runtime_error(
             fmt::format("Serialized tensor with version_id: {}. Loader version: {}", version_id, VERSION_ID));
     }
 
     if (version_id < 5) {
-        return load_tensor_helper_legacy_impl(input_stream, device, version_id);
+        return load_tensor_helper_legacy_impl(input_file, device, version_id);
     }
 
-    auto spec = load_tensor_spec(input_stream);
+    auto spec = load_tensor_spec(input_file);
     StorageType storage_type;
-    input_stream.read(reinterpret_cast<char*>(&storage_type), sizeof(StorageType));
-    auto storage = load_storage(input_stream, spec.data_type(), spec.layout(), storage_type, device, version_id);
+    fread(&storage_type, sizeof(storage_type), 1, input_file);
+    auto storage = load_storage(input_file, spec.data_type(), spec.layout(), storage_type, device, version_id);
     Tensor tensor(std::move(storage), spec);
     if (device != nullptr) {
         tensor = tensor.to_device(device, spec.memory_config());
     }
+    fclose(input_file);
     return tensor;
 }
 
@@ -432,60 +435,61 @@ Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
     return load_tensor_helper<MeshDevice*>(file_name, device);
 }
 
-void dump_memory_config(std::ostream& output_stream, const MemoryConfig& memory_config) {
-    output_stream.write(reinterpret_cast<const char*>(&VERSION_ID), sizeof(std::uint8_t));
+void dump_memory_config(FILE* output_file, const MemoryConfig& memory_config) {
+    fwrite(&VERSION_ID, sizeof(VERSION_ID), 1, output_file);
     flatbuffers::FlatBufferBuilder builder;
     auto flat_config = ttnn::to_flatbuffer(memory_config, builder);
     builder.Finish(flat_config);
     uint64_t buf_size = builder.GetSize();
-    output_stream.write(reinterpret_cast<const char*>(&buf_size), sizeof(uint64_t));
-    output_stream.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), buf_size);
+    fwrite(&buf_size, sizeof(buf_size), 1, output_file);
+    fwrite(builder.GetBufferPointer(), buf_size, 1, output_file);
 }
 
 void dump_memory_config(const std::string& file_name, const MemoryConfig& memory_config) {
-    std::ofstream output_stream(file_name, std::ios::out | std::ios::binary);
-    if (not output_stream) {
+    FILE* output_file = fopen(file_name.c_str(), "wb");
+    if (not output_file) {
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));
     }
-    dump_memory_config(output_stream, memory_config);
+    dump_memory_config(output_file, memory_config);
+    fclose(output_file);
 }
 
-MemoryConfig load_memory_config_legacy_impl(std::ifstream& input_stream, uint8_t version_id) {
+MemoryConfig load_memory_config_legacy_impl(FILE* input_file, uint8_t version_id) {
     TensorMemoryLayout memory_layout;
     BufferType buffer_type;
     bool has_shard_spec;
-    input_stream.read(reinterpret_cast<char*>(&memory_layout), sizeof(TensorMemoryLayout));
-    input_stream.read(reinterpret_cast<char*>(&buffer_type), sizeof(BufferType));
-    input_stream.read(reinterpret_cast<char*>(&has_shard_spec), sizeof(bool));
+    fread(&memory_layout, sizeof(memory_layout), 1, input_file);
+    fread(&buffer_type, sizeof(buffer_type), 1, input_file);
+    fread(&has_shard_spec, sizeof(has_shard_spec), 1, input_file);
 
     std::optional<ShardSpec> shard_spec = std::nullopt;
     if (has_shard_spec) {
-        std::size_t num_core_ranges;
+        uint64_t num_core_ranges;
         std::set<CoreRange> core_ranges;
         std::array<uint32_t, 2> shape;
         ShardOrientation orientation;
 
-        input_stream.read(reinterpret_cast<char*>(&num_core_ranges), sizeof(std::size_t));
+        fread(&num_core_ranges, sizeof(num_core_ranges), 1, input_file);
         for (auto index = 0; index < num_core_ranges; index++) {
             CoreRange core_range{{}, {}};
-            input_stream.read(reinterpret_cast<char*>(&core_range), sizeof(CoreRange));
+            fread(&core_range, sizeof(core_range), 1, input_file);
             core_ranges.insert(core_range);
         }
-        input_stream.read(reinterpret_cast<char*>(&shape), sizeof(std::array<uint32_t, 2>));
-        input_stream.read(reinterpret_cast<char*>(&orientation), sizeof(ShardOrientation));
+        fread(&shape, sizeof(shape), 1, input_file);
+        fread(&orientation, sizeof(orientation), 1, input_file);
         if (version_id <= 3) {
             // Read halo for backward compatibility.
             bool halo;
-            input_stream.read(reinterpret_cast<char*>(&halo), sizeof(bool));
+            fread(&halo, sizeof(halo), 1, input_file);
         }
         shard_spec = {CoreRangeSet{core_ranges}, shape, orientation};
     }
     return MemoryConfig{memory_layout, buffer_type, shard_spec};
 }
 
-MemoryConfig load_memory_config(std::ifstream& input_stream) {
+MemoryConfig load_memory_config(FILE* input_file) {
     std::uint8_t version_id;
-    input_stream.read(reinterpret_cast<char*>(&version_id), sizeof(std::uint8_t));
+    fread(&version_id, sizeof(version_id), 1, input_file);
 
     // Allow only backward compatible versions
     if (version_id > VERSION_ID) {
@@ -494,23 +498,25 @@ MemoryConfig load_memory_config(std::ifstream& input_stream) {
     }
 
     if (version_id < 5) {
-        return load_memory_config_legacy_impl(input_stream, version_id);
+        return load_memory_config_legacy_impl(input_file, version_id);
     }
 
     uint64_t bin_size = 0;
-    input_stream.read(reinterpret_cast<char*>(&bin_size), sizeof(uint64_t));
+    fread(&bin_size, sizeof(bin_size), 1, input_file);
     std::vector<uint8_t> bin(bin_size);
-    input_stream.read(reinterpret_cast<char*>(&bin[0]), bin_size);
+    fread(bin.data(), bin_size, 1, input_file);
     auto mem_config = flatbuffers::GetRoot<ttnn::flatbuffer::MemoryConfig>(bin.data());
     return ttnn::from_flatbuffer(mem_config);
 }
 
 MemoryConfig load_memory_config(const std::string& file_name) {
-    std::ifstream input_stream(file_name, std::ios::in | std::ios::binary);
-    if (not input_stream) {
+    FILE* input_file = fopen(file_name.c_str(), "rb");
+    if (not input_file) {
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));
     }
-    return load_memory_config(input_stream);
+    auto res = load_memory_config(input_file);
+    fclose(input_file);
+    return res;
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -10,10 +10,14 @@
 #include <string>
 #include <type_traits>
 
+#include <flatbuffers/flatbuffers.h>
+
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/flatbuffer/tensor_types_from_flatbuffer.hpp"
+#include "ttnn/tensor/flatbuffer/tensor_types_to_flatbuffer.hpp"
 
 namespace tt::tt_metal {
 
@@ -71,6 +75,24 @@ struct LegacyShape {
 
 static constexpr std::size_t SENTINEL_VALUE = std::numeric_limits<std::size_t>::max();
 
+void dump_tensor_spec(const TensorSpec& tensor_spec, std::ostream& output_stream) {
+    flatbuffers::FlatBufferBuilder builder;
+    auto flat_spec = ttnn::to_flatbuffer(tensor_spec, builder);
+    builder.Finish(flat_spec);
+    uint64_t buffer_size = builder.GetSize();
+    output_stream.write(reinterpret_cast<const char*>(&buffer_size), sizeof(uint64_t));
+    output_stream.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), sizeof(buffer_size));
+}
+
+TensorSpec load_tensor_spec(std::istream& input_stream) {
+    uint64_t bin_size = 0;
+    input_stream.read(reinterpret_cast<char*>(&bin_size), sizeof(uint64_t));
+    std::vector<char> bin(bin_size);
+    input_stream.read(&bin[0], bin_size);
+    auto spec = flatbuffers::GetRoot<ttnn::flatbuffer::TensorSpec>(bin.data());
+    return ttnn::from_flatbuffer(spec);
+}
+
 void dump_owned_storage(std::ofstream& output_stream, const OwnedStorage& storage) {
     std::visit(
         [&output_stream]<typename T>(const owned_buffer::Buffer<T>& generic_buffer) {
@@ -111,8 +133,7 @@ void dump_multi_device_host_storage(
             },
             storage.get_buffer(0));
         auto spec = storage.specs.at(0);
-        LegacyShape shape(spec.logical_shape(), spec.padded_shape());
-        output_stream.write(reinterpret_cast<const char*>(&shape), sizeof(LegacyShape));
+        dump_tensor_spec(spec, output_stream);
     } else {
         for (int i = 0; i < num_buffers; i++) {
             std::visit(
@@ -125,8 +146,7 @@ void dump_multi_device_host_storage(
                 storage.get_buffer(i));
         }
         for (const auto& spec : storage.specs) {
-            LegacyShape shape(spec.logical_shape(), spec.padded_shape());
-            output_stream.write(reinterpret_cast<const char*>(&shape), sizeof(LegacyShape));
+            dump_tensor_spec(spec, output_stream);
         }
     }
 }
@@ -142,7 +162,7 @@ OwnedStorage load_owned_storage(std::ifstream& input_stream) {
 
 template <typename T>
 MultiDeviceHostStorage load_multi_device_host_storage(
-    std::ifstream& input_stream, DataType data_type, Layout layout, MeshDevice* mesh_device) {
+    std::ifstream& input_stream, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
     std::size_t num_buffers = 0;
     DistributedTensorConfig strategy;
     input_stream.read(reinterpret_cast<char*>(&num_buffers), sizeof(std::size_t));
@@ -154,14 +174,19 @@ MultiDeviceHostStorage load_multi_device_host_storage(
         std::size_t size = 0;
         input_stream.read(reinterpret_cast<char*>(&size), sizeof(std::size_t));
         auto buffer = owned_buffer::create<T>(size);
-        auto shape = LegacyShape{};
         input_stream.read(reinterpret_cast<char*>(buffer.begin()), sizeof(T) * size);
-        input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
         buffers.push_back(buffer);
-        TensorSpec spec(
-            shape.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                data_type, PageConfig(layout), MemoryConfig{}, shape.logical_shape(), shape.padded_shape()));
+        auto spec = [&] {
+            if (version_id >= 5) {
+                return load_tensor_spec(input_stream);
+            }
+            auto shape = LegacyShape{};
+            input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
+            return TensorSpec(
+                shape.logical_shape(),
+                TensorLayout::fromPaddedShape(
+                    data_type, PageConfig(layout), MemoryConfig{}, shape.logical_shape(), shape.padded_shape()));
+        }();
         specs.push_back(spec);
 
         for (std::size_t i = 1; i < mesh_device->num_devices(); ++i) {
@@ -180,13 +205,17 @@ MultiDeviceHostStorage load_multi_device_host_storage(
             buffers.push_back(std::move(buffer));
         }
         for (std::size_t i = 0; i < num_buffers; ++i) {
-            auto shape = LegacyShape{};
-            input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
-            TensorSpec spec(
-                shape.logical_shape(),
-                TensorLayout::fromPaddedShape(
-                    data_type, PageConfig(layout), MemoryConfig{}, shape.logical_shape(), shape.padded_shape()));
-            specs.push_back(spec);
+            if (version_id >= 5) {
+                specs.push_back(load_tensor_spec(input_stream));
+            } else {
+                auto shape = LegacyShape{};
+                input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
+                TensorSpec spec(
+                    shape.logical_shape(),
+                    TensorLayout::fromPaddedShape(
+                        data_type, PageConfig(layout), MemoryConfig{}, shape.logical_shape(), shape.padded_shape()));
+                specs.push_back(spec);
+            }
         }
     }
 
@@ -218,19 +247,19 @@ OwnedStorage load_owned_storage(std::ifstream& input_stream, DataType data_type)
 }
 
 MultiDeviceHostStorage load_multi_device_host_storage(
-    std::ifstream& input_stream, DataType data_type, Layout layout, MeshDevice* mesh_device) {
+    std::ifstream& input_stream, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
     if (data_type == DataType::UINT32 or data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
         using T = std::uint32_t;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device);
+        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
     } else if (data_type == DataType::UINT16) {
         using T = std::uint16_t;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device);
+        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
     } else if (data_type == DataType::FLOAT32) {
         using T = float;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device);
+        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
     } else if (data_type == DataType::BFLOAT16) {
         using T = bfloat16;
-        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device);
+        return load_multi_device_host_storage<T>(input_stream, data_type, layout, mesh_device, version_id);
     } else {
         TT_THROW("Unsupported DataType");
     }
@@ -238,10 +267,15 @@ MultiDeviceHostStorage load_multi_device_host_storage(
 
 template <typename T>
 Storage load_storage(
-    std::ifstream& input_stream, DataType data_type, Layout layout, StorageType storage_type, T device) {
+    std::ifstream& input_stream,
+    DataType data_type,
+    Layout layout,
+    StorageType storage_type,
+    T device,
+    uint8_t version_id) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::MULTI_DEVICE) {
         if constexpr (std::is_same_v<T, MeshDevice*>) {
-            return load_multi_device_host_storage(input_stream, data_type, layout, device);
+            return load_multi_device_host_storage(input_stream, data_type, layout, device, version_id);
         } else {
             TT_THROW("MeshDevice is required for MULTI_DEVICE_HOST storage");
         }
@@ -259,27 +293,15 @@ void dump_tensor(
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));
     }
 
-    LegacyShape shape(tensor.get_logical_shape(), tensor.get_padded_shape());
-    auto data_type = tensor.get_dtype();
-    auto layout = tensor.get_layout();
-    auto storage_type = tensor.storage_type();
-
     output_stream.write(reinterpret_cast<const char*>(&SENTINEL_VALUE), sizeof(std::size_t));
     output_stream.write(reinterpret_cast<const char*>(&VERSION_ID), sizeof(std::uint8_t));
-    output_stream.write(reinterpret_cast<const char*>(&shape), sizeof(LegacyShape));
-    output_stream.write(reinterpret_cast<const char*>(&data_type), sizeof(DataType));
-    output_stream.write(reinterpret_cast<const char*>(&layout), sizeof(Layout));
+
+    dump_tensor_spec(tensor.get_tensor_spec(), output_stream);
+
+    auto storage_type = tensor.storage_type();
     output_stream.write(reinterpret_cast<const char*>(&storage_type), sizeof(StorageType));
 
     bool is_on_device = is_tensor_on_device_or_multidevice(tensor);
-    bool has_memory_config = is_on_device;
-    if (VERSION_ID >= 2) {
-        output_stream.write(reinterpret_cast<const char*>(&has_memory_config), sizeof(bool));
-        if (has_memory_config) {
-            tt::tt_metal::dump_memory_config(output_stream, tensor.memory_config());
-        }
-    }
-
     Tensor tensor_to_dump = tensor;
     if (is_on_device) {
         tensor_to_dump = tensor_to_dump.cpu();
@@ -307,6 +329,66 @@ void dump_tensor(
 }
 
 template <typename T>
+Tensor load_tensor_helper_legacy_impl(std::ifstream& input_stream, T device, uint8_t version_id) {
+    auto shape = LegacyShape{};
+    DataType data_type;
+    Layout layout;
+    StorageType storage_type;
+    input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
+    input_stream.read(reinterpret_cast<char*>(&data_type), sizeof(DataType));
+    input_stream.read(reinterpret_cast<char*>(&layout), sizeof(Layout));
+    input_stream.read(reinterpret_cast<char*>(&storage_type), sizeof(StorageType));
+
+    bool has_memory_config = false;
+    MemoryConfig memory_config =
+        MemoryConfig{.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::DRAM};
+
+    if (version_id >= 2) {
+        input_stream.read(reinterpret_cast<char*>(&has_memory_config), sizeof(bool));
+        if (has_memory_config) {
+            memory_config = tt::tt_metal::load_memory_config(input_stream);
+        }
+    }
+
+    auto storage = load_storage(input_stream, data_type, layout, storage_type, device, version_id);
+
+    auto tensor = Tensor(
+        std::move(storage),
+        TensorSpec(
+            shape.logical_shape(),
+            TensorLayout::fromPaddedShape(
+                data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
+    if (device != nullptr) {
+        tensor = tensor.to_device(device, memory_config);
+    } else if (has_memory_config) {
+        tt::log_warning("Memory config is ignored when loading the tensor because device is not provided");
+    }
+    return tensor;
+}
+
+template <typename T>
+Tensor load_tensor_helper_very_legacy_impl(std::ifstream& input_stream, T device) {
+    auto shape = LegacyShape{};
+    DataType data_type;
+    Layout layout;
+    input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
+    input_stream.read(reinterpret_cast<char*>(&data_type), sizeof(DataType));
+    input_stream.read(reinterpret_cast<char*>(&layout), sizeof(Layout));
+
+    auto storage = load_owned_storage(input_stream, data_type);
+    auto tensor = Tensor(
+        std::move(storage),
+        TensorSpec(
+            shape.logical_shape(),
+            TensorLayout::fromPaddedShape(
+                data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
+    if (device != nullptr) {
+        tensor = tensor.to_device(device);
+    }
+    return tensor;
+}
+
+template <typename T>
 Tensor load_tensor_helper(const std::string& file_name, T device) {
     std::ifstream input_stream(file_name, std::ios::in | std::ios::binary);
     if (not input_stream) {
@@ -315,72 +397,31 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
 
     std::size_t read_sentinel;
     input_stream.read(reinterpret_cast<char*>(&read_sentinel), sizeof(read_sentinel));
-    if (read_sentinel == SENTINEL_VALUE) {
-        std::uint8_t version_id;
-        input_stream.read(reinterpret_cast<char*>(&version_id), sizeof(version_id));
-
-        // Allow only backward compatible versions
-        if (version_id > VERSION_ID) {
-            throw std::runtime_error(
-                fmt::format("Serialized tensor with version_id: {}. Loader version: {}", version_id, VERSION_ID));
-        }
-        auto shape = LegacyShape{};
-        DataType data_type;
-        Layout layout;
-        StorageType storage_type;
-        input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
-        input_stream.read(reinterpret_cast<char*>(&data_type), sizeof(DataType));
-        input_stream.read(reinterpret_cast<char*>(&layout), sizeof(Layout));
-        input_stream.read(reinterpret_cast<char*>(&storage_type), sizeof(StorageType));
-
-        bool has_memory_config = false;
-        MemoryConfig memory_config = MemoryConfig{
-            .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::DRAM};
-
-        if (version_id >= 2) {
-            input_stream.read(reinterpret_cast<char*>(&has_memory_config), sizeof(bool));
-            if (has_memory_config) {
-                memory_config = tt::tt_metal::load_memory_config(input_stream);
-            }
-        }
-
-        auto storage = load_storage(input_stream, data_type, layout, storage_type, device);
-
-        auto tensor = Tensor(
-            std::move(storage),
-            TensorSpec(
-                shape.logical_shape(),
-                TensorLayout::fromPaddedShape(
-                    data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
-        if (device != nullptr) {
-            tensor = tensor.to_device(device, memory_config);
-        } else if (has_memory_config) {
-            tt::log_warning("Memory config is ignored when loading the tensor because device is not provided");
-        }
-        return tensor;
-
-    } else {
-        input_stream.seekg(0, std::ios::beg);  // No sentinel found, assume it's an older format and rewind
-
-        auto shape = LegacyShape{};
-        DataType data_type;
-        Layout layout;
-        input_stream.read(reinterpret_cast<char*>(&shape), sizeof(LegacyShape));
-        input_stream.read(reinterpret_cast<char*>(&data_type), sizeof(DataType));
-        input_stream.read(reinterpret_cast<char*>(&layout), sizeof(Layout));
-
-        auto storage = load_owned_storage(input_stream, data_type);
-        auto tensor = Tensor(
-            std::move(storage),
-            TensorSpec(
-                shape.logical_shape(),
-                TensorLayout::fromPaddedShape(
-                    data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
-        if (device != nullptr) {
-            tensor = tensor.to_device(device);
-        }
-        return tensor;
+    if (read_sentinel != SENTINEL_VALUE) {
+        input_stream.seekg(0, std::ios::beg);
+        return load_tensor_helper_very_legacy_impl(input_stream, device);
     }
+
+    std::uint8_t version_id;
+    input_stream.read(reinterpret_cast<char*>(&version_id), sizeof(version_id));
+    if (version_id > VERSION_ID) {
+        throw std::runtime_error(
+            fmt::format("Serialized tensor with version_id: {}. Loader version: {}", version_id, VERSION_ID));
+    }
+
+    if (version_id < 5) {
+        return load_tensor_helper_legacy_impl(input_stream, device, version_id);
+    }
+
+    auto spec = load_tensor_spec(input_stream);
+    StorageType storage_type;
+    input_stream.read(reinterpret_cast<char*>(&storage_type), sizeof(StorageType));
+    auto storage = load_storage(input_stream, spec.data_type(), spec.layout(), storage_type, device, version_id);
+    Tensor tensor(std::move(storage), spec);
+    if (device != nullptr) {
+        tensor = tensor.to_device(device, spec.memory_config());
+    }
+    return tensor;
 }
 
 // Explicit instantiations
@@ -393,22 +434,12 @@ Tensor load_tensor(const std::string& file_name, MeshDevice* device) {
 
 void dump_memory_config(std::ostream& output_stream, const MemoryConfig& memory_config) {
     output_stream.write(reinterpret_cast<const char*>(&VERSION_ID), sizeof(std::uint8_t));
-    output_stream.write(reinterpret_cast<const char*>(&memory_config.memory_layout), sizeof(TensorMemoryLayout));
-    output_stream.write(reinterpret_cast<const char*>(&memory_config.buffer_type), sizeof(BufferType));
-
-    bool has_shard_spec = memory_config.shard_spec.has_value();
-    output_stream.write(reinterpret_cast<const char*>(&has_shard_spec), sizeof(bool));
-    if (has_shard_spec) {
-        const auto& shard_spec = memory_config.shard_spec.value();
-        const auto& core_ranges = shard_spec.grid.ranges();
-        std::size_t num_core_ranges = core_ranges.size();
-        output_stream.write(reinterpret_cast<const char*>(&num_core_ranges), sizeof(std::size_t));
-        for (const auto& core_range : core_ranges) {
-            output_stream.write(reinterpret_cast<const char*>(&core_range), sizeof(CoreRange));
-        }
-        output_stream.write(reinterpret_cast<const char*>(&shard_spec.shape), sizeof(std::array<uint32_t, 2>));
-        output_stream.write(reinterpret_cast<const char*>(&shard_spec.orientation), sizeof(ShardOrientation));
-    }
+    flatbuffers::FlatBufferBuilder builder;
+    auto flat_config = ttnn::to_flatbuffer(memory_config, builder);
+    builder.Finish(flat_config);
+    uint64_t buf_size = builder.GetSize();
+    output_stream.write(reinterpret_cast<const char*>(&buf_size), sizeof(uint64_t));
+    output_stream.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), buf_size);
 }
 
 void dump_memory_config(const std::string& file_name, const MemoryConfig& memory_config) {
@@ -419,18 +450,10 @@ void dump_memory_config(const std::string& file_name, const MemoryConfig& memory
     dump_memory_config(output_stream, memory_config);
 }
 
-MemoryConfig load_memory_config(std::ifstream& input_stream) {
-    std::uint8_t version_id;
+MemoryConfig load_memory_config_legacy_impl(std::ifstream& input_stream, uint8_t version_id) {
     TensorMemoryLayout memory_layout;
     BufferType buffer_type;
     bool has_shard_spec;
-    input_stream.read(reinterpret_cast<char*>(&version_id), sizeof(std::uint8_t));
-
-    // Allow only backward compatible versions
-    if (version_id > VERSION_ID) {
-        throw std::runtime_error(
-            fmt::format("Serialized tensor with version_id: {}. Loader version: {}", version_id, VERSION_ID));
-    }
     input_stream.read(reinterpret_cast<char*>(&memory_layout), sizeof(TensorMemoryLayout));
     input_stream.read(reinterpret_cast<char*>(&buffer_type), sizeof(BufferType));
     input_stream.read(reinterpret_cast<char*>(&has_shard_spec), sizeof(bool));
@@ -458,6 +481,28 @@ MemoryConfig load_memory_config(std::ifstream& input_stream) {
         shard_spec = {CoreRangeSet{core_ranges}, shape, orientation};
     }
     return MemoryConfig{memory_layout, buffer_type, shard_spec};
+}
+
+MemoryConfig load_memory_config(std::ifstream& input_stream) {
+    std::uint8_t version_id;
+    input_stream.read(reinterpret_cast<char*>(&version_id), sizeof(std::uint8_t));
+
+    // Allow only backward compatible versions
+    if (version_id > VERSION_ID) {
+        throw std::runtime_error(
+            fmt::format("Serialized tensor with version_id: {}. Loader version: {}", version_id, VERSION_ID));
+    }
+
+    if (version_id < 5) {
+        return load_memory_config_legacy_impl(input_stream, version_id);
+    }
+
+    uint64_t bin_size = 0;
+    input_stream.read(reinterpret_cast<char*>(&bin_size), sizeof(uint64_t));
+    std::vector<uint8_t> bin(bin_size);
+    input_stream.read(reinterpret_cast<char*>(&bin[0]), bin_size);
+    auto mem_config = flatbuffers::GetRoot<ttnn::flatbuffer::MemoryConfig>(bin.data());
+    return ttnn::from_flatbuffer(mem_config);
 }
 
 MemoryConfig load_memory_config(const std::string& file_name) {

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -5,8 +5,7 @@
 #include "ttnn/tensor/serialization.hpp"
 
 #include <cstdint>
-#include <fstream>
-#include <iostream>
+#include <cstdio>
 #include <string>
 #include <type_traits>
 
@@ -376,7 +375,6 @@ MemoryConfig load_memory_config_legacy_impl(FILE* input_file, uint8_t version_id
 
 template <typename T>
 Tensor load_tensor_helper(const std::string& file_name, T device) {
-    std::cout << "Loading tensor " << file_name << std::endl;
     FILE* input_file = fopen(file_name.c_str(), "rb");
     if (not input_file) {
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));
@@ -416,7 +414,6 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
 
 void dump_tensor(
     const std::string& file_name, const Tensor& tensor, const std::unordered_map<std::string, std::string>& strategy) {
-    std::cout << "Dumping tensor " << file_name << std::endl;
     FILE* output_file = fopen(file_name.c_str(), "wb");
     if (not output_file) {
         throw std::runtime_error(fmt::format("Cannot open \"{}\"", file_name));

--- a/ttnn/cpp/ttnn/tensor/serialization.hpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.hpp
@@ -17,10 +17,10 @@ void dump_tensor(
 Tensor load_tensor(const std::string& file_name, IDevice* device = nullptr);
 Tensor load_tensor(const std::string& file_name, distributed::MeshDevice* device = nullptr);
 
-void dump_memory_config(std::ostream& output_stream, const MemoryConfig& memory_config);
+void dump_memory_config(FILE* output_file, const MemoryConfig& memory_config);
 void dump_memory_config(const std::string& file_name, const MemoryConfig& memory_config);
 
-MemoryConfig load_memory_config(std::ifstream& input_stream);
+MemoryConfig load_memory_config(FILE* input_file);
 MemoryConfig load_memory_config(const std::string& file_name);
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -29,7 +29,7 @@ namespace tt {
 
 namespace tt_metal {
 
-static constexpr std::uint8_t VERSION_ID = 4;
+static constexpr std::uint8_t VERSION_ID = 5;
 
 enum class DataType {
     BFLOAT16 = 0,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15496 
#16067

### Problem description
Currently TensorSpec isn't being serialized properly, which causes issues in some cases.
In particular, it causes bugs in `as_tensor` with transposed tiles.

### What's changed
Introduce flatbuffer schema for TensorSpec serialization.
Added conversion code to/from TensorSpec to flatbuffer struct.
Heavily modified serialization code to preserve compatibility with the old format, but serialize TensorSpec with flatbuffer in newer versions. 
Changed fstream io into fread/fwrite to improve performance.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13213319656) CI passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/13209781898)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/13209784841)
- [x] New/Existing tests provide coverage for changes
