### PR TITLE
[Fabric] Support for routing planes

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
@@ -29,5 +29,6 @@ void kernel_main() {
 
     // do a noc multicast to tx kernels
     uint64_t mcast_dest_addr = get_noc_addr_helper(mcast_encoding, tx_signal_addr);
-    noc_async_write_multicast_one_packet((uint32_t)mcast_sem, mcast_dest_addr, sizeof(uint32_t), num_mcast_dests);
+    noc_async_write_multicast_loopback_src((uint32_t)mcast_sem, mcast_dest_addr, sizeof(uint32_t), num_mcast_dests);
+    noc_async_writes_flushed();
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -23,8 +23,6 @@ constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(2);
 constexpr uint32_t data_buffer_start_addr = get_compile_time_arg_val(3);
 constexpr uint32_t data_buffer_size_words = get_compile_time_arg_val(4);
 
-constexpr uint32_t routing_table_start_addr = get_compile_time_arg_val(5);
-
 constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(6);
 constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(7);
 
@@ -53,7 +51,7 @@ uint32_t base_target_address = get_compile_time_arg_val(17);
 
 // atomic increment for the ATOMIC_INC command
 constexpr uint32_t atomic_increment = get_compile_time_arg_val(18);
-// constexpr uint32_t dest_device = get_compile_time_arg_val(21);
+
 uint32_t dest_device;
 
 constexpr uint32_t signal_address = get_compile_time_arg_val(19);
@@ -65,10 +63,7 @@ constexpr uint32_t w_depth = get_compile_time_arg_val(25);
 constexpr uint32_t n_depth = get_compile_time_arg_val(26);
 constexpr uint32_t s_depth = get_compile_time_arg_val(27);
 
-volatile local_pull_request_t* local_pull_request = (volatile local_pull_request_t*)(data_buffer_start_addr - 1024);
-volatile tt_l1_ptr fabric_router_l1_config_t* routing_table =
-    reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(routing_table_start_addr);
-volatile fabric_client_interface_t* client_interface = (volatile fabric_client_interface_t*)client_interface_addr;
+volatile fabric_client_interface_t* client_interface;
 
 uint64_t xy_local_addr;
 uint32_t target_address;
@@ -94,15 +89,12 @@ inline void notify_traffic_controller() {
 }
 
 void kernel_main() {
-    tt_fabric_init();
-
     uint32_t rt_args_idx = 0;
     time_seed = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     src_endpoint_id = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     controller_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
-    uint32_t router_x = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
-    uint32_t router_y = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t routing_plane = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     dest_device = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t rx_buf_size = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     gk_interface_addr_l = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -114,26 +106,13 @@ void kernel_main() {
 
     target_address = base_target_address;
 
-    // Read in the routing table
-    uint64_t router_config_addr =
-        NOC_XY_ADDR(NOC_X(router_x), NOC_Y(router_y), eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
-    noc_async_read_one_packet(router_config_addr, routing_table_start_addr, sizeof(fabric_router_l1_config_t));
-    noc_async_read_barrier();
-
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
-    test_results[PQ_TEST_STATUS_INDEX + 1] = (uint32_t)local_pull_request;
-
     test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
     test_results[PQ_TEST_MISC_INDEX + 1] = 0xcc000000 | src_endpoint_id;
 
     zero_l1_buf(
         reinterpret_cast<tt_l1_ptr uint32_t*>(data_buffer_start_addr), data_buffer_size_words * PACKET_WORD_SIZE_BYTES);
-    zero_l1_buf((uint32_t*)local_pull_request, sizeof(local_pull_request_t));
-    zero_l1_buf((uint32_t*)client_interface, sizeof(fabric_client_interface_t));
-    client_interface->gk_interface_addr = ((uint64_t)gk_interface_addr_h << 32) | gk_interface_addr_l;
-    client_interface->gk_msg_buf_addr =
-        (((uint64_t)gk_interface_addr_h << 32) | gk_interface_addr_l) + offsetof(gatekeeper_info_t, gk_msg_buf);
 
     uint64_t data_words_sent = 0;
     uint32_t packet_count = 0;
@@ -160,8 +139,8 @@ void kernel_main() {
         );
     }
 
-    // make sure fabric node gatekeeper is available.
-    fabric_endpoint_init();
+    // initalize client
+    fabric_endpoint_init(client_interface_addr, gk_interface_addr_l, gk_interface_addr_h);
 
     // notify the controller kernel that this worker is ready to proceed
     notify_traffic_controller();
@@ -171,17 +150,18 @@ void kernel_main() {
     // all tx workers are ready to send data
     while (*(volatile tt_l1_ptr uint32_t*)signal_address == 0);
 
-    uint64_t start_timestamp = get_timestamp();
     fabric_setup_pull_request(
         data_buffer_start_addr,     // source address in sender’s memory
         max_packet_size_words * 16  // number of bytes to write to remote destination
     );
 
+    uint64_t start_timestamp = get_timestamp();
+
     while (true) {
         client_interface->local_pull_request.pull_request.words_read = 0;
         if constexpr (mcast_data) {
             fabric_async_write_multicast<ASYNC_WR_SEND>(
-                0,                       // the network plane to use for this transaction
+                routing_plane,           // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
                 dest_device >> 16,
                 dest_device & 0xFFFF,
@@ -190,11 +170,10 @@ void kernel_main() {
                 e_depth,
                 w_depth,
                 n_depth,
-                s_depth
-            );
+                s_depth);
         } else {
             fabric_async_write<ASYNC_WR_SEND>(
-                0,                       // the network plane to use for this transaction
+                routing_plane,           // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
                 dest_device >> 16,
                 dest_device & 0xFFFF,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -450,6 +450,10 @@ typedef struct test_board {
         return control_plane->get_intra_chip_neighbors(src_mesh_id, src_chip_id, routing_direction);
     }
 
+    inline routing_plane_id_t get_routing_plane_from_chan(chan_id_t eth_chan) {
+        return control_plane->get_routing_plane_id(eth_chan);
+    }
+
     inline void close_devices() { tt::tt_metal::detail::CloseDevices(device_handle_map); }
 
 } test_board_t;
@@ -472,8 +476,8 @@ typedef struct test_device {
     uint32_t router_mask = 0;
     uint32_t gk_noc_offset;
     metal_SocDescriptor soc_desc;
-    std::unordered_map<CoreCoord, std::vector<std::pair<uint32_t, CoreCoord>>>
-        router_worker_map;  // router phys to worker logical cores
+    std::unordered_map<chan_id_t, std::vector<std::pair<uint32_t, CoreCoord>>>
+        router_worker_map;  // router chan to worker logical cores
 
     test_device(chip_id_t chip_id_, test_board_t* board_handle_) {
         physical_chip_id = chip_id_;
@@ -646,8 +650,8 @@ typedef struct test_device {
     void get_available_router_cores(
         uint32_t num_hops,
         std::shared_ptr<test_device>& rx_device,
-        std::vector<CoreCoord>& src_routers,
-        std::vector<CoreCoord>& dest_routers) {
+        std::vector<chan_id_t>& src_routers,
+        std::vector<chan_id_t>& dest_routers) {
         // shortest route possible with least number of internal noc hops
         uint32_t shortest_route_length = 2 * num_hops - 1;
         bool select_router = false;
@@ -656,16 +660,15 @@ typedef struct test_device {
         for (auto i = 0; i < router_logical_cores.size(); i++) {
             std::vector<std::pair<chip_id_t, chan_id_t>> route;
             std::set<chip_id_t> chips_in_route;
-            chan_id_t eth_chan = soc_desc.logical_eth_core_to_chan_map.at(router_logical_cores[i]);
+            chan_id_t src_eth_chan = soc_desc.logical_eth_core_to_chan_map.at(router_logical_cores[i]);
             chips_in_route.insert(physical_chip_id);
             try {
-                route = _get_route_to_chip(rx_device->mesh_id, rx_device->logical_chip_id, eth_chan);
+                route = _get_route_to_chip(rx_device->mesh_id, rx_device->logical_chip_id, src_eth_chan);
             } catch (const std::exception& e) {
                 continue;
             }
 
-            auto dest_router =
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(physical_chip_id, route.back().second);
+            auto dest_eth_chan = route.back().second;
 
             if (DEFAULT_NUM_HOPS == num_hops) {
                 // no need to check for path length for default case, all routers can be used
@@ -684,8 +687,8 @@ typedef struct test_device {
             }
 
             if (select_router) {
-                src_routers.push_back(router_virtual_cores[i]);
-                dest_routers.push_back(dest_router);
+                src_routers.push_back(src_eth_chan);
+                dest_routers.push_back(dest_eth_chan);
             }
         }
 
@@ -695,16 +698,16 @@ typedef struct test_device {
         }
     }
 
-    std::vector<std::tuple<CoreCoord, uint32_t, CoreCoord>> select_worker_cores(
-        const std::vector<CoreCoord>& router_cores,
+    std::vector<std::tuple<chan_id_t, uint32_t, CoreCoord>> select_worker_cores(
+        const std::vector<chan_id_t>& router_cores,
         uint32_t num_links,
         uint32_t count,
         uint32_t skip_first_n_workers = 0) {
-        std::vector<std::tuple<CoreCoord, uint32_t, CoreCoord>> result;
+        std::vector<std::tuple<chan_id_t, uint32_t, CoreCoord>> result;
         uint32_t link_idx = 0;
         if (benchmark_mode) {
             // temp map to keep a track of indices to start lookup from
-            std::unordered_map<CoreCoord, uint32_t> router_worker_idx;
+            std::unordered_map<chan_id_t, uint32_t> router_worker_idx;
             for (auto i = 0; i < count; i++) {
                 if (link_idx == num_links) {
                     link_idx = 0;
@@ -772,6 +775,7 @@ typedef struct test_device {
         uint32_t noc_dist, noc_index, noc0_dist, noc1_dist;
         for (auto i = 0; i < router_logical_cores.size(); i++) {
             router_phys_core = router_phys_cores[i];
+            chan_id_t eth_chan = soc_desc.logical_eth_core_to_chan_map.at(router_logical_cores[i]);
             std::vector<std::pair<uint32_t, std::pair<uint32_t, CoreCoord>>> temp_map;
             for (auto j = 0; j < worker_logical_cores.size(); j++) {
                 worker_phys_core = worker_phys_cores[j];
@@ -790,7 +794,7 @@ typedef struct test_device {
             std::sort(temp_map.begin(), temp_map.end());
 
             for (auto& [noc_dist, pair] : temp_map) {
-                router_worker_map[router_virtual_cores[i]].push_back(pair);
+                router_worker_map[eth_chan].push_back(pair);
             }
         }
     }
@@ -807,8 +811,8 @@ typedef struct test_traffic {
     uint32_t num_tx_workers;
     uint32_t num_rx_workers;
     uint32_t target_address;
-    std::vector<std::tuple<CoreCoord, uint32_t, CoreCoord>> tx_workers;
-    std::vector<std::tuple<CoreCoord, uint32_t, CoreCoord>> rx_workers;
+    std::vector<std::tuple<chan_id_t, uint32_t, CoreCoord>> tx_workers;
+    std::vector<std::tuple<chan_id_t, uint32_t, CoreCoord>> rx_workers;
     std::vector<CoreCoord> tx_virtual_cores;
     std::vector<CoreCoord> rx_virtual_cores;
     CoreCoord controller_logical_core;
@@ -848,8 +852,8 @@ typedef struct test_traffic {
             throw std::runtime_error("Number of dest endpoints should be less than or equal to src endpoints");
         }
 
-        std::vector<CoreCoord> src_routers;
-        std::vector<CoreCoord> dest_routers;
+        std::vector<chan_id_t> src_routers;
+        std::vector<chan_id_t> dest_routers;
         // For Unicast there is only one rx device
         // For mcast, this only supports line mcast, we pass the last device as the rx device
         tx_device->get_available_router_cores(num_hops, *rx_devices.rbegin(), src_routers, dest_routers);
@@ -889,7 +893,7 @@ typedef struct test_traffic {
         CoreCoord tx_core, rx_core;
         tt_metal::NOC noc_id;
         std::vector<uint32_t> zero_buf(2, 0);
-        CoreCoord router_virtual_core;
+        chan_id_t eth_chan;
         uint32_t mesh_chip_id = rx_devices[0]->mesh_chip_id;
 
         // update the test results address, which will be used later for polling, collecting results
@@ -933,23 +937,24 @@ typedef struct test_traffic {
 
         // launch tx kernels
         for (auto i = 0; i < num_tx_workers; i++) {
-            router_virtual_core = std::get<0>(tx_workers[i]);
+            eth_chan = std::get<0>(tx_workers[i]);
             noc_id = (std::get<1>(tx_workers[i]) == 0) ? tt_metal::NOC::NOC_0 : tt_metal::NOC::NOC_1;
             tx_core = std::get<2>(tx_workers[i]);
             rx_core = std::get<2>(rx_workers[tx_to_rx_map[i]]);
+
+            auto routing_plane = tx_device->board_handle->get_routing_plane_from_chan(eth_chan);
 
             // setup runtime args
             std::vector<uint32_t> runtime_args = {
                 time_seed,                                           // 0: time based seed
                 tx_device->get_endpoint_id(tx_core),                 // 1: src_endpoint_id
-                rx_devices[0]->get_noc_offset(rx_core),                  // 2: dest_noc_offset
+                rx_devices[0]->get_noc_offset(rx_core),              // 2: dest_noc_offset
                 tx_device->get_noc_offset(controller_logical_core),  // 3: controller noc offset
-                router_virtual_core.x,                               // 4: router_x
-                router_virtual_core.y,                               // 5: router_y
-                mesh_chip_id,                                        // 6: mesh and chip id
-                rx_buf_size,                                         // 7: space in rx's L1
-                gk_interface_addr,                                   // 8: gk_message_addr_l
-                tx_device->gk_noc_offset,                            // 9: gk_message_addr_h
+                routing_plane,                                       // 4: routing plane to use
+                mesh_chip_id,                                        // 5: mesh and chip id
+                rx_buf_size,                                         // 6: space in rx's L1
+                gk_interface_addr,                                   // 7: gk_message_addr_l
+                tx_device->gk_noc_offset,                            // 8: gk_message_addr_h
             };
 
             if (ASYNC_WR & fabric_command) {
@@ -962,8 +967,9 @@ typedef struct test_traffic {
 
             log_info(
                 LogTest,
-                "Device: {}, TX kernel running on: logical: x={},y={}; virtual: x={},y={}",
+                "[Device: Phys: {}, Logical: {}] TX kernel running on: logical: x={},y={}; virtual: x={},y={}",
                 tx_device->physical_chip_id,
+                (uint32_t)tx_device->logical_chip_id,
                 tx_core.x,
                 tx_core.y,
                 tx_virtual_cores[i].x,
@@ -1017,8 +1023,9 @@ typedef struct test_traffic {
 
                 log_info(
                     LogTest,
-                    "Device: {}, RX kernel running on: logical: x={},y={}; virtual: x={},y={}",
+                    "[Device: Phys: {}, Logical: {}] RX kernel running on: logical: x={},y={}; virtual: x={},y={}",
                     rx_device->physical_chip_id,
+                    (uint32_t)rx_device->logical_chip_id,
                     rx_core.x,
                     rx_core.y,
                     rx_virtual_cores[i].x,
@@ -1074,8 +1081,9 @@ typedef struct test_traffic {
                 tx_device->physical_chip_id, tx_virtual_cores[i], test_results_address, 128));
             log_info(
                 LogTest,
-                "Device {} TX{} status = {}",
+                "[Device: Phys: {}, Logical: {}] TX{} status = {}",
                 tx_device->physical_chip_id,
+                (uint32_t)tx_device->logical_chip_id,
                 i,
                 packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
@@ -1089,8 +1097,9 @@ typedef struct test_traffic {
                     rx_devices[d]->physical_chip_id, rx_virtual_cores[i], test_results_address, 128));
                 log_info(
                     LogTest,
-                    "Device {} RX{} status = {}",
+                    "[Device: Phys: {}, Logical: {}] RX{} status = {}",
                     rx_devices[d]->physical_chip_id,
+                    (uint32_t)rx_devices[d]->logical_chip_id,
                     i,
                     packet_queue_test_status_to_string(rx_results[d][i][PQ_TEST_STATUS_INDEX]));
                 pass &= (rx_results[d][i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
@@ -1149,8 +1158,9 @@ typedef struct test_traffic {
 
             log_info(
                 LogTest,
-                "Device: {}, TX {} words sent: {}, elapsed cycles: {} -> BW: {:.2f} B/cycle",
+                "[Device: Phys: {}, Logical: {}] TX {} words sent: {}, elapsed cycles: {} -> BW: {:.2f} B/cycle",
                 tx_device->physical_chip_id,
+                tx_device->logical_chip_id,
                 i,
                 tx_words_sent,
                 tx_elapsed_cycles,
@@ -1176,8 +1186,9 @@ typedef struct test_traffic {
                 uint32_t num_tx = rx_to_tx_map[i].size();
                 log_info(
                     LogTest,
-                    "Device: {}, RX {}, num producers = {}, words received = {}",
+                    "[Device: Phys: {}, Logical: {}] RX {}, num producers = {}, words received = {}",
                     rx_devices[d]->physical_chip_id,
+                    (uint32_t)rx_devices[d]->logical_chip_id,
                     i,
                     num_tx,
                     words_received);
@@ -1495,8 +1506,6 @@ int main(int argc, char **argv) {
     }
 
     global_rng.seed(prng_seed);
-    log_info(LogTest, "PRNG seed = {}", prng_seed);
-
     time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
     try {
@@ -1605,10 +1614,13 @@ int main(int argc, char **argv) {
             throw std::runtime_error("Test cannot run on specified device.");
         } */
 
+        uint32_t worker_unreserved_base_addr =
+            hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+
         if (run_gk_on_idle_ethernet) {
             routing_table_addr = hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
         } else {
-            routing_table_addr = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+            routing_table_addr = worker_unreserved_base_addr;
         }
         gk_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         socket_info_addr = gk_interface_addr + sizeof(gatekeeper_info_t);
@@ -1641,8 +1653,9 @@ int main(int argc, char **argv) {
             defines["CHECK_TIMEOUT"] = "";
         }
 
-        uint32_t client_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
-        uint32_t client_pull_req_buf_addr = client_interface_addr + sizeof(fabric_client_interface_t);
+        uint32_t client_interface_addr = worker_unreserved_base_addr;
+        uint32_t client_pull_req_buf_addr =
+            client_interface_addr + sizeof(fabric_client_interface_t) + sizeof(fabric_router_l1_config_t) * 4;
 
         std::vector<uint32_t> tx_compile_args = {
             0,                           //(device->id() << 8) + src_endpoint_start_id + i,  // 0: src_endpoint_id

--- a/tt_fabric/control_plane.hpp
+++ b/tt_fabric/control_plane.hpp
@@ -46,6 +46,8 @@ class ControlPlane {
        std::vector<chip_id_t> get_intra_chip_neighbors(
            mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
 
+       routing_plane_id_t get_routing_plane_id(chan_id_t eth_chan_id) const;
+
    private:
        std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
        std::vector<std::vector<chip_id_t>> logical_mesh_chip_id_to_physical_chip_id_mapping_;
@@ -71,8 +73,6 @@ class ControlPlane {
 
        std::tuple<mesh_id_t, chip_id_t, chan_id_t> get_connected_mesh_chip_chan_ids(
            mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t chan_id) const;
-
-       routing_plane_id_t get_routing_plane_id(chan_id_t eth_chan_id) const;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_fabric/hw/inc/tt_fabric_interface.h
@@ -331,7 +331,8 @@ typedef struct _fabric_client_interface {
     uint64_t gk_interface_addr;
     uint64_t gk_msg_buf_addr;
     uint64_t pull_req_buf_addr;
-    uint32_t padding[2];
+    uint32_t num_routing_planes;
+    uint32_t routing_tables_l1_offset;
     uint32_t return_status[3];
     uint32_t socket_count;
     chan_ptr wrptr;

--- a/tt_fabric/impl/kernels/tt_fabric_gatekeeper.cpp
+++ b/tt_fabric/impl/kernels/tt_fabric_gatekeeper.cpp
@@ -59,6 +59,39 @@ inline void notify_all_routers(uint32_t notification) {
     }
 }
 
+inline void get_routing_tables() {
+    uint32_t temp_mask = router_mask;
+    uint32_t channel = 0;
+    uint32_t routing_plane = 0;
+    for (uint32_t i = 0; i < 4; i++) {
+        if (temp_mask & 0xF) {
+            temp_mask &= 0xF;
+            break;
+        } else {
+            temp_mask >>= 4;
+        }
+        channel += 4;
+    }
+
+    if (temp_mask) {
+        for (uint32_t i = 0; i < 4; i++) {
+            if (temp_mask & 0x1) {
+                uint64_t router_config_addr = ((uint64_t)eth_chan_to_noc_xy[noc_index][channel] << 32) |
+                                              eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE;
+                noc_async_read_one_packet(
+                    router_config_addr,
+                    (uint32_t)&routing_table[routing_plane],
+                    sizeof(tt::tt_fabric::fabric_router_l1_config_t));
+                routing_plane++;
+            }
+            temp_mask >>= 1;
+            channel++;
+        }
+    }
+    gk_info->routing_planes = routing_plane;
+    noc_async_read_barrier();
+}
+
 inline void sync_all_routers() {
     // wait for all device routers to have incremented the sync semaphore.
     // sync_val is equal to number of tt-fabric routers running on a device.
@@ -68,6 +101,7 @@ inline void sync_all_routers() {
     // semaphore notifies all other routers that this router has completed
     // startup handshake with its ethernet peer.
     notify_all_routers(sync_val);
+    get_routing_tables();
     gk_info->ep_sync.val = sync_val;
 }
 
@@ -394,39 +428,6 @@ inline void process_pending_socket() {
     }
 }
 
-inline void get_routing_tables() {
-    uint32_t temp_mask = router_mask;
-    uint32_t channel = 0;
-    uint32_t routing_plane = 0;
-    for (uint32_t i = 0; i < 4; i++) {
-        if (temp_mask & 0xF) {
-            temp_mask &= 0xF;
-            break;
-        } else {
-            temp_mask >>= 4;
-        }
-        channel += 4;
-    }
-
-    if (temp_mask) {
-        for (uint32_t i = 0; i < 4; i++) {
-            if (temp_mask & 0x1) {
-                uint64_t router_config_addr = ((uint64_t)eth_chan_to_noc_xy[noc_index][channel] << 32) |
-                                              eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE;
-                noc_async_read_one_packet(
-                    router_config_addr,
-                    (uint32_t)&routing_table[routing_plane],
-                    sizeof(tt::tt_fabric::fabric_router_l1_config_t));
-                routing_plane++;
-            }
-            temp_mask >>= 1;
-            channel++;
-        }
-    }
-    gk_info->routing_planes = routing_plane;
-    noc_async_read_barrier();
-}
-
 void kernel_main() {
     sync_val = get_arg_val<uint32_t>(0);
     router_mask = get_arg_val<uint32_t>(1);
@@ -445,7 +446,6 @@ void kernel_main() {
     zero_l1_buf((tt_l1_ptr uint32_t*)socket_info, sizeof(socket_info_t));
 
     sync_all_routers();
-    get_routing_tables();
     uint64_t start_timestamp = get_timestamp();
 
     uint32_t loop_count = 0;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17573)

### Problem description
The kernels were loading only 1 routing plane.

### What's changed
Added support to load and use all the available routing planes

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13228586327)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
