### PR TITLE
Fix memory usage for repack mixtral script

### DIFF
--- a/models/demos/llama3/scripts/repack_weights.py
+++ b/models/demos/llama3/scripts/repack_weights.py
@@ -30,6 +30,9 @@ def repack_mixtral_weights(ckpt_dir, repack_dir):
         )
     }
 
+    # clear the state dict to lower the memory footprint
+    state_dict.clear()
+
     base_address = "feed_forward."
     for l in range(model_args.n_layers):
         print(f"Updating layer {l}...")

--- a/models/demos/t3000/mixtral8x7b/scripts/repack_weights.py
+++ b/models/demos/t3000/mixtral8x7b/scripts/repack_weights.py
@@ -30,6 +30,9 @@ def repack_mixtral_weights(ckpt_dir, repack_dir):
         )
     }
 
+    # clear the state dict to lower the memory footprint
+    state_dict.clear()
+
     base_address = "feed_forward."
     for l in range(model_args.n_layers):
         print(f"Updating layer {l}...")


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
When running the mixtral weight repacking script, the process was getting killed due to OOM. 

### What's changed
The fix is to release the `state_dict` instance as soon as possible. This allows the script to run to completion and the repacked weights to be loaded.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
