### PR TITLE
[skip ci] Add CMake hookup for code coverage

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -141,7 +141,7 @@ while true; do
             enable_tsan="ON";;
         -u|--enable-ubsan)
             enable_ubsan="ON";;
-        -u|--enable-coverage)
+        --enable-coverage)
             enable_coverage="ON";;
         -b|--build-type)
             build_type="$2";shift;;

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -36,6 +36,7 @@ show_help() {
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
     echo "  --configure-only                 Only configure the project, do not build."
+    echo "  --enable-coverage                Instrument the binaries for code coverage."
 }
 
 clean() {
@@ -69,6 +70,7 @@ c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
 configure_only="OFF"
+enable_coverage="OFF"
 
 declare -a cmake_args
 
@@ -105,6 +107,7 @@ c-compiler-path:
 ttnn-shared-sub-libs
 toolchain-path:
 configure-only
+enable-coverage
 "
 
 # Flatten LONGOPTIONS into a comma-separated string for getopt
@@ -138,6 +141,8 @@ while true; do
             enable_tsan="ON";;
         -u|--enable-ubsan)
             enable_ubsan="ON";;
+        -u|--enable-coverage)
+            enable_coverage="ON";;
         -b|--build-type)
             build_type="$2";shift;;
         -p|--enable-profiler)
@@ -228,6 +233,7 @@ echo "INFO: Enable AddressSanitizer: $enable_asan"
 echo "INFO: Enable MemorySanitizer: $enable_msan"
 echo "INFO: Enable ThreadSanitizer: $enable_tsan"
 echo "INFO: Enable UndefinedBehaviorSanitizer: $enable_ubsan"
+echo "INFO: Enable Coverage: $enable_coverage"
 echo "INFO: Build directory: $build_dir"
 echo "INFO: Install Prefix: $cmake_install_prefix"
 echo "INFO: Build tests: $build_tests"
@@ -282,6 +288,10 @@ fi
 
 if [ "$enable_profiler" = "ON" ]; then
     cmake_args+=("-DENABLE_TRACY=ON")
+fi
+
+if [ "$enable_coverage" = "ON" ]; then
+    cmake_args+=("-DENABLE_COVERAGE=ON")
 fi
 
 if [ "$export_compile_commands" = "ON" ]; then

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -20,6 +20,7 @@ option(TT_UNITY_BUILDS "Build with Unity builds" ON)
 option(BUILD_TT_TRAIN "Enables build of tt-train" OFF)
 option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up incremental builds" OFF)
 option(TT_ENABLE_LIGHT_METAL_TRACE "Enable Light Metal Trace" ON)
+option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 
 ###########################################################################################
 

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(STATUS "Enabling code coverage flags for all tt_metal targets")
+    add_compile_options(--coverage)
+    add_link_options(--coverage)
+endif()
+
 add_library(tt_metal)
 add_library(Metalium::Metal ALIAS tt_metal)
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(STATUS "Enabling code coverage flags for all ttnn targets")
+    add_compile_options(--coverage)
+    add_link_options(--coverage)
+endif()
+
 set(TTNN_BASE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/config.cpp


### PR DESCRIPTION
### Ticket
#17852 

### Problem description
Small step towards having code coverage in CI.

### What's changed
Just CMake magic.
Use option to set coverage flags in a certain scope. I think it’s very important to control what targets are instrumented. So I chose this approach vs coverage build type. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
