### PR TITLE
LightMetal - SetRuntimeArgsUint32VecPerCore Trace + Replay support (some TTNN ops use) (Issue #17779)

### DIFF
--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -25,7 +25,8 @@ namespace tt::tt_metal {
 namespace {
 
 // Single RISC, no CB's here. Very simple.
-Program create_simple_datamovement_program(Buffer& input, Buffer& output, Buffer& l1_buffer) {
+Program create_simple_datamovement_program(
+    const Buffer& input, const Buffer& output, const Buffer& l1_buffer, bool rt_arg_per_core_vec = false) {
     Program program = CreateProgram();
     IDevice* device = input.device();
     constexpr CoreCoord core = {0, 0};
@@ -44,8 +45,15 @@ Program create_simple_datamovement_program(Buffer& input, Buffer& output, Buffer
     const std::vector<uint32_t> runtime_args = {
         l1_buffer.address(), input.address(), input_bank_id, output.address(), output_bank_id, l1_buffer.size()};
 
-    // Note - this interface doesn't take Buffer, just data.
-    SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
+    // Very minimal testing/usage of other SetRuntimeArgs API that TTNN uses for ops here, j
+    // just to see it go through the light-metal capture + replay flow.
+    if (rt_arg_per_core_vec) {
+        const std::vector<std::vector<uint32_t>> runtime_args_per_core = {runtime_args};
+        SetRuntimeArgs(program, dram_copy_kernel_id, {core}, runtime_args_per_core);
+    } else {
+        // Note - this interface doesn't take Buffer, just data.
+        SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
+    }
 
     return program;
 }
@@ -125,7 +133,7 @@ using LightMetalBasicTest = SingleDeviceLightMetalFixture;
 TEST_F(LightMetalBasicTest, CreateBufferEnqueueWriteRead) {
     CreateDeviceAndBeginCapture(4096);
 
-    CommandQueue& command_queue = this->device_->command_queue();
+    CommandQueue& command_queue = device_->command_queue();
     uint32_t num_loops = 5;
     bool keep_buffers_alive = true;
     std::vector<std::shared_ptr<Buffer>> buffers_vec;
@@ -135,7 +143,7 @@ TEST_F(LightMetalBasicTest, CreateBufferEnqueueWriteRead) {
 
         // Switch to use top level CreateBuffer API that has trace support.
         uint32_t size_bytes = 64;  // 16 elements.
-        auto buffer = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
+        auto buffer = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
         log_debug(
             tt::LogTest,
             "created buffer loop: {} with size: {} bytes addr: 0x{:x}",
@@ -182,14 +190,11 @@ TEST_F(LightMetalBasicTest, CreateBufferEnqueueWriteRead) {
     Finish(command_queue);
 }
 
-// Test simple case of single datamovement program on single RISC works for trace + replay.
-TEST_F(LightMetalBasicTest, SingleRISCDataMovement) {
-    CreateDeviceAndBeginCapture(4096);
-
+void SingleRISCDataMovement_test(tt::tt_metal::IDevice* device, bool rt_arg_per_core_vec) {
     uint32_t size_bytes = 64;  // 16 elements.
-    auto input = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
-    auto output = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
-    auto l1_buffer = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::L1});
+    auto input = CreateBuffer(InterleavedBufferConfig{device, size_bytes, size_bytes, BufferType::DRAM});
+    auto output = CreateBuffer(InterleavedBufferConfig{device, size_bytes, size_bytes, BufferType::DRAM});
+    auto l1_buffer = CreateBuffer(InterleavedBufferConfig{device, size_bytes, size_bytes, BufferType::L1});
     log_debug(
         tt::LogTest,
         "Created 3 Buffers. input: 0x{:x} output: 0x{:x} l1_buffer: 0x{:x}",
@@ -197,9 +202,9 @@ TEST_F(LightMetalBasicTest, SingleRISCDataMovement) {
         output->address(),
         l1_buffer->address());
 
-    CommandQueue& command_queue = this->device_->command_queue();
+    CommandQueue& command_queue = device->command_queue();
 
-    Program simple_program = create_simple_datamovement_program(*input, *output, *l1_buffer);
+    Program simple_program = create_simple_datamovement_program(*input, *output, *l1_buffer, rt_arg_per_core_vec);
     vector<uint32_t> input_data(input->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
         input_data[i] = i;
@@ -224,15 +229,27 @@ TEST_F(LightMetalBasicTest, SingleRISCDataMovement) {
     Finish(command_queue);
 }
 
+// Test simple case of single datamovement program on single RISC works for trace + replay.
+TEST_F(LightMetalBasicTest, SingleRISCDataMovement) {
+    CreateDeviceAndBeginCapture(4096);
+    SingleRISCDataMovement_test(device_, false);
+}
+
+// Same as above but with SetRuntimeArgs API that uses vec of CoreCoord and vec of vec rtargs.
+TEST_F(LightMetalBasicTest, SingleRISCDataMovementRtArgsPerCoreVec) {
+    CreateDeviceAndBeginCapture(4096);
+    SingleRISCDataMovement_test(device_, true);
+}
+
 // Test simple case of 3 riscs used for datamovement and compute works for trace + replay.
 TEST_F(LightMetalBasicTest, ThreeRISCDataMovementCompute) {
     CreateDeviceAndBeginCapture(4096);
 
     uint32_t size_bytes = 64;  // 16 elements.
-    auto input = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
-    auto output = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto input = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto output = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
 
-    CommandQueue& command_queue = this->device_->command_queue();
+    CommandQueue& command_queue = device_->command_queue();
 
     // TODO (kmabee) - There is issue with using make_shared, revisit this.
     // auto simple_program = std::make_shared<Program>(create_simple_unary_program(*input,
@@ -259,10 +276,9 @@ TEST_F(LightMetalBasicTest, ThreeRISCDataMovementComputeDynamicCB) {
 
     uint32_t buf_size_bytes = 64;  // 16 elements.
     uint32_t cb_size_bytes = 2048;
-    auto input = CreateBuffer(InterleavedBufferConfig{this->device_, buf_size_bytes, buf_size_bytes, BufferType::DRAM});
-    auto output =
-        CreateBuffer(InterleavedBufferConfig{this->device_, buf_size_bytes, buf_size_bytes, BufferType::DRAM});
-    auto cb_in_buf = CreateBuffer(InterleavedBufferConfig{this->device_, cb_size_bytes, cb_size_bytes, BufferType::L1});
+    auto input = CreateBuffer(InterleavedBufferConfig{device_, buf_size_bytes, buf_size_bytes, BufferType::DRAM});
+    auto output = CreateBuffer(InterleavedBufferConfig{device_, buf_size_bytes, buf_size_bytes, BufferType::DRAM});
+    auto cb_in_buf = CreateBuffer(InterleavedBufferConfig{device_, cb_size_bytes, cb_size_bytes, BufferType::L1});
     log_info(
         tt::LogTest,
         "Created 3 Buffers. 0x{:x} 0x{:x} 0x{:x}",
@@ -270,7 +286,7 @@ TEST_F(LightMetalBasicTest, ThreeRISCDataMovementComputeDynamicCB) {
         output->address(),
         cb_in_buf->address());
 
-    CommandQueue& command_queue = this->device_->command_queue();
+    CommandQueue& command_queue = device_->command_queue();
     auto simple_program = create_simple_unary_program(*input, *output, cb_in_buf.get());
 
     vector<uint32_t> input_data(input->size() / sizeof(uint32_t), 0);
@@ -292,10 +308,10 @@ TEST_F(LightMetalBasicTest, SingleProgramTraceCapture) {
     CreateDeviceAndBeginCapture(4096);
 
     uint32_t size_bytes = 64;  // 16 elements. Was 2048 in original test.
-    auto input = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
-    auto output = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto input = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto output = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
 
-    CommandQueue& command_queue = this->device_->command_queue();
+    CommandQueue& command_queue = device_->command_queue();
     Program simple_program = create_simple_unary_program(*input, *output);
 
     // Setup input data for program with some simple values.
@@ -316,16 +332,16 @@ TEST_F(LightMetalBasicTest, SingleProgramTraceCapture) {
     write_junk_to_buffer(command_queue, *output);
 
     // Now enable Metal Trace and run program again for capture.
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
+    uint32_t tid = BeginTraceCapture(device_, command_queue.id());
     EnqueueProgram(command_queue, simple_program, false);
-    EndTraceCapture(this->device_, command_queue.id(), tid);
+    EndTraceCapture(device_, command_queue.id(), tid);
 
     // Verify trace output during replay matches expected output from original capture.
     LightMetalCompareToGolden(command_queue, *output, eager_output_data.data());
 
     // Done
     Finish(command_queue);
-    ReleaseTrace(this->device_, tid);
+    ReleaseTrace(device_, tid);
 }
 
 // Test simple compute test with metal trace, but no explicit trace replay (added automatically by light metal trace).
@@ -333,11 +349,11 @@ TEST_F(LightMetalBasicTest, TwoProgramTraceCapture) {
     CreateDeviceAndBeginCapture(4096);
 
     uint32_t size_bytes = 64;  // 16 elements. Was 2048 in original test.
-    auto input = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
-    auto interm = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
-    auto output = CreateBuffer(InterleavedBufferConfig{this->device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto input = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto interm = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
+    auto output = CreateBuffer(InterleavedBufferConfig{device_, size_bytes, size_bytes, BufferType::DRAM});
 
-    CommandQueue& command_queue = this->device_->command_queue();
+    CommandQueue& command_queue = device_->command_queue();
 
     Program op0 = create_simple_unary_program(*input, *interm);
     Program op1 = create_simple_unary_program(*interm, *output);
@@ -362,17 +378,17 @@ TEST_F(LightMetalBasicTest, TwoProgramTraceCapture) {
     write_junk_to_buffer(command_queue, *output);
 
     // Now enable Metal Trace and run program again for capture.
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
+    uint32_t tid = BeginTraceCapture(device_, command_queue.id());
     EnqueueProgram(command_queue, op0, false);
     EnqueueProgram(command_queue, op1, false);
-    EndTraceCapture(this->device_, command_queue.id(), tid);
+    EndTraceCapture(device_, command_queue.id(), tid);
 
     // Verify trace output during replay matches expected output from original capture.
     LightMetalCompareToGolden(command_queue, *output, eager_output_data.data());
 
     // Done
     Finish(command_queue);
-    ReleaseTrace(this->device_, tid);
+    ReleaseTrace(device_, tid);
 }
 
 }  // namespace

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -81,6 +81,13 @@ table SetRuntimeArgsUint32Command {
   args: [uint32];             // Arguments to be passed to kernel
 }
 
+table SetRuntimeArgsUint32VecPerCoreCommand {
+  program_global_id: uint32;  // Reference to Program
+  kernel_global_id: uint32;   // Reference to Kernel
+  core_spec: [CoreCoord];
+  args: [UInt32Vector];       // vector of vector of uint32_t
+}
+
 table SetRuntimeArgsCommand {
   kernel_global_id: uint32;   // Reference to Kernel
   core_spec: CoreSpec;
@@ -115,6 +122,7 @@ union CommandType {
   EnqueueProgramCommand,
   CreateKernelCommand,
   SetRuntimeArgsUint32Command,
+  SetRuntimeArgsUint32VecPerCoreCommand,
   SetRuntimeArgsCommand,
   CreateCircularBufferCommand,
   LightMetalCompareCommand,

--- a/tt_metal/impl/flatbuffer/program_types.fbs
+++ b/tt_metal/impl/flatbuffer/program_types.fbs
@@ -72,3 +72,7 @@ union RuntimeArgValue {
 table RuntimeArg {
   value: RuntimeArgValue;
 }
+
+table UInt32Vector {
+    values: [uint32];
+}

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -92,4 +92,27 @@ std::vector<SubDeviceId> from_flatbuffer(const flatbuffers::Vector<uint8_t>* fb_
     return sub_device_ids;
 }
 
+std::vector<CoreCoord> from_flatbuffer(
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffer::CoreCoord>>* core_spec_fbs) {
+    TT_FATAL(core_spec_fbs, "Invalid Vector of CoreCoord data from flatbuffer.");
+
+    std::vector<CoreCoord> core_spec(core_spec_fbs->size());
+    for (const auto* coord_fbs : *core_spec_fbs) {
+        core_spec.emplace_back(coord_fbs->x(), coord_fbs->y());
+    }
+    return core_spec;
+}
+
+std::vector<std::vector<uint32_t>> from_flatbuffer(
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffer::UInt32Vector>>* vec_of_vec_fbs) {
+    TT_FATAL(vec_of_vec_fbs, "Invalid FlatBuffer data: expected a vector of vector of uint32_t.");
+
+    std::vector<std::vector<uint32_t>> result(vec_of_vec_fbs->size());
+    for (const auto* sub_vector_fbs : *vec_of_vec_fbs) {
+        std::vector<uint32_t> sub_vector(sub_vector_fbs->values()->begin(), sub_vector_fbs->values()->end());
+        result.push_back(std::move(sub_vector));
+    }
+    return result;
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
@@ -16,6 +16,11 @@ ComputeConfig from_flatbuffer(const flatbuffer::ComputeConfig* fb_config);
 EthernetConfig from_flatbuffer(const flatbuffer::EthernetConfig* fb_config);
 std::vector<SubDeviceId> from_flatbuffer(const flatbuffers::Vector<uint8_t>* fb_sub_device_ids);
 
+std::vector<CoreCoord> from_flatbuffer(
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffer::CoreCoord>>* core_spec_fbs);
+std::vector<std::vector<uint32_t>> from_flatbuffer(
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffer::UInt32Vector>>* vec_of_vec_fbs);
+
 template <typename CommandType>
 std::variant<CoreCoord, CoreRange, CoreRangeSet> core_spec_from_flatbuffer(const CommandType* cmd) {
     switch (cmd->core_spec_type()) {

--- a/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.cpp
@@ -38,6 +38,27 @@ std::pair<flatbuffer::CoreSpec, ::flatbuffers::Offset<void>> to_flatbuffer(
         core_spec);
 }
 
+FlatbufferCoreCoordVector to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const std::vector<CoreCoord>& core_spec) {
+    std::vector<flatbuffers::Offset<flatbuffer::CoreCoord>> core_offsets;
+    for (const auto& coord : core_spec) {
+        core_offsets.push_back(flatbuffer::CreateCoreCoord(builder, coord.x, coord.y));
+    }
+    return builder.CreateVector(core_offsets);
+}
+
+FlatbufferUInt32VecOfVec to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const std::vector<std::vector<uint32_t>>& vec_of_vec) {
+    std::vector<flatbuffers::Offset<flatbuffer::UInt32Vector>> vec_offsets;
+
+    for (const auto& sub_vector : vec_of_vec) {
+        auto values_offset = builder.CreateVector(sub_vector);
+        vec_offsets.push_back(flatbuffer::CreateUInt32Vector(builder, values_offset));
+    }
+
+    return builder.CreateVector(vec_offsets);
+}
+
 // Original types defined in kernel_types.hpp
 std::pair<flatbuffer::KernelConfig, flatbuffers::Offset<void>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const DataMovementConfig& config) {

--- a/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.hpp
@@ -14,8 +14,18 @@
 
 namespace tt::tt_metal {
 
+using FlatbufferCoreCoordVector = flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::CoreCoord>>>;
+using FlatbufferUInt32VecOfVec =
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffer::UInt32Vector>>>;
+
 std::pair<flatbuffer::CoreSpec, ::flatbuffers::Offset<void>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec);
+
+FlatbufferCoreCoordVector to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const std::vector<CoreCoord>& core_spec);
+
+FlatbufferUInt32VecOfVec to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const std::vector<std::vector<uint32_t>>& vec_of_vec);
 
 std::pair<flatbuffer::KernelConfig, flatbuffers::Offset<void>> to_flatbuffer(
     flatbuffers::FlatBufferBuilder& builder, const DataMovementConfig& config);

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -112,6 +112,12 @@ void CaptureSetRuntimeArgsUint32(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     tt::stl::Span<const uint32_t> runtime_args);
 
+void CaptureSetRuntimeArgsUint32VecPerCore(
+    const Program& program,
+    KernelHandle kernel_id,
+    const std::vector<CoreCoord>& core_spec,
+    const std::vector<std::vector<uint32_t>>& runtime_args);
+
 void CaptureSetRuntimeArgs(
     IDevice* device,
     const std::shared_ptr<Kernel>& kernel,

--- a/tt_metal/impl/lightmetal/lightmetal_replay.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay.hpp
@@ -33,6 +33,7 @@ struct CreateProgramCommand;
 struct EnqueueProgramCommand;
 struct CreateKernelCommand;
 struct SetRuntimeArgsUint32Command;
+struct SetRuntimeArgsUint32VecPerCoreCommand;
 struct SetRuntimeArgsCommand;
 struct CreateCircularBufferCommand;
 struct LightMetalCompareCommand;
@@ -76,6 +77,7 @@ private:
     void execute(const tt::tt_metal::flatbuffer::EnqueueProgramCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateKernelCommand* command);
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32Command* command);
+    void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32VecPerCoreCommand* cmd);
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateCircularBufferCommand* command);
     void execute(const tt::tt_metal::flatbuffer::LightMetalCompareCommand* command);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1253,6 +1253,8 @@ void SetRuntimeArgs(
     const std::vector<CoreCoord>& core_spec,
     const std::vector<std::vector<uint32_t>>& runtime_args) {
     ZoneScoped;
+    LIGHT_METAL_TRACE_FUNCTION_ENTRY();
+    LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureSetRuntimeArgsUint32VecPerCore, program, kernel, core_spec, runtime_args);
     TT_FATAL(
         core_spec.size() == runtime_args.size(),
         "Mistmatch between number of cores {} and number of runtime args {} getting updated",


### PR DESCRIPTION
### Ticket
#17779 

### Problem description
Add LightMetal capture + replay support for more host_api.hpp APIs. Initial commit handled just a few, there are more to cover.

### What's changed
- Add LightMetal capture + replay support for the SetRuntimeArgs() API used by TTNN ops, call it `SetRuntimeArgsUint32VecPerCore` in flatbuffer schema, similar name to other flavors.
- Add C++ lightmetal unit test that lightly tests this SetRuntimeArgs() API (will be tested more by TTNN tests in follow up PR).

```
void SetRuntimeArgs(
    const Program& program,
    KernelHandle kernel,
    const std::vector<CoreCoord>& core_spec,
    const std::vector<std::vector<uint32_t>>& runtime_args);
```


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
