### PR TITLE
#17477: Adopt ND coordinate system in system mesh, coordinate translation

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <unordered_set>
 
 #include "mesh_coord.hpp"
 
@@ -11,7 +12,7 @@ namespace tt::tt_metal::distributed {
 namespace {
 
 using ::testing::ElementsAre;
-
+using ::testing::UnorderedElementsAre;
 TEST(SimpleMeshShapeTest, Construction) {
     SimpleMeshShape shape_1d(3);
     EXPECT_EQ(shape_1d.dims(), 1);
@@ -98,6 +99,21 @@ TEST(MeshCoordinateTest, Comparison) {
     EXPECT_EQ(coord1, MeshCoordinate(1, 2));
     EXPECT_NE(coord1, MeshCoordinate(2, 1));
     EXPECT_NE(coord1, MeshCoordinate(1, 2, 1));
+}
+
+TEST(MeshCoordinateTest, UnorderedSet) {
+    std::unordered_set<MeshCoordinate> set;
+    set.insert(MeshCoordinate(0, 0, 0));
+    set.insert(MeshCoordinate(0, 0, 1));
+    set.insert(MeshCoordinate(0, 0, 2));
+
+    EXPECT_FALSE(set.insert(MeshCoordinate(0, 0, 2)).second);
+    EXPECT_THAT(
+        set,
+        UnorderedElementsAre(
+            MeshCoordinate(0, 0, 0),  //
+            MeshCoordinate(0, 0, 1),
+            MeshCoordinate(0, 0, 2)));
 }
 
 TEST(MeshCoordinateRangeTest, FromShape) {
@@ -232,6 +248,7 @@ TEST(MeshContainerTest, ElementAccessRowMajor) {
             MeshCoordinate(1, 1),
             MeshCoordinate(1, 2)));
     EXPECT_THAT(values, ElementsAre(0, 1, 2, 3, 4, 5));
+    EXPECT_THAT(container.values(), ElementsAre(0, 1, 2, 3, 4, 5));
 }
 
 TEST(MeshContainerTest, ConstContainer) {
@@ -254,6 +271,7 @@ TEST(MeshContainerTest, ConstContainer) {
             MeshCoordinate(1, 1),
             MeshCoordinate(1, 2)));
     EXPECT_THAT(values, ElementsAre(0, 0, 0, 0, 0, 0));
+    EXPECT_THAT(container.values(), ElementsAre(0, 0, 0, 0, 0, 0));
 }
 
 TEST(MeshContainerTest, MutateThroughProxy) {
@@ -276,6 +294,7 @@ TEST(MeshContainerTest, MutateThroughProxy) {
         values.push_back(value);
     }
     EXPECT_THAT(values, ElementsAre(0, 1, 2, 3, 4, 5));
+    EXPECT_THAT(container.values(), ElementsAre(0, 1, 2, 3, 4, 5));
 }
 
 TEST(MeshContainerTest, OutOfBounds) {

--- a/tests/ttnn/distributed/test_distributed.cpp
+++ b/tests/ttnn/distributed/test_distributed.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <ttnn/core.hpp>
 #include <ttnn/distributed/api.hpp>
 
@@ -19,11 +18,16 @@ protected:
 TEST_F(DistributedTest, TestSystemMeshTearDownWithoutClose) {
     auto& sys = SystemMesh::instance();
     auto mesh = ttnn::distributed::open_mesh_device(
-        {2, 4}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
+        /*mesh_shape=*/{2, 4},
+        DEFAULT_L1_SMALL_SIZE,
+        DEFAULT_TRACE_REGION_SIZE,
+        1,
+        tt::tt_metal::DispatchCoreType::WORKER);
 
-    auto [rows, cols] = sys.get_shape();
-    EXPECT_GT(rows, 0);
-    EXPECT_GT(cols, 0);
+    const auto system_shape = sys.get_shape();
+    ASSERT_EQ(system_shape.dims(), 2);
+    EXPECT_EQ(system_shape[0], 2);
+    EXPECT_EQ(system_shape[1], 4);
 }
 
 TEST_F(DistributedTest, TestMemoryAllocationStatistics) {

--- a/tests/ttnn/distributed/test_distributed_atexit.cpp
+++ b/tests/ttnn/distributed/test_distributed_atexit.cpp
@@ -18,9 +18,10 @@ TEST(DistributedTestStandalone, TestSystemMeshTearDownWithoutClose) {
     mesh = ttnn::distributed::open_mesh_device(
         {2, 4}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
 
-    auto [rows, cols] = sys.get_shape();
-    EXPECT_GT(rows, 0);
-    EXPECT_GT(cols, 0);
+    const auto system_shape = sys.get_shape();
+    ASSERT_EQ(system_shape.dims(), 2);
+    EXPECT_EQ(system_shape[0], 2);
+    EXPECT_EQ(system_shape[1], 4);
 }
 
 }  // namespace ttnn::distributed::test

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -33,7 +33,7 @@ private:
     class ScopedDevices {
     private:
         std::map<chip_id_t, IDevice*> opened_devices_;
-        std::vector<IDevice*> devices_;
+        MeshContainer<IDevice*> devices_;
 
     public:
         // Constructor acquires physical resources
@@ -50,6 +50,7 @@ private:
         ScopedDevices& operator=(const ScopedDevices&) = delete;
 
         const std::vector<IDevice*>& get_devices() const;
+        IDevice* get_device(const MeshCoordinate& coord) const;
     };
 
     std::shared_ptr<ScopedDevices> scoped_devices_;
@@ -202,7 +203,6 @@ public:
 
     // Returns the devices in the mesh in row-major order.
     std::vector<IDevice*> get_devices() const;
-    IDevice* get_device_index(size_t logical_device_id) const;
     IDevice* get_device(chip_id_t physical_device_id) const;
     IDevice* get_device(size_t row_idx, size_t col_idx) const;
     IDevice* get_device(const MeshCoordinate& coord) const;

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -8,8 +8,7 @@
 #include <vector>
 
 #include "mesh_config.hpp"
-#include "mesh_device.hpp"
-#include "device.hpp"
+#include "mesh_coord.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -21,7 +20,6 @@ private:
     class Impl;  // Forward declaration only
     std::unique_ptr<Impl> pimpl_;
     SystemMesh();
-    ~SystemMesh();
 
 public:
     static SystemMesh& instance();
@@ -30,11 +28,10 @@ public:
     SystemMesh(SystemMesh&&) = delete;
     SystemMesh& operator=(SystemMesh&&) = delete;
 
-    const MeshShape& get_shape() const;
-    size_t get_num_devices() const;
+    const SimpleMeshShape& get_shape() const;
 
     // Gets the physical device ID for a given logical row and column index
-    chip_id_t get_physical_device_id(size_t logical_row_idx, size_t logical_col_idx) const;
+    chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
 
     // Get the physical device IDs mapped to a MeshDevice
     std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -71,12 +71,17 @@ const std::pair<CoordinateTranslationMap, SimpleMeshShape>& get_system_mesh_coor
             "Unsupported number of devices: {}",
             system_num_devices);
 
-        auto [translation_config_file, shape] = system_mesh_translation_map.at(system_num_devices);
-        TT_ASSERT(system_num_devices == shape.mesh_size());
+        const auto [translation_config_file, shape] = system_mesh_translation_map.at(system_num_devices);
+        TT_FATAL(
+            system_num_devices == shape.mesh_size(),
+            "Mismatch between number of devices and the mesh shape: {} != {}",
+            system_num_devices,
+            shape.mesh_size());
         log_debug(LogMetal, "Logical SystemMesh Shape: {}", shape);
 
         return std::pair<CoordinateTranslationMap, SimpleMeshShape>{
-            load_translation_map(translation_config_file, /*key=*/"logical_to_physical_coordinates"), shape};
+            load_translation_map(get_config_path(translation_config_file), /*key=*/"logical_to_physical_coordinates"),
+            shape};
     }());
 
     return *cached_translation_map;

