### PR TITLE
Install RPATH ORIGIN

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties(
     tt_metal
     PROPERTIES
         INSTALL_RPATH
-            "${PROJECT_BINARY_DIR}/lib"
+            "${PROJECT_BINARY_DIR}/lib;$ORIGIN"
         ADDITIONAL_CLEAN_FILES
             "${PROJECT_BINARY_DIR}/lib;${PROJECT_BINARY_DIR}/obj"
 )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -861,6 +861,7 @@ TT_ENABLE_UNITY_BUILD(ttnn)
 set(TTNN_INSTALL_RPATH
     "${PROJECT_BINARY_DIR}/lib"
     "$ORIGIN/build/lib"
+    "$ORIGIN"
 )
 
 #Make sure library built is _ttnn.so and that it can find all it's linked libraries


### PR DESCRIPTION
Add ORIGIN to both ttnn and tt_metal library RPATH's to simplify wheel installation for upstream consumers.