### PR TITLE
#0: report host copy bandwidth in test prefetcher

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -529,7 +529,7 @@ void DeviceData::overflow_check(IDevice* device) {
 template <bool is_dram_variant, bool is_host_variant>
 void configure_kernel_variant(
     Program& program,
-    string path,
+    const string& path,
     std::vector<uint32_t> compile_args,  // yes, copy
     CoreCoord my_core,
     CoreCoord phys_my_core,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Need to see host copy to hugepage perf on `test_prefetcher`

### What's changed
- Swapped out the `nt_memcpy` function to use the real one from production `memcpy_to_device`
- Output bytes written and time elapsed for writing the prefetcher commands to hugepage

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
