### PR TITLE
Ensure get_profiler_artifacts_dir respects TT_METAL_HOME by default.

### DIFF
--- a/tt_metal/api/tt-metalium/common.hpp
+++ b/tt_metal/api/tt-metalium/common.hpp
@@ -15,15 +15,20 @@ constexpr std::string_view PROFILER_RUNTIME_ROOT_DIR = "generated/profiler/";
 constexpr std::string_view PROFILER_LOGS_DIR_NAME = ".logs/";
 
 inline std::string get_profiler_artifacts_dir() {
-    std::string artifactDir = string(PROFILER_RUNTIME_ROOT_DIR);
-    const auto PROFILER_ARTIFACTS_DIR = std::getenv("TT_METAL_PROFILER_DIR");
-    if (PROFILER_ARTIFACTS_DIR != nullptr) {
-        artifactDir = string(PROFILER_ARTIFACTS_DIR) + "/";
+    std::string artifacts_dir;
+    if (std::getenv("TT_METAL_PROFILER_DIR")) {
+        artifacts_dir = std::string(std::getenv("TT_METAL_PROFILER_DIR")) + "/";
+    } else {
+        std::string prefix;
+        if (std::getenv("TT_METAL_HOME")) {
+            prefix = std::string(std::getenv("TT_METAL_HOME")) + "/";
+        }
+        artifacts_dir = prefix + std::string(PROFILER_RUNTIME_ROOT_DIR);
     }
-    return artifactDir;
+    return artifacts_dir;
 }
 
-inline std::string get_profiler_logs_dir() { return get_profiler_artifacts_dir() + string(PROFILER_LOGS_DIR_NAME); }
+inline std::string get_profiler_logs_dir() { return get_profiler_artifacts_dir() + std::string(PROFILER_LOGS_DIR_NAME); }
 
 inline std::string PROFILER_ZONE_SRC_LOCATIONS_LOG = get_profiler_logs_dir() + "zone_src_locations.log";
 }  // namespace tt_metal


### PR DESCRIPTION
### Ticket

#17939

### Problem description

The default profiler artifacts path was relative, which caused a mismatch with the Python `tt_metal.tools.profiler.common` implementation which respects `TT_METAL_HOME`.

### What's changed

If `TT_METAL_PROFILER_DIR` is not set, then the default path should be `$TT_METAL_HOME` + `/generated/profiler/`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
