### PR TITLE
#17277: switch run_without_autoformat to run in reduce_op.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -222,7 +222,7 @@ Tensor reduce(
                         ttnn::operations::experimental::auto_format::AutoFormat::format_input_tensor(
                             input_tensor, device, input_tensor_pad_shape, pad_value, Layout::TILE);
                 }
-                const Tensor output_tensor = operation::run_without_autoformat(
+                const Tensor output_tensor = operation::run(
                                                  Reduce{
                                                      reduce_math,
                                                      ReduceOpDim::W,
@@ -232,7 +232,7 @@ Tensor reduce(
                                                      config},
                                                  {formatted_input_tensor})
                                                  .at(0);
-                return operation::run_without_autoformat(
+                return operation::run(
                     Reduce{
                         reduce_math,
                         ReduceOpDim::H,


### PR DESCRIPTION
### Ticket
Link to Github Issue #17277

### Problem description
- operation::run_without_autoformat is being removed

### What's changed
- switch to using operation::run

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13419982451
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13419994272
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13419999018/job/37490243801 failures exist in main https://github.com/tenstorrent/tt-metal/actions/runs/13418125200/job/37484190615
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13419997336
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
