### PR TITLE
#17829: Binary_ng survey

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -327,6 +327,7 @@ on:
           - eltwise.binary.add.add_different_memory_configs
           - eltwise.binary.add.add_forge
           - eltwise.binary.add.add_llama
+          - eltwise.binary.add.add_survey_ng
           - eltwise.binary.atan2.atan2
           - eltwise.binary.atan2.atan2_sharded
           - eltwise.unary.gtz.gtz
@@ -351,6 +352,7 @@ on:
           - eltwise.binary.subtract.subtract
           - eltwise.binary.subtract.subtract_tensor_pytorch2
           - eltwise.binary.subtract.subtract_forge
+          - eltwise.binary.subtract.subtract_ng_survey
           - eltwise.binary.multiply.multiply
           - eltwise.binary.multiply.mul_tensor_pytorch2
           - eltwise.binary.multiply.multiply_scalar_pytorch2

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -391,6 +391,7 @@ on:
           - eltwise.binary.squared_difference_output.squared_difference_output
           - eltwise.binary.squared_difference.squared_difference_ng_survey
           - eltwise.binary.rsub.rsub_ng_survey
+          - eltwise.binary.rsub.rsub_ng_scalar_survey
           - eltwise.binary.scatter.scatter_forge
           - eltwise.binary.bcast.bcast_h_sharded
           - eltwise.binary.bcast.bcast

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -385,6 +385,7 @@ on:
           - eltwise.binary.squared_difference.squared_difference
           - eltwise.binary.squared_difference_output.squared_difference_output
           - eltwise.binary.squared_difference.squared_difference_ng_survey
+          - eltwise.binary.rsub.rsub_ng_survey
           - eltwise.binary.scatter.scatter_forge
           - eltwise.binary.bcast.bcast_h_sharded
           - eltwise.binary.bcast.bcast
@@ -401,8 +402,10 @@ on:
           - eltwise.binary.floor_divide.floor_divide
           - eltwise.binary.logaddexp.logaddexp
           - eltwise.binary.logaddexp.logaddexp_sharded
+          - eltwise.binary.logaddexp.logaddexp_ng_survey
           - eltwise.binary.logaddexp2.logaddexp2
           - eltwise.binary.logaddexp2.logaddexp2_sharded
+          - eltwise.binary.logaddexp2.logaddexp2_ng_survey
           - eltwise.binary.ldexp.ldexp
           - eltwise.binary.ldexp.ldexp_sharded
           - eltwise.binary.lt.lt_tensor_pytorch2

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -111,10 +111,12 @@ on:
           - eltwise.unary.bitwise.bitwise_and.bitwise_and_sharded
           - eltwise.unary.bitwise.bitwise_and.bitwise_and_unary
           - eltwise.unary.bitwise.bitwise_and.bitwise_and_unary_sharded
+          - eltwise.unary.bitwise.bitwise_and.bitwise_and_ng_survey
           - eltwise.unary.bitwise.bitwise_left_shift.bitwise_left_shift
           - eltwise.unary.bitwise.bitwise_left_shift.bitwise_left_shift_sharded
           - eltwise.unary.bitwise.bitwise_left_shift.bitwise_left_shift_unary
           - eltwise.unary.bitwise.bitwise_left_shift.bitwise_left_shift_unary_sharded
+          - eltwise.unary.bitwise_left_shift.bitwise_left_shift_ng_survey
           - eltwise.unary.bitwise.bitwise_not.bitwise_not
           - eltwise.unary.bitwise.bitwise_not.bitwise_not_sharded
           - eltwise.unary.bitwise.bitwise_not.bitwise_not_pytorch2
@@ -122,14 +124,17 @@ on:
           - eltwise.unary.bitwise.bitwise_or.bitwise_or_sharded
           - eltwise.unary.bitwise.bitwise_or.bitwise_or_unary
           - eltwise.unary.bitwise.bitwise_or.bitwise_or_unary_sharded
+          - eltwise.unary.bitwise.bitwise_or.bitwise_or_ng_survey
           - eltwise.unary.bitwise.bitwise_right_shift.bitwise_right_shift
           - eltwise.unary.bitwise.bitwise_right_shift.bitwise_right_shift_sharded
           - eltwise.unary.bitwise.bitwise_right_shift.bitwise_right_shift_unary
           - eltwise.unary.bitwise.bitwise_right_shift.bitwise_right_shift_unary_sharded
+          - eltwise.unary.bitwise_right_shift.bitwise_right_shift_ng_survey
           - eltwise.unary.bitwise.bitwise_xor.bitwise_xor
           - eltwise.unary.bitwise.bitwise_xor.bitwise_xor_sharded
           - eltwise.unary.bitwise.bitwise_xor.bitwise_xor_unary
           - eltwise.unary.bitwise.bitwise_xor.bitwise_xor_unary_sharded
+          - eltwise.unary.bitwise.bitwise_xor.bitwise_xor_ng_survey
           - eltwise.unary.log_sigmoid.log_sigmoid
           - eltwise.unary.logical_not.logical_not_
           - eltwise.unary.logical_not.logical_not

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -371,16 +371,20 @@ on:
           - eltwise.binary.logical_or.logical_or_output
           - eltwise.binary.logical_or.logical_or_forge
           - eltwise.binary.logical_or.logical_or_sharded
+          - eltwise.binary.logical_or.logical_or_ng_survey
           - eltwise.binary.logical_xor.logical_xor_
           - eltwise.binary.logical_xor.logical_xor
           - eltwise.binary.logical_xor.logical_xor_sharded
+          - eltwise.binary.logical_xor.logical_xor_ng_survey
           - eltwise.binary.logical_and.logical_and_
           - eltwise.binary.logical_and.logical_and
           - eltwise.binary.logical_and.logical_and_output
           - eltwise.binary.logical_and.logical_and_forge
           - eltwise.binary.logical_and.logical_and_sharded
