### PR TITLE
#17482: Add matmul validation to prevent illegal width + block sharded inputs

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1528,19 +1528,6 @@ void Matmul::validate(
             this->output_dtype.value());
     }
 
-    const bool has_width_sharded_input = (input_tensor_a.is_sharded() && input_tensor_a.memory_config().memory_layout ==
-                                                                             TensorMemoryLayout::WIDTH_SHARDED) ||
-                                         (input_tensor_b.is_sharded() && input_tensor_b.memory_config().memory_layout ==
-                                                                             TensorMemoryLayout::WIDTH_SHARDED);
-
-    const bool has_block_sharded_input = (input_tensor_a.is_sharded() && input_tensor_a.memory_config().memory_layout ==
-                                                                             TensorMemoryLayout::BLOCK_SHARDED) ||
-                                         (input_tensor_b.is_sharded() && input_tensor_b.memory_config().memory_layout ==
-                                                                             TensorMemoryLayout::BLOCK_SHARDED);
-    TT_FATAL(
-        !(has_width_sharded_input && has_block_sharded_input),
-        "Cannot have one input width sharded and one input block sharded");
-
     std::visit(
         [input_tensor_a, input_tensor_b, optional_bias, in0_tile_shape, in1_tile_shape, this](
             const auto& program_config) {
@@ -1860,6 +1847,14 @@ void Matmul::validate(
                     auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout;
                     TT_FATAL(tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
                     if (input_tensor_b.buffer()->buffer_type() != tt_metal::BufferType::DRAM) {
+                        const auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout;
+                        TT_FATAL(
+                            (input_tensor_a.memory_config().is_sharded() &&
+                             tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                                tensor_a_memory_layout == TensorMemoryLayout::INTERLEAVED,
+                            "Error - non-DRAM width sharded input B requires input A to be interleaved or height "
+                            "sharded, rather than {}",
+                            tensor_a_memory_layout);
                         TT_FATAL(
                             program_config.per_core_N ==
                                 (input_tensor_b.shard_spec().value().shape[1] / in1_tile_shape[1]),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1528,6 +1528,19 @@ void Matmul::validate(
             this->output_dtype.value());
     }
 
+    const bool has_width_sharded_input = (input_tensor_a.is_sharded() && input_tensor_a.memory_config().memory_layout ==
+                                                                             TensorMemoryLayout::WIDTH_SHARDED) ||
+                                         (input_tensor_b.is_sharded() && input_tensor_b.memory_config().memory_layout ==
+                                                                             TensorMemoryLayout::WIDTH_SHARDED);
+
+    const bool has_block_sharded_input = (input_tensor_a.is_sharded() && input_tensor_a.memory_config().memory_layout ==
+                                                                             TensorMemoryLayout::BLOCK_SHARDED) ||
+                                         (input_tensor_b.is_sharded() && input_tensor_b.memory_config().memory_layout ==
+                                                                             TensorMemoryLayout::BLOCK_SHARDED);
+    TT_FATAL(
+        !(has_width_sharded_input && has_block_sharded_input),
+        "Cannot have one input width sharded and one input block sharded");
+
     std::visit(
         [input_tensor_a, input_tensor_b, optional_bias, in0_tile_shape, in1_tile_shape, this](
             const auto& program_config) {


### PR DESCRIPTION
### Ticket
[17482](https://github.com/tenstorrent/tt-metal/issues/17482)

### Problem description
Performing matmul with a block sharded + a width sharded input resulted in a device hang

### What's changed
Added validation to error when invalid combination of block + non-DRAM width sharded inputs are received.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- https://github.com/tenstorrent/tt-metal/actions/runs/13460303299
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
