### PR TITLE
Apply EDM Fabric Optimizations - Up to 13.5 GB/s bidir unicast and 10.5 GB/s bidir mcast

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -139,13 +139,9 @@ void kernel_main() {
                 safe_get_noc_addr(static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr);
             noc_async_write(source_l1_buffer_address, dest_addr, packet_payload_size_bytes);
             if (fabric_connection.has_forward_connection()) {
-                DeviceZoneScopedN("WR-FWD");
                 mcast_fwd_packet_header->to_noc_unicast_write(
                     NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
-                {
-                    DeviceZoneScopedN("WR-FWD-WAIT");
-                    fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-                }
+                fabric_connection.get_forward_connection().wait_for_empty_write_slot();
                 print_pkt_header(mcast_fwd_packet_header);
                 fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
                     source_l1_buffer_address, packet_payload_size_bytes);
@@ -154,13 +150,9 @@ void kernel_main() {
             }
 
             if (fabric_connection.has_backward_connection()) {
-                DeviceZoneScopedN("WR-BWD");
                 mcast_bwd_packet_header->to_noc_unicast_write(
                     NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
-                {
-                    DeviceZoneScopedN("WR-BWD-WAIT");
-                    fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-                }
+                fabric_connection.get_backward_connection().wait_for_empty_write_slot();
                 print_pkt_header(mcast_bwd_packet_header);
                 fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
                     source_l1_buffer_address, packet_payload_size_bytes);
@@ -176,7 +168,6 @@ void kernel_main() {
     for (size_t i = 0; i < num_unicasts; i++) {
         auto noc0_dest_addr =
             safe_get_noc_addr(static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr, 0);
-        DeviceZoneScopedN("UNICAST-WRITE");
         auto& fabric_conn =
             unicast_is_fwd ? fabric_connection.get_forward_connection() : fabric_connection.get_backward_connection();
         unicast_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -3590,6 +3590,17 @@ TEST(EdmFabric, BasicMcastThroughputTest_2) {
 
     RunWriteThroughputStabilityTestWithPersistentFabric(num_mcasts, num_unicasts, num_links, num_op_invocations);
 }
+TEST(EdmFabric, BasicMcastThroughputTest_3_SingleLink) {
+    const size_t num_mcasts = 200000;
+    const size_t num_unicasts = 0;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 1;
+    const bool line_sync = true;
+    WriteThroughputStabilityTestWithPersistentFabricParams params;
+    params.line_sync = line_sync;
+    RunWriteThroughputStabilityTestWithPersistentFabric(
+        num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
 TEST(EdmFabric, BasicMcastThroughputTest_3) {
     const size_t num_mcasts = 200000;
     const size_t num_unicasts = 2;

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -78,21 +78,36 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     const std::size_t channel_buffer_size_with_channel_sync =
         channel_buffer_size_bytes + sizeof(tt::fabric::PacketHeader); // + 16 // sizeof(tt::fabric::PacketHeader);
 
-    this->channel_buffer_size_bytes = channel_buffer_size_bytes;
+    const size_t next_lowest_power_of_2_buffer_slot_count =
+
+        this->channel_buffer_size_bytes = channel_buffer_size_bytes;
     this->channel_buffer_size_bytes_with_channel_sync = channel_buffer_size_with_channel_sync;
     const std::size_t total_ratio_count = 2 * sender_ratio_size + receiver_ratio_size;
+
     this->sender_0_channel_size_bytes = tt::round_down(
         (available_channel_buffering_space / total_ratio_count) * sender_ratio_size,
         channel_buffer_size_with_channel_sync);
-    this->sender_0_num_buffers = this->sender_0_channel_size_bytes / channel_buffer_size_with_channel_sync;
+    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_clunts) {
+        this->sender_0_num_buffers = 8;
+    } else {
+        this->sender_0_num_buffers = this->sender_0_channel_size_bytes / channel_buffer_size_with_channel_sync;
+    }
     this->sender_1_channel_size_bytes = tt::round_down(
         (available_channel_buffering_space / total_ratio_count) * sender_ratio_size,
         channel_buffer_size_with_channel_sync);
-    this->sender_1_num_buffers = this->sender_1_channel_size_bytes / channel_buffer_size_with_channel_sync;
+    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_clunts) {
+        this->sender_1_num_buffers = 8;
+    } else {
+        this->sender_1_num_buffers = this->sender_1_channel_size_bytes / channel_buffer_size_with_channel_sync;
+    }
     this->receiver_channel_size_bytes = tt::round_down(
         (available_channel_buffering_space / total_ratio_count) * receiver_ratio_size,
         channel_buffer_size_with_channel_sync);
-    this->receiver_num_buffers = this->receiver_channel_size_bytes / channel_buffer_size_with_channel_sync;
+    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_clunts) {
+        this->receiver_num_buffers = 16;
+    } else {
+        this->receiver_num_buffers = this->receiver_channel_size_bytes / channel_buffer_size_with_channel_sync;
+    }
 
     this->sender_0_channel_base_address = buffer_region_start;
     this->sender_1_channel_base_address = this->sender_0_channel_base_address + this->sender_0_channel_size_bytes;

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -75,6 +75,10 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     TT_FATAL(sender_channel_1_buffer_index_address != sender_channel_0_buffer_index_address, "FabricEriscDatamoverConfig was constructed with illegal buffer index address");
     const size_t min_buffer_size = sizeof(tt::fabric::PacketHeader) + 2 * FabricEriscDatamoverConfig::eth_channel_sync_size;
     TT_FATAL(channel_buffer_size_bytes >= min_buffer_size, "FabricEriscDatamoverConfig was constructed with `channel_buffer_size_bytes` argument set smaller than minimum size of {}", min_buffer_size);
+
+    constexpr size_t default_pow2_num_sender_buffer_slots = 8;
+    constexpr size_t default_pow2_num_receiver_buffer_slots = 16;
+
     const std::size_t channel_buffer_size_with_channel_sync =
         channel_buffer_size_bytes + sizeof(tt::fabric::PacketHeader); // + 16 // sizeof(tt::fabric::PacketHeader);
 
@@ -87,24 +91,24 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     this->sender_0_channel_size_bytes = tt::round_down(
         (available_channel_buffering_space / total_ratio_count) * sender_ratio_size,
         channel_buffer_size_with_channel_sync);
-    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_clunts) {
-        this->sender_0_num_buffers = 8;
+    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
+        this->sender_0_num_buffers = default_pow2_num_sender_buffer_slots;
     } else {
         this->sender_0_num_buffers = this->sender_0_channel_size_bytes / channel_buffer_size_with_channel_sync;
     }
     this->sender_1_channel_size_bytes = tt::round_down(
         (available_channel_buffering_space / total_ratio_count) * sender_ratio_size,
         channel_buffer_size_with_channel_sync);
-    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_clunts) {
-        this->sender_1_num_buffers = 8;
+    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
+        this->sender_1_num_buffers = default_pow2_num_sender_buffer_slots;
     } else {
         this->sender_1_num_buffers = this->sender_1_channel_size_bytes / channel_buffer_size_with_channel_sync;
     }
     this->receiver_channel_size_bytes = tt::round_down(
         (available_channel_buffering_space / total_ratio_count) * receiver_ratio_size,
         channel_buffer_size_with_channel_sync);
-    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_clunts) {
-        this->receiver_num_buffers = 16;
+    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
+        this->receiver_num_buffers = default_pow2_num_receiver_buffer_slots;
     } else {
         this->receiver_num_buffers = this->receiver_channel_size_bytes / channel_buffer_size_with_channel_sync;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -30,7 +30,7 @@ namespace ccl {
 
 
 struct FabricEriscDatamoverConfig {
-    static constexpr bool constrain_to_power_of_2_buffer_slot_clunts = true;
+    static constexpr bool constrain_to_power_of_2_buffer_slot_counts = true;
 
     static constexpr std::size_t field_size = 16;
     static constexpr std::size_t buffer_alignment = 32;

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -30,6 +30,8 @@ namespace ccl {
 
 
 struct FabricEriscDatamoverConfig {
+    static constexpr bool constrain_to_power_of_2_buffer_slot_clunts = true;
+
     static constexpr std::size_t field_size = 16;
     static constexpr std::size_t buffer_alignment = 32;
     static constexpr std::size_t eth_word_l1_alignment = 16;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp
@@ -40,7 +40,7 @@ FORCE_INLINE auto wrap_increment(T val) -> T {
     } else if constexpr (LIMIT == 2) {
         return 1 - val;
     } else if constexpr (is_pow2) {
-        return (val + 1) & (LIMIT - 1);
+        return (val + 1) & (static_cast<T>(LIMIT - 1));
     } else {
         return (val == static_cast<T>(LIMIT - 1)) ? static_cast<T>(0) : static_cast<T>(val + 1);
     }
@@ -80,9 +80,9 @@ FORCE_INLINE auto normalize_ptr(BufferPtr ptr) -> BufferIndex {
     constexpr bool is_size_1 = NUM_BUFFERS == 1;
     constexpr uint8_t wrap_mask = NUM_BUFFERS - 1;
     if constexpr (is_size_pow2) {
-        return BufferIndex{ptr & wrap_mask};
+        return BufferIndex{static_cast<uint8_t>(ptr.get() & wrap_mask)};
     } else if constexpr (is_size_2) {
-        return BufferIndex{(uint8_t)1 - ptr};
+        return BufferIndex{(uint8_t)1 - ptr.get()};
     } else if constexpr (is_size_1) {
         return BufferIndex{0};
     } else {
@@ -149,7 +149,7 @@ public:
     FORCE_INLINE void increment_n(uint8_t n) {
         this->ptr = BufferPtr{wrap_increment_n<2 * NUM_BUFFERS>(this->ptr.get(), n)};
     }
-    FORCE_INLINE void increment() { this->ptr = wrap_increment<2 * NUM_BUFFERS>(this->ptr); }
+    FORCE_INLINE void increment() { this->ptr = BufferPtr{wrap_increment<2 * NUM_BUFFERS>(this->ptr.get())}; }
 
 private:
     // Make these private to make sure caller doesn't accidentally mix two pointers pointing to

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp
@@ -33,7 +33,6 @@ using BufferPtr = NamedType<uint8_t, struct BufferPtrType>;
 // Increments val and wraps to 0 if it reaches limit
 template <size_t LIMIT = 0, typename T>
 FORCE_INLINE auto wrap_increment(T val) -> T {
-    // static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
     constexpr bool is_pow2 = LIMIT != 0 && is_power_of_2(LIMIT);
     if constexpr (LIMIT == 1) {
         return val;
@@ -47,7 +46,6 @@ FORCE_INLINE auto wrap_increment(T val) -> T {
 }
 template <size_t LIMIT, typename T>
 FORCE_INLINE auto wrap_increment_n(T val, uint8_t increment) -> T {
-    // static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
     constexpr bool is_pow2 = LIMIT != 0 && is_power_of_2(LIMIT);
     if constexpr (LIMIT == 1) {
         return val;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "tt_metal/hw/inc/utils/utils.h"
+#include "risc_attribs.h"
+
+namespace tt::fabric {
+
+template <typename T, typename Parameter>
+class NamedType {
+public:
+    FORCE_INLINE explicit NamedType(const T& value) : value_(value) {}
+    FORCE_INLINE explicit NamedType(T&& value) : value_(std::move(value)) {}
+    FORCE_INLINE NamedType<T, Parameter>& operator=(const NamedType<T, Parameter>& rhs) = default;
+    FORCE_INLINE T& get() { return value_; }
+    FORCE_INLINE const T& get() const { return value_; }
+    FORCE_INLINE operator T() const { return value_; }
+    FORCE_INLINE operator T&() { return value_; }
+
+private:
+    T value_;
+};
+
+using BufferIndex = NamedType<uint8_t, struct BufferIndexType>;
+using BufferPtr = NamedType<uint8_t, struct BufferPtrType>;
+
+// Increments val and wraps to 0 if it reaches limit
+template <size_t LIMIT = 0, typename T>
+FORCE_INLINE auto wrap_increment(T val) -> T {
+    // static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
+    constexpr bool is_pow2 = LIMIT != 0 && is_power_of_2(LIMIT);
+    if constexpr (LIMIT == 1) {
+        return val;
+    } else if constexpr (LIMIT == 2) {
+        return 1 - val;
+    } else if constexpr (is_pow2) {
+        return (val + 1) & (LIMIT - 1);
+    } else {
+        return (val == static_cast<T>(LIMIT - 1)) ? static_cast<T>(0) : static_cast<T>(val + 1);
+    }
+}
+template <size_t LIMIT, typename T>
+FORCE_INLINE auto wrap_increment_n(T val, uint8_t increment) -> T {
+    // static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
+    constexpr bool is_pow2 = LIMIT != 0 && is_power_of_2(LIMIT);
+    if constexpr (LIMIT == 1) {
+        return val;
+    } else if constexpr (LIMIT == 2) {
+        return 1 - val;
+    } else if constexpr (is_pow2) {
+        return (val + increment) & (LIMIT - 1);
+    } else {
+        T new_unadjusted_val = val + increment;
+        bool wraps = new_unadjusted_val >= LIMIT;
+        return wraps ? static_cast<T>(new_unadjusted_val - LIMIT) : static_cast<T>(new_unadjusted_val);
+    }
+}
+
+FORCE_INLINE
+auto normalize_ptr(BufferPtr ptr, uint8_t num_buffers) -> BufferIndex {
+    // note it may make sense to calculate this only when we increment
+    // which will save calculations overall (but may add register pressure)
+    // and introduce undesirable loads
+    bool normalize = ptr >= num_buffers;
+    uint8_t normalized_ptr = ptr.get() - static_cast<uint8_t>(normalize * num_buffers);
+    ASSERT(normalized_ptr < num_buffers);
+    return BufferIndex{normalized_ptr};
+}
+template <uint8_t NUM_BUFFERS>
+FORCE_INLINE auto normalize_ptr(BufferPtr ptr) -> BufferIndex {
+    static_assert(NUM_BUFFERS != 0, "normalize_ptr called with NUM_BUFFERS of 0; it must be greater than 0");
+    constexpr bool is_size_pow2 = NUM_BUFFERS != 0 && (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
+    constexpr bool is_size_2 = NUM_BUFFERS == 2;
+    constexpr bool is_size_1 = NUM_BUFFERS == 1;
+    constexpr uint8_t wrap_mask = NUM_BUFFERS - 1;
+    if constexpr (is_size_pow2) {
+        return BufferIndex{ptr & wrap_mask};
+    } else if constexpr (is_size_2) {
+        return BufferIndex{(uint8_t)1 - ptr};
+    } else if constexpr (is_size_1) {
+        return BufferIndex{0};
+    } else {
+        // note it may make sense to calculate this only when we increment
+        // which will save calculations overall (but may add register pressure)
+        // and introduce undesirable loads
+        return normalize_ptr(ptr, NUM_BUFFERS);
+    }
+}
+
+FORCE_INLINE uint8_t
+distance_behind(const BufferPtr& trailing_ptr, const BufferPtr& leading_ptr, uint8_t ptr_wrap_size) {
+    bool leading_gte_trailing_ptr = leading_ptr >= trailing_ptr;
+    return leading_gte_trailing_ptr ? leading_ptr - trailing_ptr : ptr_wrap_size - (trailing_ptr - leading_ptr);
+}
+template <uint8_t NUM_BUFFERS>
+FORCE_INLINE uint8_t distance_behind(const BufferPtr& trailing_ptr, const BufferPtr& leading_ptr) {
+    static_assert(NUM_BUFFERS != 0, "distance_behind called with NUM_BUFFERS of 0; it must be greater than 0");
+    constexpr bool is_size_pow2 = is_power_of_2(NUM_BUFFERS);
+    constexpr uint8_t ptr_wrap_mask = (2 * NUM_BUFFERS) - 1;
+    constexpr uint8_t ptr_wrap_size = 2 * NUM_BUFFERS;
+    bool leading_gte_trailing_ptr = leading_ptr >= trailing_ptr;
+    if constexpr (is_size_pow2) {
+        return (leading_ptr - trailing_ptr) & ptr_wrap_mask;
+    } else {
+        return distance_behind(trailing_ptr, leading_ptr, ptr_wrap_size);
+    }
+}
+
+template <uint8_t NUM_BUFFERS>
+class ChannelBufferPointer {
+    static_assert(
+        NUM_BUFFERS <= std::numeric_limits<uint8_t>::max() / 2,
+        "NUM_BUFFERS must be less than or half of std::numeric_limits<uint8_t>::max() due to the internal "
+        "implementation");
+
+public:
+    static constexpr bool is_size_pow2 = (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
+    static constexpr bool is_size_2 = NUM_BUFFERS == 2;
+    static constexpr bool is_size_1 = NUM_BUFFERS == 1;
+    static constexpr uint8_t ptr_wrap_size = 2 * NUM_BUFFERS;
+
+    // Only to use if is_size_pow2
+    static constexpr uint8_t ptr_wrap_mask = (2 * NUM_BUFFERS) - 1;
+    static constexpr uint8_t buffer_wrap_mask = NUM_BUFFERS - 1;
+    ChannelBufferPointer() : ptr(0) {}
+    /*
+     * Returns the "raw" pointer - not usable to index the buffer channel
+     */
+    FORCE_INLINE BufferPtr get_ptr() const { return this->ptr; }
+
+    FORCE_INLINE bool is_caught_up_to(const ChannelBufferPointer<NUM_BUFFERS>& leading_ptr) const {
+        return this->is_caught_up_to(leading_ptr.get_ptr());
+    }
+    FORCE_INLINE uint8_t distance_behind(const ChannelBufferPointer<NUM_BUFFERS>& leading_ptr) const {
+        return this->distance_behind(leading_ptr.get_ptr());
+    }
+
+    /*
+     * Returns the buffer index pointer which is usable to index into the buffer memory
+     */
+    FORCE_INLINE BufferIndex get_buffer_index() const { return BufferIndex{normalize_ptr<NUM_BUFFERS>(this->ptr)}; }
+
+    FORCE_INLINE void increment_n(uint8_t n) {
+        this->ptr = BufferPtr{wrap_increment_n<2 * NUM_BUFFERS>(this->ptr.get(), n)};
+    }
+    FORCE_INLINE void increment() { this->ptr = wrap_increment<2 * NUM_BUFFERS>(this->ptr); }
+
+private:
+    // Make these private to make sure caller doesn't accidentally mix two pointers pointing to
+    // different sized channels
+    FORCE_INLINE bool is_caught_up_to(const BufferPtr& leading_ptr) const { return this->get_ptr() == leading_ptr; }
+    FORCE_INLINE uint8_t distance_behind(const BufferPtr& leading_ptr) const {
+        return tt::fabric::distance_behind<NUM_BUFFERS>(this->ptr, leading_ptr);
+    }
+    BufferPtr ptr = BufferPtr{0};
+};
+
+}  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -10,6 +10,8 @@
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp"
+#include "tt_metal/hw/inc/utils/utils.h"
 #include "debug/assert.h"
 #include "debug/dprint.h"
 #include <cstdint>
@@ -17,7 +19,7 @@
 namespace tt::fabric {
 
 /*
- * The WorkerToFabricEdmSender acts as an adapter between the worker and the EDM, it hides details
+ * The WorkerToFabricEdmSenderImpl acts as an adapter between the worker and the EDM, it hides details
  * of the communication between worker and EDM to provide flexibility for the implementation to change
  * over time without kernel updates. Additionally, details for adapter setup w.r.t runtime args is also hidden.
  * The main functionality provided is:
@@ -34,15 +36,20 @@ namespace tt::fabric {
  * As the adapter writes into the EDM, it updates the local wrptr. As the EDM reads from its local L1 channel buffer,
  * it will notify the worker/adapter (here) by updating the worker remote_rdptr to carry the value of the EDM rdptr.
  */
-struct WorkerToFabricEdmSender {
+template <uint8_t EDM_NUM_BUFFER_SLOTS = 0>
+struct WorkerToFabricEdmSenderImpl {
+    static constexpr bool USER_DEFINED_NUM_BUFFER_SLOTS = EDM_NUM_BUFFER_SLOTS != 0;
+    static constexpr bool IS_POW2_NUM_BUFFERS = USER_DEFINED_NUM_BUFFER_SLOTS && is_power_of_2(EDM_NUM_BUFFER_SLOTS);
+    static constexpr size_t BUFFER_SLOT_PTR_WRAP = EDM_NUM_BUFFER_SLOTS * 2;
+    static constexpr size_t LAST_BUFFER_SLOT_PTR_BEFORE_WRAP = BUFFER_SLOT_PTR_WRAP - 1;
     static constexpr uint32_t unused_connection_value = 0;
     static constexpr uint32_t open_connection_value = 1;
     static constexpr uint32_t close_connection_request_value = 2;
 
-    WorkerToFabricEdmSender() : from_remote_buffer_slot_rdptr_ptr(nullptr) {}
+    WorkerToFabricEdmSenderImpl() : from_remote_buffer_slot_rdptr_ptr(nullptr) {}
 
     template <ProgrammableCoreType my_core_type>
-    static WorkerToFabricEdmSender build_from_args(std::size_t& arg_idx) {
+    static WorkerToFabricEdmSenderImpl build_from_args(std::size_t& arg_idx) {
         bool is_persistent_fabric = get_arg_val<uint32_t>(arg_idx++);
         WorkerXY const edm_worker_xy = WorkerXY::from_uint32(get_arg_val<uint32_t>(arg_idx++));
         auto const edm_buffer_base_addr = get_arg_val<uint32_t>(arg_idx++);
@@ -64,7 +71,7 @@ struct WorkerToFabricEdmSender {
             (my_core_type == ProgrammableCoreType::TENSIX && (uint32_t)writer_send_sem_addr < 1499136) ||
             (my_core_type == ProgrammableCoreType::ACTIVE_ETH && (uint32_t)writer_send_sem_addr < 262144));
         ASSERT(edm_buffer_index_addr < 262144);
-        return WorkerToFabricEdmSender(
+        return WorkerToFabricEdmSenderImpl(
             is_persistent_fabric,
             edm_worker_xy.x,
             edm_worker_xy.y,
@@ -80,7 +87,7 @@ struct WorkerToFabricEdmSender {
             worker_buffer_index_semaphore_addr);
     }
 
-    WorkerToFabricEdmSender(
+    WorkerToFabricEdmSenderImpl(
         bool connected_to_persistent_fabric,
         uint8_t edm_worker_x,
         uint8_t edm_worker_y,
@@ -116,18 +123,45 @@ struct WorkerToFabricEdmSender {
         edm_noc_x(edm_worker_x),
         edm_noc_y(edm_worker_y) {
         ASSERT(buffer_size_bytes > 0);
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
+        }
     }
 
     FORCE_INLINE bool edm_has_space_for_packet() const {
-        auto const wrptr = *this->buffer_slot_wrptr_ptr;
-        auto const rdptr = *this->from_remote_buffer_slot_rdptr_ptr;
-        bool wrptr_ge_rptr = wrptr >= rdptr;
-        uint8_t slots_used = wrptr_ge_rptr ? (wrptr - rdptr) : ((2 * this->num_buffers_per_channel) - rdptr) + wrptr;
-        return slots_used < this->num_buffers_per_channel;
+        using namespace tt::fabric;
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            auto slots_used = distance_behind<EDM_NUM_BUFFER_SLOTS>(
+                       BufferPtr{static_cast<uint8_t>(*this->from_remote_buffer_slot_rdptr_ptr)},
+                       BufferPtr{static_cast<uint8_t>(*this->buffer_slot_wrptr_ptr)});
+            return slots_used < this->num_buffers_per_channel;
+        } else {
+            auto const rdptr = *this->from_remote_buffer_slot_rdptr_ptr;
+            auto const wrptr = *this->buffer_slot_wrptr_ptr;
+            auto buffer_ptr_wrap = 2 * this->num_buffers_per_channel;
+            auto slots_used = distance_behind(
+                                 BufferPtr{static_cast<uint8_t>(rdptr)},
+                                 BufferPtr{static_cast<uint8_t>(wrptr)},
+                                 buffer_ptr_wrap);
+            return slots_used < this->num_buffers_per_channel;
+        }
     }
 
     FORCE_INLINE void wait_for_empty_write_slot() const {
-        while (!this->edm_has_space_for_packet());
+        using namespace tt::fabric;
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            while (distance_behind<EDM_NUM_BUFFER_SLOTS>(BufferPtr{static_cast<uint8_t>(*this->from_remote_buffer_slot_rdptr_ptr)}, BufferPtr{static_cast<uint8_t>(*this->buffer_slot_wrptr_ptr)}) < this->num_buffers_per_channel);
+        } else {
+            auto const first_rdptr = *this->from_remote_buffer_slot_rdptr_ptr;
+            auto buffer_ptr_wrap = 2 * this->num_buffers_per_channel;
+            bool has_space = distance_behind(
+                                 BufferPtr{static_cast<uint8_t>(first_rdptr)},
+                                 BufferPtr{static_cast<uint8_t>(*this->buffer_slot_wrptr_ptr)},
+                                 buffer_ptr_wrap) < this->num_buffers_per_channel;
+            if (!has_space) {
+                while (first_rdptr == *this->from_remote_buffer_slot_rdptr_ptr);
+            }
+        }
     }
 
     FORCE_INLINE void send_payload_blocking(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
@@ -192,6 +226,8 @@ struct WorkerToFabricEdmSender {
         const uint64_t edm_connection_handshake_noc_addr = dest_noc_addr_coord_only | edm_connection_handshake_l1_addr;
         noc_inline_dw_write(edm_connection_handshake_noc_addr, open_connection_value);
         noc_async_read_barrier();
+
+        this->edm_buffer_addr = this->edm_buffer_base_addr + (this->get_buffer_slot_index() * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
         ASSERT(*this->buffer_slot_wrptr_ptr < 20);
     }
 
@@ -249,25 +285,28 @@ private:
         noc_inline_dw_write(noc_sem_addr, *this->buffer_slot_wrptr_ptr);
     }
 
+    FORCE_INLINE uint8_t get_buffer_slot_index() const {
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            return normalize_ptr<EDM_NUM_BUFFER_SLOTS>(BufferPtr{static_cast<uint8_t>(*this->buffer_slot_wrptr_ptr)});
+        } else {
+            return normalize_ptr(BufferPtr{static_cast<uint8_t>(*this->buffer_slot_wrptr_ptr)}, this->num_buffers_per_channel);
+        }
+    }
+
     FORCE_INLINE void advance_buffer_slot_wrptr() {
         // TODO: smarter addition if we are working with pow2
-        uint8_t wrptr = *this->buffer_slot_wrptr_ptr;
-        *this->buffer_slot_wrptr_ptr =
-            !(wrptr == ((this->num_buffers_per_channel * 2) - 1)) ? wrptr + 1 : 0;
-    }
-
-    FORCE_INLINE uint8_t get_buffer_slot_index() const {
-        auto const wrptr = *this->buffer_slot_wrptr_ptr;
-        bool normalize = wrptr >= this->num_buffers_per_channel;
-        return wrptr - (normalize * this->num_buffers_per_channel);
-    }
-
-    FORCE_INLINE uint32_t compute_dest_buffer_slot_bank_address() const {
-        return this->edm_buffer_addr + (this->get_buffer_slot_index() * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            *this->buffer_slot_wrptr_ptr = wrap_increment<BUFFER_SLOT_PTR_WRAP>(*this->buffer_slot_wrptr_ptr);
+        } else {
+            uint8_t wrptr = *this->buffer_slot_wrptr_ptr;
+            *this->buffer_slot_wrptr_ptr =
+                !(wrptr == ((this->num_buffers_per_channel * 2) - 1)) ? wrptr + 1 : 0;
+        }
+        this->edm_buffer_addr = this->edm_buffer_base_addr + (this->get_buffer_slot_index() * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
     }
 
     FORCE_INLINE uint64_t compute_dest_buffer_slot_noc_addr() const {
-        return get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->compute_dest_buffer_slot_bank_address());
+        return get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_addr);
     }
 
     FORCE_INLINE void post_send_payload_increment_pointers() {
@@ -318,5 +357,10 @@ private:
         post_send_payload_increment_pointers();
     }
 };
+
+using WorkerToFabricEdmSender = WorkerToFabricEdmSenderImpl<0>;
+
+template <uint8_t EDM_SENDER_CHANNEL_NUM_BUFFERS>
+using EdmToEdmSender = WorkerToFabricEdmSenderImpl<EDM_SENDER_CHANNEL_NUM_BUFFERS>;
 
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -294,7 +294,6 @@ private:
     }
 
     FORCE_INLINE void advance_buffer_slot_wrptr() {
-        // TODO: smarter addition if we are working with pow2
         if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
             *this->buffer_slot_wrptr_ptr = wrap_increment<BUFFER_SLOT_PTR_WRAP>(*this->buffer_slot_wrptr_ptr);
         } else {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -66,9 +66,6 @@ FORCE_INLINE void print_pkt_header(volatile tt::fabric::PacketHeader *const pack
 // Since we unicast to local, we must omit the packet header
 FORCE_INLINE void execute_chip_unicast_to_local_chip(
     volatile tt::fabric::PacketHeader *const packet_start, uint16_t payload_size_bytes, uint32_t transaction_id) {
-    // TODO [volatile-use]: do word-based reads of packet header when enterring the fwd packet path
-    //                      we end up grabbing many individual fields from the same word region
-    //                      which will resolve as many separate loads
     auto const& header = *packet_start;
     uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(tt::fabric::PacketHeader);
 
@@ -136,7 +133,6 @@ FORCE_INLINE void forward_payload_to_downstream_edm(
     tt::fabric::EdmToEdmSender<NUM_SENDER_BUFFERS> &downstream_edm_interface,
     uint8_t transaction_id
     ) {
-    // DPRINT << "Fwding pkt to downstream\n";
     // TODO: PERF - this should already be getting checked by the caller so this should be redundant make it an ASSERT
     ASSERT(downstream_edm_interface.edm_has_space_for_packet()); // best effort check
 
@@ -146,6 +142,5 @@ FORCE_INLINE void forward_payload_to_downstream_edm(
     downstream_edm_interface.send_payload_non_blocking_from_address_with_trid(
         reinterpret_cast<size_t>(packet_header),
         payload_size_bytes + sizeof(tt::fabric::PacketHeader),
-        // packet_header->get_payload_size_including_header(),
         transaction_id);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -16,7 +16,7 @@ static constexpr size_t DESTINATION_HOP_COUNT = 1;
 // TODO: make 0 and the associated field to num mcast destinations
 static constexpr size_t LAST_MCAST_DESTINATION = 1;
 
-void print_pkt_hdr_routing_fields(volatile tt::fabric::PacketHeader *const packet_start) {
+FORCE_INLINE void print_pkt_hdr_routing_fields(volatile tt::fabric::PacketHeader *const packet_start) {
 #ifdef DEBUG_PRINT_ENABLED
     switch (packet_start->chip_send_type) {
         case tt::fabric::CHIP_UNICAST: {
@@ -32,7 +32,7 @@ void print_pkt_hdr_routing_fields(volatile tt::fabric::PacketHeader *const packe
 #endif
 }
 
-void print_pkt_header_noc_fields(volatile tt::fabric::PacketHeader *const packet_start) {
+FORCE_INLINE void print_pkt_header_noc_fields(volatile tt::fabric::PacketHeader *const packet_start) {
 #ifdef DEBUG_PRINT_ENABLED
     switch (packet_start->noc_send_type) {
         case tt::fabric::NocSendType::NOC_UNICAST_WRITE: {
@@ -50,7 +50,7 @@ void print_pkt_header_noc_fields(volatile tt::fabric::PacketHeader *const packet
 #endif
 }
 
-void print_pkt_header(volatile tt::fabric::PacketHeader *const packet_start) {
+FORCE_INLINE void print_pkt_header(volatile tt::fabric::PacketHeader *const packet_start) {
 #ifdef DEBUG_PRINT_ENABLED
     auto const& header = *packet_start;
     DPRINT << "PKT: nsnd_t:" << (uint32_t) packet_start->noc_send_type <<
@@ -136,7 +136,7 @@ FORCE_INLINE void forward_payload_to_downstream_edm(
     tt::fabric::EdmToEdmSender<NUM_SENDER_BUFFERS> &downstream_edm_interface,
     uint8_t transaction_id
     ) {
-    DPRINT << "Fwding pkt to downstream\n";
+    // DPRINT << "Fwding pkt to downstream\n";
     // TODO: PERF - this should already be getting checked by the caller so this should be redundant make it an ASSERT
     ASSERT(downstream_edm_interface.edm_has_space_for_packet()); // best effort check
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -925,9 +925,9 @@ void run_fabric_edm_main_loop(
                 return;
             }
         }
-
+        bool did_something = false;
+        for (size_t i = 0; i < 32; i++) {
         // Capture these to see if we made progress
-        auto old_recv_state = receiver_state;
 
         // There are some cases, mainly for performance, where we don't want to switch between sender channels
         // so we interoduce this to provide finer grain control over when we disable the automatic switching
@@ -939,7 +939,7 @@ void run_fabric_edm_main_loop(
             sender_channel_counters_ptrs[sender_channel_index],
             sender_channel_packet_recorders[sender_channel_index],
             channel_connection_established[sender_channel_index],
-            sender_channel_index);
+            sender_channel_index) || did_something_sender;
 
         sender_channel_index = 1 - sender_channel_index;
 
@@ -951,7 +951,9 @@ void run_fabric_edm_main_loop(
             receiver_channel_trid_tracker,
             &receiver_state);
 
-        bool did_something = did_something_sender || old_recv_state != receiver_state;
+            did_something = did_something || did_something_sender;
+        }
+        // bool did_something = did_something_sender;
 
         if (did_something) {
             did_nothing_count = 0;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -600,7 +600,6 @@ FORCE_INLINE void receiver_send_completion_ack(
 
 template <uint8_t SENDER_NUM_BUFFERS>
 FORCE_INLINE bool can_forward_packet_completely(
-    // const volatile tt::fabric::PacketHeader* packet_header,
     tt::fabric::RoutingFields cached_routing_fields,
     tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>& downstream_edm_interface) {
     // We always check if it is the terminal mcast packet value. We can do this because all unicast packets have the
@@ -662,7 +661,6 @@ FORCE_INLINE bool run_sender_channel_step(
                     tt::fabric::validate(*packet_header);
                     packet_header_recorder.record_packet_header(packet_header);
                 }
-                // print_pkt_header(packet_header);
                 send_next_data(
                     local_sender_channel,
                     local_sender_channel_worker_interface,

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -748,8 +748,7 @@ FORCE_INLINE void run_receiver_channel_step(
     std::array<tt::fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> &remote_eth_sender_wrptrs,
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> &receiver_channel_pointers,
     PacketHeaderRecorder &packet_header_recorder,
-    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> &receiver_channel_trid_tracker,
-    ReceiverState *const receiver_state_out) {
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> &receiver_channel_trid_tracker) {
 
     auto &ack_ptr = receiver_channel_pointers.ack_ptr;
     auto pkts_received_since_last_check = get_ptr_val<to_receiver_pkts_sent_id>();
@@ -779,14 +778,11 @@ FORCE_INLINE void run_receiver_channel_step(
         volatile auto packet_header = local_receiver_channel.get_packet_header(receiver_buffer_index);
 
         tt::fabric::RoutingFields cached_routing_fields = const_cast<tt::fabric::PacketHeader*>(packet_header)->routing_fields;
-        // print_pkt_header(packet_header);
         bool can_send_to_all_local_chip_receivers =
             can_forward_packet_completely(
-                // packet_header,
                 cached_routing_fields, downstream_edm_interface);
         bool trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
         if (can_send_to_all_local_chip_receivers && trid_flushed) {
-            // DeviceZoneScopedN("EDMR-Send-Impl");
             uint8_t trid = receiver_channel_trid_tracker.update_buffer_slot_to_next_trid_and_advance_trid_counter(receiver_buffer_index);
             receiver_forward_packet(packet_header, cached_routing_fields, downstream_edm_interface, trid);
             wr_sent_ptr.increment();
@@ -895,7 +891,6 @@ void run_fabric_edm_main_loop(
     std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS> &sender_channel_packet_recorders) {
     std::array<SenderState, NUM_SENDER_CHANNELS> sender_states = {
         SenderState::SENDER_WAIT_WORKER_HANDSHAKE, SenderState::SENDER_WAIT_WORKER_HANDSHAKE};
-    ReceiverState receiver_state = ReceiverState::RECEIVER_WAITING_FOR_ETH;
     size_t sender_channel_index = 0;
     size_t did_nothing_count = 0;
     *termination_signal_ptr = tt::fabric::TerminationSignal::KEEP_RUNNING;
@@ -927,33 +922,39 @@ void run_fabric_edm_main_loop(
         }
         bool did_something = false;
         for (size_t i = 0; i < 32; i++) {
-        // Capture these to see if we made progress
+            // Capture these to see if we made progress
 
-        // There are some cases, mainly for performance, where we don't want to switch between sender channels
-        // so we interoduce this to provide finer grain control over when we disable the automatic switching
-        bool did_something_sender = run_sender_channel_step<enable_packet_header_recording, enable_fabric_counters>(
-            local_sender_channels[sender_channel_index],
-            local_sender_channel_worker_interfaces[sender_channel_index],
-            outbound_to_receiver_channel_pointers,
-            remote_receiver_channel,
-            sender_channel_counters_ptrs[sender_channel_index],
-            sender_channel_packet_recorders[sender_channel_index],
-            channel_connection_established[sender_channel_index],
-            sender_channel_index) || did_something_sender;
+            // There are some cases, mainly for performance, where we don't want to switch between sender channels
+            // so we interoduce this to provide finer grain control over when we disable the automatic switching
+            bool did_something_sender = run_sender_channel_step<enable_packet_header_recording, enable_fabric_counters>(
+                local_sender_channels[0],
+                local_sender_channel_worker_interfaces[0],
+                outbound_to_receiver_channel_pointers,
+                remote_receiver_channel,
+                sender_channel_counters_ptrs[0],
+                sender_channel_packet_recorders[0],
+                channel_connection_established[0],
+                0);
 
-        sender_channel_index = 1 - sender_channel_index;
+            run_receiver_channel_step<enable_packet_header_recording, enable_fabric_counters, RECEIVER_NUM_BUFFERS, SENDER_NUM_BUFFERS, NUM_SENDER_CHANNELS>(
+                local_receiver_channel, remote_sender_channels, downstream_edm_noc_interface, receiver_channel_counters_ptr,
+                remote_eth_sender_wrptrs,
+                receiver_channel_pointers,
+                receiver_channel_packet_recorder,
+                receiver_channel_trid_tracker);
 
-        run_receiver_channel_step<enable_packet_header_recording, enable_fabric_counters, RECEIVER_NUM_BUFFERS, SENDER_NUM_BUFFERS, NUM_SENDER_CHANNELS>(
-            local_receiver_channel, remote_sender_channels, downstream_edm_noc_interface, receiver_channel_counters_ptr,
-            remote_eth_sender_wrptrs,
-            receiver_channel_pointers,
-            receiver_channel_packet_recorder,
-            receiver_channel_trid_tracker,
-            &receiver_state);
+            bool did_something_sender2 = run_sender_channel_step<enable_packet_header_recording, enable_fabric_counters>(
+                local_sender_channels[1],
+                local_sender_channel_worker_interfaces[1],
+                outbound_to_receiver_channel_pointers,
+                remote_receiver_channel,
+                sender_channel_counters_ptrs[1],
+                sender_channel_packet_recorders[1],
+                channel_connection_established[1],
+                1);
 
-            did_something = did_something || did_something_sender;
+            did_something = did_something || did_something_sender || did_something_sender2;
         }
-        // bool did_something = did_something_sender;
 
         if (did_something) {
             did_nothing_count = 0;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -907,6 +907,11 @@ void run_fabric_edm_main_loop(
 
     WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> receiver_channel_trid_tracker;
 
+    // This value defines the number of loop iterations we perform of the main control sequence before exiting
+    // to check for termination and context switch. Removing the these checks from the inner loop can drastically
+    // improve performance. The value of 32 was chosen somewhat empirically and then raised up slightly.
+    constexpr uint32_t DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS = 32;
+
     while (!got_immediate_termination_signal(termination_signal_ptr)) {
         bool got_graceful_termination = got_graceful_termination_signal(termination_signal_ptr);
         if (got_graceful_termination) {
@@ -919,7 +924,7 @@ void run_fabric_edm_main_loop(
             }
         }
         bool did_something = false;
-        for (size_t i = 0; i < 32; i++) {
+        for (size_t i = 0; i < DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS; i++) {
             // Capture these to see if we made progress
 
             // There are some cases, mainly for performance, where we don't want to switch between sender channels

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -14,6 +14,7 @@
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 
 #include "noc_overlay_parameters.h"
+#include "tt_metal/hw/inc/utils/utils.h"
 
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_counters.hpp"
 
@@ -23,7 +24,7 @@
 
 using ttnn::ccl::WorkerXY;
 
-static constexpr bool enable_first_level_ack = true;
+static constexpr bool enable_first_level_ack = false;
 static constexpr bool fuse_receiver_flush_and_completion_ptr = true;
 
 /*
@@ -265,40 +266,64 @@ struct TransactionIdCounter {
 template <size_t NUM_CHANNELS, size_t MAX_TRANSACTION_IDS>
 struct WriteTransactionIdTracker {
     static constexpr uint8_t INVALID_TRID = MAX_TRANSACTION_IDS;
+    static constexpr bool N_TRIDS_IS_POW2 = is_power_of_2(MAX_TRANSACTION_IDS);
+    static constexpr bool N_CHANS_IS_POW2 = is_power_of_2(NUM_CHANNELS);
+    static constexpr uint8_t TRID_POW2_MASK = MAX_TRANSACTION_IDS - 1;
+    static constexpr bool BOTH_PARAMS_ARE_POW2 = N_TRIDS_IS_POW2 && N_CHANS_IS_POW2;
+
     WriteTransactionIdTracker() {
         for (size_t i = 0; i < NUM_CHANNELS; i++) {
             this->buffer_slot_trids[i] = INVALID_TRID;
         }
     }
     FORCE_INLINE void set_buffer_slot_trid(uint8_t trid, tt::fabric::BufferIndex buffer_index) {
-        this->buffer_slot_trids[buffer_index] = trid;
-    }
-
-    FORCE_INLINE void advance_trid_counter() {
-        this->trid_counter.increment();
+        if constexpr (!BOTH_PARAMS_ARE_POW2) {
+            this->buffer_slot_trids[buffer_index] = trid;
+        }
     }
 
     FORCE_INLINE uint8_t update_buffer_slot_to_next_trid_and_advance_trid_counter(tt::fabric::BufferIndex buffer_index) {
-        uint8_t next_trid = this->trid_counter.get();
-        this->buffer_slot_trids[buffer_index] = next_trid;
-        this->trid_counter.increment();
-        return next_trid;
+        if constexpr (BOTH_PARAMS_ARE_POW2) {
+            uint8_t next_trid = buffer_index & TRID_POW2_MASK;
+            this->trid_counter.increment();
+            return next_trid;
+        } else {
+            uint8_t next_trid = this->trid_counter.get();
+            this->buffer_slot_trids[buffer_index] = next_trid;
+            this->trid_counter.increment();
+            return next_trid;
+        }
     }
 
     FORCE_INLINE void clear_trid_at_buffer_slot(tt::fabric::BufferIndex buffer_index) {
-        this->buffer_slot_trids[buffer_index] = INVALID_TRID;
+        if constexpr (!BOTH_PARAMS_ARE_POW2) {
+            this->buffer_slot_trids[buffer_index] = INVALID_TRID;
+        }
     }
 
     FORCE_INLINE uint8_t get_buffer_slot_trid(tt::fabric::BufferIndex buffer_index) const {
-        return this->buffer_slot_trids[buffer_index];
+        if constexpr (BOTH_PARAMS_ARE_POW2) {
+            return buffer_index & TRID_POW2_MASK;
+        } else {
+            return this->buffer_slot_trids[buffer_index];
+        }
     }
     FORCE_INLINE bool transaction_flushed(tt::fabric::BufferIndex buffer_index) const {
-        auto trid = this->get_buffer_slot_trid(buffer_index);
-        return trid == INVALID_TRID || ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, trid);
+        if constexpr (BOTH_PARAMS_ARE_POW2) {
+            auto trid = this->get_buffer_slot_trid(buffer_index);
+            return ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, trid);
+        } else {
+            // TODO: should be able to remove compare against INVALID_TRID
+            auto trid = this->get_buffer_slot_trid(buffer_index);
+            return trid == INVALID_TRID || ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, trid);
+        }
     }
     private:
     std::array<uint8_t, NUM_CHANNELS> buffer_slot_trids;
     TransactionIdCounter<MAX_TRANSACTION_IDS> trid_counter;
+
+    // TODO: cleanup - only used for when both params are pow2, else above are used.
+    uint8_t next_trid = 0;
 };
 
 static constexpr uint32_t DEFAULT_ETH_TXQ = 0;
@@ -366,6 +391,8 @@ constexpr std::array<uint32_t, 2> to_sender_packets_completed_streams = {{
  */
 template <uint8_t RECEIVER_NUM_BUFFERS>
 struct OutboundReceiverChannelPointers {
+    static constexpr bool is_pow2 = is_power_of_2(RECEIVER_NUM_BUFFERS);
+
     tt::fabric::ChannelBufferPointer<RECEIVER_NUM_BUFFERS> wrptr;
     tt::fabric::ChannelBufferPointer<RECEIVER_NUM_BUFFERS> ack_ptr;
     tt::fabric::ChannelBufferPointer<RECEIVER_NUM_BUFFERS> completion_ptr;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -17,147 +17,8 @@
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp"
-
+#include "cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_flow_control_helpers.hpp"
 namespace tt::fabric {
-
-template <typename T, typename Parameter>
-class NamedType
-{
-public:
-    FORCE_INLINE explicit NamedType(T const& value) : value_(value) {}
-    FORCE_INLINE explicit NamedType(T&& value) : value_(std::move(value)) {}
-    FORCE_INLINE NamedType<T,Parameter> &operator=(NamedType<T,Parameter> const& rhs) = default;
-    FORCE_INLINE T& get() { return value_; }
-    FORCE_INLINE T const& get() const {return value_; }
-    FORCE_INLINE operator T() const { return value_; }
-    FORCE_INLINE operator T&() { return value_; }
-private:
-    T value_;
-};
-
-using BufferIndex = NamedType<uint8_t, struct BufferIndexType>;
-using BufferPtr = NamedType<uint8_t, struct BufferPtrType>;
-
-
-// Increments val and wraps to 0 if it reaches limit
-template <size_t LIMIT, typename T>
-FORCE_INLINE
-auto wrap_increment(T val) -> T {
-    static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
-    constexpr bool is_pow2 = is_power_of_2(LIMIT);
-    if constexpr (LIMIT == 1) {
-        return val;
-    } else if constexpr (LIMIT == 2) {
-        return 1 - val;
-    } else if constexpr (is_pow2) {
-        return (val + 1) & (LIMIT - 1);
-    } else {
-        return (val == static_cast<T>(LIMIT - 1)) ? static_cast<T>(0) : static_cast<T>(val + 1);
-    }
-}
-template <size_t LIMIT, typename T>
-FORCE_INLINE
-auto wrap_increment_n(T val, uint8_t increment) -> T {
-    static_assert(LIMIT != 0, "wrap_increment called with limit of 0; it must be greater than 0");
-    constexpr bool is_pow2 = is_power_of_2(LIMIT);
-    if constexpr (LIMIT == 1) {
-        return val;
-    } else if constexpr (LIMIT == 2) {
-        return 1 - val;
-    } else if constexpr (is_pow2) {
-        return (val + increment) & (LIMIT - 1);
-    } else {
-        T new_unadjusted_val = val + increment;
-        bool wraps = new_unadjusted_val >= LIMIT;
-        return wraps ? static_cast<T>(new_unadjusted_val - LIMIT) : static_cast<T>(new_unadjusted_val);
-    }
-}
-
-template <uint8_t NUM_BUFFERS>
-FORCE_INLINE
-auto normalize_ptr(BufferPtr ptr) -> BufferIndex {
-    static_assert(NUM_BUFFERS != 0, "normalize_ptr called with NUM_BUFFERS of 0; it must be greater than 0");
-    constexpr bool is_size_pow2 = (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
-    constexpr bool is_size_2 = NUM_BUFFERS == 2;
-    constexpr bool is_size_1 = NUM_BUFFERS == 1;
-    constexpr uint8_t wrap_mask = NUM_BUFFERS - 1;
-    if constexpr (is_size_pow2) {
-        return BufferIndex{ptr & wrap_mask};
-    } else if constexpr (is_size_2) {
-        return BufferIndex{(uint8_t)1 - ptr};
-    } else if constexpr (is_size_1) {
-        return BufferIndex{0};
-    } else {
-        // note it may make sense to calculate this only when we increment
-        // which will save calculations overall (but may add register pressure)
-        // and introduce undesirable loads
-        bool normalize = ptr >= NUM_BUFFERS;
-        uint8_t normalized_ptr = ptr.get() - static_cast<uint8_t>(normalize * NUM_BUFFERS);
-        ASSERT(normalized_ptr < NUM_BUFFERS);
-        return BufferIndex{normalized_ptr};
-    }
-}
-
-
-template <uint8_t NUM_BUFFERS>
-class ChannelBufferPointer {
-    static_assert(NUM_BUFFERS <= std::numeric_limits<uint8_t>::max() / 2, "NUM_BUFFERS must be less than or half of std::numeric_limits<uint8_t>::max() due to the internal implementation");
-    public:
-    static constexpr bool is_size_pow2 = (NUM_BUFFERS & (NUM_BUFFERS - 1)) == 0;
-    static constexpr bool is_size_2 = NUM_BUFFERS == 2;
-    static constexpr bool is_size_1 = NUM_BUFFERS == 1;
-    static constexpr uint8_t ptr_wrap_size = 2 * NUM_BUFFERS;
-
-    // Only to use if is_size_pow2
-    static constexpr uint8_t ptr_wrap_mask = (2 * NUM_BUFFERS) - 1;
-    static constexpr uint8_t buffer_wrap_mask = NUM_BUFFERS - 1;
-    ChannelBufferPointer() : ptr(0) {}
-    /*
-     * Returns the "raw" pointer - not usable to index the buffer channel
-     */
-    FORCE_INLINE BufferPtr get_ptr() const {
-        return this->ptr;
-    }
-
-    FORCE_INLINE bool is_caught_up_to(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
-        return this->is_caught_up_to(leading_ptr.get_ptr());
-    }
-    FORCE_INLINE uint8_t distance_behind(ChannelBufferPointer<NUM_BUFFERS> const& leading_ptr) const {
-        return this->distance_behind(leading_ptr.get_ptr());
-    }
-
-    /*
-     * Returns the buffer index pointer which is usable to index into the buffer memory
-     */
-    FORCE_INLINE BufferIndex get_buffer_index() const {
-        return BufferIndex{normalize_ptr<NUM_BUFFERS>(this->ptr)};
-    }
-
-    FORCE_INLINE void increment_n(uint8_t n) {
-        this->ptr = BufferPtr{wrap_increment_n<2*NUM_BUFFERS>(this->ptr.get(), n)};
-    }
-    FORCE_INLINE void increment() {
-        this->ptr = wrap_increment<2*NUM_BUFFERS>(this->ptr);
-    }
-
-    private:
-    // Make these private to make sure caller doesn't accidentally mix two pointers pointing to
-    // different sized channels
-    FORCE_INLINE bool is_caught_up_to(BufferPtr const& leading_ptr) const {
-        return this->get_ptr() == leading_ptr;
-    }
-    FORCE_INLINE uint8_t distance_behind(BufferPtr const& leading_ptr) const {
-        bool leading_gte_trailing_ptr = leading_ptr >= this->ptr;
-        if constexpr (is_size_pow2) {
-            return (leading_ptr - this->ptr) & ptr_wrap_mask;
-        } else {
-            return leading_gte_trailing_ptr ?
-                leading_ptr - this->ptr :
-                ptr_wrap_size - (this->ptr - leading_ptr);
-        }
-    }
-    BufferPtr ptr = BufferPtr{0};
-};
 
 
 template <typename T>
@@ -310,7 +171,7 @@ struct EdmChannelWorkerInterface {
             (uint32_t)worker_info.worker_xy.x, (uint32_t)worker_info.worker_xy.y, worker_info.worker_teardown_semaphore_address);
 
         // Set connection to unused so it's available for next worker
-        *this->connection_live_semaphore = tt::fabric::WorkerToFabricEdmSender::unused_connection_value;
+        *this->connection_live_semaphore = tt::fabric::EdmToEdmSender<0>::unused_connection_value;
 
         *reinterpret_cast<volatile uint32_t*>(&(worker_location_info_ptr->edm_rdptr)) = last_edm_rdptr_value;
 
@@ -329,8 +190,8 @@ struct EdmChannelWorkerInterface {
         worker_location_info_ptr->edm_rdptr = local_ackptr.get_ptr();
     }
 
-    [[nodiscard]] FORCE_INLINE bool has_worker_teardown_request() const { return *connection_live_semaphore == tt::fabric::WorkerToFabricEdmSender::close_connection_request_value; }
-    [[nodiscard]] FORCE_INLINE bool connection_is_live() const { return *connection_live_semaphore == tt::fabric::WorkerToFabricEdmSender::open_connection_value; }
+    [[nodiscard]] FORCE_INLINE bool has_worker_teardown_request() const { return *connection_live_semaphore == tt::fabric::EdmToEdmSender<0>::close_connection_request_value; }
+    [[nodiscard]] FORCE_INLINE bool connection_is_live() const { return *connection_live_semaphore == tt::fabric::EdmToEdmSender<0>::open_connection_value; }
 
     volatile EDMChannelWorkerLocationInfo *worker_location_info_ptr;
     volatile tt_l1_ptr uint32_t *const remote_producer_wrptr;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17423


### What's changed
Numerous EDM Fabric (1D Fabric) optimizations that take the EDM fabric to the following approximate performance with 4K packet size:
- 13.5 GB/s in neighbour exchange test
- 10.5 GB/s in 4chip mcast test

Measured ~ 1 GB/s higher when compiling with -O3 but that is currently not enabled in this PR

The optimizations in this PR include:
- Add optimized power-of-2 queue pointer handling and enable power-of-2 buffer slot counts
- Add optimized power-of-2 transaction ID handling and use power-of-2 transaction IDs on write
- Mild cleanup/optimizations of volatile pointer usage
- Optimize main top level control loop of EDM fabric
  - Reduce the frequency of context switch/teardown checks
    - Nest main control loop in a tight loop
    - Partially unrol sender state execution steps (one for each channel) instead of using a sender channel ID to alternate through them 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13384077763
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13384080435
  - Same failures on main (see [here](https://github.com/tenstorrent/tt-metal/actions/runs/13386851540), [here](https://github.com/tenstorrent/tt-metal/actions/runs/13385849167/job/37382568116), and [here](https://github.com/tenstorrent/tt-metal/actions/runs/13380678828/job/37368744576))
- [x] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13384082337
  - Same failures on main (see [here](https://github.com/tenstorrent/tt-metal/actions/runs/13380476266) and [here](https://github.com/tenstorrent/tt-metal/actions/runs/13384259211))
- [x] New/Existing tests provide coverage for changes
