### PR TITLE
#17477: Adopt ND coordinate system in `MeshDeviceView` and the related abstractions

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -137,9 +137,9 @@ TEST_F(MeshBufferTestT3000, GetDeviceBuffer) {
         MeshBuffer::create(ReplicatedBufferConfig{.size = 16 << 10}, device_local_config, mesh_device_.get());
 
     // Out of bounds coordinates.
-    EXPECT_ANY_THROW(replicated_buffer->get_device_buffer(Coordinate{2, 4}));
+    EXPECT_ANY_THROW(replicated_buffer->get_device_buffer(MeshCoordinate{2, 4}));
 
-    EXPECT_NO_THROW(replicated_buffer->get_device_buffer(Coordinate{1, 3}));
+    EXPECT_NO_THROW(replicated_buffer->get_device_buffer(MeshCoordinate{1, 3}));
 }
 
 class DeviceLocalMeshBufferShardingTest
@@ -174,14 +174,14 @@ TEST_P(DeviceLocalMeshBufferShardingTest, ShardingTest) {
 
     for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
         for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
-            WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, Coordinate(logical_y, logical_x));
+            WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, MeshCoordinate(logical_y, logical_x));
         }
     }
 
     for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
         for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
             std::vector<uint32_t> dst_vec = {};
-            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, Coordinate(logical_y, logical_x));
+            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, MeshCoordinate(logical_y, logical_x));
             EXPECT_EQ(dst_vec, src_vec);
         }
     }
@@ -304,14 +304,14 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
             std::iota(src_vec.begin(), src_vec.end(), i);
             for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
                 for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
-                    WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, Coordinate(logical_y, logical_x));
+                    WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, MeshCoordinate(logical_y, logical_x));
                 }
             }
 
             for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
                 for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
                     std::vector<uint32_t> dst_vec = {};
-                    ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, Coordinate(logical_y, logical_x));
+                    ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, MeshCoordinate(logical_y, logical_x));
                     EXPECT_EQ(dst_vec, src_vec);
                 }
             }

--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -13,6 +13,7 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
+
 TEST(SimpleMeshShapeTest, Construction) {
     SimpleMeshShape shape_1d(3);
     EXPECT_EQ(shape_1d.dims(), 1);
@@ -172,6 +173,31 @@ TEST(MeshCoordinateRangeTest, SubrangeOneElement) {
     EXPECT_THAT(coords, ElementsAre(MeshCoordinate(1, 1, 1)));
 }
 
+TEST(MeshCoordinateRangeTest, Contains) {
+    MeshCoordinateRange range(MeshCoordinate(1, 1, 3), MeshCoordinate(1, 1, 3));
+    EXPECT_TRUE(range.contains(MeshCoordinate(1, 1, 3)));
+
+    range = MeshCoordinateRange(MeshCoordinate(0, 2), MeshCoordinate(1, 2));
+    EXPECT_TRUE(range.contains(MeshCoordinate(0, 2)));
+    EXPECT_TRUE(range.contains(MeshCoordinate(1, 2)));
+    EXPECT_FALSE(range.contains(MeshCoordinate(0, 1)));
+    EXPECT_FALSE(range.contains(MeshCoordinate(2, 1)));
+    EXPECT_FALSE(range.contains(MeshCoordinate(2, 2)));
+}
+
+TEST(MeshCoordinateRangeTest, Dimensionality) {
+    EXPECT_EQ(MeshCoordinateRange(MeshCoordinate(0), MeshCoordinate(5)).dims(), 1);
+    EXPECT_EQ(MeshCoordinateRange(MeshCoordinate(0, 1), MeshCoordinate(5, 1)).dims(), 2);
+    EXPECT_EQ(MeshCoordinateRange(MeshCoordinate(0, 1, 2), MeshCoordinate(5, 1, 2)).dims(), 3);
+}
+
+TEST(MeshCoordinateRangeTest, ContainsMismatchedDimensions) {
+    MeshCoordinateRange range(MeshCoordinate(1, 1, 3), MeshCoordinate(1, 1, 3));
+
+    EXPECT_EQ(range.dims(), 3);
+    EXPECT_ANY_THROW(range.contains(MeshCoordinate(1, 1)));
+}
+
 TEST(MeshCoordinateRangeTest, MismatchedDimensions) {
     MeshCoordinate start(1, 0);
     MeshCoordinate end(2, 3, 1);
@@ -219,6 +245,22 @@ TEST(MeshContainerTest, InitialValues) {
         initial_values.push_back(value);
     }
     EXPECT_THAT(initial_values, ElementsAre(3, 3, 3, 3, 3, 3));
+}
+
+TEST(MeshContainerTest, FromVector) {
+    SimpleMeshShape shape(2, 3);
+    MeshContainer<int> container(shape, std::vector<int>{0, 1, 2, 3, 4, 5});
+
+    std::vector<int> initial_values;
+    for (const auto& [_, value] : container) {
+        initial_values.push_back(value);
+    }
+    EXPECT_THAT(initial_values, ElementsAre(0, 1, 2, 3, 4, 5));
+}
+
+TEST(MeshContainerTest, FromVectorInvalidSize) {
+    SimpleMeshShape shape(2, 3);
+    EXPECT_ANY_THROW(MeshContainer<int>(shape, std::vector<int>{0, 1, 2, 3, 4}));
 }
 
 TEST(MeshContainerTest, ElementAccessRowMajor) {

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -50,9 +50,12 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
         for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
             for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
                 readback_vecs.push_back({});
-                auto shard = buf->get_device_buffer(Coordinate(logical_y, logical_x));
+                auto shard = buf->get_device_buffer(MeshCoordinate(logical_y, logical_x));
                 ReadShard(
-                    mesh_device_->mesh_command_queue(1), readback_vecs.back(), buf, Coordinate(logical_y, logical_x));
+                    mesh_device_->mesh_command_queue(1),
+                    readback_vecs.back(),
+                    buf,
+                    MeshCoordinate(logical_y, logical_x));
             }
         }
 
@@ -173,7 +176,7 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
                             mesh_device_->mesh_command_queue(1),
                             dst_vec,
                             output_bufs[col_idx * worker_grid_size.y + row_idx],
-                            Coordinate(logical_y, logical_x));
+                            MeshCoordinate(logical_y, logical_x));
                         if (logical_y == 0) {
                             for (int i = 0; i < dst_vec.size(); i++) {
                                 EXPECT_EQ(dst_vec[i].to_float(), (2 * iter + 5));
@@ -224,9 +227,12 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
         for (std::size_t logical_x = devices_0.start_coord.x; logical_x < devices_0.end_coord.x; logical_x++) {
             for (std::size_t logical_y = devices_0.start_coord.y; logical_y < devices_0.end_coord.y; logical_y++) {
                 readback_vecs.push_back({});
-                auto shard = buf->get_device_buffer(Coordinate(logical_y, logical_x));
+                auto shard = buf->get_device_buffer(MeshCoordinate(logical_y, logical_x));
                 ReadShard(
-                    mesh_device_->mesh_command_queue(0), readback_vecs.back(), buf, Coordinate(logical_y, logical_x));
+                    mesh_device_->mesh_command_queue(0),
+                    readback_vecs.back(),
+                    buf,
+                    MeshCoordinate(logical_y, logical_x));
             }
         }
 
@@ -237,9 +243,12 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
         for (std::size_t logical_x = devices_1.start_coord.x; logical_x < devices_1.end_coord.x; logical_x++) {
             for (std::size_t logical_y = devices_1.start_coord.y; logical_y < devices_1.end_coord.y; logical_y++) {
                 readback_vecs.push_back({});
-                auto shard = buf->get_device_buffer(Coordinate(logical_y, logical_x));
+                auto shard = buf->get_device_buffer(MeshCoordinate(logical_y, logical_x));
                 ReadShard(
-                    mesh_device_->mesh_command_queue(0), readback_vecs.back(), buf, Coordinate(logical_y, logical_x));
+                    mesh_device_->mesh_command_queue(0),
+                    readback_vecs.back(),
+                    buf,
+                    MeshCoordinate(logical_y, logical_x));
             }
         }
         for (auto& vec : readback_vecs) {

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -129,7 +129,8 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
         for (std::size_t logical_x = 0; logical_x < output_buf->device()->num_cols(); logical_x++) {
             for (std::size_t logical_y = 0; logical_y < output_buf->device()->num_rows(); logical_y++) {
                 std::vector<uint32_t> dst_vec;
-                ReadShard(mesh_device_->mesh_command_queue(), dst_vec, output_buf, Coordinate(logical_y, logical_x));
+                ReadShard(
+                    mesh_device_->mesh_command_queue(), dst_vec, output_buf, MeshCoordinate(logical_y, logical_x));
                 EXPECT_EQ(dst_vec, src_vec);
             }
         }

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -570,7 +570,7 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
                         mesh_device_->mesh_command_queue(),
                         dst_vec,
                         output_bufs[col_idx * worker_grid_size.y + row_idx],
-                        Coordinate(logical_y, logical_x));
+                        MeshCoordinate(logical_y, logical_x));
                     if (logical_y == 0) {
                         for (int i = 0; i < dst_vec.size(); i++) {
                             EXPECT_EQ(dst_vec[i].to_float(), 5);
@@ -687,7 +687,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
                             mesh_device_->mesh_command_queue(),
                             dst_vec,
                             output_buffers[col_idx * worker_grid_size.y + row_idx],
-                            Coordinate(logical_y, logical_x));
+                            MeshCoordinate(logical_y, logical_x));
                         for (int i = 0; i < dst_vec.size(); i++) {
                             float ref_val = std::pow(2, (iter % 2) + 1);
                             if (i >= 512) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -33,6 +33,7 @@
 #include "eth_l1_address_map.h"
 
 using tt::tt_metal::IDevice;
+using tt::tt_metal::distributed::MeshCoordinate;
 using tt::tt_metal::distributed::MeshDevice;
 using tt::tt_metal::distributed::MeshDeviceConfig;
 using tt::tt_metal::distributed::MeshDeviceView;
@@ -453,44 +454,44 @@ int main(int argc, char** argv) {
         switch (n_hops) {
             case 2:
                 return std::vector<IDevice*>{
-                    view.get_device(0, 0),
-                    view.get_device(0, 1),
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(0, 1)),
                 };
 
             case 4:
                 return std::vector<IDevice*>{
-                    view.get_device(1, 1),
-                    view.get_device(0, 1),
-                    view.get_device(0, 2),
-                    view.get_device(1, 2),
+                    view.get_device(MeshCoordinate(1, 1)),
+                    view.get_device(MeshCoordinate(0, 1)),
+                    view.get_device(MeshCoordinate(0, 2)),
+                    view.get_device(MeshCoordinate(1, 2)),
                 };
 
             case 8:
                 return std::vector<IDevice*>{
-                    view.get_device(1, 1),
-                    view.get_device(1, 0),
-                    view.get_device(0, 0),
-                    view.get_device(0, 1),
-                    view.get_device(0, 2),
-                    view.get_device(0, 3),
-                    view.get_device(1, 3),
-                    view.get_device(1, 2),
+                    view.get_device(MeshCoordinate(1, 1)),
+                    view.get_device(MeshCoordinate(1, 0)),
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(0, 1)),
+                    view.get_device(MeshCoordinate(0, 2)),
+                    view.get_device(MeshCoordinate(0, 3)),
+                    view.get_device(MeshCoordinate(1, 3)),
+                    view.get_device(MeshCoordinate(1, 2)),
                 };
 
             case 12:  // Does an extra loop through the inner ring
                 return std::vector<IDevice*>{
-                    view.get_device(1, 1),
-                    view.get_device(1, 0),
-                    view.get_device(0, 0),
-                    view.get_device(0, 1),
-                    view.get_device(0, 2),
-                    view.get_device(1, 2),
-                    view.get_device(1, 1),
-                    view.get_device(0, 1),
-                    view.get_device(0, 2),
-                    view.get_device(0, 3),
-                    view.get_device(1, 3),
-                    view.get_device(1, 2),
+                    view.get_device(MeshCoordinate(1, 1)),
+                    view.get_device(MeshCoordinate(1, 0)),
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(0, 1)),
+                    view.get_device(MeshCoordinate(0, 2)),
+                    view.get_device(MeshCoordinate(1, 2)),
+                    view.get_device(MeshCoordinate(1, 1)),
+                    view.get_device(MeshCoordinate(0, 1)),
+                    view.get_device(MeshCoordinate(0, 2)),
+                    view.get_device(MeshCoordinate(0, 3)),
+                    view.get_device(MeshCoordinate(1, 3)),
+                    view.get_device(MeshCoordinate(1, 2)),
                 };
 
             default: TT_THROW("Unsupported hop_count"); return std::vector<IDevice*>{};

