### PR TITLE
Ppopovic/conv2d slices

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2937,7 +2937,7 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
         (1, 1, 4, 32, 1024, 1024, 5, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 32, 48, 1020, 1020, 7, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 32, 48, 1020, 1020, 6, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        # (1, 1, 48, 56, 1016, 1016, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # PCC
+        (1, 1, 48, 56, 1016, 1016, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 56, 64, 1008, 1008, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 64, 128, 992, 992, 12, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
     ),

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2927,21 +2927,20 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
 @pytest.mark.parametrize(
     "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, dram_slice, weights_dtype, activations_dtype, kernel, stride, padding, dilation, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
     (
-        #
-        (1, 1, 10, 64, 4096, 512, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 32*64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 2048, 256, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 32*16 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 1024, 128, 1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 512 , 64 , 1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        # TODO(mbezulj): to further optimize act_block_h_override
-        (1, 1, 4, 32, 1024, 1024, 2, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 32*6, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 32, 48, 1020, 1020, 3, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 32*16, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 48, 56, 1016, 1016, 4, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 32*3, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 56, 64, 1008, 1008, 12, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # pcc if act_block_h_override, 6 slices ...
-        (1, 1, 64, 128, 992, 992, 5, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 32*8, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        pytest.param
+        (1, 1, 10, 64, 4096,  512,  2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 32*64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False, marks=pytest.mark.skipif(is_grayskull(), reason="Skipping on Grayskull")),
+        (1, 1, 64, 64, 2048,  256,  2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 32*16 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 1024,  128,  1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64,  512,   64,  1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1,  4, 32, 1024, 1024,  2, DramSlice.Width,  ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 32*6, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 32, 48, 1020, 1020,  3, DramSlice.Width,  ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 32*16, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 48, 56, 1016, 1016,  4, DramSlice.Width,  ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 32*3, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 56, 64, 1008, 1008, 12, DramSlice.Width,  ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # pcc if act_block_h_override, 6 slices ...
+        (1, 1, 64, 128, 992,  992,  5, DramSlice.Width,  ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 32*8, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
     ),
 )
-
 #fmt: on
+
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384*2}], indirect=True)
 def test_dram_slice_conv2d(
     device,

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2928,23 +2928,21 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
     "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, dram_slice, weights_dtype, activations_dtype, kernel, stride, padding, dilation, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
     (
         #
-        (1, 1, 10, 64, 4096, 512, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 2048, 256, 4, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 1024, 128, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 512 , 64 , 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        #
-        (1, 1, 4, 32, 1024, 1024, 8, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 4, 32, 1024, 1024, 5, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 32, 48, 1020, 1020, 7, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 32, 48, 1020, 1020, 6, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 48, 56, 1016, 1016, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 56, 64, 1008, 1008, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 128, 992, 992, 12, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 10, 64, 4096, 512, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 32*64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 2048, 256, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 32*16 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 1024, 128, 1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 512 , 64 , 1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        # TODO(mbezulj): to further optimize act_block_h_override
+        (1, 1, 4, 32, 1024, 1024, 2, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 32*6, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 32, 48, 1020, 1020, 3, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 32*16, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 48, 56, 1016, 1016, 4, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 32*3, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 56, 64, 1008, 1008, 12, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # pcc if act_block_h_override, 6 slices ...
+        (1, 1, 64, 128, 992, 992, 5, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 32*8, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
     ),
 )
 
 #fmt: on
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384*2}], indirect=True)
 def test_dram_slice_conv2d(
     device,
     batch,

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2927,8 +2927,7 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
 @pytest.mark.parametrize(
     "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, dram_slice, weights_dtype, activations_dtype, kernel, stride, padding, dilation, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
     (
-        pytest.param
-        (1, 1, 10, 64, 4096,  512,  2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 32*64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False, marks=pytest.mark.skipif(is_grayskull(), reason="Skipping on Grayskull")),
+        (1, 1, 10, 64, 4096,  512,  2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 32*64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 64, 64, 2048,  256,  2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 32*16 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 64, 64, 1024,  128,  1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 64, 64,  512,   64,  1, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
@@ -2940,7 +2939,7 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
     ),
 )
 #fmt: on
-
+@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384*2}], indirect=True)
 def test_dram_slice_conv2d(
     device,
@@ -2969,6 +2968,9 @@ def test_dram_slice_conv2d(
     dst_full_sync_en,
 ):
     torch.manual_seed(11234)
+
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
 
     conv_input_shape = [batch, input_channels, input_height, input_width]
     conv_weight_shape = [output_channels, input_channels // groups, kernel[0], kernel[1]]

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2930,8 +2930,42 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
         (1, 1, 64, 64, 2048, 256, 4, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 64, 64, 1024, 128, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
         (1, 1, 64, 64, 512 , 64 , 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 4, 32, 1024, 1024, 8, ttnn.bfloat8_b, ttnn.bfloat16, (5, 5), (1, 1), (0, 0), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        # (1, 1, 32, 48, 1020, 1020, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 16, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False), # dillation required
+        # (1, 1, 48, 56, 1016, 1016, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 16, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False), # dillation required
+        # (1, 1, 56, 56, 1008, 1008, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 16, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False), # dillation required
+        (1, 1, 64, 128, 992, 992, 32, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 32, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+
     ),
 )
+
+# @skip_for_grayskull()
+# @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+# @pytest.mark.parametrize(
+#     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, groups, split_factor",
+#     (
+#         (1, 32, 4, 1024, 1024, 5, 5, 1, 1, 0, 0, 1, 1, 1, 1),  # 1
+#         (1, 48, 32, 1020, 1020, 3, 3, 1, 1, 0, 0, 2, 2, 1, 32 // 16),  # 2
+#         (1, 56, 48, 1016, 1016, 3, 3, 1, 1, 0, 0, 4, 4, 1, 48 // 16),  # 3
+#         (1, 64, 56, 1008, 1008, 3, 3, 1, 1, 0, 0, 8, 8, 1, 56 // 16),  # 4
+#         (1, 128, 64, 992, 992, 2, 2, 1, 1, 0, 0, 1, 1, 1, 64 // 16),  # 5
+#         (1, 256, 128, 991, 991, 1, 1, 1, 1, 0, 0, 1, 1, 1, 128 // 16),  # 6
+#         (1, 1, 256, 991, 991, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1),  # 7 Pass
+#         # quarter resolution
+#         (1, 32, 4, 512, 512, 5, 5, 1, 1, 0, 0, 1, 1, 1, 1),  # 1 Pass
+#         (1, 48, 32, 508, 508, 3, 3, 1, 1, 0, 0, 2, 2, 1, 1),  # 2 Pass
+#         (1, 56, 48, 504, 504, 3, 3, 1, 1, 0, 0, 4, 4, 1, 2),  # 3 Pass
+#         #  (added ttnn.deallocate); split=3 pcc fails badly
+#         (1, 64, 56, 496, 496, 3, 3, 1, 1, 0, 0, 8, 8, 1, 4),  # 4
+#         # => split 2 cannot fit, split 3 isnt divisible, split 4 fails pcc AssertionError: -0.0006819625298742717
+#         (1, 128, 64, 480, 480, 2, 2, 1, 1, 0, 0, 1, 1, 1, 4),  # 5
+#         # => split 2 out of space; split 4 AssertionError: 0.985573911170021
+#         (1, 256, 128, 479, 479, 1, 1, 1, 1, 0, 0, 1, 1, 1, 2),  # 6
+#         # => split=8 AssertionError: 0.8749055727907059, split 4 AssertionError: 0.9715589592838946, split 2 AssertionError: 0.996589061082462
+#         (1, 1, 256, 479, 479, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1),  # 7 Pass
+#     ),
+# )
+
 #fmt: on
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_height_split_conv2d(
@@ -3013,6 +3047,7 @@ def test_height_split_conv2d(
         act_block_h_override=act_block_h_override,
         act_block_w_div=act_block_w_div,
         override_sharding_config = False,
+        reallocate_halo_output = True,
     )
 
     compute_config = ttnn.init_device_compute_kernel_config(
@@ -3059,4 +3094,4 @@ def test_height_split_conv2d(
     target_pcc = 0.995
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=target_pcc)
     logger.info(f"PCC = {pcc_msg}. Threshold = {target_pcc}")
-    assert passing
+    assert passing, pcc_msg

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -3038,7 +3038,7 @@ def test_dram_slice_conv2d(
         dst_full_sync_en=dst_full_sync_en,
     )
 
-    tt_output_tensor, [out_height, out_width], [weight, bias] = ttnn.conv2d_dram_slice(
+    tt_output_tensor, [out_height, out_width], [weight, bias] = ttnn.experimental.conv2d_dram_slice(
         input_tensor = tt_input_tensor,
         weight_tensor = tt_weight_tensor,
         bias_tensor = tt_bias_tensor,

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -14,6 +14,7 @@ from models.utility_functions import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
 import ttnn
+from ttnn.operations.conv2d import DramSlice
 
 HS = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 BS = ttnn.TensorMemoryLayout.BLOCK_SHARDED
@@ -2924,26 +2925,27 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
 
 # fmt: off
 @pytest.mark.parametrize(
-    "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, weights_dtype, activations_dtype, kernel, stride, padding, dilation, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
+    "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, dram_slice, weights_dtype, activations_dtype, kernel, stride, padding, dilation, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
     (
         #
-        (1, 1, 10, 64, 4096, 512, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 2048, 256, 4, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 1024, 128, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 512 , 64 , 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 10, 64, 4096, 512, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 2048, 256, 4, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 1024, 128, 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 512 , 64 , 2, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
         #
-        (1, 1, 4, 32, 1024, 1024, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 32, 48, 1020, 1020, 7, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        # (1, 1, 48, 56, 1016, 1016, 32, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # 32 PCC
-        # (1, 1, 56, 64, 1008, 1008, 4, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # out of memory
-        (1, 1, 64, 128, 992, 992, 14, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-
+        (1, 1, 4, 32, 1024, 1024, 8, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 4, 32, 1024, 1024, 5, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 32, 48, 1020, 1020, 7, DramSlice.Height, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 32, 48, 1020, 1020, 6, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        # (1, 1, 48, 56, 1016, 1016, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # PCC
+        (1, 1, 56, 64, 1008, 1008, 11, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 128, 992, 992, 12, DramSlice.Width, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
     ),
 )
 
 #fmt: on
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_height_split_conv2d(
+def test_dram_slice_conv2d(
     device,
     batch,
     groups,
@@ -2952,6 +2954,7 @@ def test_height_split_conv2d(
     input_height,
     input_width,
     num_input_slices,
+    dram_slice,
     weights_dtype,
     activations_dtype,
     kernel,
@@ -3035,7 +3038,7 @@ def test_height_split_conv2d(
         dst_full_sync_en=dst_full_sync_en,
     )
 
-    tt_output_tensor, [out_height, out_width], [weight, bias] = ttnn.conv2d_sliced(
+    tt_output_tensor, [out_height, out_width], [weight, bias] = ttnn.conv2d_dram_slice(
         input_tensor = tt_input_tensor,
         weight_tensor = tt_weight_tensor,
         bias_tensor = tt_bias_tensor,
@@ -3046,6 +3049,7 @@ def test_height_split_conv2d(
         input_height = input_height,
         input_width = input_width,
         num_input_slices = num_input_slices,
+        dram_slice = dram_slice,
         kernel_size = kernel,
         stride = stride,
         padding = padding,

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2924,47 +2924,22 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
 
 # fmt: off
 @pytest.mark.parametrize(
-    "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, weights_dtype, activations_dtype, kernel, stride, padding, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
+    "batch, groups, input_channels, output_channels, input_height, input_width, num_input_slices, weights_dtype, activations_dtype, kernel, stride, padding, dilation, input_channels_alignment, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, math_approx_mode, dst_full_sync_en",
     (
-        (1, 1, 10, 64, 4096, 512, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 16, 64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 2048, 256, 4, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 1024, 128, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 64, 64, 512 , 64 , 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
-        (1, 1, 4, 32, 1024, 1024, 8, ttnn.bfloat8_b, ttnn.bfloat16, (5, 5), (1, 1), (0, 0), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
-        # (1, 1, 32, 48, 1020, 1020, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 16, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False), # dillation required
-        # (1, 1, 48, 56, 1016, 1016, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 16, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False), # dillation required
-        # (1, 1, 56, 56, 1008, 1008, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 16, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False), # dillation required
-        (1, 1, 64, 128, 992, 992, 32, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), 32, 0, 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        #
+        (1, 1, 10, 64, 4096, 512, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 16, 64, 1, True , ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 2048, 256, 4, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 1024, 128, 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 64, 64, 512 , 64 , 2, ttnn.bfloat8_b, ttnn.bfloat8_b, (4, 4), (2, 2), (1, 1), (1, 1), 32, 0 , 1, False, ttnn.MathFidelity.LoFi, True, False, True, False),
+        #
+        (1, 1, 4, 32, 1024, 1024, 8, ttnn.bfloat8_b, ttnn.bfloat8_b, (5, 5), (1, 1), (0, 0), (1, 1), 16, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        (1, 1, 32, 48, 1020, 1020, 7, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (2, 2), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
+        # (1, 1, 48, 56, 1016, 1016, 32, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (4, 4), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # 32 PCC
+        # (1, 1, 56, 64, 1008, 1008, 4, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (0, 0), (8, 8), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False), # out of memory
+        (1, 1, 64, 128, 992, 992, 14, ttnn.bfloat8_b, ttnn.bfloat8_b, (2, 2), (1, 1), (0, 0), (1, 1), 32, 0, 1, True, ttnn.MathFidelity.LoFi, True, False, True, False),
 
     ),
 )
-
-# @skip_for_grayskull()
-# @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-# @pytest.mark.parametrize(
-#     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, groups, split_factor",
-#     (
-#         (1, 32, 4, 1024, 1024, 5, 5, 1, 1, 0, 0, 1, 1, 1, 1),  # 1
-#         (1, 48, 32, 1020, 1020, 3, 3, 1, 1, 0, 0, 2, 2, 1, 32 // 16),  # 2
-#         (1, 56, 48, 1016, 1016, 3, 3, 1, 1, 0, 0, 4, 4, 1, 48 // 16),  # 3
-#         (1, 64, 56, 1008, 1008, 3, 3, 1, 1, 0, 0, 8, 8, 1, 56 // 16),  # 4
-#         (1, 128, 64, 992, 992, 2, 2, 1, 1, 0, 0, 1, 1, 1, 64 // 16),  # 5
-#         (1, 256, 128, 991, 991, 1, 1, 1, 1, 0, 0, 1, 1, 1, 128 // 16),  # 6
-#         (1, 1, 256, 991, 991, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1),  # 7 Pass
-#         # quarter resolution
-#         (1, 32, 4, 512, 512, 5, 5, 1, 1, 0, 0, 1, 1, 1, 1),  # 1 Pass
-#         (1, 48, 32, 508, 508, 3, 3, 1, 1, 0, 0, 2, 2, 1, 1),  # 2 Pass
-#         (1, 56, 48, 504, 504, 3, 3, 1, 1, 0, 0, 4, 4, 1, 2),  # 3 Pass
-#         #  (added ttnn.deallocate); split=3 pcc fails badly
-#         (1, 64, 56, 496, 496, 3, 3, 1, 1, 0, 0, 8, 8, 1, 4),  # 4
-#         # => split 2 cannot fit, split 3 isnt divisible, split 4 fails pcc AssertionError: -0.0006819625298742717
-#         (1, 128, 64, 480, 480, 2, 2, 1, 1, 0, 0, 1, 1, 1, 4),  # 5
-#         # => split 2 out of space; split 4 AssertionError: 0.985573911170021
-#         (1, 256, 128, 479, 479, 1, 1, 1, 1, 0, 0, 1, 1, 1, 2),  # 6
-#         # => split=8 AssertionError: 0.8749055727907059, split 4 AssertionError: 0.9715589592838946, split 2 AssertionError: 0.996589061082462
-#         (1, 1, 256, 479, 479, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1),  # 7 Pass
-#     ),
-# )
 
 #fmt: on
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
@@ -2982,6 +2957,7 @@ def test_height_split_conv2d(
     kernel,
     stride,
     padding,
+    dilation,
     input_channels_alignment,
     act_block_h_override,
     act_block_w_div,
@@ -3010,7 +2986,7 @@ def test_height_split_conv2d(
         bias=torch_bias_tensor.reshape(-1),
         stride=stride,
         padding=padding,
-        dilation=(1, 1),
+        dilation=dilation,
         groups=groups,
     )
     torch_out_golden_tensor = torch.nn.functional.relu(torch_out_golden_tensor)
@@ -3073,6 +3049,7 @@ def test_height_split_conv2d(
         kernel_size = kernel,
         stride = stride,
         padding = padding,
+        dilation = dilation,
         groups = groups,
         conv_config = conv_config,
         compute_config = compute_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -317,6 +317,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("tile_size"));
 
     auto py_conv_config = py::class_<Conv2dConfig>(module, "Conv2dConfig");
+    py_conv_config.def(py::init<const Conv2dConfig&>());
     py_conv_config.def(
         py::init<
             DataType,

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -265,7 +265,7 @@ class DramSlice(Enum):
     Height = "height"
 
 
-@ttnn.register_python_operation(name="ttnn.conv2d_dram_slice")
+@ttnn.register_python_operation(name="ttnn.experimental.conv2d_dram_slice")
 def conv2d_dram_slice(
     *,
     input_tensor: ttnn.Tensor,  # may or may not be sharded

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -414,12 +414,12 @@ def conv2d_dram_slice(
             compute_config=compute_config,
             memory_config=memory_config,  # should be ttnn.DRAM_MEMORY_CONFIG, but fails on PCC with that
         )
-
         # # temp workaround
         # print(f"PRE conv_output_slice.memory_config()={conv_output_slice.memory_config()}")
         # to_layout with memory_config can override memory_config if sharded and on untilize with unpadding path
-        conv_output_slice = ttnn.to_layout(conv_output_slice, ttnn.ROW_MAJOR_LAYOUT)
+        # also if to_layout is called with memory_config, it will cause PCC on the case with a 56 output channels
         conv_output_slice = ttnn.to_memory_config(conv_output_slice, ttnn.DRAM_MEMORY_CONFIG)
+        conv_output_slice = ttnn.to_layout(conv_output_slice, ttnn.ROW_MAJOR_LAYOUT)
 
         if dram_slice == DramSlice.Width:
             # As it is width sliced, restore it back to [N, H, W, C] format to allow mid results concat

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -351,7 +351,7 @@ def conv2d_dram_slice(
     for input_slice_start, input_slice_end, pad_start, pad_end in conv_slice_params:
         if dram_slice == DramSlice.Height:
             slice_starts = (0, input_slice_start, 0, 0)
-            slice_ends = (batch_size, input_slice_end, input_width, in_channels)
+            slice_ends = (batch_size, input_slice_end, input_width, input_tensor.shape[-1])
             pad_width = (0, 0)
             pad_height = (pad_start, pad_end)
             extra_padding = pad_start + pad_end
@@ -360,7 +360,7 @@ def conv2d_dram_slice(
             input_slice_padding = (0, padding[1])
         else:
             slice_starts = (0, 0, input_slice_start, 0)
-            slice_ends = (batch_size, input_height, input_slice_end, in_channels)
+            slice_ends = (batch_size, input_height, input_slice_end, input_tensor.shape[-1])
             pad_width = (pad_start, pad_end)
             pad_height = (0, 0)
             extra_padding = pad_start + pad_end

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -4,7 +4,7 @@
 
 from loguru import logger
 
-from typing import Tuple, Union, Dict, Optional
+from typing import Tuple, Union, Dict, Optional, List
 import torch
 import warnings
 import math
@@ -13,6 +13,7 @@ from ttnn.device import (
     is_grayskull,
     is_wormhole_b0,
 )
+import copy
 
 
 def _nearest_32(x):
@@ -160,6 +161,31 @@ def convert_conv_weight_tensor_to_grouped_layout(conv_weight_tensor, num_groups,
     )
 
 
+def calculate_conv_height_split_params(
+    input_height: int,
+    num_input_slices: int,
+    kernel_size: int,
+    stride: int,
+    padding: int,
+) -> List[Tuple[int, int, int, int]]:
+    # if input is sliced into num_input_slices, so is output
+    # we use output slices to figure out where are they coming from input image
+    output_height = get_conv_output_dim(input_height, kernel_size, stride, padding)
+    output_values = []
+    output_slice_height = output_height // num_input_slices
+    for output_slice_height_start in range(0, output_height, output_slice_height):
+        output_slice_height_end = output_slice_height_start + output_slice_height
+
+        input_slice_height_start = output_slice_height_start * stride - padding
+        input_slice_height_end = (output_slice_height_end - 1) * stride + kernel_size - padding
+        pad_top = max(0, -input_slice_height_start)
+        pad_bottom = max(0, input_slice_height_end - input_height)
+        input_slice_height_start = max(0, input_slice_height_start)
+        input_slice_height_end = min(input_height, input_slice_height_end)
+        output_values.append((input_slice_height_start, input_slice_height_end, pad_top, pad_bottom))
+    return output_values
+
+
 @ttnn.register_python_operation(name="ttnn.conv2d")
 def conv2d(
     *,
@@ -219,6 +245,169 @@ def conv2d(
         return conv_output, [output_height, output_width]
     else:
         return conv_output
+
+
+@ttnn.register_python_operation(name="ttnn.conv2d_sliced")
+def conv2d_sliced(
+    *,
+    input_tensor: ttnn.Tensor,  # may or may not be sharded
+    weight_tensor: ttnn.Tensor,
+    device: ttnn.Device,
+    in_channels: int,
+    out_channels: int,
+    batch_size: int,
+    input_height: int,
+    input_width: int,
+    num_input_slices: int,
+    kernel_size: Union[int, Tuple[int, int]],
+    stride: Union[int, Tuple[int, int]],
+    padding: Union[int, Tuple[int, int]],
+    dilation: Union[int, Tuple[int, int]] = (1, 1),
+    groups: int = 1,
+    bias_tensor: ttnn.Tensor = None,
+    conv_config: Conv2dConfig = None,  # config overrides by user
+    compute_config=None,  # compute config overrides by user
+    memory_config: ttnn.MemoryConfig = None,  # memory config overrides by user
+    conv_op_cache={},  # basic conv object caching in python needed for intermediate refactoring. Not needed after full op refactoring in C++.
+    debug=False,  # ignored
+    return_output_dim=False,
+    return_weights_and_bias=False,
+) -> Tuple[ttnn.Tensor, int, int, ttnn.Tensor, ttnn.Tensor]:
+    if num_input_slices <= 1:
+        return conv2d(
+            input_tensor=input_tensor,
+            weight_tensor=weight_tensor,
+            device=device,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            batch_size=batch_size,
+            input_height=input_height,
+            input_width=input_width,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias_tensor=bias_tensor,
+            conv_config=conv_config,
+            compute_config=compute_config,
+            memory_config=memory_config,
+            conv_op_cache=conv_op_cache,
+            debug=debug,
+            return_output_dim=return_output_dim,
+            return_weights_and_bias=return_weights_and_bias,
+        )
+
+    assert dilation == (1, 1), "Dilatation != (1, 1) is not supported for sliced conv2d at the moment"
+    assert groups == 1, "Groups != 1 is not supported for sliced conv2d t the moment"
+    assert batch_size == 1, "Batch size != 1 is not supported for sliced conv2d at the moment"
+    # What to do with output mem config?
+
+    # Expect input tensor to be in [1, 1, N * H * W, C] format
+    # At the moment, restore it back to [N, H, W, C] format
+    input_tensor = input_tensor.reshape(batch_size, input_height, input_width, -1)
+
+    # Need this for slice op
+    if input_tensor.storage_type() != ttnn.StorageType.DEVICE:
+        input_tensor = ttnn.to_device(input_tensor, device)
+
+    conv_height_split_params = calculate_conv_height_split_params(
+        input_height,
+        num_input_slices,
+        kernel_size[0],
+        stride[0],
+        padding[0],
+    )
+
+    # Prepare conv config for slices
+    # conv2d_config_for_slices = copy.deepcopy(conv_config) # this is impossible
+    conv2d_config_for_slices = conv_config  # todo, this ruins the original config
+    # conv2d_config_for_slices.output_layout = ttnn.ROW_MAJOR_LAYOUT, cant set RM, leads to OOM
+    conv_output_tensor = None
+    conv_prepared_device_weight = None
+    conv_prepared_device_bias = None
+    conv_output_height = 0
+    conv_output_width = 0
+
+    for input_slice_height_start, input_slice_height_end, pad_top, pad_bottom in conv_height_split_params:
+        input_tensor_slice = ttnn.slice(
+            input_tensor,
+            starts=(0, input_slice_height_start, 0, 0),
+            ends=(batch_size, input_slice_height_end, input_width, in_channels),
+            steps=(1, 1, 1, 1),
+        )
+
+        if pad_top or pad_bottom:
+            input_tensor_slice = ttnn.pad(
+                input_tensor_slice,
+                padding=((0, 0), (pad_top, pad_bottom), (0, 0), (0, 0)),
+                value=0,
+            )
+        # Move to [1, 1, N * H * W, C] format
+        input_tensor_slice = input_tensor_slice.reshape(
+            1,
+            1,
+            input_tensor_slice.shape[0] * input_tensor_slice.shape[1] * input_tensor_slice.shape[2],
+            input_tensor_slice.shape[3],
+        )
+
+        (
+            conv_output_slice,
+            conv_output_height_slice,
+            output_width,
+            prepared_device_weight,
+            prepared_device_bias,
+        ) = ttnn._ttnn.operations.conv.conv2d(
+            input_tensor=input_tensor_slice,
+            weight_tensor=weight_tensor if conv_prepared_device_weight is None else conv_prepared_device_weight,
+            device=device,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            batch_size=batch_size,
+            input_height=input_slice_height_end - input_slice_height_start + pad_top + pad_bottom,
+            input_width=input_width,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=(0, padding[1]),
+            dilation=dilation,
+            groups=groups,
+            bias_tensor=bias_tensor if conv_prepared_device_bias is None else conv_prepared_device_bias,
+            conv_config=conv2d_config_for_slices,
+            compute_config=compute_config,
+            memory_config=memory_config,  # should be DRAM, but fails on PCC with that
+        )
+
+        # # temp workaround
+        conv_output_slice = ttnn.to_layout(
+            conv_output_slice, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+        if conv_output_tensor is None:
+            conv_output_tensor = conv_output_slice
+            conv_prepared_device_weight = prepared_device_weight
+            conv_prepared_device_bias = prepared_device_bias
+            conv_output_height = conv_output_height_slice * num_input_slices
+            conv_output_width = output_width
+        else:
+            conv_output_tensor = ttnn.concat([conv_output_tensor, conv_output_slice], dim=2)
+
+    # Restore input tensor to be in [1, 1, N * H * W, C] format
+    input_tensor = input_tensor.reshape(
+        1, 1, input_tensor.shape[0] * input_tensor.shape[1] * input_tensor.shape[2], input_tensor.shape[3]
+    )
+
+    if return_output_dim and return_weights_and_bias:
+        return (
+            conv_output_tensor,
+            [conv_output_height, conv_output_width],
+            [conv_prepared_device_weight, conv_prepared_device_bias],
+        )
+    elif return_weights_and_bias:
+        return conv_output_tensor, [conv_prepared_device_weight, conv_prepared_device_bias]
+    elif return_output_dim:
+        return conv_output_tensor, [conv_output_height, conv_output_width]
+    else:
+        return conv_output_tensor
 
 
 def get_activation_function(name: str):


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/17493)

### Problem description
Today we cannot run conv2d op if the activation, weights and output cannot fit into L1.

### What's changed
Added ttnn.experimental.conv2d_dram_slice(..) that
- slices input tensor to `num_input_slices` along input `height` or `width` dims. 
- runs number of smaller convs
- stitches sliced outputs together 
- validates against cpu conv2d without slicing

Known limitations:
- Non-efficient implementation that provides new functionality. 
- Supported only height sharded memory layout.
- Height sharded + height sliced uses more L1 memory than Height sharded + width sliced. 
- Height sliced more efficiently merges outputs (with a concat).
- Channel slicing is not supported.

Added test_dram_slice_conv2d(..) with some real world examples optimized to run on N150. Thus skipping GS and N300.

As a side change, pybinding Conv2dConfig copy constructor. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13325614645)
