### PR TITLE
Extend Tensor creation APIs to support borrowed storage

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -13,6 +13,7 @@
 #include "tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include <vector>
+#include "ttnn/tensor/enum_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -44,28 +45,12 @@ const std::vector<ttnn::Shape>& get_shapes_for_test() {
     return *shapes;
 }
 
-TensorSpec get_tensor_spec_with_memory(
+TensorSpec get_tensor_spec(
     const ttnn::Shape& shape,
     DataType dtype,
     Layout layout = Layout::ROW_MAJOR,
-    TensorMemoryLayout mem_layout = TensorMemoryLayout::SINGLE_BANK) {
-    return TensorSpec(
-        shape,
-        TensorLayout(
-            dtype,
-            layout,
-            MemoryConfig{
-                .memory_layout = mem_layout,
-                .buffer_type = BufferType::DRAM,
-                .shard_spec = ShardSpec{
-                    ttnn::CoreRangeSet{ttnn::CoreRange{ttnn::CoreRange{ttnn::CoreCoord{0, 0}, ttnn::CoreCoord{4, 1}}}},
-                    {32, 64},
-                    ShardOrientation::ROW_MAJOR,
-                    ShardMode::LOGICAL}}));
-}
-
-TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype, Layout layout = Layout::ROW_MAJOR) {
-    return TensorSpec(shape, TensorLayout(dtype, layout, MemoryConfig{}));
+    const MemoryConfig& memory_config = MemoryConfig{}) {
+    return TensorSpec(shape, TensorLayout(dtype, layout, memory_config));
 }
 
 template <typename T>
@@ -88,65 +73,12 @@ class VectorConversionTest : public ::testing::Test {};
 using TestTypes = ::testing::Types<float, bfloat16, uint8_t, uint16_t, uint32_t, int32_t>;
 TYPED_TEST_SUITE(VectorConversionTest, TestTypes);
 
-TYPED_TEST(VectorConversionTest, TensorShape) {
-    for (const auto& shape : get_shapes_for_test()) {
-        auto input = arange<TypeParam>(0, static_cast<int64_t>(shape.volume()), 1);
-        Tensor output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()));
-
-        EXPECT_THAT(output.get_tensor_spec().logical_shape(), Eq(shape)) << "for shape: " << shape;
-    }
-}
-
-TYPED_TEST(VectorConversionTest, Roundtrip) {
-    for (const auto& shape : get_shapes_for_test()) {
-        auto input = arange<TypeParam>(0, static_cast<int64_t>(shape.volume()), 1);
-        auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()));
-
-        TensorSpec tensor_spec = tensor.get_tensor_spec();
-
-        EXPECT_THAT(tensor_spec.logical_shape(), Eq(shape)) << "for shape: " << shape;
-        EXPECT_THAT(tensor_spec.data_type(), Eq(convert_to_data_type<TypeParam>()));
-
-        auto output = tensor.template to_vector<TypeParam>();
-
-        EXPECT_THAT(output, Pointwise(Eq(), input)) << "for shape: " << shape;
-    }
-}
-
 TYPED_TEST(VectorConversionTest, InvalidSize) {
     ttnn::Shape shape{32, 32};
     auto input = arange<TypeParam>(0, 42, 1);
 
     ASSERT_NE(input.size(), shape.volume());
     EXPECT_ANY_THROW(Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>())));
-}
-
-TYPED_TEST(VectorConversionTest, OddshapeRoundtripTilizedLayout) {
-    ttnn::Shape shape{1, 40, 3, 121};
-
-    auto input = arange<TypeParam>(0, shape.volume(), 1);
-
-    auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE));
-
-    ASSERT_NE(tensor.tensor_spec().padded_shape(), tensor.tensor_spec().logical_shape());
-
-    EXPECT_THAT(tensor.tensor_spec().logical_shape(), ShapeIs(1, 40, 3, 121));
-    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(1, 40, 32, 128));
-
-    auto output = tensor.template to_vector<TypeParam>();
-
-    EXPECT_THAT(output, Pointwise(Eq(), input));
-}
-
-TYPED_TEST(VectorConversionTest, RoundtripTilezedLayout) {
-    ttnn::Shape shape{128, 128};
-
-    auto input = arange<TypeParam>(0, shape.volume(), 1);
-
-    auto output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE))
-                      .template to_vector<TypeParam>();
-
-    EXPECT_THAT(output, Pointwise(Eq(), input));
 }
 
 TYPED_TEST(VectorConversionTest, InvalidDtype) {
@@ -161,9 +93,75 @@ TYPED_TEST(VectorConversionTest, InvalidDtype) {
             (std::is_same_v<TypeParam, int32_t> ? DataType::FLOAT32 : DataType::INT32))));
 }
 
