### PR TITLE
#0: Make DispatchQueryManager::get_dispatch_core thread-safe

### DIFF
--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -112,6 +112,7 @@ const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores(u
 }
 
 tt_cxy_pair DispatchQueryManager::get_dispatch_core(uint8_t cq_id) const {
+    std::scoped_lock<std::mutex> lock(modifier_mutex);
     if (dispatch_cores_.empty()) {
         for (auto cq = 0; cq < num_hw_cqs_; cq++) {
             // Populate when queried. Statically allocating at

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <mutex>
+
 #include <dispatch_core_manager.hpp>
 
 namespace tt::tt_metal {
@@ -45,6 +47,7 @@ private:
     // Make this mutable, since this is JIT populated
     // through a const instance when queried
     mutable std::vector<tt_cxy_pair> dispatch_cores_;
+    mutable std::mutex modifier_mutex;
 };
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
`DispatchQueryManager::get_dispatch_core` is called inside worker threads when async mode is enabled. This function lazily/dynamically populates dispatch cores when queried for the first time. This process is not thread-safe on main and causes ND hangs/segfaults.

### What's changed
Add a `modifier_mutex` to the `DispatchQueryManager` and use it when populating dispatch cores

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
