### PR TITLE
[skip ci] Dockerize tt-train cpp tests workflow

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -157,6 +157,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
   run-profiler-regression:
     needs: build-artifact-profiler
     strategy:

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -26,3 +26,4 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -9,23 +9,9 @@ on:
       runner-label:
         required: true
         type: string
-      timeout:
-        required: false
-        type: number
-        default: 20
-  workflow_dispatch:
-    inputs:
-      arch:
+      docker-image:
         required: true
-        type: choice
-        options:
-          - wormhole_b0
-      runner-label:
-        required: true
-        type: choice
-        options:
-          - N150
-          - N300
+        type: string
       timeout:
         required: false
         type: number
@@ -43,38 +29,59 @@ jobs:
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
-      ARCH_NAME: ${{ inputs.arch }}
-      LOGURU_LEVEL: INFO
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-      TEST_DATA_DIR: ${{ github.workspace }}/data
-      ENABLE_CI_ONLY_TT_TRAIN_TESTS: 1
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine
       - in-service
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        TT_METAL_HOME: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        TEST_DATA_DIR: /work/data
+        ENABLE_CI_ONLY_TT_TRAIN_TESTS: 1
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: >
+        --device /dev/tenstorrent
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
       - uses: ./.github/actions/prepare-metal-run
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          source ${{ github.workspace }}/python_env/bin/activate
-          export PYTHONPATH=$TT_METAL_HOME
-          cd $TT_METAL_HOME
           cp ./build/tt-train/3rd_party/wandb-cpp/libwandbcpp.so build/lib/
-          find ./build -type f -name "*.tcl" -o -name "*.cmake" -exec sed -i "s|/home/ubuntu/[^/]*/_work/tt-metal/tt-metal/build_Release|${TT_METAL_HOME}/build|g" {} +
-          cd $TT_METAL_HOME/build/tt-train
+          find ./build -type f -name "*.tcl" -o -name "*.cmake" -exec sed -i "s|/home/ubuntu/[^/]*/_work/tt-metal/tt-metal/build_Release|/work/build|g" {} +
+          cd /work/build/tt-train
           ldd tests/ttml_tests || true
           ${{ matrix.test-group.cmd }}
+
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U07ASPTGJTS # Denys
+
       - name: Generate system logs on failure
         uses: ./.github/actions/generate-system-logs
         if: ${{ failure() }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # We are forced to checkout the repo into a subdir of the host's workdir; this pollutes the host
+          # with root-owned files.  Be sure to clean up after ourselves in case we're on a non-ephemeral runner.
+          echo "pre rm"
+          ls -al /__w/tt-metal/tt-metal
+          rm -rf /__w/tt-metal/tt-metal/docker-job
+          echo "post rm"
+          ls -al /__w/tt-metal/tt-metal

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -42,8 +42,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: >
-        --device /dev/tenstorrent
+      options: "--device /dev/tenstorrent"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -73,10 +73,6 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U07ASPTGJTS # Denys
 
-      - name: Generate system logs on failure
-        uses: ./.github/actions/generate-system-logs
-        if: ${{ failure() }}
-
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -63,7 +63,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           cp ./build/tt-train/3rd_party/wandb-cpp/libwandbcpp.so build/lib/
-          find ./build -type f -name "*.tcl" -o -name "*.cmake" -exec sed -i "s|/home/ubuntu/[^/]*/_work/tt-metal/tt-metal/build_Release|/work/build|g" {} +
+          find ./build -type f -name "*.tcl" -o -name "*.cmake" -exec sed -i "s|/work/build_Release|/work/build|g" {} +
           cd /work/build/tt-train
           ldd tests/ttml_tests || true
           ${{ matrix.test-group.cmd }}

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -28,7 +28,6 @@ jobs:
           {name: tt-train, cmd: ctest --no-tests=error --output-on-failure},
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
-    env:
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_any
+          path: docker-job
       - name: Extract files
         run: tar -xvf ttm_any.tar
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -53,7 +53,11 @@ jobs:
         with:
           submodules: recursive
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
-      - uses: ./.github/actions/prepare-metal-run
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_any
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/17833

### Problem description
We need all workflows dockerized so we can flip the switch and move to ubuntu 22.04

### What's changed
Used native github workflow support for Docker.

### Checklist
- [x] [tt-train-cpp-tests](https://github.com/tenstorrent/tt-metal/actions/runs/13282236527/job/37083125033) CI passes
- [x] [All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/13282474165) CI passes
