### PR TITLE
Fix issue with `ttnn.from_torch(...)` when using MeshDevice

### DIFF
--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -718,3 +718,14 @@ def test_line_all_gather_after_reshape(mesh_device):
         mesh_device=mesh_device,
         topology=ttnn.Topology.Linear,
     )
+
+
+def test_distribute_api(mesh_device):
+    torch_hidden_states = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+    with ttnn.distribute(ttnn.ReplicateTensorToMesh(mesh_device)):
+        hidden_states = ttnn.from_torch(
+            torch_hidden_states,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+        )

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -200,7 +200,7 @@ def from_torch(
         if layout != ttnn.TILE_LAYOUT:
             raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
         # Tilize tensor
-        tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile, pad_value=pad_value)
+        tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile, pad_value=pad_value, mesh_mapper=None)
         logical_shape = tensor.shape
         padded_shape = tensor.padded_shape
         tensor = tensor.reshape(tensor.padded_shape)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Customer reported issue for using `ttnn.distribute(..)` API using `ttnn.from_torch(..., dtype=bfloat8_b)`. 

### What's changed
- To match parity in behavior without using `ttnn.distribute(mesh_mapper=...)` ctx manager, we need to explicitly pass in `mesh_mapper=None`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13408929912
- [x] T3000 Regressions: https://github.com/tenstorrent/tt-metal/actions/runs/13402274697
