### PR TITLE
#17829: binary_ng survey sweeps

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -325,6 +325,7 @@ on:
           - eltwise.binary.add.add_different_memory_configs
           - eltwise.binary.add.add_forge
           - eltwise.binary.add.add_llama
+          - eltwise.binary.add.add_ng_survey
           - eltwise.binary.atan2.atan2
           - eltwise.binary.atan2.atan2_sharded
           - eltwise.unary.gtz.gtz
@@ -347,6 +348,7 @@ on:
           - eltwise.unary_complex.angle_bw.angle_bw
           - eltwise.unary_complex.conj_bw
           - eltwise.binary.subtract.subtract
+          - eltwise.binary.subtract.subtract_ng_survey
           - eltwise.binary.subtract.subtract_tensor_pytorch2
           - eltwise.binary.subtract.subtract_forge
           - eltwise.binary.multiply.multiply
@@ -432,6 +434,17 @@ on:
           - eltwise.binary_backward.remainder_bw.remainder_bw
           - eltwise.binary_backward.rsub_bw.rsub_bw
           - eltwise.binary_backward.squared_difference_bw.squared_difference_bw
+          - eltwise.binary_ng.binary_ng
+          - eltwise.binary_ng.binary_ng_sub
+          - eltwise.binary_ng.binary_ng_mul
+          - eltwise.binary_ng.binary_ng_div
+          - eltwise.binary_ng.binary_ng_rsub
+          - eltwise.binary_ng.binary_ng_pow
+          - eltwise.binary_ng.binary_ng_activ
+          - eltwise.binary_ng.binary_ng_exp_ops
+          - eltwise.binary_ng.binary_ng_relational
+          - eltwise.binary_ng.binary_ng_logical
+          - eltwise.binary_ng.binary_ng_bitwise
           - eltwise.composite.binary.addalpha.addalpha
           - eltwise.composite.binary.subalpha.subalpha
           - eltwise.composite.binary.minimum.minimum
@@ -447,6 +460,7 @@ on:
           - eltwise.composite.binary.maximum.maximum_pytorch2
           - eltwise.composite.binary.maximum.maximum_forge
           - eltwise.composite.binary.pow.pow_pytorch2
+          - eltwise.composite.binary.pow.pow_ng_survey
           - eltwise.composite.binary.pow.pow_scalar_pytorch2
           - eltwise.composite.binary.pow.pow_tensor_pytorch2
           - eltwise.ternary.addcmul.addcmul

