### PR TITLE
#17787: Use input tensor approx size for auto-shard heuristic

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2966,3 +2966,35 @@ def test_split_reader_regression(
         shard_layout=shard_layout,
         enable_split_reader=True,
     )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_small_in_large_out_channels_auto_shard(device, torch_tensor_map):
+    batch_size = 2
+    in_channels = 16
+    out_channels = 1536
+    kernel_size = (2, 2)
+    stride = (2, 2)
+    padding = (0, 0)
+    height = 128
+    width = 128
+    run_conv(
+        device,
+        torch_tensor_map,
+        ttnn.MathFidelity.LoFi,
+        ttnn.bfloat16,
+        ttnn.bfloat16,
+        batch_size,
+        out_channels,
+        in_channels,
+        height,
+        width,
+        kernel_size[0],
+        kernel_size[1],
+        stride[0],
+        stride[1],
+        padding[0],
+        padding[1],
+        None,
+        auto_shard=True,
+    )


### PR DESCRIPTION
Current auto-shard heuristic is based on minimising
circular buffer size allocation per core, and
output tensor buffer size per core.

In this case number of input channels is small, but number of output channels is large. Since Width
sharding can decouple input and output parallel
config and input is based input channels and output is based on output channels, output buffer size per core is small. Problem is currently we ignore the
the input tensor size per core. Width sharding
input parallel core can only use a single core
which means that input tensor and halo output
have to go to a single core and we run out of memory.

Use approx input size per core as factor for
auto-shard heuristic. Ideally we would use halo
output size for this, but using approx input
tensor size is a good enough proxy for now.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17787)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13357876939)
- [x] [Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/13358226446)
