### PR TITLE
#18082: Fix creation of mesh devices

### DIFF
--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -10,6 +10,10 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 
+// This is required for automatic conversions, as in the creation of mesh devices
+// https://github.com/tenstorrent/tt-metal/issues/18082
+#include "pybind11/stl.h"
+
 using namespace tt::tt_metal;
 
 namespace ttnn::distributed {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18082

### Problem description
Due to a missing include, automatic pybind11 conversions were not possible, so the creation of mesh devices failed.

### What's changed

Added the missing include to fix automatic pybind11 conversion.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