+          - eltwise.binary.logical_and.logical_and_ng_survey
           - eltwise.binary.polyval.polyval
           - eltwise.binary.polyval.polyval_sharded
+          - eltwise.binary.pow.pow_ng_survey
           - eltwise.binary.remainder.remainder
           - eltwise.binary.remainder.remainder_scalar_pytorch2
           - eltwise.binary.remainder.remainder_forge
@@ -399,10 +403,14 @@ on:
           - eltwise.binary.bcast.bcast
           - eltwise.binary.eq.eq_scalar_pytorch2
           - eltwise.binary.eq.eq_forge
+          - eltwise.binary.eq.eq_ng_survey
           - eltwise.binary.ge.ge_forge
+          - eltwise.binary.ge.ge_ng_survey
           - eltwise.binary.gt.gt_scalar_pytorch2
           - eltwise.binary.gt.gt_forge
+          - eltwise.binary.gt.gt_ng_survey
           - eltwise.binary.le.le_tensor_pytorch2
+          - eltwise.binary.le.le_ng_survey
           - eltwise.binary.fmod.fmod
           - eltwise.binary.fmod.fmod_unary
           - eltwise.binary.fmod.fmod_unary_sharded
@@ -416,15 +424,19 @@ on:
           - eltwise.binary.logaddexp2.logaddexp2_ng_survey
           - eltwise.binary.ldexp.ldexp
           - eltwise.binary.ldexp.ldexp_sharded
+          - eltwise.binary.ldexp.ldexp_ng_survey
           - eltwise.binary.lt.lt_tensor_pytorch2
           - eltwise.binary.lt.lt_scalar_pytorch2
           - eltwise.binary.lt.lt_forge
+          - eltwise.binary.lt.lt_ng_survey
           - eltwise.binary.ne.ne_scalar_pytorch2
           - eltwise.binary.ne.ne_forge
+          - eltwise.binary.ne.ne_ng_survey
           - eltwise.binary.isclose.isclose
           - eltwise.binary.isclose.isclose_sharded
           - eltwise.binary.hypot.hypot
           - eltwise.binary.xlogy.xlogy
+          - eltwise.binary_ng.binary_ng_all_ops
           - eltwise.binary_backward.ldexp_bw.ldexp_bw
           - eltwise.binary_backward.ldexp_bw.ldexp_bw_sharded
           - eltwise.binary_backward.logaddexp_bw.logaddexp_bw

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -352,9 +352,12 @@ on:
           - eltwise.binary.multiply.multiply_forge
           - eltwise.binary.multiply.multiply_llama
           - eltwise.binary.multiply.mul_no_act_llama
+          - eltwise.binary.multiply.multiply_ng_survey
           - eltwise.binary.div.div
           - eltwise.binary.div.div_tensor_pytorch2
           - eltwise.binary.div.div_forge
+          - eltwise.binary.div.div_ng_survey
+          - eltwise.binary.bias_gelu.bias_gelu_ng_survey
           - eltwise.binary.div_no_nan.div_no_nan
           - eltwise.binary.logical_or.logical_or_
           - eltwise.binary.logical_or.logical_or
@@ -381,6 +384,7 @@ on:
           - eltwise.binary.rpow.rpow_sharded
           - eltwise.binary.squared_difference.squared_difference
           - eltwise.binary.squared_difference_output.squared_difference_output
+          - eltwise.binary.squared_difference.squared_difference_ng_survey
           - eltwise.binary.scatter.scatter_forge
           - eltwise.binary.bcast.bcast_h_sharded
           - eltwise.binary.bcast.bcast

--- a/tests/sweep_framework/sweeps/eltwise/binary/add/add_survey_ng.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/add/add_survey_ng.py
@@ -17,36 +17,36 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "sq_diff_bcast_1": {
+    "add_bcast_mixed_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
         # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
         "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
         ],  # for bcast
         "input_dtype": [
-            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
@@ -202,11 +202,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.squared_difference)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.add)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.squared_difference(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.add(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/add/add_survey_ng.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/add/add_survey_ng.py
@@ -17,24 +17,24 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "add_bcast_mixed_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
-        ],  # for bcast
+    "add_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
+        # "input_shape": [
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
+        # ],  # bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -48,31 +48,33 @@ parameters = {
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -87,6 +89,8 @@ def return_dtype(dtype):
         return ttnn.bfloat8_b
     elif dtype == "ttnn.bfloat4_b":
         return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
 
 
 def return_mem_config(mem_config_string):
@@ -173,12 +177,9 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
-    if isinstance(input_shape["other"], list):
-        torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-        )(input_shape["other"])
-    else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+    )(input_shape["other"])
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]

--- a/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
@@ -2,40 +2,42 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-# TIMEOUT = 30
-
-# random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "bias_gelu_bf4b_1": {
-        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
-        # "input_a_dtype": [ttnn.bfloat16],
-        # "input_b_dtype": [ttnn.bfloat16],
-        # "input_a_dtype": [ttnn.float32],
-        # "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
-        "input_a_dtype": [ttnn.bfloat4_b],
-        "input_b_dtype": [ttnn.bfloat4_b],
+    "bias_gelu_mixed_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -66,6 +68,17 @@ parameters = {
 }
 
 
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
 def return_mem_config(mem_config_string):
     if mem_config_string == "l1_interleaved":
         return ttnn.L1_MEMORY_CONFIG
@@ -73,8 +86,8 @@ def return_mem_config(mem_config_string):
         return ttnn.DRAM_MEMORY_CONFIG
     elif mem_config_string == "l1_height_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -82,8 +95,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_height_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -91,8 +104,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -100,8 +113,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -109,8 +122,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -118,8 +131,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -134,8 +147,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,16 +156,19 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -174,17 +189,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.bias_gelu)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "bias_gelu_bf4b_1": {
