### PR TITLE
#17758: Update Batch Norm Running stats kernel for training mode

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -13,18 +13,18 @@ void MAIN {
     constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t old_running_var_has_value = get_compile_time_arg_val(1) == 1;
 
-    constexpr auto cb_batch_mean = tt::CBIndex::c_0;  // batch mean
-    constexpr auto cb_batch_var = tt::CBIndex::c_1;   // batch var
-    constexpr auto cb_out0 = tt::CBIndex::c_2;
-    constexpr auto cb_old_running_mean = tt::CBIndex::c_3;       // old running mean tensor
-    constexpr auto cb_old_running_var = tt::CBIndex::c_4;        // old running var tensor
-    constexpr auto cb_updated_running_mean = tt::CBIndex::c_27;  // updated running mean tensor
-    constexpr auto cb_updated_running_var = tt::CBIndex::c_28;   // updated running var tensor
-    constexpr auto cb_momentum = tt::CBIndex::c_5;               // momentum
-    constexpr auto cb_one = tt::CBIndex::c_6;                    // stores 1
-    constexpr auto cb_tmp1 = tt::CBIndex::c_21;                  // tmp 1
-    constexpr auto cb_tmp2 = tt::CBIndex::c_22;                  // tmp 2
-    constexpr auto cb_tmp3 = tt::CBIndex::c_23;                  // tmp 3
+    constexpr auto cb_batch_mean = get_compile_time_arg_val(2);  // batch mean
+    constexpr auto cb_batch_var = get_compile_time_arg_val(3);   // batch var
+    constexpr auto cb_out0 = get_compile_time_arg_val(4);
+    constexpr auto cb_old_running_mean = get_compile_time_arg_val(5);      // old running mean tensor
+    constexpr auto cb_old_running_var = get_compile_time_arg_val(6);       // old running var tensor
+    constexpr auto cb_updated_running_mean = get_compile_time_arg_val(7);  // updated running mean tensor
+    constexpr auto cb_updated_running_var = get_compile_time_arg_val(8);   // updated running var tensor
+    constexpr auto cb_momentum = get_compile_time_arg_val(9);              // momentum
+    constexpr auto cb_one = get_compile_time_arg_val(10);                  // stores 1
+    constexpr auto cb_tmp1 = get_compile_time_arg_val(11);                 // tmp 1
+    constexpr auto cb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
+    constexpr auto cb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
 
     binary_op_init_common(cb_batch_mean, cb_batch_var, cb_out0);
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -16,18 +16,18 @@ void MAIN {
     constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t old_running_var_has_value = get_compile_time_arg_val(1) == 1;
 
-    constexpr auto cb_batch_mean = tt::CBIndex::c_0;  // batch mean
-    constexpr auto cb_batch_var = tt::CBIndex::c_1;   // batch var
-    constexpr auto cb_out0 = tt::CBIndex::c_2;
-    constexpr auto cb_old_running_mean = tt::CBIndex::c_3;       // old running mean tensor
-    constexpr auto cb_old_running_var = tt::CBIndex::c_4;        // old running var tensor
-    constexpr auto cb_updated_running_mean = tt::CBIndex::c_27;  // updated running mean tensor
-    constexpr auto cb_updated_running_var = tt::CBIndex::c_28;   // updated running var tensor
-    constexpr auto cb_momentum = tt::CBIndex::c_5;               // momentum
-    constexpr auto cb_one = tt::CBIndex::c_6;                    // stores 1
-    constexpr auto cb_tmp1 = tt::CBIndex::c_21;                  // tmp 1
-    constexpr auto cb_tmp2 = tt::CBIndex::c_22;                  // tmp 2
-    constexpr auto cb_tmp3 = tt::CBIndex::c_23;                  // tmp 3
+    constexpr auto cb_batch_mean = get_compile_time_arg_val(2);  // batch mean
+    constexpr auto cb_batch_var = get_compile_time_arg_val(3);   // batch var
+    constexpr auto cb_out0 = get_compile_time_arg_val(4);
+    constexpr auto cb_old_running_mean = get_compile_time_arg_val(5);      // old running mean tensor
+    constexpr auto cb_old_running_var = get_compile_time_arg_val(6);       // old running var tensor
+    constexpr auto cb_updated_running_mean = get_compile_time_arg_val(7);  // updated running mean tensor
+    constexpr auto cb_updated_running_var = get_compile_time_arg_val(8);   // updated running var tensor
+    constexpr auto cb_momentum = get_compile_time_arg_val(9);              // momentum
+    constexpr auto cb_one = get_compile_time_arg_val(10);                  // stores 1
+    constexpr auto cb_tmp1 = get_compile_time_arg_val(11);                 // tmp 1
+    constexpr auto cb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
+    constexpr auto cb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
 
     unary_op_init_common(cb_batch_mean, cb_out0);
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -21,9 +21,9 @@ void kernel_main() {
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 
-    constexpr auto cb_id_src = tt::CBIndex::c_0;
-    constexpr auto cb_id_momentum = tt::CBIndex::c_5;
-    constexpr auto cb_id_one = tt::CBIndex::c_6;
+    constexpr auto cb_id_src = get_compile_time_arg_val(1);
+    constexpr auto cb_id_momentum = get_compile_time_arg_val(2);
+    constexpr auto cb_id_one = get_compile_time_arg_val(3);
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr auto cb_id_src = tt::CBIndex::c_1;
+    constexpr auto cb_id_src = get_compile_time_arg_val(6);
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const DataFormat src_data_format = get_dataformat(cb_id_src);
@@ -30,7 +30,7 @@ void kernel_main() {
     const InterleavedAddrGenFast<src_is_dram> src = {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 
-    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    constexpr auto cb_id_dst = get_compile_time_arg_val(7);
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const DataFormat dst_data_format = get_dataformat(cb_id_dst);
@@ -39,7 +39,7 @@ void kernel_main() {
         .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 
     // old running mean
-    constexpr auto cb_id_old_running_mean = tt::CBIndex::c_3;
+    constexpr auto cb_id_old_running_mean = get_compile_time_arg_val(8);
     constexpr bool old_running_mean_is_dram = get_compile_time_arg_val(2) == 1;
     const uint32_t old_running_mean_tile_bytes = get_tile_size(cb_id_old_running_mean);
     const DataFormat old_running_mean_data_format = get_dataformat(cb_id_old_running_mean);
@@ -50,7 +50,7 @@ void kernel_main() {
         .data_format = old_running_mean_data_format};
 
     // old running var
-    constexpr auto cb_id_old_running_var = tt::CBIndex::c_4;
+    constexpr auto cb_id_old_running_var = get_compile_time_arg_val(9);
     constexpr bool old_running_var_is_dram = get_compile_time_arg_val(3) == 1;
     const uint32_t old_running_var_tile_bytes = get_tile_size(cb_id_old_running_var);
     const DataFormat old_running_var_data_format = get_dataformat(cb_id_old_running_var);
@@ -62,8 +62,8 @@ void kernel_main() {
 
     constexpr bool old_running_mean_has_value = get_compile_time_arg_val(4) == 1;
     constexpr bool old_running_var_has_value = get_compile_time_arg_val(5) == 1;
-    constexpr auto cb_id_updated_running_mean = tt::CBIndex::c_27;
-    constexpr auto cb_id_updated_running_var = tt::CBIndex::c_28;
+    constexpr auto cb_id_updated_running_mean = get_compile_time_arg_val(10);
+    constexpr auto cb_id_updated_running_var = get_compile_time_arg_val(11);
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -214,14 +214,14 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         b_num_tiles_per_cb,
         b_data_format);  // to store 1
     auto [updated_m_cb, updated_m_cb_handle] = create_cb(
-        tt::CBIndex::c_27,
+        tt::CBIndex::c_7,
         program,
         all_device_cores,
         d_single_tile_size,
         b_num_tiles_per_cb,
         d_data_format);  // updated running mean
     auto [updated_v_cb, updated_v_cb_handle] = create_cb(
-        tt::CBIndex::c_28,
+        tt::CBIndex::c_8,
         program,
         all_device_cores,
         e_single_tile_size,
@@ -230,13 +230,13 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
 
     // Intermediate buffers required for updation of running stats
     auto [tmp1_cb, tmp1_cb_handle] =
-        create_cb(tt::CBIndex::c_21, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+        create_cb(tt::CBIndex::c_9, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
 
     auto [tmp2_cb, tmp2_cb_handle] =
-        create_cb(tt::CBIndex::c_22, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+        create_cb(tt::CBIndex::c_10, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
 
     auto [tmp3_cb, tmp3_cb_handle] =
-        create_cb(tt::CBIndex::c_23, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+        create_cb(tt::CBIndex::c_11, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
 
     auto a_is_dram = static_cast<uint32_t>(batch_mean_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     auto b_is_dram = static_cast<uint32_t>(batch_var_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -278,6 +278,12 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
                 e_is_dram,
                 static_cast<uint32_t>(running_mean_has_value),
                 static_cast<uint32_t>(running_var_has_value),
+                batch_var_tensor_cb,
+                output_tensor_cb,
+                old_running_mean_tensor_cb,
+                old_running_var_tensor_cb,
+                updated_m_cb,
+                updated_v_cb,
             },
             std::move(writer_defines)));
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -261,7 +261,8 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp",
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig({a_is_dram}, std::move(reader_defines)));
+        tt_metal::ReaderDataMovementConfig(
+            {a_is_dram, batch_mean_tensor_cb, momentum_cb, one_cb}, std::move(reader_defines)));
 
     // WRITER KERNEL
     auto writer_defines = dataflow_defines;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17758

### Problem description
[Comment Link](https://github.com/tenstorrent/tt-metal/pull/17587#discussion_r1945931451)

### What's changed

- Updated BN to use compile-time arguments for buffer indexing, replacing hardcoded values for better flexibility.
- Sequential buffer index

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13243753579)
- [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13240640266)
- [x] [(Single-card) Tests for new models](https://github.com/tenstorrent/tt-metal/actions/runs/13240642580)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/13261107414)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/13240646576)
- [x] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/13240648042)
