### PR TITLE
Remove Taskflow from tt-train dependencies

### DIFF
--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -84,11 +84,6 @@ CPMAddPackage(
         "XTENSOR_ENABLE_TESTS OFF"
 )
 
-CPMAddPackage(NAME Taskflow GITHUB_REPOSITORY taskflow/taskflow GIT_TAG v3.7.0 OPTIONS "TF_BUILD_TESTS OFF")
-if(Taskflow_ADDED AND NOT TARGET Taskflow::Taskflow)
-    add_library(Taskflow::Taskflow ALIAS Taskflow)
-endif()
-
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_cli11.cmake)
 
 # gersemi: off


### PR DESCRIPTION
### Problem description
tt-train does not depend on taskflow

### What's changed
rm -rf

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13429032310) CI passes