### PR TITLE
enable -O3 opt level for active eth kernels

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -438,7 +438,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
         case 0: {
             this->target_name_ = "active_erisc";
             this->cflags_ =
-                env_.cflags_ + "-Os " + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
+                env_.cflags_ + "-O3 " + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
 
             this->defines_ +=
                 "-DCOMPILE_FOR_ERISC "
@@ -452,7 +452,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
             } else {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/active_erisck.cc");
             }
-            this->lflags_ = env_.lflags_ + "-Os ";
+            this->lflags_ = env_.lflags_ + "-O3 ";
 
             if (this->is_fw_) {
                 this->lflags_ +=
@@ -466,7 +466,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
         }
         case 1: {
             this->target_name_ = "erisc";
-            this->cflags_ = env_.cflags_ + "-Os -fno-delete-null-pointer-checks ";
+            this->cflags_ = env_.cflags_ + "-O3 -fno-delete-null-pointer-checks ";
 
             this->defines_ +=
                 "-DCOMPILE_FOR_ERISC "
@@ -489,7 +489,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
                 linker_str = "tt_metal/hw/toolchain/erisc-b0-kernel.ld ";
             }
             this->lflags_ = env_.lflags_ +
-                            "-Os "
+                            "-O3 "
                             "-L" +
                             env_.root_ +
                             "/tt_metal/hw/toolchain "


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17423

### Problem description
Active ethernet kernels are compiled with -Os. Fabric kernels can fit within the new binary size limit even with -O3 enabled.

### What's changed
Enable -O3 for active ethernet kernels. For 1D fabric, this results in a throughput improvement of 800-1000 MB/s when sending 4KB sized packets.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13405235373
- [ ] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13415973303
- [ ] TG: https://github.com/tenstorrent/tt-metal/actions/runs/13405251335
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/13405236857
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
