### PR TITLE
[skip ci] Create pr-comment-trigger.yaml

### DIFF
--- a/.github/workflows/pr-comment-trigger.yaml
+++ b/.github/workflows/pr-comment-trigger.yaml
@@ -1,0 +1,63 @@
+name: PR Comment Trigger Workflow
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  detect_trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      mirror_triggered: ${{ steps.mirror_check.outputs.triggered }}
+      test_triggered: ${{ steps.test_check.outputs.triggered }}
+    steps:
+      - name: Check for trigger (mirror)
+        uses: khan/pull-request-comment-trigger@v1.1.0
+        id: mirror_check
+        with:
+          trigger: ':mirror:'
+          reaction: eyes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for trigger (test)
+        uses: khan/pull-request-comment-trigger@v1.1.0
+        id: test_check
+        with:
+          trigger: ':test:'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  mirror:
+    needs: detect_trigger
+    if: needs.detect_trigger.outputs.mirror_triggered == 'true'
+    uses: ./.github/workflows/mirror-branch-workflow.yml
+    with:
+      # Build the source input as "<fork_owner>:<branch>" using the PR head info.
+      source: "${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}"
+
+  test:
+    needs: detect_trigger
+    if: needs.detect_trigger.outputs.test_triggered == 'true'
+    uses: ./.github/workflows/all-post-commit-tests.yml
+    with:
+      build-type: Release
+      # For PRs from a fork, run tests on the mirror branch in our repo;
+      # otherwise, run on the PR’s head branch.
+      branch: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'mirror/' + github.event.pull_request.head.repo.owner.login + '/' + github.event.pull_request.head.ref || github.event.pull_request.head.ref }}
+
+  post_comment:
+    needs: [mirror, test]
+    if: (needs.detect_trigger.outputs.test_triggered == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post workflow run link comment on PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          # If this is a PR event, use its number.
+          issue: ${{ github.event.pull_request.number }}
+          message: |
+            ✨ Tests workflow run is available [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
### Problem description
This PR introduces a new GitHub Actions workflow (PR Comment Trigger Workflow) that automates specific tasks based on comments made on pull requests (PRs). The workflow is designed to trigger actions like mirroring a branch or running tests when specific keywords (:mirror: or :test:) are detected in PR comments.