### PR TITLE
Revert "#17094: fill implicit pad sharded using the new shardedAddrGen"

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -5,7 +5,6 @@
 import pytest
 import torch
 import ttnn
-import math
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random, run_for_wormhole_b0
 
@@ -53,12 +52,12 @@ ttnn_dtype_to_torch_dtype = {
     ttnn.bfloat16: torch.float32,
 }
 
-# torch.set_printoptions(threshold=10000)
 
-
+# @pytest.mark.parametrize("shape", [(2, 32, 300, 256)])
 @pytest.mark.parametrize(
     "shape",
     [
+        # 2D shapes with edge cases for fill_pad
         (1, 16),
         (16, 1),
         (1, 17),
@@ -68,7 +67,6 @@ ttnn_dtype_to_torch_dtype = {
         (31, 31),
         (33, 33),
         (65, 65),
-        (97, 97),
         (1, 2, 3, 2, 1, 2, 97, 97),
     ],
 )
@@ -98,150 +96,3 @@ def test_fill_pad(
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
 
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
-
-
-@pytest.mark.parametrize("fill_value", [1])
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (1, 16),
-        (97, 97),
-    ],
-)
-@pytest.mark.parametrize(
-    "shard_scheme",
-    [
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-    ],
-)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32])
-def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtype):
-    torch.manual_seed(1234)
-    torch_input_tensor, padded_torch_tensor = create_nd_padded_tiled_tensor(
-        shape, 32, fill_value, ttnn_dtype_to_torch_dtype[dtype]
-    )
-    num_cores_xblock = 2
-    num_cores_yblock = 4
-    num_cores = num_cores_xblock * num_cores_yblock
-
-    # Add complex shard grid with 2 X 4 = 8 cores
-    shard_grid = ttnn.CoreRangeSet(
-        [
-            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1)),
-            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 1)),
-            ttnn.CoreRange(ttnn.CoreCoord(0, 4), ttnn.CoreCoord(0, 5)),
-        ]
-    )
-
-    tiles_per_2d = padded_torch_tensor.shape[-2] * padded_torch_tensor.shape[-1] / (32 * 32)
-    dims_b4_last_dim = 1
-    for i in range(len(padded_torch_tensor.shape) - 1):
-        dims_b4_last_dim *= padded_torch_tensor.shape[i]
-
-    shard_shape = [32, 32]
-    if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
-        shard_shape = (dims_b4_last_dim, 32 * math.ceil((math.ceil(padded_torch_tensor.shape[-1] / 32) / num_cores)))
-    elif shard_scheme == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
-        tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores)
-        shard_shape = (32 * tile_widths_per_core, padded_torch_tensor.shape[-1])
-    elif shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
-        tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores_xblock)
-        shard_shape = (
-            32 * tile_widths_per_core,
-            32 * math.ceil((math.ceil(padded_torch_tensor.shape[-1] / 32) / num_cores_yblock)),
-        )
-    else:
-        shard_shape = (math.ceil(math.sqrt(tiles_per_core)), math.ceil(math.sqrt(tiles_per_core)))
-
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(
-        shard_scheme,
-        ttnn.BufferType.L1,
-        shard_spec,
-    )
-
-    input_tensor = ttnn.to_device(
-        ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT),
-        device,
-        memory_config=output_mem_config,
-    )
-
-    output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
-
-    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)
-
-
-@pytest.mark.parametrize("fill_value", [1])
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (1, 16),
-        (16, 1),
-        (17, 17),
-        (17, 1),
-        (16, 16),
-        (17, 17),
-        (31, 31),
-        (33, 33),
-        (97, 97),
-    ],
-)
-@pytest.mark.parametrize(
-    "shard_scheme",
-    [
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-    ],
-)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32])
-def test_fill_pad_sharded(device, fill_value, shape, shard_scheme, dtype):
-    torch.manual_seed(1234)
-    torch_input_tensor, padded_torch_tensor = create_nd_padded_tiled_tensor(
-        shape, 32, fill_value, ttnn_dtype_to_torch_dtype[dtype]
-    )
-
-    num_cores_x = 8
-    num_cores_y = 7
-    num_cores = num_cores_x * num_cores_y
-    shard_grid = ttnn.CoreRangeSet(
-        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))]
-    )
-
-    tiles_per_2d = padded_torch_tensor.shape[-2] * padded_torch_tensor.shape[-1] / (32 * 32)
-    dims_b4_last_dim = 1
-    for i in range(len(padded_torch_tensor.shape) - 1):
-        dims_b4_last_dim *= padded_torch_tensor.shape[i]
-
-    shard_shape = [32, 32]
-    if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
-        shard_shape = (dims_b4_last_dim, 32 * math.ceil((math.ceil(padded_torch_tensor.shape[-1] / 32) / num_cores)))
-    elif shard_scheme == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
-        tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores)
-        shard_shape = (32 * tile_widths_per_core, padded_torch_tensor.shape[-1])
-    elif shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
-        tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores_x)
-        shard_shape = (32 * tile_widths_per_core, 32 * math.ceil((padded_torch_tensor.shape[-1] / 32 / num_cores_y)))
-    else:
-        shard_shape = (math.ceil(math.sqrt(tiles_per_core)), math.ceil(math.sqrt(tiles_per_core)))
-
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    output_mem_config = ttnn.MemoryConfig(
-        shard_scheme,
-        ttnn.BufferType.L1,
-        shard_spec,
-    )
-
-    input_tensor = ttnn.to_device(
-        ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT),
-        device,
-        memory_config=output_mem_config,
-    )
-
-    output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
-
-    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_op.cpp
@@ -14,6 +14,12 @@ namespace ttnn::operations::data_movement {
 void FillPad::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.get_layout() == TILE_LAYOUT, "FillPad should only be used for tile layout");
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "FillPad does not currently support sharding");
+    TT_FATAL(
+        this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "FillPad does not currently support sharding");
 }
 
 std::vector<TensorSpec> FillPad::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include "cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