--- a/tt_metal/distributed/coordinate_translation.hpp
+++ b/tt_metal/distributed/coordinate_translation.hpp
@@ -7,17 +7,18 @@
 #include <unordered_map>
 
 #include "umd/device/types/cluster_descriptor_types.h"
+#include <mesh_coord.hpp>
 #include <mesh_device_view.hpp>
 
 namespace tt::tt_metal::distributed {
 
 // TODO: Consider conversion to StrongType instead of alias
-using LogicalCoordinate = Coordinate;
 using PhysicalCoordinate = eth_coord_t;
-using CoordinateTranslationMap = std::unordered_map<LogicalCoordinate, PhysicalCoordinate>;
+using CoordinateTranslationMap = std::unordered_map<MeshCoordinate, PhysicalCoordinate>;
 
-// Returns a translation map between logical coordinates in logical 2D space
+// Returns a translation map between logical coordinates in logical ND space
 // to the physical coordinates as defined by the UMD layer.
-std::pair<CoordinateTranslationMap, MeshShape> get_system_mesh_coordinate_translation_map();
+// TODO: #17477 - Return MeshContainer<PhysicalCoordinate> that contains everything we need.
+const std::pair<CoordinateTranslationMap, SimpleMeshShape>& get_system_mesh_coordinate_translation_map();
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -77,8 +77,8 @@ MeshDevice::ScopedDevices::ScopedDevices(
         physical_device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
 
     TT_FATAL(
-        opened_devices_.size() == devices_.shape().mesh_size(),
-        "Opened devices size mismatch; expected: {}, actual: {}",
+        physical_device_ids.size() == devices_.shape().mesh_size(),
+        "Device size mismatch; expected: {}, actual: {}",
         devices_.shape().mesh_size(),
         opened_devices_.size());
 

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -257,12 +257,11 @@ uint32_t MeshWorkload::get_sem_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t sem_size = 0;
     uint32_t program_idx = 0;
-    IDevice* device = mesh_device->get_device_index(0);
     for (auto& [device_range, program] : programs_) {
         if (program_idx) {
-            TT_ASSERT(sem_size == program.get_sem_size(device, logical_core, core_type));
+            TT_ASSERT(sem_size == program.get_sem_size(mesh_device.get(), logical_core, core_type));
         } else {
-            sem_size = program.get_sem_size(device, logical_core, core_type);
+            sem_size = program.get_sem_size(mesh_device.get(), logical_core, core_type);
         }
         program_idx++;
     }
@@ -281,12 +280,11 @@ uint32_t MeshWorkload::get_cb_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t cb_size = 0;
     uint32_t program_idx = 0;
-    IDevice* device = mesh_device->get_device_index(0);
     for (auto& [device_range, program] : programs_) {
         if (program_idx) {
-            TT_ASSERT(cb_size == program.get_cb_size(device, logical_core, core_type));
+            TT_ASSERT(cb_size == program.get_cb_size(mesh_device.get(), logical_core, core_type));
         } else {
-            cb_size = program.get_cb_size(device, logical_core, core_type);
+            cb_size = program.get_cb_size(mesh_device.get(), logical_core, core_type);
         }
         program_idx++;
     }

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -92,8 +92,8 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
     // TODO: #17477 - Extend to ND.
     TT_FATAL(
         logical_mesh_shape_.dims() == 2,
-        "SystemMesh only supports 2D meshes; requested shape: {}",
-        logical_mesh_shape_);
+        "SystemMesh only supports 2D meshes; requested dimensions: {}",
+        logical_mesh_shape_.dims());
 
     auto [system_mesh_rows, system_mesh_cols] = std::make_tuple(logical_mesh_shape_[0], logical_mesh_shape_[1]);
     auto [requested_num_rows, requested_num_cols] = config.mesh_shape;

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -7,31 +7,30 @@
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/distributed/coordinate_translation.hpp"
 
+#include "mesh_coord.hpp"
 #include "tt_cluster.hpp"
 
 namespace tt::tt_metal::distributed {
 
 class SystemMesh::Impl {
 private:
-    MeshShape logical_mesh_shape_;
+    SimpleMeshShape logical_mesh_shape_;
     CoordinateTranslationMap logical_to_physical_coordinates_;
-    std::unordered_map<LogicalCoordinate, chip_id_t> logical_to_device_id_;
+    std::unordered_map<MeshCoordinate, chip_id_t> logical_to_device_id_;
     std::unordered_map<PhysicalCoordinate, chip_id_t> physical_coordinate_to_device_id_;
     std::unordered_map<chip_id_t, PhysicalCoordinate> physical_device_id_to_coordinate_;
 
 public:
     Impl() = default;
-    ~Impl() = default;
 
     bool is_system_mesh_initialized() const;
     void initialize();
-    const MeshShape& get_shape() const;
-    size_t get_num_devices() const;
+    const SimpleMeshShape& get_shape() const;
     std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;
     std::vector<chip_id_t> request_available_devices(const MeshDeviceConfig& config) const;
-    IDevice* get_device(const chip_id_t physical_device_id) const;
 
-    chip_id_t get_physical_device_id(size_t logical_row_idx, size_t logical_col_idx) const;
+    IDevice* get_device(const chip_id_t physical_device_id) const;
+    chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
 };
 
 // Implementation of public methods
@@ -69,30 +68,34 @@ void SystemMesh::Impl::initialize() {
     }
 }
 
-const MeshShape& SystemMesh::Impl::get_shape() const { return logical_mesh_shape_; }
-size_t SystemMesh::Impl::get_num_devices() const {
-    auto [num_rows, num_cols] = this->get_shape();
-    return num_rows * num_cols;
-}
+const SimpleMeshShape& SystemMesh::Impl::get_shape() const { return logical_mesh_shape_; }
 
-chip_id_t SystemMesh::Impl::get_physical_device_id(size_t logical_row_idx, size_t logical_col_idx) const {
+chip_id_t SystemMesh::Impl::get_physical_device_id(const MeshCoordinate& coord) const {
     TT_FATAL(
-        logical_row_idx < logical_mesh_shape_.num_rows,
-        "Row index out of bounds: {} >= {}",
-        logical_row_idx,
-        logical_mesh_shape_.num_rows);
-    TT_FATAL(
-        logical_col_idx < logical_mesh_shape_.num_cols,
-        "Column index out of bounds: {} >= {}",
-        logical_col_idx,
-        logical_mesh_shape_.num_cols);
-    auto logical_coordinate = Coordinate{logical_row_idx, logical_col_idx};
-    return logical_to_device_id_.at(logical_coordinate);
+        coord.dims() == logical_mesh_shape_.dims(),
+        "Coordinate dimensions mismatch: {} != {}",
+        coord.dims(),
+        logical_mesh_shape_.dims());
+    for (size_t i = 0; i < coord.dims(); ++i) {
+        TT_FATAL(
+            coord[i] < logical_mesh_shape_[i],
+            "Coordinate at index {} out of bounds; mesh shape {}, coordinate {}",
+            i,
+            logical_mesh_shape_,
+            coord);
+    }
+    return logical_to_device_id_.at(coord);
 }
 
 std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const MeshDeviceConfig& config) const {
     std::vector<chip_id_t> physical_device_ids;
-    auto [system_mesh_rows, system_mesh_cols] = this->get_shape();
+    // TODO: #17477 - Extend to ND.
+    TT_FATAL(
+        logical_mesh_shape_.dims() == 2,
+        "SystemMesh only supports 2D meshes; requested shape: {}",
+        logical_mesh_shape_);
+
+    auto [system_mesh_rows, system_mesh_cols] = std::make_tuple(logical_mesh_shape_[0], logical_mesh_shape_[1]);
     auto [requested_num_rows, requested_num_cols] = config.mesh_shape;
     auto [row_offset, col_offset] = config.offset;
 
@@ -112,7 +115,8 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
         auto line_coords = MeshDeviceView::get_line_coordinates(
             line_length, Coordinate{row_offset, col_offset}, system_mesh_rows, system_mesh_cols);
         for (const auto& logical_coordinate : line_coords) {
-            auto physical_device_id = logical_to_device_id_.at(logical_coordinate);
+            auto physical_device_id =
+                logical_to_device_id_.at(MeshCoordinate(logical_coordinate.row, logical_coordinate.col));
             physical_device_ids.push_back(physical_device_id);
 
             log_debug(
@@ -178,17 +182,18 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
             }
 
             TT_FATAL(
-                logical_coordinate.row < logical_mesh_shape_.num_rows,
+                logical_coordinate.row < system_mesh_rows,
                 "Row coordinate out of bounds: {} >= {}",
                 logical_coordinate.row,
-                logical_mesh_shape_.num_rows);
+                system_mesh_rows);
             TT_FATAL(
-                logical_coordinate.col < logical_mesh_shape_.num_cols,
+                logical_coordinate.col < system_mesh_cols,
                 "Column coordinate out of bounds: {} >= {}",
                 logical_coordinate.col,
-                logical_mesh_shape_.num_cols);
+                system_mesh_cols);
 