-TEST(FloatVectorConversionTest, RoundtripBfloat16) {
+TYPED_TEST(VectorConversionTest, Roundtrip) {
     for (const auto& shape : get_shapes_for_test()) {
-        auto input_bf16 = arange<bfloat16>(0, static_cast<int64_t>(shape.volume()), 1);
+        auto input = arange<TypeParam>(0, shape.volume(), 1);
+        auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()));
+
+        EXPECT_THAT(tensor.get_logical_shape(), Eq(shape)) << "for shape: " << shape;
+        EXPECT_THAT(tensor.get_dtype(), Eq(convert_to_data_type<TypeParam>())) << "for shape: " << shape;
+
+        auto output = tensor.template to_vector<TypeParam>();
+
+        EXPECT_THAT(output, Pointwise(Eq(), input)) << "for shape: " << shape;
+    }
+}
+
+TYPED_TEST(VectorConversionTest, RoundtripTilizedLayout) {
+    ttnn::Shape shape{128, 128};
+    auto input = arange<TypeParam>(0, shape.volume(), 1);
+    auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE));
+
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(128, 128));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
+
+    auto output = tensor.template to_vector<TypeParam>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TYPED_TEST(VectorConversionTest, RoundtripTilizedLayoutOddShape) {
+    ttnn::Shape shape{1, 40, 3, 121};
+    auto input = arange<TypeParam>(0, shape.volume(), 1);
+    auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE));
+
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(1, 40, 3, 121));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(1, 40, 32, 128));
+
+    auto output = tensor.template to_vector<TypeParam>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TYPED_TEST(VectorConversionTest, RoundtripWithShardedLayout) {
+    ttnn::Shape shape{56, 56, 30};
+    auto input = arange<TypeParam>(0, shape.volume(), 1);
+    auto tensor = Tensor::from_vector(
+        input,
+        get_tensor_spec(
+            shape,
+            convert_to_data_type<TypeParam>(),
+            Layout::TILE,
+            MemoryConfig{
+                .memory_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+                .buffer_type = BufferType::L1,
+                .shard_spec = ShardSpec{
+                    ttnn::CoreRangeSet{ttnn::CoreRange{ttnn::CoreCoord{0, 0}, ttnn::CoreCoord{63, 63}}},
+                    /*shard_shape_=*/{49, 30},
+                    ShardOrientation::ROW_MAJOR,
+                    ShardMode::LOGICAL}}));
+
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(56, 56, 30));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(56, 64, 32));
+
+    auto output = tensor.template to_vector<TypeParam>();
+
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TEST(FloatVectorConversionTest, Float32Bfloat16Interop) {
+    for (const auto& shape : get_shapes_for_test()) {
+        auto input_bf16 = arange<bfloat16>(0, shape.volume(), 1);
         std::vector<float> input_ft;
         input_ft.reserve(input_bf16.size());
         std::transform(input_bf16.begin(), input_bf16.end(), std::back_inserter(input_ft), [](bfloat16 bf) {
@@ -192,20 +190,22 @@ TEST_P(BlockFloatVectorConversionTest, Roundtrip) {
     ttnn::Shape shape{32, 32};
     std::vector<float> input = arange<float>(0, shape.volume(), 1, /*cap=*/32);
 
-    auto output = Tensor::from_vector(input, get_tensor_spec(shape, GetParam(), Layout::TILE)).to_vector<float>();
-    EXPECT_THAT(output, Pointwise(FloatNear(4.0f), input));
+    auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, GetParam(), Layout::TILE));
+
+    EXPECT_THAT(tensor.get_logical_shape(), Eq(shape));
+    EXPECT_THAT(tensor.get_dtype(), Eq(GetParam()));
+    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
 }
 
 TEST_P(BlockFloatVectorConversionTest, RoundtripWithPadding) {
     ttnn::Shape shape{14, 47};
     std::vector<float> input = arange<float>(0, shape.volume(), 1, /*cap=*/32);
 
-    auto output = Tensor::from_vector(input, get_tensor_spec(shape, GetParam(), Layout::TILE));
+    auto tensor = Tensor::from_vector(input, get_tensor_spec(shape, GetParam(), Layout::TILE));
 
-    EXPECT_THAT(output.get_logical_shape(), ShapeIs(14, 47));
-    EXPECT_THAT(output.get_padded_shape(), ShapeIs(32, 64));
-
-    EXPECT_THAT(output.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(14, 47));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(32, 64));
+    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
 }
 
 TEST_P(BlockFloatVectorConversionTest, RoundtripWithPaddingAndCustomTile) {
@@ -213,12 +213,11 @@ TEST_P(BlockFloatVectorConversionTest, RoundtripWithPaddingAndCustomTile) {
     std::vector<float> input = arange<float>(0, shape.volume(), 1, /*cap=*/32);
 
     TensorSpec spec(shape, TensorLayout(GetParam(), PageConfig(Layout::TILE, Tile({16, 16})), MemoryConfig{}));
-    auto output = Tensor::from_vector(input, spec);
+    auto tensor = Tensor::from_vector(input, spec);
 
-    EXPECT_THAT(output.get_logical_shape(), ShapeIs(14, 47));
-    EXPECT_THAT(output.get_padded_shape(), ShapeIs(16, 48));
-
-    EXPECT_THAT(output.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
+    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(14, 47));
+    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(16, 48));
+    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -242,140 +241,6 @@ TEST_F(DeviceVectorConversionTest, RoundtripWithMemoryConfig) {
 
     EXPECT_THAT(output.to_vector<float>(), Pointwise(Eq(), input));
 }
-
-// TODO: simplify into two layered class TYPED_TEST_P
-class ShardVectorConversionTest : public ::testing::TestWithParam<TensorMemoryLayout> {};
-
-TEST_P(ShardVectorConversionTest, UInt32RoundtripRowMajShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input = arange<uint32_t>(0, shape.volume(), 1);
-
-    auto tensor =
-        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::UINT32, Layout::ROW_MAJOR, GetParam()));
-
-    auto output = tensor.template to_vector<uint32_t>();
-
-    EXPECT_THAT(output, Pointwise(Eq(), input));
-}
-
-TEST_P(ShardVectorConversionTest, UInt32RoundtripTilizedShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input = arange<uint32_t>(0, shape.volume(), 1);
-
-    auto tensor =
-        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::UINT32, Layout::TILE, GetParam()));
-
-    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(121, 128));
-    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
-
-    auto output = tensor.template to_vector<uint32_t>();
-
-    EXPECT_THAT(output, Pointwise(Eq(), input));
-}
-
-TEST_P(ShardVectorConversionTest, FloatRoundtripRowMajShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input = arange<float>(0, shape.volume(), 1);
-
-    auto tensor = Tensor::from_vector(
-        input, get_tensor_spec_with_memory(shape, DataType::FLOAT32, Layout::ROW_MAJOR, GetParam()));
-
-    auto output = tensor.template to_vector<float>();
-
-    EXPECT_THAT(output, Pointwise(Eq(), input));
-}
-
-TEST_P(ShardVectorConversionTest, FloatRoundtripTilizedShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input = arange<float>(0, shape.volume(), 1);
-
-    auto tensor =
-        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::FLOAT32, Layout::TILE, GetParam()));
-
-    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(121, 128));
-    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
-
-    auto output = tensor.template to_vector<float>();
-
-    EXPECT_THAT(output, Pointwise(Eq(), input));
-}
-
-TEST_P(ShardVectorConversionTest, Bfloat16RoundtripRowMajShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input_bf16 = arange<bfloat16>(0, static_cast<int64_t>(shape.volume()), 1);
-
-    std::vector<float> input_ft;
-    input_ft.reserve(input_bf16.size());
-    std::transform(
-        input_bf16.begin(), input_bf16.end(), std::back_inserter(input_ft), [](bfloat16 bf) { return bf.to_float(); });
-
-    auto tensor_bf = Tensor::from_vector(
-        input_ft, get_tensor_spec_with_memory(shape, DataType::BFLOAT16, Layout::ROW_MAJOR, GetParam()));
-
-    auto output_ft = tensor_bf.to_vector<float>();
-
-    EXPECT_THAT(output_ft, Pointwise(Eq(), input_ft));
-}
-
-TEST_P(ShardVectorConversionTest, Bfloat16RoundtripTilizedShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input_bf16 = arange<bfloat16>(0, static_cast<int64_t>(shape.volume()), 1);
-
-    std::vector<float> input_ft;
-    input_ft.reserve(input_bf16.size());
-    std::transform(
-        input_bf16.begin(), input_bf16.end(), std::back_inserter(input_ft), [](bfloat16 bf) { return bf.to_float(); });
-
-    auto tensor_bf =
-        Tensor::from_vector(input_ft, get_tensor_spec_with_memory(shape, DataType::BFLOAT16, Layout::TILE, GetParam()));
-
-    EXPECT_THAT(tensor_bf.get_logical_shape(), ShapeIs(121, 128));
-    EXPECT_THAT(tensor_bf.get_padded_shape(), ShapeIs(128, 128));
-
-    auto output_ft = tensor_bf.to_vector<float>();
-
-    EXPECT_THAT(output_ft, Pointwise(FloatNear(4.0f), input_ft));
-}
-
-TEST_P(ShardVectorConversionTest, BlockfloatRoundtripRowMajShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input = arange<float>(0, shape.volume(), 1, 32);
-
-    auto tensor =
-        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::BFLOAT8_B, Layout::TILE, GetParam()));
-
-    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
-}
-
-TEST_P(ShardVectorConversionTest, BlockfloatRoundtripTilizedShardMapping) {
-    ttnn::Shape shape{121, 128};
-
-    auto input = arange<float>(0, shape.volume(), 1, 32);
-
-    auto tensor =
-        Tensor::from_vector(input, get_tensor_spec_with_memory(shape, DataType::BFLOAT8_B, Layout::TILE, GetParam()));
-
-    EXPECT_THAT(tensor.get_logical_shape(), ShapeIs(121, 128));
-    EXPECT_THAT(tensor.get_padded_shape(), ShapeIs(128, 128));
-
-    EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatNear(4.0f), input));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    ShardVectorConversionTests,
-    ShardVectorConversionTest,
-    ::testing::Values(TensorMemoryLayout::INTERLEAVED, TensorMemoryLayout::SINGLE_BANK));
-// #17806: Fix illegal shard spec and re-enable!
-// TensorMemoryLayout::HEIGHT_SHARDED,
-// TensorMemoryLayout::WIDTH_SHARDED,
-// TensorMemoryLayout::BLOCK_SHARDED));
 
 }  // namespace
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -177,6 +177,82 @@ TEST(FloatVectorConversionTest, Float32Bfloat16Interop) {
     }
 }
 
