### PR TITLE
Remove `tt_cluster.hpp` from public API

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "galaxy_fixture.hpp"
-#include <tt-metalium/tt_cluster.hpp>
+#include "tt_cluster.hpp"
 #include <tt-metalium/host_api.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -12,11 +12,14 @@
 #include "logger.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/rtoptions.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/event.hpp>
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/device.hpp>
+
+#include "tt_cluster.hpp"
 
 constexpr uint32_t DEFAULT_ITERATIONS = 1000;
 constexpr uint32_t DEFAULT_WARMUP_ITERATIONS = 2;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/hal_exp.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/rtoptions.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
@@ -21,6 +21,8 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 
+#include "tt_cluster.hpp"
+
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -23,6 +23,8 @@
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 
+#include "tt_cluster.hpp"
+
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/device.hpp>
 #include "dprint_server.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "tt_cluster.hpp"
 
 using namespace tt;
 //

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/test_tiles.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "dprint_server.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/test_tiles.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "dprint_server.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/test_tiles.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "dprint_server.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/test_tiles.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "dprint_server.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/command_queue.hpp>
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/command_queue.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/host_api.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/host_api.hpp>
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -18,6 +18,7 @@
 #include "logger.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/test_common.hpp>
 #include <tt-metalium/rtoptions.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/event.hpp>
@@ -25,6 +26,7 @@
 #include <tt-metalium/device_impl.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/hal.hpp>
+#include "tt_cluster.hpp"
 
 using namespace tt;
 

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -13,6 +13,8 @@
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn_multi_command_queue_fixture.hpp"
 
+#include "tt_cluster.hpp"
+
 using namespace tt;
 using namespace tt_metal;
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -14,7 +14,7 @@
 #include "core/tt_tensor_utils.hpp"
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
 }
 
 class N300UtilsTest : public ::testing::Test {

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <umd/device/tt_cluster_descriptor.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
@@ -13,8 +14,9 @@
 #include "core/tt_tensor_utils.hpp"
 
 auto check_board_is_n300() {
-    return tt::Cluster::instance().get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
 }
+
 class N300UtilsTest : public ::testing::Test {
 protected:
     void SetUp() override {

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <umd/device/tt_cluster_descriptor.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
@@ -22,7 +23,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt::Cluster::instance().get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
 }
 
 }  // namespace

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -17,7 +17,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
 }
 
 ttml::autograd::TensorPtr get_parameter(auto& parameters, const std::string& name_substring) {

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -5,6 +5,7 @@
 #include "modules/distributed/linear.hpp"
 
 #include <gtest/gtest.h>
+#include <umd/device/tt_cluster_descriptor.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
@@ -16,7 +17,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt::Cluster::instance().get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
 }
 
 ttml::autograd::TensorPtr get_parameter(auto& parameters, const std::string& name_substring) {

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -5,6 +5,7 @@
 #include "ops/distributed/comm_ops.hpp"
 
 #include <gtest/gtest.h>
+#include <umd/device/tt_cluster_descriptor.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
@@ -17,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt::Cluster::instance().get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
 }
 
 }  // namespace

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
 }
 
 }  // namespace

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <umd/device/tt_cluster_descriptor.h>
 
 #include <core/ttnn_all_includes.hpp>
 #include <memory>
