### PR TITLE
#17966 add RM support for eltwise

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -717,7 +717,7 @@ def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, 
     "memory_config",
     ([ttnn.DRAM_MEMORY_CONFIG]),
 )
-@pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
+@pytest.mark.parametrize("scalar", [-1.0, -2.0, 0.0, 1.0, 2.0, 19.0])
 @pytest.mark.parametrize(
     "ttnn_fn",
     [
@@ -738,10 +738,11 @@ def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memo
     a_shape = input_shape
 
     ttnn_op = getattr(ttnn.experimental, ttnn_fn)
-    torch_input_tensor_a = torch.randn(a_shape, dtype=torch.bfloat16)
-    # guarantee at least one equal value
+    torch_input_tensor_a = torch.randint(low=-50, high=50, size=a_shape, dtype=torch.bfloat16)
+    # guarantee a few equal values
     if (ttnn_fn == "eq" or ttnn_fn == "ne" or ttnn_fn == "gte" or ttnn_fn == "lte") and input_shape != (1, 1, 1, 1):
         torch_input_tensor_a[0, 0, 0, 0] = scalar
+        torch_input_tensor_a[-1, -1, -1, -1] = scalar
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -888,6 +889,7 @@ def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_c
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.999)
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shape, input_layout, input_shard_grid, input_shard_orientation, input_sharding_scheme",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -761,6 +761,7 @@ def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memo
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.999)
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shapes",
     [

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -43,11 +43,28 @@ Tensor BinaryNg<binary_op_type>::invoke(
     bool typecast_b = needs_typecast_to_bfloat16(b_dtype);
     bool typecast_out = needs_typecast_to_bfloat16(out_dtype);
 
+    // RM is never BFLOAT8 or BFLOAT4 so we can assume it goes in here.
     if (!typecast_a && !typecast_b) {
-        return ttnn::prim::binary_ng(
+        bool input_a_rm = input_tensor_a.get_layout() == Layout::ROW_MAJOR;
+        bool input_b_rm = input_tensor_b.get_layout() == Layout::ROW_MAJOR;
+        Tensor input_a =
+            input_a_rm ? ttnn::to_layout(input_tensor_a, Layout::TILE, std::nullopt, std::nullopt, (IDevice*)nullptr)
+                       : input_tensor_a;
+        Tensor input_b =
+            input_b_rm ? ttnn::to_layout(input_tensor_b, Layout::TILE, std::nullopt, std::nullopt, (IDevice*)nullptr)
+                       : input_tensor_b;
+
+        if (input_a_rm && input_b_rm) {
+            // we don't support to_layout with optional output tensor
+            TT_FATAL(
+                !output_preallocated,
+                "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
+        }
+
+        Tensor result = ttnn::prim::binary_ng(
             queue_id,
-            input_tensor_a,
-            input_tensor_b,
+            input_a,
+            input_b,
             binary_op_type,
             out_dtype,
             output_preallocated ? optional_output_tensor->memory_config()
@@ -56,6 +73,20 @@ Tensor BinaryNg<binary_op_type>::invoke(
             lhs_activations,
             rhs_activations,
             post_activations);
+
+        // if both inputs are in row major, convert the output to row major
+        // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
+        // since it leads to better perf
+        if (input_a_rm && input_b_rm) {
+            result = ttnn::to_layout(
+                result,
+                Layout::ROW_MAJOR,
+                std::nullopt,
+                memory_config.value_or(input_tensor_a.memory_config()),
+                (IDevice*)nullptr);
+        }
+
+        return result;
     } else {
         Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
         Tensor input_b = typecast_to(DataType::BFLOAT16, input_tensor_b);
@@ -116,6 +147,8 @@ Tensor BinaryNg<binary_op_type>::invoke(
     const bool output_preallocated = optional_output_tensor.has_value();
     const ttnn::DataType out_dtype =
         output_preallocated ? optional_output_tensor->get_dtype() : output_dtype.value_or(a_dtype);
+    const auto mem_config = output_preallocated ? optional_output_tensor->memory_config()
+                                                : memory_config.value_or(input_tensor_a.memory_config());
 
     if (output_dtype.has_value() && output_preallocated) {
         TT_FATAL(
@@ -127,18 +160,35 @@ Tensor BinaryNg<binary_op_type>::invoke(
     bool typecast_out = needs_typecast_to_bfloat16(out_dtype);
 
     if (!typecast_a) {
-        return ttnn::prim::binary_ng(
+        bool input_a_rm = input_tensor_a.get_layout() == Layout::ROW_MAJOR;
+        if (input_a_rm) {
+            // we don't support to_layout with optional output tensor
+            TT_FATAL(
+                !output_preallocated,
+                "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
+        }
+        Tensor input_a =
+            input_a_rm
+                ? ttnn::to_layout(
+                      input_tensor_a, Layout::TILE, std::nullopt, input_tensor_a.memory_config(), (IDevice*)nullptr)
+                : input_tensor_a;
+        Tensor result = ttnn::prim::binary_ng(
             queue_id,
-            input_tensor_a,
+            input_a,
             scalar,
             binary_op_type,
             out_dtype,
-            output_preallocated ? optional_output_tensor->memory_config()
-                                : memory_config.value_or(input_tensor_a.memory_config()),
+            mem_config,
             optional_output_tensor,
             lhs_activations,
             rhs_activations,
             post_activations);
+
+        // if input is in row major, convert the output to row major
+        if (input_a_rm) {
+            result = ttnn::to_layout(result, Layout::ROW_MAJOR, std::nullopt, mem_config, (IDevice*)nullptr);
+        }
+        return result;
     } else {
         Tensor input_a = typecast_to(DataType::BFLOAT16, input_tensor_a);
         const auto output_tensor = output_preallocated and typecast_out
@@ -151,7 +201,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
             scalar,
             binary_op_type,
             input_a.get_dtype(),
-            input_a.memory_config(),
+            mem_config,
             output_tensor,
             lhs_activations,
             rhs_activations,


### PR DESCRIPTION
### Ticket
#17966
#17356

### Problem description
Eltwise currently has 0 row major support at all. Also need a test confirming that fused dtype works.

### What's changed
As a first step I'm supporting it via untilize/tilize support to unblock any models going forward. Next step will be adding native kernel support.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13421572742
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13399500242
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
