### PR TITLE
[tt-train] Add bf16 support

### DIFF
--- a/tt-train/sources/ttml/core/xtensor_utils.hpp
+++ b/tt-train/sources/ttml/core/xtensor_utils.hpp
@@ -5,11 +5,11 @@
 #pragma once
 
 #include <core/ttnn_all_includes.hpp>
+#include <core/xtensor_utils.hpp>
 #include <span>
 #include <ttnn/tensor/shape/shape.hpp>
 #include <ttnn/tensor/xtensor/conversion_utils.hpp>
 #include <ttnn/tensor/xtensor/partition.hpp>
-
 // TODO: decide if we want to use xarray everwhere or xtensor is ok
 /*
 Difference between xtensor and xarray:

--- a/tt-train/sources/ttml/math/bf16.cpp
+++ b/tt-train/sources/ttml/math/bf16.cpp
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-#include "bf16.hpp"
-
-namespace ttml::math {}

--- a/tt-train/sources/ttml/math/bf16.cpp
+++ b/tt-train/sources/ttml/math/bf16.cpp
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bf16.hpp"
+
+namespace ttml::math {}

--- a/tt-train/sources/ttml/math/bf16.hpp
+++ b/tt-train/sources/ttml/math/bf16.hpp
@@ -6,14 +6,19 @@
 
 #include <array>
 #include <cstdint>
-
+#include <ostream>
 namespace ttml::math {
 
 class bfloat16 {
-public:
+private:
     uint16_t m_raw_value = 0;
 
+public:
     bfloat16() = default;
+
+    constexpr inline explicit bfloat16(int v) noexcept {
+        m_raw_value = float_to_bfloat16(static_cast<float>(v));
+    }
 
     constexpr inline explicit bfloat16(float f) noexcept {
         m_raw_value = float_to_bfloat16(f);
@@ -90,6 +95,12 @@ public:
     constexpr inline bool operator>=(const bfloat16 &rhs) const noexcept {
         return !(*this < rhs);
     }
+    constexpr inline uint16_t get_raw_value() const noexcept {
+        return m_raw_value;
+    }
+    constexpr bfloat16 operator-() const noexcept {
+        return bfloat16(-static_cast<float>(*this));
+    }
 
 private:
     constexpr static uint16_t float_to_bfloat16(float f) noexcept {
@@ -123,4 +134,171 @@ private:
     }
 };
 
+// ----------------------------------------------------------------------
+// Non-member overloads for arithmetic operators with arithmetic types
+// These allow mixing bfloat16 with types like double, float, int, etc.
+// ----------------------------------------------------------------------
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator+(const bfloat16 &lhs, T rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) + static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator+(T lhs, const bfloat16 &rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) + static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator-(const bfloat16 &lhs, T rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) - static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator-(T lhs, const bfloat16 &rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) - static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator*(const bfloat16 &lhs, T rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) * static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator*(T lhs, const bfloat16 &rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) * static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator/(const bfloat16 &lhs, T rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) / static_cast<float>(rhs));
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bfloat16 operator/(T lhs, const bfloat16 &rhs) noexcept {
+    return bfloat16(static_cast<float>(lhs) / static_cast<float>(rhs));
+}
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bool operator==(const bfloat16 &lhs, T rhs) noexcept {
+    return static_cast<float>(lhs) == static_cast<float>(rhs);
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bool operator==(T lhs, const bfloat16 &rhs) noexcept {
+    return static_cast<float>(lhs) == static_cast<float>(rhs);
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bool operator!=(const bfloat16 &lhs, T rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr bool operator!=(T lhs, const bfloat16 &rhs) noexcept {
+    return !(lhs == rhs);
+}
 }  // namespace ttml::math
+
+// ============================================================
+// STL integration
+
+namespace ttml {
+namespace math {
+
+constexpr bool isnan(bfloat16 x) noexcept {
+    // Convert to float and then use std::isnan
+    return std::isnan(static_cast<float>(x));
+}
+
+inline std::ostream &operator<<(std::ostream &os, const bfloat16 &bf) {
+    os << static_cast<float>(bf);
+    return os;
+}
+}  // namespace math
+}  // namespace ttml
+
+namespace std {
+template <>
+class numeric_limits<ttml::math::bfloat16> {
+public:
+    static constexpr bool is_specialized = true;
+    static constexpr bool is_signed = true;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+    static constexpr int radix = 2;
+    // bfloat16 has 7 explicit fraction bits plus 1 implicit bit.
+    static constexpr int digits = 8;
+    static constexpr int digits10 = 2;
+    static constexpr int max_digits10 = 4;
+
+    static ttml::math::bfloat16 min() noexcept {
+        // Smallest positive normalized value in bfloat16.
+        // (Exponent = 1, Fraction = 0 → 2^(1-127))
+        return ttml::math::bfloat16(1.17549435e-38f);
+    }
+
+    static ttml::math::bfloat16 max() noexcept {
+        constexpr uint16_t raw = 0x7F7F;
+        constexpr uint32_t bits = static_cast<uint32_t>(raw) << 16;
+        constexpr float f = std::bit_cast<float>(bits);
+        return ttml::math::bfloat16(f);
+    }
+
+    // The lowest (most negative) finite bfloat16 value is represented by:
+    // sign = 1, exponent = 0xFE, fraction = 0x7F.
+    // That is: 1 1111110 1111111 in binary, which as a 16-bit integer is 0xFF7F.
+    static ttml::math::bfloat16 lowest() noexcept {
+        constexpr uint16_t raw = 0xFF7F;
+        constexpr uint32_t bits = static_cast<uint32_t>(raw) << 16;
+        constexpr float f = std::bit_cast<float>(bits);
+        return ttml::math::bfloat16(f);
+    }
+    static ttml::math::bfloat16 epsilon() noexcept {
+        // The difference between 1.0 and the next representable value.
+        // For bfloat16 this is 2^-7 = 0.0078125.
+        return ttml::math::bfloat16(0.0078125f);
+    }
+    static ttml::math::bfloat16 round_error() noexcept {
+        return ttml::math::bfloat16(0.5f);
+    }
+
+    static constexpr int min_exponent = -126;
+    static constexpr int max_exponent = 127;
+    static constexpr int min_exponent10 = -37;
+    static constexpr int max_exponent10 = 38;
+
+    static constexpr bool has_infinity = true;
+    static constexpr bool has_quiet_NaN = true;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_present;
+    static constexpr bool is_iec559 = true;
+    static constexpr bool is_bounded = true;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr std::float_round_style round_style = std::round_to_nearest;
+};
+
+template <>
+struct hash<ttml::math::bfloat16> {
+    size_t operator()(const ttml::math::bfloat16 &bf) const noexcept {
+        return std::hash<uint16_t>()(bf.get_raw_value());
+    }
+};
+
+template <>
+struct common_type<ttml::math::bfloat16, float> {
+    using type = float;
+};
+template <>
+struct common_type<float, ttml::math::bfloat16> {
+    using type = float;
+};
+template <>
+struct common_type<ttml::math::bfloat16, double> {
+    using type = double;
+};
+template <>
+struct common_type<double, ttml::math::bfloat16> {
+    using type = double;
+};
+
+}  // namespace std

--- a/tt-train/sources/ttml/math/bf16.hpp
+++ b/tt-train/sources/ttml/math/bf16.hpp
@@ -7,6 +7,11 @@
 #include <array>
 #include <cstdint>
 #include <ostream>
+#include <xtensor/xarray.hpp>
+#include <xtensor/xeval.hpp>
+#include <xtensor/xio.hpp>
+#include <xtensor/xnoalias.hpp>
+
 namespace ttml::math {
 
 class bfloat16 {
@@ -302,3 +307,8 @@ struct common_type<double, ttml::math::bfloat16> {
 };
 
 }  // namespace std
+
+namespace xt {
+template <>
+struct xscalar<ttml::math::bfloat16> : std::true_type {};
+}  // namespace xt

--- a/tt-train/sources/ttml/math/bf16.hpp
+++ b/tt-train/sources/ttml/math/bf16.hpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sys/types.h>
+
+#include <array>
+#include <cstdint>
+
+namespace ttml::math {
+
+class bfloat16 {
+public:
+    uint16_t m_raw_value = 0;
+
+    bfloat16() = default;
+
+    constexpr inline explicit bfloat16(float f) noexcept {
+        m_raw_value = float_to_bfloat16(f);
+    }
+
+    constexpr inline explicit bfloat16(double d) noexcept {
+        m_raw_value = float_to_bfloat16(static_cast<float>(d));
+    }
+
+    constexpr inline operator float() const noexcept {
+        return bfloat16_to_float(m_raw_value);
+    }
+
+    constexpr inline operator double() const noexcept {
+        return static_cast<double>(bfloat16_to_float(m_raw_value));
+    }
+
+    constexpr inline bfloat16 operator+(const bfloat16 &rhs) const noexcept {
+        float lhs_f = static_cast<float>(*this);
+        float rhs_f = static_cast<float>(rhs);
+        return bfloat16(lhs_f + rhs_f);
+    }
+
+    constexpr inline bfloat16 operator-(const bfloat16 &rhs) const noexcept {
+        float lhs_f = static_cast<float>(*this);
+        float rhs_f = static_cast<float>(rhs);
+        return bfloat16(lhs_f - rhs_f);
+    }
+
+    constexpr inline bfloat16 operator*(const bfloat16 &rhs) const noexcept {
+        float lhs_f = static_cast<float>(*this);
+        float rhs_f = static_cast<float>(rhs);
+        return bfloat16(lhs_f * rhs_f);
+    }
+
+    constexpr inline bfloat16 operator/(const bfloat16 &rhs) const noexcept {
+        float lhs_f = static_cast<float>(*this);
+        float rhs_f = static_cast<float>(rhs);
+        return bfloat16(lhs_f / rhs_f);
+    }
+
+    constexpr inline bfloat16 &operator+=(const bfloat16 &rhs) noexcept {
+        *this = *this + rhs;
+        return *this;
+    }
+    constexpr inline bfloat16 &operator-=(const bfloat16 &rhs) noexcept {
+        *this = *this - rhs;
+        return *this;
+    }
+    constexpr inline bfloat16 &operator*=(const bfloat16 &rhs) noexcept {
+        *this = *this * rhs;
+        return *this;
+    }
+    constexpr inline bfloat16 &operator/=(const bfloat16 &rhs) noexcept {
+        *this = *this / rhs;
+        return *this;
+    }
+
+    constexpr inline bool operator==(const bfloat16 &rhs) const noexcept {
+        return static_cast<float>(*this) == static_cast<float>(rhs);
+    }
+    constexpr inline bool operator!=(const bfloat16 &rhs) const noexcept {
+        return !(*this == rhs);
+    }
+    constexpr inline bool operator<(const bfloat16 &rhs) const noexcept {
+        return static_cast<float>(*this) < static_cast<float>(rhs);
+    }
+    constexpr inline bool operator>(const bfloat16 &rhs) const noexcept {
+        return rhs < *this;
+    }
+    constexpr inline bool operator<=(const bfloat16 &rhs) const noexcept {
+        return !(*this > rhs);
+    }
+    constexpr inline bool operator>=(const bfloat16 &rhs) const noexcept {
+        return !(*this < rhs);
+    }
+
+private:
+    constexpr static uint16_t float_to_bfloat16(float f) noexcept {
+        std::array<uint16_t, 2> raw_arr = std::bit_cast<std::array<uint16_t, 2>>(f);
+        uint16_t raw_res = 0;
+
+        switch (std::fpclassify(f)) {
+            case FP_SUBNORMAL:
+            case FP_ZERO:
+                raw_res = raw_arr[1];
+                raw_res &= 0x8000;
+                break;
+            case FP_INFINITE: raw_res = raw_arr[1]; break;
+            case FP_NAN:
+                raw_res = raw_arr[1];
+                raw_res |= 1 << 6;
+                break;
+            case FP_NORMAL:
+                const uint32_t rounding_bias = 0x00007FFF + (raw_arr[1] & 0x1);
+                const uint32_t int_raw = std::bit_cast<uint32_t>(f) + rounding_bias;
+                raw_arr = std::bit_cast<std::array<uint16_t, 2>>(int_raw);
+                raw_res = raw_arr[1];
+                break;
+        }
+        return raw_res;
+    }
+
+    constexpr static float bfloat16_to_float(uint16_t v) noexcept {
+        std::array<uint16_t, 2> raw_arr = {{0, v}};
+        return bit_cast<float>(raw_arr);
+    }
+};
+
+}  // namespace ttml::math

--- a/tt-train/tests/math/bf16_tests.cpp
+++ b/tt-train/tests/math/bf16_tests.cpp
@@ -181,3 +181,17 @@ TEST(BFloat16Test, Xtensor) {
     xt::xarray<float> bf16_sum_back = xt::cast<float>(sum_bf16);
     EXPECT_TRUE(xt::allclose(bf16_sum_back, sum_orig, /*rtol=*/1e-3, /*atol=*/1e-2));
 }
