### PR TITLE
Unit test insert_write_packed_payloads

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -176,29 +176,33 @@ TEST(DeviceCommandTest, AddPrefetchRelayPagedPacked) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchWritePacked) {
+template <typename T>
+class WritePackedCommandTest : public ::testing::Test {};
+
+using TestTypes = testing::Types<CQDispatchWritePackedMulticastSubCmd, CQDispatchWritePackedUnicastSubCmd>;
+TYPED_TEST_SUITE(WritePackedCommandTest, TestTypes);
+
+TYPED_TEST(WritePackedCommandTest, AddDispatchWritePacked) {
     {
         DeviceCommandCalculator calculator;
-        calculator.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(2, 5, 100, /*no_stride*/ false);
+        calculator.add_dispatch_write_packed<TypeParam>(2, 5, 100, /*no_stride*/ false);
 
         HostMemDeviceCommand command(calculator.write_offset_bytes());
-        std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds(2);
+        std::vector<TypeParam> sub_cmds(2);
         uint32_t data[1] = {};
         std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}, {data, 4}};
-        command.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
-            2, 0, 5, 0, sub_cmds, data_collection, 100, 0, false);
+        command.add_dispatch_write_packed<TypeParam>(2, 0, 5, 0, sub_cmds, data_collection, 100, 0, false);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
         DeviceCommandCalculator calculator;
-        calculator.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(2, 5, 100, /*no_stride*/ true);
+        calculator.add_dispatch_write_packed<TypeParam>(2, 5, 100, /*no_stride*/ true);
 
         HostMemDeviceCommand command(calculator.write_offset_bytes());
-        std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds(2);
+        std::vector<TypeParam> sub_cmds(2);
         uint32_t data[1] = {};
         std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}};
-        command.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
-            2, 0, 5, 0, sub_cmds, data_collection, 100, 0, true);
+        command.add_dispatch_write_packed<TypeParam>(2, 0, 5, 0, sub_cmds, data_collection, 100, 0, true);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
 }
