### PR TITLE
Use the namespaced target for magic_enum

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(
         pthread
         gmock_main
         nlohmann_json::nlohmann_json
-        magic_enum
+        magic_enum::magic_enum
         fmt::fmt-header-only
         span
         small_vector

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -104,7 +104,7 @@ target_link_libraries(
         Metalium::TTNN
         Python::Python
         fmt::fmt-header-only
-        magic_enum
+        magic_enum::magic_enum
         yaml-cpp::yaml-cpp
         xtensor
         xtensor-blas

--- a/tt_fabric/CMakeLists.txt
+++ b/tt_fabric/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(
         Metalium::Metal::LLRT
         umd::device
         metal_common_libs
-        magic_enum
+        magic_enum::magic_enum
         fmt::fmt-header-only
         yaml-cpp::yaml-cpp
 )

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(
     tt_metal
     PUBLIC
         umd::device
-        magic_enum
+        magic_enum::magic_enum
         fmt::fmt-header-only
         span
         small_vector

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(
     common
     PUBLIC
         nlohmann_json::nlohmann_json
-        magic_enum
+        magic_enum::magic_enum
         fmt::fmt-header-only
         span
         small_vector

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -107,7 +107,7 @@ target_link_libraries(
         nlohmann_json::nlohmann_json
         Reflect::Reflect
         yaml-cpp::yaml-cpp
-        magic_enum
+        magic_enum::magic_enum
         span
         common
 )


### PR DESCRIPTION
### Ticket
#15795

### Problem description
We always should use the namespaced target, and we MUST use the namespaced target when using an externally provided dependency.

### What's changed
magic_enum -> magic_enum::magic_enum
