### PR TITLE
#17912: add fatal to disable uint32 transpose and permute

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1168,3 +1168,14 @@ def test_transpose_high_rank(*, device: ttnn.Device, rank: int, indices, layout)
 
     assert torch.allclose(a, output_a)
     assert torch.allclose(b, output_b)
+
+
+def test_transpose_17912(device):
+    import torch, ttnn
+
+    x = ttnn.from_torch(torch.arange(0, 32 * 32).reshape(32, 32)).to(ttnn.TILE_LAYOUT).to(device)
+    with pytest.raises(
+        RuntimeError,
+        match="Uint32 is not a supported data type for LLK transpose",
+    ) as exception:
+        x = ttnn.transpose(x, 0, 1)

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -48,6 +48,10 @@ void Transpose::validate(const std::vector<Tensor>& input_tensors) const {
     }
     uint32_t ROW_MAJOR_STICK_WIDTH = 16;
     if (this->dim == TransposeOpDim::WH) {
+        TT_FATAL(
+            !(input_tensor.element_size() > 2 && input_tensor.device()->arch() == tt::ARCH::GRAYSKULL),
+            "Grayskull does not support 4B or bigger element sizes for LLK transposes");
+        TT_FATAL(input_tensor.get_dtype() != DataType::UINT32, "Uint32 is not a supported data type for LLK transpose");
         if (row_major) {
             TT_FATAL(
                 (W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0 &&


### PR DESCRIPTION
### Ticket
#17912 

### Problem description
Uint32 hangs on GS and gives bad PCC on WH

### What's changed
assert out when the input is uint32

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
