### PR TITLE
#0: Add new fabric apis for atomics and add a mode to bypass router lookup on device

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -228,9 +228,7 @@ int main(int argc, char** argv) {
 
     CoreCoord gk_core = {gk_x, gk_y};
 
-    std::map<string, string> defines = {
-        {"FD_CORE_TYPE", std::to_string(0)},  // todo, support dispatch on eth
-    };
+    std::map<string, string> defines;
 
     try {
         const std::filesystem::path tg_mesh_graph_desc_path =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -1406,9 +1406,7 @@ int main(int argc, char **argv) {
     bool pass = true;
     uint32_t num_available_devices, num_allocated_devices = 0;
 
-    std::map<string, string> defines = {
-        {"FD_CORE_TYPE", std::to_string(0)}, // todo, support dispatch on eth
-    };
+    std::map<string, string> defines;
 
     if (benchmark_mode) {
         prng_seed = 100;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -226,9 +226,7 @@ int main(int argc, char** argv) {
 
     CoreCoord gk_core = {gk_x, gk_y};
 
-    std::map<string, string> defines = {
-        {"FD_CORE_TYPE", std::to_string(0)},  // todo, support dispatch on eth
-    };
+    std::map<string, string> defines;
 
     try {
         const std::filesystem::path tg_mesh_graph_desc_path =

--- a/tt_fabric/control_plane.cpp
+++ b/tt_fabric/control_plane.cpp
@@ -561,33 +561,22 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
                 dst_chip_id);
         }
         auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
+        chan_id_t next_chan_id = 0;
         if (src_mesh_id != dst_mesh_id) {
             // Inter-mesh routing
-            chan_id_t next_chan_id =
-                this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id];
-            if (src_chan_id != next_chan_id) {
-                // Chan to chan within chip
-                route.push_back({physical_chip_id, next_chan_id});
-            }
-            std::tie(src_mesh_id, src_chip_id, src_chan_id) =
-                this->get_connected_mesh_chip_chan_ids(src_mesh_id, src_chip_id, next_chan_id);
-            auto connected_physical_chip_id =
-                logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
-            route.push_back({connected_physical_chip_id, src_chan_id});
+            next_chan_id = this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id];
         } else if (src_chip_id != dst_chip_id) {
             // Intra-mesh routing
-            chan_id_t next_chan_id =
-                this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
-            if (src_chan_id != next_chan_id) {
-                // Chan to chan within chip
-                route.push_back({physical_chip_id, next_chan_id});
-            }
-            std::tie(src_mesh_id, src_chip_id, src_chan_id) =
-                this->get_connected_mesh_chip_chan_ids(src_mesh_id, src_chip_id, next_chan_id);
-            auto connected_physical_chip_id =
-                logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
-            route.push_back({connected_physical_chip_id, src_chan_id});
+            next_chan_id = this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
         }
+        if (src_chan_id != next_chan_id) {
+            // Chan to chan within chip
+            route.push_back({physical_chip_id, next_chan_id});
+        }
+        std::tie(src_mesh_id, src_chip_id, src_chan_id) =
+            this->get_connected_mesh_chip_chan_ids(src_mesh_id, src_chip_id, next_chan_id);
+        auto connected_physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
+        route.push_back({connected_physical_chip_id, src_chan_id});
     }
 
     return route;

--- a/tt_fabric/hw/inc/tt_fabric.h
+++ b/tt_fabric/hw/inc/tt_fabric.h
@@ -15,11 +15,9 @@
 
 using namespace tt::tt_fabric;
 
-constexpr ProgrammableCoreType fd_core_type = static_cast<ProgrammableCoreType>(FD_CORE_TYPE);
-
-const uint32_t SYNC_BUF_SIZE = 16;  // must be 2^N
-const uint32_t SYNC_BUF_SIZE_MASK = (SYNC_BUF_SIZE - 1);
-const uint32_t SYNC_BUF_PTR_MASK = ((SYNC_BUF_SIZE << 1) - 1);
+constexpr uint32_t SYNC_BUF_SIZE = 16;  // must be 2^N
+constexpr uint32_t SYNC_BUF_SIZE_MASK = (SYNC_BUF_SIZE - 1);
+constexpr uint32_t SYNC_BUF_PTR_MASK = ((SYNC_BUF_SIZE << 1) - 1);
 
 extern uint64_t xy_local_addr;
 extern volatile local_pull_request_t* local_pull_request;

--- a/tt_fabric/hw/inc/tt_fabric_api.h
+++ b/tt_fabric/hw/inc/tt_fabric_api.h
@@ -13,13 +13,17 @@
 
 using namespace tt::tt_fabric;
 
-extern volatile local_pull_request_t* local_pull_request;
 extern volatile fabric_client_interface_t* client_interface;
 
-#define ASYNC_WR_ALL 1
-#define ASYNC_WR_ADD_PR 2
-#define ASYNC_WR_SEND 3
+#define ASYNC_WR_ADD_PR 1
+#define ASYNC_WR_SEND 2
 #define ASYNC_WR_ADD_HEADER 4
+#define ASYNC_WR_ALL ASYNC_WR_ADD_HEADER | ASYNC_WR_ADD_PR | ASYNC_WR_SEND
+
+enum RoutingType : uint8_t {
+    ROUTING_TABLE,
+    ROUTER_XY,
+};
 
 inline uint32_t get_next_hop_router_noc_xy(uint32_t routing_plane, uint32_t dst_mesh_id, uint32_t dst_dev_id) {
     ASSERT(routing_plane < client_interface->num_routing_planes);
@@ -47,10 +51,35 @@ inline void fabric_setup_pull_request(uint32_t src_addr, uint32_t size) {
     client_interface->local_pull_request.pull_request.flags = FORWARD;
 }
 
-inline void fabric_send_pull_request(uint32_t routing_plane, uint16_t dst_mesh_id, uint16_t dst_dev_id) {
-    uint64_t router_addr = ((uint64_t)get_next_hop_router_noc_xy(routing_plane, dst_mesh_id, dst_dev_id) << 32) |
-                           FABRIC_ROUTER_REQ_QUEUE_START;
+template <RoutingType routing_type = RoutingType::ROUTING_TABLE>
+inline void fabric_send_pull_request(uint32_t routing, uint16_t dst_mesh_id, uint16_t dst_dev_id) {
+    uint64_t router_addr;
+    if constexpr (routing_type == RoutingType::ROUTING_TABLE) {
+        router_addr = ((uint64_t)get_next_hop_router_noc_xy(routing, dst_mesh_id, dst_dev_id) << 32) |
+                      FABRIC_ROUTER_REQ_QUEUE_START;
+    } else {
+        router_addr = get_noc_addr_helper(routing, FABRIC_ROUTER_REQ_QUEUE_START);
+    }
     tt_fabric_send_pull_request(router_addr, (volatile local_pull_request_t*)&client_interface->local_pull_request);
+}
+
+FORCE_INLINE void fabric_wait_for_pull_request_words_flushed(uint32_t words) {
+    while (client_interface->local_pull_request.pull_request.words_read < words) {
+#pragma GCC unroll 4
+        for (int i = 0; i < 4; i++) {
+            asm("nop");
+        }
+    }
+}
+
+inline void fabric_wait_for_pull_request_bytes_flushed(uint32_t size) {
+    uint32_t size_in_words = (size + PACKET_WORD_SIZE_BYTES - 1) >> 4;
+    fabric_wait_for_pull_request_words_flushed(size_in_words);
+}
+
+inline void fabric_wait_for_pull_request_flushed() {
+    uint32_t words_written = client_interface->local_pull_request.pull_request.words_written;
+    fabric_wait_for_pull_request_words_flushed(words_written);
 }
 
 inline void fabric_async_write_add_header(
@@ -70,27 +99,28 @@ inline void fabric_async_write_add_header(
     packet_header->session.target_offset_h = dst_addr >> 32;
     tt_fabric_add_header_checksum(packet_header);
 }
+
 // Write packetized data over fabric to dst_mesh, dst_dev.
 // Packet is at src_addr in sender L1.
-template <uint8_t mode = ASYNC_WR_ALL>
+template <uint8_t mode = ASYNC_WR_ALL, RoutingType routing_type = RoutingType::ROUTING_TABLE>
 inline void fabric_async_write(
-    uint32_t routing_plane,  // the network plane to use for this transaction
-    uint32_t src_addr,       // source address in sender’s memory
+    uint32_t routing,   // the network plane to use for this transaction
+    uint32_t src_addr,  // source address in sender’s memory
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
     uint64_t dst_addr,
     uint32_t size  // number of bytes to write to remote destination
 ) {
-    if constexpr (mode == ASYNC_WR_ALL or mode == ASYNC_WR_ADD_HEADER) {
+    if constexpr (mode & ASYNC_WR_ADD_HEADER) {
         fabric_async_write_add_header(src_addr, dst_mesh_id, dst_dev_id, dst_addr, size);
     }
 
-    if constexpr (mode == ASYNC_WR_ALL or mode == ASYNC_WR_ADD_PR) {
+    if constexpr (mode & ASYNC_WR_ADD_PR) {
         fabric_setup_pull_request(src_addr, size);
     }
 
-    if constexpr (mode == ASYNC_WR_ALL or mode == ASYNC_WR_SEND) {
-        fabric_send_pull_request(routing_plane, dst_mesh_id, dst_dev_id);
+    if constexpr (mode & ASYNC_WR_SEND) {
+        fabric_send_pull_request<routing_type>(routing, dst_mesh_id, dst_dev_id);
     }
 }
 
@@ -100,10 +130,10 @@ inline void fabric_async_write_multicast_add_header(
     uint16_t dst_dev_id,
     uint64_t dst_addr,
     uint32_t size,  // number of bytes to write to remote destination
-    uint32_t e_depth,
-    uint32_t w_depth,
-    uint32_t n_depth,
-    uint32_t s_depth) {
+    uint16_t e_depth,
+    uint16_t w_depth,
+    uint16_t n_depth,
+    uint16_t s_depth) {
     packet_header_t* packet_header = (packet_header_t*)(src_addr);
     packet_header->routing.flags = FORWARD | MCAST_DATA;
     packet_header->routing.packet_size_bytes = size;
@@ -120,7 +150,7 @@ inline void fabric_async_write_multicast_add_header(
 }
 // Write packetized data over fabric to dst_mesh, dst_dev.
 // Packet is at src_addr in sender L1.
-template <uint8_t mode = ASYNC_WR_ALL>
+template <uint8_t mode = ASYNC_WR_ALL, RoutingType routing_type = RoutingType::ROUTING_TABLE>
 inline void fabric_async_write_multicast(
     uint32_t routing_plane,  // the network plane to use for this transaction
     uint32_t src_addr,       // source address in sender’s memory
@@ -128,21 +158,113 @@ inline void fabric_async_write_multicast(
     uint16_t dst_dev_id,
     uint64_t dst_addr,
     uint32_t size,  // number of bytes to write to remote destination
-    uint32_t e_depth,
-    uint32_t w_depth,
-    uint32_t n_depth,
-    uint32_t s_depth) {
-    if constexpr (mode == ASYNC_WR_ALL or mode == ASYNC_WR_ADD_HEADER) {
+    uint16_t e_depth,
+    uint16_t w_depth,
+    uint16_t n_depth,
+    uint16_t s_depth) {
+    if constexpr (mode & ASYNC_WR_ADD_HEADER) {
         fabric_async_write_multicast_add_header(
             src_addr, dst_mesh_id, dst_dev_id, dst_addr, size, e_depth, w_depth, n_depth, s_depth);
     }
 
-    if constexpr (mode == ASYNC_WR_ALL or mode == ASYNC_WR_ADD_PR) {
+    if constexpr (mode & ASYNC_WR_ADD_PR) {
         fabric_setup_pull_request(src_addr, size);
     }
 
-    if constexpr (mode == ASYNC_WR_ALL or mode == ASYNC_WR_SEND) {
-        fabric_send_pull_request(routing_plane, dst_mesh_id, dst_dev_id);
+    if constexpr (mode & ASYNC_WR_SEND) {
+        fabric_send_pull_request<routing_type>(routing_plane, dst_mesh_id, dst_dev_id);
+    }
+}
+
+inline void fabric_atomic_inc_add_header(
+    uint32_t src_addr,  // source address in sender’s memory
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_addr,
+    uint32_t atomic_inc,
+    uint32_t wrap_boundary) {
+    packet_header_t* packet_header = (packet_header_t*)(src_addr);
+    packet_header->routing.flags = INLINE_FORWARD;
+    packet_header->routing.packet_size_bytes = PACKET_HEADER_SIZE_BYTES;
+    packet_header->routing.dst_mesh_id = dst_mesh_id;
+    packet_header->routing.dst_dev_id = dst_dev_id;
+    packet_header->session.command = ATOMIC_INC;
+    packet_header->session.target_offset_l = (uint32_t)dst_addr;
+    packet_header->session.target_offset_h = dst_addr >> 32;
+    packet_header->packet_parameters.atomic_parameters.wrap_boundary = wrap_boundary;
+    packet_header->packet_parameters.atomic_parameters.increment = atomic_inc;
+    tt_fabric_add_header_checksum(packet_header);
+}
+
+// Write packetized data over fabric to dst_mesh, dst_dev.
+// Packet is at src_addr in sender L1.
+template <uint8_t mode = ASYNC_WR_ALL, RoutingType routing_type = RoutingType::ROUTING_TABLE>
+inline void fabric_atomic_inc(
+    uint32_t routing,   // the network plane to use for this transaction
+    uint32_t src_addr,  // source address in sender’s memory
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_addr,
+    uint32_t atomic_inc,
+    uint32_t wrap_boundary) {
+    if constexpr (mode & ASYNC_WR_ADD_HEADER) {
+        fabric_atomic_inc_add_header(src_addr, dst_mesh_id, dst_dev_id, dst_addr, atomic_inc, wrap_boundary);
+    }
+
+    if constexpr (mode & ASYNC_WR_ADD_PR) {
+        fabric_setup_pull_request(src_addr, PACKET_HEADER_SIZE_BYTES);
+    }
+
+    if constexpr (mode & ASYNC_WR_SEND) {
+        fabric_send_pull_request<routing_type>(routing, dst_mesh_id, dst_dev_id);
+    }
+}
+
+inline void fabric_async_write_atomic_inc_add_header(
+    uint32_t src_addr,  // source address in sender’s memory
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_write_addr,
+    uint64_t dst_atomic_addr,
+    uint32_t size,  // number of bytes to write to remote destination
+    uint32_t atomic_inc) {
+    packet_header_t* packet_header = (packet_header_t*)(src_addr);
+    packet_header->routing.flags = FORWARD;
+    packet_header->routing.packet_size_bytes = size;
+    packet_header->routing.dst_mesh_id = dst_mesh_id;
+    packet_header->routing.dst_dev_id = dst_dev_id;
+    packet_header->session.command = ASYNC_WR | ATOMIC_INC;
+    packet_header->session.target_offset_l = (uint32_t)dst_write_addr;
+    packet_header->session.target_offset_h = dst_atomic_addr >> 32;
+    packet_header->packet_parameters.async_wr_atomic_parameters.noc_xy = dst_atomic_addr >> 32;
+    packet_header->packet_parameters.async_wr_atomic_parameters.l1_offset = (uint32_t)dst_atomic_addr;
+    packet_header->packet_parameters.async_wr_atomic_parameters.increment = atomic_inc;
+    tt_fabric_add_header_checksum(packet_header);
+}
+
+// Write packetized data over fabric to dst_mesh, dst_dev.
+// Packet is at src_addr in sender L1.
+template <uint8_t mode = ASYNC_WR_ALL, RoutingType routing_type = RoutingType::ROUTING_TABLE>
+inline void fabric_async_write_atomic_inc(
+    uint32_t routing,   // the network plane to use for this transaction
+    uint32_t src_addr,  // source address in sender’s memory
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_write_addr,
+    uint64_t dst_atomic_addr,
+    uint32_t size,  // number of bytes to write to remote destination
+    uint32_t atomic_inc) {
+    if constexpr (mode & ASYNC_WR_ADD_HEADER) {
+        fabric_async_write_atomic_inc_add_header(
+            src_addr, dst_mesh_id, dst_dev_id, dst_write_addr, dst_atomic_addr, size, atomic_inc);
+    }
+
+    if constexpr (mode & ASYNC_WR_ADD_PR) {
+        fabric_setup_pull_request(src_addr, size);
+    }
+
+    if constexpr (mode & ASYNC_WR_SEND) {
+        fabric_send_pull_request<routing_type>(routing, dst_mesh_id, dst_dev_id);
     }
 }
 
@@ -245,9 +367,9 @@ inline void fabric_socket_connect(socket_handle_t* socket_handle) {
     while (((volatile socket_handle_t*)socket_handle)->socket_state != SocketState::ACTIVE);
 }
 
+template <RoutingType routing_type = RoutingType::ROUTING_TABLE>
 inline void fabric_endpoint_init(uint32_t base_address, uint32_t outbound_eth_chan) {
     tt_fabric_init();
-
     client_interface = (volatile fabric_client_interface_t*)base_address;
     uint32_t routing_tables_offset = base_address + sizeof(fabric_client_interface_t);
 
@@ -255,9 +377,11 @@ inline void fabric_endpoint_init(uint32_t base_address, uint32_t outbound_eth_ch
     client_interface->routing_tables_l1_offset = routing_tables_offset;
     client_interface->num_routing_planes = 1;
 
-    // read routing table
-    uint64_t dest_addr = get_noc_addr_helper(
-        eth_chan_to_noc_xy[noc_index][outbound_eth_chan], eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
-    noc_async_read_one_packet(dest_addr, routing_tables_offset, sizeof(fabric_router_l1_config_t));
-    noc_async_read_barrier();
+    if constexpr (routing_type == RoutingType::ROUTING_TABLE) {
+        // read routing table
+        uint64_t dest_addr = get_noc_addr_helper(
+            eth_chan_to_noc_xy[noc_index][outbound_eth_chan], eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
+        noc_async_read_one_packet(dest_addr, routing_tables_offset, sizeof(fabric_router_l1_config_t));
+        noc_async_read_barrier();
+    }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Missing fabric apis for atomic related txns.
Original code also forces reading routing tables/lookup on device, when this can be resolved on host to improve device perf instead.

### What's changed
Add apis for atomic and fused write + atomic.
Add mode to fabric apis that take in a router xy instead of a routing plane.
Some cleanup of fabric code.
This also fixes the jit compile error for fabric tests on ci.

I have unit tests that can be ported to test the new atomic and existing fabric user apis, but would require a new fabric fixture that does fabric setup. Ideally the automatic fabric setup can be merged first so we don't need this new fixture. If this goes in soon then I can add the tests after without merging the fixture.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

TG fabric tests passing: https://github.com/tenstorrent/tt-metal/actions/runs/13392490818/job/37403500910