### PR TITLE
Fix matrix shard config.

### DIFF
--- a/models/demos/llama3/tt/llama_attention.py
+++ b/models/demos/llama3/tt/llama_attention.py
@@ -206,7 +206,7 @@ class TtLlamaAttention(LightweightModule):
         pt_wo = self.state_dict[f"{wo_str}.weight"].transpose(-1, -2).unsqueeze(0).unsqueeze(0)
 
         wo_mem_config = configuration.create_dram_sharded_mem_config(
-            configuration.dim // configuration.num_devices, configuration.dim
+            (configuration.n_heads * configuration.head_dim) // configuration.num_devices, configuration.dim
         )
 
         self.wo = ttnn.as_tensor(


### PR DESCRIPTION
### Ticket
`google/gemma-2-2b-it` fails to load correctly on N300. 

### Problem description
The `wo` matrix was using an incorrect memory config causing some models to fail in sharding.

### What's changed
Fixed the dimension of the matrix to account to use `n_heads*head_dim` instead of model dim. 
Testing with `google/gemma-2-2b-it` on N300 verifies that the model loading succeeds. 
Note - `google/gemma-2-2b-it` produces incorrect output due to unsupported ops which are being worked on. This PR unblocks work on those operations. 

Fix thanks to @yieldthought 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