--- a/tests/ttnn/distributed/test_distributed.cpp
+++ b/tests/ttnn/distributed/test_distributed.cpp
@@ -4,10 +4,14 @@
 
 #include <gtest/gtest.h>
 
+#include <tt-metalium/mesh_coord.hpp>
+
 #include <ttnn/core.hpp>
 #include <ttnn/distributed/api.hpp>
 
 namespace ttnn::distributed::test {
+
+using ::tt::tt_metal::distributed::MeshContainer;
 
 class DistributedTest : public ::testing::Test {
 protected:
@@ -44,6 +48,24 @@ TEST_F(DistributedTest, TestNumDramChannels) {
     auto mesh = ttnn::distributed::open_mesh_device(
         {2, 4}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
     EXPECT_EQ(mesh->num_dram_channels(), 96); // 8 devices * 12 channels
+}
+
+TEST_F(DistributedTest, ViewIs2D) {
+    auto mesh = ttnn::distributed::open_mesh_device(
+        {2, 4}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
+    std::vector<IDevice*> devices = mesh->get_devices();
+
+    MeshContainer<IDevice*> container_1d(SimpleMeshShape(8), devices);
+    MeshDeviceView view_1d(container_1d);
+    EXPECT_FALSE(view_1d.is_mesh_2d());
+
+    MeshContainer<IDevice*> container_2d(SimpleMeshShape(2, 4), devices);
+    MeshDeviceView view_2d(container_2d);
+    EXPECT_TRUE(view_2d.is_mesh_2d());
+
+    MeshContainer<IDevice*> container_3d(SimpleMeshShape(2, 2, 2), devices);
+    MeshDeviceView view_3d(container_3d);
+    EXPECT_FALSE(view_3d.is_mesh_2d());
 }
 
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/distributed/test_distributed_reshape.cpp
+++ b/tests/ttnn/distributed/test_distributed_reshape.cpp
@@ -3,17 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-
+#include <gmock/gmock.h>
 #include <cstddef>
 #include <array>
 #include <ttnn/core.hpp>
 #include <ttnn/distributed/api.hpp>
+#include "mesh_coord.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 
 namespace ttnn::distributed::test {
+namespace {
+
+using ::testing::SizeIs;
 
 // Helper function to check test environment
-void check_test_environment() {
+void check_t3k_test_environment() {
     auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
     const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
@@ -39,10 +43,10 @@ static constexpr std::array<MeshShape, 24> kMeshShapes{
 
 class MeshConfigurationTest : public ::testing::TestWithParam<MeshShape> {
 protected:
-    void SetUp() override { check_test_environment(); }
+    void SetUp() override { check_t3k_test_environment(); }
 };
 
-TEST_P(MeshConfigurationTest, TestMeshConfigurations) {
+TEST_P(MeshConfigurationTest, MeshConfigurations) {
     const auto& shape = GetParam();
     auto mesh = ttnn::distributed::open_mesh_device(
         {shape.num_rows, shape.num_cols},
@@ -55,15 +59,24 @@ TEST_P(MeshConfigurationTest, TestMeshConfigurations) {
     ttnn::distributed::close_mesh_device(mesh);
 }
 
+TEST_P(MeshConfigurationTest, GetPhysicalDeviceIds) {
+    const auto& shape = GetParam();
+
+    auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
+    EXPECT_THAT(
+        system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(shape)}),
+        SizeIs(shape.num_cols * shape.num_rows));
+}
+
 // Test all possible mesh configurations on T3000
 INSTANTIATE_TEST_SUITE_P(MeshShapes, MeshConfigurationTest, ::testing::ValuesIn(kMeshShapes));
 
 class MeshReshapeTest : public ::testing::TestWithParam<std::tuple<MeshShape, MeshShape>> {
 protected:
-    void SetUp() override { check_test_environment(); }
+    void SetUp() override { check_t3k_test_environment(); }
 };
 
-TEST_P(MeshReshapeTest, TestReshapeBetweenConfigurations) {
+TEST_P(MeshReshapeTest, ReshapeBetweenConfigurations) {
     const auto& [old_shape, new_shape] = GetParam();
 
     if ((old_shape.num_rows * old_shape.num_cols) != (new_shape.num_rows * new_shape.num_cols)) {
@@ -105,8 +118,30 @@ INSTANTIATE_TEST_SUITE_P(
 // Base class for non-parameterized tests
 class T3000ReshapeTest : public ::testing::Test {
 protected:
-    void SetUp() override { check_test_environment(); }
+    void SetUp() override { check_t3k_test_environment(); }
 };
+
+TEST_F(T3000ReshapeTest, InvalidRequestedShape) {
+    auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
+
+    // Shape too big.
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(9)}));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 5)}));
+
+    // Invalid offset.
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
+        MeshDeviceConfig{.mesh_shape = SimpleMeshShape(1, 8), .offset = MeshCoordinate(0, 1)}));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
+        MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 3), .offset = MeshCoordinate(1, 1)}));
+
+    // Offset dimensionality mismatch.
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
+        MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 3), .offset = MeshCoordinate(1)}));
+
+    // Mismatch system mesh shape.
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
+        MeshDeviceConfig{.mesh_shape = SimpleMeshShape(8), .offset = MeshCoordinate(1)}));
+}
 
 TEST_F(T3000ReshapeTest, InvalidReshapeDimensions) {
     auto mesh = ttnn::distributed::open_mesh_device(
@@ -201,7 +236,7 @@ TEST_F(T3000ReshapeTest, From1x4To2x2Valid) {
 
     // Fetch the device ids for a physically connected 2x2 mesh.
     auto physical_device_ids = system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{
-        .mesh_shape = MeshShape{2, 2},
+        .mesh_shape = SimpleMeshShape(2, 2),
     });
 
     // Supply the physical device ids to the mesh constructor that we know we know is 2x2 physically connected.
@@ -245,4 +280,5 @@ TEST_F(T3000ReshapeTest, From2x2To1x4) {
     EXPECT_EQ(mesh_1x4_device_ids, expected_1x4_device_ids);
 }
 
+}  // namespace
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -56,6 +56,7 @@ struct SubdeviceInfo {
     std::unordered_map<chip_id_t, SubDeviceId> fabric_subdevice_id;
 };
 
+using tt::tt_metal::distributed::MeshCoordinate;
 using tt::tt_metal::distributed::MeshDevice;
 using tt::tt_metal::distributed::MeshDeviceConfig;
 using tt::tt_metal::distributed::MeshDeviceView;
@@ -1125,7 +1126,10 @@ int TestLineFabricEntrypoint(
 
     // build a line of devices
     std::vector<IDevice*> devices = {
-        view.get_device(0, 0), view.get_device(0, 1), view.get_device(0, 2), view.get_device(0, 3)};
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3))};
     std::vector<Program> programs(enable_persistent_fabric ? 1 : devices.size());
     std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
     std::optional<std::vector<Program>> fabric_programs;
