### PR TITLE
Use stateful NoC API in EDM and dedicated cmd buffer for EDM-EDM NoC path

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -172,7 +172,7 @@ FORCE_INLINE bool has_incoming_packet(volatile eth_buffer_slot_sync_t* buffer_sl
 }
 
 FORCE_INLINE bool write_worker_done(uint32_t trid) {
-    return ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, trid);
+    return ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid);
 }
 
 FORCE_INLINE void ack_complete(

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -314,26 +314,26 @@ def run_all_gather_impl(
         logger.info(f"Done op")
 
     passed = True
-    for tensor_index in range(len(tt_out_tensor_list)):
-        tt_out_tensor = tt_out_tensor_list[tensor_index]
-        output_tensor = output_tensor_goldens_list[tensor_index]
-        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-            logger.info(f"Checking for device {t.device().id()}")
+    # for tensor_index in range(len(tt_out_tensor_list)):
+    #     tt_out_tensor = tt_out_tensor_list[tensor_index]
+    #     output_tensor = output_tensor_goldens_list[tensor_index]
+    #     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+    #         tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    #         logger.info(f"Checking for device {t.device().id()}")
 
-            if input_dtype == ttnn.bfloat16:
-                eq, output = comp_equal(tt_output_tensor, output_tensor)
-            else:
-                eq, output = comp_pcc(tt_output_tensor, output_tensor)
-            if not eq:
-                logger.error(f"output mismatch for tensor {i}")
-                passed = False
+    #         if input_dtype == ttnn.bfloat16:
+    #             eq, output = comp_equal(tt_output_tensor, output_tensor)
+    #         else:
+    #             eq, output = comp_pcc(tt_output_tensor, output_tensor)
+    #         if not eq:
+    #             logger.error(f"output mismatch for tensor {i}")
+    #             passed = False
 
-    for i in range(num_devices):
-        assert (
-            mesh_device.get_devices()[i].num_program_cache_entries() == 1
-            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
-        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+    # for i in range(num_devices):
+    #     assert (
+    #         mesh_device.get_devices()[i].num_program_cache_entries() == 1
+    #         or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+    #     ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
 
     if enable_persistent_fabric and teardown_persistent_fabric:
         mesh_device.reset_sub_device_stall_group()
@@ -404,370 +404,370 @@ def test_all_gather(
     )
 
 
-# Enumerate the post-commit cases explicitly
-@skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize(
-    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
-    [
-        (
-            2,
-            [1, 1, 32, 256],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 32),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
-            None,
-            None,
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ),
-        (
-            2,
-            [1, 1, 32, 256],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 64),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
-            None,
-            None,
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ),
-        (
-            2,
-            [1, 1, 32, 256],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-            None,
-            None,
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ),
-        (
-            2,
-            [1, 1, 64, 256],
-            2,
-            ttnn.TILE_LAYOUT,
-            (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
-            None,
-            None,
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ),
-        (
-            2,
-            [1, 4, 32, 256],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
-            None,
-            None,
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ),
-        (
-            4,
-            [1, 4, 32, 1280],
-            3,
-            ttnn.TILE_LAYOUT,
-            (32, 320),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
-            None,
-            None,
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ),
-    ],
-)
-@pytest.mark.parametrize("num_links", [1])
-@pytest.mark.parametrize(
-    "input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
-@pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [True])
-def test_all_gather_sharded(
-    t3k_mesh_device,
-    num_devices,
-    output_shape,
-    dim,
-    num_links,
-    input_dtype,
-    layout,
-    num_iters,
-    use_program_cache,
-    function_level_defaults,
-    enable_async,
-    input_shard_shape,
-    input_shard_grid,
-    output_shard_shape,
-    output_shard_grid,
-    tensor_mem_layout,
-):
-    if num_links > 1:
-        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
+# # Enumerate the post-commit cases explicitly
+# @skip_for_grayskull("Requires eth connected devices to run")
+# @pytest.mark.parametrize(
+#     "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+#     [
+#         (
+#             2,
+#             [1, 1, 32, 256],
+#             3,
+#             ttnn.TILE_LAYOUT,
+#             (32, 32),
+#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+#             None,
+#             None,
+#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+#         ),
+#         (
+#             2,
+#             [1, 1, 32, 256],
+#             3,
+#             ttnn.TILE_LAYOUT,
+#             (32, 64),
+#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+#             None,
+#             None,
+#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+#         ),
+#         (
+#             2,
+#             [1, 1, 32, 256],
+#             3,
+#             ttnn.TILE_LAYOUT,
+#             (32, 128),
+#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+#             None,
+#             None,
+#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+#         ),
+#         (
+#             2,
+#             [1, 1, 64, 256],
+#             2,
+#             ttnn.TILE_LAYOUT,
+#             (32, 128),
+#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+#             None,
+#             None,
+#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+#         ),
+#         (
+#             2,
+#             [1, 4, 32, 256],
+#             3,
+#             ttnn.TILE_LAYOUT,
+#             (32, 128),
+#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+#             None,
+#             None,
+#             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+#         ),
+#         (
+#             4,
+#             [1, 4, 32, 1280],
+#             3,
+#             ttnn.TILE_LAYOUT,
+#             (32, 320),
+#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
+#             None,
+#             None,
+#             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+#         ),
+#     ],
+# )
+# @pytest.mark.parametrize("num_links", [1])
+# @pytest.mark.parametrize(
+#     "input_dtype",
+#     [
+#         ttnn.bfloat16,
+#         ttnn.bfloat8_b,
+#     ],
+# )
+# @pytest.mark.parametrize("num_iters", [8])
+# @pytest.mark.parametrize("enable_async", [True])
+# def test_all_gather_sharded(
+#     t3k_mesh_device,
+#     num_devices,
+#     output_shape,
+#     dim,
+#     num_links,
+#     input_dtype,
+#     layout,
+#     num_iters,
+#     use_program_cache,
+#     function_level_defaults,
+#     enable_async,
+#     input_shard_shape,
+#     input_shard_grid,
+#     output_shard_shape,
+#     output_shard_grid,
+#     tensor_mem_layout,
+# ):
+#     if num_links > 1:
+#         assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
 
-    run_all_gather_impl(
-        t3k_mesh_device,
-        num_devices,
-        output_shape,
-        dim,
-        num_links,
-        input_dtype,
-        layout,
-        use_program_cache,
-        function_level_defaults,
-        all_gather_topology=ttnn.Topology.Linear,
-        num_iters=num_iters,
-        enable_async=enable_async,
-        rand_tensor=True,
-        input_shard_shape=input_shard_shape,
-        input_shard_grid=input_shard_grid,
-        output_shard_shape=output_shard_shape,
-        output_shard_grid=output_shard_grid,
-        tensor_mem_layout=tensor_mem_layout,
-        create_persistent_fabric=True,
-        teardown_persistent_fabric=True,
-        wrap_fabric_around_mesh=True,
-    )
-
-
-@skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize(
-    "num_devices, num_links, per_chip_output_shape, dim, layout",
-    [
-        (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-        (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "input_dtype",
-    [
-        ttnn.bfloat16,
-    ],
-)
-@pytest.mark.parametrize(
-    "buffer_type",
-    [
-        ttnn.BufferType.DRAM,
-    ],
-)
-@pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("replication_factor", [4])
-@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
-def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
-    mesh_device,
-    num_devices,
-    per_chip_output_shape,
-    dim,
-    num_links,
-    input_dtype,
-    layout,
-    buffer_type,
-    use_program_cache,
-    function_level_defaults,
-    enable_async,
-    replication_factor,
-    num_iters=1,
-):
-    if len(mesh_device.get_devices()) < 8:
-        pytest.skip("Not T3K!")
-    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-        mesh_device,
-        num_devices,
-        per_chip_output_shape,
-        ttnn.TensorMemoryLayout.INTERLEAVED,
-        dim,
-        num_links,
-        input_dtype,
-        layout,
-        buffer_type,
-        use_program_cache,
-        function_level_defaults,
-        enable_async=enable_async,
-        num_iters=num_iters,
-        num_all_gather_instances=replication_factor,
-        cluster_axis=0,
-        use_all_gather_async=True,
-        enable_persistent_fabric=True,
-        create_persistent_fabric=True,
-        teardown_persistent_fabric=True,
-    )
+#     run_all_gather_impl(
+#         t3k_mesh_device,
+#         num_devices,
+#         output_shape,
+#         dim,
+#         num_links,
+#         input_dtype,
+#         layout,
+#         use_program_cache,
+#         function_level_defaults,
+#         all_gather_topology=ttnn.Topology.Linear,
+#         num_iters=num_iters,
+#         enable_async=enable_async,
+#         rand_tensor=True,
+#         input_shard_shape=input_shard_shape,
+#         input_shard_grid=input_shard_grid,
+#         output_shard_shape=output_shard_shape,
+#         output_shard_grid=output_shard_grid,
+#         tensor_mem_layout=tensor_mem_layout,
+#         create_persistent_fabric=True,
+#         teardown_persistent_fabric=True,
+#         wrap_fabric_around_mesh=True,
+#     )
 
 
-# Enumerate the post-commit cases explicitly
-@skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize(
-    "num_devices, num_links, per_chip_output_shape, dim, layout",
-    [
-        (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "input_dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
-@pytest.mark.parametrize(
-    "buffer_type",
-    [
-        ttnn.BufferType.DRAM,
-        ttnn.BufferType.L1,
-    ],
-)
-@pytest.mark.parametrize("replication_factor", [2])
-@pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
-def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
-    num_devices,
-    per_chip_output_shape,
-    dim,
-    num_links,
-    input_dtype,
-    layout,
-    buffer_type,
-    use_program_cache,
-    function_level_defaults,
-    mesh_device,
-    enable_async,
-    replication_factor,
-    num_iters=1,
-):
-    if len(mesh_device.get_devices()) < 8:
-        pytest.skip("Not T3K!")
-    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-        mesh_device,
-        num_devices,
-        per_chip_output_shape,
-        ttnn.TensorMemoryLayout.INTERLEAVED,
-        dim,
-        num_links,
-        input_dtype,
-        layout,
-        buffer_type,
-        use_program_cache,
-        function_level_defaults,
-        enable_async=enable_async,
-        num_iters=num_iters,
-        num_all_gather_instances=replication_factor,
-        cluster_axis=1,
-        use_all_gather_async=True,
-        enable_persistent_fabric=True,
-        create_persistent_fabric=True,
-        teardown_persistent_fabric=True,
-    )
+# @skip_for_grayskull("Requires eth connected devices to run")
+# @pytest.mark.parametrize(
+#     "num_devices, num_links, per_chip_output_shape, dim, layout",
+#     [
+#         (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
+#         (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+#         (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
+#         (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
+#         (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "input_dtype",
+#     [
+#         ttnn.bfloat16,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "buffer_type",
+#     [
+#         ttnn.BufferType.DRAM,
+#     ],
+# )
+# @pytest.mark.parametrize("enable_async", [True])
+# @pytest.mark.parametrize("replication_factor", [4])
+# @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+# def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
+#     mesh_device,
+#     num_devices,
+#     per_chip_output_shape,
+#     dim,
+#     num_links,
+#     input_dtype,
+#     layout,
+#     buffer_type,
+#     use_program_cache,
+#     function_level_defaults,
+#     enable_async,
+#     replication_factor,
+#     num_iters=1,
+# ):
+#     if len(mesh_device.get_devices()) < 8:
+#         pytest.skip("Not T3K!")
+#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+#         mesh_device,
+#         num_devices,
+#         per_chip_output_shape,
+#         ttnn.TensorMemoryLayout.INTERLEAVED,
+#         dim,
+#         num_links,
+#         input_dtype,
+#         layout,
+#         buffer_type,
+#         use_program_cache,
+#         function_level_defaults,
+#         enable_async=enable_async,
+#         num_iters=num_iters,
+#         num_all_gather_instances=replication_factor,
+#         cluster_axis=0,
+#         use_all_gather_async=True,
+#         enable_persistent_fabric=True,
+#         create_persistent_fabric=True,
+#         teardown_persistent_fabric=True,
+#     )
 
 
-@skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize(
-    "num_devices1, num_links1, per_chip_output_shape1, dim1, layout1",
-    [
-        (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-        (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
-        (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize(
-    "input_dtype",
-    [
-        ttnn.bfloat16,
-    ],
-)
-@pytest.mark.parametrize(
-    "buffer_type",
-    [
-        ttnn.BufferType.DRAM,
-    ],
-)
-@pytest.mark.parametrize("replication_factor1", [4])
-@pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize(
-    "num_devices2, num_links2, per_chip_output_shape2, dim2, layout2",
-    [
-        (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
-        (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
-    ],
-)
-@pytest.mark.parametrize("replication_factor2", [2])
-@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
-def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabric_post_commit(
-    mesh_device,
-    num_devices1,
-    per_chip_output_shape1,
-    dim1,
-    num_links1,
-    layout1,
-    num_devices2,
-    per_chip_output_shape2,
-    dim2,
-    num_links2,
-    input_dtype,
-    layout2,
-    buffer_type,
-    use_program_cache,
-    function_level_defaults,
-    enable_async,
-    replication_factor1,
-    replication_factor2,
-    num_iters=1,
-):
-    if len(mesh_device.get_devices()) < 8:
-        pytest.skip("Not T3K!")
-    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-        mesh_device,
-        num_devices1,
-        per_chip_output_shape1,
-        ttnn.TensorMemoryLayout.INTERLEAVED,
-        dim1,
-        num_links1,
-        input_dtype,
-        layout1,
-        buffer_type,
-        use_program_cache,
-        function_level_defaults,
-        enable_async=enable_async,
-        num_iters=num_iters,
-        num_all_gather_instances=replication_factor1,
-        cluster_axis=0,
-        use_all_gather_async=True,
-        enable_persistent_fabric=True,
-        create_persistent_fabric=True,
-        teardown_persistent_fabric=False,
-    )
+# # Enumerate the post-commit cases explicitly
+# @skip_for_grayskull("Requires eth connected devices to run")
+# @pytest.mark.parametrize(
+#     "num_devices, num_links, per_chip_output_shape, dim, layout",
+#     [
+#         (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "input_dtype",
+#     [
+#         ttnn.bfloat16,
+#         ttnn.bfloat8_b,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "buffer_type",
+#     [
+#         ttnn.BufferType.DRAM,
+#         ttnn.BufferType.L1,
+#     ],
+# )
+# @pytest.mark.parametrize("replication_factor", [2])
+# @pytest.mark.parametrize("enable_async", [True])
+# @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+# def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
+#     num_devices,
+#     per_chip_output_shape,
+#     dim,
+#     num_links,
+#     input_dtype,
+#     layout,
+#     buffer_type,
+#     use_program_cache,
+#     function_level_defaults,
+#     mesh_device,
+#     enable_async,
+#     replication_factor,
+#     num_iters=1,
+# ):
+#     if len(mesh_device.get_devices()) < 8:
+#         pytest.skip("Not T3K!")
+#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+#         mesh_device,
+#         num_devices,
+#         per_chip_output_shape,
+#         ttnn.TensorMemoryLayout.INTERLEAVED,
+#         dim,
+#         num_links,
+#         input_dtype,
+#         layout,
+#         buffer_type,
+#         use_program_cache,
+#         function_level_defaults,
+#         enable_async=enable_async,
+#         num_iters=num_iters,
+#         num_all_gather_instances=replication_factor,
+#         cluster_axis=1,
+#         use_all_gather_async=True,
+#         enable_persistent_fabric=True,
+#         create_persistent_fabric=True,
+#         teardown_persistent_fabric=True,
+#     )
 
-    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-        mesh_device,
-        num_devices2,
-        per_chip_output_shape2,
-        ttnn.TensorMemoryLayout.INTERLEAVED,
-        dim2,
-        num_links2,
-        input_dtype,
-        layout2,
-        buffer_type,
-        use_program_cache,
-        function_level_defaults,
-        enable_async=enable_async,
-        num_iters=num_iters,
-        num_all_gather_instances=replication_factor2,
-        cluster_axis=1,
-        use_all_gather_async=True,
-        enable_persistent_fabric=True,
-        create_persistent_fabric=False,
-        teardown_persistent_fabric=True,
-    )
+
+# @skip_for_grayskull("Requires eth connected devices to run")
+# @pytest.mark.parametrize(
+#     "num_devices1, num_links1, per_chip_output_shape1, dim1, layout1",
+#     [
+#         (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
+#         (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+#         (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
+#         (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
+#         (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "input_dtype",
+#     [
+#         ttnn.bfloat16,
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "buffer_type",
+#     [
+#         ttnn.BufferType.DRAM,
+#     ],
+# )
+# @pytest.mark.parametrize("replication_factor1", [4])
+# @pytest.mark.parametrize("enable_async", [True])
+# @pytest.mark.parametrize(
+#     "num_devices2, num_links2, per_chip_output_shape2, dim2, layout2",
+#     [
+#         (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
+#         (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
+#     ],
+# )
+# @pytest.mark.parametrize("replication_factor2", [2])
+# @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+# def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabric_post_commit(
+#     mesh_device,
+#     num_devices1,
+#     per_chip_output_shape1,
+#     dim1,
+#     num_links1,
+#     layout1,
+#     num_devices2,
+#     per_chip_output_shape2,
+#     dim2,
+#     num_links2,
+#     input_dtype,
+#     layout2,
+#     buffer_type,
+#     use_program_cache,
+#     function_level_defaults,
+#     enable_async,
+#     replication_factor1,
+#     replication_factor2,
+#     num_iters=1,
+# ):
+#     if len(mesh_device.get_devices()) < 8:
+#         pytest.skip("Not T3K!")
+#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+#         mesh_device,
+#         num_devices1,
+#         per_chip_output_shape1,
+#         ttnn.TensorMemoryLayout.INTERLEAVED,
+#         dim1,
+#         num_links1,
+#         input_dtype,
+#         layout1,
+#         buffer_type,
+#         use_program_cache,
+#         function_level_defaults,
+#         enable_async=enable_async,
+#         num_iters=num_iters,
+#         num_all_gather_instances=replication_factor1,
+#         cluster_axis=0,
+#         use_all_gather_async=True,
+#         enable_persistent_fabric=True,
+#         create_persistent_fabric=True,
+#         teardown_persistent_fabric=False,
+#     )
+
+#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+#         mesh_device,
+#         num_devices2,
+#         per_chip_output_shape2,
+#         ttnn.TensorMemoryLayout.INTERLEAVED,
+#         dim2,
+#         num_links2,
+#         input_dtype,
+#         layout2,
+#         buffer_type,
+#         use_program_cache,
+#         function_level_defaults,
+#         enable_async=enable_async,
+#         num_iters=num_iters,
+#         num_all_gather_instances=replication_factor2,
+#         cluster_axis=1,
+#         use_all_gather_async=True,
+#         enable_persistent_fabric=True,
+#         create_persistent_fabric=False,
+#         teardown_persistent_fabric=True,
+#     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -314,26 +314,26 @@ def run_all_gather_impl(
         logger.info(f"Done op")
 
     passed = True
-    # for tensor_index in range(len(tt_out_tensor_list)):
-    #     tt_out_tensor = tt_out_tensor_list[tensor_index]
-    #     output_tensor = output_tensor_goldens_list[tensor_index]
-    #     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-    #         tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-    #         logger.info(f"Checking for device {t.device().id()}")
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list[tensor_index]
+        output_tensor = output_tensor_goldens_list[tensor_index]
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
 
-    #         if input_dtype == ttnn.bfloat16:
-    #             eq, output = comp_equal(tt_output_tensor, output_tensor)
-    #         else:
-    #             eq, output = comp_pcc(tt_output_tensor, output_tensor)
-    #         if not eq:
-    #             logger.error(f"output mismatch for tensor {i}")
-    #             passed = False
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
 
-    # for i in range(num_devices):
-    #     assert (
-    #         mesh_device.get_devices()[i].num_program_cache_entries() == 1
-    #         or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
-    #     ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
 
     if enable_persistent_fabric and teardown_persistent_fabric:
         mesh_device.reset_sub_device_stall_group()
@@ -404,370 +404,370 @@ def test_all_gather(
     )
 
 
-# # Enumerate the post-commit cases explicitly
-# @skip_for_grayskull("Requires eth connected devices to run")
-# @pytest.mark.parametrize(
-#     "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
-#     [
-#         (
-#             2,
-#             [1, 1, 32, 256],
-#             3,
-#             ttnn.TILE_LAYOUT,
-#             (32, 32),
-#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
-#             None,
-#             None,
-#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-#         ),
-#         (
-#             2,
-#             [1, 1, 32, 256],
-#             3,
-#             ttnn.TILE_LAYOUT,
-#             (32, 64),
-#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
-#             None,
-#             None,
-#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-#         ),
-#         (
-#             2,
-#             [1, 1, 32, 256],
-#             3,
-#             ttnn.TILE_LAYOUT,
-#             (32, 128),
-#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-#             None,
-#             None,
-#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-#         ),
-#         (
-#             2,
-#             [1, 1, 64, 256],
-#             2,
-#             ttnn.TILE_LAYOUT,
-#             (32, 128),
-#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
-#             None,
-#             None,
-#             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-#         ),
-#         (
-#             2,
-#             [1, 4, 32, 256],
-#             3,
-#             ttnn.TILE_LAYOUT,
-#             (32, 128),
-#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
-#             None,
-#             None,
-#             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-#         ),
-#         (
-#             4,
-#             [1, 4, 32, 1280],
-#             3,
-#             ttnn.TILE_LAYOUT,
-#             (32, 320),
-#             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
-#             None,
-#             None,
-#             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-#         ),
-#     ],
-# )
-# @pytest.mark.parametrize("num_links", [1])
-# @pytest.mark.parametrize(
-#     "input_dtype",
-#     [
-#         ttnn.bfloat16,
-#         ttnn.bfloat8_b,
-#     ],
-# )
-# @pytest.mark.parametrize("num_iters", [8])
-# @pytest.mark.parametrize("enable_async", [True])
-# def test_all_gather_sharded(
-#     t3k_mesh_device,
-#     num_devices,
-#     output_shape,
-#     dim,
-#     num_links,
-#     input_dtype,
-#     layout,
-#     num_iters,
-#     use_program_cache,
-#     function_level_defaults,
-#     enable_async,
-#     input_shard_shape,
-#     input_shard_grid,
-#     output_shard_shape,
-#     output_shard_grid,
-#     tensor_mem_layout,
-# ):
-#     if num_links > 1:
-#         assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        (
+            2,
+            [1, 1, 32, 256],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            2,
+            [1, 1, 32, 256],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            2,
+            [1, 1, 32, 256],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            2,
+            [1, 1, 64, 256],
+            2,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            2,
+            [1, 4, 32, 256],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            4,
+            [1, 4, 32, 1280],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 320),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [True])
+def test_all_gather_sharded(
+    t3k_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    if num_links > 1:
+        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the t3k_mesh_device (and hence only has 1 link available for use)"
 
-#     run_all_gather_impl(
-#         t3k_mesh_device,
-#         num_devices,
-#         output_shape,
-#         dim,
-#         num_links,
-#         input_dtype,
-#         layout,
-#         use_program_cache,
-#         function_level_defaults,
-#         all_gather_topology=ttnn.Topology.Linear,
-#         num_iters=num_iters,
-#         enable_async=enable_async,
-#         rand_tensor=True,
-#         input_shard_shape=input_shard_shape,
-#         input_shard_grid=input_shard_grid,
-#         output_shard_shape=output_shard_shape,
-#         output_shard_grid=output_shard_grid,
-#         tensor_mem_layout=tensor_mem_layout,
-#         create_persistent_fabric=True,
-#         teardown_persistent_fabric=True,
-#         wrap_fabric_around_mesh=True,
-#     )
-
-
-# @skip_for_grayskull("Requires eth connected devices to run")
-# @pytest.mark.parametrize(
-#     "num_devices, num_links, per_chip_output_shape, dim, layout",
-#     [
-#         (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
-#         (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-#         (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
-#         (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
-#         (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "input_dtype",
-#     [
-#         ttnn.bfloat16,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "buffer_type",
-#     [
-#         ttnn.BufferType.DRAM,
-#     ],
-# )
-# @pytest.mark.parametrize("enable_async", [True])
-# @pytest.mark.parametrize("replication_factor", [4])
-# @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
-# def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
-#     mesh_device,
-#     num_devices,
-#     per_chip_output_shape,
-#     dim,
-#     num_links,
-#     input_dtype,
-#     layout,
-#     buffer_type,
-#     use_program_cache,
-#     function_level_defaults,
-#     enable_async,
-#     replication_factor,
-#     num_iters=1,
-# ):
-#     if len(mesh_device.get_devices()) < 8:
-#         pytest.skip("Not T3K!")
-#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-#         mesh_device,
-#         num_devices,
-#         per_chip_output_shape,
-#         ttnn.TensorMemoryLayout.INTERLEAVED,
-#         dim,
-#         num_links,
-#         input_dtype,
-#         layout,
-#         buffer_type,
-#         use_program_cache,
-#         function_level_defaults,
-#         enable_async=enable_async,
-#         num_iters=num_iters,
-#         num_all_gather_instances=replication_factor,
-#         cluster_axis=0,
-#         use_all_gather_async=True,
-#         enable_persistent_fabric=True,
-#         create_persistent_fabric=True,
-#         teardown_persistent_fabric=True,
-#     )
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        rand_tensor=True,
+        input_shard_shape=input_shard_shape,
+        input_shard_grid=input_shard_grid,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+        wrap_fabric_around_mesh=True,
+    )
 
 
-# # Enumerate the post-commit cases explicitly
-# @skip_for_grayskull("Requires eth connected devices to run")
-# @pytest.mark.parametrize(
-#     "num_devices, num_links, per_chip_output_shape, dim, layout",
-#     [
-#         (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "input_dtype",
-#     [
-#         ttnn.bfloat16,
-#         ttnn.bfloat8_b,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "buffer_type",
-#     [
-#         ttnn.BufferType.DRAM,
-#         ttnn.BufferType.L1,
-#     ],
-# )
-# @pytest.mark.parametrize("replication_factor", [2])
-# @pytest.mark.parametrize("enable_async", [True])
-# @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
-# def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
-#     num_devices,
-#     per_chip_output_shape,
-#     dim,
-#     num_links,
-#     input_dtype,
-#     layout,
-#     buffer_type,
-#     use_program_cache,
-#     function_level_defaults,
-#     mesh_device,
-#     enable_async,
-#     replication_factor,
-#     num_iters=1,
-# ):
-#     if len(mesh_device.get_devices()) < 8:
-#         pytest.skip("Not T3K!")
-#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-#         mesh_device,
-#         num_devices,
-#         per_chip_output_shape,
-#         ttnn.TensorMemoryLayout.INTERLEAVED,
-#         dim,
-#         num_links,
-#         input_dtype,
-#         layout,
-#         buffer_type,
-#         use_program_cache,
-#         function_level_defaults,
-#         enable_async=enable_async,
-#         num_iters=num_iters,
-#         num_all_gather_instances=replication_factor,
-#         cluster_axis=1,
-#         use_all_gather_async=True,
-#         enable_persistent_fabric=True,
-#         create_persistent_fabric=True,
-#         teardown_persistent_fabric=True,
-#     )
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, per_chip_output_shape, dim, layout",
+    [
+        (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "buffer_type",
+    [
+        ttnn.BufferType.DRAM,
+    ],
+)
+@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("replication_factor", [4])
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
+    mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    buffer_type,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    replication_factor,
+    num_iters=1,
+):
+    if len(mesh_device.get_devices()) < 8:
+        pytest.skip("Not T3K!")
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+        mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        ttnn.TensorMemoryLayout.INTERLEAVED,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        buffer_type,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        num_all_gather_instances=replication_factor,
+        cluster_axis=0,
+        use_all_gather_async=True,
+        enable_persistent_fabric=True,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+    )
 
 
-# @skip_for_grayskull("Requires eth connected devices to run")
-# @pytest.mark.parametrize(
-#     "num_devices1, num_links1, per_chip_output_shape1, dim1, layout1",
-#     [
-#         (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
-#         (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-#         (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
-#         (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
-#         (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "input_dtype",
-#     [
-#         ttnn.bfloat16,
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "buffer_type",
-#     [
-#         ttnn.BufferType.DRAM,
-#     ],
-# )
-# @pytest.mark.parametrize("replication_factor1", [4])
-# @pytest.mark.parametrize("enable_async", [True])
-# @pytest.mark.parametrize(
-#     "num_devices2, num_links2, per_chip_output_shape2, dim2, layout2",
-#     [
-#         (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
-#         (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
-#     ],
-# )
-# @pytest.mark.parametrize("replication_factor2", [2])
-# @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
-# def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabric_post_commit(
-#     mesh_device,
-#     num_devices1,
-#     per_chip_output_shape1,
-#     dim1,
-#     num_links1,
-#     layout1,
-#     num_devices2,
-#     per_chip_output_shape2,
-#     dim2,
-#     num_links2,
-#     input_dtype,
-#     layout2,
-#     buffer_type,
-#     use_program_cache,
-#     function_level_defaults,
-#     enable_async,
-#     replication_factor1,
-#     replication_factor2,
-#     num_iters=1,
-# ):
-#     if len(mesh_device.get_devices()) < 8:
-#         pytest.skip("Not T3K!")
-#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-#         mesh_device,
-#         num_devices1,
-#         per_chip_output_shape1,
-#         ttnn.TensorMemoryLayout.INTERLEAVED,
-#         dim1,
-#         num_links1,
-#         input_dtype,
-#         layout1,
-#         buffer_type,
-#         use_program_cache,
-#         function_level_defaults,
-#         enable_async=enable_async,
-#         num_iters=num_iters,
-#         num_all_gather_instances=replication_factor1,
-#         cluster_axis=0,
-#         use_all_gather_async=True,
-#         enable_persistent_fabric=True,
-#         create_persistent_fabric=True,
-#         teardown_persistent_fabric=False,
-#     )
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, per_chip_output_shape, dim, layout",
+    [
+        (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "buffer_type",
+    [
+        ttnn.BufferType.DRAM,
+        ttnn.BufferType.L1,
+    ],
+)
+@pytest.mark.parametrize("replication_factor", [2])
+@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
+    num_devices,
+    per_chip_output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    buffer_type,
+    use_program_cache,
+    function_level_defaults,
+    mesh_device,
+    enable_async,
+    replication_factor,
+    num_iters=1,
+):
+    if len(mesh_device.get_devices()) < 8:
+        pytest.skip("Not T3K!")
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+        mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        ttnn.TensorMemoryLayout.INTERLEAVED,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        buffer_type,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        num_all_gather_instances=replication_factor,
+        cluster_axis=1,
+        use_all_gather_async=True,
+        enable_persistent_fabric=True,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+    )
 
-#     run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
-#         mesh_device,
-#         num_devices2,
-#         per_chip_output_shape2,
-#         ttnn.TensorMemoryLayout.INTERLEAVED,
-#         dim2,
-#         num_links2,
-#         input_dtype,
-#         layout2,
-#         buffer_type,
-#         use_program_cache,
-#         function_level_defaults,
-#         enable_async=enable_async,
-#         num_iters=num_iters,
-#         num_all_gather_instances=replication_factor2,
-#         cluster_axis=1,
-#         use_all_gather_async=True,
-#         enable_persistent_fabric=True,
-#         create_persistent_fabric=False,
-#         teardown_persistent_fabric=True,
-#     )
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices1, num_links1, per_chip_output_shape1, dim1, layout1",
+    [
+        (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 2048], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 2304], 1, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 2, 32, 4096], 1, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "buffer_type",
+    [
+        ttnn.BufferType.DRAM,
+    ],
+)
+@pytest.mark.parametrize("replication_factor1", [4])
+@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize(
+    "num_devices2, num_links2, per_chip_output_shape2, dim2, layout2",
+    [
+        (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 1, 32, 16384 * 4], 3, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 4, 32, 4096], 1, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 4, 32, 6656], 1, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize("replication_factor2", [2])
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
+def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabric_post_commit(
+    mesh_device,
+    num_devices1,
+    per_chip_output_shape1,
+    dim1,
+    num_links1,
+    layout1,
+    num_devices2,
+    per_chip_output_shape2,
+    dim2,
+    num_links2,
+    input_dtype,
+    layout2,
+    buffer_type,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    replication_factor1,
+    replication_factor2,
+    num_iters=1,
+):
+    if len(mesh_device.get_devices()) < 8:
+        pytest.skip("Not T3K!")
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+        mesh_device,
+        num_devices1,
+        per_chip_output_shape1,
+        ttnn.TensorMemoryLayout.INTERLEAVED,
+        dim1,
+        num_links1,
+        input_dtype,
+        layout1,
+        buffer_type,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        num_all_gather_instances=replication_factor1,
+        cluster_axis=0,
+        use_all_gather_async=True,
+        enable_persistent_fabric=True,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=False,
+    )
+
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+        mesh_device,
+        num_devices2,
+        per_chip_output_shape2,
+        ttnn.TensorMemoryLayout.INTERLEAVED,
+        dim2,
+        num_links2,
+        input_dtype,
+        layout2,
+        buffer_type,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        num_all_gather_instances=replication_factor2,
+        cluster_axis=1,
+        use_all_gather_async=True,
+        enable_persistent_fabric=True,
+        create_persistent_fabric=False,
+        teardown_persistent_fabric=True,
+    )

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -292,9 +292,14 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_flushed(u
     return (NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED) == noc_nonposted_writes_acked[noc]);
 }
 
-inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_flushed(
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_sent(
     uint32_t noc, uint32_t transcation_id) {
     return (NOC_STATUS_READ_REG(noc, NIU_MST_WRITE_REQS_OUTGOING_ID(transcation_id)) == 0);
+}
+
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_flushed(
+    uint32_t noc, uint32_t transcation_id) {
+    return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2085,8 +2085,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
-    noc_nonposted_writes_num_issued[noc] += 1;
-    noc_nonposted_writes_acked[noc] += 1;
+    // noc_nonposted_writes_num_issued[noc] += 1;
+    // noc_nonposted_writes_acked[noc] += 1;
 #endif
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2084,9 +2084,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-
-    // noc_nonposted_writes_num_issued[noc] += 1;
-    // noc_nonposted_writes_acked[noc] += 1;
 #endif
 }
 
@@ -2120,7 +2117,7 @@ FORCE_INLINE
 void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NWTW");
 #ifndef ARCH_GRAYSKULL
-    while (!ncrisc_noc_nonposted_write_with_transaction_id_sent(noc, trid));
+    while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc, trid));
 #endif
     invalidate_l1_cache();
     WAYPOINT("NWTD");

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2079,6 +2079,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NWPD");
 
+    // In order to sanitize, need to grab full noc addr + xfer size from state.
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_noc_addr, src_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2046,26 +2046,24 @@ void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTD");
 }
 
