### PR TITLE
Additional EDM fabric optimizations (mix of low level and experimental flow control protocol trimming)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
 
     mcast_fwd_packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_fwd_hops)});
     mcast_bwd_packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_bwd_hops)});
-    unicast_packet_header->to_chip_unicast(UnicastRoutingCommandHeader{static_cast<uint8_t>(unicast_hops)});
+    unicast_packet_header->to_chip_unicast(static_cast<uint8_t>(unicast_hops));
 
     {
         DeviceZoneScopedN("MAIN-WRITE-ZONE");

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -140,8 +140,8 @@ void kernel_main() {
             noc_async_write(source_l1_buffer_address, dest_addr, packet_payload_size_bytes);
             if (fabric_connection.has_forward_connection()) {
                 DeviceZoneScopedN("WR-FWD");
-                mcast_fwd_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{
-                    noc0_dest_addr, packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader)});
+                mcast_fwd_packet_header->to_noc_unicast_write(
+                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
                 {
                     DeviceZoneScopedN("WR-FWD-WAIT");
                     fabric_connection.get_forward_connection().wait_for_empty_write_slot();
@@ -155,8 +155,8 @@ void kernel_main() {
 
             if (fabric_connection.has_backward_connection()) {
                 DeviceZoneScopedN("WR-BWD");
-                mcast_bwd_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{
-                    noc0_dest_addr, packet_payload_size_bytes + sizeof(tt::fabric::PacketHeader)});
+                mcast_bwd_packet_header->to_noc_unicast_write(
+                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
                 {
                     DeviceZoneScopedN("WR-BWD-WAIT");
                     fabric_connection.get_backward_connection().wait_for_empty_write_slot();
@@ -179,7 +179,7 @@ void kernel_main() {
         DeviceZoneScopedN("UNICAST-WRITE");
         auto& fabric_conn =
             unicast_is_fwd ? fabric_connection.get_forward_connection() : fabric_connection.get_backward_connection();
-        unicast_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr, packet_payload_size_bytes});
+        unicast_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
         fabric_conn.wait_for_empty_write_slot();
         fabric_conn.send_payload_without_header_non_blocking_from_address(
             source_l1_buffer_address, packet_payload_size_bytes);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -122,20 +122,18 @@ void kernel_main() {
 
         // bit of a hack to extract X/Y
         const auto dest_noc_address = get_noc_addr(p, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
-        const size_t packet_size = page_size + sizeof(tt::fabric::PacketHeader);
+        const size_t packet_size = page_size;
         auto packet_addr = get_read_ptr(cb_id_in0);
         auto& packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(packet_addr);
         if constexpr (mcast_mode) {
             packet_header
                 .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
-                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                    dest_noc_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
-            packet_header.reserved2 = 0x1111;  // debug only
+                .to_noc_unicast_write(
+                    tt::fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         } else {
             packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
-                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                    dest_noc_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
-            packet_header.reserved2 = 0x1111;  // debug only
+                .to_noc_unicast_write(
+                    tt::fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         }
 
         sender.send_payload_blocking_from_address(packet_addr, packet_size);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -131,7 +131,7 @@ void kernel_main() {
                 .to_noc_unicast_write(
                     tt::fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         } else {
-            packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
+            packet_header.to_chip_unicast(config.unicast.distance)
                 .to_noc_unicast_write(
                     tt::fabric::NocUnicastCommandHeader{dest_noc_address}, (pages_to_send * page_size));
         }
@@ -148,7 +148,7 @@ void kernel_main() {
         ASSERT(*last_message_semaphore_address == 0);
         uint64_t last_message_semaphore_noc0_addr =
             safe_get_noc_addr(my_x[0], my_y[0], (uint32_t)last_message_semaphore_address, 0);
-        packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{2});
+        packet_header.to_chip_unicast(2);
         packet_header.to_noc_unicast_atomic_inc(
             tt::fabric::NocUnicastAtomicIncCommandHeader(last_message_semaphore_noc0_addr, 1, 32));
 

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
@@ -61,7 +61,7 @@ auto forward_to_fabric_from_cb(
             .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
             .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_address}, (pages_to_send * page_size));
     } else {
-        packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
+        packet_header.to_chip_unicast(config.unicast.distance)
             .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_address}, (pages_to_send * page_size));
     }
 
@@ -187,7 +187,7 @@ void kernel_main() {
     packet_header.reserved = 0xE;
     packet_header.reserved2 = 0xFFFF;
     uint64_t last_message_sem_noc_addr = get_noc_addr(my_x[0], my_y[0], last_message_semaphore_address);
-    packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{kLoopbackNumHopsToMyChip});
+    packet_header.to_chip_unicast(kLoopbackNumHopsToMyChip);
     packet_header.to_noc_unicast_atomic_inc(
         tt::fabric::NocUnicastAtomicIncCommandHeader(last_message_sem_noc_addr, 1, 32));
 

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
@@ -59,12 +59,10 @@ auto forward_to_fabric_from_cb(
     if constexpr (mcast_mode) {
         packet_header
             .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_address}, (pages_to_send * page_size));
     } else {
         packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{config.unicast.distance})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_address, (pages_to_send * page_size) + sizeof(tt::fabric::PacketHeader)});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_address}, (pages_to_send * page_size));
     }
 
     uint64_t buffer_address = sender.edm_buffer_addr + (*sender.buffer_index_ptr * (sender.buffer_size_bytes + sizeof(eth_channel_sync_t)));

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
@@ -32,7 +32,7 @@ bool terminate_fabric_endpoints_farthest_to_nearest (
             auto &packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(a_packet_header_addr);
             reinterpret_cast<volatile uint32_t*>(a_packet_header_addr)[sizeof(tt::fabric::PacketHeader) >> 2] = tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE;
             sender.wait_for_empty_write_slot();
-            packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{static_cast<uint8_t>(distance)})
+            packet_header.to_chip_unicast(static_cast<uint8_t>(distance))
                 .to_noc_unicast_write(
                     tt::fabric::NocUnicastCommandHeader{termination_sig_noc_addr},
                     sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t));

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
@@ -33,8 +33,9 @@ bool terminate_fabric_endpoints_farthest_to_nearest (
             reinterpret_cast<volatile uint32_t*>(a_packet_header_addr)[sizeof(tt::fabric::PacketHeader) >> 2] = tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE;
             sender.wait_for_empty_write_slot();
             packet_header.to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{static_cast<uint8_t>(distance)})
