### PR TITLE
#0: binary_ng scalar - fix const qualifier

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -571,3 +571,28 @@ def test_bitwise_right_shift(device, ttnn_function):
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
     assert status
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.experimental.sub,
+        ttnn.experimental.add,
+        ttnn.experimental.rsub,
+        ttnn.experimental.mul,
+        ttnn.experimental.div,
+    ],
+)
+def test_ng_scalar_fp32(device, ttnn_function):
+    x_torch = torch.tensor([[1]], dtype=torch.float32)
+    y_torch = 0.00030171126
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    z_torch = golden_fn(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = y_torch
+    z_tt_out = ttnn_function(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt_out)
+
+    status = torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=False)
+    assert status

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
     // we only need to fill a tile with the scalar value once
     cb_reserve_back(cb_id_src, onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
-    float* float_ptr = reinterpret_cast<float*>(&packed_scalar);
+    const auto float_ptr = reinterpret_cast<const float*>(&packed_scalar);
     FILL_WITH_VALUE_FLOAT(cb_id_src, *float_ptr);
 #endif
 #ifdef FILL_WITH_VALUE


### PR DESCRIPTION
### Ticket
Link to Github Issue 

### Problem description
Adding tests for binary_ng - scalar input

### What's changed
- fix const qualifier
- added new tests

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13407843503
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
