### PR TITLE
Fixed closing files in serialization

### DIFF
--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -27,7 +27,9 @@ namespace {
 struct FileCloser {
     void operator()(FILE* file) const {
         if (file) {
-            TT_ASSERT(fclose(file) == 0, "Failed to close file");
+            if (fclose(file) != 0) {
+                log_warning("Failed to close file");
+            }
         }
     }
 };


### PR DESCRIPTION
### Ticket

### Problem description
In the recent [PR](https://github.com/tenstorrent/tt-metal/pull/17906) we used TT_ASSERT to check if file close failed, but TT_ASSERTs get compiled out in release mode, so we end up not closing files.

### What's changed
Changed TT_ASSERT to check and a log

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes
