### PR TITLE
fix to_layout sharded bug

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -369,9 +369,6 @@ def test_interleaved_to_sharded_block_shareded_unaligned_width(device):
 def test_shard_untilize(device):
     torch.manual_seed(2005)
 
-    # conv_output_slice.shape=Shape([1, 1, 29640, 128])
-    # conv_output_slice.memory_config()=MemoryConfig(memory_layout=TensorMemoryLayout::HEIGHT_SHARDED,buffer_type=BufferType::L1,shard_spec=ShardSpec(grid={[(x=0,y=0) - (x=7,y=6)], [(x=0,y=7) - (x=5,y=7)]},shape={480, 128},orientation=ShardOrientation::ROW_MAJOR,mode=ShardMode::PHYSICAL,physical_shard_shape=std::nullopt))
-
     torch_tensor = torch.rand(1, 1, 29640, 128, dtype=torch.bfloat16)
 
     sharded_memory_config = ttnn.create_sharded_memory_config(
@@ -398,8 +395,6 @@ def test_shard_untilize(device):
     input_tensor = ttnn.from_torch(
         torch_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=sharded_memory_config
     )
-    # uncomment to test on dram (passes)
-    # input_tensor = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
 
     output_tensor = ttnn.to_layout(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     print(f"output_tensor.memory_config()={output_tensor.memory_config()}")

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -10,14 +10,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
-from models.utility_functions import (
-    is_grayskull,
-    is_blackhole,
-    torch_random,
-    skip_for_grayskull,
-    skip_for_wormhole_b0,
-    is_wormhole_b0,
-)
+from models.utility_functions import is_grayskull, is_blackhole, torch_random, skip_for_grayskull
 
 
 @pytest.mark.parametrize("height", [32, 30])
@@ -370,42 +363,6 @@ def test_interleaved_to_sharded_block_shareded_unaligned_width(device):
 
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_input, output_torch)
     assert passing, pcc_msg
-
-
-@skip_for_wormhole_b0()
-@pytest.mark.parametrize("width", [56, 64])
-def test_shard_untilize_with_unpad(device, width):
-    torch.manual_seed(2005)
-    torch_tensor = torch.rand(1, 1, 127008, width, dtype=torch.bfloat16)
-    sharded_memory_config = ttnn.create_sharded_memory_config(
-        [
-            127008 // 63,  # division with // 63 because shard is on that many cores,
-            64,  # width is 64 because it needs to be padded when going to TILE_LAYOUT
-        ],
-        core_grid=ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(7, 6),
-                ),
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 7),
-                    ttnn.CoreCoord(6, 7),
-                ),
-            }
-        ),
-        strategy=ttnn.ShardStrategy.HEIGHT,
-        use_height_and_width_as_shard_shape=True,
-    )
-    input_tensor = ttnn.from_torch(
-        torch_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=sharded_memory_config
-    )
-    # uncomment to test on dram (passes)
-    # input_tensor = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
-    output_tensor = ttnn.to_layout(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.to_torch(output_tensor)
-    assert torch_tensor.shape == output_tensor.shape
-    assert_with_pcc(torch_tensor, output_tensor, 0.9999)
 
 
 @skip_for_wormhole_b0()

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -10,7 +10,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
-from models.utility_functions import is_grayskull, is_blackhole, torch_random, skip_for_grayskull
+from models.utility_functions import is_grayskull, is_blackhole, torch_random, skip_for_grayskull, skip_for_wormhole_b0
 
 
 @pytest.mark.parametrize("height", [32, 30])

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -363,3 +363,47 @@ def test_interleaved_to_sharded_block_shareded_unaligned_width(device):
 
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_input, output_torch)
     assert passing, pcc_msg
