### PR TITLE
Simplify repeat device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -37,29 +37,7 @@ std::vector<TensorSpec> RepeatDeviceOperation::compute_output_specs(const std::v
         mem_config.shard_spec = shard_spec;
     }
     return {TensorSpec(
-        output_shape,
-        TensorLayout::fromPaddedShape(
-            input_tensor_a.get_dtype(),
-            PageConfig(input_tensor_a.get_layout()),
-            mem_config,
-            output_shape,
-            output_shape))};  // no padding requried because we are RM only right now
-}
-
-std::vector<Tensor> RepeatDeviceOperation::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    // Create the output tensor
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto output_shape = this->compute_output_specs(input_tensors).at(0).logical_shape();
-
-    // is this relevant?
-    auto mem_config = this->m_output_mem_config;
-    if (input_tensor_a.memory_config().is_sharded()) {
-        auto shard_spec = input_tensor_a.shard_spec().value();
-        shard_spec.shape[0] = output_shape[0];
-        mem_config.shard_spec = shard_spec;
-    }
-    return {create_device_tensor(
-        output_shape, input_tensor_a.get_dtype(), input_tensor_a.get_layout(), input_tensor_a.device(), mem_config)};
+        output_shape, TensorLayout(input_tensor_a.get_dtype(), PageConfig(input_tensor_a.get_layout()), mem_config))};
 }
 
 operation::ProgramWithCallbacks RepeatDeviceOperation::create_program(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
@@ -15,7 +15,6 @@ struct RepeatDeviceOperation {
     // Required functions to all tensor op functions
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };


### PR DESCRIPTION
### Ticket

### Problem description
There is a redundant `create_output_tensors` in repeat_device_operation, which duplicates the logic of `compute_output_specs`

### What's changed
Remove `create_output_tensors`, it will be automatically generated using `compute_output_specs`.
Use regular TensorLayout constructor instead of `TensorLayout::fromPaddedShape`

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13442465835)
- [x] New/Existing tests provide coverage for changes