@@ -1206,8 +1210,8 @@ int TestLoopbackEntrypoint(
     T3000TestDevice test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
-    const auto& device_0 = view.get_device(0, 0);
-    const auto& device_1 = view.get_device(0, 1);
+    const auto& device_0 = view.get_device(MeshCoordinate(0, 0));
+    const auto& device_1 = view.get_device(MeshCoordinate(0, 1));
 
     auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
     auto eth_sender_core_iter = active_eth_cores.begin();
@@ -1390,7 +1394,7 @@ bool TestMultiInputReaderKernel(
     std::vector<IDevice*> devices;
     devices.reserve(fabric_num_devices);
     for (size_t i = 0; i < fabric_num_devices; i++) {
-        devices.push_back(view.get_device(0, i));
+        devices.push_back(view.get_device(MeshCoordinate(0, i)));
     }
 
     std::vector<Program> programs(enable_persistent_fabric ? 1 : devices.size());
@@ -2201,7 +2205,7 @@ bool RunPipelinedWorkersTest(
     T3000TestDevice test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
-    IDevice* device = view.get_device(0, 0);
+    IDevice* device = view.get_device(MeshCoordinate(0, 0));
     ;
 
     // General setup is as follows:
@@ -2741,7 +2745,10 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
 
     // build a line of devices
     std::vector<IDevice*> devices = {
-        view.get_device(0, 1), view.get_device(1, 1), view.get_device(1, 2), view.get_device(0, 2)};
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(1, 1)),
+        view.get_device(MeshCoordinate(1, 2)),
+        view.get_device(MeshCoordinate(0, 2))};
     const size_t num_devices = devices.size();
     TT_FATAL(
         test_expected_num_devices == num_devices,
@@ -2861,7 +2868,10 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
 
     // build a line of devices
     std::vector<IDevice*> devices = {
-        view.get_device(0, 0), view.get_device(0, 1), view.get_device(0, 2), view.get_device(0, 3)};
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3))};
     const size_t num_devices = devices.size();
     TT_FATAL(
         test_expected_num_devices == num_devices,
@@ -3001,7 +3011,10 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
 
     // Get the inner 4 device ring on a WH T3K device so that we can use both links for all devices
     std::vector<IDevice*> devices_ = {
-        view.get_device(0, 1), view.get_device(0, 2), view.get_device(1, 2), view.get_device(1, 1)};
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(1, 2)),
+        view.get_device(MeshCoordinate(1, 1))};
     std::vector<IDevice*> devices;
     devices.reserve(line_size);
     for (size_t i = 0; i < line_size; i++) {

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -6,6 +6,7 @@
 
 #include "mesh_buffer.hpp"
 #include "mesh_command_queue.hpp"
+#include "mesh_coord.hpp"
 #include "mesh_event.hpp"
 
 namespace tt::tt_metal {
@@ -29,7 +30,7 @@ void WriteShard(
     MeshCommandQueue& mesh_cq,
     std::shared_ptr<MeshBuffer>& mesh_buffer,
     std::vector<DType>& src,
-    const Coordinate& coord,
+    const MeshCoordinate& coord,
     bool blocking = false) {
     std::vector<MeshCommandQueue::ShardDataTransfer> shard_data_transfers = {{
         .shard_coord = coord,
@@ -44,7 +45,7 @@ void ReadShard(
     MeshCommandQueue& mesh_cq,
     std::vector<DType>& dst,
     std::shared_ptr<MeshBuffer>& mesh_buffer,
-    const Coordinate& coord,
+    const MeshCoordinate& coord,
     bool blocking = true) {
     auto shard = mesh_buffer->get_device_buffer(coord);
     dst.resize(shard->page_size() * shard->num_pages() / sizeof(DType));

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -96,7 +96,6 @@ public:
     const ShardedBufferConfig& global_shard_spec() const;
     const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
 
-    std::shared_ptr<Buffer> get_device_buffer(const Coordinate& device_coord) const;
     std::shared_ptr<Buffer> get_device_buffer(const MeshCoordinate& device_coord) const;
     uint32_t datum_size_bytes() const;
     Shape2D physical_shard_shape() const;

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -66,7 +66,7 @@ public:
 
     // Specifies host data to be written to or read from a MeshBuffer shard.
     struct ShardDataTransfer {
-        Coordinate shard_coord;
+        MeshCoordinate shard_coord;
         void* host_data = nullptr;
         std::optional<BufferRegion> region;
     };

--- a/tt_metal/api/tt-metalium/mesh_config.hpp
+++ b/tt_metal/api/tt-metalium/mesh_config.hpp
@@ -7,6 +7,8 @@
 #include <cstddef>
 #include <vector>
 
+#include "mesh_coord.hpp"
+
 namespace tt::tt_metal::distributed {
 
 using DeviceIds = std::vector<int>;
@@ -38,8 +40,8 @@ struct MeshShape {
  */
 
 struct MeshDeviceConfig {
-    MeshShape mesh_shape{0, 0};
-    MeshOffset offset{0, 0};
+    SimpleMeshShape mesh_shape{0, 0};
+    std::optional<MeshCoordinate> offset;
     std::vector<chip_id_t> physical_device_ids{};
 };
 

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -13,32 +13,14 @@
 
 #include "device.hpp"
 #include "mesh_config.hpp"
+#include "mesh_coord.hpp"
+#include "shape2d.hpp"
 
 namespace tt::tt_metal::distributed {
 
 // Forward declaration of MeshDevice
 class MeshDevice;
-struct Coordinate {
-    size_t row = 0;
-    size_t col = 0;
-    auto operator<=>(const Coordinate&) const = default;
 
-    // Add support for structured bindings
-    template <size_t I>
-    decltype(auto) get() const {
-        if constexpr (I == 0) {
-            return row;
-        } else if constexpr (I == 1) {
-            return col;
-        } else {
-            static_assert(I < 2, "Index out of bounds for Coordinate");
-        }
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, const Coordinate& coord) {
-        return os << "Coord(" << coord.row << ", " << coord.col << ")";
-    }
-};
 // TODO (Issue #17477): MeshWorkload and MeshEvent currently rely on the coordinate systems
 // exposed below. These must be uplifted to an ND coordinate system (DeviceCoord and DeviceRange),
 // keeping things more consistent  across the stack.
@@ -70,45 +52,49 @@ class MeshDeviceView {
 public:
     using DeviceView = std::vector<IDevice*>;
     using DeviceViews = std::vector<std::vector<IDevice*>>;
-    using CoordinateMapper = std::function<std::optional<Coordinate>(int device_id)>;
 
-    MeshDeviceView(const std::vector<IDevice*>& devices, const MeshShape& shape);
-    MeshDeviceView(const std::vector<IDevice*>& devices, Coordinate top_left, Coordinate bottom_right);
-    MeshDeviceView(const MeshDevice& mesh_device);
-    MeshDeviceView(const std::vector<IDevice*>& devices, const CoordinateMapper& mapper);
+    // Create a view of the entire mesh.
+    // MeshDeviceView(const MeshDevice& mesh_device);
 
-    [[nodiscard]] IDevice* get_device(size_t row, size_t col) const;
+    // // Create a view of a sub-region of the mesh defined by `range`.
+    // MeshDeviceView(const std::vector<IDevice*>& devices, const MeshCoordinateRange& range);
+    explicit MeshDeviceView(const MeshContainer<IDevice*>& devices);
+    explicit MeshDeviceView(const MeshDevice& mesh_device);
 
-    // Get devices spanning the rectangular region defined by the top-left and bottom-right coordinates
-    // devices are returned in row-major order with start/end coordinates inclusive
-    [[nodiscard]] DeviceView get_devices(const Coordinate& start, const Coordinate& end) const;
-    [[nodiscard]] DeviceView get_devices(const MeshShape& submesh_shape) const;
+    // Get devices spanning the region defined by `range` in row-major order with start/end coordinates inclusive
+    [[nodiscard]] DeviceView get_devices(const MeshCoordinateRange& range) const;
+    [[nodiscard]] DeviceView get_devices(const SimpleMeshShape& submesh_shape) const;
     [[nodiscard]] DeviceView get_devices() const;
-
-    [[nodiscard]] DeviceView get_devices_on_row(size_t row) const;
-    [[nodiscard]] DeviceView get_devices_on_column(size_t col) const;
-
-    [[nodiscard]] DeviceViews get_row_views() const;
-    [[nodiscard]] DeviceViews get_column_views() const;
+    [[nodiscard]] size_t num_devices() const;
 
     [[nodiscard]] bool empty() const noexcept;
     [[nodiscard]] size_t size() const noexcept;
-    [[nodiscard]] MeshShape shape() const noexcept;
-    [[nodiscard]] bool contains(const Coordinate& coord) const noexcept;
-    [[nodiscard]] const IDevice* at(const Coordinate& coord) const noexcept;
+    [[nodiscard]] SimpleMeshShape shape() const noexcept;
+    [[nodiscard]] bool contains(const MeshCoordinate& coord) const noexcept;
+    [[nodiscard]] IDevice* get_device(const MeshCoordinate& coord) const;
+    [[nodiscard]] const IDevice* at(const MeshCoordinate& coord) const noexcept;
 
     bool operator==(const MeshDeviceView& other) const;
 
-    auto begin() const { return devices_.begin(); }
-    auto end() const { return devices_.end(); }
-
-    [[nodiscard]] size_t num_rows() const { return bottom_right_.row - top_left_.row + 1; }
-    [[nodiscard]] size_t num_cols() const { return bottom_right_.col - top_left_.col + 1; }
-    [[nodiscard]] size_t num_devices() const { return devices_.size(); }
+    auto begin() const { return devices_.values().begin(); }
+    auto end() const { return devices_.values().end(); }
 
     [[nodiscard]] bool contains_device(chip_id_t device_id) const;
-    [[nodiscard]] Coordinate find_device(chip_id_t device_id) const;
-    [[nodiscard]] chip_id_t find_device_id(const Coordinate& coord) const;
+
+    // Throws if no device corresponds to `device_id`.
+    [[nodiscard]] MeshCoordinate find_device(chip_id_t device_id) const;
+
+    // Throws if the `coord` is out of bounds of this view.
+    [[nodiscard]] chip_id_t find_device_id(const MeshCoordinate& coord) const;
+
+    // TODO: Remove the methods that assume 2D mesh.
+    [[nodiscard]] bool is_mesh_2d() const;
+    [[nodiscard]] size_t num_rows() const;
+    [[nodiscard]] size_t num_cols() const;
+    [[nodiscard]] DeviceView get_devices_on_row(size_t row) const;
+    [[nodiscard]] DeviceView get_devices_on_column(size_t col) const;
+    [[nodiscard]] DeviceViews get_row_views() const;
+    [[nodiscard]] DeviceViews get_column_views() const;
 
     // These utility methods linearize the set of devices in a mesh into a line or ring.
     // Linearizing a mesh into a line asserts the condition that device[i-1] is connected to device[i].
@@ -117,47 +103,21 @@ public:
     //
     // Given a starting coordinate, get the coordinates of a line of devices where device[i-1] is connected to device[i]
     // The current support only provides left-to-right and right-to-left snaking of the line.
-    [[nodiscard]] static std::vector<Coordinate> get_line_coordinates(
-        size_t length, const Coordinate& offset, size_t num_rows, size_t num_cols);
-    [[nodiscard]] std::vector<Coordinate> get_ring_coordinates(
-        const MeshShape& ring_shape, const Coordinate& offset, size_t num_rows, size_t num_cols) const;
+    //
+    // Important: these utilities currently only support 2D meshes.
+    [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(size_t length, const Shape2D& mesh_shape);
+    [[nodiscard]] static std::vector<MeshCoordinate> get_ring_coordinates(
+        const Shape2D& ring_shape, const Shape2D& mesh_shape);
     [[nodiscard]] std::vector<IDevice*> get_ring_devices() const;
     [[nodiscard]] std::vector<IDevice*> get_line_devices() const;
 
 private:
-    std::vector<IDevice*> devices_;
-    std::unordered_map<chip_id_t, Coordinate> device_coordinates_;
-    Coordinate top_left_;
-    Coordinate bottom_right_;
+    MeshContainer<IDevice*> devices_;
+    std::unordered_map<chip_id_t, MeshCoordinate> device_coordinates_;
 
-    void initialize_from_devices(const std::vector<IDevice*>& devices, const CoordinateMapper& mapper);
-    void validate_coordinates() const;
+    // Set if the view is 2D to enable row/col APIs, otherwise nullopt.
+    // TODO: remove this?
+    std::optional<Shape2D> shape_2d_;
 };
-
-// Helper function to create a MeshDeviceView
-inline MeshDeviceView make_mesh_device_view(std::vector<IDevice*> devices, MeshDeviceView::CoordinateMapper mapper) {
-    return MeshDeviceView(std::move(devices), std::move(mapper));
-}
 
 }  // namespace tt::tt_metal::distributed
-
-namespace std {
-// Specializations to enable structured bindings
-template <>
-struct tuple_size<tt::tt_metal::distributed::Coordinate> : std::integral_constant<size_t, 2> {};
-template <size_t I>
-struct tuple_element<I, tt::tt_metal::distributed::Coordinate> {
-    using type = size_t;
-};
-
-// Specialization to enable hashing of Coordinate
-template <>
-struct hash<tt::tt_metal::distributed::Coordinate> {
-    size_t operator()(const tt::tt_metal::distributed::Coordinate& coord) const noexcept {
-        size_t seed = 0;
-        tt::utils::hash_combine(seed, coord.row);
-        tt::utils::hash_combine(seed, coord.col);
-        return seed;
-    }
-};
-}  // namespace std

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -105,8 +105,19 @@ MeshCoordinateRange::MeshCoordinateRange(const MeshCoordinate& start, const Mesh
 MeshCoordinateRange::MeshCoordinateRange(const SimpleMeshShape& shape) :
     MeshCoordinateRange(zero_coordinate(shape.dims()), shape_back(shape)) {}
 
+size_t MeshCoordinateRange::dims() const { return start_.dims(); }
 const MeshCoordinate& MeshCoordinateRange::start_coord() const { return start_; }
 const MeshCoordinate& MeshCoordinateRange::end_coord() const { return end_; }
+
+bool MeshCoordinateRange::contains(const MeshCoordinate& coord) const {
+    TT_FATAL(coord.dims() == dims(), "Coordinate dimensions do not match: {} != {}", coord.dims(), dims());
+    for (int i = 0; i < coord.dims(); ++i) {
+        if (coord[i] < start_[i] || coord[i] > end_[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 MeshCoordinateRange::Iterator::Iterator(
     const MeshCoordinateRange* range, const MeshCoordinate& current, size_t linear_index) :
@@ -142,6 +153,11 @@ MeshCoordinateRange::Iterator MeshCoordinateRange::end() const {
     // Set `start_` coordinate but `range_size` linear index as the wrap around condition.
     return Iterator(this, start_, range_size);
 }
+
+bool operator==(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs) {
+    return lhs.start_coord() == rhs.start_coord() && lhs.end_coord() == rhs.end_coord();
+}
+bool operator!=(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs) { return !(lhs == rhs); }
 
 size_t to_linear_index(const SimpleMeshShape& shape, const MeshCoordinate& coord) {
     TT_FATAL(

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -134,10 +134,6 @@ bool MeshBuffer::is_allocated() const { return not std::holds_alternative<Deallo
 
 void MeshBuffer::deallocate() { state_ = DeallocatedState{}; }
 
-std::shared_ptr<Buffer> MeshBuffer::get_device_buffer(const Coordinate& device_coord) const {
-    return get_device_buffer(MeshCoordinate(device_coord.row, device_coord.col));
-}
-
 std::shared_ptr<Buffer> MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const {
     return buffers_.at(device_coord);
 }

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -271,7 +271,7 @@ void MeshCommandQueue::write_sharded_buffer(const MeshBuffer& buffer, const void
                     for (std::size_t replicated_device_y = 0; replicated_device_y < num_devices_y;
                          replicated_device_y++) {
                         auto device_shard_view =
-                            buffer.get_device_buffer(Coordinate(replicated_device_y, replicated_device_x));
+                            buffer.get_device_buffer(MeshCoordinate(replicated_device_y, replicated_device_x));
                         const BufferRegion region(0, device_shard_view->size());
                         this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                     }
@@ -279,21 +279,23 @@ void MeshCommandQueue::write_sharded_buffer(const MeshBuffer& buffer, const void
             } else if (height_replicated or width_replicated) {
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     for (auto replicated_device_y = 0; replicated_device_y < num_devices_y; replicated_device_y++) {
-                        auto device_shard_view = buffer.get_device_buffer(Coordinate(replicated_device_y, device_x));
+                        auto device_shard_view =
+                            buffer.get_device_buffer(MeshCoordinate(replicated_device_y, device_x));
                         const BufferRegion region(0, device_shard_view->size());
                         this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                     }
                     device_x++;
                 } else {
                     for (auto replicated_device_x = 0; replicated_device_x < num_devices_x; replicated_device_x++) {
-                        auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, replicated_device_x));
+                        auto device_shard_view =
+                            buffer.get_device_buffer(MeshCoordinate(device_y, replicated_device_x));
                         const BufferRegion region(0, device_shard_view->size());
                         this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                     }
                     device_y++;
                 }
             } else {
-                auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, device_x));
+                auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(device_y, device_x));
                 const BufferRegion region(0, device_shard_view->size());
                 this->write_shard_to_device(device_shard_view, shard_data.data(), region);
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
@@ -334,7 +336,7 @@ void MeshCommandQueue::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
     std::vector<uint32_t> shard_data = std::vector<uint32_t>(total_write_size_per_shard / sizeof(uint32_t), 0);
     for (std::size_t shard_y = 0; shard_y < num_shards_y; shard_y++) {
         for (std::size_t shard_x = 0; shard_x < num_shards_x; shard_x++) {
-            auto device_shard_view = buffer.get_device_buffer(Coordinate(device_y, device_x));
+            auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(device_y, device_x));
             const BufferRegion region(0, device_shard_view->size());
             this->read_shard_from_device(device_shard_view, shard_data.data(), region);
 
@@ -371,7 +373,7 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
              logical_x++) {
             for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y + 1;
                  logical_y++) {
-                auto device_shard_view = buffer.get_device_buffer(Coordinate(logical_y, logical_x));
+                auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(logical_y, logical_x));
                 const BufferRegion region(0, device_shard_view->size());
                 this->write_shard_to_device(device_shard_view, host_data, region);
             }

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -7,189 +7,146 @@
 
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
+#include "buffer.hpp"
+#include "mesh_coord.hpp"
+#include "shape2d.hpp"
 
 namespace tt::tt_metal::distributed {
+namespace {
 
-static std::vector<IDevice*> get_devices_from_coordinates(
-    const MeshDeviceView& mesh, const std::vector<Coordinate>& coords) {
+std::vector<IDevice*> get_devices_from_coordinates(
+    const MeshDeviceView& mesh, const std::vector<MeshCoordinate>& coords) {
     std::vector<IDevice*> devices;
     for (const auto& coord : coords) {
-        if (auto device = mesh.get_device(coord.row, coord.col)) {
+        if (auto device = mesh.get_device(coord)) {
             devices.push_back(device);
         }
     }
     return devices;
 }
 
-MeshDeviceView::MeshDeviceView(const std::vector<IDevice*>& devices, Coordinate top_left, Coordinate bottom_right) :
-    top_left_(0, 0), bottom_right_(Coordinate{bottom_right.row - top_left.row, bottom_right.col - top_left.col}) {
-    auto num_rows = bottom_right.row - top_left.row + 1;
-    auto num_cols = bottom_right.col - top_left.col + 1;
+}  // namespace
 
-    for (size_t row = top_left.row; row <= bottom_right.row; ++row) {
-        for (size_t col = top_left.col; col <= bottom_right.col; ++col) {
-            auto device_index = row * num_cols + col;
-            TT_FATAL(device_index < devices.size(), "Device index out of bounds");
-            auto device = devices[device_index];
-            devices_.push_back(device);
-            device_coordinates_[device->id()] = {row - top_left.row, col - top_left.col};
-        }
+MeshDeviceView::MeshDeviceView(const MeshContainer<IDevice*>& devices) : devices_(devices) {
+    if (devices_.shape().dims() == 2) {
+        shape_2d_ = Shape2D(devices_.shape()[0], devices_.shape()[1]);
     }
-    validate_coordinates();
+    for (const auto& [coord, device] : devices_) {
+        device_coordinates_.emplace(device->id(), coord);
+    }
 }
 
 MeshDeviceView::MeshDeviceView(const MeshDevice& mesh_device) :
-    MeshDeviceView(mesh_device.get_devices(), mesh_device.shape()) {}
+    MeshDeviceView(MeshContainer<IDevice*>(SimpleMeshShape(mesh_device.shape()), mesh_device.get_devices())) {}
 
-MeshDeviceView::MeshDeviceView(const std::vector<IDevice*>& devices, const MeshShape& shape) :
-    MeshDeviceView(devices, Coordinate{0, 0}, Coordinate{shape.num_rows - 1, shape.num_cols - 1}) {}
-
-MeshDeviceView::MeshDeviceView(const std::vector<IDevice*>& devices, const CoordinateMapper& mapper) :
-    devices_(std::move(devices)) {
-    initialize_from_devices(devices_, std::move(mapper));
-}
-
-IDevice* MeshDeviceView::get_device(size_t row, size_t col) const {
-    for (const auto& device : devices_) {
-        auto it = device_coordinates_.find(device->id());
-        if (it != device_coordinates_.end() && it->second.row == row && it->second.col == col) {
-            return device;
-        }
-    }
-    return nullptr;
-}
-
-MeshDeviceView::DeviceView MeshDeviceView::get_devices(const Coordinate& start, const Coordinate& end) const {
-    if (start.row > end.row || start.col > end.col) {
-        log_fatal("Invalid coordinates: start {} must be less than or equal to end {}", start, end);
-    }
-
+MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshCoordinateRange& range) const {
     DeviceView devices_in_region;
-    for (size_t row = start.row; row <= end.row; ++row) {
-        for (size_t col = start.col; col <= end.col; ++col) {
-            if (auto device = get_device(row, col)) {
-                devices_in_region.push_back(device);
-            }
-        }
+    for (const auto& coord : range) {
+        devices_in_region.push_back(devices_.at(coord));
     }
     return devices_in_region;
 }
 
-MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshShape& submesh_shape) const {
-    return get_devices({0, 0}, {submesh_shape.num_rows - 1, submesh_shape.num_cols - 1});
+MeshDeviceView::DeviceView MeshDeviceView::get_devices(const SimpleMeshShape& submesh_shape) const {
+    return get_devices(MeshCoordinateRange(submesh_shape));
 }
 
 std::vector<IDevice*> MeshDeviceView::get_devices_on_row(size_t row) const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    TT_FATAL(row < shape_2d_->height(), "Row index out of bounds: {}", row);
     std::vector<IDevice*> row_devices;
-    for (const auto& device : devices_) {
-        auto it = device_coordinates_.find(device->id());
-        if (it != device_coordinates_.end() && it->second.row == row) {
-            row_devices.push_back(device);
-        }
+    for (int col = 0; col < shape_2d_->width(); ++col) {
+        row_devices.push_back(devices_.at(MeshCoordinate(row, col)));
     }
     return row_devices;
 }
 
 std::vector<IDevice*> MeshDeviceView::get_devices_on_column(size_t col) const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    TT_FATAL(col < shape_2d_->width(), "Column index out of bounds: {}", col);
     std::vector<IDevice*> col_devices;
-    for (const auto& device : devices_) {
-        auto it = device_coordinates_.find(device->id());
-        if (it != device_coordinates_.end() && it->second.col == col) {
-            col_devices.push_back(device);
-        }
+    for (int row = 0; row < shape_2d_->height(); ++row) {
+        col_devices.push_back(devices_.at(MeshCoordinate(row, col)));
     }
     return col_devices;
 }
 
 std::vector<std::vector<IDevice*>> MeshDeviceView::get_row_views() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
     std::vector<std::vector<IDevice*>> row_views;
-    for (size_t row = top_left_.row; row <= bottom_right_.row; ++row) {
+    for (size_t row = 0; row < shape_2d_->height(); ++row) {
         row_views.push_back(get_devices_on_row(row));
     }
     return row_views;
 }
 
 std::vector<std::vector<IDevice*>> MeshDeviceView::get_column_views() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
     std::vector<std::vector<IDevice*>> column_views;
-    for (size_t col = top_left_.col; col <= bottom_right_.col; ++col) {
+    for (size_t col = 0; col < shape_2d_->width(); ++col) {
         column_views.push_back(get_devices_on_column(col));
     }
     return column_views;
 }
 
-bool MeshDeviceView::empty() const noexcept { return devices_.empty(); }
+bool MeshDeviceView::empty() const noexcept { return devices_.shape().mesh_size() == 0; }
+size_t MeshDeviceView::size() const noexcept { return devices_.shape().mesh_size(); }
+SimpleMeshShape MeshDeviceView::shape() const noexcept { return devices_.shape(); }
 
-size_t MeshDeviceView::size() const noexcept { return devices_.size(); }
-
-MeshShape MeshDeviceView::shape() const noexcept { return {num_rows(), num_cols()}; }
-
-bool MeshDeviceView::contains(const Coordinate& coord) const noexcept {
-    return coord.row >= top_left_.row && coord.row <= bottom_right_.row && coord.col >= top_left_.col &&
-           coord.col <= bottom_right_.col;
+bool MeshDeviceView::contains(const MeshCoordinate& coord) const noexcept {
+    return devices_.coord_range().contains(coord);
 }
 
-const IDevice* MeshDeviceView::at(const Coordinate& coord) const noexcept {
-    if (contains(coord)) {
-        return get_device(coord.row, coord.col);
-    }
-    return nullptr;
+IDevice* MeshDeviceView::get_device(const MeshCoordinate& coord) const {
+    return contains(coord) ? devices_.at(coord) : nullptr;
+}
+const IDevice* MeshDeviceView::at(const MeshCoordinate& coord) const noexcept {
+    return contains(coord) ? devices_.at(coord) : nullptr;
 }
 
 bool MeshDeviceView::operator==(const MeshDeviceView& other) const {
     return devices_ == other.devices_ && device_coordinates_ == other.device_coordinates_ &&
-           top_left_ == other.top_left_ && bottom_right_ == other.bottom_right_;
+           shape_2d_ == other.shape_2d_;
 }
+
+size_t MeshDeviceView::num_rows() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    return shape_2d_->height();
+}
+size_t MeshDeviceView::num_cols() const {
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    return shape_2d_->width();
+}
+size_t MeshDeviceView::num_devices() const { return devices_.shape().mesh_size(); }
 
 bool MeshDeviceView::contains_device(chip_id_t device_id) const {
     return device_coordinates_.find(device_id) != device_coordinates_.end();
 }
 
-Coordinate MeshDeviceView::find_device(chip_id_t device_id) const {
+MeshCoordinate MeshDeviceView::find_device(chip_id_t device_id) const {
     auto it = device_coordinates_.find(device_id);
-    if (it != device_coordinates_.end()) {
-        return it->second;
-    }
-    TT_THROW("Device not found in mesh: {}", device_id);
+    TT_FATAL(it != device_coordinates_.end(), "Device not found in mesh: {}", device_id);
+    return it->second;
 }
 
-chip_id_t MeshDeviceView::find_device_id(const Coordinate& coord) const {
-    TT_FATAL(
-        coord.row >= 0 and coord.row < num_rows() and coord.col >= 0 and coord.col < num_cols(),
-        "Invalid coordinate: ({}, {})",
-        coord.row,
-        coord.col);
-    return this->devices_.at(coord.row * num_cols() + coord.col)->id();
+chip_id_t MeshDeviceView::find_device_id(const MeshCoordinate& coord) const {
+    TT_FATAL(contains(coord), "Coordinate {} not found in mesh {}", coord, devices_.shape());
+    return devices_.at(coord)->id();
 }
 
-void MeshDeviceView::initialize_from_devices(const std::vector<IDevice*>& devices, const CoordinateMapper& mapper) {
-    size_t min_row = std::numeric_limits<size_t>::max(), min_col = std::numeric_limits<size_t>::max();
-    size_t max_row = std::numeric_limits<size_t>::min(), max_col = std::numeric_limits<size_t>::min();
+bool MeshDeviceView::is_mesh_2d() const { return shape_2d_.has_value(); }
 
-    for (const auto& device : devices) {
-        auto coord = mapper(device->id());
-        if (!coord) {
-            throw std::runtime_error("Failed to map device ID to coordinate");
-        }
-
-        device_coordinates_[device->id()] = *coord;
-        min_row = std::min(min_row, coord->row);
-        min_col = std::min(min_col, coord->col);
-        max_row = std::max(max_row, coord->row);
-        max_col = std::max(max_col, coord->col);
-    }
-
-    top_left_ = {min_row, min_col};
-    bottom_right_ = {max_row, max_col};
-}
-
-std::vector<Coordinate> MeshDeviceView::get_line_coordinates(
-    size_t length, const Coordinate& offset, size_t num_rows, size_t num_cols) {
-    std::vector<Coordinate> line_coords;
-    auto [row_index, col_index] = offset;
+std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(size_t length, const Shape2D& mesh_shape) {
+    // Iterate in a zigzag pattern from top-left to bottom-right.
+    std::vector<MeshCoordinate> line_coords;
+    line_coords.reserve(length);
+    const auto [num_rows, num_cols] = mesh_shape;
+    int row_index = 0;
+    int col_index = 0;
     bool left_to_right = true;
 
     for (size_t i = 0; i < length && row_index < num_rows && col_index < num_cols; ++i) {
-        line_coords.emplace_back(Coordinate{row_index, col_index});
+        line_coords.emplace_back(MeshCoordinate(row_index, col_index));
 
         if (left_to_right && col_index < num_cols - 1) {
             col_index++;
@@ -205,62 +162,55 @@ std::vector<Coordinate> MeshDeviceView::get_line_coordinates(
     return line_coords;
 }
 
-std::vector<Coordinate> MeshDeviceView::get_ring_coordinates(
-    const MeshShape& ring_shape, const Coordinate& offset, size_t num_rows, size_t num_cols) const {
-    auto [start_row, start_col] = offset;
-    auto [ring_rows, ring_cols] = ring_shape;
-    auto end_row = start_row + ring_rows - 1;
-    auto end_col = start_col + ring_cols - 1;
+std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& ring_shape, const Shape2D& mesh_shape) {
+    const auto [ring_rows, ring_cols] = ring_shape;
+    const auto end_row = ring_rows - 1;
+    const auto end_col = ring_cols - 1;
 
     // Validate the specified subgrid
-    std::vector<Coordinate> boundary_coords;
-    if (start_row + ring_rows > num_rows || start_col + ring_cols > num_cols) {
-        throw std::invalid_argument("Subgrid is out of mesh bounds.");
+    std::vector<MeshCoordinate> boundary_coords;
+    if (ring_rows > mesh_shape.height() || ring_cols > mesh_shape.width()) {
+        TT_THROW("Subgrid is out of mesh bounds.");
     }
 
     // Traverse the top row from left to right
-    for (size_t col = start_col; col <= end_col; ++col) {
-        boundary_coords.emplace_back(Coordinate{start_row, col});
+    for (size_t col = 0; col <= end_col; ++col) {
+        boundary_coords.emplace_back(MeshCoordinate{0, col});
     }
 
     // Traverse the rightmost column from top+1 to bottom
-    for (size_t row = start_row + 1; row <= end_row; ++row) {
-        boundary_coords.emplace_back(Coordinate{row, end_col});
+    for (size_t row = 1; row <= end_row; ++row) {
+        boundary_coords.emplace_back(MeshCoordinate{row, end_col});
     }
 
     // Traverse the bottom row from right to left, if there is more than one row
     if (ring_rows > 1 and ring_cols > 1) {
         // Traverse the bottom row from right to left
-        for (int col = static_cast<int>(end_col - 1); col >= static_cast<int>(start_col); --col) {
-            boundary_coords.emplace_back(Coordinate{end_row, static_cast<size_t>(col)});
+        for (int col = static_cast<int>(end_col - 1); col >= 0; --col) {
+            boundary_coords.emplace_back(MeshCoordinate{end_row, static_cast<size_t>(col)});
         }
 
         // Traverse the leftmost column from bottom-1 to top+1
-        for (int row = static_cast<int>(end_row - 1); row > static_cast<int>(start_row); --row) {
-            boundary_coords.emplace_back(Coordinate{static_cast<size_t>(row), start_col});
+        for (int row = static_cast<int>(end_row - 1); row > 0; --row) {
+            boundary_coords.emplace_back(MeshCoordinate{static_cast<size_t>(row), 0});
         }
     }
 
     return boundary_coords;
 }
 
-void MeshDeviceView::validate_coordinates() const {
-    if (top_left_.row > bottom_right_.row || top_left_.col > bottom_right_.col) {
-        throw std::invalid_argument("Invalid coordinates: top_left must be less than or equal to bottom_right");
-    }
-}
-
 std::vector<IDevice*> MeshDeviceView::get_line_devices() const {
-    auto boundary_coords =
-        get_line_coordinates(this->num_rows() * this->num_cols(), this->top_left_, this->num_rows(), this->num_cols());
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    auto boundary_coords = get_line_coordinates(devices_.shape().mesh_size(), *shape_2d_);
     return get_devices_from_coordinates(*this, boundary_coords);
 }
 
 std::vector<IDevice*> MeshDeviceView::get_ring_devices() const {
-    auto boundary_coords = get_ring_coordinates(shape(), this->top_left_, this->num_rows(), this->num_cols());
+    TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
+    auto boundary_coords = get_ring_coordinates(*shape_2d_, *shape_2d_);
     return get_devices_from_coordinates(*this, boundary_coords);
 }
 
-MeshDeviceView::DeviceView MeshDeviceView::get_devices() const { return this->devices_; }
+MeshDeviceView::DeviceView MeshDeviceView::get_devices() const { return this->devices_.values(); }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -4,6 +4,7 @@
 
 #include <system_mesh.hpp>
 
+#include "small_vector.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/distributed/coordinate_translation.hpp"
 
@@ -89,34 +90,45 @@ chip_id_t SystemMesh::Impl::get_physical_device_id(const MeshCoordinate& coord) 
 
 std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const MeshDeviceConfig& config) const {
     std::vector<chip_id_t> physical_device_ids;
-    // TODO: #17477 - Extend to ND.
+
     TT_FATAL(
-        logical_mesh_shape_.dims() == 2,
-        "SystemMesh only supports 2D meshes; requested dimensions: {}",
-        logical_mesh_shape_.dims());
+        config.mesh_shape.mesh_size() <= logical_mesh_shape_.mesh_size(),
+        "Requested mesh is too big: {}, SystemMesh {}",
+        config.mesh_shape.mesh_size(),
+        logical_mesh_shape_.mesh_size());
 
-    auto [system_mesh_rows, system_mesh_cols] = std::make_tuple(logical_mesh_shape_[0], logical_mesh_shape_[1]);
-    auto [requested_num_rows, requested_num_cols] = config.mesh_shape;
-    auto [row_offset, col_offset] = config.offset;
+    const size_t system_dimensions = logical_mesh_shape_.dims();
 
-    // First check if total size fits
-    TT_FATAL(
-        requested_num_rows * requested_num_cols <= system_mesh_rows * system_mesh_cols,
-        "Requested submesh is too big: {}x{}, SystemMesh shape: {}x{}",
-        requested_num_rows,
-        requested_num_cols,
-        system_mesh_rows,
-        system_mesh_cols);
+    const MeshCoordinate system_offset = [&config, system_dimensions]() {
+        if (config.offset.has_value()) {
+            TT_FATAL(
+                config.offset->dims() == system_dimensions,
+                "Provided offset dimensions mismatch: {} != {}",
+                config.offset,
+                system_dimensions);
+            return *config.offset;
+        } else {
+            return MeshCoordinate(tt::stl::SmallVector<uint32_t>(system_dimensions, 0));
+        }
+    }();
 
-    bool is_single_row_or_column = requested_num_rows == 1 or requested_num_cols == 1;
-    if (is_single_row_or_column) {
-        TT_FATAL(row_offset == 0 and col_offset == 0, "Row and column offsets unsupported for single row mesh");
-        auto line_length = requested_num_rows * requested_num_cols;
-        auto line_coords = MeshDeviceView::get_line_coordinates(
-            line_length, Coordinate{row_offset, col_offset}, system_mesh_rows, system_mesh_cols);
-        for (const auto& logical_coordinate : line_coords) {
-            auto physical_device_id =
-                logical_to_device_id_.at(MeshCoordinate(logical_coordinate.row, logical_coordinate.col));
+    const bool line_topology = [&config]() {
+        const int non_unit_dims =
+            std::count_if(config.mesh_shape.cbegin(), config.mesh_shape.cend(), [](int dim) { return dim != 1; });
+        return non_unit_dims <= 1;
+    }();
+    if (line_topology) {
+        TT_FATAL(
+            std::all_of(system_offset.coords().begin(), system_offset.coords().end(), [](int dim) { return dim == 0; }),
+            "Offsets are unsupported for a line mesh");
+
+        // TODO: consider if we can do this in 3D.
+        TT_FATAL(logical_mesh_shape_.dims() == 2, "Line topology is only supported for 2D meshes");
+        Shape2D shape_2d(logical_mesh_shape_[0], logical_mesh_shape_[1]);
+
+        auto line_length = config.mesh_shape.mesh_size();
+        for (const auto& logical_coordinate : MeshDeviceView::get_line_coordinates(line_length, shape_2d)) {
+            auto physical_device_id = logical_to_device_id_.at(logical_coordinate);
             physical_device_ids.push_back(physical_device_id);
 
             log_debug(
@@ -124,96 +136,58 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
         }
         return physical_device_ids;
     }
-    bool requires_rotation = requested_num_rows > system_mesh_rows || requested_num_cols > system_mesh_cols;
 
-    if (requires_rotation) {
-        bool can_rotate = requested_num_rows <= system_mesh_cols && requested_num_cols <= system_mesh_rows;
-        if (can_rotate) {
-            // Rotate requested shape; row_offset and col_offset refer to original orientation
-            std::swap(requested_num_rows, requested_num_cols);
-        } else {
-            TT_THROW(
-                "User has requested a submesh that is too big and is not rotatable: {}x{} and SystemMesh is {}x{}.",
-                requested_num_rows,
-                requested_num_cols,
-                system_mesh_rows,
-                system_mesh_cols);
+    TT_FATAL(
+        config.mesh_shape.dims() == system_dimensions,
+        "Requested mesh shape dimensions mismatch: {} != {}",
+        config.mesh_shape,
+        logical_mesh_shape_);
+
+    // Attempt to fit the requested mesh into the system mesh, potentially rotating it.
+    auto requested_mesh_fits = [this, &system_offset](const tt::stl::SmallVector<uint32_t>& rotated_shape) {
+        for (int i = 0; i < logical_mesh_shape_.dims(); ++i) {
+            if (system_offset[i] + rotated_shape[i] > logical_mesh_shape_[i]) {
+                return false;
+            }
         }
-    } else {
-        // If no rotation, check dimensions directly
-        TT_FATAL(
-            requested_num_rows <= system_mesh_rows && requested_num_cols <= system_mesh_cols,
-            "Requested submesh is too big: {}x{} and SystemMesh is {}x{}",
-            requested_num_rows,
-            requested_num_cols,
-            system_mesh_rows,
-            system_mesh_cols);
+        return true;
+    };
+
+    tt::stl::SmallVector<uint32_t> rotated_dims(config.mesh_shape.cbegin(), config.mesh_shape.cend());
+    size_t rotations = 0;
+    while (!requested_mesh_fits(rotated_dims) && rotations < system_dimensions) {
+        std::rotate(rotated_dims.begin(), rotated_dims.begin() + 1, rotated_dims.end());
+        ++rotations;
+    }
+    // After rotating N times, no luck. The requested mesh it too big.
+    if (rotations == system_dimensions) {
+        TT_THROW(
+            "Requested mesh is too big and is not rotatable: {} and SystemMesh {}, offset {}",
+            config.mesh_shape,
+            logical_mesh_shape_,
+            system_offset);
     }
 
-    size_t original_rows = system_mesh_rows;
-    size_t original_cols = system_mesh_cols;
+    tt::stl::SmallVector<uint32_t> end_coord;
+    for (int i = 0; i < system_dimensions; ++i) {
+        end_coord.push_back(system_offset[i] + rotated_dims[i]);
+    }
 
-    // Check that offsets fit in the original mesh
-    TT_FATAL(
-        row_offset + requested_num_rows <= original_rows,
-        "Row offset + requested rows exceeds mesh size: {} + {} > {}",
-        row_offset,
-        requested_num_rows,
-        original_rows);
-    TT_FATAL(
-        col_offset + requested_num_cols <= original_cols,
-        "Column offset + requested columns exceeds mesh size: {} + {} > {}",
-        col_offset,
-        requested_num_cols,
-        original_cols);
+    MeshCoordinateRange system_range(system_offset, MeshCoordinate(end_coord));
 
-    // Map each submesh coordinate to the original logical coordinates
-    for (size_t row = 0; row < requested_num_rows; row++) {
-        for (size_t col = 0; col < requested_num_cols; col++) {
-            Coordinate logical_coordinate;
-            if (requires_rotation) {
-                // After swapping requested_num_rows and requested_num_cols,
-                // (row, col) now iterate over the rotated shape.
-                size_t old_row = row_offset + row;  // top row
-                size_t old_col = col_offset + col;  // increasing columns horizontally
-                logical_coordinate = Coordinate{old_row, old_col};
-            } else {
-                logical_coordinate = Coordinate{row + row_offset, col + col_offset};
-            }
-
-            TT_FATAL(
-                logical_coordinate.row < system_mesh_rows,
-                "Row coordinate out of bounds: {} >= {}",
-                logical_coordinate.row,
-                system_mesh_rows);
-            TT_FATAL(
-                logical_coordinate.col < system_mesh_cols,
-                "Column coordinate out of bounds: {} >= {}",
-                logical_coordinate.col,
-                system_mesh_cols);
-
-            auto physical_device_id =
-                logical_to_device_id_.at(MeshCoordinate(logical_coordinate.row, logical_coordinate.col));
-            physical_device_ids.push_back(physical_device_id);
-
-            log_debug(
-                LogMetal, "Logical coordinate: {}, Physical device ID: {}", logical_coordinate, physical_device_id);
-        }
+    for (const auto& system_coord : system_range) {
+        auto physical_device_id = logical_to_device_id_.at(system_coord);
+        physical_device_ids.push_back(physical_device_id);
+        log_debug(LogMetal, "Logical coordinate: {}, Physical device ID: {}", system_coord, physical_device_id);
     }
     return physical_device_ids;
 }
 
 std::vector<chip_id_t> SystemMesh::Impl::request_available_devices(const MeshDeviceConfig& config) const {
-    auto [requested_num_rows, requested_num_cols] = config.mesh_shape;
-    auto [row_offset, col_offset] = config.offset;
-
-    log_debug(
-        LogMetal,
-        "Mapping MeshDevice ({}x{}) with offset: {}, {}",
-        requested_num_rows,
-        requested_num_cols,
-        row_offset,
-        col_offset);
+    log_debug(LogMetal, "Mapping MeshDevice ({})", config.mesh_shape);
+    if (config.offset.has_value()) {
+        log_debug(LogMetal, "Offset: {}", config.offset.value());
+    }
 
     return config.physical_device_ids.empty() ? this->get_mapped_physical_device_ids(config)
                                               : config.physical_device_ids;

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing a program dispatch across a mesh of devices.
 int main(int argc, char** argv) {
     using namespace tt::tt_metal::distributed;
 
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape{2, 4}});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 4)});
     auto& cq = mesh_device->mesh_command_queue();
 
     // In a typical single-device fashion, instantiate a program with

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
     using namespace tt::tt_metal::distributed;
     using tt::tt_metal::distributed::ShardedBufferConfig;
 
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape{2, 4}});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 4)});
     auto& cq = mesh_device->mesh_command_queue();
 
     // Define the shape of the shard and the distributed buffer.

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -85,7 +85,7 @@ Program CreateEltwiseAddProgram(
 // The example showcases TT-Metalium's ability to abstract away the complexity
 // of distributed memory management and compute.
 int main(int argc, char** argv) {
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape{2, 4}});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 4)});
 
     // Define the global buffer shape and shard shape for distributed buffers
     auto shard_shape = Shape2D{32, 32};

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <tt-metalium/overloaded.hpp>
+#include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
@@ -26,8 +27,10 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     const DispatchCoreConfig& dispatch_core_config,
     const MeshOffset& offset,
     const std::vector<int>& physical_device_ids) {
-    auto config =
-        MeshDeviceConfig{.mesh_shape = mesh_shape, .offset = offset, .physical_device_ids = physical_device_ids};
+    std::optional<MeshCoordinate> offset_opt =
+        offset.row != 0 || offset.col != 0 ? std::make_optional<MeshCoordinate>(offset.row, offset.col) : std::nullopt;
+    auto config = MeshDeviceConfig{
+        .mesh_shape = SimpleMeshShape(mesh_shape), .offset = offset_opt, .physical_device_ids = physical_device_ids};
     return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
 }
 
@@ -128,7 +131,7 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
 
     auto physical_device_ids =
-        instance.get_mapped_physical_device_ids(MeshDeviceConfig{MeshShape{1, 8}, MeshOffset{0, 0}});
+        instance.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(1, 8)});
     return physical_device_ids;
 }
 

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/pytypes.h>
 
 #include <tt-metalium/command_queue.hpp>
+#include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
@@ -66,8 +67,10 @@ void py_module(py::module& module) {
                         const std::vector<chip_id_t>& physical_device_ids) {
                 return MeshDevice::create(
                     MeshDeviceConfig{
-                        .mesh_shape = mesh_device_shape,
-                        .offset = offset,
+                        .mesh_shape = SimpleMeshShape(mesh_device_shape),
+                        .offset = offset.row != 0 || offset.col != 0
+                                      ? std::make_optional<MeshCoordinate>(offset.row, offset.col)
+                                      : std::nullopt,
                         .physical_device_ids = physical_device_ids,
                     },
                     l1_small_size,

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -13,6 +13,8 @@
 namespace ttnn::distributed {
 
 using MeshShape = tt::tt_metal::distributed::MeshShape;
+using SimpleMeshShape = tt::tt_metal::distributed::SimpleMeshShape;
+using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshOffset = tt::tt_metal::distributed::MeshOffset;
 using DeviceIds = tt::tt_metal::distributed::DeviceIds;
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
@@ -27,12 +29,14 @@ namespace ttnn {
 
 // These types are exported to the ttnn namespace for convenience.
 using ttnn::distributed::DeviceIds;
+using ttnn::distributed::MeshCoordinate;
 using ttnn::distributed::MeshDevice;
 using ttnn::distributed::MeshDeviceConfig;
 using ttnn::distributed::MeshDeviceView;
 using ttnn::distributed::MeshOffset;
 using ttnn::distributed::MeshShape;
 using ttnn::distributed::MeshSubDeviceManagerId;
+using ttnn::distributed::SimpleMeshShape;
 using ttnn::distributed::SystemMesh;
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -361,7 +361,9 @@ Tensor all_gather(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
-            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
+            TT_FATAL(
+                mesh_view.is_mesh_2d(),
+                "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
             const auto view_index = (cluster_axis == 0) ? coordinate[1] : coordinate[0];
             const auto device_index = (cluster_axis == 0) ? coordinate[0] : coordinate[1];

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/math.hpp"
 
 #include <tt-metalium/hal_exp.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 #include "ttnn/tensor/tensor_utils.hpp"
 
@@ -360,18 +361,20 @@ Tensor all_gather(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
+            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
-            const auto view_index = (cluster_axis == 0) ? coordinate.col : coordinate.row;
-            const auto device_index = (cluster_axis == 0) ? coordinate.row : coordinate.col;
+            const auto view_index = (cluster_axis == 0) ? coordinate[1] : coordinate[0];
+            const auto device_index = (cluster_axis == 0) ? coordinate[0] : coordinate[1];
 
             auto get_chip_id = [&](std::size_t line_index) -> std::optional<chip_id_t> {
-                auto new_coord = coordinate;
+                auto new_row = coordinate[0];
+                auto new_col = coordinate[1];
                 if (cluster_axis == 0) {
-                    new_coord.row = line_index % num_devices;
+                    new_row = line_index % num_devices;
                 } else {
-                    new_coord.col = line_index % num_devices;
+                    new_col = line_index % num_devices;
                 }
-                return mesh_view.find_device_id(new_coord);
+                return mesh_view.find_device_id(MeshCoordinate(new_row, new_col));
             };
 
             bool is_last_chip_in_clockwise_direction = device_index == (num_devices - 1);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -223,7 +223,9 @@ Tensor reduce_scatter(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
-            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
+            TT_FATAL(
+                mesh_view.is_mesh_2d(),
+                "reduce-scatter invoked with cluster_axis API on >2D mesh, which is currently unsupported");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
             const auto view_index = (cluster_axis == 0) ? coordinate[1] : coordinate[0];
             const auto device_index = (cluster_axis == 0) ? coordinate[0] : coordinate[1];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -399,9 +399,10 @@ Tensor all_gather_async(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
+            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
-            std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate.col)
-                                                               : mesh_view.get_devices_on_row(coordinate.row);
+            std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate[1])
+                                                                : mesh_view.get_devices_on_row(coordinate[0]);
 
             const auto& input_tensor = input_tensors.at(0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -399,7 +399,9 @@ Tensor all_gather_async(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
-            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
+            TT_FATAL(
+                mesh_view.is_mesh_2d(),
+                "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
             std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate[1])
                                                                 : mesh_view.get_devices_on_row(coordinate[0]);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -335,9 +335,10 @@ Tensor reduce_scatter(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
+            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
-            std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate.col)
-                                                               : mesh_view.get_devices_on_row(coordinate.row);
+            std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate[1])
+                                                                : mesh_view.get_devices_on_row(coordinate[0]);
 
             const auto& input_tensor = input_tensors.at(0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -335,7 +335,9 @@ Tensor reduce_scatter(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_device_tensor = input_tensors.at(0);
 
-            TT_FATAL(mesh_view.is_mesh_2d(), "Mesh view is not 2D");
+            TT_FATAL(
+                mesh_view.is_mesh_2d(),
+                "reduce-scatter invoked with cluster_axis API on >2D mesh, which is currently unsupported");
             const auto coordinate = mesh_view.find_device(input_device_tensor.device()->id());
             std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate[1])
                                                                 : mesh_view.get_devices_on_row(coordinate[0]);

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -34,7 +34,7 @@ MultiDeviceStorage::MultiDeviceStorage(
 
     for (int row = 0; row < num_rows; ++row) {
         for (int col = 0; col < num_cols; ++col) {
-            auto buffer = mesh_buffer->get_device_buffer(distributed::Coordinate{row, col});
+            auto buffer = mesh_buffer->get_device_buffer(distributed::MeshCoordinate(row, col));
             const int device_id = buffer->device()->id();
             ordered_device_ids.push_back(device_id);
             buffers.emplace(device_id, std::move(buffer));

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -592,7 +592,9 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking) {
     specs.reserve(num_buffers);
     buffers.reserve(num_buffers);
     shard_data_transfers.reserve(num_buffers);
-    distributed::Coordinate shard_coord = {0, 0};
+    distributed::MeshCoordinateRange coord_range(
+        distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(num_rows - 1, num_cols - 1));
+    auto shard_coord = coord_range.begin();
     for (int id : storage.ordered_device_ids) {
         std::vector<T> host_buffer;
         const auto& shard_tensor_spec = storage.specs.at(id);
@@ -602,14 +604,10 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking) {
         buffers.push_back(owned_buffer::create<T>(std::move(host_buffer)));
 
         shard_data_transfers.push_back(distributed::MeshCommandQueue::ShardDataTransfer{
-            .shard_coord = shard_coord,
+            .shard_coord = *shard_coord,
             .host_data = std::visit([](auto& b) { return b.data(); }, buffers.back()),
             .region = BufferRegion(0, tensor_size_bytes)});
-
-        if (++shard_coord.col == num_cols) {
-            shard_coord.col = 0;
-            ++shard_coord.row;
-        }
+        ++shard_coord;
     }
 
     mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, /*blocking=*/true);
@@ -782,14 +780,17 @@ MultiDeviceStorage shard_to_mesh_buffer(
 
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
     shard_data_transfers.reserve(storage.buffers.size());
-    distributed::Coordinate shard_coord = {0, 0};
-    for (int i = 0; i < storage.buffers.size(); i++) {
+
+    distributed::MeshCoordinateRange coord_range(
+        distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(num_rows - 1, num_cols - 1));
+    auto shard_coord = coord_range.begin();
+    for (int i = 0; i < storage.buffers.size(); ++shard_coord, i++) {
         TensorSpec shard_tensor_spec(
             storage.specs[i].logical_shape(),
             storage.specs[i].tensor_layout().with_memory_config(tensor_spec.memory_config()));
         const auto& shard_host_buffer = storage.buffers[i];
 
-        const auto& shard_buffer = mesh_buffer->get_device_buffer(shard_coord);
+        const auto& shard_buffer = mesh_buffer->get_device_buffer(*shard_coord);
         ordered_device_ids.push_back(shard_buffer->device()->id());
         buffers.insert({shard_buffer->device()->id(), shard_buffer});
         specs.insert({shard_buffer->device()->id(), shard_tensor_spec});
@@ -806,13 +807,9 @@ MultiDeviceStorage shard_to_mesh_buffer(
             expected_packed_buffer_size_bytes <= tensor_spec.compute_packed_buffer_size_bytes(),
             "Shard tensor size exceeds the global tensor size!");
         shard_data_transfers.push_back(distributed::MeshCommandQueue::ShardDataTransfer{
-            .shard_coord = shard_coord,
+            .shard_coord = *shard_coord,
             .host_data = data_to_write.data(),
             .region = BufferRegion(0, input_size_bytes)});
-        if (++shard_coord.col == num_cols) {
-            shard_coord.col = 0;
-            ++shard_coord.row;
-        }
     }
 
     mesh_device->mesh_command_queue().enqueue_write_shards(mesh_buffer, shard_data_transfers, /*blocking=*/false);


### PR DESCRIPTION
### Ticket
#17477

### Problem description
Continuing plumbing ND coordinate system across Metal / TTNN.

### What's changed
* Adopted `SimpleMeshShape` in `MeshDeviceView`.
* Removed `Coordinate`.
* Simplified `MeshDeviceView` construction (unused `CoordinateMapper`), simplified getting line/ring coordinates.
* Support ND rotation when requesting specific mesh shape from `SystemMesh`.
* More features in ND `MeshContainer`, `MeshCoordinate`, `MeshCoordinateRange`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13441887717) - pending
  - [Build failures in programming examples fixed and verified](https://github.com/tenstorrent/tt-metal/actions/runs/13444193986)
- [X] New/Existing tests provide coverage for changes
- [X] Ran the affected T3K distributed tests locally (`unit_tests_ttnn_cc`, `unit_tests_ttnn_tensor`, `test_distributed`, `distributed_unit_tests_wormhole_b0`).
