### PR TITLE
#0: [tt-train] DRAFT add new ttml ops

### DIFF
--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -83,4 +83,10 @@ tt::tt_metal::Tensor from_xtensor(
     const XTensorToMeshVariant<T>& composer,
     Layout layout = Layout::TILE);
 
+// Unsqueeze tensor to specified rank by adding leading dimensions of size 1
+ttnn::Tensor unsqueeze_to_rank(const ttnn::Tensor& t, size_t rank);
+
+// Squeeze tensor to specified rank by removing leading dimensions of size 1
+ttnn::Tensor squeeze_to_rank(const ttnn::Tensor& t, size_t rank);
+
 }  // namespace ttml::core

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -4,6 +4,7 @@
 
 #include "binary_ops.hpp"
 
+#include <core/compute_kernel_config.hpp>
 #include <core/ttnn_all_includes.hpp>
 #include <memory>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
@@ -102,6 +103,42 @@ autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::Tens
         auto a_grad = ttnn::multiply(out->get_grad(), b->get_value());
         auto b_grad = ttnn::multiply(out->get_grad(), a->get_value());
 
+        auto clamp_to_rank = [](const ttnn::Tensor& tensor, size_t rank) {
+            auto tensor_rank = tensor.logical_shape().rank();
+            if (tensor_rank == rank) {
+                return tensor;
+            } else if (tensor_rank > rank) {
+                return ttml::core::squeeze_to_rank(tensor, rank);
+            } else {
+                return ttml::core::unsqueeze_to_rank(tensor, rank);
+            }
+        };
+
+        auto logical_suffixes_match = [](const ttnn::Tensor& a, const ttnn::Tensor& b) {
+            auto a_shape = a.get_logical_shape();
+            auto b_shape = b.get_logical_shape();
+
+            auto suffix_len = std::min(a_shape.size(), b_shape.size());
+            for (auto i = -1; i >= -suffix_len; i--) {
+                if (a_shape[i] != b_shape[i]) {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        if (a->get_value().logical_shape().rank() != a_grad.logical_shape().rank()) {
+            if (logical_suffixes_match(a->get_value(), a_grad)) {
+                a_grad = clamp_to_rank(a_grad, a->get_value().logical_shape().rank());
+            }
+        }
+
+        if (b->get_value().logical_shape().rank() != b_grad.logical_shape().rank()) {
+            if (logical_suffixes_match(b->get_value(), b_grad)) {
+                b_grad = clamp_to_rank(b_grad, b->get_value().logical_shape().rank());
+            }
+        }
+
         a->add_grad(a_grad);
         b->add_grad(b_grad);
     };
@@ -122,6 +159,14 @@ autograd::TensorPtr operator*(const autograd::TensorPtr& a, float b) {
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
 
     return out;
+}
+
+autograd::TensorPtr operator*(float a, const autograd::TensorPtr& b) {
+    return b * a;
+}
+
+autograd::TensorPtr operator/(const autograd::TensorPtr& a, float b) {
+    return a * (1.F / b);
 }
 
 autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
@@ -155,12 +200,70 @@ autograd::TensorPtr mul(const autograd::TensorPtr& a, const autograd::TensorPtr&
     return a * b;
 }
 
+autograd::TensorPtr mul(const autograd::TensorPtr& a, float b) {
+    return a * b;
+}
+
+autograd::TensorPtr mul(float a, const autograd::TensorPtr& b) {
+    return b * a;
+}
+
 autograd::TensorPtr div(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
     return a / b;
 }
 
-autograd::TensorPtr mul(const autograd::TensorPtr& a, float b) {
-    return a * b;
+autograd::TensorPtr div(const autograd::TensorPtr& a, float b) {
+    return a / b;
+}
+
+tt::tt_metal::Tensor ttnn_matmul(
+    const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& b, bool transpose_a, bool transpose_b) {
+    return ttnn::matmul(
+        a,
+        b,
+        transpose_a,
+        transpose_b,
+        /* memory_config */ std::nullopt,
+        /* dtype */ std::nullopt,
+        /* program_config */ std::nullopt,
+        /* activation */ std::nullopt,
+        /* compute_kernel_config */ core::ComputeKernelConfig::matmul(),
+        /* core_grid */ std::nullopt,  // NOTE: I believe matmul will use the
+                                       // core grid for the device it ends up
+                                       // running on, but should confirm.
+        /* output_tile */ std::nullopt);
+}
+
+autograd::TensorPtr matmul(
+    const autograd::TensorPtr& a, const autograd::TensorPtr& b, bool transpose_a, bool transpose_b) {
+    auto out = autograd::create_tensor();
+    out->set_value(ttnn_matmul(a->get_value(), b->get_value(), transpose_a, transpose_b));
+
+    autograd::GradFunction grad = [a, b, out, transpose_a, transpose_b]() {
+        // For loss function L and matmul C = AB:
+        // dL/dA = dL/dC * B^T
+        // dL/dB = A^T * dL/dC
+
+        // where L is the loss function
+        auto grad_a = ttnn_matmul(
+            out->get_grad(),
+            b->get_value(),
+            /* transpose_a */ transpose_a,
+            /* transpose_b */ !transpose_b);
+        auto grad_b = ttnn_matmul(
+            a->get_value(),
+            out->get_grad(),
+            /* transpose_a */ !transpose_a,
+            /* transpose_b */ transpose_b);
+
+        a->add_grad(grad_a);
+        b->add_grad(grad_b);
+    };
+
+    auto links = autograd::get_links(a, b);
+    out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
+
+    return out;
 }
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/binary_ops.hpp
+++ b/tt-train/sources/ttml/ops/binary_ops.hpp
@@ -12,14 +12,21 @@ autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::Auto
 autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator*(const autograd::TensorPtr& a, float b);
+autograd::TensorPtr operator*(float a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator-(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
+autograd::TensorPtr operator/(const autograd::TensorPtr& a, float b);
 
 autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::AutocastTensor& b);
 autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr sub(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr mul(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr mul(const autograd::TensorPtr& a, float b);
+autograd::TensorPtr mul(float a, const autograd::TensorPtr& b);
 autograd::TensorPtr div(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
+autograd::TensorPtr div(const autograd::TensorPtr& a, float b);
+
+autograd::TensorPtr matmul(
+    const autograd::TensorPtr& a, const autograd::TensorPtr& b, bool transpose_a, bool transpose_b);
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/unary_ops.hpp
+++ b/tt-train/sources/ttml/ops/unary_ops.hpp
@@ -15,4 +15,6 @@ autograd::TensorPtr sum(const autograd::TensorPtr& tensor);
 autograd::TensorPtr broadcast_batch(const autograd::TensorPtr& tensor, uint32_t new_batch_dim);
 autograd::TensorPtr log_softmax(const autograd::TensorPtr& tensor, int dim);
 autograd::TensorPtr log_softmax_moreh(const autograd::TensorPtr& tensor, int dim);
+autograd::TensorPtr sqrt(const autograd::TensorPtr& tensor);
+
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
@@ -73,6 +73,15 @@ tt::tt_metal::Tensor sum_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
     return res;
 }
+
+// Overload supporting generic sum over multiple dimensions
+tt::tt_metal::Tensor sum_moreh(
+    const tt::tt_metal::Tensor& t, std::optional<ttnn::SmallVector<int64_t>> dims, bool keep_dim) {
+    tt::tt_metal::Tensor res =
+        ttnn::moreh_sum(t, dims, keep_dim, std::nullopt, std::nullopt, core::ComputeKernelConfig::precise());
+    return res;
+}
+
 tt::tt_metal::Tensor sum_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
     return ttnn::sum(t, dim, keep_dim, std::nullopt, core::ComputeKernelConfig::precise());
 }

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.hpp
@@ -19,5 +19,9 @@ tt::tt_metal::Tensor mean_moreh(const tt::tt_metal::Tensor& t, int dim, bool kee
 tt::tt_metal::Tensor mean_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
 
 tt::tt_metal::Tensor sum_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
+tt::tt_metal::Tensor sum_moreh(
+    const tt::tt_metal::Tensor& t,
+    std::optional<ttnn::SmallVector<int64_t>> dims = std::nullopt,
+    bool keep_dim = false);
 tt::tt_metal::Tensor sum_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim);
 }  // namespace ttml::ttnn_fixed


### PR DESCRIPTION
Placeholder PR to save some work that spilled out of another PR:

- Adds matmul and sqrt with backward support
- Attempt at adding generic backward with broadcasting for ttml::mul; IIRC this is incomplete and ought to be revisited.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
