### PR TITLE
Add support for height sharded and tiled inputs in `ttnn.concat`

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -50,10 +50,6 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor>& input_tensors) c
         TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
         if (shard_first) {
-            // TODO(jerrysky3): Remove this when we replace the two tensors concat kernel with the general one.
-            TT_FATAL(
-                input_tensors.size() > 2 || in_ref.get_layout() == Layout::ROW_MAJOR,
-                "Only row major supported for sharded two tensors concat.");
             TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
             TT_FATAL(
                 in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -32,6 +32,201 @@ uint32_t find_greatest_common_page_size(std::vector<uint32_t>& stick_sizes, uint
 
 namespace ttnn::operations::data_movement::detail {
 
+tt_metal::operation::ProgramWithCallbacks s2s_tiled_concat_two_tensors_height_multi_core(
+    const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
+    // If we end up here for concat with more than 2 tensors on any other dim we should have
+    // taken another path
+    TT_FATAL(dim == 3, "Sharded concat with tiled inputs only supports dim=3 (was {})", dim);
+    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors (was {})", input_tensors.size());
+
+    TT_FATAL(
+        input_tensors[0].get_logical_shape()[-1] == input_tensors[0].get_padded_shape()[-1],
+        "Cannot have padding along width dimension in input tensor 0 ({} != {})",
+        input_tensors[0].get_logical_shape()[-1],
+        input_tensors[0].get_padded_shape()[-1]);
+    TT_FATAL(
+        input_tensors[1].get_logical_shape()[-1] == input_tensors[1].get_padded_shape()[-1],
+        "Cannot have padding along width dimension in input tensor 1 ({} != {})",
+        input_tensors[1].get_logical_shape()[-1],
+        input_tensors[1].get_padded_shape()[-1]);
+
+    TT_FATAL(
+        input_tensors[0].get_padded_shape()[-1] % groups == 0,
+        "Input tensor 0 columns must be evenly divisible by groups (W={}, groups={})",
+        input_tensors[0].get_padded_shape()[-1],
+        groups);
+    TT_FATAL(
+        input_tensors[1].get_padded_shape()[-1] % groups == 0,
+        "Input tensor 1 columns must be evenly divisible by groups (W={}, groups={})",
+        input_tensors[1].get_padded_shape()[-1],
+        groups);
+
+    // The current implementation relies on not having break up tile faces so if we would
+    // need to split tiles because dim[-1] / groups < 16, we cannot proceed
+    TT_FATAL(
+        input_tensors[0].get_padded_shape()[-1] / groups >= TILE_HEIGHT / 2,
+        "Group size must be at least 16 for input0 (was {})",
+        input_tensors[0].get_padded_shape()[-1] / groups);
+    TT_FATAL(
+        input_tensors[1].get_padded_shape()[-1] / groups >= TILE_HEIGHT / 2,
+        "Group size must be at least 16 for input1 (was {})",
+        input_tensors[1].get_padded_shape()[-1] / groups);
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    const auto all_cores = input_tensors[0].shard_spec().value().grid;  // assume all inputs have same grid
+
+    const auto get_num_tiles_per_shard =
+        [](const std::array<uint32_t, 2>& shard_shape) -> std::tuple<uint32_t, uint32_t> {
+        TT_FATAL(shard_shape[0] % TILE_HEIGHT == 0, "Shard height must be aligned to tile height");
+        TT_FATAL(shard_shape[1] % TILE_WIDTH == 0, "Shard width must be aligned to tile width");
+        const uint32_t num_tiles_along_height = shard_shape[0] / TILE_HEIGHT;
+        const uint32_t num_tiles_along_width = shard_shape[1] / TILE_WIDTH;
+        TT_FATAL(num_tiles_along_height != 0 && num_tiles_along_width != 0, "Expected tensor to have at least 1 tiles");
+        return {num_tiles_along_height, num_tiles_along_width};
+    };
+
+    const auto get_total_num_tiles_per_shard = [](const std::tuple<uint32_t, uint32_t>& num_tiles) -> uint32_t {
+        return std::get<0>(num_tiles) * std::get<1>(num_tiles);
+    };
+
+    std::vector<std::tuple<uint32_t, uint32_t>> num_tiles_for_each_input_shard;
+    for (const auto& input_tensor : input_tensors) {
+        num_tiles_for_each_input_shard.push_back(get_num_tiles_per_shard(input_tensor.shard_spec()->shape));
+    }
+    const auto num_tiles_for_output_shard = get_num_tiles_per_shard(output.shard_spec()->shape);
+
+    log_debug("Number of tiles per input tensor shard: {}", num_tiles_for_each_input_shard);
+    log_debug("Number of tiles for output tensor shard: {}", num_tiles_for_output_shard);
+
+    const auto create_circular_buffer = [&program, &cores = all_cores](
+                                            uint32_t index,
+                                            uint32_t num_tiles,
+                                            uint32_t tile_size,
+                                            const tt::DataFormat& format,
+                                            Buffer* buffer) -> tt::tt_metal::CBHandle {
+        tt::log_debug(
+            "Creating CB (id={}) for {} tiles (each {} B) with total size {} B",
+            index,
+            num_tiles,
+            tile_size,
+            num_tiles * tile_size);
+        tt::tt_metal::CircularBufferConfig config =
+            tt::tt_metal::CircularBufferConfig(num_tiles * tile_size, {{index, format}})
+                .set_page_size(index, tile_size);
+        if (buffer) {
+            config.set_globally_allocated_address(*buffer);
+        }
+        return tt::tt_metal::CreateCircularBuffer(program, cores, config);
+    };
+
+    const auto create_cb_from_tensor =
+        [&create_circular_buffer](
+            uint32_t idx, const Tensor& input_tensor, uint32_t total_num_tiles) -> tt::tt_metal::CBHandle {
+        const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+        const auto tile_size = tt::tt_metal::detail::TileSize(data_format);
+        return create_circular_buffer(idx, total_num_tiles, tile_size, data_format, input_tensor.buffer());
+    };
+
+    TT_FATAL(input_tensors.at(0).dtype() == input_tensors.at(1).dtype(), "Input tensor data types must match");
+    const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).dtype());
+    const auto tile_size = tt::tt_metal::detail::TileSize(data_format);
+
+    const uint32_t num_input_tensors = input_tensors.size();
+    std::vector<CBHandle> cb_inputs(num_input_tensors);
+    for (uint32_t idx = 0; idx < num_input_tensors; idx++) {
+        const auto& input_tensor = input_tensors.at(idx);
+        const auto total_num_tiles = get_total_num_tiles_per_shard(num_tiles_for_each_input_shard[idx]);
+        cb_inputs[idx] = create_cb_from_tensor(idx, input_tensor, total_num_tiles);
+    }
+
+    const uint32_t cb_output_id = cb_inputs.size();
+    const auto total_num_output_tiles = get_total_num_tiles_per_shard(num_tiles_for_output_shard);
+    const CBHandle cb_output = create_cb_from_tensor(cb_output_id, output, total_num_output_tiles);
+
+    const auto bf16_data_format = tt::tt_metal::datatype_to_dataformat_converter(DataType::BFLOAT16);
+    const auto bf16_tile_size = tt::tt_metal::detail::TileSize(bf16_data_format);
+
+    const auto in0_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[0]);
+    const uint32_t cb_input0_transpose_id = cb_inputs.size() + 1;
+    CBHandle cb_input0_transpose = create_circular_buffer(
+        cb_input0_transpose_id, in0_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+
+    const auto in1_total_tiles_width = std::get<1>(num_tiles_for_each_input_shard[1]);
+    const uint32_t cb_input1_transpose_id = cb_inputs.size() + 2;
+    CBHandle cb_input1_transpose = create_circular_buffer(
+        cb_input1_transpose_id, in1_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+
+    const auto out_total_tiles_width = in0_total_tiles_width + in1_total_tiles_width;
+    const uint32_t cb_concat_id = cb_inputs.size() + 3;
+    CBHandle cb_concat =
+        create_circular_buffer(cb_concat_id, out_total_tiles_width, bf16_tile_size, bf16_data_format, nullptr);
+
+    const uint32_t cb_output_transpose_id = cb_inputs.size() + 4;
+    CBHandle cb_output_transpose =
+        create_circular_buffer(cb_output_transpose_id, out_total_tiles_width, tile_size, data_format, nullptr);
+
+    const bool is_rm_shard_orientation = output.shard_spec()->orientation == ShardOrientation::ROW_MAJOR;
+    const auto cores = corerange_to_cores(all_cores, std::nullopt, is_rm_shard_orientation);
+
+    for (const auto& core : cores) {
+        std::vector<uint32_t> compile_time_args_0 = {
+            0,
+            1,
+            cb_input0_transpose_id,
+            cb_input1_transpose_id,
+            cb_concat_id,
+            cb_output_transpose_id,
+            cb_output_id,
+            std::get<0>(num_tiles_for_each_input_shard[0]),
+            std::get<1>(num_tiles_for_each_input_shard[0]),
+            std::get<0>(num_tiles_for_each_input_shard[1]),
+            std::get<1>(num_tiles_for_each_input_shard[1]),
+            tile_size,
+            groups,
+        };
+        tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "reader_height_sharded_width_concat_two_tensors_tiled.cpp",
+            core,
+            tt_metal::ReaderDataMovementConfig(compile_time_args_0));
+        tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+            "writer_height_sharded_width_concat_two_tensors_tiled.cpp",
+            core,
+            tt_metal::WriterDataMovementConfig(compile_time_args_0));
+        // TODO: Skip the tile transpose in compute kernel if the following condition is true:
+        // >> (input_tensors[0].get_padded_shape()[-1] / groups % TILE_WIDTH == 0
+        // >> && input_tensors[1].get_padded_shape()[-1] / groups % TILE_WIDTH == 0)
+        tt_metal::KernelHandle compute_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/"
+            "height_sharded_width_concat_two_tensors.cpp",
+            core,
+            tt_metal::ComputeConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .fp32_dest_acc_en = false,
+                .math_approx_mode = false,
+                .compile_args = compile_time_args_0});
+    }
+
+    auto override_runtime_arguments_callback = [num_input_tensors, cb_inputs, cb_output](
+                                                   const void* operation,
+                                                   Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
+        for (uint32_t idx = 0; idx < num_input_tensors; idx++) {
+            UpdateDynamicCircularBufferAddress(program, cb_inputs[idx], *input_tensors[idx].buffer());
+        }
+        UpdateDynamicCircularBufferAddress(program, cb_output, *output_tensors[0].buffer());
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
 tt_metal::operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_height_multi_core(
     const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
     TT_FATAL(dim == 3, "Sharded concat RM only supports dim=3");
@@ -224,16 +419,16 @@ tt_metal::operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_height_multi
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
-// Concat sharded tensors into sharded output in row-major/tile layout. Currently it only supports height-sharded width
-// concat or width-sharded height concat.
+// Concat sharded tensors into sharded output in row-major/tile layout. Currently it only supports height-sharded
+// width concat or width-sharded height concat.
 //
-// It is done by copying each row of each input sharded tensor to the right offset in the sharded output tensor based on
-// the sharded output width in bytes (output stride). This way works for both width and height concat.
+// It is done by copying each row of each input sharded tensor to the right offset in the sharded output tensor
+// based on the sharded output width in bytes (output stride). This way works for both width and height concat.
 //
-// For example in width concat, rows of an input tensor are placed at the same column offset but sequential rows in the
-// output. The memory address gap between neighbor input rows is exactly the output width. In height concat, all input
-// rows are placed at column 0 but sequential rows in the output. The address gap between neighbor input rows is still
-// the output width (which is equal to the input width).
+// For example in width concat, rows of an input tensor are placed at the same column offset but sequential rows in
+// the output. The memory address gap between neighbor input rows is exactly the output width. In height concat, all
+// input rows are placed at column 0 but sequential rows in the output. The address gap between neighbor input rows
+// is still the output width (which is equal to the input width).
 tt_metal::operation::ProgramWithCallbacks s2s_concat_multi_core(
     const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output) {
     TT_FATAL(dim == 2 || dim == 3, "Sharded concat only supports dim=2 or 3");
@@ -493,14 +688,21 @@ tt_metal::operation::ProgramWithCallbacks sharded_concat_multi_core(
     const std::vector<Tensor>& input_tensors, uint32_t dim, Tensor& output, unsigned int groups) {
     if (output.is_sharded()) {
         if (input_tensors.size() == 2) {
-            // TODO(jerrysky3): Keep the unrolled two tensor concat tensor for now but it only supports height-sharded
-            // width concat. Need to unroll s2s_rm_concat_multi_core if width-sharded height concat is needed for this
-            // case.
-            return s2s_rm_concat_two_tensors_height_multi_core(input_tensors, dim, output, groups);
+            // There are unrolled kernels for the case where we have 2 hight-sharded kernels. Currently
+            // we only support 2 tile inputs OR 2 row-major inputs.
+            TT_FATAL(
+                input_tensors.at(0).layout() == input_tensors.at(1).layout(),
+                "Expected all input tensors to have the same layout");
+            if (input_tensors.at(0).layout() == Layout::ROW_MAJOR) {
+                return s2s_rm_concat_two_tensors_height_multi_core(input_tensors, dim, output, groups);
+            } else {
+                return s2s_tiled_concat_two_tensors_height_multi_core(input_tensors, dim, output, groups);
+            }
         } else {
             TT_FATAL(
                 groups == 1,
-                "Sharded ttnn.concat with groups > 1 is only supported for 2 sharded input and sharded output tensors");
+                "Sharded ttnn.concat with groups > 1 is only supported for 2 sharded input and sharded output "
+                "tensors");
             return s2s_concat_multi_core(input_tensors, dim, output);
         }
     } else {
@@ -660,7 +862,8 @@ tt_metal::operation::ProgramWithCallbacks concat_multi_core(
         program,
         rm_layout
             ? "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+              "writer_unary_interleaved_start_id.cpp",
         all_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/compute/height_sharded_width_concat_two_tensors.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/transpose_wh.h"
+
+constexpr uint32_t ONE_TILE = 1;
+
+FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
+    cb_wait_front(cb_in, ONE_TILE);
+
+    tile_regs_acquire();
+    tile_regs_wait();
+
+    transpose_wh_init_short(cb_in);
+    transpose_wh_tile(cb_in, 0, 0);
+
+    cb_reserve_back(cb_out, ONE_TILE);
+    pack_tile(0, cb_out);
+
+    tile_regs_commit();
+    tile_regs_release();
+
+    cb_push_back(cb_out, ONE_TILE);
+    cb_pop_front(cb_in, ONE_TILE);
+}
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t input0_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t input1_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t input0_transpose_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t input1_transpose_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t concat_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t output_transpose_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t output_cb = get_compile_time_arg_val(6);
+
+    constexpr uint32_t input0_num_tiles_height = get_compile_time_arg_val(7);
+    constexpr uint32_t input0_num_tiles_width = get_compile_time_arg_val(8);
+    constexpr uint32_t input1_num_tiles_height = get_compile_time_arg_val(9);
+    constexpr uint32_t input1_num_tiles_width = get_compile_time_arg_val(10);
+
+    constexpr uint32_t tile_size = get_compile_time_arg_val(11);
+    constexpr uint32_t groups = get_compile_time_arg_val(12);
+
+    transpose_wh_init(input0_cb, input0_transpose_cb);
+
+    constexpr uint32_t output_num_tiles_width = input0_num_tiles_width + input1_num_tiles_width;
+
+    // TODO: Add blocking on transposes to see if it improves performance
+    for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
+        reconfig_data_format_srca(input0_cb);
+        pack_reconfig_data_format(input0_transpose_cb);
+        for (uint32_t j = 0; j < input0_num_tiles_width; j++) {
+            transpose(input0_cb, input0_transpose_cb);
+        }
+        for (uint32_t j = 0; j < input1_num_tiles_width; j++) {
+            transpose(input1_cb, input1_transpose_cb);
+        }
+        reconfig_data_format_srca(concat_cb);
+        pack_reconfig_data_format(output_transpose_cb);
+        for (uint32_t j = 0; j < output_num_tiles_width; j++) {
+            transpose(concat_cb, output_transpose_cb);
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+void kernel_main() {
+    constexpr uint32_t input0_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t input1_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t input0_transpose_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t input1_transpose_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t concat_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t output_transpose_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t output_cb = get_compile_time_arg_val(6);
+
+    constexpr uint32_t input0_num_tiles_height = get_compile_time_arg_val(7);
+    constexpr uint32_t input0_num_tiles_width = get_compile_time_arg_val(8);
+    constexpr uint32_t input1_num_tiles_height = get_compile_time_arg_val(9);
+    constexpr uint32_t input1_num_tiles_width = get_compile_time_arg_val(10);
+
+    constexpr uint32_t output_num_tiles_width = input0_num_tiles_width + input1_num_tiles_width;
+
+    constexpr uint32_t tile_size = get_compile_time_arg_val(11);
+    constexpr uint32_t groups = get_compile_time_arg_val(12);
+
+    constexpr uint32_t bf16_tile_size = 32 * 32 * 2;
+    constexpr uint32_t input0_stride = bf16_tile_size * input0_num_tiles_width / groups;
+    constexpr uint32_t input1_stride = bf16_tile_size * input1_num_tiles_width / groups;
+    constexpr uint32_t group_stride = input0_stride + input1_stride;
+
+    const uint32_t base_l1_read_addr_0 = get_read_ptr(input0_transpose_cb);
+    const uint64_t noc_addr_0 = get_noc_addr(base_l1_read_addr_0);
+    const uint32_t base_l1_read_addr_1 = get_read_ptr(input1_transpose_cb);
+    const uint64_t noc_addr_1 = get_noc_addr(base_l1_read_addr_1);
+    const uint32_t base_l1_write_addr = get_write_ptr(concat_cb);
+
+    cb_push_back(input0_cb, input0_num_tiles_height * input0_num_tiles_width);
+    cb_push_back(input1_cb, input1_num_tiles_height * input1_num_tiles_width);
+
+    for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
+        cb_reserve_back(concat_cb, output_num_tiles_width);
+
+        cb_wait_front(input0_transpose_cb, input0_num_tiles_width);
+
+        uint32_t l1_read_addr = base_l1_read_addr_0;
+        noc_async_read_one_packet_set_state(noc_addr_0, input0_stride);
+
+        uint32_t l1_write_addr = base_l1_write_addr;
+        for (uint32_t j = 0; j < groups; j++) {
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+            l1_read_addr += input0_stride;
+            l1_write_addr += group_stride;
+        }
+
+        noc_async_read_barrier();
+        cb_pop_front(input0_transpose_cb, input0_num_tiles_width);
+
+        cb_wait_front(input1_transpose_cb, input1_num_tiles_width);
+
+        l1_read_addr = base_l1_read_addr_1;
+        noc_async_read_one_packet_set_state(noc_addr_1, input1_stride);
+
+        l1_write_addr = base_l1_write_addr + input0_stride;
+        for (uint32_t j = 0; j < groups; j++) {
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+            l1_read_addr += input1_stride;
+            l1_write_addr += group_stride;
+        }
+
+        noc_async_read_barrier();
+        cb_pop_front(input1_transpose_cb, input1_num_tiles_width);
+
+        cb_push_back(concat_cb, output_num_tiles_width);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_height_sharded_width_concat_two_tensors_tiled.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <debug/dprint.h>
+
+void kernel_main() {
+    constexpr uint32_t input0_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t input1_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t input0_transpose_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t input1_transpose_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t concat_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t output_transpose_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t output_cb = get_compile_time_arg_val(6);
+
+    constexpr uint32_t input0_num_tiles_height = get_compile_time_arg_val(7);
+    constexpr uint32_t input0_num_tiles_width = get_compile_time_arg_val(8);
+    constexpr uint32_t input1_num_tiles_height = get_compile_time_arg_val(9);
+    constexpr uint32_t input1_num_tiles_width = get_compile_time_arg_val(10);
+
+    constexpr uint32_t tile_size = get_compile_time_arg_val(11);
+    constexpr uint32_t groups = get_compile_time_arg_val(12);
+
+    constexpr uint32_t input0_stride = tile_size * input0_num_tiles_width / groups;
+    constexpr uint32_t input1_stride = tile_size * input1_num_tiles_width / groups;
+
+    constexpr uint32_t width_len_bytes = tile_size * (input0_num_tiles_width + input1_num_tiles_width);
+
+    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    uint32_t l1_write_addr = base_l1_write_addr;
+    for (uint32_t i = 0; i < input0_num_tiles_height; i++) {
+        cb_reserve_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);
+        cb_wait_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
+
+        const uint32_t base_l1_read_addr_0 = get_read_ptr(output_transpose_cb);
+        const uint64_t noc_addr_0 = get_noc_addr(base_l1_read_addr_0);
+        noc_async_read_one_packet_set_state(noc_addr_0, width_len_bytes);
+        noc_async_read_one_packet_with_state<true>(base_l1_read_addr_0, l1_write_addr);
+        l1_write_addr += width_len_bytes;
+
+        noc_async_write_barrier();
+
+        cb_pop_front(output_transpose_cb, input0_num_tiles_width + input1_num_tiles_width);
+        cb_push_back(output_cb, input0_num_tiles_width + input1_num_tiles_width);
+    }
+}


### PR DESCRIPTION
### Summary

This change adds support for height sharded and tiled inputs in `ttnn.concat`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13569925068
- [x] New/Existing tests provide coverage for changes
