### PR TITLE
[skip ci] Update bisect-dispatch.yaml

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -10,9 +10,33 @@ on:
           - grayskull
           - wormhole_b0
           - blackhole
+      tracy:
+        required: true
+        type: boolean
+        default: false
+        description: "Build with tracy enabled"
+      build-wheel:
+        required: true
+        type: boolean
+        default: false
+        description: "Build Python Wheel"
       runner-label:
         required: true
+        type: choice
+        options:
+          - E150
+          - N150
+          - N300
+          - P150
+          - config-t3000
+          - config-tg
+          - config-tgg
+        description: "Runner Type Label"
+      extra-label:
+        required: true
         type: string
+        default: "in-service"
+        description: "Secondary tag to filter runners"
       good-commit:
         required: true
         type: string
@@ -32,6 +56,9 @@ jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
+    with:
+      tracy: ${{ inputs.tracy }}
+      build-wheel: ${{ inputs.build-wheel }}
   test-dispatch:
     needs: build-artifact
     timeout-minutes: 1440
@@ -40,7 +67,7 @@ jobs:
       ARCH_NAME: ${{ inputs.arch }}
     runs-on:
       - ${{ inputs.runner-label }}
-      - "in-service"
+      - ${{ inputs.extra-label }}
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - name: Set up dyanmic env vars for build

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - uses: actions/download-artifact@v4
         with:
-          name: TTMetal_build_any
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       - name: Extract files
         run: tar -xvf ttm_any.tar
       - uses: ./.github/actions/install-python-deps

--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -64,7 +64,7 @@ while [[ "$found" = "false" ]]; do
       continue
    fi
 
-   timeout $timeout_duration $test
+   timeout $timeout_duration bash -c "$test"
    timeout_code=${PIPESTATUS[0]}
    echo $timeout_code
 


### PR DESCRIPTION
### Problem description
- Workflow can only run on in-service machines
- Workflow does not support profiler build
- Workflow does not support build wheel
- Workflow hardcode's the build artifact name
- Script does not support sourcing bash scripts (i.e. `source this && do that`)

### What's changed
Fix above
