### PR TITLE
#17811: Change job_success criteria so skipped jobs are not failing jobs

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -232,7 +232,8 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations):
 
     job_end_ts = github_job["completed_at"]
 
-    job_success = github_job["conclusion"] == "success"
+    # skipped jobs are considered passing jobs (nothing was run)
+    job_success = github_job["conclusion"] in ["success", "skipped"]
 
     is_build_job = "build" in name or "build" in labels
 

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -104,8 +104,8 @@ def test_create_pipeline_json_to_detect_runner_comm_error_v1_among_other_failure
 
     failing_jobs = get_non_success_jobs_(pipeline)
 
-    # some are skipped
-    assert len(failing_jobs) == 4
+    # some are skipped (skipped jobs are considered success)
+    assert len(failing_jobs) == 2
 
     assert pipeline.github_pipeline_id == 11110261767
 


### PR DESCRIPTION
### Ticket
[17811](https://github.com/tenstorrent/tt-metal/issues/17811)

### Problem description
Skipped jobs (such as build jobs) are being pushed as failing jobs in superset.

### What's changed
Changed the criteria in the python workflow so that jobs that have github API `conclusion` field set to `success` or `skipped`  have `job_success=true`

### TODO:
Schema change to add `job_conclusion` as a new column in `sw_test.cicd_jobs` to distinguish between passing jobs and skipped jobs.

### Checklist
- [x] New/Existing tests provide coverage for changes
Unit test changes