### PR TITLE
#0: Switch tensor.to_torch to return logical tensor shape

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1718,7 +1718,7 @@ def tilize_with_zero_padding(x, *args, device, dtype, layout, input_mem_config, 
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.tilize_with_zero_padding(t0, memory_config=output_mem_config)
 
-    return t1.cpu().to_torch()
+    return t1.cpu().to_torch_with_padded_shape()
 
 
 @setup_host_and_device
@@ -1742,7 +1742,7 @@ def tilize_with_val_padding(
         memory_config=output_mem_config,
     )
 
-    return t1.cpu().to_torch()
+    return t1.cpu().to_torch_with_padded_shape()
 
 
 @setup_host_and_device
@@ -2224,7 +2224,10 @@ def tensor_pad(
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = t0.pad(output_tensor_shape, input_tensor_start, pad_value)
 
-    return tt2torch_tensor(t1)
+    tt_output = t1.cpu()
+    if tt_output.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+        tt_output = tt_output.to(ttnn.ROW_MAJOR_LAYOUT)
+    return tt_output.to_torch_with_padded_shape()
 
 
 @setup_host_and_device
@@ -2271,7 +2274,10 @@ def pad_to_tile(
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = t0.pad_to_tile(pad_value)
 
-    return tt2torch_tensor(t1)
+    tt_output = t1.cpu()
+    if tt_output.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+        tt_output = tt_output.to(ttnn.ROW_MAJOR_LAYOUT)
+    return tt_output.to_torch_with_padded_shape()
 
 
 @setup_host_and_device

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py
@@ -29,7 +29,7 @@ def test_run_padding_test(input_tensor_shape, output_tensor_shape, input_tensor_
 
     # Pad inputs on host
     a_pad = a.pad(output_tensor_shape, input_tensor_start, pad_value)
-    a_pt = a_pad.to_torch()
+    a_pt = a_pad.to_torch_with_padded_shape()
 
     # Pytorch reference
     input_tensor_end = tuple(input_tensor_start[i] + input_tensor_shape[i] for i in range(len(input_tensor_shape)))
@@ -172,7 +172,7 @@ def test_run_tile_padding_test(input_tensor_shape, pad_value):
 
     # Pad inputs on host
     a_pad = a.pad_to_tile(pad_value)
-    a_pt = a_pad.to_torch()
+    a_pt = a_pad.to_torch_with_padded_shape()
 
     # Pytorch reference
     input_tensor_end = tuple(input_tensor_shape[i] for i in range(len(input_tensor_shape)))

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1797,7 +1797,7 @@ def test_sharded_tilize_with_val_padding(input_shape, sharding_config, output_dt
             interleaved_mem_config,
         )
 
-    tt_got_back = yt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_got_back = yt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch_with_padded_shape()
 
     y = torch.nn.functional.pad(x, [0, 0, 0, roundup32(H) - H], "constant", 1.0)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
@@ -49,7 +49,7 @@ def run_tilize_matmul_test(M, K, N, device):
     print("Shape of B_t - " + str(b_t.padded_shape))
     t2 = ttnn.matmul(a_t, b_t)
     assert list(t2.padded_shape) == output_shape
-    tt_host_rm = t2.cpu().to_torch()
+    tt_host_rm = t2.cpu().to_torch_with_padded_shape()
     pyt_got_back = tt_host_rm.reshape(output_shape)
     # TODO: add support to remove padding in untilize
     pyt_got_back_rm = untilize(pyt_got_back)

--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -93,7 +93,7 @@ def test_fill_pad(
     )
 
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
-    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
+    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
 
@@ -160,7 +160,7 @@ def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtyp
     )
 
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
+    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)
 
@@ -233,6 +233,6 @@ def test_fill_pad_sharded(device, fill_value, shape, shard_scheme, dtype):
     )
 
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch()
+    padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
     assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, 0.99)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -243,8 +243,8 @@ def test_tensor_creation_with_memory_config(shape, memory_config, tt_dtype, layo
     tt_tensor_1 = tt_tensor_1.cpu()
     tt_tensor_2 = tt_tensor_2.cpu()
 
-    py_tensor_after_round_trip_1 = tt_tensor_1.to_torch_with_logical_shape()
-    py_tensor_after_round_trip_2 = tt_tensor_2.to_torch_with_logical_shape()
+    py_tensor_after_round_trip_1 = tt_tensor_1.to_torch()
+    py_tensor_after_round_trip_2 = tt_tensor_2.to_torch()
     py_tensor_after_round_trip_3 = ttnn.to_torch(tt_tensor_1)
     py_tensor_after_round_trip_4 = ttnn.to_torch(tt_tensor_2)
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -312,14 +312,14 @@ def to_torch(
         raise RuntimeError("ttnn.to_torch: Shard spec must not be None for sharded tensors")
 
     if memory_config.is_sharded() and memory_config.shard_spec.mode == ttnn.ShardMode.LOGICAL:
-        tensor = tensor.to_torch_with_logical_shape()
+        tensor = tensor.to_torch()
     else:
         if (tensor.layout != ttnn.ROW_MAJOR_LAYOUT) and not (
             tensor.dtype == ttnn.bfloat8_b or tensor.dtype == ttnn.bfloat4_b
         ):
             tensor = tensor.to(ttnn.ROW_MAJOR_LAYOUT, device)
 
-        tensor = tensor.to_torch_with_logical_shape()
+        tensor = tensor.to_torch()
 
     if torch_rank is not None:
         while len(tensor.shape) > torch_rank:


### PR DESCRIPTION
### Ticket
None

### Problem description
Switch `tensor.to_torch` to return logical tensor shape by default. Still need to maintain backwards support for returning padded tensor, but it will be removed once the few tests that use it are updated to return padded tensor in another way.

### What's changed
- Rename/merge to_torch_logical_shape with to_torch
- Add to_torch_with_padded_shape to support returning padded tensor
  * Switch tests that depend on returning padded tensor to use this
  * Rename legacy_output to padded_output for clarity
  * TODO: Remove this path after removing usage of to_torch_with_padded_shape

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13441501696
  - [x] nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/13441566630
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
