### PR TITLE
Comment trigger fixes

### DIFF
--- a/.github/workflows/mirror-fork-branch.yaml
+++ b/.github/workflows/mirror-fork-branch.yaml
@@ -1,6 +1,18 @@
 name: Mirror Fork Branch to Origin
 
 on:
+  workflow_call:
+    inputs:
+      source:
+        description: 'Source in format <fork_owner>:<branch>'
+        required: true
+        type: string
+      target_branch:
+        description: >
+          Optional. Target branch name in origin. If not provided, the branch will be named
+          `mirror/<fork_owner>/<branch>`.
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       source:


### PR DESCRIPTION
### Ticket
None

### Problem description
It is not possible to trigger mirror workflow from a different workflow.

### What's changed
Add workflow_call support.
I researched if its possible to share inputs, but its not possible. Sad.