+
+TEST(BFloat16Test, Matmul16vs32) {
+    xt::random::seed(42);
+    xt::xarray<float> a_fp32 = xt::random::randn<float>({32, 64}, -0.5f, 0.5f);
+    xt::xarray<float> b_fp32 = xt::random::randn<float>({64, 16}, -0.5f, 0.5f);
+    xt::xarray<ttml::math::bfloat16> a_bf16 = xt::cast<ttml::math::bfloat16>(a_fp32);
+    xt::xarray<ttml::math::bfloat16> b_bf16 = xt::cast<ttml::math::bfloat16>(b_fp32);
+
+    xt::xarray<float> c_fp32 = xt::linalg::dot(a_fp32, b_fp32);
+    xt::xarray<ttml::math::bfloat16> c_bf16 = xt::linalg::dot(a_bf16, b_bf16);
+    xt::xarray<float> c_bf16_out = xt::cast<float>(b_fp32);
+
+    EXPECT_TRUE(xt::allclose(c_fp32, c_bf16_out, /*rtol=*/1e-3, /*atol=*/1e-2));
+}

--- a/tt-train/tests/math/bf16_tests.cpp
+++ b/tt-train/tests/math/bf16_tests.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt-train/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/include/gtest/gtest.h>
+
+#include <cmath>
+#include <core/xtensor_utils.hpp>
+
+#include "math/bf16.hpp"
+#include "xtensor/xmath.hpp"
+
+// Test construction from float and reconversion
+TEST(BFloat16Test, BasicConstruction) {
+    // 1) Zero
+    ttml::math::bfloat16 z(0.0f);
+    EXPECT_EQ(static_cast<float>(z), 0.0f);
+
+    // 2) Positive value
+    ttml::math::bfloat16 p(1.0f);
+    EXPECT_FLOAT_EQ(static_cast<float>(p), 1.0f);
+
+    // 3) Negative value
+    ttml::math::bfloat16 n(-2.5f);
+    EXPECT_FLOAT_EQ(static_cast<float>(n), -2.5f);
+}
+
+TEST(BFloat16Test, ValueRounding) {
+    // This test checks that rounding to nearest-even is happening.
+    // Example: 1.00007f is slightly more than 1, might round up or remain 1
+    float val = 1.00007f;
+    ttml::math::bfloat16 a(val);
+    float reconstructed = static_cast<float>(a);
+
+    // We can't say EXACT, because we expect it to be 1.0 or slightly more
+    // Check closeness with an appropriate epsilon
+    EXPECT_NEAR(reconstructed, val, 1e-3f);
+}
+
+TEST(BFloat16Test, ConversionDouble) {
+    // Construct from double
+    double d = 3.141592653589793;
+    ttml::math::bfloat16 bf(d);
+
+    // Check float equivalence
+    float f = static_cast<float>(bf);
+    EXPECT_NEAR(f, static_cast<float>(d), 1e-3f);
+}
+/*
+import torch
+
+# Create bfloat16 tensors for a and b
+a = torch.tensor(1.5, dtype=torch.bfloat16)
+b = torch.tensor(2.5, dtype=torch.bfloat16)
+
+# Perform arithmetic operations
+sum_val = a + b
+diff_val = a - b
+prod_val = a * b
+quot_val = a / b
+
+# Print results. Note that arithmetic with bfloat16 might internally use float32 for computation.
+print("a      =", a.item())
+print("b      =", b.item())
+print("sum    =", sum_val.item())
+print("diff   =", diff_val.item())
+print("prod   =", prod_val.item())
+print("quot   =", quot_val.item())
+
+# Output:
+a      = 1.5
+b      = 2.5
+sum    = 4.0
+diff   = -1.0
+prod   = 3.75
+quot   = 0.6015625
+*/
+TEST(BFloat16Test, ArithmeticOperations) {
+    ttml::math::bfloat16 a(1.5f);
+    ttml::math::bfloat16 b(2.5f);
+
+    ttml::math::bfloat16 sum = a + b;
+    ttml::math::bfloat16 diff = a - b;
+    ttml::math::bfloat16 prod = a * b;
+    ttml::math::bfloat16 quot = a / b;
+
+    EXPECT_NEAR(static_cast<float>(sum), 4.0f, 1e-3f);
+    EXPECT_NEAR(static_cast<float>(diff), -1.0f, 1e-3f);
+    EXPECT_NEAR(static_cast<float>(prod), 3.75f, 1e-3f);
+    EXPECT_NEAR(static_cast<float>(quot), 0.6f, 1e-2f);
+
+    // Compound assignments
+    ttml::math::bfloat16 c(2.0f);
+    c += ttml::math::bfloat16(3.0f);
+    EXPECT_NEAR(static_cast<float>(c), 5.0f, 1e-3f);
+
+    c -= ttml::math::bfloat16(1.0f);
+    EXPECT_NEAR(static_cast<float>(c), 4.0f, 1e-3f);
+
+    c *= ttml::math::bfloat16(2.0f);
+    EXPECT_NEAR(static_cast<float>(c), 8.0f, 1e-3f);
+
+    c /= ttml::math::bfloat16(4.0f);
+    EXPECT_NEAR(static_cast<float>(c), 2.0f, 1e-3f);
+}
+
+TEST(BFloat16Test, ComparisonOperators) {
+    ttml::math::bfloat16 a(1.0f), b(2.0f), c(1.0f);
+
+    EXPECT_TRUE(a < b);
+    EXPECT_TRUE(a <= b);
+    EXPECT_TRUE(b > a);
+    EXPECT_TRUE(b >= a);
+    EXPECT_TRUE(a == c);
+    EXPECT_TRUE(a != b);
+}
+/*
+import torch
+import math
+
+# Create a list with the desired values
+values = [65504.0, -65504.0, float('inf'), float('-inf'), float('nan')]
+
+# Create a tensor with dtype torch.bfloat16
+bf16_tensor = torch.tensor(values, dtype=torch.bfloat16)
+
+# Print the bfloat16 tensor
+print("bfloat16 tensor:", bf16_tensor)
+
+# Optionally, convert it back to float for a clearer view
+print("Converted to float:", bf16_tensor.to(torch.float32))
+
+# Output:
+
+bfloat16 tensor: tensor([ 65536., -65536.,     inf,    -inf,     nan], dtype=torch.bfloat16)
+Converted to float: tensor([ 65536., -65536.,     inf,    -inf,     nan])
+*/
+TEST(BFloat16Test, CornerCases) {
+    // Very large float
+    float large_f = 65504.0f;  // near max for float16, but let's see for ttml::math::bfloat16
+    ttml::math::bfloat16 large_bf(large_f);
+    float large_f_back = static_cast<float>(large_bf);
+    std::cout << "large_f_back: " << large_f_back << std::endl;
+    float expected_value = 65536;  // 65504 + 32
+    EXPECT_NEAR(large_f_back, expected_value, 1e-1f);
+
+    // Negative large
+    float neg_large_f = -65504.0f;
+    ttml::math::bfloat16 neg_large_bf(neg_large_f);
+    float neg_large_f_back = static_cast<float>(neg_large_bf);
+    std::cout << "neg_large_f_back: " << neg_large_f_back << std::endl;
+    float expected_neg_value = -65536;  // 65504 + 32
+    EXPECT_NEAR(neg_large_f_back, expected_neg_value, 1e-1f);
+
+    // Infinity
+    float inf = std::numeric_limits<float>::infinity();
+    ttml::math::bfloat16 bf_inf(inf);
+    float reconstructed_inf = static_cast<float>(bf_inf);
+    EXPECT_TRUE(std::isinf(reconstructed_inf));
+
+    // Negative Infinity
+    float neg_inf = -std::numeric_limits<float>::infinity();
+    ttml::math::bfloat16 bf_neg_inf(neg_inf);
+    float reconstructed_neg_inf = static_cast<float>(bf_neg_inf);
+    EXPECT_TRUE(std::isinf(reconstructed_neg_inf));
+    EXPECT_LT(reconstructed_neg_inf, 0.0f);
+
+    // NaN
+    float nan_val = std::numeric_limits<float>::quiet_NaN();
+    ttml::math::bfloat16 bf_nan(nan_val);
+    float reconstructed_nan = static_cast<float>(bf_nan);
+    EXPECT_TRUE(std::isnan(reconstructed_nan));
+}
+TEST(BFloat16Test, Xtensor) {
+    // Create an xtensor array of floats
+    xt::xarray<float> float_array = {1.5f, 2.5f, 3.5f};
+
+    xt::xarray<ttml::math::bfloat16> bf16_array = xt::cast<ttml::math::bfloat16>(float_array);
+    xt::xarray<float> sum_orig = float_array + float_array;
+    xt::xarray<ttml::math::bfloat16> sum_bf16 = bf16_array + bf16_array;
+    xt::xarray<float> bf16_sum_back = xt::cast<float>(sum_bf16);
+    std::cout << "sum_orig: " << sum_orig << std::endl;
+    std::cout << "sum_bf16: " << bf16_sum_back << std::endl;
+    EXPECT_TRUE(xt::allclose(bf16_sum_back, sum_orig, /*rtol=*/1e-3, /*atol=*/1e-2));
+}

