### PR TITLE
[skip ci] Fix build and test wheel workflow

### DIFF
--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -15,6 +15,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
+    with:
+      build-wheel: true
   test-wheels:
     needs: build-artifact
     if: ${{ always() }}


### PR DESCRIPTION
### Problem description
Workflow doesn't work, because build-wheel option wasn't passed.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/13398987372