+        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_b_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_b_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_b_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_b_dtype": [ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat4_b],
+        "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.bias_gelu)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.bias_gelu(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
@@ -17,62 +17,63 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "bias_gelu_bcast_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
-        ],  # for bcast
+    "bias_gelu_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
+        # "input_shape": [
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        # ],  # bcast
         "input_dtype": [
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }

--- a/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/bias_gelu/bias_gelu_ng_survey.py
@@ -17,26 +17,36 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "bias_gelu_mixed_1": {
+    "bias_gelu_bcast_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],  # for bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
-            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
-            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
-            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
-            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
-            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
-            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
-            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
-            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
-            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],

--- a/tests/sweep_framework/sweeps/eltwise/binary/div/div_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/div/div_ng_survey.py
@@ -2,40 +2,42 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-# TIMEOUT = 30
-
-# random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_bf16_1": {
-        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
-        # "input_a_dtype": [ttnn.float32],
-        # "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
-        # "input_a_dtype": [ttnn.bfloat4_b],
-        # "input_b_dtype": [ttnn.bfloat4_b],
+    "div_mixed_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -66,6 +68,17 @@ parameters = {
 }
 
 
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
 def return_mem_config(mem_config_string):
     if mem_config_string == "l1_interleaved":
         return ttnn.L1_MEMORY_CONFIG
@@ -73,8 +86,8 @@ def return_mem_config(mem_config_string):
         return ttnn.DRAM_MEMORY_CONFIG
     elif mem_config_string == "l1_height_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -82,8 +95,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_height_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -91,8 +104,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -100,8 +113,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -109,8 +122,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -118,8 +131,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -134,8 +147,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,16 +156,19 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -174,17 +189,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.div)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/sweep_framework/sweeps/eltwise/binary/div/div_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/div/div_ng_survey.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "div_bf4b_1": {
+        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.bfloat16],
+        "input_b_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_b_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_b_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_b_dtype": [ttnn.bfloat8_b],
+        # "input_a_dtype": [ttnn.bfloat4_b],
+        # "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=-1, dtype=torch.bfloat16), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/div/div_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/div/div_ng_survey.py
@@ -17,14 +17,24 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_mixed_1": {
+    "div_bcast_mixed_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],  # for bcast
         "input_dtype": [
             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},

