### PR TITLE
Fix incorrect tracer error when fast runtime mode is enabled.

### DIFF
--- a/ttnn/ttnn/tracer.py
+++ b/ttnn/ttnn/tracer.py
@@ -456,7 +456,7 @@ def enable_tracing():
     global ENABLE_TRACER
     global GRAPH_STACK
     if ttnn.CONFIG.enable_fast_runtime_mode:
-        raise ValueError("Tracing is only supported in fast runtime mode.")
+        raise ValueError("Tracing is not supported in fast runtime mode.")
     if ENABLE_TRACER:
         raise ValueError("Tracing is already enabled.")
     ENABLE_TRACER = True


### PR DESCRIPTION
Fixes #17773.

### Ticket

#17773 

### Problem description

The error message is wrong when fast runtime mode is enabled.  It should say the opposite of what it says currently.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
