### PR TITLE
lower edm fabric switch interval

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -181,7 +181,7 @@ size_t log_worker_to_fabric_edm_sender_rt_args(std::vector<uint32_t> const& args
 
 class FabricEriscDatamoverBuilder {
    public:
-       static constexpr size_t default_firmware_context_switch_interval = 200000;
+       static constexpr size_t default_firmware_context_switch_interval = 10000;
        // payload only, no header
        static constexpr size_t default_packet_payload_size_bytes = 4096;
 


### PR DESCRIPTION
to account for less frequent idle counter increments because of recent addition of inner loop that doesn't ctx-switch.

This is needed now because some systems are seeing excessively long teardown times due to teardown signals being blocked behind context switches to eth fw routing.

The drop in context switch interval is roughly proportional to the inner loop count in the main EDM fabric control loop.



### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13423103833
- [ ] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13423118050
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
