### PR TITLE
#0: add .ttinsn to sfpi

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -21,8 +21,8 @@ set(TYPES
 
 include(FetchContent)
 set(SFPI_x86_64_Linux_RELEASE
-    "v6.1.0/sfpi-release.tgz"
-    "da98a135fe95a462c3b6b4e054dc159f"
+    "v6.2.0/sfpi-release.tgz"
+    "c546b57c3161b06d03de7473c4add5e5"
 )
 if(DEFINED SFPI_${CMAKE_HOST_SYSTEM_PROCESSOR}_${CMAKE_HOST_SYSTEM_NAME}_RELEASE)
     set(SFPI_RELEASE "${SFPI_${CMAKE_HOST_SYSTEM_PROCESSOR}_${CMAKE_HOST_SYSTEM_NAME}_RELEASE}")


### PR DESCRIPTION
### Ticket
NA

### Problem description
We currently create bespoke sfpu insns using .word, that has 2 shortcomings
1) because of mapping symbols, they never disassemble to instructions (the dissassembler always shows them as data)
2) we have to manually swizzle them (move 2 bits from the front to the back)

We can't use `.insn` because spu insns do not use the regular riscv encoding, so its length checking goes wrong.

### What's changed
Added `.ttinsn` to the assembler.  This will do the swizzling, and arrange for them to be disassemblable.
Alter the ckernel_ops.h header appropriately (although this is machine-generated the generator is unavailable)
There are other instances of the ckernel_ops.h headers in submodules, that will also need updating.

This makes disassembling kernels much more pleasant. See SFPI release notes for example (https://github.com/tenstorrent/sfpi/releases/tag/v6.2.0)

### Checklist
- [ YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