-                .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                    termination_sig_noc_addr, sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t)});
+                .to_noc_unicast_write(
+                    tt::fabric::NocUnicastCommandHeader{termination_sig_noc_addr},
+                    sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t));
             sender.send_payload_blocking_from_address(a_packet_header_addr, packet_header.get_payload_size_including_header());
             noc_async_writes_flushed();
         }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -3266,7 +3266,6 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWra
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-// hangs with DPRINT
 TEST(EdmFabric, BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_2Device) {
     const size_t num_mcasts = 9;
     const size_t num_unicasts = 0;
@@ -3294,7 +3293,6 @@ TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWra
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }
-// First to hang - maybe somethign to do with merging traffic
 TEST(EdmFabric, DISABLED_BasicMcastThroughputTest_SenderFullNoWrap_ReceiverNoWrap_TwoWorkers_4Device) {
     const size_t num_mcasts = 9;
     const size_t num_unicasts = 0;
@@ -3600,6 +3598,18 @@ TEST(EdmFabric, BasicMcastThroughputTest_3) {
     const bool line_sync = true;
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+TEST(EdmFabric, BasicMcastThroughputTest_3_onehop) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 2;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    params.line_size = 2;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
 }

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -464,6 +464,17 @@ def test_all_gather(
             None,
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
+        (
+            4,
+            [1, 4, 32, 1280],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
     ],
 )
 @pytest.mark.parametrize("num_links", [1])

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -469,7 +469,7 @@ def test_all_gather(
             [1, 4, 32, 1280],
             3,
             ttnn.TILE_LAYOUT,
-            (32, 128),
+            (32, 320),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
             None,
             None,

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -96,6 +96,12 @@ void eth_write_remote_reg(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
     eth_txq_reg_write(q_num, ETH_TXQ_REMOTE_REG_DATA, val);
     eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_REG);
 }
+FORCE_INLINE
+void eth_write_remote_reg_no_txq_check(uint32_t q_num, uint32_t reg_addr, uint32_t val) {
+    eth_txq_reg_write(q_num, ETH_TXQ_DEST_ADDR, reg_addr);
+    eth_txq_reg_write(q_num, ETH_TXQ_REMOTE_REG_DATA, val);
+    eth_txq_reg_write(q_num, ETH_TXQ_CMD, ETH_TXQ_CMD_START_REG);
+}
 
 void check_and_context_switch() {
     uint32_t start_time = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/global_semaphore.hpp>
 #include "cpp/ttnn/global_semaphore.hpp"
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 namespace ttnn::global_semaphore {
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
@@ -33,8 +33,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     pkt_hdr->reserved2 = my_chip_id;
 #endif
 
-    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
+    pkt_hdr->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr}, payload_size_bytes);
 
     switch (current_cmd_header.dest_type) {
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: {

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
@@ -41,7 +41,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
             auto& fabric_conn = unicast_args.is_forward_direction ? fabric_connection.get_forward_connection()
                                                                   : fabric_connection.get_backward_connection();
 
-            pkt_hdr->to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{unicast_args.distance_in_hops});
+            pkt_hdr->to_chip_unicast(unicast_args.distance_in_hops);
             fabric_conn.wait_for_empty_write_slot();
             fabric_conn.send_payload_without_header_non_blocking_from_address(l1_read_addr, payload_size_bytes);
             fabric_conn.send_payload_flush_blocking_from_address((uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -450,8 +450,7 @@ void try_advance_inline_write_or_atomic_inc(command_context_t<Addrgen>& cmd_ctx)
 
         switch (cmd_ctx.current_cmd_header.dest_type) {
             case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: {
-                pkt_hdr->to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{
-                    cmd_ctx.current_cmd_header.get_unicast_dest_args().distance_in_hops});
+                pkt_hdr->to_chip_unicast(cmd_ctx.current_cmd_header.get_unicast_dest_args().distance_in_hops);
 
                 auto& fabric_connection = cmd_ctx.current_cmd_header.get_unicast_dest_args().is_forward_direction
                                               ? cmd_ctx.fabric_connection.get_forward_connection()
@@ -570,7 +569,7 @@ void write_and_advance_local_read_address_for_fabric_write(
             auto& fabric_conn = unicast_args.is_forward_direction ? fabric_connection.get_forward_connection()
                                                                   : fabric_connection.get_backward_connection();
 
-            pkt_hdr->to_chip_unicast(tt::fabric::UnicastRoutingCommandHeader{unicast_args.distance_in_hops});
+            pkt_hdr->to_chip_unicast(unicast_args.distance_in_hops);
 
             fabric_conn.wait_for_empty_write_slot();
             fabric_conn.send_payload_without_header_non_blocking_from_address(l1_read_addr, payload_size_bytes);

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_utils.hpp
@@ -118,9 +118,7 @@ void mcast_contig_pages_to_noc_address(
         pkt_hdr
             .to_chip_multicast(
                 tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(forward_direction_num_hops)})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_addr,
-                packet_send_size_bytes});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_addr}, packet_send_size_bytes);
         forward_fabric_sender.wait_for_empty_write_slot();
         forward_fabric_sender.send_payload_flush_blocking_from_address(l1_read_addr, packet_send_size_bytes);
     }
@@ -131,9 +129,7 @@ void mcast_contig_pages_to_noc_address(
         pkt_hdr
             .to_chip_multicast(
                 tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(backward_direction_num_hops)})
-            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{
-                noc0_dest_addr,
-                packet_send_size_bytes});
+            .to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_addr}, packet_send_size_bytes);
         backward_fabric_sender.wait_for_empty_write_slot();
         backward_fabric_sender.send_payload_non_blocking_from_address(l1_read_addr, packet_send_size_bytes);
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
@@ -19,13 +19,13 @@ enum TerminationSignal : uint32_t {
     IMMEDIATELY_TERMINATE = 2
 };
 
