### PR TITLE
Add ttnn-pytorch and tt-forge conv2d sweeps to nightly

### DIFF
--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -220,7 +220,6 @@ def run_conv2d_short_sweep(
             dilation_w,
             has_bias,
         ] = input_specs
-    print(input_specs)
 
     if is_forge_suite:
         torch_input_dtype = torch.bfloat16 if input_dtype == ttnn.DataType(ttnn.bfloat16) else torch.float32
@@ -317,7 +316,6 @@ def run_conv2d_short_sweep(
 
     torch_output_tensor = torch.permute(torch_output_tensor, (0, 3, 1, 2))
 
-    print("End of test case")
     return [check_with_pcc(torch_output_tensor, torch_out_golden_tensor, pcc=0.985), e2e_perf]
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/conv2d/test_conv2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv2d/test_conv2d_sweeps.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.sweep_framework.sweep_utils.conv2d_common import run_conv2d_short_sweep
+from tests.sweep_framework.sweeps.conv2d.short.conv2d_short_sweep import parameters as parameters_ttnn_pytorch
+from tests.sweep_framework.sweeps.conv2d.short.conv2d_short_sweep import (
+    failing_parameters as failing_parameters_ttnn_pytorch,
+)
+
+from tests.sweep_framework.sweeps.conv2d.short.conv2d_ttforge_sweep import parameters as parameters_ttnn_forge
+from tests.sweep_framework.sweeps.conv2d.short.conv2d_ttforge_sweep import (
+    failing_parameters as failing_parameters_ttnn_forge,
+)
+
+from models.utility_functions import (
+    skip_for_grayskull,
+    is_wormhole_b0,
+)
+
+import pytest
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("input_spec", parameters_ttnn_pytorch["short_sweep_suite_conv2d"]["input_specs"])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_ttnn_pytorch_sweep(device, input_spec):
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
+
+    # Check if input_spec is in failing_parameters
+    if input_spec in failing_parameters_ttnn_pytorch:
+        pytest.skip(f"Skipping test for failing input_spec: {input_spec}")
+
+    pcc, messsage = run_conv2d_short_sweep(
+        input_spec,
+        device,
+    )[0]
+    assert pcc, messsage
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("input_spec", parameters_ttnn_forge["ttforge_sweep_conv2d"]["input_specs"])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_tt_forge_sweep(device, input_spec):
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
+
+    # Check if input_spec is in failing_parameters
+    if input_spec in failing_parameters_ttnn_forge:
+        pytest.skip(f"Skipping test for failing input_spec: {input_spec}")
+
+    pcc, messsage = run_conv2d_short_sweep(
+        input_spec,
+        device,
+    )[0]
+    assert pcc, messsage

--- a/tests/ttnn/nightly/unit_tests/operations/max_pool2d/test_max_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/max_pool2d/test_max_pool2d_sweeps.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.sweep_framework.sweep_utils.max_pool2d_common import run_max_pool2d
+from tests.sweep_framework.sweeps.max_pool2d.short.max_pool2d_short_sweep import parameters as parameters_ttnn_pytorch
+
+from models.utility_functions import skip_for_grayskull
+
+import pytest
+import ttnn
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("input_spec", parameters_ttnn_pytorch["max_pool2d_short_sweep_suite"]["input_specs"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_ttnn_pytorch_sweep(device, dtype, input_spec):
+    (
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ceil_mode,
+    ) = input_spec
+    run_max_pool2d(
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        dtype,
+        device,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode,
+    )


### PR DESCRIPTION
Add ttnn-pytorch and ttnn-forge sweeps to nightly CI in order to prevent regressions.

### Checklist
- [x] [ tt-metal l2 nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/13413470602/job/37468974612)