-#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
     constexpr uint32_t cb_id_0 = get_compile_time_arg_val(0);
@@ -21,38 +19,20 @@ void kernel_main() {
     constexpr uint32_t tile_size = get_compile_time_arg_val(10);
     constexpr uint32_t tile_hw = tile_size * tile_size;
     constexpr uint32_t face_size = get_compile_time_arg_val(11);
-#define SHARDED get_compile_time_arg_val(12) == 1
     constexpr uint32_t face_hw = face_size * face_size;
     constexpr uint32_t alignment_adjustor = 16;
 
-    uint32_t rt_arg_ind = 0;
-    uint32_t dst_addr = get_arg_val<uint32_t>(rt_arg_ind++);
-    uint32_t cb_page_size = get_arg_val<uint32_t>(rt_arg_ind++);
-    uint32_t starting_tile_offset = get_arg_val<uint32_t>(rt_arg_ind++);
-    uint32_t num_2d_tensors = get_arg_val<uint32_t>(rt_arg_ind++);
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t cb_page_size = get_arg_val<uint32_t>(1);
+    uint32_t starting_tile_offset = get_arg_val<uint32_t>(2);
+    uint32_t num_2d_tensors = get_arg_val<uint32_t>(3);
 
-#if (SHARDED)
-    typedef ShardedInfo<
-        get_compile_time_arg_val(13),
-        get_compile_time_arg_val(14),
-        get_compile_time_arg_val(15),
-        get_compile_time_arg_val(16),
-        get_compile_time_arg_val(17),
-        get_compile_time_arg_val(18),
-        get_compile_time_arg_val(19)>
-        tensor_shard_info;
-
-    const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(rt_arg_ind));
-    experimental::ShardedAddrGen<tensor_shard_info> s0 = {.bank_base_address = dst_addr, .shard_array = mapping_table};
-#else
     const DataFormat data_format = get_dataformat(cb_id_0);
     const InterleavedAddrGenFast<tensor_in_dram> s0 = {
         .bank_base_address = dst_addr,
         .page_size = tile_hw * element_size_bytes,
         .data_format = data_format  // page_size needs to be tile_size_bytes
     };
-#endif
 
     // Reserve and push the fill value into the circular buffer
     cb_reserve_back(cb_id_0, 1);


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#17692

Seeing post commit errors on all cards 
https://github.com/tenstorrent/tt-metal/actions/runs/13395569920/job/37419451997
https://github.com/tenstorrent/tt-metal/actions/runs/13397389066/job/37420504407
https://github.com/tenstorrent/tt-metal/actions/runs/13396935467/job/37419214586
```
FAILED tests/ttnn/unit_tests/operations/test_fill_pad.py::test_fill_pad_complex_sharding[dtype=DataType.BFLOAT16-shard_scheme=TensorMemoryLayout.BLOCK_SHARDED-shape=(1, 16)-fill_value=1]
```