-            auto physical_device_id = logical_to_device_id_.at(logical_coordinate);
+            auto physical_device_id =
+                logical_to_device_id_.at(MeshCoordinate(logical_coordinate.row, logical_coordinate.col));
             physical_device_ids.push_back(physical_device_id);
 
             log_debug(
@@ -200,7 +205,6 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
 
 std::vector<chip_id_t> SystemMesh::Impl::request_available_devices(const MeshDeviceConfig& config) const {
     auto [requested_num_rows, requested_num_cols] = config.mesh_shape;
-    auto [max_num_rows, max_num_cols] = logical_mesh_shape_;
     auto [row_offset, col_offset] = config.offset;
 
     log_debug(
@@ -216,7 +220,6 @@ std::vector<chip_id_t> SystemMesh::Impl::request_available_devices(const MeshDev
 }
 
 SystemMesh::SystemMesh() : pimpl_(std::make_unique<Impl>()) {}
-SystemMesh::~SystemMesh() = default;
 
 SystemMesh& SystemMesh::instance() {
     static SystemMesh instance;
@@ -226,13 +229,11 @@ SystemMesh& SystemMesh::instance() {
     return instance;
 }
 
-chip_id_t SystemMesh::get_physical_device_id(size_t logical_row_idx, size_t logical_col_idx) const {
-    return pimpl_->get_physical_device_id(logical_row_idx, logical_col_idx);
+chip_id_t SystemMesh::get_physical_device_id(const MeshCoordinate& coord) const {
+    return pimpl_->get_physical_device_id(coord);
 }
 
-const MeshShape& SystemMesh::get_shape() const { return pimpl_->get_shape(); }
-
-size_t SystemMesh::get_num_devices() const { return pimpl_->get_num_devices(); }
+const SimpleMeshShape& SystemMesh::get_shape() const { return pimpl_->get_shape(); }
 
 std::vector<chip_id_t> SystemMesh::request_available_devices(const MeshDeviceConfig& config) const {
     return pimpl_->request_available_devices(config);

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -124,7 +124,7 @@ Tensor aggregate_as_tensor(
 std::vector<int> get_t3k_physical_device_ids_ring() {
     using namespace tt::tt_metal::distributed;
     auto& instance = SystemMesh::instance();
-    auto num_devices = instance.get_num_devices();
+    auto num_devices = instance.get_shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
 
     auto physical_device_ids =


### PR DESCRIPTION
### Ticket
#17477

### Problem description
TT-distributed needs to adopt ND coordinate system for mesh primitives.

### What's changed
Plumbed `SimpleMeshShape` in `SystemMesh`, logical to physical coordinate translation mapping.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13395057290)
- [X] New/Existing tests provide coverage for changes