@@ -223,6 +227,51 @@ TEST(DeviceCommandTest, AddDispatchWritePackedLarge) {
         uint8_t data[4] = {};
         std::vector<tt::stl::Span<const uint8_t>> data_collection{{data, 4}};
         command.add_dispatch_write_packed_large(0, 1, sub_cmds, data_collection, nullptr);
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+    }
+}
+
+TYPED_TEST(WritePackedCommandTest, RandomAddDispatchWritePacked) {
+    srand(0);
+    for (size_t i = 0; i < 100; i++) {
+        DeviceCommandCalculator calculator;
+        uint32_t random_start = (rand() % 4) % 32;
+        calculator.add_data(random_start);
+        uint32_t num_sub_cmds = rand() % 100 + 1;
+        uint32_t sub_cmd_sizeB = rand() % 2000 + 1;
+        uint32_t max_prefetch_command_size = 16384;
+        uint32_t packed_write_max_unicast_sub_cmds = 64;
+
+        std::vector<std::pair<uint32_t, uint32_t>> packed_cmd_payloads;
+        calculator.insert_write_packed_payloads<TypeParam>(
+            num_sub_cmds,
+            sub_cmd_sizeB,
+            max_prefetch_command_size,
+            packed_write_max_unicast_sub_cmds,
+            packed_cmd_payloads);
+
+        uint32_t data[2001] = {};
+        std::vector<std::pair<const void*, uint32_t>> data_collection;
+        for (size_t j = 0; j < num_sub_cmds; j++) {
+            data_collection.push_back({data, sub_cmd_sizeB});
+        }
+
+        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        command.add_data(nullptr, 0, random_start);
+        uint32_t curr_sub_cmd_idx = 0;
+        for (const auto& [sub_cmd_ct, payload_size] : packed_cmd_payloads) {
+            std::vector<TypeParam> sub_cmds(sub_cmd_ct);
+            command.add_dispatch_write_packed<TypeParam>(
+                sub_cmd_ct,
+                0,
+                sub_cmd_sizeB,
+                payload_size,
+                sub_cmds,
+                data_collection,
+                packed_write_max_unicast_sub_cmds,
+                curr_sub_cmd_idx);
+            curr_sub_cmd_idx += sub_cmd_ct;
+        }
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
 }

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -23,6 +23,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/program/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/host_runtime_commands.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/device_command_calculator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_query_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_core_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/dispatch_core_manager.cpp

--- a/tt_metal/impl/dispatch/device_command_calculator.cpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_command_calculator.hpp"
+
+namespace tt::tt_metal {
+
+template <typename PackedSubCmd>
+uint32_t DeviceCommandCalculator::get_max_write_packed_sub_cmds(
+    uint32_t data_size,
+    uint32_t max_prefetch_cmd_size,
+    uint32_t packed_write_max_unicast_sub_cmds,
+    bool no_stride) const {
+    static_assert(
+        std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
+        std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
+    constexpr bool is_unicast = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value;
+    uint32_t sub_cmd_sizeB =
+        is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
+    // Approximate calculation due to alignment
+    uint32_t max_prefetch_size = max_prefetch_cmd_size - sizeof(CQPrefetchCmd) - this->pcie_alignment -
+                                 sizeof(CQDispatchCmd) - this->l1_alignment;
+    uint32_t max_prefetch_num_packed_cmds =
+        no_stride ? (max_prefetch_size - tt::align(data_size * sizeof(uint32_t), l1_alignment)) / sub_cmd_sizeB
+                  : max_prefetch_size / (tt::align(data_size * sizeof(uint32_t), l1_alignment) + sub_cmd_sizeB);
+
+    uint32_t packed_write_max_multicast_sub_cmds =
+        get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
+    return std::min(
+        max_prefetch_num_packed_cmds,
+        is_unicast ? packed_write_max_unicast_sub_cmds : packed_write_max_multicast_sub_cmds);
+};
+
+// Explicit template instantiations
+template uint32_t DeviceCommandCalculator::get_max_write_packed_sub_cmds<CQDispatchWritePackedMulticastSubCmd>(
+    uint32_t, uint32_t, uint32_t, bool) const;
+template uint32_t DeviceCommandCalculator::get_max_write_packed_sub_cmds<CQDispatchWritePackedUnicastSubCmd>(
+    uint32_t, uint32_t, uint32_t, bool) const;
+
+template <typename PackedSubCmd>
+void DeviceCommandCalculator::insert_write_packed_payloads(
+    const uint32_t num_sub_cmds,
+    const uint32_t sub_cmd_sizeB,
+    const uint32_t max_prefetch_command_size,
+    const uint32_t packed_write_max_unicast_sub_cmds,
+    std::vector<std::pair<uint32_t, uint32_t>>& packed_cmd_payloads) {
+    uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+    const uint32_t aligned_sub_cmd_sizeB = tt::align(sub_cmd_sizeB, l1_alignment);
+    const uint32_t max_packed_sub_cmds_per_cmd = get_max_write_packed_sub_cmds<PackedSubCmd>(
+        aligned_sub_cmd_sizeB, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
+    uint32_t rem_num_sub_cmds = num_sub_cmds;
+    while (rem_num_sub_cmds != 0) {
+        const uint32_t num_sub_cmds_in_cmd = std::min(max_packed_sub_cmds_per_cmd, rem_num_sub_cmds);
+        const uint32_t aligned_data_sizeB = aligned_sub_cmd_sizeB * num_sub_cmds_in_cmd;
+        const uint32_t dispatch_cmd_sizeB =
+            tt::align(sizeof(CQDispatchCmd) + num_sub_cmds_in_cmd * sizeof(PackedSubCmd), l1_alignment);
+        packed_cmd_payloads.emplace_back(num_sub_cmds_in_cmd, dispatch_cmd_sizeB + aligned_data_sizeB);
+        rem_num_sub_cmds -= num_sub_cmds_in_cmd;
+        this->add_dispatch_write_packed<PackedSubCmd>(
+            num_sub_cmds_in_cmd, sub_cmd_sizeB, packed_write_max_unicast_sub_cmds);
+    }
+}
+
+// Explicit template instantiations
+template void DeviceCommandCalculator::insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
+    uint32_t, uint32_t, uint32_t, uint32_t, std::vector<std::pair<uint32_t, uint32_t>>&);
+
+template void DeviceCommandCalculator::insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
+    uint32_t, uint32_t, uint32_t, uint32_t, std::vector<std::pair<uint32_t, uint32_t>>&);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -4,6 +4,7 @@
 
 #include "hal.hpp"
 #include "tt_align.hpp"
+#include <tt-metalium/cq_commands.hpp>
 
 namespace tt::tt_metal {
 class DeviceCommandCalculator {
@@ -171,6 +172,23 @@ public:
         this->cmd_write_offsetB += tt::align(payload_sizeB, this->l1_alignment);
         this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
+
+    template <typename PackedSubCmd>
+    uint32_t get_max_write_packed_sub_cmds(
+        uint32_t data_size,
+        uint32_t max_prefetch_cmd_size,
+        uint32_t packed_write_max_unicast_sub_cmds,
+        bool no_stride) const;
+
+    // Divide the sub commands into multiple dispatch commands if the number of sub commands exceeds the maximum number
+    // of sub commands that can be written in a single dispatch command.
+    template <typename PackedSubCmd>
+    void insert_write_packed_payloads(
+        const uint32_t num_sub_cmds,
+        const uint32_t sub_cmd_sizeB,
+        const uint32_t max_prefetch_command_size,
+        const uint32_t packed_write_max_unicast_sub_cmds,
+        std::vector<std::pair<uint32_t, uint32_t>>& packed_cmd_payloads);
 
 private:
     void add_prefetch_relay_inline() { this->cmd_write_offsetB += sizeof(CQPrefetchCmd); }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -430,30 +430,6 @@ void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDevi
 }
 
 template <typename PackedSubCmd>
-uint32_t get_max_write_packed_sub_cmds(
-    uint32_t data_size, uint32_t max_prefetch_cmd_size, uint32_t packed_write_max_unicast_sub_cmds, bool no_stride) {
-    static_assert(
-        std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
-        std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
-    constexpr bool is_unicast = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value;
-    uint32_t sub_cmd_sizeB =
-        is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
-    // Approximate calculation due to alignment
-    uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
-    uint32_t max_prefetch_size = max_prefetch_cmd_size - sizeof(CQPrefetchCmd) - hal.get_alignment(HalMemType::HOST) -
-                                 sizeof(CQDispatchCmd) - l1_alignment;
-    uint32_t max_prefetch_num_packed_cmds =
-        no_stride ? (max_prefetch_size - tt::align(data_size * sizeof(uint32_t), l1_alignment)) / sub_cmd_sizeB
-                  : max_prefetch_size / (tt::align(data_size * sizeof(uint32_t), l1_alignment) + sub_cmd_sizeB);
-
-    uint32_t packed_write_max_multicast_sub_cmds =
-        get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
-    return std::min(
-        max_prefetch_num_packed_cmds,
-        is_unicast ? packed_write_max_unicast_sub_cmds : packed_write_max_multicast_sub_cmds);
-};
-
-template <typename PackedSubCmd>
 void generate_runtime_args_cmds(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
     const uint32_t& l1_arg_base_addr,
@@ -493,7 +469,8 @@ void generate_runtime_args_cmds(
     constexpr bool unicast = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value;
 
     uint32_t num_packed_cmds_in_seq = sub_cmds.size();
-    uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<PackedSubCmd>(
+    DeviceCommandCalculator calculator;
+    uint32_t max_packed_cmds = calculator.get_max_write_packed_sub_cmds<PackedSubCmd>(
         max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, no_stride);
     uint32_t offset_idx = 0;
     if (no_stride) {
@@ -568,6 +545,7 @@ void assemble_runtime_args_commands(
 
     program_command_sequence.runtime_args_command_sequences = {};
     uint32_t command_count = 0;
+    const DeviceCommandCalculator calculator;
 
     // Unique RTAs
     for (uint32_t programmable_core_type_index = 0;
@@ -581,8 +559,9 @@ void assemble_runtime_args_commands(
             if (kg->total_rta_size != 0) {
                 uint32_t num_sub_cmds = kg->core_ranges.num_cores();
                 uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
-                uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
-                    max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
+                uint32_t max_packed_cmds =
+                    calculator.get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
+                        max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
                 command_count += div_up(num_sub_cmds, max_packed_cmds);
             }
         }
@@ -605,13 +584,15 @@ void assemble_runtime_args_commands(
                 CoreType core_type = hal.get_core_type(programmable_core_type_index);
                 if (core_type == CoreType::ETH) {
                     uint32_t num_sub_cmds = kernel->logical_cores().size();
-                    uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<CQDispatchWritePackedUnicastSubCmd>(
-                        max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, true);
+                    uint32_t max_packed_cmds =
+                        calculator.get_max_write_packed_sub_cmds<CQDispatchWritePackedUnicastSubCmd>(
+                            max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, true);
                     command_count += div_up(num_sub_cmds, max_packed_cmds);
                 } else {
                     uint32_t num_sub_cmds = kernel->logical_coreranges().size();
-                    uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<CQDispatchWritePackedMulticastSubCmd>(
-                        max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, true);
+                    uint32_t max_packed_cmds =
+                        calculator.get_max_write_packed_sub_cmds<CQDispatchWritePackedMulticastSubCmd>(
+                            max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, true);
                     command_count += div_up(num_sub_cmds, max_packed_cmds);
                 }
             }
@@ -788,31 +769,6 @@ void assemble_runtime_args_commands(
     program_command_sequence.runtime_args_fetch_size_bytes = runtime_args_fetch_size_bytes;
 }
 
-template <typename PackedSubCmd>
-void insert_write_packed_payloads(
-    DeviceCommandCalculator& calculator,
-    const uint32_t num_sub_cmds,
-    const uint32_t sub_cmd_sizeB,
-    const uint32_t max_prefetch_command_size,
-    const uint32_t packed_write_max_unicast_sub_cmds,
-    std::vector<std::pair<uint32_t, uint32_t>>& packed_cmd_payloads) {
-    uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
-    const uint32_t aligned_sub_cmd_sizeB = tt::align(sub_cmd_sizeB, l1_alignment);
-    const uint32_t max_packed_sub_cmds_per_cmd = get_max_write_packed_sub_cmds<PackedSubCmd>(
-        aligned_sub_cmd_sizeB, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
-    uint32_t rem_num_sub_cmds = num_sub_cmds;
-    while (rem_num_sub_cmds != 0) {
-        const uint32_t num_sub_cmds_in_cmd = std::min(max_packed_sub_cmds_per_cmd, rem_num_sub_cmds);
-        const uint32_t aligned_data_sizeB = aligned_sub_cmd_sizeB * num_sub_cmds_in_cmd;
-        const uint32_t dispatch_cmd_sizeB =
-            tt::align(sizeof(CQDispatchCmd) + num_sub_cmds_in_cmd * sizeof(PackedSubCmd), l1_alignment);
-        packed_cmd_payloads.emplace_back(num_sub_cmds_in_cmd, dispatch_cmd_sizeB + aligned_data_sizeB);
-        rem_num_sub_cmds -= num_sub_cmds_in_cmd;
-        calculator.add_dispatch_write_packed<PackedSubCmd>(
-            num_sub_cmds_in_cmd, sub_cmd_sizeB, packed_write_max_unicast_sub_cmds);
-    }
-}
-
 void assemble_device_commands(
     ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device, SubDeviceId sub_device_id) {
     DeviceCommandCalculator calculator;
@@ -890,8 +846,7 @@ void assemble_device_commands(
                         transfer_info.data.data(), transfer_info.data.size() * sizeof(uint32_t));
                 }
             }
-            insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
-                calculator,
+            calculator.insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
                 unicast_sem_sub_cmds[i].size(),
                 unicast_sem_dst_size.back().second,
                 max_prefetch_command_size,
@@ -1196,8 +1151,7 @@ void assemble_device_commands(
         }
     }
     if (multicast_go_signal_sub_cmds.size() > 0) {
-        insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
-            calculator,
+        calculator.insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
             multicast_go_signal_sub_cmds.size(),
             go_signal_sizeB,
             max_prefetch_command_size,
@@ -1233,8 +1187,7 @@ void assemble_device_commands(
     }
 
     if (unicast_go_signal_sub_cmds.size() > 0) {
-        insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
-            calculator,
+        calculator.insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
             unicast_go_signal_sub_cmds.size(),
             go_signal_sizeB,
             max_prefetch_command_size,


### PR DESCRIPTION
### Problem description
Currently insert_write_packed_payloads is complicated code handling splitting up write packed lists, but it can't be unit tested. Certain problems with it are only detected on T3K or TG, because other systems don't have enough active ethernet cores.

### What's changed
Move insert_write_packed_payloads to DeviceCommandCalculator so it can be unit tested. Add a random test of it, templated over both subcommand types.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
