### PR TITLE
Fix the version tag in python wheel

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -211,7 +211,7 @@ jobs:
       - name: 🐍 Build wheel
         if: ${{ inputs.build-wheel }}
         run: |
-          git clean -xfd
+          git clean -xffd
           nice -n 19 python3 -m build
 
       - name: ☁️ Upload wheel

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -143,6 +143,7 @@ jobs:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
 

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -211,7 +211,7 @@ jobs:
       - name: 🐍 Build wheel
         if: ${{ inputs.build-wheel }}
         run: |
-          git clean -xffd
+          git clean -xfd
           nice -n 19 python3 -m build
 
       - name: ☁️ Upload wheel

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -189,25 +189,12 @@ jobs:
         run: |
           nice -19 cmake --build $build_dir --target package
 
-      - name: 🐍 Build wheel
-        if: ${{ inputs.build-wheel }}
-        run: |
-          nice -n 19 python3 -m build
-
       - name: Publish ccache summary
         run: |
           echo '## CCache Summary' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           ccache -s >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: ☁️ Upload wheel
-        if: ${{ inputs.build-wheel }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: eager-dist-${{ inputs.distro }}-${{ inputs.version }}-any
-          path: /work/dist/
-          if-no-files-found: error
 
       - name: 'Tar files'
         if: ${{ inputs.publish-artifact }}
@@ -219,6 +206,20 @@ jobs:
         with:
           name: TTMetal_build_any${{ (inputs.tracy && '_profiler') || '' }}
           path: /work/ttm_any.tar
+          if-no-files-found: error
+
+      - name: 🐍 Build wheel
+        if: ${{ inputs.build-wheel }}
+        run: |
+          git clean -xffd
+          nice -n 19 python3 -m build
+
+      - name: ☁️ Upload wheel
+        if: ${{ inputs.build-wheel }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: eager-dist-${{ inputs.distro }}-${{ inputs.version }}-any
+          path: /work/dist/
           if-no-files-found: error
 
       - name: Cleanup

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -189,12 +189,25 @@ jobs:
         run: |
           nice -19 cmake --build $build_dir --target package
 
+      - name: 🐍 Build wheel
+        if: ${{ inputs.build-wheel }}
+        run: |
+          nice -n 19 python3 -m build
+
       - name: Publish ccache summary
         run: |
           echo '## CCache Summary' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           ccache -s >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: ☁️ Upload wheel
+        if: ${{ inputs.build-wheel }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: eager-dist-${{ inputs.distro }}-${{ inputs.version }}-any
+          path: /work/dist/
+          if-no-files-found: error
 
       - name: 'Tar files'
         if: ${{ inputs.publish-artifact }}
@@ -206,20 +219,6 @@ jobs:
         with:
           name: TTMetal_build_any${{ (inputs.tracy && '_profiler') || '' }}
           path: /work/ttm_any.tar
-          if-no-files-found: error
-
-      - name: 🐍 Build wheel
-        if: ${{ inputs.build-wheel }}
-        run: |
-          git clean -xffd
-          nice -n 19 python3 -m build
-
-      - name: ☁️ Upload wheel
-        if: ${{ inputs.build-wheel }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: eager-dist-${{ inputs.distro }}-${{ inputs.version }}-any
-          path: /work/dist/
           if-no-files-found: error
 
       - name: Cleanup

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -14,6 +14,8 @@ jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
+    with:
+      build-wheel: true
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     with:


### PR DESCRIPTION
### Problem description
Our Package and Release pipeline got broke by me.
This happened when I moved wheel generation into our build-artifact job.

### What's changed
The version detection scheme seems to rely on having the full git history (or at least more history than we have).
Change fetch-depth to 0.
Additionally, it seems the working directory needs to be clean, to avoid having the image tagged as "dev".
Trying to reorder build steps to deal with this.

### Checklist
- [ ] [Package And Release](https://github.com/tenstorrent/tt-metal/actions/runs/13279694570) CI passes