### PR TITLE
#0: Fix produce_data bug "jq: error: writing output failed: Broken pipe"

### DIFF
--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -17,7 +17,9 @@ download_artifacts() {
     local repo=$1
     local workflow_run_id=$2
 
-    if gh api --paginate /repos/$repo/actions/runs/$workflow_run_id/artifacts | jq '.artifacts[] | .name' | grep -q "test_reports_"; then
+    echo "[info] Downloading test reports for workflow run $workflow_run_id"
+    api_output=$(gh api --paginate /repos/$repo/actions/runs/$workflow_run_id/artifacts | jq -r '.artifacts[] | .name')
+    if echo "$api_output" | grep -q "test_reports_"; then
         gh run download --repo $repo -D generated/cicd/$workflow_run_id/artifacts --pattern test_reports_* $workflow_run_id
     else
         echo "[Warning] Test reports not found for workflow run $workflow_run_id"


### PR DESCRIPTION
### Ticket

### Problem description
Recent produce_data workflows started bugging out on a line that checks github API for artifacts starting with "test_reports_*" with `jq: error: writing output failed: Broken pipe`
https://github.com/tenstorrent/tt-metal/actions/runs/13382103493/job/37372300588#step:7:9

### What's changed
Store all output from gh api into var, and then `grep -q` after.

### Checklist
- [x] New/Existing tests provide coverage for changes
Same failing workflow, rerun on branch with fix:
https://github.com/tenstorrent/tt-metal/actions/runs/13396159663