--- a/tt-train/tests/math/bf16_tests.cpp
+++ b/tt-train/tests/math/bf16_tests.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <tt-train/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/include/gtest/gtest.h>
 
 #include <cmath>
 #include <core/xtensor_utils.hpp>
@@ -180,7 +179,5 @@ TEST(BFloat16Test, Xtensor) {
     xt::xarray<float> sum_orig = float_array + float_array;
     xt::xarray<ttml::math::bfloat16> sum_bf16 = bf16_array + bf16_array;
     xt::xarray<float> bf16_sum_back = xt::cast<float>(sum_bf16);
-    std::cout << "sum_orig: " << sum_orig << std::endl;
-    std::cout << "sum_bf16: " << bf16_sum_back << std::endl;
     EXPECT_TRUE(xt::allclose(bf16_sum_back, sum_orig, /*rtol=*/1e-3, /*atol=*/1e-2));
 }

--- a/tt-train/tests/math/bf16_tests.cpp
+++ b/tt-train/tests/math/bf16_tests.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <tt-train/.cpmcache/googletest/96129d89f45386492ae46d6bb8c027bc3df5f949/googletest/include/gtest/gtest.h>
 
 #include <cmath>
 #include <core/xtensor_utils.hpp>


### PR DESCRIPTION
### Problem description
Sometimes during tests it more convenient to use bf16 arithmetic to compare vs ttnn.

### What's changed
* add bf16 class
* add arithmetics tests for bf16
* add one xtensor test

### Checklist
- [x] New/Existing tests provide coverage for changes
