### PR TITLE
#17878: Update failed test logging to appear in GHA job+workflow annotations

### DIFF
--- a/.github/actions/generate-gtest-failure-message/action.yml
+++ b/.github/actions/generate-gtest-failure-message/action.yml
@@ -1,0 +1,17 @@
+name: "Generate gtest failure message"
+description: "Generate gtest failure message for Github workflow annotations"
+
+inputs:
+  path:
+    description: "Paths to pass containing gtest XML files"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate gtest failure messages
+      id: generate-gtest-message
+      shell: bash
+      run: |
+        set +e
+        python3 .github/scripts/data_analysis/print_gtest_annotations.py ${{ inputs.path }}

--- a/.github/scripts/data_analysis/print_gtest_annotations.py
+++ b/.github/scripts/data_analysis/print_gtest_annotations.py
@@ -1,0 +1,89 @@
+import argparse
+import xmltodict
+import glob
+import os
+from typing import Union
+
+
+def _guaranteed_list(x):
+    if not x:
+        return []
+    elif isinstance(x, list):
+        return x
+    else:
+        return [x]
+
+
+def _build_workflow_command(
+    command_name: str,
+    file: str,
+    line: int,
+    end_line: Union[int, None] = None,
+    column: Union[int, None] = None,
+    end_column: Union[int, None] = None,
+    title: Union[str, None] = None,
+    message: Union[str, None] = None,
+):
+    result = f"::{command_name} "
+
+    entries = [
+        ("file", file),
+        ("line", line),
+        ("endLine", end_line),
+        ("col", column),
+        ("endColumn", end_column),
+        ("title", title),
+    ]
+
+    result = result + ",".join(f"{k}={v}" for k, v in entries if v is not None)
+
+    if message is not None:
+        result = result + "::" + _escape(message)
+
+    return result
+
+
+def _escape(s: str) -> str:
+    return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+if __name__ == "__main__":
+    # Get xml dir path from cmdline
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory", type=str, help="Path to the GoogleTest XML directory")
+    args = parser.parse_args()
+
+    # Path to the directory containing XML files
+    xml_dir = args.directory
+
+    # Use glob to find all XML files in the directory
+    xml_files = glob.glob(os.path.join(xml_dir, "*.xml"))
+
+    # Iterate through each XML file
+    for xml_file in xml_files:
+        with open(xml_file, "r") as f:
+            results = xmltodict.parse(f.read())
+
+        # Check for failed tests
+        failed_tests = []
+        for testsuite in _guaranteed_list(results["testsuites"]["testsuite"]):
+            for testcase in _guaranteed_list(testsuite["testcase"]):
+                if "failure" in testcase:
+                    failed_tests.append(testcase)
+
+        # Create error annotations for each failed test
+        for failed_test in failed_tests:
+            failure_messages = _guaranteed_list(failed_test["failure"])
+            if failure_messages:
+                # first message is often enough
+                failure_message = failure_messages[0]["@message"]
+            else:
+                failure_message = "unknown_failure_message"
+
+            msg = _build_workflow_command(
+                command_name="error",
+                file=failed_test["@file"].lstrip("/work/"),
+                line=int(failed_test["@line"]),
+                message=failure_message,
+            )
+            print(msg)

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -108,3 +108,9 @@ jobs:
       - name: Generate system logs on failure
         uses: ./.github/actions/generate-system-logs
         if: ${{ failure() }}
+      - name: Generate gtest annotations on failure
+        uses: ./.github/actions/generate-gtest-failure-message
+        if: ${{ failure() }}
+        with:
+          path: |
+            generated/test_reports/

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -113,3 +113,9 @@ jobs:
       - name: Generate system logs on failure
         uses: ./.github/actions/generate-system-logs
         if: ${{ failure() }}
+      - name: Generate gtest annotations on failure
+        uses: ./.github/actions/generate-gtest-failure-message
+        if: ${{ failure() }}
+        with:
+          path: |
+            generated/test_reports/

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -91,3 +91,9 @@ jobs:
       - name: Generate system logs on failure
         uses: ./.github/actions/generate-system-logs
         if: ${{ failure() }}
