### PR TITLE
Support MS/Phi3.5 by updating qkv/gate_up_proj tensors

### DIFF
--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -204,6 +204,7 @@ class TtModelArgs:
                 "DeepSeek-R1-Distill-Llama-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128},
                 "Qwen2.5-7B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
                 "Qwen2.5-72B": {"N150": None, "N300": None, "T3K": 32, "TG": 128},
+                "Phi-3.5-mini-instruct": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
             }
             try:
                 max_prefill_chunk_size_div1024 = MAX_PREFILL_CHUNK_SIZES_DIV1024[self.base_model_name][self.device_name]

--- a/models/demos/phi3/ref_demo.py
+++ b/models/demos/phi3/ref_demo.py
@@ -1,0 +1,35 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+torch.random.manual_seed(0)
+
+# Load the model from the custom path
+custom_path = "/proj_sw/user_dev/hf_data/"
+model = AutoModelForCausalLM.from_pretrained("microsoft/Phi-3.5-mini-instruct", cache_dir=custom_path)
+tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-mini-instruct", cache_dir=custom_path)
+
+messages = [
+    {"role": "system", "content": "You are a helpful AI assistant."},
+    {"role": "user", "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"},
+    {
+        "role": "assistant",
+        "content": "Sure! Here are some ways to eat bananas and dragonfruits together: 1. Banana and dragonfruit smoothie: Blend bananas and dragonfruits together with some milk and honey. 2. Banana and dragonfruit salad: Mix sliced bananas and dragonfruits together with some lemon juice and honey.",
+    },
+    {"role": "user", "content": "What about solving an 2x + 3 = 7 equation?"},
+]
+
+pipe = pipeline(
+    "text-generation",
+    model=model,
+    tokenizer=tokenizer,
+)
+
+generation_args = {
+    "max_new_tokens": 500,
+    "return_full_text": False,
+    "temperature": 0.0,
+    "do_sample": False,
+}
+
+output = pipe(messages, **generation_args)
+print(output[0]["generated_text"])

--- a/models/demos/phi3/ref_demo.py
+++ b/models/demos/phi3/ref_demo.py
@@ -5,8 +5,12 @@ torch.random.manual_seed(0)
 
 # Load the model from the custom path
 custom_path = "/proj_sw/user_dev/hf_data/"
-model = AutoModelForCausalLM.from_pretrained("microsoft/Phi-3.5-mini-instruct", cache_dir=custom_path)
-tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3.5-mini-instruct", cache_dir=custom_path)
+model = AutoModelForCausalLM.from_pretrained(
+    "microsoft/Phi-3.5-mini-instruct", cache_dir=custom_path, trust_remote_code=True
+)
+tokenizer = AutoTokenizer.from_pretrained(
+    "microsoft/Phi-3.5-mini-instruct", cache_dir=custom_path, trust_remote_code=True
+)
 
 messages = [
     {"role": "system", "content": "You are a helpful AI assistant."},

--- a/models/demos/phi3/rms_norm_unit_test_sample.py
+++ b/models/demos/phi3/rms_norm_unit_test_sample.py
@@ -1,0 +1,57 @@
+import torch
+import pytest
+import ttnn
+from models.utility_functions import comp_pcc
+from models.common.rmsnorm import RMSNorm as TtRMSNorm
+
+
+class Phi3RMSNorm(torch.nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        Phi3RMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+def test_phi3_rms_norm(mesh_device, use_program_cache, reset_seeds):
+    hidden_size = 3072  # Taken from config
+
+    ref_model = Phi3RMSNorm(hidden_size)
+    input_tensor = torch.randn(1, 1, 32, hidden_size)
+    ref_output = ref_model(input_tensor)
+
+    ttnn_input = ttnn.from_torch(
+        input_tensor,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Dummy weights
+    state_dict = ref_model.state_dict()
+    # Rename the keys to match the TtRMSNorm
+    state_dict = {f"rmsnorm.{k}": v for k, v in state_dict.items()}
+
+    ttnn_model = TtRMSNorm(
+        device=mesh_device,
+        dim=hidden_size,
+        state_dict=state_dict,
+        weight_key="rmsnorm",
+    )
+
+    ttnn_output = ttnn_model(ttnn_input, mode="decode")
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    passing, pcc_message = comp_pcc(ref_output, ttnn_output, 0.99)
+    print(f"PCC: {pcc_message}")
+    assert passing, f"RMSNorm output does not meet PCC requirement {0.99}."


### PR DESCRIPTION
### Ticket
Tenstorrent-Together Hackathon 
### Problem description
`microsoft/Phi-3.5-mini-instruct` was not running correctly since the weight keys are different from the meta/llama naming conventions.

### What's changed
Updated the hf_to_meta mapping to preserve the key names and then added a function which would do slice the qkv vector to individual tensors as well as the `gate_up_proj` tensors. 
Verified working with `microsoft/Phi-3.5-mini-instruct` model with instructions from hackathon.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