--- a/tests/sweep_framework/sweeps/eltwise/binary/eq/eq_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/eq/eq_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "eq_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.eq)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.eq(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/ge/ge_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/ge/ge_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "ge_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.gte)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.gte(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/gt/gt_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/gt/gt_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "gt_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.gt)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.gt(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/ldexp/ldexp_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/ldexp/ldexp_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "ldexp_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -171,12 +171,12 @@ def run(
     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-60, high=60, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-60, high=60, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.ldexp)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.ldexp(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/le/le_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/le/le_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "le_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.lte)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.lte(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp_ng_survey.py
@@ -2,40 +2,42 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-# TIMEOUT = 30
-
-# random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "logaddexp_bf4b_1": {
-        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        # "input_a_dtype": [ttnn.bfloat16],
-        # "input_b_dtype": [ttnn.bfloat16],
-        # "input_a_dtype": [ttnn.float32],
-        # "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        "input_a_dtype": [ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat8_b],
-        # "input_a_dtype": [ttnn.bfloat4_b],
-        # "input_b_dtype": [ttnn.bfloat4_b],
+    "logaddexp_mixed_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -66,6 +68,17 @@ parameters = {
 }
 
 
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
 def return_mem_config(mem_config_string):
     if mem_config_string == "l1_interleaved":
         return ttnn.L1_MEMORY_CONFIG
@@ -73,8 +86,8 @@ def return_mem_config(mem_config_string):
         return ttnn.DRAM_MEMORY_CONFIG
     elif mem_config_string == "l1_height_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -82,8 +95,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_height_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -91,8 +104,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -100,8 +113,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -109,8 +122,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -118,8 +131,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -134,8 +147,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,16 +156,19 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-91, high=91, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-67, high=67, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-91, high=91, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-67, high=67, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -174,17 +189,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.logaddexp)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp_ng_survey.py
@@ -23,17 +23,17 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_bf16_1": {
+    "logaddexp_bf4b_1": {
         "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_b_dtype": [ttnn.bfloat16],
         # "input_a_dtype": [ttnn.float32],
         # "input_b_dtype": [ttnn.float32],
         # "input_a_dtype": [ttnn.int32],
         # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat8_b],
+        "input_b_dtype": [ttnn.bfloat8_b],
         # "input_a_dtype": [ttnn.bfloat4_b],
         # "input_b_dtype": [ttnn.bfloat4_b],
         "input_a_layout": [ttnn.TILE_LAYOUT],
@@ -145,12 +145,12 @@ def run(
     torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-91, high=91, dtype=torch.bfloat16), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-91, high=91, dtype=torch.bfloat16), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
@@ -186,11 +186,11 @@ def run(
     if input_b_dtype == ttnn.bfloat4_b:
         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.logaddexp)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.logaddexp(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp/logaddexp_ng_survey.py
@@ -17,14 +17,13 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "logaddexp_mixed_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+    "logaddexp_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -38,31 +37,33 @@ parameters = {
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -160,12 +161,12 @@ def run(
     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-67, high=67, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-87, high=87, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-67, high=67, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-87, high=87, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2_ng_survey.py
@@ -17,14 +17,13 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "logaddexp2_mixed_2": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+    "logaddexp2_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -38,31 +37,33 @@ parameters = {
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -160,12 +161,12 @@ def run(
     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-64, high=64, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-72, high=72, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-64, high=64, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-72, high=72, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2_ng_survey.py
@@ -2,40 +2,42 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-# TIMEOUT = 30
-
-# random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "logaddexp2_bf4b_1": {
-        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        # "input_a_dtype": [ttnn.bfloat16],
-        # "input_b_dtype": [ttnn.bfloat16],
-        # "input_a_dtype": [ttnn.float32],
-        # "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
-        "input_a_dtype": [ttnn.bfloat4_b],
-        "input_b_dtype": [ttnn.bfloat4_b],
+    "logaddexp2_mixed_2": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -66,6 +68,17 @@ parameters = {
 }
 
 
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
 def return_mem_config(mem_config_string):
     if mem_config_string == "l1_interleaved":
         return ttnn.L1_MEMORY_CONFIG
@@ -73,8 +86,8 @@ def return_mem_config(mem_config_string):
         return ttnn.DRAM_MEMORY_CONFIG
     elif mem_config_string == "l1_height_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -82,8 +95,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_height_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -91,8 +104,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -100,8 +113,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -109,8 +122,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -118,8 +131,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -134,8 +147,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,16 +156,19 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-65, high=65, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-64, high=64, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-65, high=65, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-64, high=64, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -174,17 +189,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.logaddexp2)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logaddexp2/logaddexp2_ng_survey.py
@@ -23,19 +23,19 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_bf16_1": {
+    "logaddexp2_bf4b_1": {
         "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_b_dtype": [ttnn.bfloat16],
         # "input_a_dtype": [ttnn.float32],
         # "input_b_dtype": [ttnn.float32],
         # "input_a_dtype": [ttnn.int32],
         # "input_b_dtype": [ttnn.int32],
         # "input_a_dtype": [ttnn.bfloat8_b],
         # "input_b_dtype": [ttnn.bfloat8_b],
-        # "input_a_dtype": [ttnn.bfloat4_b],
-        # "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_dtype": [ttnn.bfloat4_b],
+        "input_b_dtype": [ttnn.bfloat4_b],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -145,12 +145,12 @@ def run(
     torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-65, high=65, dtype=torch.bfloat16), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-65, high=65, dtype=torch.bfloat16), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
@@ -186,11 +186,11 @@ def run(
     if input_b_dtype == ttnn.bfloat4_b:
         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.logaddexp2)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.logaddexp2(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/logical_and/logical_and_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logical_and/logical_and_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "logical_and_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.logical_and)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.logical_and(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/logical_or/logical_or_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logical_or/logical_or_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "logical_or_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.logical_or)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.logical_or(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/logical_xor/logical_xor_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/logical_xor/logical_xor_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "logical_xor_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -171,12 +171,12 @@ def run(
     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-50, high=50, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-50, high=50, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.logical_xor)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.logical_xor(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/lt/lt_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/lt/lt_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "lt_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.lt)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.lt(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_ng_survey.py
@@ -16,24 +16,23 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "mul_bcast_mixed_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
-        ],  # for bcast
+    "mul_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
+        # "input_shape": [
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        # ],  # bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -47,31 +46,33 @@ parameters = {
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -208,9 +209,5 @@ def run(
     result = ttnn.experimental.mul(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
-
-    diff = torch.abs(torch_output_tensor - output_tensor)
-    max_atol = torch.max(diff)
-    print(f"Max absolute tolerance (atol): {max_atol.item()}")
 
     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_ng_survey.py
@@ -2,40 +2,41 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-# TIMEOUT = 30
-
-# random.seed(0)
-
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "mul_fp32_1": {
+    "mul_mixed_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        # "input_a_dtype": [ttnn.bfloat16],
-        # "input_b_dtype": [ttnn.bfloat16],
-        "input_a_dtype": [ttnn.float32],
-        "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
-        # "input_a_dtype": [ttnn.bfloat4_b],
-        # "input_b_dtype": [ttnn.bfloat4_b],
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -43,27 +44,38 @@ parameters = {
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
+
+
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
 
 
 def return_mem_config(mem_config_string):
@@ -134,8 +146,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,13 +155,16 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-2, high=2, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-2, high=2, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -174,17 +188,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.mul)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_ng_survey.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "mul_fp32_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_b_dtype": [ttnn.bfloat16],
+        "input_a_dtype": [ttnn.float32],
+        "input_b_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_b_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_b_dtype": [ttnn.bfloat8_b],
+        # "input_a_dtype": [ttnn.bfloat4_b],
+        # "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.mul)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.mul(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/ne/ne_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/ne/ne_ng_survey.py
@@ -17,10 +17,10 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "ne_rm_2": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
         #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
         #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
         #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
@@ -176,7 +176,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.ne)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.ne(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/pow/pow_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/pow/pow_ng_survey.py
@@ -17,23 +17,24 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_rm_2": {
+    "pow_rm_1": {
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
         # "input_shape": [
-        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
-        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
         # ],  # bcast
         "input_dtype": [
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -88,6 +89,8 @@ def return_dtype(dtype):
         return ttnn.bfloat8_b
     elif dtype == "ttnn.bfloat4_b":
         return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
 
 
 def return_mem_config(mem_config_string):
@@ -174,12 +177,9 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
-    if isinstance(input_shape["other"], list):
-        torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.float32), input_b_dtype
-        )(input_shape["other"])
-    else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+    )(input_shape["other"])
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -203,11 +203,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.pow)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.pow(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_scalar_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_scalar_survey.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_scalar_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_scalar_survey.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "rsub_scalar_1": {
+        "input_shape": [[1, 1, 1024, 1024]],
+        "input_a_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_a_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_memory_config": [
+            {"a_mem_config": "l1_interleaved"},
+            {"a_mem_config": "dram_interleaved"},
+            {"a_mem_config": "l1_height_sharded_rm"},
+            {"a_mem_config": "l1_height_sharded_cm"},
+            {"a_mem_config": "l1_width_sharded_rm"},
+            {"a_mem_config": "l1_width_sharded_cm"},
+            {"a_mem_config": "l1_block_sharded_rm"},
+            {"a_mem_config": "l1_block_sharded_cm"},
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_a_layout,
+    input_memory_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+    input_a_memory_config = input_memory_config["a_mem_config"]
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    scalar_value = random.uniform(-100, 100)
+    # scalar_value = random.randint(0, 32)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    golden_function = ttnn.get_golden_function(ttnn.rsub)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar_value)
+    start_time = start_measuring_time()
+    result = ttnn.experimental.rsub(input_tensor_a, scalar_value)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+    # print("torch_output_tensor", torch_output_tensor)
+    # print("output_tensor", output_tensor)
+    # diff = torch.abs(torch_output_tensor - output_tensor)
+    # max_atol = torch.max(diff)
+    # print(f"Max absolute tolerance (atol): {max_atol.item()}")
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
@@ -23,19 +23,27 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "rsub_bf16_1": {
-        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
-        # "input_a_dtype": [ttnn.float32],
-        # "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
-        # "input_a_dtype": [ttnn.bfloat4_b],
-        # "input_b_dtype": [ttnn.bfloat4_b],
+    "rsub_mixed_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -66,6 +74,17 @@ parameters = {
 }
 
 
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
 def return_mem_config(mem_config_string):
     if mem_config_string == "l1_interleaved":
         return ttnn.L1_MEMORY_CONFIG
@@ -73,8 +92,8 @@ def return_mem_config(mem_config_string):
         return ttnn.DRAM_MEMORY_CONFIG
     elif mem_config_string == "l1_height_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -82,8 +101,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_height_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -91,8 +110,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -100,8 +119,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -109,8 +128,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -118,8 +137,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -134,8 +153,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,16 +162,18 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -174,17 +194,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.rsub)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
@@ -193,5 +204,10 @@ def run(
     result = ttnn.experimental.rsub(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
+    print(torch_output_tensor)
+    print(output_tensor)
+    diff = torch.abs(torch_output_tensor - output_tensor)
+    max_atol = torch.max(diff)
+    print(f"Max absolute tolerance (atol): {max_atol.item()}")
 
     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
@@ -23,9 +23,9 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "div_bf16_1": {
+    "rsub_bf16_1": {
         "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
         "input_a_dtype": [ttnn.bfloat16],
         "input_b_dtype": [ttnn.bfloat16],
         # "input_a_dtype": [ttnn.float32],
@@ -150,7 +150,7 @@ def run(
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=-1, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
         )(input_shape["other"])
     else:
         torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
@@ -186,11 +186,11 @@ def run(
     if input_b_dtype == ttnn.bfloat4_b:
         torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.div)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.rsub)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.div(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.rsub(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
@@ -16,24 +16,23 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "rsub_bcast_mixed_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
-        ],  # for bcast
+    "rsub_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
+        # "input_shape": [
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        # ],  # bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -47,31 +46,33 @@ parameters = {
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -207,10 +208,5 @@ def run(
     result = ttnn.experimental.rsub(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
-    # print("torch_output_tensor", torch_output_tensor)
-    # print("output_tensor", output_tensor)
-    diff = torch.abs(torch_output_tensor - output_tensor)
-    max_atol = torch.max(diff)
-    print(f"Max absolute tolerance (atol): {max_atol.item()}")
 
     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/rsub/rsub_ng_survey.py
@@ -16,14 +16,24 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "rsub_mixed_1": {
+    "rsub_bcast_mixed_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_shape": [
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        ],  # for bcast
         "input_dtype": [
             # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
             # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
             # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -44,24 +54,24 @@ parameters = {
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -197,5 +207,10 @@ def run(
     result = ttnn.experimental.rsub(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
+    # print("torch_output_tensor", torch_output_tensor)
+    # print("output_tensor", output_tensor)
+    diff = torch.abs(torch_output_tensor - output_tensor)
+    max_atol = torch.max(diff)
+    print(f"Max absolute tolerance (atol): {max_atol.item()}")
 
     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/squared_difference/squared_difference_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/squared_difference/squared_difference_ng_survey.py
@@ -2,40 +2,42 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-# TIMEOUT = 30
-
-# random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "sq_diff_bf4b_1": {
-        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
-        # "input_a_dtype": [ttnn.bfloat16],
-        # "input_b_dtype": [ttnn.bfloat16],
-        # "input_a_dtype": [ttnn.float32],
-        # "input_b_dtype": [ttnn.float32],
-        # "input_a_dtype": [ttnn.int32],
-        # "input_b_dtype": [ttnn.int32],
-        # "input_a_dtype": [ttnn.bfloat8_b],
-        # "input_b_dtype": [ttnn.bfloat8_b],
-        "input_a_dtype": [ttnn.bfloat4_b],
-        "input_b_dtype": [ttnn.bfloat4_b],
+    "sq_diff_mixed_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_dtype": [
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"}, # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+        ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_mem_config": [
@@ -66,6 +68,17 @@ parameters = {
 }
 
 
+def return_dtype(dtype):
+    if dtype == "ttnn.bfloat16":
+        return ttnn.bfloat16
+    elif dtype == "ttnn.float32":
+        return ttnn.float32
+    elif dtype == "ttnn.bfloat8_b":
+        return ttnn.bfloat8_b
+    elif dtype == "ttnn.bfloat4_b":
+        return ttnn.bfloat4_b
+
+
 def return_mem_config(mem_config_string):
     if mem_config_string == "l1_interleaved":
         return ttnn.L1_MEMORY_CONFIG
@@ -73,8 +86,8 @@ def return_mem_config(mem_config_string):
         return ttnn.DRAM_MEMORY_CONFIG
     elif mem_config_string == "l1_height_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -82,8 +95,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_height_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -91,8 +104,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512, 512 // 8),
-            shape=(1024, 1024 // 8),
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -100,8 +113,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_width_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 8, 512),
-            shape=(1024 // 8, 1024),
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.WIDTH,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -109,8 +122,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_rm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -118,8 +131,8 @@ def return_mem_config(mem_config_string):
         )
     elif mem_config_string == "l1_block_sharded_cm":
         return ttnn.create_sharded_memory_config(
-            # shape=(512 // 2, 512 // 4),
-            shape=(1024 // 2, 1024 // 4),
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
             core_grid=ttnn.CoreGrid(y=2, x=4),
             strategy=ttnn.ShardStrategy.BLOCK,
             orientation=ttnn.ShardOrientation.COL_MAJOR,
@@ -134,8 +147,7 @@ def return_mem_config(mem_config_string):
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_b_dtype,
+    input_dtype,
     input_a_layout,
     input_b_layout,
     input_mem_config,
@@ -144,16 +156,19 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
+    input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
+
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -174,17 +189,8 @@ def run(
         memory_config=return_mem_config(input_b_memory_config),
     )
 
-    if input_a_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat8_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
-
-    if input_a_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
-
-    if input_b_dtype == ttnn.bfloat4_b:
-        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+    torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+    torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
     golden_function = ttnn.get_golden_function(ttnn.experimental.squared_difference)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
@@ -193,5 +199,11 @@ def run(
     result = ttnn.experimental.squared_difference(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
+
+    # print(torch_output_tensor)
+    # print(output_tensor)
+    # diff = torch.abs(torch_output_tensor - output_tensor)
+    # max_atol = torch.max(diff)
+    # print(f"Max absolute tolerance (atol): {max_atol.item()}")
 
     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/squared_difference/squared_difference_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/squared_difference/squared_difference_ng_survey.py
@@ -17,62 +17,63 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "sq_diff_bcast_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
-        ],  # for bcast
+    "sq_diff_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
+        # "input_shape": [
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+        # ],  # bcast
         "input_dtype": [
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }

--- a/tests/sweep_framework/sweeps/eltwise/binary/squared_difference/squared_difference_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/squared_difference/squared_difference_ng_survey.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "sq_diff_bf4b_1": {
+        "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}], # for float32 and int32 dtypes
+        # "input_a_dtype": [ttnn.bfloat16],
+        # "input_b_dtype": [ttnn.bfloat16],
+        # "input_a_dtype": [ttnn.float32],
+        # "input_b_dtype": [ttnn.float32],
+        # "input_a_dtype": [ttnn.int32],
+        # "input_b_dtype": [ttnn.int32],
+        # "input_a_dtype": [ttnn.bfloat8_b],
+        # "input_b_dtype": [ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat4_b],
+        "input_b_dtype": [ttnn.bfloat4_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512, 512 // 8),
+            shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 8, 512),
+            shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            # shape=(512 // 2, 512 // 4),
+            shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat8_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    if input_a_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+    if input_b_dtype == ttnn.bfloat4_b:
+        torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.squared_difference)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.squared_difference(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_ng_survey.py
@@ -17,36 +17,36 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "sq_diff_bcast_1": {
+    "sub_bcast_mixed_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
         # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
         "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
         ],  # for bcast
         "input_dtype": [
-            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
@@ -202,11 +202,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.squared_difference)
+    golden_function = ttnn.get_golden_function(ttnn.experimental.sub)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.squared_difference(input_tensor_a, input_tensor_b)
+    result = ttnn.experimental.sub(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_ng_survey.py
@@ -17,24 +17,23 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "sub_bcast_mixed_1": {
-        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
-        # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
-        "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
-        ],  # for bcast
+    "sub_rm_2": {
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # no bcast
+        # "input_shape": [
+        #     {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
+        #     {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
+        #     {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
+        #     {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
+        #     {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
+        #     {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
+        #     {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
+        #     {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
+        # ],  # bcast
         "input_dtype": [
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
             {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
@@ -48,31 +47,33 @@ parameters = {
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
             {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_layout": [ttnn.TILE_LAYOUT],
+        # "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }

--- a/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_all_ops.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_ng/binary_ng_all_ops.py
@@ -17,36 +17,58 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "sq_diff_bcast_1": {
+    "sub_bcast_1": {
+        "binary_op": [
+            # {"tt_op": "add"},
+            {"tt_op": "sub"},
+            # {"tt_op" :"rsub"},
+            # {"tt_op" :"mul"},
+            # {"tt_op" :"div"},
+            # {"tt_op" :"gte"},
+            # {"tt_op" :"gt"},
+            # {"tt_op" :"lte"},
+            # {"tt_op" :"lt"},
+            # {"tt_op" :"eq"},
+            # {"tt_op" :"ne"},
+            # {"tt_op" :"logical_and"},
+            # {"tt_op" :"logical_or"},
+            # {"tt_op" :"logical_xor"},
+            # {"tt_op" :"ldexp"},
+            # {"tt_op" :"logaddexp"},
+            # {"tt_op" :"logaddexp2"},
+            # {"tt_op" :"squared_difference"},
+            # {"tt_op" :"bias_gelu"},
+        ],
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
         # "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
         "input_shape": [
-            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b #0.98
-            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b
-            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar
-            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a
-            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a
-            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar
-            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b
-            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a
+            {"self": [4, 8, 64, 512], "other": [1, 8, 64, 1]},  # col_b, N_b   # bf4b passes for [-100, 100]
+            {"self": [4, 8, 64, 512], "other": [4, 1, 1, 512]},  # row_b, C_b  # atol = nan for bf4b
+            {"self": [4, 8, 64, 512], "other": [4, 8, 1, 1]},  # B scalar      # bf4b passes for [-74, 74]
+            {"self": [1, 8, 64, 1], "other": [4, 8, 64, 512]},  # col_a, N_a   # atol = nan for bf4b
+            {"self": [4, 1, 1, 512], "other": [4, 8, 64, 512]},  # row_a, C_a  # atol = nan for bf4b
+            {"self": [4, 8, 1, 1], "other": [4, 8, 64, 512]},  # A scalar      # atol = nan for bf4b
+            {"self": [4, 8, 1, 512], "other": [4, 8, 64, 1]},  # row_a, col_b  # bf4b passes for [-100, 100]
+            {"self": [4, 8, 64, 1], "other": [4, 8, 1, 512]},  # row_b, col_a    # atol = nan for bf4b
         ],  # for bcast
         "input_dtype": [
-            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
-            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
-            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
-            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
-            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
-            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
+            # {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat16"},
+            # {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.float32"},
+            # {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat8_b"},
+            # {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat4_b"},  # same dtype
+            # {"input_a_dtype": "ttnn.int32", "input_b_dtype": "ttnn.int32"},  # same dtype - only for add/bitwise
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.bfloat16", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat8_b"},
+            {"input_a_dtype": "ttnn.float32", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat8_b", "input_b_dtype": "ttnn.bfloat4_b"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.float32"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat16"},
+            {"input_a_dtype": "ttnn.bfloat4_b", "input_b_dtype": "ttnn.bfloat8_b"},  # mixed dtype
         ],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
@@ -55,24 +77,24 @@ parameters = {
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
-            # {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
-            # {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
-            # {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
-            # {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
-            # {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
-            # {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
         ],
     },
 }
@@ -87,6 +109,8 @@ def return_dtype(dtype):
         return ttnn.bfloat8_b
     elif dtype == "ttnn.bfloat4_b":
         return ttnn.bfloat4_b
+    elif dtype == "ttnn.int32":
+        return ttnn.int32
 
 
 def return_mem_config(mem_config_string):
@@ -156,6 +180,7 @@ def return_mem_config(mem_config_string):
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
+    binary_op,
     input_shape,
     input_dtype,
     input_a_layout,
@@ -166,19 +191,23 @@ def run(
 ) -> list:
     torch.manual_seed(0)
 
+    ttnn_fn = getattr(ttnn.experimental, binary_op["tt_op"])
     input_a_dtype = return_dtype(input_dtype["input_a_dtype"])
     input_b_dtype = return_dtype(input_dtype["input_b_dtype"])
 
+    torch_dtype = torch.float32
+    if input_a_dtype == ttnn.int32 and input_b_dtype == ttnn.int32:
+        torch_dtype = torch.int32
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch_dtype), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
         torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+            partial(torch_random, low=-100, high=100, dtype=torch_dtype), input_b_dtype
         )(input_shape["other"])
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch_dtype)
 
     input_a_memory_config = input_mem_config["a_mem"]
     input_b_memory_config = input_mem_config["b_mem"]
@@ -202,11 +231,11 @@ def run(
     torch_input_tensor_a = ttnn.to_torch(input_tensor_a)
     torch_input_tensor_b = ttnn.to_torch(input_tensor_b)
 
-    golden_function = ttnn.get_golden_function(ttnn.experimental.squared_difference)
+    golden_function = ttnn.get_golden_function(ttnn_fn)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     start_time = start_measuring_time()
-    result = ttnn.experimental.squared_difference(input_tensor_a, input_tensor_b)
+    result = ttnn_fn(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_and/bitwise_and_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_and/bitwise_and_ng_survey.py
@@ -23,13 +23,13 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "bitwise_and_1": {
+    "bitwise_and_rm_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
         "input_a_dtype": [ttnn.int32],
         "input_b_dtype": [ttnn.int32],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_and/bitwise_and_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_and/bitwise_and_ng_survey.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "bitwise_and_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.int32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.bitwise_and)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.bitwise_and(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_left_shift/bitwise_left_shift_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_left_shift/bitwise_left_shift_ng_survey.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "bitwise_left_shift_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.int32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.bitwise_left_shift)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.bitwise_left_shift(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_or/bitwise_or_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_or/bitwise_or_ng_survey.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "bitwise_or_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.int32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.bitwise_or)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.bitwise_or(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_or/bitwise_or_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_or/bitwise_or_ng_survey.py
@@ -23,13 +23,13 @@ from models.utility_functions import torch_random
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "bitwise_or_1": {
+    "bitwise_or_rm_1": {
         # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
         "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
         "input_a_dtype": [ttnn.int32],
         "input_b_dtype": [ttnn.int32],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_b_layout": [ttnn.ROW_MAJOR_LAYOUT],
         "input_mem_config": [
             {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
             {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_right_shift/bitwise_right_shift_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_right_shift/bitwise_right_shift_ng_survey.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "bitwise_right_shift_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=0, high=32, dtype=torch.int32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.bitwise_right_shift)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.bitwise_right_shift(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_xor/bitwise_xor_ng_survey.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_xor/bitwise_xor_ng_survey.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+# TIMEOUT = 30
+
+# random.seed(0)
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "bitwise_xor_1": {
+        # "input_shape": [{"self": [1, 1, 1024, 1024], "other": [1, 1, 1024, 1024]}],
+        "input_shape": [{"self": [1, 1, 512, 512], "other": [1, 1, 512, 512]}],  # for float32 and int32 dtypes
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_mem_config": [
+            {"a_mem": "l1_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "l1_interleaved", "b_mem": "dram_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_interleaved"},
+            {"a_mem": "dram_interleaved", "b_mem": "dram_interleaved"},  # l1 - dram combination
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_rm"},
+            {"a_mem": "l1_height_sharded_rm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_rm"},
+            {"a_mem": "l1_width_sharded_rm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_rm"},
+            {"a_mem": "l1_block_sharded_rm", "b_mem": "dram_interleaved"},  # BS #row_major orientation
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_height_sharded_cm"},
+            {"a_mem": "l1_height_sharded_cm", "b_mem": "dram_interleaved"},  # HS
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_width_sharded_cm"},
+            {"a_mem": "l1_width_sharded_cm", "b_mem": "dram_interleaved"},  # WS
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "dram_interleaved", "b_mem": "l1_block_sharded_cm"},
+            {"a_mem": "l1_block_sharded_cm", "b_mem": "dram_interleaved"},  # BS #col_major orientation
+        ],
+    },
+}
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_interleaved":
+        return ttnn.L1_MEMORY_CONFIG
+    elif mem_config_string == "dram_interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    elif mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            # shape=(1024, 1024 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            # shape=(1024 // 8, 1024),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            # shape=(1024 // 2, 1024 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_mem_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.int32), input_a_dtype
+    )(input_shape["self"])
+
+    if isinstance(input_shape["other"], list):
+        torch_input_tensor_b = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.int32), input_b_dtype
+        )(input_shape["other"])
+    else:
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.int32)
+
+    input_a_memory_config = input_mem_config["a_mem"]
+    input_b_memory_config = input_mem_config["b_mem"]
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=return_mem_config(input_a_memory_config),
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=return_mem_config(input_b_memory_config),
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.experimental.bitwise_xor)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    start_time = start_measuring_time()
+    result = ttnn.experimental.bitwise_xor(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -10,6 +10,7 @@ import datetime
 import os
 import json
 import enlighten
+import csv
 from tt_metal.tools.profiler.process_ops_logs import get_device_data_generate_report
 from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR
 from multiprocessing import Process
@@ -23,6 +24,58 @@ from framework.elastic_config import *
 from framework.sweeps_logger import sweeps_logger as logger
 
 ARCH = os.getenv("ARCH_NAME")
+
+
+# def file_handler():
+#     current_directory = os.getcwd()
+#     file_path = os.path.join(current_directory, "results", "test_results_sub.txt")
+#     csv_file_path = os.path.join(current_directory, "results", "test_results_sub.csv")
+#     print(f"Pass Results will be saved to: {file_path} or {csv_file_path}")
+
+#     if os.path.exists(file_path):
+#         os.remove(file_path)
+#     if os.path.exists(csv_file_path):
+#         os.remove(csv_file_path)
+#     return file_path, csv_file_path
+
+
+# txt_file, csv_file = file_handler()
+
+
+# def write_to_file(file_path, test_vector, status, message):
+#     with open(file_path, "a") as f:
+#         binary_op = test_vector.get("binary_op", {})
+#         input_dtype = test_vector.get("input_dtype", {})
+#         input_mem_config = test_vector.get("input_mem_config", {})
+
+#         op = binary_op.get("tt_op", "unknown")
+#         input_a_dtype = input_dtype.get("input_a_dtype", "unknown")
+#         input_b_dtype = input_dtype.get("input_b_dtype", "unknown")
+#         a_mem = input_mem_config.get("a_mem", "unknown")
+#         b_mem = input_mem_config.get("b_mem", "unknown")
+
+#         f.write(f"{op} : ({input_a_dtype}, {input_b_dtype}) - ({a_mem}, {b_mem}) - {message}\n")
+
+
+# def write_to_csv_file(file_path, test_vector, status, message):
+#     with open(file_path, "a", newline="") as f:
+#         writer = csv.writer(f)
+
+#         f.seek(0, 2)
+#         if f.tell() == 0:
+#             writer.writerow(["op", "input_a_dtype", "input_b_dtype", "a_mem", "b_mem", "message"])
+
+#         binary_op = test_vector.get("binary_op", {})
+#         input_dtype = test_vector.get("input_dtype", {})
+#         input_mem_config = test_vector.get("input_mem_config", {})
+
+#         op = binary_op.get("tt_op", "unknown")
+#         input_a_dtype = input_dtype.get("input_a_dtype", "unknown")
+#         input_b_dtype = input_dtype.get("input_b_dtype", "unknown")
+#         a_mem = input_mem_config.get("a_mem", "unknown")
+#         b_mem = input_mem_config.get("b_mem", "unknown")
+
+#         writer.writerow([op, input_a_dtype, input_b_dtype, a_mem, b_mem, message])
 
 
 def git_hash():
@@ -95,6 +148,23 @@ def run(test_module, input_queue, output_queue):
                 output_queue.put([status, message, e2e_perf, perf_result])
             else:
                 output_queue.put([status, message, e2e_perf, None])
+
+            # if status:
+            #     # write_to_file(txt_file, test_vector, status, message)
+            #     write_to_csv_file(csv_file, test_vector, status, message)
+            #     # print("-----------------------")
+            #     # print("current parameter ", test_vector)
+            #     # print("STATUS", status)
+            #     # print("message", message)
+            # # if not status:
+            # #     write_to_file(txt_file, test_vector, status, "FAILED")
+            # #     write_to_csv_file(csv_file, test_vector, status, "FAILED")
+            # #     print("********* FAILED *********")
+            # #     print("current parameter ", test_vector)
+            # #     print("STATUS", status)
+            # #     print("message", message)
+            # #     print("**************************")
+
             if not status:
                 print("-----------------------")
                 print("current parameter ", test_vector)

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -95,6 +95,11 @@ def run(test_module, input_queue, output_queue):
                 output_queue.put([status, message, e2e_perf, perf_result])
             else:
                 output_queue.put([status, message, e2e_perf, None])
+            if not status:
+                print("-----------------------")
+                print("current parameter ", test_vector)
+                print("STATUS", status)
+                print("message", message)
     except Empty as e:
         try:
             # Run teardown in mesh_device_fixture


### PR DESCRIPTION
### Ticket
#17829 

### Problem description
To track the available and missing functionalities of binary_ng ops

### What's changed
Tested the following ops:
- [ ] mul
- [ ] div
- [ ] bias_gelu
- [ ] squared_difference
- [ ] logaddexp
- [ ] logaddexp2
- [ ] sub

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
