### PR TITLE
LightMetal - Store Program obj by id instead of ptr at capture time (Issue #17761)

### DIFF
--- a/tt_metal/impl/lightmetal/lightmetal_capture.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.cpp
@@ -62,7 +62,7 @@ void LightMetalCaptureContext::reset() {
     cmds_vec_.clear();
     trace_descs_vec_.clear();
     buffer_to_global_id_map_.clear();
-    program_to_global_id_map_.clear();
+    program_id_to_global_id_map_.clear();
     kernel_to_global_id_map_.clear();
     cb_handle_to_global_id_map_.clear();
 }
@@ -101,31 +101,31 @@ uint32_t LightMetalCaptureContext::get_global_id(const Buffer* obj) {
 }
 
 bool LightMetalCaptureContext::is_in_map(const Program* obj) {
-    return program_to_global_id_map_.find(obj) != program_to_global_id_map_.end();
+    return program_id_to_global_id_map_.find(obj->get_id()) != program_id_to_global_id_map_.end();
 }
 
 uint32_t LightMetalCaptureContext::add_to_map(const Program* obj) {
     if (is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Program already exists in global_id map.");
+        log_warning(tt::LogMetalTrace, "Program id: {} already exists in global_id map.", obj->get_id());
     }
     uint32_t global_id = next_global_id_++;
-    program_to_global_id_map_[obj] = global_id;
+    program_id_to_global_id_map_[obj->get_id()] = global_id;
     return global_id;
 }
 
 void LightMetalCaptureContext::remove_from_map(const Program* obj) {
     if (!is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Program not found in global_id map.");
+        log_warning(tt::LogMetalTrace, "Program id: {} not found in global_id map.", obj->get_id());
     }
-    program_to_global_id_map_.erase(obj);
+    program_id_to_global_id_map_.erase(obj->get_id());
 }
 
 uint32_t LightMetalCaptureContext::get_global_id(const Program* obj) {
-    auto it = program_to_global_id_map_.find(obj);
-    if (it != program_to_global_id_map_.end()) {
+    auto it = program_id_to_global_id_map_.find(obj->get_id());
+    if (it != program_id_to_global_id_map_.end()) {
         return it->second;
     } else {
-        TT_THROW("Program not found in global_id map.");
+        TT_THROW("Program id: {} not found in global_id map.", obj->get_id());
     }
 }
 

--- a/tt_metal/impl/lightmetal/lightmetal_capture.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.hpp
@@ -73,10 +73,11 @@ private:
     std::vector<flatbuffers::Offset<tt::tt_metal::flatbuffer::Command>> cmds_vec_;
     std::vector<TraceDescriptorByTraceIdOffset> trace_descs_vec_;
 
-    // Object maps for associating each object with a global_id
+    // Object maps for associating each object (or identifier) with a global_id
+    // TODO (kmabee) - upgrade all global_id to be uint64_t for capture + replay.
     uint32_t next_global_id_ = 0;  // Shared across all object types.
     std::unordered_map<const Buffer*, uint32_t> buffer_to_global_id_map_;
-    std::unordered_map<const Program*, uint32_t> program_to_global_id_map_;
+    std::unordered_map<uint64_t, uint32_t> program_id_to_global_id_map_;
     std::unordered_map<const Kernel*, uint32_t> kernel_to_global_id_map_;
     std::unordered_map<CBHandle, uint32_t> cb_handle_to_global_id_map_;
     // TODO (kmabee) - consider adding map for CommandQueue object.


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/17761

### Problem description

- More details in issue, but TTNN path does `std::move(program)` between Program creation and `EnqueueProgram(program)` call which invalidates Program ptr/address stored by LightMetal Capture code for tracking Program object usage across APIs.  
- We can use the already-existing unique Program `id` to know which Program is being passed to APIs instead of ptr to solve this problem.

### What's changed

 - In lightmetal_capture.cpp store Program obj by id (via program.get_id()) instead of ptr at capture time, update map name and usage.
 - Only impacts lightmetal cpp unit tests so far, but will help with upcoming python ttnn tests
 - Not bothering updating all global_id tracking to be uint64_t which now makes more sense, in order to keep this PR small/contained.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13219588486
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