@@ -17,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt::Cluster::instance().get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
 }
 
 class TrivialTnnFixedDistributedTest : public ::testing::Test {

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor().create()->get_board_type(0) == BoardType::N300;
+    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
 }
 
 class TrivialTnnFixedDistributedTest : public ::testing::Test {

--- a/tt_fabric/CMakeLists.txt
+++ b/tt_fabric/CMakeLists.txt
@@ -9,12 +9,18 @@ target_sources(
         mesh_graph.cpp
 )
 
-target_include_directories(tt_fabric PRIVATE .)
+target_include_directories(
+    tt_fabric
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal/api/tt-metalium
+)
 
 target_link_libraries(
     tt_fabric
     PRIVATE
         Metalium::Metal
+        Metalium::Metal::LLRT
         umd::device
         metal_common_libs
         magic_enum

--- a/tt_fabric/control_plane.cpp
+++ b/tt_fabric/control_plane.cpp
@@ -6,6 +6,8 @@
 #include "control_plane.hpp"
 #include <queue>
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_fabric {
 
 // Get the physical chip ids for a mesh

--- a/tt_fabric/mesh_graph.hpp
+++ b/tt_fabric/mesh_graph.hpp
@@ -11,8 +11,10 @@
 #include <magic_enum/magic_enum.hpp>
 
 #include <tt-metalium/assert.hpp>
-#include <tt-metalium/tt_cluster.hpp>
 #include <tt-metalium/reflection.hpp>
+
+#include <umd/device/types/arch.h>                      // tt::ARCH
+#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 
 namespace tt::tt_fabric {
 struct ChipSpec {

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -5,9 +5,11 @@
 #pragma once
 
 #include "core_coord.hpp"
-#include "tt_cluster.hpp"
 #include "hal.hpp"
 #include "dispatch_core_common.hpp"
+
+#include <umd/device/types/arch.h>                      // tt::ARCH
+#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 
 namespace tt {
 
@@ -38,18 +40,8 @@ const core_descriptor_t& get_core_descriptor_config(
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
     chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
-inline std::optional<uint32_t> get_storage_core_bank_size(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
-    if (core_desc.storage_core_bank_size.has_value()) {
-        TT_FATAL(
-            core_desc.storage_core_bank_size.value() % tt_metal::hal.get_alignment(tt_metal::HalMemType::L1) == 0,
-            "Storage core bank size must be {} B aligned",
-            tt_metal::hal.get_alignment(tt_metal::HalMemType::L1));
-    }
-    return core_desc.storage_core_bank_size;
-}
+std::optional<uint32_t> get_storage_core_bank_size(
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
 inline const std::vector<CoreCoord>& get_logical_storage_cores(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -15,7 +15,6 @@
 #include "data_types.hpp"
 #include "program_device_map.hpp"
 #include "build.hpp"
-#include "tt_cluster.hpp"
 #include "hal.hpp"
 #include "command_queue_interface.hpp"
 #include "sub_device_manager.hpp"

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -15,7 +15,6 @@
 #include "data_types.hpp"
 #include "program_device_map.hpp"
 #include "build.hpp"
-#include "tt_cluster.hpp"
 #include "hal.hpp"
 #include "command_queue_interface.hpp"
 #include "command_queue.hpp"

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -9,6 +9,8 @@
 #include "data_types.hpp"
 #include "reflection.hpp"
 
+#include <umd/device/tt_core_coordinates.h>  // CoreType
+
 namespace tt::tt_metal {
 
 enum DispatchWorkerType : uint32_t {

--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -7,11 +7,15 @@
 #include <cstdint>
 #include <magic_enum/magic_enum.hpp>
 #include <unordered_map>
+#include "dev_msgs.h"  // go_msg_t
 #include "hal.hpp"
-#include "tt_cluster.hpp"
 #include <tt-metalium/cq_commands.hpp>
 #include <utility>
 #include "umd/device/tt_core_coordinates.h"
+
+namespace tt {
+class Cluster;
+}
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/hal_exp.hpp
+++ b/tt_metal/api/tt-metalium/hal_exp.hpp
@@ -6,8 +6,16 @@
 
 #include <cstdint>
 #include <string>
+#include <umd/device/types/arch.h>
 
 namespace tt::tt_metal::experimental::hal {
+
+/**
+ * @brief Uses the hardware abstraction layer to inform client of the architecture
+ *
+ * @return Architecture enum defined by UMD
+ */
+tt::ARCH get_arch();
 
 /**
  * @brief Uses the hardware abstraction layer to inform client of the architecture name

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(COMMON_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/core_assignment.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core_descriptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal_soc_descriptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shape2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shape_base.cpp

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "assert.hpp"
 #include "core_assignment.hpp"
 
 namespace tt {

--- a/tt_metal/common/core_assignment.hpp
+++ b/tt_metal/common/core_assignment.hpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "core_coord.hpp"
-#include <tt_cluster.hpp>
+
+#include <umd/device/types/arch.h>  // tt::ARCH
 
 namespace tt {
 namespace tt_metal {
@@ -12,7 +13,7 @@ namespace tt_metal {
 // a DRAM read or write.
 // Worker cores are derived based on architecture, harvesting configurations and DRAM Controller placement.
 std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
-    ARCH arch,
+    tt::ARCH arch,
     const std::vector<CoreCoord>& dram_phy_coords,
     uint32_t full_grid_size_x,
     uint32_t full_grid_size_y,

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -17,5 +17,6 @@ target_link_libraries(
         common
     PRIVATE
         Metalium::Metal::Impl
+        Metalium::Metal::LLRT
         TT::Metalium::HostDevCommon
 )

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -4,6 +4,8 @@
 
 #include "tt_metal/distributed/coordinate_translation.hpp"
 
+#include "tt_cluster.hpp"
+
 #include <nlohmann/json.hpp>
 
 namespace tt::tt_metal::distributed {

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -14,6 +14,7 @@
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
+#include "tt_cluster.hpp"
 namespace tt::tt_metal::distributed {
 
 struct MeshReadEventDescriptor {

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -7,6 +7,8 @@
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/distributed/coordinate_translation.hpp"
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal::distributed {
 
 class SystemMesh::Impl {

--- a/tt_metal/experimental/hal.cpp
+++ b/tt_metal/experimental/hal.cpp
@@ -17,6 +17,8 @@ using tt::tt_metal::HalSingleton;
 
 namespace tt::tt_metal::experimental::hal {
 
+tt::ARCH get_arch() { return HalSingleton::getInstance().get_arch(); }
+
 std::string get_arch_name() {
     auto arch_enum = HalSingleton::getInstance().get_arch();
     return tt::get_string_lowercase(arch_enum);

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -9,6 +9,8 @@
 #include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal {
 namespace buffer_dispatch {
 

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -18,6 +18,8 @@
 #include <hal.hpp>
 #include <tt_align.hpp>
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal {
 
 namespace v1 {

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -18,6 +18,8 @@
 #include <device.hpp>
 #include <hal.hpp>
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal {
 
 GlobalSemaphore::GlobalSemaphore(

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -6,6 +6,8 @@
 
 #include <device.hpp>
 
+struct metal_SocDescriptor;
+
 namespace tt {
 
 void watcher_init(tt_metal::IDevice* device);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -22,6 +22,8 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
+#include "tt_cluster.hpp"
+
 using namespace tt::tt_metal;
 
 namespace tt {

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "debug_tools.hpp"
+
+#include "tt_cluster.hpp"
+
 namespace internal {
 
 using namespace tt::tt_metal;

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -12,6 +12,8 @@
 #include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
 
+#include "tt_cluster.hpp"
+
 // Because we are a Friend of Program, accessing Program::get_program_transfer_info() and Program::get_kernels_buffer()
 // MUST REMOVE
 #include <program_impl.hpp>

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -6,6 +6,7 @@
 #include <device_impl.hpp>
 #include <program_impl.hpp>
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "tt_cluster.hpp"
 
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
 #define UNUSED_SEM_ID 0

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -15,6 +15,8 @@
 #include "kernel_config/eth_router.hpp"
 #include "kernel_config/eth_tunneler.hpp"
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal {
 
 // For readablity, unset = x = -1

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -7,6 +7,8 @@
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include <tt_align.hpp>
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal {
 
 namespace event_dispatch {

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -20,6 +20,8 @@
 #include <tt_align.hpp>
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
+#include "tt_cluster.hpp"
+
 namespace tt::tt_metal {
 
 // assert here to avoid the need to include command_queue_interface.hpp in header

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(
 
 set(LLRT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/llrt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_descriptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rtoptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tlb_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_cluster.cpp
@@ -105,6 +106,7 @@ target_link_libraries(
         Tracy::TracyClient
         nlohmann_json::nlohmann_json
         Reflect::Reflect
+        yaml-cpp::yaml-cpp
         magic_enum
         span
         common

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -4,6 +4,7 @@
 
 #include "core_descriptor.hpp"
 #include "rtoptions.hpp"
+#include "tt_cluster.hpp"
 
 #include "yaml-cpp/yaml.h"
 
@@ -239,6 +240,19 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
             {config_hash, std::make_tuple(tensix_num_worker_cores, tensix_worker_physical_grid)});
     }
     return physical_grid_config_cache.at(config_hash);
+}
+
+std::optional<uint32_t> get_storage_core_bank_size(
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
+    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+    if (core_desc.storage_core_bank_size.has_value()) {
+        TT_FATAL(
+            core_desc.storage_core_bank_size.value() % tt_metal::hal.get_alignment(tt_metal::HalMemType::L1) == 0,
+            "Storage core bank size must be {} B aligned",
+            tt_metal::hal.get_alignment(tt_metal::HalMemType::L1));
+    }
+    return core_desc.storage_core_bank_size;
 }
 
 }  // namespace tt

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -12,8 +12,12 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 
+#include "tt-metalium/hal_exp.hpp"
+
 namespace ttnn {
 namespace ccl {
+
+using namespace tt::tt_metal::experimental;
 
 void SyncModeSpec::add_signal(uint32_t sem_id, uint32_t wait_count) {
     this->sem_ids.push_back(sem_id);
@@ -213,8 +217,8 @@ void generate_edm_kernels_for_ring_or_linear_topology(
     std::vector<ccl::EriscDatamoverBuilder> const& counter_clockwise_edm_builders,
     std::optional<uint32_t> receiver_device_id,
     std::optional<uint32_t> sender_device_id) {
-    auto sender_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch());
-    auto receiver_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch());
+    auto sender_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(hal::get_arch());
+    auto receiver_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(hal::get_arch());
     uint32_t sender_socket_idx = 0;
     uint32_t receiver_socket_idx = 0;
     if (receiver_device_id == sender_device_id) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -11,11 +11,14 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/util.hpp>
 
+#include "tt-metalium/hal_exp.hpp"
+
 namespace ttnn {
 namespace operations {
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using namespace constants;
 
 std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
@@ -102,7 +105,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
         core_spec,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch()),
+            .noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(hal::get_arch()),
             .compile_args = compile_args,
             .defines = std::move(defines)});
 }
@@ -119,7 +122,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
         core_spec,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch()),
+            .noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(hal::get_arch()),
             .compile_args = compile_args,
             .defines = std::move(defines)});
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -11,6 +11,8 @@
 #include <ttnn/operations/functions.hpp>
 #include "tools/profiler/op_profiler.hpp"
 
+#include <umd/device/tt_cluster_descriptor.h>  // tt_ClusterDescriptor
+
 namespace tt {
 using namespace constants;
 namespace operations {


### PR DESCRIPTION
### Problem description
`tt_cluster.hpp` is part of the "low level runtime" and should be an internal implementation detail of tt_metal.
However, it currently resides in the public API interface.
People had already began using it in `ttnn` and `tt-train`.

### What's changed
Move the file back to the `llrt` directory, and deal with the collateral damage.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13277663689) CI passes
- [x] New/Existing tests provide coverage for changes
