### PR TITLE
#0: increase test vc/mux demux thresholds

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -553,10 +553,10 @@ int main(int argc, char **argv) {
                 && (demux_queue_size_bytes >= 0x20000)) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 1024) {
-                        target_bandwidth = 10;
+                        target_bandwidth = 13;
                         log_info(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 256) {
-                        target_bandwidth = 3;
+                        target_bandwidth = 4;
                         log_info(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (mux_bw < target_bandwidth) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
@@ -593,10 +593,10 @@ int main(int argc, char **argv) {
                 && (demux_queue_size_bytes >= 0x20000)) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 1024) {
-                        target_bandwidth = 11;
+                        target_bandwidth = 17;
                         log_info(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 256) {
-                        target_bandwidth = 3;
+                        target_bandwidth = 7;
                         log_info(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (mux_bw < target_bandwidth) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
VC Mux/Demux test perf was increased lately. Increase the perf amount in CI

### What's changed
N/A

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
