### PR TITLE
[skip ci] #0: Fix crash due to strict xml filename checking

### DIFF
--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -24,9 +24,15 @@ def get_workflow_run_uuids_to_test_reports_paths_(workflow_outputs_dir, workflow
         assert test_report_dir.is_dir(), f"{test_report_dir} is not dir"
 
         test_report_uuid = test_report_dir.name.replace("test_reports_", "")
-        workflow_run_test_reports_path[test_report_uuid] = (test_report_dir / "most_recent_tests.xml").resolve(
-            strict=True
-        )
+
+        try:
+            xml_file_paths = (test_report_dir / "most_recent_tests.xml").resolve(strict=True)
+        except FileNotFoundError as e:
+            logger.warning(
+                f"no pytest xml file found matching most_recent_tests.xml (likely gtest xml) in {test_report_dir}"
+            )
+        else:
+            workflow_run_test_reports_path[test_report_uuid] = xml_file_paths
 
     return workflow_run_test_reports_path
 


### PR DESCRIPTION
Fix crash due to strict filename checking (gtest xmls don't necessarily match the name)

### Ticket
Link to Github Issue

### Problem description
Temporary fix for the strict filename checking (https://github.com/tenstorrent/tt-metal/actions/runs/13290740712/job/37110666839). Correct checking of all xml paths is WIP in https://github.com/tenstorrent/tt-metal/tree/williamly/data-pipeline-gtest-upload

### What's changed
Add try-except block to catch FileNotFound exception thrown 

### Checklist
- [x] New/Existing tests provide coverage for changes
https://github.com/tenstorrent/tt-metal/actions/runs/13291104817/job/37111891262