### PR TITLE
Fall back to non-instruct prompt encoding if required

### DIFF
--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -1540,9 +1540,13 @@ class TtModelArgs:
                 return self.tokenizer.encode(prompt_text, bos=True, eos=False)
         else:
             if instruct:
-                return encode_prompt_hf(self.tokenizer, prompt_text, system_prompt_text)
-            else:
-                return self.tokenizer.encode(prompt_text, add_special_tokens=False)
+                try:
+                    return encode_prompt_hf(self.tokenizer, prompt_text, system_prompt_text)
+                except ValueError as e:
+                    logger.warning(f"Failed to encode chat prompt, are you sure this is an instruct model? Error: {e}")
+                    logger.warning(f"Falling back to base model encoding with no chat template")
+
+            return self.tokenizer.encode(prompt_text, add_special_tokens=False)
 
     def reference_lm_head(self):
         if self.checkpoint_type == CheckpointType.Meta:


### PR DESCRIPTION
### Problem description
HuggingFace models raise an error if you try to use a chat template and they are not instruct-tuned or are too old to have a template provided. This stops us sweeping them to see which architectures are compatible with our code.

### What's changed
Fall back to using base-model prompt encoding without a chat template if huggingface says none is available, show a clear warning to the user. This doesn't affect existing model tests as we don't have HF tests in CI yet.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13293185990) CI passes