-inline void noc_async_write_one_packet_with_trid_set_state(std::uint64_t dst_noc_addr, uint8_t noc = noc_index) {
+FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
+    std::uint64_t dst_noc_addr, uint8_t cmd_buf = write_cmd_buf, uint8_t noc = noc_index) {
 #ifndef ARCH_GRAYSKULL
     WAYPOINT("NAWW");
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NAWD");
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
                              0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
                              0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                              NOC_CMD_RESP_MARKED;
 
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
 #ifdef ARCH_BLACKHOLE
     // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
 #endif
     NOC_CMD_BUF_WRITE_REG(
-        noc,
-        write_cmd_buf,
-        NOC_RET_ADDR_COORDINATE,
-        (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
 #endif
 }
 
@@ -2074,24 +2072,25 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     std::uint32_t dst_noc_addr,
     std::uint32_t size,
     std::uint32_t trid,
+    uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index) {
 #ifndef ARCH_GRAYSKULL
     WAYPOINT("NWPW");
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NWPD");
 
-    // In order to sanitize, need to grab full noc addr + xfer size from state.
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_noc_addr, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    // noc_nonposted_writes_num_issued[noc] += 1;
+    // noc_nonposted_writes_acked[noc] += 1;
 #endif
 }
 
-inline void noc_async_write_one_packet_with_trid(
+FORCE_INLINE void noc_async_write_one_packet_with_trid(
     std::uint32_t src_local_l1_addr,
     std::uint64_t dst_noc_addr,
     std::uint32_t size,
@@ -2121,7 +2120,7 @@ FORCE_INLINE
 void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NWTW");
 #ifndef ARCH_GRAYSKULL
-    while (!ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc, trid));
+    while (!ncrisc_noc_nonposted_write_with_transaction_id_sent(noc, trid));
 #endif
     invalidate_l1_cache();
     WAYPOINT("NWTD");

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -2085,8 +2085,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
-    // noc_nonposted_writes_num_issued[noc] += 1;
-    // noc_nonposted_writes_acked[noc] += 1;
+    noc_nonposted_writes_num_issued[noc] += 1;
+    noc_nonposted_writes_acked[noc] += 1;
 #endif
 }
 

--- a/tt_metal/hw/inc/ethernet/erisc.h
+++ b/tt_metal/hw/inc/ethernet/erisc.h
@@ -18,5 +18,7 @@ inline __attribute__((always_inline)) void risc_context_switch() {
 #endif
 }
 
+inline __attribute__((always_inline)) void risc_context_switch_without_noc_sync() { rtos_context_switch_ptr(); }
+
 inline __attribute__((always_inline)) void disable_erisc_app() { flag_disable[0] = 0; }
 }  // namespace internal_

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -154,9 +154,4 @@ void run_routing() {
 }
 
 FORCE_INLINE
