### PR TITLE
#17992: fix overflow on TG

### DIFF
--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -202,7 +202,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < demux_fan_out; i++) {
         output_queues[i].init(i + 1, remote_tx_queue_start_addr_words[i], remote_tx_queue_size_words[i],
                               remote_tx_x[i], remote_tx_y[i], remote_tx_queue_id[i], remote_tx_network_type[i],
-                              &input_queue, 1,
+                              &input_queue,
                               output_depacketize[i], output_depacketize_log_page_size[i],
                               output_depacketize_local_sem[i], output_depacketize_downstream_sem[i],
                               output_depacketize_remove_header[i]);

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -157,7 +157,7 @@ void kernel_main() {
 
     output_queue.init(mux_fan_in, remote_tx_queue_start_addr_words, remote_tx_queue_size_words,
                       remote_tx_x, remote_tx_y, remote_tx_queue_id, tx_network_type,
-                      input_queues, mux_fan_in,
+                      input_queues,
                       output_depacketize, output_depacketize_log_page_size,
                       output_depacketize_downstream_sem, output_depacketize_local_sem,
                       output_depacketize_remove_header);

--- a/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
@@ -250,8 +250,7 @@ void kernel_main() {
             remote_receiver_y[i],
             remote_receiver_queue_id[i],
             remote_receiver_network_type[i],
-            &input_queues[i],
-            1);
+            &input_queues[i]);
     }
 
     if (!wait_all_input_output_ready<input_queue_network_sequence,

--- a/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
@@ -224,7 +224,7 @@ void kernel_main() {
 
         output_queues[i].init(i + router_lanes, remote_tx_queue_start_addr_words[i], remote_tx_queue_size_words[i],
                               remote_tx_x[i], remote_tx_y[i], remote_tx_queue_id[i], remote_tx_network_type[i],
-                              &input_queues[i], 1,
+                              &input_queues[i],
                               output_depacketize[i], output_depacketize_log_page_size[i],
                               output_depacketize_local_sem[i], output_depacketize_downstream_sem[i],
                               output_depacketize_remove_header[i]);
@@ -249,7 +249,7 @@ void kernel_main() {
     uint32_t heartbeat = 0;
     while (!all_outputs_finished && !timeout) {
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
-        if (timeout_cycles > 0) {
+        if constexpr (timeout_cycles > 0) {
             uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
             if (cycles_since_progress > timeout_cycles) {
                 timeout = true;


### PR DESCRIPTION

### Ticket
#17992

### Problem description
`/localdev/aho/tt-metal/runtime/sfpi/compiler/bin/../lib/gcc/riscv32-unknown-elf/12.4.0/../../../../riscv32-unknown-elf/bin/ld: region 'NCRISC_LOCAL_DATA_MEM' overflowed by 20 bytes`

### What's changed
- Col dispatch had a kernel overflow on the TG system by several bytes
- Remove some unused data
- Moved some members to type traits to be resolved at compiletime
- Comment out all the DPRINT code


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
