### PR TITLE
Fix I2S alignment issue on BH

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -290,7 +290,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
                  num_units_per_row,
                  shard_height,
                  shard_width,
-                 (is_blackhole) ? shard_width : padded_offset_bytes,
+                 padded_offset_bytes,
                  static_cast<uint32_t>(aligned),
                  aligned_width_offset,
                  aligned_shard_width,


### PR DESCRIPTION
Running conv2d sweeps on BH exposed ~150 pcc issues. 
TT_METAL_WATCHER exposed unaligned noc transaction in ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp  
In these test cases. block_width_bytes wasn't aligned to 16B in these cases. 
For some reason BH codepath was setting unaligned size in this case.

This change brings parity between WH and BH on conv2d sweeps.
[Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13227335482)