### PR TITLE
[skip ci] Show All Post Commit Status Badge from main on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![tt-metal CI](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
+
 <div align="center">
 
 <h1>


### PR DESCRIPTION
Lets be transparent, and report the status of our primary CI pipeline on main on the README.md like many other open source projects.

It will look like this:

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/f9e443d9-888b-4d9a-9848-49e0c0d72aaa" />
