### PR TITLE
Update get_dispatch_core() for unused TG MMIO dispatch cores

### DIFF
--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -34,8 +34,13 @@ tt_cxy_pair dispatch_core(uint8_t cq_id) {
     for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
         uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
         if (tt::Cluster::instance().get_associated_mmio_device(device_id) == device_id) {
-            // Dispatch core is not allocated on this MMIO device, skip it
-            if (not dispatch_core_mgr::instance().is_dispatcher_core_allocated(device_id, channel, cq_id)) {
+            // Dispatch core is not allocated on this MMIO device or this is a TG system, skip it
+            // On TG, local dispatch cores are allocated on MMIO devices, but are not used
+            // since programs are not run on these devices. The placement of these cores is
+            // irrelevant for the runtime layer, since these are not used. Hence, these are
+            // skipped.
+            if (not dispatch_core_mgr::instance().is_dispatcher_core_allocated(device_id, channel, cq_id) or
+                tt::Cluster::instance().is_galaxy_cluster()) {
                 continue;
             }
             dispatch_core = dispatch_core_mgr::instance().dispatcher_core(device_id, channel, cq_id);


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- https://github.com/tenstorrent/tt-metal/commit/d54089cafece8198ed7a7be54004567b3fa07da3 broke TG initialization, since it introduces the `dispatch_query_manager::get_dispatch_core()` API, which loops over all devices in the cluster (MMIO + Remote) and asserts if local dispatch core placement is heterogenous.
- On TG systems, local dispatch cores are allocated but unused by runtime (we do not run programs on gateway chips), and their placement does not match that of the remote chips, leading to the assert being fired for a valid case.

### What's changed
- Modify logic in `dispatch_query_manager::get_dispatch_core()` to skip MMIO chips on TG when asserting that core placement matches. This assert is only in place to ensure that the runtime layer can interface with dispatch cores across all devices through a single API when issuing host -> device commands (which should not be issued directly to MMIO chips).
- Additionally ensure that no runtime traffic is sent to MMIO chip dispatch cores when the device is closed, since these core are idle and this is unnecessary. This specifically refers to issuing event based synchronization to MMIO dispatch cores (this is not needed, since no programs are run through these cores).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
