### PR TITLE
Create workflow to mirror a branch from fork

### DIFF
--- a/.github/workflows/mirror-fork-branch.yaml
+++ b/.github/workflows/mirror-fork-branch.yaml
@@ -1,16 +1,14 @@
 name: Mirror Fork Branch to Origin
+
 on:
   workflow_dispatch:
     inputs:
-      fork_repo:
-        description: 'Full name of the fork repository (e.g., user/repo)'
-        required: true
-      branch:
-        description: 'Branch name in the fork to mirror'
+      source:
+        description: 'Source in format <fork_owner>:<branch> (e.g., philei-tt:philei/speed-up-host-tilizing)'
         required: true
       target_branch:
         description: >
-          Target branch name in origin (optional). If not provided, the branch will be named
+          Optional. Target branch name in origin. If not provided, the branch will be named
           `mirror/<fork_owner>/<branch>`.
         required: false
 
@@ -18,8 +16,30 @@ jobs:
   mirror-fork-branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Parse input
+        id: parse_input
+        shell: bash
+        run: |
+          # Expect input format: <fork_owner>:<branch>
+          IFS=":" read -r FORK_OWNER SRC_BRANCH <<< "${{ github.event.inputs.source }}"
+          if [ -z "$FORK_OWNER" ] || [ -z "$SRC_BRANCH" ]; then
+            echo "Error: Input must be in the format <fork_owner>:<branch>"
+            exit 1
+          fi
+          # Derive the fork repository name from the current repository.
+          ORIGIN_REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          FORK_REPO="${FORK_OWNER}/${ORIGIN_REPO_NAME}"
+          echo "FORK_OWNER: $FORK_OWNER"
+          echo "Source branch: $SRC_BRANCH"
+          echo "Fork repository: $FORK_REPO"
+          echo "fork_owner=$FORK_OWNER" >> $GITHUB_OUTPUT
+          echo "src_branch=$SRC_BRANCH" >> $GITHUB_OUTPUT
+          echo "fork_repo=$FORK_REPO" >> $GITHUB_OUTPUT
+
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
@@ -28,34 +48,33 @@ jobs:
 
       - name: Add fork remote and fetch branch
         run: |
-          echo "Adding remote for fork: ${{ github.event.inputs.fork_repo }}"
-          # If the remote already exists, ignore the error.
-          git remote add fork https://github.com/${{ github.event.inputs.fork_repo }}.git || echo "Remote 'fork' already exists"
-          echo "Fetching branch: ${{ github.event.inputs.branch }}"
-          git fetch fork ${{ github.event.inputs.branch }}
+          echo "Adding remote for fork: ${{ steps.parse_input.outputs.fork_repo }}"
+          git remote add fork https://github.com/${{ steps.parse_input.outputs.fork_repo }}.git || echo "Remote 'fork' already exists"
+          echo "Fetching branch: ${{ steps.parse_input.outputs.src_branch }}"
+          git fetch fork ${{ steps.parse_input.outputs.src_branch }}
 
       - name: Create or update local branch from fork branch
         id: create_branch
+        shell: bash
         run: |
           # Determine the target branch name.
           if [ -n "${{ github.event.inputs.target_branch }}" ]; then
             TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
           else
-            FORK_OWNER=$(echo "${{ github.event.inputs.fork_repo }}" | cut -d'/' -f1)
-            TARGET_BRANCH="mirror/${FORK_OWNER}/${{ github.event.inputs.branch }}"
+            TARGET_BRANCH="mirror/${{ steps.parse_input.outputs.fork_owner }}/${{ steps.parse_input.outputs.src_branch }}"
           fi
           echo "Using target branch: $TARGET_BRANCH"
 
-          # Check if the branch already exists locally.
+          # If the branch exists locally, reset it; otherwise, create it.
           if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
-            echo "Branch '$TARGET_BRANCH' exists locally. Updating with latest commits from fork."
+            echo "Branch '$TARGET_BRANCH' exists. Updating with latest commits from fork."
             git checkout "$TARGET_BRANCH"