+
+
+def test_shard_untilize(device):
+    torch.manual_seed(2005)
+
+    # conv_output_slice.shape=Shape([1, 1, 29640, 128])
+    # conv_output_slice.memory_config()=MemoryConfig(memory_layout=TensorMemoryLayout::HEIGHT_SHARDED,buffer_type=BufferType::L1,shard_spec=ShardSpec(grid={[(x=0,y=0) - (x=7,y=6)], [(x=0,y=7) - (x=5,y=7)]},shape={480, 128},orientation=ShardOrientation::ROW_MAJOR,mode=ShardMode::PHYSICAL,physical_shard_shape=std::nullopt))
+
+    torch_tensor = torch.rand(1, 1, 29640, 128, dtype=torch.bfloat16)
+
+    sharded_memory_config = ttnn.create_sharded_memory_config(
+        [
+            480,
+            128,
+        ],
+        core_grid=ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 6),
+                ),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 7),
+                    ttnn.CoreCoord(5, 7),
+                ),
+            }
+        ),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    input_tensor = ttnn.from_torch(
+        torch_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=sharded_memory_config
+    )
+    # uncomment to test on dram (passes)
+    # input_tensor = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+
+    output_tensor = ttnn.to_layout(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    print(f"output_tensor.memory_config()={output_tensor.memory_config()}")
+    assert output_tensor.memory_config() == ttnn.DRAM_MEMORY_CONFIG, "Memory config is not DRAM"
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert torch_tensor.shape == output_tensor.shape
+    assert_with_pcc(torch_tensor, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -93,8 +93,7 @@ Tensor to_layout_impl(
     auto tensor = tensor_arg;
     const auto tile = tensor.get_tensor_spec().tile();
     auto output_shape = tensor_arg.get_logical_shape();
-    auto output_memory_config =
-        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+    auto output_memory_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
 
     TensorSpec tile_spec(
         tensor_arg.get_logical_shape(),
@@ -142,7 +141,8 @@ Tensor to_layout_impl(
                 "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device!");
 
             if (tensor.is_sharded()) {
-                if (memory_config != tensor.memory_config()) {
+                if ((output_memory_config == ttnn::DRAM_MEMORY_CONFIG && tensor.memory_config().is_l1()) ||
+                    (output_memory_config == ttnn::L1_MEMORY_CONFIG && tensor.memory_config().is_dram())) {
                     tensor = ttnn::to_memory_config(tensor, output_memory_config);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -93,7 +93,17 @@ Tensor to_layout_impl(
     auto tensor = tensor_arg;
     const auto tile = tensor.get_tensor_spec().tile();
     auto output_shape = tensor_arg.get_logical_shape();
-    auto output_memory_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
+
+    auto output_memory_config = ttnn::DRAM_MEMORY_CONFIG;
+    if (memory_config.has_value()) {
+        output_memory_config = memory_config.value();
+        if ((output_memory_config == ttnn::DRAM_MEMORY_CONFIG && tensor.memory_config().is_l1()) ||
+            (output_memory_config == ttnn::L1_MEMORY_CONFIG && tensor.memory_config().is_dram())) {
+            tensor = ttnn::to_memory_config(tensor, output_memory_config);
+        }
+    } else if (tensor.memory_config().is_l1()) {
+        output_memory_config = ttnn::L1_MEMORY_CONFIG;
+    }
 
     TensorSpec tile_spec(
         tensor_arg.get_logical_shape(),
@@ -140,12 +150,6 @@ Tensor to_layout_impl(
                 !dtype.has_value() || dtype.value() == tensor_arg.dtype(),
                 "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device!");
 
-            if (tensor.is_sharded()) {
-                if ((output_memory_config == ttnn::DRAM_MEMORY_CONFIG && tensor.memory_config().is_l1()) ||
-                    (output_memory_config == ttnn::L1_MEMORY_CONFIG && tensor.memory_config().is_dram())) {
-                    tensor = ttnn::to_memory_config(tensor, output_memory_config);
-                }
-            }
             Shape output_tensor_end(SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
             int logical_rank = tensor.get_logical_shape().rank();
             for (int index = -1; index >= -logical_rank; --index) {

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -142,16 +142,15 @@ Tensor to_layout_impl(
                 "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device!");
 
             if (tensor.is_sharded()) {
-                const auto memory_config = tensor.memory_config();
-                // output_memory_config =
-                //     tt::tt_metal::MemoryConfig{memory_config.memory_layout, memory_config.buffer_type};
+                if (memory_config != tensor.memory_config()) {
+                    tensor = ttnn::to_memory_config(tensor, output_memory_config);
+                }
             }
             Shape output_tensor_end(SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
             int logical_rank = tensor.get_logical_shape().rank();
             for (int index = -1; index >= -logical_rank; --index) {
                 output_tensor_end[index] = tensor.get_logical_shape()[index] - 1;
             }
-
             tensor =
                 ttnn::untilize_with_unpadding(tensor, output_tensor_end, output_memory_config, use_multicore_untilize);
             return ttnn::reshape(tensor, ttnn::Shape{output_shape});

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -143,8 +143,8 @@ Tensor to_layout_impl(
 
             if (tensor.is_sharded()) {
                 const auto memory_config = tensor.memory_config();
-                output_memory_config =
-                    tt::tt_metal::MemoryConfig{memory_config.memory_layout, memory_config.buffer_type};
+                // output_memory_config =
+                //     tt::tt_metal::MemoryConfig{memory_config.memory_layout, memory_config.buffer_type};
             }
             Shape output_tensor_end(SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
             int logical_rank = tensor.get_logical_shape().rank();


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/17706

### Problem description
to_layout doesn't change the memory configuration of sharded tensors for untilize with unpadding if needed. The memory config stays L1

### What's changed
Change the memory config if the requested configuration is different than the input tensor one

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13249266656
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
