### PR TITLE
Disable test_data_parallel_falcon_mlp till it's be fixed

### DIFF
--- a/tests/ttnn/distributed/test_data_parallel_example_TG.py
+++ b/tests/ttnn/distributed/test_data_parallel_example_TG.py
@@ -26,6 +26,7 @@ class TtFalconMLP:
         return ff2_linear
 
 
+@pytest.mark.skip(reason="This test is temporarily skipped due to failure for TG frequent test, see issue #17595")
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 4), id="1x4_grid")], indirect=True)
 def test_data_parallel_falcon_mlp(mesh_device):
     torch.manual_seed(0)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17595)

### Problem description
test_data_parallel_falcon_mlp fails 95% chance, as validated on IRD galaxy. 
TG frequent tests have slight chance to pass but mostly failed

### What's changed
Disable the test, until further investigation and fix.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