--- a/tests/sweep_framework/sweeps/eltwise/binary/add/add_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/add/add_ng_survey.py
@@ -1,0 +1,802 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# # ----- same dtype ------- #
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t8_ngadd_bf4b": {
+#         "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+#         # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], // for float32 and int32 dtypes
+#         # "input_a_dtype": [ttnn.bfloat16],
+#         # "input_b_dtype": [ttnn.bfloat16],
+#         # "input_a_dtype": [ttnn.float32],
+#         # "input_b_dtype": [ttnn.float32],
+#         # "input_a_dtype": [ttnn.int32],
+#         # "input_b_dtype": [ttnn.int32],
+#         # "input_a_dtype": [ttnn.bfloat8_b],
+#         # "input_b_dtype": [ttnn.bfloat8_b],
+#         "input_a_dtype": [ttnn.bfloat4_b],
+#         "input_b_dtype": [ttnn.bfloat4_b],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_b_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+#         ],
+#         # "input_a_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#         # "input_b_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#         # "out_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#     },
+# }
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 8, 512),
+#             shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512, 512 // 8),
+#             shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512, 512 // 8),
+#             shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 8, 512),
+#             shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 2, 512 // 4),
+#             shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 2, 512 // 4),
+#             shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_a_dtype,
+#     input_b_dtype,
+#     input_a_layout,
+#     input_b_layout,
+#     input_mem_config,
+#     # input_a_memory_config,
+#     # input_b_memory_config,
+#     # out_memory_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+#     )(input_shape["self"])
+
+#     if isinstance(input_shape["other"], list):
+#         torch_input_tensor_b = gen_func_with_cast_tt(
+#             partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+#         )(input_shape["other"])
+#     else:
+#         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+#     input_b_memory_config = input_mem_config["b_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     input_tensor_b = ttnn.from_torch(
+#         torch_input_tensor_b,
+#         dtype=input_b_dtype,
+#         layout=input_b_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_b_memory_config),
+#     )
+
+#     if input_a_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_b_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     if input_a_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_b_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.add)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+#     start_time = start_measuring_time()
+#     # result = ttnn.experimental.add(input_tensor_a, input_tensor_b, memory_config=return_mem_config(out_memory_config))
+#     result = ttnn.experimental.add(input_tensor_a, input_tensor_b)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# # sweeps output
+# # using ttnn.add - all 22 vectors pass
+# # | t4_add |  22  |            0            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.add - 16 vectors pass (bf16)
+# # | t5_ngadd |  16  |            6            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.add - 10 vectors pass (fp32) - 6 L1 fail (1,1,1024, 1024)
+# # | t5_ngadd_fp32 |  10  |            6            |         0         |    0    |          6           |       0        |               0                |
+# # using ttnn.experimental.add - 16 vectors pass (fp32) -(1,1,512, 512)
+# # | t6_ngadd_fp32 |  16  |            6            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.add - 16 vectors pass (int32) -(1,1,512, 512)
+# # | t6_ngadd_int32 |  16  |           6            |         0         |    0    |          0          |       0        |                0                |
+# # using ttnn.experimental.add - 4 vectors pass (bf8b) - all sharding configs fail with ( we typecast bf8b -> bf16)
+# # message TT_FATAL @ /home/ubuntu/Kalai/tt-metal/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp:45: input_tile_size == output_tile_size
+# # info:
+# # Input and output tile size should be same
+# # | t7_ngadd_bf8b  |  4   |           18           |         0         |    0    |          0          |       0        |                0                |
+# # using ttnn.experimental.add - 4 vectors pass (bf4b) - all sharding configs fail with ( we typecast bf4b -> bf16)
+# # message TT_FATAL @ /home/ubuntu/Kalai/tt-metal/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp:45: input_tile_size == output_tile_size
+# # info:
+# # Input and output tile size should be same
+# # | t8_ngadd_bf4b  |  4   |           18           |         0         |    0    |          0          |       0        |                0                |
+
+
+# # ----- tensor - scalar ------- #
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t12_add_int32": {
+#         # "input_shape": [{"self": [1, 1, 1024, 1024]}],
+#         "input_shape": [{"self": [1, 1, 512, 512]}],
+#         # "input_a_dtype": [ttnn.bfloat16],
+#         # "input_a_dtype": [ttnn.float32],
+#         "input_a_dtype": [ttnn.int32],
+#         # "input_a_dtype": [ttnn.bfloat8_b],
+#         # "input_a_dtype": [ttnn.bfloat4_b],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved"},
+#             {"a_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "l1_block_sharded_cm"},
+#         ],
+#     },
+# }
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_a_dtype,
+#     input_a_layout,
+#     input_mem_config,
+#     # input_a_memory_config,
+#     # input_b_memory_config,
+#     # out_memory_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+#     )(input_shape["self"])
+
+#     torch_input_b = random.randint(-100, 100)
+#     # torch_input_b = round(torch_input_b, 5)
+
+#     print("torch_input_b", torch_input_b)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     if input_a_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_a_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.add)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_b)
+
+#     start_time = start_measuring_time()
+#     result = ttnn.experimental.add(input_tensor_a, torch_input_b)
+#     print("result", result)
+#     print("torch_output_tensor", torch_output_tensor)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+# # sweeps output
+# # ---- bf16
+# # |     t2_ts      |  2   |           6           |        0         |    0    |         0          |       0        |               0                |
+# # shard Cannot broadcast sharded tensors on dims other than W, violation for rank -2, dim a: 1024, dim b: 1
+# # sub
+# # |     t2_sub     |  2   |           6           |        0         |    0    |         0          |       0        |               0                |
+# # |  t2_add_bf8b   |  2   |           6           |        0         |    0    |         0          |       0        |               0                |
+# # |  t4_add_bf4b   |  2   |           6           |        0         |    0    |         0          |       0        |               0                |
+# #|  t4_add_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |   t6_gt_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |   t6_lt_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t6_lte_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t7_gte_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t12_pow_fp32  |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t12_gt_fp32   |  4   |           12            |         0         |    0    |          0           |       0        |               0                |
+# # |  t12_gte_fp32  |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t12_lte_fp32  |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t12_lt_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # | t12_add_int32  |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# #
+
+
+# # ----- tensor - tensor - mixed dtype ------- #
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t2_mx_add_03": {
+#         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+#         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+#         "input_dtype": [
+#             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+#             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+#             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+#             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+#             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+#             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+#             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+#             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+#             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+#             # |  t2_mx_add_00  |  69  |           195           |         0         |    0    |          0           |       0        |               0                |
+#             # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+#             # |  t2_mx_add_01  |  0   |           22            |         0         |    0    |          0           |       0        |               0                |
+#             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+#             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+#             # |  t2_mx_add_02  |  0   |           44            |         0         |    0    |          0           |       0        |               0                |
+#         ],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_b_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+#             # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+#             # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+#             # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+#             # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+#             # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+#             # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+#             # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+#             # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+#             # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+#             # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+#             # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+#             # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+#             # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+#             # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+#             # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+#             # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+#             # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+#             # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+#         ],
+#     },
+# }
+
+
+# def return_dtype(dtype):
+#     if dtype == "ttnn.bfloat16":
+#         return ttnn.bfloat16
+#     elif dtype == "ttnn.float32":
+#         return ttnn.float32
+#     elif dtype == "ttnn.bfloat8_b":
+#         return ttnn.bfloat8_b
+#     elif dtype == "ttnn.bfloat4_b":
+#         return ttnn.bfloat4_b
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_dtype,
+#     input_a_layout,
+#     input_b_layout,
+#     input_mem_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+#     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+#     )(input_shape["self"])
+
+#     if isinstance(input_shape["other"], list):
+#         torch_input_tensor_b = gen_func_with_cast_tt(
+#             partial(torch_random, low=-99, high=101, dtype=torch.float32), input_b_dtype
+#         )(input_shape["other"])
+#     else:
+#         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+#     input_b_memory_config = input_mem_config["b_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     input_tensor_b = ttnn.from_torch(
+#         torch_input_tensor_b,
+#         dtype=input_b_dtype,
+#         layout=input_b_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_b_memory_config),
+#     )
+
+#     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+#     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.add)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+#     start_time = start_measuring_time()
+#     result = ttnn.experimental.add(input_tensor_a, input_tensor_b)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# ----- same dtype , bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_05": {
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], // for float32 and int32 dtypes
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_b_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_b_dtype": [ttnn.float32],
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_b_dtype": [ttnn.bfloat8_b],
+        # "input_a_dtype": [ttnn.bfloat4_b],
+        # "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.int32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.add)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    # result = ttnn.experimental.add(input_tensor_a, input_tensor_b, memory_config=return_mem_config(out_memory_config))
+    result = ttnn.experimental.add(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# output
+# bf16 - interleaved
+# |  t1_bcast_01   |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+#  bf4b
+# |  t1_bcast_02   |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+#  bf8b
+# |  t1_bcast_03   |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+# fp32
+# |  t1_bcast_04   |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+# int32
+# |  t1_bcast_05   |  32  |            0            |         0         |    0    |          0           |       0        |               0                |

--- a/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_ng_survey.py
@@ -1,0 +1,779 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t3_sub_int32": {
+#         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+#         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+#         # "input_a_dtype": [ttnn.bfloat16],
+#         # "input_b_dtype": [ttnn.bfloat16],
+#         # "input_a_dtype": [ttnn.float32],
+#         # "input_b_dtype": [ttnn.float32],
+#         "input_a_dtype": [ttnn.int32],
+#         "input_b_dtype": [ttnn.int32],
+#         # "input_a_dtype": [ttnn.bfloat8_b],
+#         # "input_b_dtype": [ttnn.bfloat8_b],
+#         # "input_a_dtype": [ttnn.bfloat4_b],
+#         # "input_b_dtype": [ttnn.bfloat4_b],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_b_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+#         ],
+#         # "input_a_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#         # "input_b_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#         # "out_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#     },
+# }
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_a_dtype,
+#     input_b_dtype,
+#     input_a_layout,
+#     input_b_layout,
+#     input_mem_config,
+#     # input_a_memory_config,
+#     # input_b_memory_config,
+#     # out_memory_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+#     )(input_shape["self"])
+
+#     if isinstance(input_shape["other"], list):
+#         torch_input_tensor_b = gen_func_with_cast_tt(
+#             partial(torch_random, low=-100, high=100, dtype=torch.int32), input_b_dtype
+#         )(input_shape["other"])
+#     else:
+#         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+#     input_b_memory_config = input_mem_config["b_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     input_tensor_b = ttnn.from_torch(
+#         torch_input_tensor_b,
+#         dtype=input_b_dtype,
+#         layout=input_b_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_b_memory_config),
+#     )
+
+#     if input_a_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_b_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     if input_a_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_b_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.sub)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+#     start_time = start_measuring_time()
+#     # result = ttnn.experimental.sub(input_tensor_a, input_tensor_b, memory_config=return_mem_config(out_memory_config))
+#     result = ttnn.experimental.sub(input_tensor_a, input_tensor_b)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# # sweeps output
+# # using ttnn.sub - bf16 - all 22 vectors pass
+# # +--------+------+-------------------------+-------------------+---------+----------------------+----------------+--------------------------------+
+# # |        | PASS | FAIL (ASSERT/EXCEPTION) | FAIL (CRASH/HANG) | NOT RUN | FAIL (L1 Out of Mem) | FAIL (Watcher) | FAIL (Unsupported Device Perf) |
+# # +--------+------+-------------------------+-------------------+---------+----------------------+----------------+--------------------------------+
+# # | t1_sub |  22  |            0            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.sub  - bf16
+# # +--------+------+-------------------------+-------------------+---------+----------------------+----------------+--------------------------------+
+# # | t2_sub |  16  |            6            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.sub  - bf8b
+# # | t3_sub_bf8b |  4   |           18            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.sub  - bf4b
+# # | t3_sub_bf4b |  4   |           18            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.sub  - fp32
+# # | t3_sub_fp32 |  16  |            6            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.sub  - fp32
+# # | t3_sub_int32 |  0   |           22            |         0         |    0    |          0           |       0        |               0                |
+
+
+# # ----- tensor - scalar ------- #
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t4_sub_bf4b": {
+#         "input_shape": [{"self": [1, 1, 1024, 1024]}],
+#         # "input_a_dtype": [ttnn.bfloat16],
+#         "input_a_dtype": [ttnn.float32],
+#         # "input_a_dtype": [ttnn.int32],
+#         # "input_a_dtype": [ttnn.bfloat8_b],
+#         # "input_a_dtype": [ttnn.bfloat4_b],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved"},
+#             {"a_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "l1_block_sharded_cm"},
+#         ],
+#     },
+# }
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 8, 512),
+#             shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512, 512 // 8),
+#             shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512, 512 // 8),
+#             shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 8, 512),
+#             shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 2, 512 // 4),
+#             shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 2, 512 // 4),
+#             shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_a_dtype,
+#     input_a_layout,
+#     input_mem_config,
+#     # input_a_memory_config,
+#     # input_b_memory_config,
+#     # out_memory_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+#     )(input_shape["self"])
+
+#     torch_input_b = random.uniform(-100, 100)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     if input_a_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_a_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.sub)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_b)
+
+#     start_time = start_measuring_time()
+#     result = ttnn.experimental.sub(input_tensor_a, torch_input_b)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# # sweeps output
+# # shard Cannot broadcast sharded tensors on dims other than W, violation for rank -2, dim a: 1024, dim b: 1
+# # sub
+# # ---- bf16
+# # |     t2_sub     |  2   |           6           |        0         |    0    |         0          |       0        |               0                |
+# # |  t4_add_bf4b   |  2   |           6           |        0         |    0    |         0          |       0        |               0                |
+# # |  t4_sub_bf8b   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# # |  t4_sub_fp32   |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# #
+
+# # ----- tensor - tensor - mixed dtype ------- #
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t2_mx_sub_01": {
+#         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+#         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+#         "input_dtype": [
+#             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+#             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+#             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+#             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+#             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+#             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+#             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+#             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+#             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+#             # | t2_mx_sub_00 |  69  |           129           |         0         |    0    |          0           |       0        |               0                |
+#             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+#             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+#             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+#             # | t2_mx_sub_01 |  0   |           66            |         0         |    0    |          0           |       0        |               0                |
+#         ],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_b_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+#         ],
+#     },
+# }
+
+
+# def return_dtype(dtype):
+#     if dtype == "ttnn.bfloat16":
+#         return ttnn.bfloat16
+#     elif dtype == "ttnn.float32":
+#         return ttnn.float32
+#     elif dtype == "ttnn.bfloat8_b":
+#         return ttnn.bfloat8_b
+#     elif dtype == "ttnn.bfloat4_b":
+#         return ttnn.bfloat4_b
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512, 512 // 8),
+#             # shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 8, 512),
+#             # shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             shape=(512 // 2, 512 // 4),
+#             # shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_dtype,
+#     input_a_layout,
+#     input_b_layout,
+#     input_mem_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+#     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+#     )(input_shape["self"])
+
+#     if isinstance(input_shape["other"], list):
+#         torch_input_tensor_b = gen_func_with_cast_tt(
+#             partial(torch_random, low=-99, high=101, dtype=torch.float32), input_b_dtype
+#         )(input_shape["other"])
+#     else:
+#         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+#     input_b_memory_config = input_mem_config["b_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     input_tensor_b = ttnn.from_torch(
+#         torch_input_tensor_b,
+#         dtype=input_b_dtype,
+#         layout=input_b_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_b_memory_config),
+#     )
+
+#     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+#     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.sub)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+#     start_time = start_measuring_time()
+#     result = ttnn.experimental.sub(input_tensor_a, input_tensor_b)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# ----- same dtype , bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], // for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.bfloat16],
+        "input_b_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_b_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_b_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_b_dtype": [ttnn.bfloat8_b],
+        # "input_a_dtype": [ttnn.bfloat4_b],
+        # "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.sub)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.sub(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# output
+# bf16 - interleaved
+# | t1_bcast_01  |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+#  bf4b
+# | t1_bcast_02  |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+#  bf8b
+# | t1_bcast_03  |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+# fp32
+# | t1_bcast_04  |  32  |            0            |         0         |    0    |          0           |       0        |               0                |
+# int32
+# | t1_bcast_05  |  0   |           32            |         0         |    0    |          0           |       0        |               0                |

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_13": {
+        "binary_op": [
+            {"tt_op": "add", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            # {"tt_op" :"sub"},
+            # {"tt_op" :"rsub"},
+            # {"tt_op" :"mul"},
+            # {"tt_op" :"div"},
+            # {"tt_op" :"gte"},
+            # {"tt_op" :"gt"},
+            # {"tt_op" :"lte"},
+            # {"tt_op" :"lt"},
+            # {"tt_op" :"eq"},
+            # {"tt_op" :"ne"},
+            # {"tt_op" :"logical_and"},
+            # {"tt_op" :"logical_or"},
+            # {"tt_op" :"logical_xor"},
+            # {"tt_op" :"ldexp"},
+            # {"tt_op" :"logaddexp"},
+            # {"tt_op" :"logaddexp2"},
+            # {"tt_op" :"squared_difference"},
+            # {"tt_op" :"bias_gelu"},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"},  # only for add/bitwise
+        ],
+        # currently we're checking for either TILE-TILE or RM-RM (yet-to). not yet, for mixed layouts
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_04": {
+        "binary_op": [
+            {"tt_op": "add", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_activ.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_activ.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_00": {
+        "binary_op": [
+            {"tt_op": "squared_difference", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "bias_gelu", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+        ],
+        # currently we're checking for either TILE-TILE or RM-RM (yet-to). not yet, for mixed layouts
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+        # torch ops don't have b-scalar
+        torch_input_tensor_b = torch.full_like(torch_input_tensor_a, input_tensor_b)
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+        # torch ops don't have b-scalar
+        torch_input_tensor_b = torch.full_like(torch_input_tensor_a, input_tensor_b)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "squared_difference", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "bias_gelu", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_bitwise.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_bitwise.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_00": {
+        "binary_op": [
+            {"tt_op": "bitwise_and", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            {"tt_op": "bitwise_or", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            {"tt_op": "bitwise_xor", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            {"tt_op": "bitwise_left_shift", "a_high": 1000, "b_high": 31, "a_low": -1000, "b_low": 0},
+            {"tt_op": "bitwise_right_shift", "a_high": 1000, "b_high": 31, "a_low": -1000, "b_low": 0},
+        ],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"},  # only for add/bitwise
+        ],
+        # currently we're checking for either TILE-TILE or RM-RM (yet-to). not yet, for mixed layouts
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "bitwise_and", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            {"tt_op": "bitwise_or", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            {"tt_op": "bitwise_xor", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+            {"tt_op": "bitwise_left_shift", "a_high": 1000, "b_high": 31, "a_low": -1000, "b_low": 0},
+            {"tt_op": "bitwise_right_shift", "a_high": 1000, "b_high": 31, "a_low": -1000, "b_low": 0},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_div.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_div.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_02": {
+        "binary_op": [
+            {"tt_op": "divide", "a_high": 100, "a_low": -100, "b_high": 100, "b_low": 1},
+            {"tt_op": "divide", "a_high": 100, "a_low": -100, "b_high": -1, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    if input_b_dtype == ttnn.float32:
+        b_low = input_dtype["b_low"]
+        b_high = input_dtype["b_high"]
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_02": {
+        "binary_op": [
+            {"tt_op": "div", "a_high": 100, "a_low": -100, "b_high": 100, "b_low": 1},
+            {"tt_op": "div", "a_high": 100, "a_low": -100, "b_high": -1, "b_low": -100},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_exp_ops.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_exp_ops.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_01": {
+        "binary_op": [
+            {"tt_op": "ldexp", "a_high": 50, "b_high": 50, "a_low": -50, "b_low": -50},
+            {"tt_op": "logaddexp", "a_high": 50, "b_high": 50, "a_low": -50, "b_low": -50},
+            {"tt_op": "logaddexp2", "a_high": 50, "b_high": 50, "a_low": -50, "b_low": -50},
+            # {"tt_op": "ldexp", "a_high": 60, "b_high": 60, "a_low": -60, "b_low": -60},
+            # {"tt_op": "logaddexp", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            # {"tt_op": "logaddexp2", "a_high": 71, "b_high": 71, "a_low": -71, "b_low": -71},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+        ],
+        # currently we're checking for either TILE-TILE or RM-RM (yet-to). not yet, for mixed layouts
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+        # torch exp ops don't have b-scalar
+        torch_input_tensor_b = torch.full_like(torch_input_tensor_a, input_tensor_b)
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+        # torch exp ops don't have b-scalar
+        torch_input_tensor_b = torch.full_like(torch_input_tensor_a, input_tensor_b)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "ldexp", "a_high": 50, "b_high": 50, "a_low": -50, "b_low": -50},
+            {"tt_op": "logaddexp", "a_high": 50, "b_high": 50, "a_low": -50, "b_low": -50},
+            {"tt_op": "logaddexp2", "a_high": 50, "b_high": 50, "a_low": -50, "b_low": -50},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_logical.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_logical.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_01": {
+        "binary_op": [
+            {"tt_op": "logical_and", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "logical_or", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "logical_xor", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+        # torch logical don't have b-scalar
+        torch_input_tensor_b = torch.full_like(torch_input_tensor_a, input_tensor_b)
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+        # torch logical don't have b-scalar
+        torch_input_tensor_b = torch.full_like(torch_input_tensor_a, input_tensor_b)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "logical_and", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "logical_or", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "logical_xor", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_mul.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_mul.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_02": {
+        "binary_op": [
+            {"tt_op": "mul", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    if input_a_dtype == ttnn.bfloat4_b and input_b_dtype == ttnn.bfloat4_b:
+        a_high = 98
+        b_high = 98
+        a_low = -98
+        b_low = -98
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "mul", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_pow.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_pow.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_00": {
+        "binary_op": [
+            {"tt_op": "pow", "a_high": 30, "a_low": -30, "b_high": 20, "b_low": -20},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32", "b_high": 100, "b_low": -100},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    if input_b_dtype == ttnn.bfloat8_b or input_b_dtype == ttnn.bfloat4_b:
+        b_low = 1
+        b_high = 10
+        a_low = 0
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "pow", "a_high": 30, "a_low": -30, "b_high": 20, "b_low": -20},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    if input_b_dtype == ttnn.bfloat8_b or input_b_dtype == ttnn.bfloat4_b:
+        b_low = 1
+        b_high = 10
+        a_low = 0
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_relational.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_relational.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_01": {
+        "binary_op": [
+            {"tt_op": "gte", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "gt", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "lte", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "lt", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "eq", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+            {"tt_op": "ne", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "gte", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "gt", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "lte", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "lt", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "eq", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+            {"tt_op": "ne", "a_high": 1000, "b_high": 1000, "a_low": -1000, "b_low": -1000},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_rsub.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_rsub.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_00": {
+        "binary_op": [
+            {"tt_op": "rsub", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "rsub", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_sub.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_sub.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import ttnn
+import random
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "tt_test_09": {
+        "binary_op": [
+            {"tt_op": "sub", "a_high": 100, "b_high": 100, "a_low": -100, "b_low": -100},
+        ],
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"}, # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "none"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "none"},  # tensor-scalar
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "none"}, # only for add/bitwise
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
+    elif dtype == "none":
+        return None
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+    torch_input_tensor_b = None
+    input_tensor_b = None
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list) and input_b_dtype != None:
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    if input_b_dtype == None and input_a_dtype == ttnn.int32:
+        torch_input_tensor_b = random.randint(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+    elif input_b_dtype == None:
+        torch_input_tensor_b = random.uniform(b_low, b_high)
+        input_tensor_b = torch_input_tensor_b
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_b_dtype != None:
+        input_tensor_b = ttnn.from_torch(
+            torch_input_tensor_b,
+            dtype=input_b_dtype,
+            layout=input_b_layout,
+            device=device,
+            memory_config=return_mem_config(input_b_memory_config),
+        )
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# -----  bcast ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_01": {
+        "binary_op": [
+            {"tt_op": "sub", "a_high": 1000, "b_high": 900, "a_low": -1000, "b_low": -900},
+        ],
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        "input_dtype": [
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+        ],
+    },
+}
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    binary_op,
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    ttnn_fn = getattr(ttnn, binary_op["tt_op"])
+    a_high = binary_op["a_high"]
+    b_high = binary_op["b_high"]
+    a_low = binary_op["a_low"]
+    b_low = binary_op["b_low"]
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=a_low, high=a_high, dtype=torch_dtype), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=b_low, high=b_high, dtype=torch_dtype), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_fn)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn_fn(input_tensor_a, input_tensor_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/pow/pow_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/pow/pow_ng_survey.py
@@ -1,0 +1,618 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# # Parameters provided to the test vector generator are defined here.
+# # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# # Developers can create their own generator functions and pass them to the parameters as inputs.
+# parameters = {
+#     "t6_pow_bf4b_range": {
+#         "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+#         # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
+#         # "input_a_dtype": [ttnn.bfloat16],
+#         # "input_b_dtype": [ttnn.bfloat16],
+#         # "input_a_dtype": [ttnn.float32],
+#         # "input_b_dtype": [ttnn.float32],
+#         # "input_a_dtype": [ttnn.int32],
+#         # "input_b_dtype": [ttnn.int32],
+#         # "input_a_dtype": [ttnn.bfloat8_b],
+#         # "input_b_dtype": [ttnn.bfloat8_b],
+#         "input_a_dtype": [ttnn.bfloat4_b],
+#         "input_b_dtype": [ttnn.bfloat4_b],
+#         "input_a_layout": [ttnn.TILE_LAYOUT],
+#         "input_b_layout": [ttnn.TILE_LAYOUT],
+#         "input_mem_config": [
+#             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+#             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combi
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+#             {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+#             {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+#             {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+#             {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+#             {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+#             {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+#         ],
+#         # "input_a_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#         # "input_b_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#         # "out_memory_config": [
+#         #     "l1_interleaved",
+#         #     "dram_interleaved",
+#         #     "l1_height_sharded_rm",
+#         #     "l1_width_sharded_rm",
+#         #     "l1_block_sharded_rm",
+#         # ],
+#     },
+# }
+
+
+# def return_mem_config(mem_config_string):
+#     if mem_config_string == "l1_interleaved":
+#         return ttnn.L1_MEMORY_CONFIG
+#     elif mem_config_string == "dram_interleaved":
+#         return ttnn.DRAM_MEMORY_CONFIG
+#     elif mem_config_string == "l1_height_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 8, 512),
+#             shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_height_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512, 512 // 8),
+#             shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.HEIGHT,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512, 512 // 8),
+#             shape=(1024, 1024 // 8),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_width_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 8, 512),
+#             shape=(1024 // 8, 1024),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.WIDTH,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_rm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 2, 512 // 4),
+#             shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.ROW_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     elif mem_config_string == "l1_block_sharded_cm":
+#         return ttnn.create_sharded_memory_config(
+#             # shape=(512 // 2, 512 // 4),
+#             shape=(1024 // 2, 1024 // 4),
+#             core_grid=ttnn.CoreGrid(y=2, x=4),
+#             strategy=ttnn.ShardStrategy.BLOCK,
+#             orientation=ttnn.ShardOrientation.COL_MAJOR,
+#             use_height_and_width_as_shard_shape=True,
+#         )
+#     raise ("Input mem_config_string is not valid!")
+
+
+# # This is the run instructions for the test, defined by the developer.
+# # The run function must take the above-defined parameters as inputs.
+# # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# def run(
+#     input_shape,
+#     input_a_dtype,
+#     input_b_dtype,
+#     input_a_layout,
+#     input_b_layout,
+#     input_mem_config,
+#     # input_a_memory_config,
+#     # input_b_memory_config,
+#     # out_memory_config,
+#     *,
+#     device,
+# ) -> list:
+#     torch.manual_seed(0)
+
+#     torch_input_tensor_a = gen_func_with_cast_tt(
+#         partial(torch_random, low=0, high=30, dtype=torch.bfloat16), input_a_dtype
+#     )(input_shape["self"])
+
+#     if isinstance(input_shape["other"], list):
+#         torch_input_tensor_b = gen_func_with_cast_tt(
+#             partial(torch_random, low=1, high=10, dtype=torch.bfloat16), input_b_dtype
+#         )(input_shape["other"])
+#     else:
+#         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+
+#     input_a_memory_config = input_mem_config["a_mem"]
+#     input_b_memory_config = input_mem_config["b_mem"]
+
+#     input_tensor_a = ttnn.from_torch(
+#         torch_input_tensor_a,
+#         dtype=input_a_dtype,
+#         layout=input_a_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_a_memory_config),
+#     )
+
+#     input_tensor_b = ttnn.from_torch(
+#         torch_input_tensor_b,
+#         dtype=input_b_dtype,
+#         layout=input_b_layout,
+#         device=device,
+#         memory_config=return_mem_config(input_b_memory_config),
+#     )
+
+#     if input_a_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_b_dtype == ttnn.bfloat8_b:
+#         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     if input_a_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+#     if input_b_dtype == ttnn.bfloat4_b:
+#         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+#     golden_function = ttnn.get_golden_function(ttnn.experimental.pow)
+#     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+#     start_time = start_measuring_time()
+#     # result = ttnn.experimental.pow(input_tensor_a, input_tensor_b, memory_config=return_mem_config(out_memory_config))
+#     result = ttnn.experimental.pow(input_tensor_a, input_tensor_b)
+#     output_tensor = ttnn.to_torch(result)
+#     e2e_perf = stop_measuring_time(start_time)
+
+#     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# # sweeps output
+# # using ttnn.pow - only 4 non-sharding pass
+# # | t1_pow_elt |  4   |           18            |         0         |    0    |          0           |       0        |               0                |
+# # using ttnn.experimental.pow - 16 vectors pass (bf16)
+# # | t1_pow |  16  |            6            |         0         |    0    |          0           |       0        |               0                |
+# # # using ttnn.experimental.pow - 10 vectors pass (fp32) - 6 L1 fail (1,1,1024, 1024)
+# # using ttnn.experimental.pow - 16 vectors pass (fp32) -(1,1,512, 512)
+# # | t4_pow_fp32 |  16  |           6           |        0         |    0    |         0          |       0        |               0                |
+# # using ttnn.experimental.pow - ( we typecast bf8b -> bf16)
+# # using -30 to 30 and -20 to 20
+# # | t3_pow_bf8b |  0   |          22           |        0         |    0    |         0          |       0        |               0                |
+# # using 0 to 30 and 1 to 10
+# # | t6_pow_bf8b_ran |  4   |          18          |        0         |    0    |         0         |       0        |              0               |
+# # |       ge        |      |                      |                  |         |                   |                |                              |
+# # using ttnn.experimental.pow
+# # using -30 to 30 and -20 to 20
+# # | t3_pow_bf4b |  0   |          22           |        0         |    0    |         0          |       0        |               0                |
+# # using 0 to 30 and 1 to 10
+# # | t6_pow_bf4b_ran |  4   |          18          |        0         |    0    |         0         |       0        |              0               |
+# # |       ge        |      |                      |                  |         |                   |                |                              |
+# # using ttnn.experimental.pow -  int32
+# # | t4_pow_int32 |  0   |          22           |        0         |    0    |         0          |       0        |               0               |
+
+
+# bcast shapes - test
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_bcast_11": {
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=0, high=30, dtype=torch.float32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=1, high=10, dtype=torch.float32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.pow)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.pow(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+# output
+#  bcast - same dtypes - interleaved
+# bf16 - 4
+# fp32 - 8
+# |  t1_bcast_03   |  52  |         12         |       0        |    0    |        0         |       0        |
+# bf16 for 0-30, 1,10 range
+# |  t1_bcast_06   |  32  |         0          |       0        |    0    |        0         |       0        |             0              |           0              |
+# fp32 for 0-30, 1,10 range
+# |  t1_bcast_05   |  32  |         0          |       0        |    0    |        0         |       0        |             0              |
+# bf8b
+# |  t1_bcast_04   |  32  |         0          |       0        |    0    |        0         |       0        |             0              |
+# bf4b
+# |  t1_bcast_07   |  32  |         0          |       0        |    0    |        0         |       0        |             0              |
+#
+# bf16 - fp32
+# |  t1_bcast_11   |  12  |         20         |       0        |    0    |        0         |       0        |             0              |
+#
+
+
+# ----- tensor - scalar ------- #
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "t1_scalar_05": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512]}],
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved"},
+            {"a_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm"},
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_a_layout,
+    input_mem_config,
+    # input_a_memory_config,
+    # input_b_memory_config,
+    # out_memory_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-30, high=30, dtype=torch.bfloat16), input_a_dtype
+    )(input_shape["self"])
+
+    torch_input_b = random.uniform(-20, 20)
+    # torch_input_b = round(torch_input_b, 5)
+
+    print("torch_input_b", torch_input_b)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.pow)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.pow(input_tensor_a, torch_input_b)
+    # print("result", result)
+    # print("torch_output_tensor", torch_output_tensor)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]
+
+
+#  output - tensor scalar
+#  bf16 and fp32
+# |   t1_scalar_03    |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# |   t1_scalar_02    |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# bf8b , bf4b
+# |   t1_scalar_04    |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+# |   t1_scalar_05    |  2   |            6            |         0         |    0    |          0           |       0        |               0                |
+#

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -275,6 +275,7 @@ void set_or_update_runtime_arguments(
     }
 
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        // tt::log_info(tt::LogOp, "********  start_tile_id : {}", start_tile_id);
         const auto& core = cores[i];
 
         uint32_t a_num_tiles = 0;


### PR DESCRIPTION
### Ticket
Link to Github Issue #17829

### Problem description
Survey tests to record available and unavailable functional support for various cases in binary_ng ops

### What's changed
- tested ops for same types, mixed dtypes, tensor-scalar (bfloat16, float32, int32, bfloat8_b, bfloat4_b)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
