### PR TITLE
Set a timeout for TG Demo

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   tg-demo-tests:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
None

### Problem description
Sometimes this hangs and clogs the runner for 3h before timing out.
A successful run seems to run in ~20m.

### What's changed
Set a timeout.