-            git reset --hard "fork/${{ github.event.inputs.branch }}"
+            git reset --hard "fork/${{ steps.parse_input.outputs.src_branch }}"
           else
-            echo "Branch '$TARGET_BRANCH' does not exist locally. Creating it from fork branch."
-            git checkout -b "$TARGET_BRANCH" "fork/${{ github.event.inputs.branch }}"
+            echo "Branch '$TARGET_BRANCH' does not exist. Creating it from fork branch."
+            git checkout -b "$TARGET_BRANCH" "fork/${{ steps.parse_input.outputs.src_branch }}"
           fi
-          echo "::set-output name=target_branch::$TARGET_BRANCH"
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Push branch to origin
         run: |

--- a/.github/workflows/mirror-fork-branch.yaml
+++ b/.github/workflows/mirror-fork-branch.yaml
@@ -1,0 +1,64 @@
+name: Mirror Fork Branch to Origin
+on:
+  workflow_dispatch:
+    inputs:
+      fork_repo:
+        description: 'Full name of the fork repository (e.g., user/repo)'
+        required: true
+      branch:
+        description: 'Branch name in the fork to mirror'
+        required: true
+      target_branch:
+        description: >
+          Target branch name in origin (optional). If not provided, the branch will be named
+          `mirror/<fork_owner>/<branch>`.
+        required: false
+
+jobs:
+  mirror-fork-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add fork remote and fetch branch
+        run: |
+          echo "Adding remote for fork: ${{ github.event.inputs.fork_repo }}"
+          # If the remote already exists, ignore the error.
+          git remote add fork https://github.com/${{ github.event.inputs.fork_repo }}.git || echo "Remote 'fork' already exists"
+          echo "Fetching branch: ${{ github.event.inputs.branch }}"
+          git fetch fork ${{ github.event.inputs.branch }}
+
+      - name: Create or update local branch from fork branch
+        id: create_branch
+        run: |
+          # Determine the target branch name.
+          if [ -n "${{ github.event.inputs.target_branch }}" ]; then
+            TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+          else
+            FORK_OWNER=$(echo "${{ github.event.inputs.fork_repo }}" | cut -d'/' -f1)
+            TARGET_BRANCH="mirror/${FORK_OWNER}/${{ github.event.inputs.branch }}"
+          fi
+          echo "Using target branch: $TARGET_BRANCH"
+
+          # Check if the branch already exists locally.
+          if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+            echo "Branch '$TARGET_BRANCH' exists locally. Updating with latest commits from fork."
+            git checkout "$TARGET_BRANCH"
+            git reset --hard "fork/${{ github.event.inputs.branch }}"
+          else
+            echo "Branch '$TARGET_BRANCH' does not exist locally. Creating it from fork branch."
+            git checkout -b "$TARGET_BRANCH" "fork/${{ github.event.inputs.branch }}"
+          fi
+          echo "::set-output name=target_branch::$TARGET_BRANCH"
+
+      - name: Push branch to origin
+        run: |
+          TARGET_BRANCH="${{ steps.create_branch.outputs.target_branch }}"
+          echo "Pushing branch '$TARGET_BRANCH' to origin"
+          git push origin "$TARGET_BRANCH" --force

--- a/.github/workflows/mirror-fork-branch.yaml
+++ b/.github/workflows/mirror-fork-branch.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       source:
-        description: 'Source in format <fork_owner>:<branch> (e.g., philei-tt:philei/speed-up-host-tilizing)'
+        description: 'Source in format <fork_owner>:<branch> (e.g., user:branch)'
         required: true
       target_branch:
         description: >


### PR DESCRIPTION
### Ticket
None

### Problem description
We can't run CI on a PR from a branch coming from a fork.
This is the typical workflow when community creates a PR.

### What's changed
Adding a workflow that helps to mirror a branch.

### Checklist
- [ ] Workflow run