-
-// 2 bits
+// 3 bits
 enum NocSendType : uint8_t {
     NOC_UNICAST_WRITE = 0,
-    NOC_MULTICAST_WRITE = 1,
-    NOC_UNICAST_ATOMIC_INC = 2,
-    NOC_MULTICAST_ATOMIC_INC = 3
+    NOC_UNICAST_INLINE_WRITE = 1,
+    NOC_MULTICAST_WRITE = 2,
+    NOC_UNICAST_ATOMIC_INC = 3,
+    NOC_MULTICAST_ATOMIC_INC = 4
 };
 // How to send the payload across the cluster
 // 1 bit
@@ -33,7 +33,6 @@ enum ChipSendType : uint8_t {
     CHIP_UNICAST = 0,
     CHIP_MULTICAST = 1,
 };
-
 
 struct UnicastRoutingCommandHeader {
     uint8_t distance_in_hops;
@@ -52,11 +51,10 @@ static_assert(sizeof(RoutingFields) == sizeof(UnicastRoutingCommandHeader), "Rou
 
 struct NocUnicastCommandHeader {
     uint64_t noc_address;
-    uint32_t size;
-    // ignores header size
-    inline uint32_t get_payload_only_size() const {
-        return size;
-    }
+};
+struct NocUnicastInlineWriteCommandHeader {
+    uint64_t noc_address;
+    uint32_t value;
 };
 struct NocUnicastAtomicIncCommandHeader {
     NocUnicastAtomicIncCommandHeader(uint64_t noc_address, uint16_t val, uint16_t wrap)
@@ -68,16 +66,10 @@ struct NocUnicastAtomicIncCommandHeader {
 };
 struct NocMulticastCommandHeader {
     uint32_t address;
-    uint32_t size;
     uint8_t noc_x_start;
     uint8_t noc_y_start;
     uint8_t mcast_rect_size_x;
     uint8_t mcast_rect_size_y;
-
-    // ignores header size
-    inline uint32_t get_payload_only_size() const {
-        return size;
-    }
 };
 struct NocMulticastAtomicIncCommandHeader {
     uint32_t address;
@@ -88,12 +80,14 @@ struct NocMulticastAtomicIncCommandHeader {
     uint8_t size_x;
     uint8_t size_y;
 };
-static_assert(sizeof(NocUnicastCommandHeader) == 16, "NocUnicastCommandHeader size is not 1 byte");
-static_assert(sizeof(NocMulticastCommandHeader) == 12, "NocMulticastCommandHeader size is not 1 byte");
+static_assert(sizeof(NocUnicastCommandHeader) == 8, "NocUnicastCommandHeader size is not 1 byte");
+static_assert(sizeof(NocMulticastCommandHeader) == 8, "NocMulticastCommandHeader size is not 1 byte");
+static_assert(sizeof(NocUnicastInlineWriteCommandHeader) == 16, "NocMulticastCommandHeader size is not 1 byte");
 static_assert(sizeof(NocUnicastAtomicIncCommandHeader) == 16, "NocUnicastCommandHeader size is not 1 byte");
 static_assert(sizeof(NocMulticastAtomicIncCommandHeader) == 12, "NocAtomicIncCommandHeader size is not 1 byte");
 union NocCommandFields{
     NocUnicastCommandHeader unicast_write;
+    NocUnicastInlineWriteCommandHeader unicast_inline_write;
     NocMulticastCommandHeader mcast_write;
     NocUnicastAtomicIncCommandHeader unicast_seminc;
     NocMulticastAtomicIncCommandHeader mcast_seminc;
@@ -106,16 +100,16 @@ struct PacketHeader {
     //   -> unicast_write, mcast_write, unicast_seminc, mcast_seminc
     // For now, kept it separate so I could do reads which would be handled differently
     // but for our purposes we shouldn't need read so we should be able to omit the support
-    NocSendType noc_send_type : 2;
+    NocSendType noc_send_type : 3;
     ChipSendType chip_send_type : 1;
-    uint8_t reserved : 1;
+
     // Used only by the EDM sender and receiver channels. Populated by EDM sender channel to
     // indicate to the receiver channel what channel was the source of this packet. Reserved
     // otherwise.
     uint8_t src_ch_id : 4;
 
     RoutingFields routing_fields;
-    uint16_t reserved2; // can be tagged with src device for debug
+    uint16_t payload_size_bytes; // excludes header size
     NocCommandFields command_fields; // size = 16B due to uint64_t alignment
 
     // Sort of hack to work-around DRAM read alignment issues that must be 32B aligned
@@ -134,23 +128,9 @@ struct PacketHeader {
     inline void set_routing_fields(RoutingFields &fields) { this->routing_fields = fields; }
     inline void set_command_fields(NocCommandFields &fields) { this->command_fields = fields; }
 
+    // Returns size of payload in bytes - TODO: convert to words (4B)
     size_t get_payload_size_excluding_header() volatile const {
-        switch(this->noc_send_type) {
-            case NOC_UNICAST_WRITE: {
-                return this->command_fields.unicast_write.size - sizeof(PacketHeader);
-            } break;
-            case NOC_MULTICAST_WRITE: {
-                return this->command_fields.mcast_write.size - sizeof(PacketHeader);
-            } break;
-            case NOC_UNICAST_ATOMIC_INC:
-            case NOC_MULTICAST_ATOMIC_INC:
-                return 0;
-            default:
-            #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-                ASSERT(false);
-            #endif
-                return 0;
-        };
+        return this->payload_size_bytes;
     }
     inline size_t get_payload_size_including_header() volatile const {
         return get_payload_size_excluding_header() + sizeof(PacketHeader);
@@ -167,26 +147,36 @@ struct PacketHeader {
         return *this;
     }
 
-    inline PacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header) {
+    inline PacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) {
         this->noc_send_type = NOC_UNICAST_WRITE;
         this->command_fields.unicast_write = noc_unicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
         return *this;
     }
-    inline PacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header) {
+    inline PacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write = noc_unicast_command_header;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline PacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
         this->noc_send_type = NOC_MULTICAST_WRITE;
         this->command_fields.mcast_write = noc_multicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
         return *this;
     }
     inline PacketHeader &to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) {
         this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
         this->command_fields.unicast_seminc = noc_unicast_atomic_inc_command_header;
+        this->payload_size_bytes = 0;
         return *this;
     }
-    inline PacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header) {
+    inline PacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
         #if defined(KERNEL_BUILD) || defined(FW_BUILD)
         ASSERT(false);
         while (1) {};
         #endif
+        this->payload_size_bytes = payload_size_bytes;
         return *this;
     }
 
@@ -201,20 +191,27 @@ struct PacketHeader {
         this->routing_fields.chip_mcast.start_distance_in_hops = chip_multicast_command_header.start_distance_in_hops;
         return this;
     }
-    inline volatile PacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header) volatile {
+    inline volatile PacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) volatile {
         this->noc_send_type = NOC_UNICAST_WRITE;
         this->command_fields.unicast_write.noc_address = noc_unicast_command_header.noc_address;
-        this->command_fields.unicast_write.size = noc_unicast_command_header.size;
+        this->payload_size_bytes = payload_size_bytes;
 
         return this;
     }
-    inline volatile PacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header) volatile {
+    inline volatile PacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) volatile {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write.noc_address = noc_unicast_command_header.noc_address;
+        this->command_fields.unicast_inline_write.value = noc_unicast_command_header.value;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline volatile PacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) volatile {
         this->noc_send_type = NOC_MULTICAST_WRITE;
         this->command_fields.mcast_write.mcast_rect_size_x = noc_multicast_command_header.mcast_rect_size_x;
         this->command_fields.mcast_write.mcast_rect_size_y = noc_multicast_command_header.mcast_rect_size_y;
         this->command_fields.mcast_write.noc_x_start = noc_multicast_command_header.noc_x_start;
         this->command_fields.mcast_write.noc_y_start = noc_multicast_command_header.noc_y_start;
-        this->command_fields.mcast_write.size = noc_multicast_command_header.size;
+        this->payload_size_bytes = payload_size_bytes;
         this->command_fields.mcast_write.address = noc_multicast_command_header.address;
 
         return this;
@@ -225,11 +222,12 @@ struct PacketHeader {
         this->command_fields.unicast_seminc.noc_address = noc_unicast_atomic_inc_command_header.noc_address;
         this->command_fields.unicast_seminc.val = noc_unicast_atomic_inc_command_header.val;
         this->command_fields.unicast_seminc.wrap = noc_unicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = 0;
 
         return this;
     }
     inline volatile PacketHeader *to_noc_multicast_atomic_inc(
-        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header) volatile {
+        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) volatile {
         this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
         this->command_fields.mcast_seminc.address = noc_multicast_atomic_inc_command_header.address;
         this->command_fields.mcast_seminc.noc_x_start = noc_multicast_atomic_inc_command_header.noc_x_start;
@@ -238,6 +236,7 @@ struct PacketHeader {
         this->command_fields.mcast_seminc.size_y = noc_multicast_atomic_inc_command_header.size_y;
         this->command_fields.mcast_seminc.val = noc_multicast_atomic_inc_command_header.val;
         this->command_fields.mcast_seminc.wrap = noc_multicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = payload_size_bytes;
 
         return this;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -23,6 +23,9 @@
 
 using ttnn::ccl::WorkerXY;
 
+static constexpr bool enable_first_level_ack = true;
+static constexpr bool fuse_receiver_flush_and_completion_ptr = true;
+
 /*
 
 The fabric Erisc Data Mover (EDM) is a component that can be used to build *very* simple linear topology fabrics.
@@ -247,11 +250,11 @@ constexpr uint8_t NUM_TRANSACTION_IDS = 4;
 
 template <uint8_t MAX_TRANSACTION_IDS>
 struct TransactionIdCounter {
-    void increment() {
+    FORCE_INLINE void increment() {
         this->next_trid = tt::fabric::wrap_increment<MAX_TRANSACTION_IDS>(this->next_trid);
     }
 
-    uint8_t get() const {
+    FORCE_INLINE uint8_t get() const {
         return this->next_trid;
     }
 
@@ -314,15 +317,11 @@ constexpr uint32_t to_sender_1_pkts_completed_id = 4;
 
 // This will be an atomic register read to the register
 template <uint32_t stream_id>
-int32_t get_ptr_val() {
+FORCE_INLINE int32_t get_ptr_val() {
     return NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-    constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-    return *reinterpret_cast<volatile uint32_t*>(addr);
 }
-int32_t get_ptr_val(uint8_t stream_id) {
+FORCE_INLINE int32_t get_ptr_val(uint8_t stream_id) {
     return NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-    const uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-    return *reinterpret_cast<volatile uint32_t*>(addr);
 }
 
 // Writing to this register will leverage the built-in stream hardware which will automatically perform an atomic increment
@@ -330,25 +329,25 @@ int32_t get_ptr_val(uint8_t stream_id) {
 // Additionally, these registers are accessible via eth_reg_write calls which can be used to write a value,
 // inline the eth command (without requiring source L1)
 template <uint32_t stream_id>
-void increment_local_update_ptr_val(int32_t val) {
+FORCE_INLINE void increment_local_update_ptr_val(int32_t val) {
     NOC_STREAM_WRITE_REG_FIELD(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX, REMOTE_DEST_BUF_WORDS_FREE_INC, val);
 }
-void increment_local_update_ptr_val(uint8_t stream_id, int32_t val) {
+FORCE_INLINE void increment_local_update_ptr_val(uint8_t stream_id, int32_t val) {
     NOC_STREAM_WRITE_REG_FIELD(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX, REMOTE_DEST_BUF_WORDS_FREE_INC, val);
 }
 
 template <uint32_t stream_id>
-void remote_update_ptr_val(int32_t val) {
+FORCE_INLINE void remote_update_ptr_val(int32_t val) {
     constexpr uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
     internal_::eth_write_remote_reg_no_txq_check(DEFAULT_ETH_TXQ, addr, val << REMOTE_DEST_BUF_WORDS_FREE_INC);
 }
-void remote_update_ptr_val(uint32_t stream_id, int32_t val) {
+FORCE_INLINE void remote_update_ptr_val(uint32_t stream_id, int32_t val) {
     const uint32_t addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
     internal_::eth_write_remote_reg_no_txq_check(DEFAULT_ETH_TXQ, addr, val << REMOTE_DEST_BUF_WORDS_FREE_INC);
 }
 
 template <uint32_t stream_id>
-void init_ptr_val(int32_t val) {
+FORCE_INLINE void init_ptr_val(int32_t val) {
     NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, val);
 }
 
@@ -371,19 +370,19 @@ struct OutboundReceiverChannelPointers {
     tt::fabric::ChannelBufferPointer<RECEIVER_NUM_BUFFERS> ack_ptr;
     tt::fabric::ChannelBufferPointer<RECEIVER_NUM_BUFFERS> completion_ptr;
 
-    bool has_space_for_packet() const {
+    FORCE_INLINE bool has_space_for_packet() const {
         return completion_ptr.distance_behind(wrptr) < RECEIVER_NUM_BUFFERS;
     }
 
-    bool has_unacknowledged_eth_packets() const {
+    FORCE_INLINE bool has_unacknowledged_eth_packets() const {
         return ack_ptr.get_ptr() != wrptr.get_ptr();
     }
 
-    bool has_incomplete_eth_packets() const {
+    FORCE_INLINE bool has_incomplete_eth_packets() const {
         return completion_ptr.get_ptr() != wrptr.get_ptr();
     }
 
-    bool has_unacknowledged_or_incomplete_eth_packets() const {
+    FORCE_INLINE bool has_unacknowledged_or_incomplete_eth_packets() const {
         return has_incomplete_eth_packets() || has_unacknowledged_eth_packets();
     }
 };
@@ -486,20 +485,9 @@ static constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 //   SENDER SIDE HELPERS
 /////////////////////////////////////////////
 
-template <uint8_t SENDER_NUM_BUFFERS, uint8_t RECEIVER_NUM_BUFFERS>
-void send_channel_sync(
-    tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS> &sender_buffer_channel,
-    tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS> &sender_wrptr,
-    tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS> &receiver_buffer_channel,
-    tt::fabric::ChannelBufferPointer<RECEIVER_NUM_BUFFERS> &remote_receiver_wrptr
-    ) {
-    auto src_addr = sender_buffer_channel.get_bytes_sent_address(sender_wrptr.get_buffer_index());
-    auto dest_addr = receiver_buffer_channel.get_bytes_sent_address(remote_receiver_wrptr.get_buffer_index());
-    internal_::eth_send_packet_bytes_unsafe(DEFAULT_ETH_TXQ, src_addr, dest_addr, sizeof(eth_channel_sync_t));
-}
 
 template <uint8_t SENDER_NUM_BUFFERS, uint8_t RECEIVER_NUM_BUFFERS>
-void send_next_data(
+FORCE_INLINE void send_next_data(
     tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS> &sender_buffer_channel,
     tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS> &sender_worker_interface,
     OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &outbound_to_receiver_channel_pointers,
@@ -550,7 +538,7 @@ void send_next_data(
  * MUST CHECK !is_eth_txq_busy() before calling
  */
 template <size_t NUM_SENDER_CHANNELS, uint8_t SENDER_NUM_BUFFERS, uint8_t RECEIVER_NUM_BUFFERS>
-void receiver_send_received_ack(
+FORCE_INLINE void receiver_send_received_ack(
     std::array<tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &remote_eth_sender_ackptrs,
     std::array<tt::fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &remote_sender_channels,
     // currently the pointer is working multiple jobs (ack, completion, read) because we haven't implemented the
@@ -595,7 +583,7 @@ FORCE_INLINE bool can_forward_packet_completely(
 }
 
 // !!!WARNING!!! - MAKE SURE CONSUMER HAS SPACE BEFORE CALLING
-void receiver_forward_packet(
+FORCE_INLINE void receiver_forward_packet(
     // TODO: have a separate cached copy of the packet header to save some additional L1 loads
     volatile tt::fabric::PacketHeader *packet_start,
     tt::fabric::RoutingFields cached_routing_fields,
@@ -663,22 +651,30 @@ FORCE_INLINE bool run_sender_channel_step(
         outbound_to_receiver_channel_pointers.completion_ptr.increment_n(completions_since_last_check);
         sender_rdptr.increment_n(completions_since_last_check);
         increment_local_update_ptr_val(to_sender_packets_completed_streams[sender_channel_index], -completions_since_last_check);
+        if constexpr (!enable_first_level_ack) {
+            if (channel_connection_established) {
+                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(sender_rdptr.get_ptr());
+            }
+        }
     }
 
     // Process ACKs from receiver
     // ACKs are processed second to avoid any sort of races. If we process acks second,
     // we are guaranteed to see equal to or greater the number of acks than completions
-    auto acks_since_last_check = get_ptr_val(to_sender_packets_acked_streams[sender_channel_index]);
-
-    auto& sender_ackptr = local_sender_channel_worker_interface.local_ackptr;
-    if (acks_since_last_check > 0) {
-        sender_ackptr.increment_n(acks_since_last_check);
-        if (channel_connection_established) {
-            local_sender_channel_worker_interface.update_worker_copy_of_read_ptr();
+    if constexpr (enable_first_level_ack) {
+        auto acks_since_last_check = get_ptr_val(to_sender_packets_acked_streams[sender_channel_index]);
+        auto& sender_ackptr = local_sender_channel_worker_interface.local_ackptr;
+        if (acks_since_last_check > 0) {
+            sender_ackptr.increment_n(acks_since_last_check);
+            if (channel_connection_established) {
+                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(sender_ackptr.get_ptr());
+            }
+            increment_local_update_ptr_val(to_sender_packets_acked_streams[sender_channel_index], -acks_since_last_check);
         }
-        increment_local_update_ptr_val(to_sender_packets_acked_streams[sender_channel_index], -acks_since_last_check);
+        did_something = did_something || (completions_since_last_check + acks_since_last_check) > 0;
+    } else {
+        did_something = did_something || (completions_since_last_check > 0);
     }
-    did_something = did_something || (completions_since_last_check + acks_since_last_check) > 0;
 
 
     if (!channel_connection_established) {
@@ -698,7 +694,11 @@ FORCE_INLINE bool run_sender_channel_step(
             }
             did_something = true;
             channel_connection_established = true;
-            local_sender_channel_worker_interface.update_worker_copy_of_read_ptr();
+            if constexpr (enable_first_level_ack) {
+                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(local_sender_channel_worker_interface.local_ackptr.get_ptr());
+            } else {
+                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(local_sender_channel_worker_interface.local_rdptr.get_ptr());
+            }
         }
     } else if (local_sender_channel_worker_interface.has_worker_teardown_request()) {
         did_something = true;
@@ -725,23 +725,27 @@ FORCE_INLINE void run_receiver_channel_step(
     auto &ack_ptr = receiver_channel_pointers.ack_ptr;
     auto pkts_received_since_last_check = get_ptr_val<to_receiver_pkts_sent_id>();
     bool pkts_received = pkts_received_since_last_check > 0;
-    bool can_send_over_eth = !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ);
-    ASSERT(receiver_channel_pointers.completion_ptr.distance_behind(ack_ptr) < RECEIVER_NUM_BUFFERS);
-    if (pkts_received && can_send_over_eth) {
-        // currently only support processing one packet at a time, so we only decrement by 1
-        increment_local_update_ptr_val<to_receiver_pkts_sent_id>(-1);
-        receiver_send_received_ack(
-            remote_eth_sender_wrptrs,
-            remote_sender_channnels,
-            ack_ptr,
-            local_receiver_channel);
-        ack_ptr.increment();
+    if constexpr (enable_first_level_ack) {
+        bool can_send_over_eth = !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ);
+        ASSERT(receiver_channel_pointers.completion_ptr.distance_behind(ack_ptr) < RECEIVER_NUM_BUFFERS);
+        if (pkts_received && can_send_over_eth) {
+            // currently only support processing one packet at a time, so we only decrement by 1
+            increment_local_update_ptr_val<to_receiver_pkts_sent_id>(-1);
+            receiver_send_received_ack(
+                remote_eth_sender_wrptrs,
+                remote_sender_channnels,
+                ack_ptr,
+                local_receiver_channel);
+            ack_ptr.increment();
+        }
+    } else {
+        increment_local_update_ptr_val<to_receiver_pkts_sent_id>(-pkts_received_since_last_check);
+        ack_ptr.increment_n(pkts_received_since_last_check);
     }
 
     auto &wr_sent_ptr = receiver_channel_pointers.wr_sent_ptr;
     bool unwritten_packets = !wr_sent_ptr.is_caught_up_to(ack_ptr);
     if (unwritten_packets) {
-        DeviceZoneScopedN("EDMR-Send-Chk");
         auto receiver_buffer_index = wr_sent_ptr.get_buffer_index();
         volatile auto packet_header = local_receiver_channel.get_packet_header(receiver_buffer_index);
 
@@ -751,37 +755,57 @@ FORCE_INLINE void run_receiver_channel_step(
             can_forward_packet_completely(packet_header, cached_routing_fields, downstream_edm_interface);
         bool trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
         if (can_send_to_all_local_chip_receivers && trid_flushed) {
-            DeviceZoneScopedN("EDMR-Send-Impl");
+            // DeviceZoneScopedN("EDMR-Send-Impl");
             uint8_t trid = receiver_channel_trid_tracker.update_buffer_slot_to_next_trid_and_advance_trid_counter(receiver_buffer_index);
             receiver_forward_packet(packet_header, cached_routing_fields, downstream_edm_interface, trid);
             wr_sent_ptr.increment();
         }
     }
 
-    auto &wr_flush_ptr = receiver_channel_pointers.wr_flush_ptr;
-    bool unflushed_writes = !wr_flush_ptr.is_caught_up_to(wr_sent_ptr);
-    if (unflushed_writes) {
-        auto receiver_buffer_index = wr_flush_ptr.get_buffer_index();
-        bool next_trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
-        if (next_trid_flushed) {
-            local_receiver_channel.eth_clear_sender_channel_ack(receiver_buffer_index);
-            wr_flush_ptr.increment();
-            receiver_channel_trid_tracker.clear_trid_at_buffer_slot(receiver_buffer_index);
+    if constexpr (!fuse_receiver_flush_and_completion_ptr) {
+        auto &wr_flush_ptr = receiver_channel_pointers.wr_flush_ptr;
+        bool unflushed_writes = !wr_flush_ptr.is_caught_up_to(wr_sent_ptr);
+        if (unflushed_writes) {
+            auto receiver_buffer_index = wr_flush_ptr.get_buffer_index();
+            bool next_trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
+            if (next_trid_flushed) {
+                wr_flush_ptr.increment();
+                receiver_channel_trid_tracker.clear_trid_at_buffer_slot(receiver_buffer_index);
+            }
         }
-    }
 
-    auto &completion_ptr = receiver_channel_pointers.completion_ptr;
-    bool unsent_completions = !completion_ptr.is_caught_up_to(wr_flush_ptr);
-    if (unsent_completions) {
-        bool can_send_without_blocking = !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ);
-        if (can_send_without_blocking) {
-            // completion ptr incremented in callee
-            receiver_send_completion_ack(
-                remote_eth_sender_wrptrs,
-                remote_sender_channnels,
-                completion_ptr,
-                local_receiver_channel);
+        auto &completion_ptr = receiver_channel_pointers.completion_ptr;
+        bool unsent_completions = !completion_ptr.is_caught_up_to(wr_flush_ptr);
+        if (unsent_completions) {
+            bool can_send_without_blocking = !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ);
+            if (can_send_without_blocking) {
+                // completion ptr incremented in callee
+                receiver_send_completion_ack(
+                    remote_eth_sender_wrptrs,
+                    remote_sender_channnels,
+                    completion_ptr,
+                    local_receiver_channel);
+            }
         }
+    } else {
+        auto &wr_flush_ptr = receiver_channel_pointers.wr_flush_ptr;
+        // Currently unclear if it's better to loop here or not... Also unclear if merging these
+        // two pointers is better or not... Seems to be maybe 5-10% better merged but need more data
+        if (!wr_flush_ptr.is_caught_up_to(wr_sent_ptr) && !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ)) {
+            auto receiver_buffer_index = wr_flush_ptr.get_buffer_index();
+            bool next_trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
+            if (next_trid_flushed) {
+                auto &completion_ptr = receiver_channel_pointers.completion_ptr;
+                wr_flush_ptr.increment();
+                receiver_channel_trid_tracker.clear_trid_at_buffer_slot(receiver_buffer_index);
+                receiver_send_completion_ack(
+                    remote_eth_sender_wrptrs,
+                    remote_sender_channnels,
+                    completion_ptr,
+                    local_receiver_channel);
+            }
+        }
+
     }
 };
 
@@ -976,7 +1000,7 @@ void kernel_main() {
     static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(18);
     static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(19);
 
-    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(20) != 0;
+    static constexpr bool enable_packet_header_recording = false; //get_compile_time_arg_val(20) != 0;
     static constexpr size_t receiver_completed_packet_header_cb_address = get_compile_time_arg_val(21);
     static constexpr size_t receiver_completed_packet_header_cb_size_headers = get_compile_time_arg_val(22);
     static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(23);

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -780,8 +780,6 @@ void run_receiver_channel_step(
     bool unflushed_writes = !wr_flush_ptr.is_caught_up_to(wr_sent_ptr);
     if (unflushed_writes) {
         auto receiver_buffer_index = wr_flush_ptr.get_buffer_index();
-        // Temporary patch for instability. Issue was not caught due to what appears to be a bug in CI
-        // not running all tests. Issue tracked here: https://github.com/tenstorrent/tt-metal/issues/17702
         bool next_trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
         if (next_trid_flushed) {
             local_receiver_channel.eth_clear_sender_channel_ack(receiver_buffer_index);

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -24,13 +24,13 @@ template <typename T, typename Parameter>
 class NamedType
 {
 public:
-    explicit NamedType(T const& value) : value_(value) {}
-    explicit NamedType(T&& value) : value_(std::move(value)) {}
-    NamedType<T,Parameter> &operator=(NamedType<T,Parameter> const& rhs) = default;
-    T& get() { return value_; }
-    T const& get() const {return value_; }
-    operator T() const { return value_; }
-    operator T&() { return value_; }
+    FORCE_INLINE explicit NamedType(T const& value) : value_(value) {}
+    FORCE_INLINE explicit NamedType(T&& value) : value_(std::move(value)) {}
+    FORCE_INLINE NamedType<T,Parameter> &operator=(NamedType<T,Parameter> const& rhs) = default;
+    FORCE_INLINE T& get() { return value_; }
+    FORCE_INLINE T const& get() const {return value_; }
+    FORCE_INLINE operator T() const { return value_; }
+    FORCE_INLINE operator T&() { return value_; }
 private:
     T value_;
 };
@@ -41,6 +41,7 @@ using BufferPtr = NamedType<uint8_t, struct BufferPtrType>;
 
 // Increments val and wraps to 0 if it reaches limit
 template <size_t LIMIT, typename T>
+FORCE_INLINE
 auto wrap_increment(T val) -> T {
     static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
     constexpr bool is_pow2 = is_power_of_2(LIMIT);
@@ -55,6 +56,7 @@ auto wrap_increment(T val) -> T {
     }
 }
 template <size_t LIMIT, typename T>
+FORCE_INLINE
 auto wrap_increment_n(T val, uint8_t increment) -> T {
     static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
     constexpr bool is_pow2 = is_power_of_2(LIMIT);
@@ -72,6 +74,7 @@ auto wrap_increment_n(T val, uint8_t increment) -> T {
 }
 
 template <uint8_t NUM_BUFFERS>
+FORCE_INLINE
 auto normalize_ptr(BufferPtr ptr) -> BufferIndex {
     static_assert(NUM_BUFFERS != 0, "normalize_ptr called with NUM_BUFFERS of 0; it must be greater than 0");
     constexpr bool is_size_pow2 = (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
@@ -112,38 +115,38 @@ class ChannelBufferPointer {
     /*
      * Returns the "raw" pointer - not usable to index the buffer channel
      */
-    BufferPtr get_ptr() const {
+    FORCE_INLINE BufferPtr get_ptr() const {
         return this->ptr;
     }
 
-    bool is_caught_up_to(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
+    FORCE_INLINE bool is_caught_up_to(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
         return this->is_caught_up_to(leading_ptr.get_ptr());
     }
-    uint8_t distance_behind(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
+    FORCE_INLINE uint8_t distance_behind(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
         return this->distance_behind(leading_ptr.get_ptr());
     }
 
     /*
      * Returns the buffer index pointer which is usable to index into the buffer memory
      */
-    BufferIndex get_buffer_index() const {
+    FORCE_INLINE BufferIndex get_buffer_index() const {
         return BufferIndex{normalize_ptr<NUM_BUFFERS>(this->ptr)};
     }
 
-    void increment_n(uint8_t n) {
+    FORCE_INLINE void increment_n(uint8_t n) {
         this->ptr = BufferPtr{wrap_increment_n<2*NUM_BUFFERS>(this->ptr.get(), n)};
     }
-    void increment() {
+    FORCE_INLINE void increment() {
         this->ptr = wrap_increment<2*NUM_BUFFERS>(this->ptr);
     }
 
     private:
     // Make these private to make sure caller doesn't accidentally mix two pointers pointing to
     // different sized channels
-    bool is_caught_up_to(BufferPtr const& leading_ptr) const {
+    FORCE_INLINE bool is_caught_up_to(BufferPtr const& leading_ptr) const {
         return this->get_ptr() == leading_ptr;
     }
-    uint8_t distance_behind(BufferPtr const& leading_ptr) const {
+    FORCE_INLINE uint8_t distance_behind(BufferPtr const& leading_ptr) const {
         bool leading_gte_trailing_ptr = leading_ptr >= this->ptr;
         if constexpr (is_size_pow2) {
             return (leading_ptr - this->ptr) & ptr_wrap_mask;
@@ -281,15 +284,15 @@ class EthChannelBuffer final {
         return drained;
     }
 
-    bool needs_to_send_channel_sync() const {
+    FORCE_INLINE bool needs_to_send_channel_sync() const {
         return this->need_to_send_channel_sync;
     }
 
-    void set_need_to_send_channel_sync(bool need_to_send_channel_sync) {
+    FORCE_INLINE void set_need_to_send_channel_sync(bool need_to_send_channel_sync) {
         this->need_to_send_channel_sync = need_to_send_channel_sync;
     }
 
-    void clear_need_to_send_channel_sync() {
+    FORCE_INLINE void clear_need_to_send_channel_sync() {
         this->need_to_send_channel_sync = false;
     }
 
@@ -376,15 +379,15 @@ struct EdmChannelWorkerInterface {
         noc_semaphore_inc(worker_semaphore_address, 1);
     }
 
-    bool all_eth_packets_acked() const {
+    FORCE_INLINE bool all_eth_packets_acked() const {
         return this->local_ackptr.is_caught_up_to(this->local_wrptr);
     }
-    bool all_eth_packets_completed() const {
+    FORCE_INLINE bool all_eth_packets_completed() const {
         return this->local_rdptr.is_caught_up_to(this->local_wrptr);
     }
 
     // Call to keep the connection flow control info fresh with worker.
-    void propagate_ackptr_to_connection_info() {
+    FORCE_INLINE void propagate_ackptr_to_connection_info() {
         worker_location_info_ptr->edm_rdptr = local_ackptr.get_ptr();
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -20,11 +20,8 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     const auto [dest_noc_xy, dest_addr] = get_noc_address_components(noc0_dest_noc_addr);
     const size_t payload_l1_address = l1_read_addr;
 
-    size_t packet_send_size_bytes = payload_size_bytes + sizeof(tt::fabric::PacketHeader);
-    pkt_hdr_forward->to_noc_unicast_write(
-        tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
-    pkt_hdr_backward->to_noc_unicast_write(
-        tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr, packet_send_size_bytes});
+    pkt_hdr_forward->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr}, payload_size_bytes);
+    pkt_hdr_backward->to_noc_unicast_write(tt::fabric::NocUnicastCommandHeader{noc0_dest_noc_addr}, payload_size_bytes);
 
     noc_async_write(payload_l1_address, safe_get_noc_addr(dest_noc_xy.x, dest_noc_xy.y, dest_addr), payload_size_bytes);
     if (fabric_connection.has_forward_connection()) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17686

### Problem description
EDM fabric perf is 💩 , make it better. We're SW bound. Put in known/obvious optimizations to make analysis less noisy.

# What's changed
High level changes:
1) Optimize size information in packet header. 
 - simplifies packet processing and setup
2) Optimize routing information storage in packet header
 - simplifies packet processing
3) Added missing inline write command type which is required after these changes
4) Migrate to more optimized eth APIs
 - eth_write_reg and eth_send_packet that omit bit shifts and omit context switch calls
5) Trimming flow control protocols further

+ various force inlines for tiny getter functions

## Packet Header Size Field Optimization
- Simplify packet size storage and access
  - promote to "top-level" of packet to remove conditionality previously needed to get size info from packet
  - NOTE: packet size now specifies PAYLOAD SIZE ONLY!!! The header size must be implicitly added by fabric.
    - net this is still fine because we had to previous subtract header size when writing out to noc.

## Packet Header Routing Info Optimization
Merged the mcast and unicast representation to match so I can uniformly process the packet to decide the following:
- Does packet get sent to local device noc?
- Does packet get forwarded through the fabric?

The previous implementation was required to first check the fabric send type before being able to do further inspection to answer the above questions. Now the code is much simpler - no fabric type info checked - single code path to check both. Additionally the check logic is also streamlined.

## New packet command type
Extra functionality: Added `NOC_UNICAST_INLINE_WRITE` eth packet command type to address a regression as a result of the above change (if the command type wasn't added)

## Optimized Eth send APIs
- Migrate `eth_send_packet` calls to new version that takes size in bytes. 
  - This version avoids a number of shift operations that were present in the previously used version.  
- Add and using new eth write remote reg (`eth_write_remote_reg_no_txq_check`) that doesn't have conditional context switch in body of function

## Flow Control Protocol Trimming
- Enabled (by default) a less granular syncing mode between sender and receiver channels. Overall, in a theoretical sense, this is suboptimal. However, in a severely SW bound implementation like present, this will save on instruction count. 

We disable the following:
- first level ack (i.e. when receiver gets the packet and notifies sender of packet received)
- separate pointer management for write flush ptr and completion pointer send on receiver channel
  - Flush ptr now merged with completion pointer so we cut down on processing.



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13228444293
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13228446457
  - Same fails as main
- [ ] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13228449579
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
