### PR TITLE
 #17846: Make build_artifact dependent on create-tag

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build-artifact:
+    needs: create-tag
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
### Ticket

#17846 

### Problem description

The build file created would have the older tag being part of the name. See example in 
https://github.com/tenstorrent/tt-metal/releases/tag/v0.56.0-rc24
with the wheel file having the name of `ttnn-0.56.0rc19.dev3+any-cp38-cp38-linux_x86_64.whl`

### What's changed

In setup.py, there is a class that determines the version name and it relies on inferring the available tags in the git checkout.
We have unbound the job named `build-artifact` from `create-tag`. This meant that the tag was not created before the wheel was created. Adding the dependency fixed the problem.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
