### PR TITLE
#0: Include <span> in xtensor conversion utils

### DIFF
--- a/ttnn/cpp/ttnn/tensor/xtensor/conversion_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/conversion_utils.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <span>
 #include <tt-metalium/small_vector.hpp>
 
 #include "ttnn/tensor/tensor.hpp"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`tt::stl::SmallVector` removed a dependency on c++20 std::span, which was transitively included in this header. 

This [breaks](https://github.com/tenstorrent/tt-mlir/actions/runs/13384256221/job/37378049606?pr=2194) tt-mlir.

### What's changed
Include `<span>`.

### Checklist
- Compilation tested locally, @brataTT confirmed the fix works for tt-mlir.
