### PR TITLE
#0: Remove the unused mesh register functionality

### DIFF
--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -39,7 +39,6 @@ public:
     // Get the physical device IDs mapped to a MeshDevice
     std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;
     std::vector<chip_id_t> request_available_devices(const MeshDeviceConfig& config) const;
-    void register_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device, const std::vector<IDevice*>& devices);
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -165,7 +165,6 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(const MeshShape& submesh_
 
     auto submesh_devices = view_->get_devices(start_coordinate, end_coordinate);
     submesh->view_ = std::make_unique<MeshDeviceView>(submesh_devices, submesh_shape);
-    SystemMesh::instance().register_mesh_device(submesh, submesh_devices);
     submeshes_.push_back(submesh);
     log_trace(
         LogMetal,
@@ -598,7 +597,6 @@ bool MeshDevice::initialize(
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal) {
     view_ = std::make_unique<MeshDeviceView>(scoped_devices_->get_devices(), mesh_shape_);
-    SystemMesh::instance().register_mesh_device(shared_from_this(), this->get_devices());
 
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -11,9 +11,6 @@ namespace tt::tt_metal::distributed {
 
 class SystemMesh::Impl {
 private:
-    std::unordered_map<MeshDeviceID, std::vector<chip_id_t>> assigned_devices_;
-    std::unordered_map<MeshDeviceID, std::weak_ptr<MeshDevice>> assigned_mesh_device_devices_;
-
     MeshShape logical_mesh_shape_;
     CoordinateTranslationMap logical_to_physical_coordinates_;
     std::unordered_map<LogicalCoordinate, chip_id_t> logical_to_device_id_;
@@ -31,7 +28,6 @@ public:
     std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;
     std::vector<chip_id_t> request_available_devices(const MeshDeviceConfig& config) const;
     IDevice* get_device(const chip_id_t physical_device_id) const;
-    void register_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device, const std::vector<IDevice*>& devices);
 
     chip_id_t get_physical_device_id(size_t logical_row_idx, size_t logical_col_idx) const;
 };
@@ -200,16 +196,6 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
     return physical_device_ids;
 }
 
-void SystemMesh::Impl::register_mesh_device(
-    const std::shared_ptr<MeshDevice>& mesh_device, const std::vector<IDevice*>& devices) {
-    std::vector<chip_id_t> physical_device_ids;
-    for (auto device : devices) {
-        physical_device_ids.push_back(device->id());
-    }
-    assigned_mesh_device_devices_.insert({mesh_device->id(), mesh_device});
-    assigned_devices_.insert({mesh_device->id(), physical_device_ids});
-}
-
 std::vector<chip_id_t> SystemMesh::Impl::request_available_devices(const MeshDeviceConfig& config) const {
     auto [requested_num_rows, requested_num_cols] = config.mesh_shape;
     auto [max_num_rows, max_num_cols] = logical_mesh_shape_;
@@ -245,11 +231,6 @@ chip_id_t SystemMesh::get_physical_device_id(size_t logical_row_idx, size_t logi
 const MeshShape& SystemMesh::get_shape() const { return pimpl_->get_shape(); }
 
 size_t SystemMesh::get_num_devices() const { return pimpl_->get_num_devices(); }
-
-void SystemMesh::register_mesh_device(
-    const std::shared_ptr<MeshDevice>& mesh_device, const std::vector<IDevice*>& devices) {
-    pimpl_->register_mesh_device(mesh_device, devices);
-}
 
 std::vector<chip_id_t> SystemMesh::request_available_devices(const MeshDeviceConfig& config) const {
     return pimpl_->request_available_devices(config);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `assigned_mesh_device_devices_` and `assigned_devices_` in `SystemMesh` appear unused.

### What's changed
Remove the data members and the associated mesh "register" functionality.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13302294435) - one unrelated test failure.
