### PR TITLE
Atulk/fill pad sharded v2 -- reverted from main due to new assert, changed tests accordingly

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -53,8 +53,6 @@ ttnn_dtype_to_torch_dtype = {
     ttnn.bfloat16: torch.float32,
 }
 
-# torch.set_printoptions(threshold=10000)
-
 
 @pytest.mark.parametrize(
     "shape",
@@ -113,7 +111,6 @@ def test_fill_pad(
     [
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32])
@@ -146,12 +143,6 @@ def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtyp
     elif shard_scheme == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
         tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores)
         shard_shape = (32 * tile_widths_per_core, padded_torch_tensor.shape[-1])
-    elif shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
-        tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores_xblock)
-        shard_shape = (
-            32 * tile_widths_per_core,
-            32 * math.ceil((math.ceil(padded_torch_tensor.shape[-1] / 32) / num_cores_yblock)),
-        )
     else:
         shard_shape = (math.ceil(math.sqrt(tiles_per_core)), math.ceil(math.sqrt(tiles_per_core)))
 

--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -27,12 +27,8 @@ def create_nd_padded_tiled_tensor(shape, tile_size, fill_value, dtype):
     # Create a tensor with random values
     if dtype == torch.float32:
         tensor = torch_random(shape, -15.0, 15.0, dtype=dtype)
-        # create tensor where the value is just incrementing per index:: 2D ONLY
-        # tensor = torch.arange(0, shape[-2] * shape[-1], dtype=dtype).reshape(shape)
     else:
         tensor = torch.randint(0, 10, shape, dtype=dtype)
-        # create tensor where the value is just incrementing per index
-        # tensor = torch.arange(0, shape[-2] * shape[-1], dtype=dtype).reshape(shape)
 
     # Calculate the padded sizes for the last two dimensions
     padded_shape = list(shape)

--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import ttnn
+import math
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random, run_for_wormhole_b0
 
@@ -26,8 +27,12 @@ def create_nd_padded_tiled_tensor(shape, tile_size, fill_value, dtype):
     # Create a tensor with random values
     if dtype == torch.float32:
         tensor = torch_random(shape, -15.0, 15.0, dtype=dtype)
+        # create tensor where the value is just incrementing per index:: 2D ONLY
+        # tensor = torch.arange(0, shape[-2] * shape[-1], dtype=dtype).reshape(shape)
     else:
         tensor = torch.randint(0, 10, shape, dtype=dtype)
+        # create tensor where the value is just incrementing per index
+        # tensor = torch.arange(0, shape[-2] * shape[-1], dtype=dtype).reshape(shape)
 
     # Calculate the padded sizes for the last two dimensions
     padded_shape = list(shape)
@@ -52,12 +57,12 @@ ttnn_dtype_to_torch_dtype = {
     ttnn.bfloat16: torch.float32,
 }
 
+# torch.set_printoptions(threshold=10000)
 
-# @pytest.mark.parametrize("shape", [(2, 32, 300, 256)])
+
 @pytest.mark.parametrize(
     "shape",
     [
-        # 2D shapes with edge cases for fill_pad
         (1, 16),
         (16, 1),
         (1, 17),
@@ -67,6 +72,7 @@ ttnn_dtype_to_torch_dtype = {
         (31, 31),
         (33, 33),
         (65, 65),
+        (97, 97),
         (1, 2, 3, 2, 1, 2, 97, 97),
     ],
 )
@@ -96,3 +102,68 @@ def test_fill_pad(
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
 
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
+
+
+@pytest.mark.parametrize("fill_value", [1])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 16),
+        (16, 1),
+        (17, 17),
+        (17, 1),
+        (16, 16),
+        (17, 17),
+        (31, 31),
+        (33, 33),
+        (97, 97),
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_scheme", [ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.TensorMemoryLayout.WIDTH_SHARDED]
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32])
+def test_fill_pad_sharded(device, fill_value, shape, shard_scheme, dtype):
+    torch.manual_seed(1234)
+    torch_input_tensor, padded_torch_tensor = create_nd_padded_tiled_tensor(
+        shape, 32, fill_value, ttnn_dtype_to_torch_dtype[dtype]
+    )
+
+    num_cores_x = 8
+    num_cores_y = 7
+    num_cores = num_cores_x * num_cores_y
+    shard_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))]
+    )
+
+    tiles_per_2d = padded_torch_tensor.shape[-2] * padded_torch_tensor.shape[-1] / (32 * 32)
+    dims_b4_last_dim = 1
+    for i in range(len(padded_torch_tensor.shape) - 1):
+        dims_b4_last_dim *= padded_torch_tensor.shape[i]
+
+    shard_shape = [32, 32]
+    if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+        shard_shape = (dims_b4_last_dim, 32 * math.ceil((padded_torch_tensor.shape[-1] / num_cores)))
+    elif shard_scheme == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+        tile_widths_per_core = math.ceil(dims_b4_last_dim / num_cores)
+        shard_shape = (32 * tile_widths_per_core, padded_torch_tensor.shape[-1])
+    else:
+        shard_shape = (math.ceil(math.sqrt(tiles_per_core)), math.ceil(math.sqrt(tiles_per_core)))
+
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(
+        shard_scheme,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+
+    input_tensor = ttnn.to_device(
+        ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT),
+        device,
+        memory_config=output_mem_config,
+    )
+
+    output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
+
+    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_op.cpp
@@ -14,12 +14,6 @@ namespace ttnn::operations::data_movement {
 void FillPad::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.get_layout() == TILE_LAYOUT, "FillPad should only be used for tile layout");
