### PR TITLE
Add per-tensor quantization op to ttnn

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_quantization.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random, skip_for_grayskull
+
+
+# Quantize to the [q_min, q_max] range (scale-then-shift)
+#   Quant:   q = t / s + z
+#   Dequant: t = (q - z) * s
+def calculate_scale_zero_point(torch_input_tensor, q_min, q_max):
+    i_min = torch.min(torch_input_tensor).item()
+    i_max = torch.max(torch_input_tensor).item()
+
+    scale = (i_max - i_min) / (q_max - q_min)
+    zero_point = q_min - int(i_min / scale)
+
+    return (scale, zero_point)
+
+
+@pytest.mark.parametrize("n", [16, 31, 63, 128, 65536])
+def test_quantize_1d(device, n):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(n, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+
+    torch_quantized_tensor = torch.quantize_per_tensor(torch_input_tensor, scale, zero_point, dtype=torch.qint32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    output_tensor = ttnn.to_torch(quantized_tensor)
+
+    assert_with_pcc(torch_quantized_tensor.int_repr(), output_tensor)
+
+
+@pytest.mark.parametrize("n", [16, 31, 63, 128, 65536])
+def test_dequantize_1d(device, n):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(n, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+
+    torch_quantized_tensor = torch.quantize_per_tensor(torch_input_tensor, scale, zero_point, dtype=torch.qint32)
+    torch_dequantized_tensor = torch.dequantize(torch_quantized_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    dequantized_tensor = ttnn.dequantize(quantized_tensor, scale, zero_point)
+    output_tensor = ttnn.to_torch(dequantized_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)
+    assert_with_pcc(torch_dequantized_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("n", [16, 41, 37, 128, 65536])
+def test_requantize_1d(device, n):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(n, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+    scale_new, zero_point_new = calculate_scale_zero_point(torch_input_tensor, -37, 73)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    requantized_tensor = ttnn.requantize(quantized_tensor, scale, zero_point, scale_new, zero_point_new)
+    dequantized_tensor = ttnn.dequantize(requantized_tensor, scale_new, zero_point_new)
+    output_tensor = ttnn.to_torch(dequantized_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("h", [16, 41, 37, 128])
+@pytest.mark.parametrize("w", [16, 31, 63, 128])
+def test_quantize_2d(device, h, w):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(h, w, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+
+    torch_quantized_tensor = torch.quantize_per_tensor(torch_input_tensor, scale, zero_point, dtype=torch.qint32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    output_tensor = ttnn.to_torch(quantized_tensor)
+
+    assert_with_pcc(torch_quantized_tensor.int_repr(), output_tensor)
+
+
+@pytest.mark.parametrize("h", [16, 41, 37, 128])
+@pytest.mark.parametrize("w", [16, 31, 63, 128])
+def test_dequantize_2d(device, h, w):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(h, w, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+
+    torch_quantized_tensor = torch.quantize_per_tensor(torch_input_tensor, scale, zero_point, dtype=torch.qint32)
+    torch_dequantized_tensor = torch.dequantize(torch_quantized_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    dequantized_tensor = ttnn.dequantize(quantized_tensor, scale, zero_point)
+    output_tensor = ttnn.to_torch(dequantized_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)
+    assert_with_pcc(torch_dequantized_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("h", [16, 41, 37, 128])
+@pytest.mark.parametrize("w", [16, 31, 63, 128])
+def test_requantize_2d(device, h, w):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(h, w, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+    scale_new, zero_point_new = calculate_scale_zero_point(torch_input_tensor, -37, 73)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    requantized_tensor = ttnn.requantize(quantized_tensor, scale, zero_point, scale_new, zero_point_new)
+    dequantized_tensor = ttnn.dequantize(requantized_tensor, scale_new, zero_point_new)
+    output_tensor = ttnn.to_torch(dequantized_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("x0", [128])
+@pytest.mark.parametrize("x1", [17])
+@pytest.mark.parametrize("x2", [3])
+@pytest.mark.parametrize("x3", [64])
+def test_quantize_4d(device, x0, x1, x2, x3):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(x0, x1, x2, x3, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+
+    torch_quantized_tensor = torch.quantize_per_tensor(torch_input_tensor, scale, zero_point, dtype=torch.qint32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    output_tensor = ttnn.to_torch(quantized_tensor)
+
+    assert_with_pcc(torch_quantized_tensor.int_repr(), output_tensor)
+
+
+@pytest.mark.parametrize("x0", [128])
+@pytest.mark.parametrize("x1", [17])
+@pytest.mark.parametrize("x2", [3])
+@pytest.mark.parametrize("x3", [64])
+def test_dequantize_4d(device, x0, x1, x2, x3):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(x0, x1, x2, x3, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+
+    torch_quantized_tensor = torch.quantize_per_tensor(torch_input_tensor, scale, zero_point, dtype=torch.qint32)
+    torch_dequantized_tensor = torch.dequantize(torch_quantized_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    dequantized_tensor = ttnn.dequantize(quantized_tensor, scale, zero_point)
+    output_tensor = ttnn.to_torch(dequantized_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)
+    assert_with_pcc(torch_dequantized_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("x0", [128])
+@pytest.mark.parametrize("x1", [17])
+@pytest.mark.parametrize("x2", [3])
+@pytest.mark.parametrize("x3", [64])
+def test_requantize_4d(device, x0, x1, x2, x3):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(x0, x1, x2, x3, dtype=torch.float32)
+    scale, zero_point = calculate_scale_zero_point(torch_input_tensor, -128, 127)
+    scale_new, zero_point_new = calculate_scale_zero_point(torch_input_tensor, -37, 73)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    quantized_tensor = ttnn.quantize(input_tensor, scale, zero_point)
+    requantized_tensor = ttnn.requantize(quantized_tensor, scale, zero_point, scale_new, zero_point_new)
+    dequantized_tensor = ttnn.dequantize(requantized_tensor, scale_new, zero_point_new)
+    output_tensor = ttnn.to_torch(dequantized_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)

--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,6 +39,7 @@
 #include <ttnn/operations/eltwise/binary/binary.hpp>                                               // NOLINT
 #include <ttnn/operations/eltwise/binary_backward/binary_backward.hpp>                             // NOLINT
 #include <ttnn/operations/eltwise/binary_ng/binary_ng.hpp>                                         // NOLINT
+#include <ttnn/operations/eltwise/quantization/quantization.hpp>                                   // NOLINT
 #include <ttnn/operations/eltwise/unary/unary.hpp>                                                 // NOLINT
 #include <ttnn/operations/eltwise/unary/unary_composite.hpp>                                       // NOLINT
 #include <ttnn/operations/eltwise/unary_backward/unary_backward.hpp>                               // NOLINT

--- a/tt_metal/include/compute_kernel_api/quantization.h
+++ b/tt_metal/include/compute_kernel_api/quantization.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_quant.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise per-tensor affine quantization operation on the first operand using the scaling factor in the second operand.
+ * Output overwrites first operand in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void quant_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_quant_int32<APPROX>(idst0, idst1)));
+}
+
+ALWI void requant_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_requant_int32<APPROX>(idst0, idst1)));
+}
+
+ALWI void dequant_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_dequant_int32<APPROX>(idst0, idst1)));
+}
+
+// clang-format off
+/**
+ * Initialize the sfpu with the zero point argument of the quantization Op.
+ * To be called once at beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Argument   | Description                           | Data type | Valid range | Required |
+ * |------------|---------------------------------------|-----------|-------------|----------|
+ * | zero_point | The zero point of the quantization Op | uint32_t  | Any number  | Yes      |
+ * */
+// clang-format on
+ALWI void quant_tile_init(const uint32_t zero_point) {
+    MATH((llk_math_eltwise_binary_sfpu_quant_int32_init<APPROX>(zero_point)));
+}
+ALWI void requant_tile_init(const uint32_t zero_point) {
+    MATH((llk_math_eltwise_binary_sfpu_requant_int32_init<APPROX>(zero_point)));
+}
+ALWI void dequant_tile_init(const uint32_t zero_point) {
+    MATH((llk_math_eltwise_binary_sfpu_dequant_int32_init<APPROX>(zero_point)));
+}
+
+}  // namespace ckernel

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -379,6 +379,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -754,6 +755,7 @@ set(TTNN_SUBLIBRARIES
     ttnn/operations/eltwise/complex_binary
     ttnn/operations/eltwise/complex_unary
     ttnn/operations/eltwise/complex_unary_backward
+    ttnn/operations/eltwise/quantization
     ttnn/operations/eltwise/ternary
     ttnn/operations/eltwise/ternary_backward
     ttnn/operations/eltwise/unary
@@ -849,6 +851,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/view/view_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/examples_pybind.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,6 +22,7 @@
 #include "ttnn/operations/eltwise/complex/complex_pybind.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary_pybind.hpp"
 #include "ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp"
+#include "ttnn/operations/eltwise/quantization/quantization_pybind.hpp"
 #include "ttnn/operations/eltwise/ternary/ternary_pybind.hpp"
 #include "ttnn/operations/eltwise/ternary_backward/ternary_backward_pybind.hpp"
 #include "ttnn/operations/eltwise/unary/unary_pybind.hpp"
@@ -75,6 +76,9 @@ void py_module(py::module& module) {
 
     auto m_binary_ng = module.def_submodule("binary_ng", "binary_ng operations");
     binary_ng::py_module(m_binary_ng);
+
+    auto m_quantization = module.def_submodule("quantization", "quantization operations");
+    quantization::py_module(m_quantization);
 
     auto m_ternary = module.def_submodule("ternary", "ternary operations");
     ternary::py_module(m_ternary);

--- a/ttnn/cpp/ttnn/operations/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/copy.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/copy.hpp
@@ -66,9 +66,6 @@ struct Typecast {
                 queue_id, input, output_dtype, memory_config_arg, optional_output_tensor);
         }
         DataType input_dtype = input.get_dtype();
-        if (input_dtype == output_dtype) {
-            return input;
-        }
         return detail::copy_impl(
             queue_id,
             input,
@@ -103,9 +100,6 @@ struct Typecast {
             TT_FATAL(
                 tt_output_dtype == optional_output_tensor.value().get_dtype(),
                 "If both output dtype and output tensor provided dtype should match");
-        }
-        if (tt_input_dtype == tt_output_dtype) {
-            return input_tensor;
         }
         return detail::copy_impl(
             queue_id,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,12 +6,11 @@
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/decorators.hpp"
 #include "device/transpose_op.hpp"
+#include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "cpp/ttnn/operations/copy.hpp"
-#include "cpp/ttnn/operations/data_movement/pad/pad.hpp"
-#include "cpp/ttnn/operations/data_movement/slice/slice.hpp"
 
 #include <tt-metalium/hal_exp.hpp>
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -77,8 +77,8 @@ Tensor BinaryNg<binary_op_type>::invoke(
 
         return result;
     } else {
-        Tensor input_a = ttnn::typecast(input_tensor_a, DataType::BFLOAT16);
-        Tensor input_b = ttnn::typecast(input_tensor_a, DataType::BFLOAT16);
+        Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
+        Tensor input_b = typecast_to(DataType::BFLOAT16, input_tensor_b);
         const auto output_tensor = output_preallocated and typecast_out
                                        ? ttnn::typecast(*optional_output_tensor, DataType::BFLOAT16)
                                        : optional_output_tensor;
@@ -157,7 +157,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
         }
         return result;
     } else {
-        Tensor input_a = ttnn::typecast(input_tensor_a, DataType::BFLOAT16);
+        Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
         const auto output_tensor = output_preallocated and typecast_out
                                        ? ttnn::typecast(*optional_output_tensor, DataType::BFLOAT16)
                                        : optional_output_tensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -4,7 +4,16 @@
 
 #include "binary_ng.hpp"
 #include "device/binary_ng_device_operation.hpp"
+#include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/core/core.hpp"
+
+ttnn::Tensor typecast_to(ttnn::DataType dtype, const ttnn::Tensor& input) {
+    return input.get_dtype() == dtype ? input : ttnn::typecast(input, dtype);
+}
+
+bool needs_typecast_to_bfloat16(const ttnn::DataType input) {
+    return (input == ttnn::DataType::BFLOAT8_B || input == ttnn::DataType::BFLOAT4_B);
+}
 
 namespace ttnn::operations::binary_ng {
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -9,6 +9,10 @@
 #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
+inline ttnn::Tensor typecast_to(ttnn::DataType dtype, const ttnn::Tensor& input) {
+    return input.get_dtype() == dtype ? input : ttnn::typecast(input, dtype);
+}
+
 inline bool needs_typecast_to_bfloat16(const ttnn::DataType input) {
     return (input == ttnn::DataType::BFLOAT8_B || input == ttnn::DataType::BFLOAT4_B);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -6,16 +6,10 @@
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/eltwise/binary_ng/types.hpp"
-#include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
-inline ttnn::Tensor typecast_to(ttnn::DataType dtype, const ttnn::Tensor& input) {
-    return input.get_dtype() == dtype ? input : ttnn::typecast(input, dtype);
-}
-
-inline bool needs_typecast_to_bfloat16(const ttnn::DataType input) {
-    return (input == ttnn::DataType::BFLOAT8_B || input == ttnn::DataType::BFLOAT4_B);
-}
+ttnn::Tensor typecast_to(ttnn::DataType dtype, const ttnn::Tensor& input);
+bool needs_typecast_to_bfloat16(const ttnn::DataType input);
 
 namespace ttnn::operations::binary_ng {
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -1,5 +1,4 @@
-
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +8,10 @@
 #include "ttnn/operations/eltwise/binary_ng/types.hpp"
 #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+inline bool needs_typecast_to_bfloat16(const ttnn::DataType input) {
+    return (input == ttnn::DataType::BFLOAT8_B || input == ttnn::DataType::BFLOAT4_B);
+}
 
 namespace ttnn::operations::binary_ng {
 
@@ -26,27 +29,7 @@ struct BinaryNg {
         tt::stl::Span<const unary::UnaryWithParam> post_activations = {});
 
     static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        const std::optional<const DataType>& output_dtype = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {});
-
-    static Tensor invoke(
         QueueId queue_id,
-        const Tensor& input_tensor_a,
-        float scalar,
-        const std::optional<const DataType>& output_dtype = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {});
-
-    static Tensor invoke(
         const Tensor& input_tensor_a,
         float scalar,
         const std::optional<const DataType>& output_dtype = std::nullopt,
@@ -67,19 +50,7 @@ struct BinaryNgBitwise {
         std::optional<Tensor> optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt);
-
-    static Tensor invoke(
         QueueId queue_id,
-        const Tensor& input_tensor_a,
-        float scalar,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt);
-
-    static Tensor invoke(
         const Tensor& input_tensor_a,
         float scalar,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
@@ -97,21 +68,7 @@ struct InplaceBinaryNg {
         tt::stl::Span<const unary::UnaryWithParam> post_activations = {});
 
     static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {});
-
-    static Tensor invoke(
         QueueId queue_id,
-        const Tensor& input_tensor,
-        float scalar,
-        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
-        tt::stl::Span<const unary::UnaryWithParam> post_activations = {});
-
-    static Tensor invoke(
         const Tensor& input_tensor,
         float scalar,
         tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -37,6 +37,9 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case BITWISE_XOR:
         case BITWISE_AND:
         case BITWISE_OR: return (a == INT32 && b == INT32);
+        case QUANT:
+        case REQUANT:
+        case DEQUANT:
         case POWER: return true;
         default: return false;
     }
@@ -103,11 +106,16 @@ SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint
 }
 
 tt::stl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
+    // TODO: a more generalized way to skip the hashing of an UnaryWithParam?
+    // Don't hash the quantization scale, otherwise we build the kernel for each different scale
+    const bool is_quant_op = (binary_op_type == BinaryOpType::QUANT) or (binary_op_type == BinaryOpType::DEQUANT) or
+                             (binary_op_type == BinaryOpType::REQUANT);
+
     return tt::stl::hash::hash_objects_with_default_seed(
         binary_op_type,
         lhs_activations,
         rhs_activations,
-        post_activations,
+        is_quant_op ? ttnn::SmallVector<unary::UnaryWithParam>{} : post_activations,
         memory_config,
         get_dtype(),
         compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -293,6 +293,17 @@ void set_or_update_runtime_arguments(
             cWt};
         handle_args(program, reader_kernel_id, core, reader_runtime_args);
 
+        const bool is_quant_op = (operation_attributes.binary_op_type == BinaryOpType::QUANT) or
+                                 (operation_attributes.binary_op_type == BinaryOpType::REQUANT) or
+                                 (operation_attributes.binary_op_type == BinaryOpType::DEQUANT);
+        TT_FATAL(
+            is_quant_op == ((operation_attributes.post_activations.size() == 1) and
+                            (operation_attributes.post_activations[0].op_type ==
+                             ttnn::operations::unary::UnaryOpType::ZERO_POINT)),
+            "Quantization op needs to exactly one zero-point value as a post activation");
+        const uint32_t quantization_zero_point =
+            is_quant_op ? std::bit_cast<uint32_t>(operation_attributes.post_activations[0].params[0]) : 0u;
+
         if (b.has_value()) {
             if (has_sharding) {
                 auto b_shard_shape = b_shard_shape_generator(core);
@@ -315,14 +326,20 @@ void set_or_update_runtime_arguments(
 
             auto [freq, counter] =
                 calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
-            std::array compute_runtime_args = {c_num_tiles, freq, counter};
+            std::array compute_runtime_args = {c_num_tiles, freq, counter, quantization_zero_point};
             handle_args(program, compute_kernel_id, core, compute_runtime_args);
         } else {
             const auto scalar = *operation_attributes.scalar;
-            const auto packed_scalar = a.get_dtype() == DataType::FLOAT32 ? std::bit_cast<uint32_t>(scalar)
-                                       : a.get_dtype() == DataType::INT32
-                                           ? std::bit_cast<uint32_t>(static_cast<int32_t>(scalar))
-                                           : pack_two_bfloat16_into_uint32({scalar, scalar});
+            // TODO: extract this to a seperate function?
+            const auto packed_scalar = [=](const DataType dtype) {
+                if (dtype == DataType::FLOAT32) {
+                    return std::bit_cast<uint32_t>(scalar);
+                } else if (dtype != DataType::INT32 or is_quant_op) {
+                    return pack_two_bfloat16_into_uint32({scalar, scalar});
+                } else {
+                    return std::bit_cast<uint32_t>(static_cast<int32_t>(scalar));
+                }
+            }(a.get_dtype());
             std::array writer_runtime_args = {
                 packed_scalar,
                 c.buffer()->address(),
@@ -338,7 +355,7 @@ void set_or_update_runtime_arguments(
                 0u};
             handle_args(program, writer_kernel_id, core, writer_runtime_args);
 
-            std::array compute_runtime_args = {c_num_tiles, 0u, 0u};
+            std::array compute_runtime_args = {c_num_tiles, 0u, 0u, quantization_zero_point};
             handle_args(program, compute_kernel_id, core, compute_runtime_args);
         }
 
@@ -418,11 +435,18 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         add_activation_defines(compute_kernel_defines, lhs_activations, "LHS");
         add_activation_defines(compute_kernel_defines, rhs_activations, "RHS");
 
-        if (lhs_activations.empty() and rhs_activations.empty() and post_activations.size() == 1 and
-            post_activations[0].op_type == unary::UnaryOpType::RELU) {
-            compute_kernel_defines["PACK_RELU"] = "1";
+        if (lhs_activations.empty() and rhs_activations.empty() and post_activations.size() == 1) {
             compute_kernel_defines["PROCESS_POST_ACTIVATIONS(i)"] = "";
-            unary::utils::update_macro_defines(unary::UnaryOpType::RELU, compute_kernel_defines);
+            if (post_activations[0].op_type == unary::UnaryOpType::RELU) {
+                compute_kernel_defines["PACK_RELU"] = "1";
+                unary::utils::update_macro_defines(unary::UnaryOpType::RELU, compute_kernel_defines);
+            } else if (post_activations[0].op_type == unary::UnaryOpType::ZERO_POINT) {
+                // Zero-point is passed as the 4th run-time kernel argument
+                compute_kernel_defines["QUANT_ZERO_POINT_RT_ARGS_IDX"] = "3";
+                unary::utils::update_macro_defines(unary::UnaryOpType::ZERO_POINT, compute_kernel_defines);
+            } else {
+                add_activation_defines(compute_kernel_defines, post_activations, "POST");
+            }
         } else {
             add_activation_defines(compute_kernel_defines, post_activations, "POST");
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -244,6 +244,27 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>) : b
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::QUANT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::QUANT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::REQUANT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::REQUANT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::DEQUANT:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::DEQUANT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         default: TT_THROW("Unsupported binary op {}", binary_op_type);
     }
 }
@@ -267,6 +288,11 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case BITWISE_AND: return {"binary_bitwise_tile_init();", "and_binary_tile"};
         case BITWISE_OR: return {"binary_bitwise_tile_init();", "or_binary_tile"};
         case BITWISE_XOR: return {"binary_bitwise_tile_init();", "xor_binary_tile"};
+        case QUANT: return {"quant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "quant_tile"};
+        case REQUANT:
+            return {"requant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "requant_tile"};
+        case DEQUANT:
+            return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -333,6 +333,16 @@ void add_activation_defines(
 
 bool OpConfig::is_sfpu_op() const { return std::holds_alternative<SfpuBinaryOp>(binary_op); }
 
+uint32_t pack_scalar_runtime_arg(const float scalar, const DataType dtype, const bool is_quant_op) {
+    if (dtype == DataType::FLOAT32) {
+        return std::bit_cast<uint32_t>(scalar);
+    } else if ((dtype != DataType::INT32) || is_quant_op) {
+        return pack_two_bfloat16_into_uint32({scalar, scalar});
+    } else {
+        return std::bit_cast<uint32_t>(static_cast<int32_t>(scalar));
+    }
+}
+
 template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<FpuBinaryOp>);
 template OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<SfpuBinaryOp>);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -77,4 +77,6 @@ void add_activation_defines(
     tt::stl::Span<const unary::UnaryWithParam> activations,
     std::string_view operand);
 
+uint32_t pack_scalar_runtime_arg(const float scalar, const DataType dtype, const bool is_quant_op);
+
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -54,7 +54,10 @@ struct OpConfig {
         RIGHT_SHIFT,
         BITWISE_AND,
         BITWISE_OR,
-        BITWISE_XOR
+        BITWISE_XOR,
+        QUANT,
+        REQUANT,
+        DEQUANT
     };
 
     template <class EnumT>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -11,6 +11,7 @@
 #include "compute_kernel_api/binary_bitwise_sfpu.h"
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
+#include "compute_kernel_api/quantization.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -11,6 +11,7 @@
 #include "compute_kernel_api/binary_bitwise_sfpu.h"
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
+#include "compute_kernel_api/quantization.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -11,6 +11,7 @@
 #include "compute_kernel_api/binary_bitwise_sfpu.h"
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
+#include "compute_kernel_api/quantization.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +31,9 @@ enum class BinaryOpType {
     BITWISE_AND,
     BITWISE_OR,
     LEFT_SHIFT,
-    RIGHT_SHIFT
+    RIGHT_SHIFT,
+    QUANT,
+    REQUANT,
+    DEQUANT
 };
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -19,7 +19,7 @@ Tensor QuantOp::invoke(
     std::optional<Tensor> optional_output_tensor) {
     const ttnn::DataType a_dtype = input_tensor.get_dtype();
     const bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
-    Tensor input_a = typecast_a ? ttnn::typecast(input_tensor, DataType::BFLOAT16) : input_tensor;
+    Tensor input_a = typecast_a ? typecast_to(DataType::BFLOAT16, input_tensor) : input_tensor;
 
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations{};
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations{};
@@ -54,7 +54,7 @@ Tensor RequantOp::invoke(
     std::optional<Tensor> optional_output_tensor) {
     const ttnn::DataType a_dtype = input_tensor.get_dtype();
     const bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
-    Tensor input_a = typecast_a ? ttnn::typecast(input_tensor, DataType::BFLOAT16) : input_tensor;
+    Tensor input_a = typecast_a ? typecast_to(DataType::BFLOAT16, input_tensor) : input_tensor;
 
     // Expansion of q' = [(q - z_in) * s_in] / s_out + z_out
     const float scale = in_scale / out_scale;
@@ -90,7 +90,7 @@ Tensor DequantOp::invoke(
     std::optional<Tensor> optional_output_tensor) {
     const ttnn::DataType a_dtype = input_tensor.get_dtype();
     const bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
-    Tensor input_a = typecast_a ? ttnn::typecast(input_tensor, DataType::BFLOAT16) : input_tensor;
+    Tensor input_a = typecast_a ? typecast_to(DataType::BFLOAT16, input_tensor) : input_tensor;
 
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations{};
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations{};

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "quantization.hpp"
+#include "ttnn/operations/eltwise/binary_ng/binary_ng.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp"
+
+namespace ttnn::operations::quantization {
+
+Tensor QuantOp::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float scale,
+    const int32_t zero_point,
+    const std::optional<int32_t> axis,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    const ttnn::DataType a_dtype = input_tensor.get_dtype();
+    const bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
+    Tensor input_a = typecast_a ? ttnn::typecast(input_tensor, DataType::BFLOAT16) : input_tensor;
+
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations{};
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations{};
+
+    std::array<const ttnn::operations::unary::UnaryWithParam, 1> post_activations{
+        ttnn::operations::unary::UnaryWithParam{unary::UnaryOpType::ZERO_POINT, static_cast<float>(zero_point)}};
+
+    // LLK quant kernel expects the reciprocal of the actual scale to avoid doing div on the device
+    return ttnn::prim::binary_ng(
+        queue_id,
+        input_a,
+        1.0f / scale,
+        binary_ng::BinaryOpType::QUANT,
+        output_dtype.value_or(DataType::INT32),
+        memory_config,
+        optional_output_tensor,
+        lhs_activations,
+        rhs_activations,
+        post_activations);
+}
+
+Tensor RequantOp::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float in_scale,
+    const int32_t in_zero_point,
+    const float out_scale,
+    const int32_t out_zero_point,
+    const std::optional<int32_t> axis,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    const ttnn::DataType a_dtype = input_tensor.get_dtype();
+    const bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
+    Tensor input_a = typecast_a ? ttnn::typecast(input_tensor, DataType::BFLOAT16) : input_tensor;
+
+    // Expansion of q' = [(q - z_in) * s_in] / s_out + z_out
+    const float scale = in_scale / out_scale;
+    const int32_t zero_point = out_zero_point - scale * in_zero_point;
+
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations{};
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations{};
+
+    std::array<const ttnn::operations::unary::UnaryWithParam, 1> post_activations{
+        ttnn::operations::unary::UnaryWithParam{unary::UnaryOpType::ZERO_POINT, static_cast<float>(zero_point)}};
+
+    return ttnn::prim::binary_ng(
+        queue_id,
+        input_a,
+        scale,
+        binary_ng::BinaryOpType::REQUANT,
+        output_dtype.value_or(DataType::INT32),
+        memory_config,
+        optional_output_tensor,
+        lhs_activations,
+        rhs_activations,
+        post_activations);
+}
+
+Tensor DequantOp::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const float scale,
+    const int32_t zero_point,
+    const std::optional<int32_t> axis,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    const ttnn::DataType a_dtype = input_tensor.get_dtype();
+    const bool typecast_a = needs_typecast_to_bfloat16(a_dtype);
+    Tensor input_a = typecast_a ? ttnn::typecast(input_tensor, DataType::BFLOAT16) : input_tensor;
+
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations{};
+    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations{};
+
+    // LLK dequant kernel does addition, so we need to negate zero_point
+    std::array<const ttnn::operations::unary::UnaryWithParam, 1> post_activations{
+        ttnn::operations::unary::UnaryWithParam{unary::UnaryOpType::ZERO_POINT, static_cast<float>(-zero_point)}};
+
+    return ttnn::prim::binary_ng(
+        queue_id,
+        input_a,
+        scale,
+        binary_ng::BinaryOpType::DEQUANT,
+        output_dtype.value_or(DataType::BFLOAT16),
+        memory_config,
+        optional_output_tensor,
+        lhs_activations,
+        rhs_activations,
+        post_activations);
+}
+
+}  // namespace ttnn::operations::quantization

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.hpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <reflect>
+#include "ttnn/decorators.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::quantization {
+
+struct QuantOp {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const float scale,
+        const int32_t zero_point,
+        const std::optional<int32_t> axis,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+};
+
+struct RequantOp {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const float in_scale,
+        const int32_t in_zero_point,
+        const float out_scale,
+        const int32_t out_zero_point,
+        const std::optional<int32_t> axis,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+};
+
+struct DequantOp {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const float scale,
+        const int32_t zero_point,
+        const std::optional<int32_t> axis,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+};
+
+}  // namespace ttnn::operations::quantization
+
+namespace ttnn {
+constexpr auto quantize =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::quantize", operations::quantization::QuantOp>();
+constexpr auto requantize =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::requantize", operations::quantization::RequantOp>();
+constexpr auto dequantize =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::dequantize", operations::quantization::DequantOp>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.cpp
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pybind11/decorators.hpp"
+
+#include "quantization_pybind.hpp"
+#include "quantization.hpp"
+
+#include <string>
+
+namespace ttnn::operations::quantization {
+namespace detail {
+
+template <typename T>
+void bind_quantize_operation(
+    py::module& module,
+    const T& operation,
+    const std::string& description,
+    const std::string& supported_dtype = "BFLOAT16") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            scale (Number): the quantization scale.
+            zero_point (Number): the quantization zero point.
+
+        Keyword Args:
+            axis (Number, optional): the axis of the quantization dimension of the input tensor.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {3}
+                 - TILE
+                 - 2, 3, 4
+
+            bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
+
+        Example:
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[0.1, 0.2], [0.3, 0.4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> scale = 0.001173
+            >>> zero_point = -213
+            >>> output = {1}(input_tensor, scale, zero_point)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        supported_dtype);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const T& self,
+               const ttnn::Tensor& input_tensor,
+               const float scale,
+               const int32_t zero_point,
+               const std::optional<int32_t> axis,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(queue_id, input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg("scale"),
+            py::arg("zero_point"),
+            py::kw_only(),
+            py::arg("axis") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+template <typename T>
+void bind_requantize_operation(
+    py::module& module,
+    const T& operation,
+    const std::string& description,
+    const std::string& supported_dtype = "BFLOAT16") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            in_scale (Number): the input quantization scale.
+            in_zero_point (Number): the input quantization zero point.
+            out_scale (Number): the output quantization scale.
+            out_zero_point (Number): the output quantization zero point.
+
+        Keyword Args:
+            axis (Number, optional): the axis of the quantization dimension of the input tensor.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {3}
+                 - TILE
+                 - 2, 3, 4
+
+            bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
+
+        Example:
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[0.1, 0.2], [0.3, 0.4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> in_scale = 0.001173
+            >>> in_zero_point = -213
+            >>> out_scale = 0.002727
+            >>> out_zero_point = -73
+            >>> output = {1}(input_tensor, in_scale, in_zero_point, out_scale, out_zero_point)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        supported_dtype);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const T& self,
+               const ttnn::Tensor& input_tensor,
+               const float in_scale,
+               const int32_t in_zero_point,
+               const float out_scale,
+               const int32_t out_zero_point,
+               const std::optional<int32_t> axis,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    in_scale,
+                    in_zero_point,
+                    out_scale,
+                    out_zero_point,
+                    axis,
+                    dtype,
+                    memory_config,
+                    output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg("in_scale"),
+            py::arg("in_zero_point"),
+            py::arg("out_scale"),
+            py::arg("out_zero_point"),
+            py::kw_only(),
+            py::arg("axis") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+template <typename T>
+void bind_dequantize_operation(
+    py::module& module,
+    const T& operation,
+    const std::string& description,
+    const std::string& supported_dtype = "BFLOAT16") {
+    auto doc = fmt::format(
+        R"doc(
+        {2}
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            scale (Number): the quantization scale.
+            zero_point (Number): the quantization zero point.
+
+        Keyword Args:
+            axis (Number, optional): the axis of the quantization dimension of the input tensor.
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - {3}
+                 - TILE
+                 - 2, 3, 4
+
+            bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
+
+        Example:
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[-127 -42], [43 127]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> scale = 0.001173
+            >>> zero_point = -213
+            >>> output = {1}(input_tensor, scale, zero_point)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description,
+        supported_dtype);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const T& self,
+               const ttnn::Tensor& input_tensor,
+               const float scale,
+               const int32_t zero_point,
+               const std::optional<int32_t> axis,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(queue_id, input_tensor, scale, zero_point, axis, dtype, memory_config, output_tensor);
+            },
+            py::arg("input_tensor"),
+            py::arg("scale"),
+            py::arg("zero_point"),
+            py::kw_only(),
+            py::arg("axis") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+}  // namespace detail
+
+void py_module(py::module& module) {
+    detail::bind_quantize_operation(module, ttnn::quantize, "Quantize Operation");
+    detail::bind_requantize_operation(module, ttnn::requantize, "Re-quantize Operation");
+    detail::bind_dequantize_operation(module, ttnn::dequantize, "De-quantize Operation");
+}
+}  // namespace ttnn::operations::quantization

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization_pybind.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind_fwd.hpp>
+
+namespace ttnn::operations::quantization {
+
+namespace py = pybind11;
+
+void py_module(py::module& module);
+
+}  // namespace ttnn::operations::quantization

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -90,6 +90,7 @@ enum class UnaryOpType {
     DROPOUT,
     FILL,
     PRELU_SFPU,
+    ZERO_POINT
 };
 
 struct UnaryWithParam {


### PR DESCRIPTION
### Ticket
#15934

### Description
This PR implements simple per-tensor affine quantize/dequantize/requantize ops for ttnn. The semantics of the API aligns with the PyTorch equivalent (in terms of how `scale` & `zero-point` are defined).

Currently the operations convert tensors between bf16 and i32 (instead of i8/u8) due to limitations in LLK and metal, this will be addressed in the future. Per-channel quantizaiton is also planned as future work.

Also did some header inclusion cleanups and removing redundant overloads for `DefaultQueueId`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
