### PR TITLE
Removal of user required globals from tt_fabric_api.h

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx_socket.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx_socket.cpp
@@ -44,7 +44,8 @@ constexpr uint32_t data_buffer_size_words = get_compile_time_arg_val(13);
 
 volatile tt_l1_ptr chan_req_buf* client_pull_req_buf =
     reinterpret_cast<tt_l1_ptr chan_req_buf*>(client_pull_req_buf_addr);
-volatile fabric_client_interface_t* client_interface = (volatile fabric_client_interface_t*)client_interface_addr;
+volatile tt_l1_ptr fabric_client_interface_t* client_interface =
+    (volatile tt_l1_ptr fabric_client_interface_t*)client_interface_addr;
 uint64_t xy_local_addr;
 socket_reader_state socket_reader;
 
@@ -87,6 +88,7 @@ void kernel_main() {
     test_results[TT_FABRIC_MISC_INDEX] = 0xff000005;
 
     fabric_socket_open(
+        client_interface,       // fabric client interface
         3,                      // the network plane to use for this socket
         2,                      // Temporal epoch for which the socket is being opened
         1,                      // Socket Id to open

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx_socket.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx_socket.cpp
@@ -81,6 +81,7 @@ void kernel_main() {
     test_results[TT_FABRIC_MISC_INDEX] = 0xff000004;
 
     // make sure fabric node gatekeeper is available.
+    tt_fabric_init();
     fabric_endpoint_init();
 
     socket_reader.init(data_buffer_start_addr, data_buffer_size_words);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
@@ -457,6 +457,7 @@ void kernel_main() {
     uint32_t packet_count = 0;
 
     // initalize client
+    tt_fabric_init();
     fabric_endpoint_init(client_interface, outbound_eth_chan);
     routing_table = reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(client_interface->routing_tables_l1_offset);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
@@ -71,7 +71,8 @@ uint32_t max_packet_size_mask;
 auto input_queue_state = select_input_queue<pkt_dest_size_choice>();
 volatile local_pull_request_t *local_pull_request = (volatile local_pull_request_t *)(data_buffer_start_addr - 1024);
 volatile tt_l1_ptr fabric_router_l1_config_t* routing_table;
-volatile fabric_client_interface_t* client_interface;
+volatile tt_l1_ptr fabric_client_interface_t* client_interface =
+    (volatile tt_l1_ptr fabric_client_interface_t*)client_interface_addr;
 
 fvc_producer_state_t test_producer __attribute__((aligned(16)));
 fvcc_inbound_state_t fvcc_test_producer __attribute__((aligned(16)));
@@ -456,7 +457,7 @@ void kernel_main() {
     uint32_t packet_count = 0;
 
     // initalize client
-    fabric_endpoint_init(client_interface_addr, outbound_eth_chan);
+    fabric_endpoint_init(client_interface, outbound_eth_chan);
     routing_table = reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(client_interface->routing_tables_l1_offset);
 
     while (true) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx_socket.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx_socket.cpp
@@ -351,6 +351,7 @@ void kernel_main() {
     zero_l1_buf((uint32_t*)&packet_header, sizeof(packet_header_t));
 
     // initalize client
+    tt_fabric_init();
     fabric_endpoint_init(client_interface, gk_interface_addr_l, gk_interface_addr_h);
     routing_table = reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(
         client_interface->routing_tables_l1_offset + sizeof(fabric_router_l1_config_t) * routing_plane);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx_socket.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx_socket.cpp
@@ -67,7 +67,8 @@ uint32_t max_packet_size_mask;
 auto input_queue_state = select_input_queue<pkt_dest_size_choice>();
 volatile local_pull_request_t* local_pull_request = (volatile local_pull_request_t*)(data_buffer_start_addr - 1024);
 volatile tt_l1_ptr fabric_router_l1_config_t* routing_table;
-volatile fabric_client_interface_t* client_interface;
+volatile tt_l1_ptr fabric_client_interface_t* client_interface =
+    (volatile tt_l1_ptr fabric_client_interface_t*)client_interface_addr;
 volatile tt_l1_ptr chan_req_buf* client_pull_req_buf =
     reinterpret_cast<tt_l1_ptr chan_req_buf*>(client_pull_req_buf_addr);
 
@@ -350,7 +351,7 @@ void kernel_main() {
     zero_l1_buf((uint32_t*)&packet_header, sizeof(packet_header_t));
 
     // initalize client
-    fabric_endpoint_init(client_interface_addr, gk_interface_addr_l, gk_interface_addr_h);
+    fabric_endpoint_init(client_interface, gk_interface_addr_l, gk_interface_addr_h);
     routing_table = reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(
         client_interface->routing_tables_l1_offset + sizeof(fabric_router_l1_config_t) * routing_plane);
 
@@ -402,6 +403,7 @@ void kernel_main() {
     uint32_t packet_count = 0;
 
     socket_handle_t* socket_handle = fabric_socket_open(
+        client_interface_addr,  // client interface address
         3,                      // the network plane to use for this socket
         2,                      // Temporal epoch for which the socket is being opened
         1,                      // Socket Id to open

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -66,7 +66,6 @@ constexpr uint32_t s_depth = get_compile_time_arg_val(27);
 volatile tt_l1_ptr fabric_client_interface_t* client_interface =
     (volatile tt_l1_ptr fabric_client_interface_t*)client_interface_addr;
 
-uint64_t xy_local_addr;
 uint32_t target_address;
 uint32_t noc_offset;
 uint32_t controller_noc_offset;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -63,7 +63,8 @@ constexpr uint32_t w_depth = get_compile_time_arg_val(25);
 constexpr uint32_t n_depth = get_compile_time_arg_val(26);
 constexpr uint32_t s_depth = get_compile_time_arg_val(27);
 
-volatile fabric_client_interface_t* client_interface;
+volatile tt_l1_ptr fabric_client_interface_t* client_interface =
+    (volatile tt_l1_ptr fabric_client_interface_t*)client_interface_addr;
 
 uint64_t xy_local_addr;
 uint32_t target_address;
@@ -136,7 +137,7 @@ void kernel_main() {
     }
 
     // initalize client
-    fabric_endpoint_init(client_interface_addr, outbound_eth_chan);
+    fabric_endpoint_init(client_interface, outbound_eth_chan);
 
     // notify the controller kernel that this worker is ready to proceed
     notify_traffic_controller();
@@ -147,6 +148,7 @@ void kernel_main() {
     while (*(volatile tt_l1_ptr uint32_t*)signal_address == 0);
 
     fabric_setup_pull_request(
+        client_interface,           // fabric client interface
         data_buffer_start_addr,     // source address in sender’s memory
         max_packet_size_words * 16  // number of bytes to write to remote destination
     );
@@ -157,6 +159,7 @@ void kernel_main() {
         client_interface->local_pull_request.pull_request.words_read = 0;
         if constexpr (mcast_data) {
             fabric_async_write_multicast<ASYNC_WR_SEND>(
+                client_interface,
                 0,                       // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
                 dest_device >> 16,
@@ -169,6 +172,7 @@ void kernel_main() {
                 s_depth);
         } else {
             fabric_async_write<ASYNC_WR_SEND>(
+                client_interface,
                 0,                       // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
                 dest_device >> 16,

--- a/tt_fabric/hw/inc/tt_fabric.h
+++ b/tt_fabric/hw/inc/tt_fabric.h
@@ -1591,9 +1591,4 @@ inline uint64_t tt_fabric_send_pull_request(uint64_t dest_addr, volatile local_p
     return words_written_addr;
 }
 
-inline void tt_fabric_init() {
-    uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc_index, 0, NOC_CFG(NOC_ID_LOGICAL));
-    uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
-    uint32_t my_y = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
-    xy_local_addr = NOC_XY_ADDR(my_x, my_y, 0);
-}
+inline void tt_fabric_init() { xy_local_addr = get_noc_addr(0); }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Users were required to declare globals (some globals were not explicitly externed in tt_fabric_api.h as well). This is not user friendly.
Having a single global for client_interface also makes it more difficult for the user when they want to have multiple interfaces to for example send in multiple directions.

### What's changed
Remove client_interface from being a global and instead take it as an arg to the fabric apis.

Remove xy_local_addr from being a depended on global from tt_fabric_api.h and remove the implicit dependency on tt_fabric.h due to the use of xy_local_addr and tt_fabric_init()

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