-    TT_FATAL(
-        input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
-        "FillPad does not currently support sharding");
-    TT_FATAL(
-        this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
-        "FillPad does not currently support sharding");
 }
 
 std::vector<TensorSpec> FillPad::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -69,10 +69,7 @@ operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& input_tensor, 
         padded_height / tt::constants::TILE_HEIGHT * padded_width / tt::constants::TILE_HEIGHT;
     uint32_t tiles_per_tile_row = padded_width / tt::constants::TILE_HEIGHT;
 
-    bool sharded = false;
-    if (input_tensor.memory_config().memory_layout != TensorMemoryLayout::INTERLEAVED) {
-        sharded = true;
-    }
+    bool sharded = input_tensor.memory_config().memory_layout != TensorMemoryLayout::INTERLEAVED;
 
     // create kernel
     // reader compile time args

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/tt_log.h>
+#include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 
 bool is_power_of_two_at_least_32(uint32_t value) { return value >= 32 && (value & (value - 1)) == 0; }
 
@@ -68,6 +69,11 @@ operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& input_tensor, 
         padded_height / tt::constants::TILE_HEIGHT * padded_width / tt::constants::TILE_HEIGHT;
     uint32_t tiles_per_tile_row = padded_width / tt::constants::TILE_HEIGHT;
 
+    bool sharded = false;
+    if (input_tensor.memory_config().memory_layout != TensorMemoryLayout::INTERLEAVED) {
+        sharded = true;
+    }
+
     // create kernel
     // reader compile time args
     std::vector<uint32_t> writer_compile_time_args = {
@@ -82,7 +88,12 @@ operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& input_tensor, 
         (std::uint32_t)tiles_per_2d_tensor,
         (std::uint32_t)tiles_per_tile_row,
         (std::uint32_t)tt::constants::TILE_HEIGHT,
-        (std::uint32_t)tt::constants::FACE_HEIGHT};
+        (std::uint32_t)tt::constants::FACE_HEIGHT,
+        (std::uint32_t)sharded};
+
+    if (sharded) {
+        shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_time_args);
+    }
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -102,6 +113,9 @@ operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& input_tensor, 
         {
             writer_runtime_args[2] = tile_offset;
             writer_runtime_args[3] = local_num_2d_tensors;
+            if (sharded) {
+                shard_builder::extend_sharding_run_time_args(input_tensor, writer_runtime_args);
+            }
             tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -102,4 +102,5 @@ void kernel_main() {
     for (uint32_t t = 0; t < num_2d_tensors; t++) {
         fill_pad_2d_tensor(t * tiles_per_2d_tensor + starting_tile_offset);
     }
+    noc_async_write_barrier();
 }


### PR DESCRIPTION
### Ticket
[#17094](https://github.com/tenstorrent/tt-metal/issues/17094)

### Problem description
Add sharded support for fill_implicit_padding

### What's changed
First op to simply utilize the new shardedAddrGen by @jvegaTT 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13399211627)