### PR TITLE
Fix for failing to build on GCC-14 

### DIFF
--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -24,6 +24,14 @@ using MeshDevice = distributed::MeshDevice;
 
 namespace {
 
+struct FileCloser {
+    void operator()(FILE* file) const {
+        if (file) {
+            fclose(file);
+        }
+    }
+};
+
 struct Padding {
     enum class PadValue { Any, Zero, Infinity, NegativeInfinity };
     struct PadDimension {
@@ -393,7 +401,7 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
     if (not input_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, decltype(&fclose)> file_guard(input_file, &fclose);
+    std::unique_ptr<FILE, FileCloser> file_guard(input_file);
 
     std::size_t read_sentinel;
     safe_fread(&read_sentinel, sizeof(read_sentinel), 1, input_file);
@@ -435,7 +443,7 @@ void dump_tensor(
     if (not output_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, decltype(&fclose)> file_guard(output_file, &fclose);
+    std::unique_ptr<FILE, FileCloser> file_guard(output_file);
 
     safe_fwrite(&SENTINEL_VALUE, sizeof(SENTINEL_VALUE), 1, output_file);
     safe_fwrite(&VERSION_ID, sizeof(VERSION_ID), 1, output_file);
@@ -495,7 +503,7 @@ void dump_memory_config(const std::string& file_name, const MemoryConfig& memory
     if (not output_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, decltype(&fclose)> file_guard(output_file, &fclose);
+    std::unique_ptr<FILE, FileCloser> file_guard(output_file);
     dump_memory_config(output_file, memory_config);
 }
 
@@ -533,7 +541,7 @@ MemoryConfig load_memory_config(const std::string& file_name) {
     if (not input_file) {
         TT_THROW("Cannot open \"{}\"", file_name);
     }
-    std::unique_ptr<FILE, decltype(&fclose)> file_guard(input_file, &fclose);
+    std::unique_ptr<FILE, FileCloser> file_guard(input_file);
     return load_memory_config(input_file);
 }
 

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -27,7 +27,7 @@ namespace {
 struct FileCloser {
     void operator()(FILE* file) const {
         if (file) {
-            fclose(file);
+            TT_ASSERT(fclose(file) == 0, "Failed to close file");
         }
     }
 };


### PR DESCRIPTION
### Ticket
#17905 

### Problem description
Latest tt-metal can't build correctly on GCC-14

### What's changed

Base on https://stackoverflow.com/questions/76867698/what-does-ignoring-attributes-on-template-argument-mean-in-this-context the error is due to the attribute being lost when casting to function pointer. The simply workaround is to write a class and pass that around. This also has the benefit of not needing the `unique_ptr` to store 2 pointers.

Please help run CI and merge the patch.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13384193646) CI passes