+template <typename T>
+class BorrowedStorageVectorConversionTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE(BorrowedStorageVectorConversionTest, TestTypes);
+
+TYPED_TEST(BorrowedStorageVectorConversionTest, InvalidSize) {
+    ttnn::Shape shape{32, 32};
+    auto input = arange<TypeParam>(0, 42, 1);
+
+    ASSERT_NE(input.size(), shape.volume());
+    EXPECT_ANY_THROW(Tensor::borrow_from_span(
+        tt::stl::Span<TypeParam>(input),
+        get_tensor_spec(shape, convert_to_data_type<TypeParam>()),
+        /*on_creation_callback=*/[]() {},
+        /*on_destruction_callback=*/[]() {}));
+}
+
+TYPED_TEST(BorrowedStorageVectorConversionTest, InvalidDtype) {
+    ttnn::Shape shape{32, 32};
+    auto input = arange<TypeParam>(0, shape.volume(), 1);
+
+    EXPECT_ANY_THROW(Tensor::borrow_from_span(
+        tt::stl::Span<TypeParam>(input),
+        get_tensor_spec(
+            shape,
+            // Use INT32 for verification, except for when the actual type is int32_t.
+            (std::is_same_v<TypeParam, int32_t> ? DataType::FLOAT32 : DataType::INT32)),
+        /*on_creation_callback=*/[]() {},
+        /*on_destruction_callback=*/[]() {}));
+}
+
+TYPED_TEST(BorrowedStorageVectorConversionTest, IsBorrowable) {
+    EXPECT_TRUE(Tensor::is_borrowable(get_tensor_spec(ttnn::Shape{1, 2, 3, 4}, DataType::FLOAT32)));
+    EXPECT_FALSE(Tensor::is_borrowable(get_tensor_spec(ttnn::Shape{1, 2, 3, 4}, DataType::FLOAT32, Layout::TILE)));
+    // `TensorSpec` itself is invalid, but `is_borrowable` is conservative in its checks.
+    EXPECT_FALSE(
+        Tensor::is_borrowable(get_tensor_spec(ttnn::Shape{1, 2, 3, 4}, DataType::BFLOAT4_B, Layout::ROW_MAJOR)));
+    EXPECT_FALSE(
+        Tensor::is_borrowable(get_tensor_spec(ttnn::Shape{1, 2, 3, 4}, DataType::BFLOAT8_B, Layout::ROW_MAJOR)));
+}
+
+TYPED_TEST(BorrowedStorageVectorConversionTest, Roundtrip) {
+    for (const auto& shape : get_shapes_for_test()) {
+        auto input = arange<TypeParam>(0, shape.volume(), 1);
+        auto tensor_spec = get_tensor_spec(shape, convert_to_data_type<TypeParam>());
+
+        ASSERT_TRUE(Tensor::is_borrowable(tensor_spec));
+
+        int ctor_count = 0;
+        int dtor_count = 0;
+        auto tensor = Tensor::borrow_from_span(
+            tt::stl::Span<TypeParam>(input),
+            tensor_spec,
+            /*on_creation_callback=*/[&]() { ctor_count++; },
+            /*on_destruction_callback=*/[&]() { dtor_count++; });
+
+        EXPECT_EQ(ctor_count, 1);
+        EXPECT_EQ(dtor_count, 0);
+        {
+            Tensor copy(tensor.get_storage(), tensor.get_tensor_spec());
+            EXPECT_EQ(ctor_count, 2);
+            EXPECT_EQ(dtor_count, 0);
+        }
+        EXPECT_EQ(ctor_count, 2);
+        EXPECT_EQ(dtor_count, 1);
+
+        EXPECT_THAT(tensor.get_logical_shape(), Eq(shape)) << "for shape: " << shape;
+        EXPECT_THAT(tensor.get_dtype(), Eq(convert_to_data_type<TypeParam>())) << "for shape: " << shape;
+        EXPECT_EQ(tensor.storage_type(), StorageType::BORROWED) << "for shape: " << shape;
+
+        auto output = tensor.template to_vector<TypeParam>();
+
+        EXPECT_THAT(output, Pointwise(Eq(), input)) << "for shape: " << shape;
+    }
+}
+
 class BlockFloatVectorConversionTest : public ::testing::TestWithParam<DataType> {};
 
 TEST_P(BlockFloatVectorConversionTest, InvalidLayout) {

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -89,9 +89,13 @@ Tensor create_typed_tt_tensor_from_py_data(
     tt::stl::Span<T> pydata_span(reinterpret_cast<T*>(py_data_ptr), tensor_spec.logical_shape().volume());
     if (pydata_borrowable && !force_disable_borrow) {
         auto output = Tensor::from_borrowed_data(
-            pydata_span, tensor_spec.logical_shape(), on_creation_callback, on_destruction_callback);
+            pydata_span,
+            tensor_spec.logical_shape(),
+            on_creation_callback,
+            on_destruction_callback,
+            tensor_spec.tile());
         if (device != nullptr) {
-            output = output.to_device(device);
+            output = output.to_device(device, tensor_spec.memory_config());
         }
         return output;
     } else {

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -82,11 +82,18 @@ Tensor create_typed_tt_tensor_from_py_data(
         !tensor_spec.memory_config().is_sharded() or tensor_spec.memory_config().shard_spec.has_value(),
         "Sharded tensors must have a shard spec when converting to tt tensors!");
 
+    const bool pydata_borrowable = tensor_spec.layout() == Layout::ROW_MAJOR &&
+                                   tensor_spec.physical_shape() == tensor_spec.logical_2d_shape() &&
+                                   tensor_spec.data_type() == convert_to_data_type<T>();
+
     tt::stl::Span<T> pydata_span(reinterpret_cast<T*>(py_data_ptr), tensor_spec.logical_shape().volume());
-    if (Tensor::is_borrowable(tensor_spec) && !force_disable_borrow &&
-        // No point in creating a borrowed storage, as uploading to device will make a copy anyways.
-        device == nullptr) {
-        return Tensor::borrow_from_span(pydata_span, tensor_spec, on_creation_callback, on_destruction_callback);
+    if (pydata_borrowable && !force_disable_borrow) {
+        auto output = Tensor::from_borrowed_data(
+            pydata_span, tensor_spec.logical_shape(), on_creation_callback, on_destruction_callback);
+        if (device != nullptr) {
+            output = output.to_device(device);
+        }
+        return output;
     } else {
         return Tensor::from_span(
             tt::stl::Span<const T>(pydata_span),

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -78,30 +78,21 @@ Tensor create_typed_tt_tensor_from_py_data(
     const std::function<void()>& on_creation_callback,
     const std::function<void()>& on_destruction_callback,
     const bool force_disable_borrow) {
-    auto layout = tensor_spec.layout();
-
-    const bool requires_padding = tensor_spec.logical_2d_shape() != tensor_spec.physical_shape();
-    const bool requires_tilization = layout != Layout::ROW_MAJOR;
-    const bool enable_borrow = !requires_padding and !requires_tilization and !force_disable_borrow;
-
     TT_FATAL(
         !tensor_spec.memory_config().is_sharded() or tensor_spec.memory_config().shard_spec.has_value(),
         "Sharded tensors must have a shard spec when converting to tt tensors!");
 
-    auto* data_ptr = reinterpret_cast<T*>(py_data_ptr);
-
-    auto data_type = tensor_spec.data_type();
-    std::size_t num_elements = tensor_spec.logical_shape().volume();
-
-    if (enable_borrow and !(data_type == DataType::BFLOAT8_B || data_type == DataType::BFLOAT4_B)) {
-        auto storage = BorrowedStorage(
-            borrowed_buffer::Buffer(data_ptr, num_elements), on_creation_callback, on_destruction_callback);
-        return Tensor(std::move(storage), tensor_spec);
+    tt::stl::Span<T> pydata_span(reinterpret_cast<T*>(py_data_ptr), tensor_spec.logical_shape().volume());
+    if (Tensor::is_borrowable(tensor_spec) && !force_disable_borrow) {
+        return Tensor::borrow_from_span(
+            pydata_span,
+            tensor_spec,
+            on_creation_callback,
+            on_destruction_callback,
+            device == nullptr ? std::nullopt : std::optional<ttnn::AnyDevice>(device));
     } else {
-        auto logical_data = std::vector<T>(data_ptr, data_ptr + num_elements);
-
-        return Tensor::from_vector(
-            std::move(logical_data),
+        return Tensor::from_span(
+            tt::stl::Span<const T>(pydata_span),
             tensor_spec,
             device == nullptr ? std::nullopt : std::optional<ttnn::AnyDevice>(device));
     }
@@ -114,47 +105,29 @@ Tensor create_tt_tensor_from_py_data(
     const bool force_disable_borrow,
     const std::function<void()>& on_creation_callback,
     const std::function<void()>& on_destruction_callback) {
-    auto layout = tensor_spec.layout();
-
-    auto data_type = tensor_spec.data_type();
-    std::size_t num_elements = tensor_spec.logical_shape().volume();
-    switch (data_type) {
-        case DataType::UINT8: {
-            return create_typed_tt_tensor_from_py_data<uint8_t>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
-        }
-        case DataType::UINT16: {
-            return create_typed_tt_tensor_from_py_data<uint16_t>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
-        }
-        case DataType::INT32: {
-            return create_typed_tt_tensor_from_py_data<int32_t>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
-        }
-        case DataType::UINT32: {
-            return create_typed_tt_tensor_from_py_data<uint32_t>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
-        }
-        case DataType::FLOAT32: {
-            return create_typed_tt_tensor_from_py_data<float>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
-        }
+    auto create_concrete = [&]<typename T>() {
+        return create_typed_tt_tensor_from_py_data<T>(
+            py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
+    };
+    switch (tensor_spec.data_type()) {
+        case DataType::UINT8: return create_concrete.operator()<uint8_t>();
+        case DataType::UINT16: return create_concrete.operator()<uint16_t>();
+        case DataType::INT32: return create_concrete.operator()<int32_t>();
+        case DataType::UINT32: return create_concrete.operator()<uint32_t>();
+        case DataType::FLOAT32: return create_concrete.operator()<float>();
         // TODO: This is not supported for numpy
-        case DataType::BFLOAT16: {
-            return create_typed_tt_tensor_from_py_data<bfloat16>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
-        }
+        case DataType::BFLOAT16: return create_concrete.operator()<bfloat16>();
+
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
-            return create_typed_tt_tensor_from_py_data<float>(
-                py_data_ptr, tensor_spec, device, on_creation_callback, on_destruction_callback, force_disable_borrow);
+            return create_concrete.operator()<float>();
         }
         case DataType::INVALID: {
-            TT_THROW("Unsupported DataType: {}", data_type);
+            TT_THROW("Unsupported DataType: {}", tensor_spec.data_type());
         }
     }
 
-    TT_THROW("Unsupported DataType: {}", data_type);
+    TT_THROW("Unsupported DataType: {}", tensor_spec.data_type());
 }
 
 Tensor convert_python_tensor_to_tt_tensor(
@@ -340,9 +313,6 @@ Tensor convert_python_tensor_to_tt_tensor(
     auto output = create_tt_tensor_from_py_data(
         py_data_ptr, tensor_spec, device, force_disable_borrow, on_creation_callback, on_destruction_callback);
 
-    if (device) {
-        output = output.to_device(device, memory_config);
-    }
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/cpp/ttnn/tensor/host_buffer/borrowed_buffer.hpp
+++ b/ttnn/cpp/ttnn/tensor/host_buffer/borrowed_buffer.hpp
@@ -14,21 +14,21 @@ struct Buffer {
     using value_type = T;
 
     explicit Buffer() = default;
-    explicit Buffer(T* data_ptr, std::size_t size) : data_ptr_(data_ptr), size_(size) {}
+    Buffer(T* data_ptr, std::size_t size) : data_ptr_(data_ptr), size_(size) {}
 
-    const std::size_t size() const { return this->size_; }
+    std::size_t size() const { return this->size_; }
 
-    inline T& operator[](std::size_t index) noexcept { return this->data_ptr_[index]; }
-    inline const T& operator[](std::size_t index) const noexcept { return this->data_ptr_[index]; }
+    T& operator[](std::size_t index) noexcept { return this->data_ptr_[index]; }
+    const T& operator[](std::size_t index) const noexcept { return this->data_ptr_[index]; }
 
-    inline T* begin() noexcept { return this->data_ptr_; }
-    inline T* end() noexcept { return this->data_ptr_ + this->size(); }
+    T* begin() noexcept { return this->data_ptr_; }
+    T* end() noexcept { return this->data_ptr_ + this->size(); }
 
-    inline const T* begin() const noexcept { return this->data_ptr_; }
-    inline const T* end() const noexcept { return this->data_ptr_ + this->size(); }
+    const T* begin() const noexcept { return this->data_ptr_; }
+    const T* end() const noexcept { return this->data_ptr_ + this->size(); }
 
-    inline void* data() noexcept { return static_cast<void*>(this->data_ptr_); }
-    inline const void* data() const noexcept { return static_cast<void*>(this->data_ptr_); }
+    void* data() noexcept { return static_cast<void*>(this->data_ptr_); }
+    const void* data() const noexcept { return static_cast<void*>(this->data_ptr_); }
 
 private:
     T* data_ptr_ = nullptr;

--- a/ttnn/cpp/ttnn/tensor/host_buffer/borrowed_buffer.hpp
+++ b/ttnn/cpp/ttnn/tensor/host_buffer/borrowed_buffer.hpp
@@ -13,7 +13,7 @@ template <typename T>
 struct Buffer {
     using value_type = T;
 
-    explicit Buffer() = default;
+    Buffer() = default;
     Buffer(T* data_ptr, std::size_t size) : data_ptr_(data_ptr), size_(size) {}
 
     std::size_t size() const { return this->size_; }

--- a/ttnn/cpp/ttnn/tensor/host_buffer/owned_buffer.hpp
+++ b/ttnn/cpp/ttnn/tensor/host_buffer/owned_buffer.hpp
@@ -13,7 +13,7 @@ template <typename T>
 struct Buffer {
     using value_type = T;
 
-    explicit Buffer() = default;
+    Buffer() = default;
     explicit Buffer(std::shared_ptr<std::vector<T>>&& shared_vector) :
         shared_vector_(shared_vector),
         pointer_for_faster_access_(shared_vector->data()),
@@ -23,25 +23,25 @@ struct Buffer {
         pointer_for_faster_access_(shared_vector->data()),
         size_(shared_vector->size()) {}
 
-    const std::size_t size() const { return this->size_; }
+    std::size_t size() const { return this->size_; }
 
-    inline T& operator[](std::size_t index) noexcept { return this->pointer_for_faster_access_[index]; }
-    inline const T& operator[](std::size_t index) const noexcept { return this->pointer_for_faster_access_[index]; }
+    T& operator[](std::size_t index) noexcept { return this->pointer_for_faster_access_[index]; }
+    const T& operator[](std::size_t index) const noexcept { return this->pointer_for_faster_access_[index]; }
 
-    inline T* begin() noexcept { return this->pointer_for_faster_access_; }
-    inline T* end() noexcept { return this->pointer_for_faster_access_ + this->size(); }
+    T* begin() noexcept { return this->pointer_for_faster_access_; }
+    T* end() noexcept { return this->pointer_for_faster_access_ + this->size(); }
 
-    inline const T* begin() const noexcept { return this->pointer_for_faster_access_; }
-    inline const T* end() const noexcept { return this->pointer_for_faster_access_ + this->size(); }
+    const T* begin() const noexcept { return this->pointer_for_faster_access_; }
+    const T* end() const noexcept { return this->pointer_for_faster_access_ + this->size(); }
 
-    inline bool is_allocated() const { return bool(this->shared_vector_); }
-    inline const std::vector<T>& get() const { return *this->shared_vector_; }
-    inline const std::shared_ptr<std::vector<T>> get_ptr() const noexcept { return this->shared_vector_; }
-    inline void reset() { this->shared_vector_.reset(); }
+    bool is_allocated() const { return bool(this->shared_vector_); }
+    const std::vector<T>& get() const { return *this->shared_vector_; }
+    const std::shared_ptr<std::vector<T>> get_ptr() const noexcept { return this->shared_vector_; }
+    void reset() { this->shared_vector_.reset(); }
 
-    inline void* data() noexcept { return static_cast<void*>(this->pointer_for_faster_access_); }
-    inline const void* data() const noexcept { return static_cast<void*>(this->pointer_for_faster_access_); }
-    inline uint32_t use_count() const noexcept { return this->shared_vector_.use_count(); }
+    void* data() noexcept { return static_cast<void*>(this->pointer_for_faster_access_); }
+    const void* data() const noexcept { return static_cast<void*>(this->pointer_for_faster_access_); }
+    uint32_t use_count() const noexcept { return this->shared_vector_.use_count(); }
 
 private:
     std::shared_ptr<std::vector<T>> shared_vector_;

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -602,7 +602,7 @@ Tensor Tensor::from_span(tt::stl::Span<const T> buffer, const TensorSpec& spec, 
 bool Tensor::is_borrowable(const TensorSpec& spec) {
     return spec.physical_shape() == spec.logical_2d_shape() &&  //
            spec.layout() == Layout::ROW_MAJOR &&                //
-           // Ideally, this should assert on `TensorSpec` creation.
+           // The block float types imply tilized layout - the extra check is conservative.
            (spec.data_type() != DataType::BFLOAT4_B && spec.data_type() != DataType::BFLOAT8_B);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -721,6 +721,12 @@ template Tensor Tensor::from_span<uint16_t>(
     tt::stl::Span<const uint16_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::from_span<uint32_t>(
     tt::stl::Span<const uint32_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::borrow_from_span<float>(
+    tt::stl::Span<float> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::borrow_from_span<bfloat16>(
     tt::stl::Span<bfloat16> buffer,
     const TensorSpec& spec,

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -605,13 +605,14 @@ Tensor Tensor::from_borrowed_data(
     tt::stl::Span<T> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback) {
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile) {
     size_t volume = shape.volume();
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
     BorrowedStorage storage(
         borrowed_buffer::Buffer(buffer.data(), buffer.size()), on_creation_callback, on_destruction_callback);
-    return Tensor(std::move(storage), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR);
+    return Tensor(std::move(storage), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR, tile);
 }
 
 template <>
@@ -707,32 +708,38 @@ template Tensor Tensor::from_borrowed_data<float>(
     tt::stl::Span<float> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback);
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<bfloat16>(
     tt::stl::Span<bfloat16> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback);
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<int32_t>(
     tt::stl::Span<int32_t> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback);
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint8_t>(
     tt::stl::Span<uint8_t> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback);
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint16_t>(
     tt::stl::Span<uint16_t> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback);
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile);
 template Tensor Tensor::from_borrowed_data<uint32_t>(
     tt::stl::Span<uint32_t> buffer,
     const ttnn::Shape& shape,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback);
+    const std::function<void()>& on_destruction_callback,
+    const std::optional<Tile>& tile);
 template Tensor Tensor::from_vector<bfloat16>(
     std::vector<bfloat16>&& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::from_vector<int32_t>(

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -611,8 +611,7 @@ Tensor Tensor::borrow_from_span(
     tt::stl::Span<T> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device) {
+    const std::function<void()>& on_destruction_callback) {
     size_t volume = spec.logical_shape().volume();
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
@@ -629,13 +628,7 @@ Tensor Tensor::borrow_from_span(
         spec.layout());
     BorrowedStorage storage(
         borrowed_buffer::Buffer(buffer.data(), buffer.size()), on_creation_callback, on_destruction_callback);
-    Tensor output(std::move(storage), spec);
-
-    if (device.has_value()) {
-        output = output.to_device(device->get_devices(), spec.memory_config());
-    }
-
-    return output;
+    return Tensor(std::move(storage), spec);
 }
 
 template <>
@@ -731,38 +724,32 @@ template Tensor Tensor::borrow_from_span<float>(
     tt::stl::Span<float> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device);
+    const std::function<void()>& on_destruction_callback);
 template Tensor Tensor::borrow_from_span<bfloat16>(
     tt::stl::Span<bfloat16> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device);
+    const std::function<void()>& on_destruction_callback);
 template Tensor Tensor::borrow_from_span<int32_t>(
     tt::stl::Span<int32_t> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device);
+    const std::function<void()>& on_destruction_callback);
 template Tensor Tensor::borrow_from_span<uint8_t>(
     tt::stl::Span<uint8_t> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device);
+    const std::function<void()>& on_destruction_callback);
 template Tensor Tensor::borrow_from_span<uint16_t>(
     tt::stl::Span<uint16_t> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device);
+    const std::function<void()>& on_destruction_callback);
 template Tensor Tensor::borrow_from_span<uint32_t>(
     tt::stl::Span<uint32_t> buffer,
     const TensorSpec& spec,
     const std::function<void()>& on_creation_callback,
-    const std::function<void()>& on_destruction_callback,
-    std::optional<ttnn::AnyDevice> device);
+    const std::function<void()>& on_destruction_callback);
 template Tensor Tensor::from_vector<bfloat16>(
     std::vector<bfloat16>&& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::from_vector<int32_t>(

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -49,50 +49,6 @@ Tensor create_owned_tensor_from_row_major_data(
     return output;
 }
 
-// TODO: optimize precomputing multipliers
-template <typename T, typename InternalType>
-std::vector<T> unpad_tensor_to_vec(const Tensor& cpu_tensor) {
-    auto tiled_buffer = host_buffer::get_as<InternalType>(cpu_tensor);
-    const auto untiled_shape = cpu_tensor.get_logical_shape();
-    const auto tiled_shape = cpu_tensor.get_padded_shape();
-
-    // Calculate total size of the untiled tensor
-    size_t total_size = untiled_shape.volume();
-
-    std::vector<T> untiled_data(total_size);
-
-    auto compute_flat_index = [](const std::vector<uint32_t>& indices, const ttnn::Shape& shape) -> uint32_t {
-        uint32_t flat_index = 0;
-        uint32_t multiplier = 1;
-        for (int i = (int)indices.size() - 1; i >= 0; --i) {
-            flat_index += indices[i] * multiplier;
-            multiplier *= shape[i];
-        }
-        return flat_index;
-    };
-
-    std::vector<uint32_t> indices(tiled_shape.rank(), 0);
-
-    for (size_t idx = 0; idx < total_size; ++idx) {
-        uint32_t untiled_index = compute_flat_index(indices, untiled_shape);
-        uint32_t tiled_index = compute_flat_index(indices, tiled_shape);
-        if constexpr (std::is_same_v<InternalType, bfloat16>) {
-            untiled_data[untiled_index] = tiled_buffer[tiled_index].to_float();
-        } else {
-            untiled_data[untiled_index] = tiled_buffer[tiled_index];
-        }
-
-        for (int dim = (int)tiled_shape.rank() - 1; dim >= 0; --dim) {
-            if (++indices[dim] < untiled_shape[dim]) {
-                break;
-            }
-            indices[dim] = 0;
-        }
-    }
-
-    return untiled_data;
-}
-
 }  // namespace
 
 Tensor::TensorAttributes::TensorAttributes() :
@@ -643,6 +599,39 @@ Tensor Tensor::from_span(tt::stl::Span<const T> buffer, const TensorSpec& spec, 
     return create_owned_tensor_from_row_major_data(std::vector<T>(buffer.begin(), buffer.end()), spec, device);
 }
 
+bool Tensor::is_borrowable(const TensorSpec& spec) {
+    return spec.physical_shape() == spec.logical_2d_shape() and spec.layout() == Layout::ROW_MAJOR;
+}
+
+template <typename T>
+Tensor Tensor::borrow_from_span(
+    tt::stl::Span<T> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device) {
+    TT_FATAL(
+        is_borrowable(spec),
+        "Tensor spec does not support borrowing a tensor from a buffer: physical shape {}, logical shape {}, layout {}",
+        spec.physical_shape(),
+        spec.logical_2d_shape(),
+        spec.layout());
+    TT_FATAL(
+        spec.data_type() == convert_to_data_type<T>(),
+        "Unsupported data type: got {}, expected: {}",
+        spec.data_type(),
+        convert_to_data_type<T>());
+    BorrowedStorage storage(
+        borrowed_buffer::Buffer(buffer.data(), buffer.size()), on_creation_callback, on_destruction_callback);
+    Tensor output(std::move(storage), spec);
+
+    if (device.has_value()) {
+        output = output.to_device(device->get_devices(), spec.memory_config());
+    }
+
+    return output;
+}
+
 template <>
 Tensor Tensor::from_vector<float>(
     std::vector<float>&& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device) {
@@ -674,8 +663,21 @@ template <>
 std::vector<float> Tensor::to_vector<float>() const {
     Tensor cpu_tensor = this->cpu();
     switch (cpu_tensor.get_dtype()) {
-        case DataType::BFLOAT16: return unpad_tensor_to_vec<float, bfloat16>(cpu_tensor.to_layout(Layout::ROW_MAJOR));
-        case DataType::FLOAT32: return unpad_tensor_to_vec<float, float>(cpu_tensor.to_layout(Layout::ROW_MAJOR));
+        case DataType::BFLOAT16: {
+            auto physical_data_bfloat16 =
+                owned_buffer::get_as<bfloat16>(std::get<OwnedStorage>(cpu_tensor.storage()).buffer).get();
+            std::vector<float> physical_data;
+            physical_data.reserve(physical_data_bfloat16.size());
+            std::transform(
+                physical_data_bfloat16.begin(), physical_data_bfloat16.end(), physical_data.begin(), [](bfloat16 val) {
+                    return val.to_float();
+                });
+            return tensor_impl::decode_tensor_data(std::move(physical_data), cpu_tensor.tensor_spec());
+        }
+        case DataType::FLOAT32: {
+            auto physical_data = owned_buffer::get_as<float>(std::get<OwnedStorage>(cpu_tensor.storage()).buffer).get();
+            return tensor_impl::decode_tensor_data(std::move(physical_data), cpu_tensor.tensor_spec());
+        }
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
             const auto& tile = cpu_tensor.get_tensor_spec().tile();
@@ -698,13 +700,14 @@ std::vector<float> Tensor::to_vector<float>() const {
 
 template <typename T>
 std::vector<T> Tensor::to_vector() const {
-    auto cpu_tensor = this->cpu().to_layout(Layout::ROW_MAJOR);
     TT_FATAL(
-        cpu_tensor.get_dtype() == convert_to_data_type<T>(),
+        this->get_dtype() == convert_to_data_type<T>(),
         "Unsupported data type for to_vector: got {}, expected: {}",
-        cpu_tensor.get_dtype(),
+        this->get_dtype(),
         convert_to_data_type<T>());
-    return unpad_tensor_to_vec<T, T>(cpu_tensor);
+    auto cpu_tensor = this->cpu();
+    auto physical_data = owned_buffer::get_as<T>(std::get<OwnedStorage>(cpu_tensor.storage()).buffer).get();
+    return tensor_impl::decode_tensor_data(std::move(physical_data), cpu_tensor.tensor_spec());
 }
 
 // Instantiate explicitly for the supported types.
@@ -718,6 +721,36 @@ template Tensor Tensor::from_span<uint16_t>(
     tt::stl::Span<const uint16_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::from_span<uint32_t>(
     tt::stl::Span<const uint32_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::borrow_from_span<bfloat16>(
+    tt::stl::Span<bfloat16> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::borrow_from_span<int32_t>(
+    tt::stl::Span<int32_t> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::borrow_from_span<uint8_t>(
+    tt::stl::Span<uint8_t> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::borrow_from_span<uint16_t>(
+    tt::stl::Span<uint16_t> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::borrow_from_span<uint32_t>(
+    tt::stl::Span<uint32_t> buffer,
+    const TensorSpec& spec,
+    const std::function<void()>& on_creation_callback,
+    const std::function<void()>& on_destruction_callback,
+    std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::from_vector<bfloat16>(
     std::vector<bfloat16>&& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
 template Tensor Tensor::from_vector<int32_t>(

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -165,7 +165,8 @@ public:
         tt::stl::Span<T> buffer,
         const ttnn::Shape& shape,
         const std::function<void()>& on_creation_callback,
-        const std::function<void()>& on_destruction_callback);
+        const std::function<void()>& on_destruction_callback,
+        const std::optional<Tile>& tile = std::nullopt);
 
     // Same as `from_span`, but operates on a vector instead.
     template <typename T>

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -148,19 +148,22 @@ public:
     static Tensor from_span(
         tt::stl::Span<const T> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt);
 
-    // Returns true if the tensor spec is such that the tensor can be created by borrowing storage from a buffer:
-    // 1. The tensor physical shape is the same as logical shape.
-    // 2. The tensor layout is row-major.
-    bool static is_borrowable(const TensorSpec& spec);
-
-    // Creates a `Tensor` with storage "borrowed" from the buffer of elements of type `T`. `on_creation_callback` and
-    // `on_destruction_callback` are called when the tensor is created and destroyed, respectively.
+    // Creates a `Tensor` with storage "borrowed" from the buffer of elements of type `T`.
     //
-    // Throws if `spec` does not satisfy the conditions for borrowing a tensor from a buffer.
+    // The primary use case for this API is to interop with Python, where `on_creation_callback` and
+    // `on_destruction_callback` are specified to be called when the tensor storage is created and destroyed (when
+    // making copies of Tensor object):
+    //
+    // py::object py_tensor = ...;
+    // auto on_creation_callback = [t = py_tensor] { t.inc_ref(); };
+    // auto on_destruction_callback = [t = py_tensor] { t.dec_ref(); };
+    //
+    // When working in C++, prefer creating owned tensors, and retaining a reference to the internal buffer, if
+    // necessary.
     template <typename T>
-    static Tensor borrow_from_span(
+    static Tensor from_borrowed_data(
         tt::stl::Span<T> buffer,
-        const TensorSpec& spec,
+        const ttnn::Shape& shape,
         const std::function<void()>& on_creation_callback,
         const std::function<void()>& on_destruction_callback);
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -148,7 +148,7 @@ public:
     static Tensor from_span(
         tt::stl::Span<const T> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt);
 
-    // Returns true if the tensor spec is such that the tensor can be borrowed:
+    // Returns true if the tensor spec is such that the tensor can be created by borrowing storage from a buffer:
     // 1. The tensor physical shape is the same as logical shape.
     // 2. The tensor layout is row-major.
     bool static is_borrowable(const TensorSpec& spec);

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -162,8 +162,7 @@ public:
         tt::stl::Span<T> buffer,
         const TensorSpec& spec,
         const std::function<void()>& on_creation_callback,
-        const std::function<void()>& on_destruction_callback,
-        std::optional<ttnn::AnyDevice> device = std::nullopt);
+        const std::function<void()>& on_destruction_callback);
 
     // Same as `from_span`, but operates on a vector instead.
     template <typename T>

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -152,18 +152,22 @@ void insert_buffer_and_shape_for_device(
         [target_device, &shard, buffer_index](auto&& s) {
             using T = std::decay_t<decltype(s)>;
             if constexpr (std::is_same_v<T, MultiDeviceHostStorage>) {
+                TT_FATAL(shard.storage_type() == StorageType::OWNED, "Shard must be an owned tensor");
                 s.insert_buffer_and_spec_for_device(
                     buffer_index.value(),
                     std::get<OwnedStorage>(shard.tensor_attributes->storage).get_buffer(),
                     shard.tensor_attributes->tensor_spec);
             } else if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
+                TT_FATAL(shard.storage_type() == StorageType::DEVICE, "Shard must be a device tensor");
                 s.insert_buffer_and_spec_for_device(
                     target_device,
                     std::get<DeviceStorage>(shard.tensor_attributes->storage).get_buffer(),
                     shard.tensor_attributes->tensor_spec);
             } else if constexpr (std::is_same_v<T, OwnedStorage>) {
+                TT_FATAL(shard.storage_type() == StorageType::OWNED, "Shard must be an owned tensor");
                 s.insert_buffer(std::get<OwnedStorage>(shard.tensor_attributes->storage).get_buffer());
             } else if constexpr (std::is_same_v<T, DeviceStorage>) {
+                TT_FATAL(shard.storage_type() == StorageType::DEVICE, "Shard must be a device tensor");
                 s.insert_buffer(std::get<DeviceStorage>(shard.tensor_attributes->storage).get_buffer());
             } else {
                 TT_THROW("Unsupported storage in insert_buffer_and_shape_for_device");


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Tensor doesn't provide good APIs for borrowed storage.

### What's changed
* `Tensor::from_borrowed_data` to create `Tensor` with borrowed storage.
* Simplified `pytensor.cpp` to use the new APIs instead of dealing with low-level details.
* Remove `unpad_tensor_to_vec` - bespoke implementation of what `tensor_impl::decode_tensor_data` is supposed to do.
* Add tests for creating `Tensor` with borrowed storage. Simplify tests that deal with shard specs.
* Removed incorrect use of `explicit`, `inline`, `const` in borrowed / owned buffer headers.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13618906914)
- [X] New/Existing tests provide coverage for changes
