### PR TITLE
cleanup packet header validation in EDM fabric

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
@@ -26,13 +26,15 @@ enum NocSendType : uint8_t {
     NOC_UNICAST_INLINE_WRITE = 1,
     NOC_MULTICAST_WRITE = 2,
     NOC_UNICAST_ATOMIC_INC = 3,
-    NOC_MULTICAST_ATOMIC_INC = 4
+    NOC_MULTICAST_ATOMIC_INC = 4,
+    NOC_SEND_TYPE_LAST = NOC_MULTICAST_ATOMIC_INC
 };
 // How to send the payload across the cluster
 // 1 bit
 enum ChipSendType : uint8_t {
     CHIP_UNICAST = 0,
     CHIP_MULTICAST = 1,
+    CHIP_SEND_TYPE_LAST = CHIP_MULTICAST
 };
 
 struct RoutingFields {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp
@@ -9,9 +9,11 @@
 
 namespace tt::fabric {
 
-FORCE_INLINE void validate(const PacketHeader& packet_header) { ASSERT(packet_header.chip_send_type < 2); }
+FORCE_INLINE void validate(const PacketHeader& packet_header) {
+    ASSERT(packet_header.chip_send_type <= CHIP_SEND_TYPE_LAST);
+}
 FORCE_INLINE bool is_valid(PacketHeader const& packet_header) {
-    return (packet_header.chip_send_type < 2) && (packet_header.noc_send_type < 2);
+    return (packet_header.chip_send_type <= CHIP_SEND_TYPE_LAST) && (packet_header.noc_send_type <= NOC_SEND_TYPE_LAST);
 }
 
 }  // namespace tt::fabric


### PR DESCRIPTION
Some device watcher asserts were made stale due to recent changes. This PR corrects those assertions to be valid again.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13415875260
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13415809496
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
