### PR TITLE
Remove unused CommandQueue functions

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -27,7 +27,6 @@ public:
     virtual ~CommandQueue() = default;
 
     virtual const CoreCoord& virtual_enqueue_program_dispatch_core() const = 0;
-    virtual const CoreCoord& completion_queue_writer_core() const = 0;
 
     virtual volatile bool is_dprint_server_hung() = 0;
     virtual volatile bool is_noc_hung() = 0;
@@ -52,9 +51,7 @@ public:
 
     virtual IDevice* device() = 0;
 
-    // These functions are temporarily needed since MeshCommandQueue relies on the CommandQueue object
-    virtual uint32_t get_expected_num_workers_completed_for_sub_device(uint32_t sub_device_index) const = 0;
-    virtual void set_expected_num_workers_completed_for_sub_device(uint32_t sub_device_index, uint32_t num_workers) = 0;
+    // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
     virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
 
     virtual void enqueue_trace(const uint32_t trace_id, bool blocking) = 0;
@@ -62,13 +59,7 @@ public:
     virtual void enqueue_program(Program& program, bool blocking) = 0;
 
     virtual void enqueue_read_buffer(
-        std::shared_ptr<Buffer>& buffer,
-        void* dst,
-        const BufferRegion& region,
-        bool blocking,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
-    virtual void enqueue_read_buffer(
-        Buffer& buffer,
+        const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         void* dst,
         const BufferRegion& region,
         bool blocking,
@@ -82,12 +73,6 @@ public:
     virtual void enqueue_write_buffer(
         const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         HostDataType src,
-        const BufferRegion& region,
-        bool blocking,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
-    virtual void enqueue_write_buffer(
-        Buffer& buffer,
-        const void* src,
         const BufferRegion& region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -28,7 +28,6 @@ public:
     ~HWCommandQueue() override;
 
     const CoreCoord& virtual_enqueue_program_dispatch_core() const override;
-    const CoreCoord& completion_queue_writer_core() const override;
 
     volatile bool is_dprint_server_hung() override;
     volatile bool is_noc_hung() override;
@@ -51,21 +50,13 @@ public:
 
     void terminate() override;
 
-    // These functions are temporarily needed since MeshCommandQueue relies on the CommandQueue object
-    uint32_t get_expected_num_workers_completed_for_sub_device(uint32_t sub_device_index) const override;
-    void set_expected_num_workers_completed_for_sub_device(uint32_t sub_device_index, uint32_t num_workers) override;
+    // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;
 
     void enqueue_trace(const uint32_t trace_id, bool blocking) override;
     void enqueue_program(Program& program, bool blocking) override;
     void enqueue_read_buffer(
-        std::shared_ptr<Buffer>& buffer,
-        void* dst,
-        const BufferRegion& region,
-        bool blocking,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
-    void enqueue_read_buffer(
-        Buffer& buffer,
+        const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         void* dst,
         const BufferRegion& region,
         bool blocking,
@@ -78,12 +69,6 @@ public:
     void enqueue_write_buffer(
         const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         HostDataType src,
-        const BufferRegion& region,
-        bool blocking,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
-    void enqueue_write_buffer(
-        Buffer& buffer,
-        const void* src,
         const BufferRegion& region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;


### PR DESCRIPTION
Just some preliminary cleanup to remove some unused functions in CommandQueue

CI: running now - https://github.com/tenstorrent/tt-metal/actions/runs/13403241779