### PR TITLE
#17491: add out of bounds matmul unit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -2017,7 +2017,8 @@ def test_small_matmul_pcc(device):
 
 
 @pytest.mark.parametrize("side", ["height", "width"])
-def test_padded_2d_matmul(device, side):
+@pytest.mark.parametrize("tile_count", [1376, 1375])
+def test_padded_2d_matmul(device, side, tile_count):
     """
     This test checks that when the program config specifies per_core_M and per_core_N
     which would multiply out to be larger than the true shape of the output, matmul
@@ -2026,7 +2027,7 @@ def test_padded_2d_matmul(device, side):
     pytest.skip("#17491: last tile bounds are not set up properly")
 
     if side == "height":
-        M = 43 * 1024
+        M = tile_count * 32
         K = 256
         N = 32
         out_block_h = 11
@@ -2036,7 +2037,7 @@ def test_padded_2d_matmul(device, side):
     else:
         M = 32
         K = 256
-        N = 43 * 1024
+        N = tile_count * 32
         out_block_h = 1
         out_block_w = 11
         per_core_M = 1

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -20,6 +20,8 @@ void kernel_main() {
     uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
 
     // padding args (WRITER)
+    const uint32_t last_num_blocks_h_dim = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_last_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
@@ -140,12 +142,14 @@ void kernel_main() {
 
 #ifndef OUT_SHARDED
                 // WRITER
+                uint32_t num_blocks_h_dim_ = bh >= last_num_blocks_h_dim - 1 ? last_num_blocks_h_dim : num_blocks_h_dim;
+                uint32_t num_blocks_w_dim_ = bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
                 uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
                 uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
-                if (bh == num_blocks_h_dim - 1) {
+                if (bh == num_blocks_h_dim_ - 1) {
                     out_num_nonzero_subblocks_h_ = out_last_num_nonzero_subblocks_h;
                 }
-                if (bw == num_blocks_w_dim - 1) {
+                if (bw == num_blocks_w_dim_ - 1) {
                     out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
                 }
                 uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
@@ -157,10 +161,10 @@ void kernel_main() {
                         uint32_t out_subblock_h_ = out_subblock_h;
                         uint32_t out_subblock_w_ = out_subblock_w;
                         uint32_t subblock_tiles_addr_skip = 0;
-                        if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
+                        if (bh == num_blocks_h_dim_ - 1 && sbh == out_num_nonzero_subblocks_h_ - 1) {
                             out_subblock_h_ = out_last_subblock_h;
                         }
-                        if (bw == num_blocks_w_dim - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
                             out_subblock_w_ = out_last_subblock_w;
                             subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                         }
@@ -171,7 +175,9 @@ void kernel_main() {
                         for (uint32_t h = 0; h < out_subblock_h_; ++h) {
                             uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                             for (uint32_t w = 0; w < out_subblock_w_; ++w) {
-                                noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                if (bh < num_blocks_h_dim_ && bw < num_blocks_w_dim_) {
+                                    noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                }
 
                                 l1_read_addr += output_single_tile_size_bytes;
 
@@ -188,14 +194,14 @@ void kernel_main() {
                         out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                     }
                     // Pop fully padded subblocks along the row
-                    if (bw == num_blocks_w_dim - 1) {
+                    if (bw == num_blocks_w_dim_ - 1) {
                         cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);
                         cb_pop_front(cb_id_out0, padded_block_tiles_w_skip);
                     }
                     out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
                 }
                 // Pop row(s) of fully padded subblocks
-                if (bh == num_blocks_h_dim - 1) {
+                if (bh == num_blocks_h_dim_ - 1) {
                     cb_wait_front(cb_id_out0, padded_block_tiles_h_skip);
                     cb_pop_front(cb_id_out0, padded_block_tiles_h_skip);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -28,6 +28,7 @@ void kernel_main() {
     // padding args (READER)
     const uint32_t last_block_w = get_arg_val<uint32_t>(rt_args_idx++);
     // padding args (WRITER)
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t padded_block_tiles_h_skip = get_arg_val<uint32_t>(rt_args_idx++);
@@ -420,9 +421,10 @@ void kernel_main() {
 
 #ifndef OUT_SHARDED
                 // WRITER
+                uint32_t num_blocks_w_dim_ = bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
                 uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
                 uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
-                if (bw == num_blocks_w_dim - 1) {
+                if (bw == num_blocks_w_dim_ - 1) {
                     out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
                 }
                 uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
@@ -437,7 +439,7 @@ void kernel_main() {
                         if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
                             out_subblock_h_ = out_last_subblock_h;
                         }
-                        if (bw == num_blocks_w_dim - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
                             out_subblock_w_ = out_last_subblock_w;
                             subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                         }
@@ -448,7 +450,9 @@ void kernel_main() {
                         for (uint32_t h = 0; h < out_subblock_h_; ++h) {
                             uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                             for (uint32_t w = 0; w < out_subblock_w_; ++w) {
-                                noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                if (bw < num_blocks_w_dim_) {
+                                    noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                }
 
                                 l1_read_addr += output_single_tile_size_bytes;
 
@@ -464,7 +468,7 @@ void kernel_main() {
                         out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                     }
                     // Pop fully padded subblocks along the row
-                    if (bw == num_blocks_w_dim - 1) {
+                    if (bw == num_blocks_w_dim_ - 1) {
                         cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);
                         cb_pop_front(cb_id_out0, padded_block_tiles_w_skip);
                     }


### PR DESCRIPTION
### Ticket
Link to Github Issue #17491

### Problem description
- matmul code assumes that less than one block h/w worth of data needs to be trimmed, which is not the case
- we do not have tests that cover cases where more than one block h/w worth of data needs to be trimmed

### What's changed
- add tests that cover larger trimming scenarios - adding fixes will be done in a separate PR (and the skips removed)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13447176614
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