-void run_routing_without_noc_sync() {
-    // router_init();
-    // TODO: maybe split into two FWs? or this may be better to sometimes allow each eth core to do both send and
-    // receive of fd packets
-    internal_::risc_context_switch_without_noc_sync();
-}
+void run_routing_without_noc_sync() { internal_::risc_context_switch_without_noc_sync(); }

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -152,3 +152,11 @@ void run_routing() {
     // receive of fd packets
     internal_::risc_context_switch();
 }
+
+FORCE_INLINE
+void run_routing_without_noc_sync() {
+    // router_init();
+    // TODO: maybe split into two FWs? or this may be better to sometimes allow each eth core to do both send and
+    // receive of fd packets
+    internal_::risc_context_switch_without_noc_sync();
+}

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -248,9 +248,14 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_flushed(u
     return (NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED) == noc_nonposted_writes_acked[noc]);
 }
 
-inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_flushed(
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_sent(
     uint32_t noc, uint32_t transcation_id) {
     return (NOC_STATUS_READ_REG(noc, NIU_MST_WRITE_REQS_OUTGOING_ID(transcation_id)) == 0);
+}
+
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_write_with_transaction_id_flushed(
+    uint32_t noc, uint32_t transcation_id) {
+    return (NOC_STATUS_READ_REG(noc, NIU_MST_REQS_OUTSTANDING_ID(transcation_id)) == 0);
 }
 
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
@@ -53,10 +53,7 @@ FORCE_INLINE void fetch_chunk(
 template<ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode = ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING>
 FORCE_INLINE void send_chunk_from_address_with_trid(
     const uint32_t& local_l1_address, const uint32_t& num_pages, const uint32_t& page_size, uint32_t remote_l1_write_addr, uint8_t trid, uint8_t cmd_buf) {
-    // const uint32_t& local_l1_address, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr, uint8_t trid, uint8_t cmd_buf) {
-    // noc_async_write_one_packet_with_trid_set_state(remote_l1_write_addr);
     noc_async_write_one_packet_with_trid_with_state(local_l1_address, remote_l1_write_addr, page_size * num_pages, trid, cmd_buf);
-    // noc_async_write_one_packet_with_trid(local_l1_address, remote_l1_write_addr, page_size * num_pages, trid);
     // TODO: this barrier will no longer be functional since we are not incrementing noc counters, remove
     if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING) {
         noc_async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
@@ -52,8 +52,12 @@ FORCE_INLINE void fetch_chunk(
 
 template<ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode = ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING>
 FORCE_INLINE void send_chunk_from_address_with_trid(
-    const uint32_t& local_l1_address, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr, uint8_t trid) {
-    noc_async_write_one_packet_with_trid(local_l1_address, remote_l1_write_addr, page_size * num_pages, trid);
+    const uint32_t& local_l1_address, const uint32_t& num_pages, const uint32_t& page_size, uint32_t remote_l1_write_addr, uint8_t trid, uint8_t cmd_buf) {
+    // const uint32_t& local_l1_address, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr, uint8_t trid, uint8_t cmd_buf) {
+    // noc_async_write_one_packet_with_trid_set_state(remote_l1_write_addr);
+    noc_async_write_one_packet_with_trid_with_state(local_l1_address, remote_l1_write_addr, page_size * num_pages, trid, cmd_buf);
+    // noc_async_write_one_packet_with_trid(local_l1_address, remote_l1_write_addr, page_size * num_pages, trid);
+    // TODO: this barrier will no longer be functional since we are not incrementing noc counters, remove
     if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING) {
         noc_async_writes_flushed();
     } else if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -285,6 +285,7 @@ struct WorkerToFabricEdmSenderImpl {
     uint8_t edm_noc_x;
     uint8_t edm_noc_y;
 
+    // the cmd buffer is used for edm-edm path
     uint8_t edm_noc_cmd_buf;
 
 private:
@@ -348,13 +349,10 @@ private:
     }
     template <ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_from_address_with_trid_impl(uint32_t source_address, size_t size_bytes, uint8_t trid) {
-        // uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
-
         ASSERT(size_bytes <= this->buffer_size_bytes);
         ASSERT(tt::fabric::is_valid(*const_cast<tt::fabric::PacketHeader*>(
             reinterpret_cast<volatile tt::fabric::PacketHeader*>(source_address))));
         send_chunk_from_address_with_trid<blocking_mode>(source_address, 1, size_bytes, this->edm_buffer_addr, trid, this->edm_noc_cmd_buf);
-        // send_chunk_from_address_with_trid<blocking_mode>(source_address, 1, size_bytes, buffer_address, trid, this->edm_noc_cmd_buf);
         post_send_payload_increment_pointers();
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -121,11 +121,18 @@ struct WorkerToFabricEdmSenderImpl {
         num_buffers_per_channel(num_buffers_per_channel),
         last_buffer_index(num_buffers_per_channel - 1),
         edm_noc_x(edm_worker_x),
-        edm_noc_y(edm_worker_y) {
+        edm_noc_y(edm_worker_y),
+        edm_noc_cmd_buf(write_reg_cmd_buf) {
+        setup_edm_noc_cmd_buf(write_reg_cmd_buf);
         ASSERT(buffer_size_bytes > 0);
         if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
             ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
         }
+    }
+
+    FORCE_INLINE void setup_edm_noc_cmd_buf(uint8_t cmd_buf) const {
+        uint64_t edm_noc_addr = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0);
+        noc_async_write_one_packet_with_trid_set_state(edm_noc_addr, cmd_buf);
     }
 
     FORCE_INLINE bool edm_has_space_for_packet() const {
@@ -278,6 +285,8 @@ struct WorkerToFabricEdmSenderImpl {
     uint8_t edm_noc_x;
     uint8_t edm_noc_y;
 
+    uint8_t edm_noc_cmd_buf;
+
 private:
 
     FORCE_INLINE void update_edm_buffer_slot_wrptr() {
@@ -339,12 +348,13 @@ private:
     }
     template <ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_from_address_with_trid_impl(uint32_t source_address, size_t size_bytes, uint8_t trid) {
-        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
+        // uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
 
         ASSERT(size_bytes <= this->buffer_size_bytes);
         ASSERT(tt::fabric::is_valid(*const_cast<tt::fabric::PacketHeader*>(
             reinterpret_cast<volatile tt::fabric::PacketHeader*>(source_address))));
-        send_chunk_from_address_with_trid<blocking_mode>(source_address, 1, size_bytes, buffer_address, trid);
+        send_chunk_from_address_with_trid<blocking_mode>(source_address, 1, size_bytes, this->edm_buffer_addr, trid, this->edm_noc_cmd_buf);
+        // send_chunk_from_address_with_trid<blocking_mode>(source_address, 1, size_bytes, buffer_address, trid, this->edm_noc_cmd_buf);
         post_send_payload_increment_pointers();
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1175,9 +1175,6 @@ void kernel_main() {
                   downstream_noc_interface_buffer_index_local_addr)
             : tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>();
 
-    // setup edm to edm noc cmd buf
-    // downstream_edm_noc_interface.setup_edm_noc_cmd_buf();
-
     auto local_receiver_channel = tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>(
         local_receiver_channel_buffer_address,
         channel_buffer_size,

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -311,11 +311,27 @@ struct WriteTransactionIdTracker {
     FORCE_INLINE bool transaction_flushed(tt::fabric::BufferIndex buffer_index) const {
         if constexpr (BOTH_PARAMS_ARE_POW2) {
             auto trid = this->get_buffer_slot_trid(buffer_index);
+            return ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid);
+        } else {
+            // TODO: should be able to remove compare against INVALID_TRID
+            auto trid = this->get_buffer_slot_trid(buffer_index);
+            return trid == INVALID_TRID || ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid);
+        }
+    }
+    FORCE_INLINE bool transaction_acked(tt::fabric::BufferIndex buffer_index) const {
+        if constexpr (BOTH_PARAMS_ARE_POW2) {
+            auto trid = this->get_buffer_slot_trid(buffer_index);
             return ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, trid);
         } else {
             // TODO: should be able to remove compare against INVALID_TRID
             auto trid = this->get_buffer_slot_trid(buffer_index);
             return trid == INVALID_TRID || ncrisc_noc_nonposted_write_with_transaction_id_flushed(noc_index, trid);
+        }
+    }
+    FORCE_INLINE void all_buffer_slot_transactions_acked() const {
+        for (uint8_t i = 0; i < NUM_CHANNELS; ++i) {
+            tt::fabric::BufferIndex buffer_index(i);
+            while(!transaction_acked(buffer_index));
         }
     }
     private:
@@ -886,7 +902,8 @@ void run_fabric_edm_main_loop(
     volatile tt::fabric::EdmFabricReceiverChannelCounters *receiver_channel_counters_ptr,
     std::array<volatile tt::fabric::EdmFabricSenderChannelCounters *, NUM_SENDER_CHANNELS> sender_channel_counters_ptrs,
     PacketHeaderRecorder &receiver_channel_packet_recorder,
-    std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS> &sender_channel_packet_recorders) {
+    std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS> &sender_channel_packet_recorders,
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> &receiver_channel_trid_tracker) {
     std::array<SenderState, NUM_SENDER_CHANNELS> sender_states = {
         SenderState::SENDER_WAIT_WORKER_HANDSHAKE, SenderState::SENDER_WAIT_WORKER_HANDSHAKE};
     size_t sender_channel_index = 0;
@@ -904,8 +921,6 @@ void run_fabric_edm_main_loop(
     OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS> outbound_to_receiver_channel_pointers;
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS> receiver_channel_pointers;
     std::array<bool, NUM_SENDER_CHANNELS> channel_connection_established = {false, false};
-
-    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> receiver_channel_trid_tracker;
 
     // This value defines the number of loop iterations we perform of the main control sequence before exiting
     // to check for termination and context switch. Removing the these checks from the inner loop can drastically
@@ -964,7 +979,8 @@ void run_fabric_edm_main_loop(
         } else {
             if (did_nothing_count++ > SWITCH_INTERVAL) {
                 did_nothing_count = 0;
-                run_routing();
+                // shouldn't do noc counter sync since we are not incrementing them
+                run_routing_without_noc_sync();
             }
         }
     }
@@ -1168,6 +1184,9 @@ void kernel_main() {
                   downstream_noc_interface_buffer_index_local_addr)
             : tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>();
 
+    // setup edm to edm noc cmd buf
+    // downstream_edm_noc_interface.setup_edm_noc_cmd_buf();
+
     auto local_receiver_channel = tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>(
         local_receiver_channel_buffer_address,
         channel_buffer_size,
@@ -1212,6 +1231,9 @@ void kernel_main() {
     }
 
 
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> receiver_channel_trid_tracker;
+
+
     if (has_downstream_edm_buffer_connection) {
         downstream_edm_noc_interface.open();
         *downstream_edm_noc_interface.from_remote_buffer_slot_rdptr_ptr = 0;
@@ -1240,7 +1262,8 @@ void kernel_main() {
         receiver_channel_counters_ptr,
         {sender_channel_0_counters_ptr, sender_channel_1_counters_ptr},
         receiver_channel_packet_recorder,
-        sender_channel_packet_recorders);
+        sender_channel_packet_recorders,
+        receiver_channel_trid_tracker);
 
 
     if constexpr (persistent_mode) {
@@ -1250,6 +1273,16 @@ void kernel_main() {
         *reinterpret_cast<volatile uint32_t*>(local_sender_channel_0_connection_buffer_index_addr) = 99;
         *sender0_worker_semaphore_ptr = 99;
     }
+
+    // make sure all the noc transactions are acked before re-init the noc counters
+    receiver_channel_trid_tracker.all_buffer_slot_transactions_acked();
+
+    // make sure all the noc transactions are flushed before reinit the noc counters
+    // for (int i = 0; i < 10000; ++i) {
+    //     asm volatile("nop");
+    // }
+    // re-init the noc counters as the noc api used is not incrementing them
+    ncrisc_noc_counters_init();
 
     DPRINT << "EDM DONE\n";
     WAYPOINT("DONE");


### PR DESCRIPTION
Previously the EDM uses the single cmd buffer for writing both to worker and EDM, this caused to re-program all the fields each time. Using dedicated cmd buf can allow use use stateful apis.

perf increase (B/c): 
mcast on 4 devices: 5.05 -> 5.65
unicast on 2 devices: 6.68->7.13

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/13420435703
- [x] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/13420449997
- [x] T3K  frequent https://github.com/tenstorrent/tt-metal/actions/runs/13420464130
- [x] T3K unit https://github.com/tenstorrent/tt-metal/actions/runs/13420458982/job/37491768972
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/13439719604