+      - name: Generate gtest annotations on failure
+        uses: ./.github/actions/generate-gtest-failure-message
+        if: ${{ failure() }}
+        with:
+          path: |
+            generated/test_reports/

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -52,14 +52,14 @@ jobs:
       matrix:
         os: ["${{ inputs.os }}"]
         test-group: [
-          {name: eager unit tests 1, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 1 },
-          {name: eager unit tests 2, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 2 },
-          {name: eager unit tests 3, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 3 },
-          {name: eager unit tests 4, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 4 },
-          {name: eager unit tests 5, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 5 },
-          {name: eager unit tests 6, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 6 },
-          {name: eager unit tests 7, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 7 },
-          {name: sweep, cmd: pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/ -xvvv},
+          {name: eager unit tests 1, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 1 --exclude-warning-annotations },
+          {name: eager unit tests 2, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 2 --exclude-warning-annotations },
+          {name: eager unit tests 3, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 3 --exclude-warning-annotations },
+          {name: eager unit tests 4, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 4 --exclude-warning-annotations },
+          {name: eager unit tests 5, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 5 --exclude-warning-annotations },
+          {name: eager unit tests 6, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 6 --exclude-warning-annotations },
+          {name: eager unit tests 7, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 7 --exclude-warning-annotations },
+          {name: sweep, cmd: pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/ -xvvv --exclude-warning-annotations },
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     env:
@@ -82,6 +82,7 @@ jobs:
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
             -e ARCH_NAME=${{ inputs.arch }}
+            -e GITHUB_ACTIONS=true
           run_args: |
             ${{ matrix.test-group.cmd }}
       - uses: ./.github/actions/slack-report

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -52,31 +52,31 @@ jobs:
         os: ["ubuntu-20.04"]
         test-group:
           - name: ttnn group 1
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 1 -m "not disable_fast_runtime_mode"
           - name: ttnn group 2
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 2 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 3 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 3 -m "not disable_fast_runtime_mode"
           - name: ttnn group 4
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 4 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 4 -m "not disable_fast_runtime_mode"
           - name: ttnn group 5
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 5 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 5 -m "not disable_fast_runtime_mode"
           - name: ttnn group 6
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 6 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 6 -m "not disable_fast_runtime_mode"
           - name: ttnn group 7
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 7 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 7 -m "not disable_fast_runtime_mode"
           - name: ttnn group 8
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 8 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 8 -m "not disable_fast_runtime_mode"
           - name: ttnn group 9
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 9 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 9 -m "not disable_fast_runtime_mode"
           - name: ttnn group 10
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 10 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 10 -m "not disable_fast_runtime_mode"
           - name: ttnn group 11
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 11 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 11 -m "not disable_fast_runtime_mode"
           - name: ttnn group 12
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 12 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 12 -m "not disable_fast_runtime_mode"
           - name: ttnn fast runtime off
-            cmd: pytest tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
+            cmd: pytest tests/ttnn/unit_tests -xv --exclude-warning-annotations -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn example tests
             cmd: ./tests/scripts/run_ttnn_examples.sh
@@ -103,6 +103,7 @@ jobs:
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
             -e ARCH_NAME=${{ inputs.arch }}
+            -e GITHUB_ACTIONS=true
           run_args: |
             WHEEL_FILENAME=$(ls -1 *.whl)
             pip3 install --user $WHEEL_FILENAME

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -4,6 +4,10 @@
 
 loguru
 
+# For github workflow unit test failure annotations
+xmltodict
+pytest-github-actions-annotate-failures==0.3.0
+
 # During dep resolution, black may install platformdirs >=4.0.0, which is
 # a breaking dependency for virtualenv installed by pre-commit. virtualenv
 # requires <4.0.0 platformdirs, so we're pinning platformdirs here


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/17878

### Problem description
Failed unit tests don't show up in GHA annotations.
To find out the test that failed you have to dig through the test job logs.

### What's changed
Expose test failure messages in pytest and gtest in GHA annotations:
- pytest: use `pytest-github-actions-annotate-failures` plugin, which handles it for us
  - requires setting `GITHUB_ACTIONS=true` [for docker containers](https://github.com/pytest-dev/pytest-github-actions-annotate-failures), and exclude warnings with `--exclude-warning-annotations`
  - example: https://github.com/tenstorrent/tt-metal/actions/runs/13443325356/job/37563108566
- gtest: create a custom action `actions/generate-gtest-failure-message` that calls `python3 .github/scripts/data_analysis/print_gtest_annotations.py`
  - unfortunately gtest doesn't have an equivalent hook/plugin like pytest 
  - requires `xmltodict`
  - runs at the end of gtest workflows and prints unit test failures to the GHA log which auto-convert into annotations
  - example: https://github.com/tenstorrent/tt-metal/actions/runs/13443325356/job/37563095078
- update all-post-commit workflows

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13449043032
- [x] Remove dummy failed tests from PR

