### PR TITLE
#18045: Increase dispatch s page size to fit llama sub-device use case

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -117,9 +117,9 @@ public:
 
     static constexpr uint32_t DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES = 64;
 
-    // dispatch_s CB page size is 128 bytes. This should currently be enough to accomodate all commands that
-    // are sent to it. Change as needed, once this endpoint is required to handle more than go signal mcasts.
-    static constexpr uint32_t DISPATCH_S_BUFFER_LOG_PAGE_SIZE = 7;
+    // dispatch_s CB page size is 256 bytes. This should currently be enough to accomodate all commands that
+    // are sent to it. Change as needed.
+    static constexpr uint32_t DISPATCH_S_BUFFER_LOG_PAGE_SIZE = 8;
 
     static constexpr uint32_t GO_SIGNAL_BITS_PER_TXN_TYPE = 4;
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -283,6 +283,8 @@ void kernel_main() {
             case CQ_DISPATCH_CMD_TERMINATE: done = true; break;
             default: DPRINT << "dispatcher_s invalid command" << ENDL(); ASSERT(0);
         }
+        // Dispatch s only supports single page commands for now
+        ASSERT(cmd_ptr <= ((uint32_t)cmd + cb_page_size));
         cmd_ptr = round_up_pow2(cmd_ptr, cb_page_size);
         // Release a single page to prefetcher. Assumption is that all dispatch_s commands fit inside a single page for
         // now.


### PR DESCRIPTION
Add better host and device asserts for when data exceeds the page size of dispatch s

### Ticket
https://github.com/tenstorrent/tt-metal/issues/18045

### Problem description
Running llama using sub-devices was tripping a watcher assert of a corrupted command. This is because dispatch s is set up to only process 1 page at a time properly, but due to the number of noc entries required to dispatch to the sub-devices, we were sending more than 1 page of data.

### What's changed
Bump up the dispatch s page size to be able to fit all entries needed for llama in one page. Add better assertions on host and in dispatch s to validate only 1 page of data was sent or processed, instead of only asserting a corrupted command.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13445066546)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
