### PR TITLE
#0: fix uneven split on height/width of out tensor in Matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -1266,14 +1266,11 @@ def test_padded_2d_matmul(device, side, tile_count):
 @pytest.mark.parametrize("side", ["height", "width"])
 @pytest.mark.parametrize(
     "has_program_config",
-    [
-        True,
-    ],
+    [True, False],
 )
 def test_padded_1d_matmul(device, side, has_program_config):
-    # pytest.skip("#17491: last tile bounds are not set up properly")
     if side == "height":
-        M = 10369
+        M = 10069
         K = 96
         N = 1152
         out_block_h = 21
@@ -1331,6 +1328,7 @@ def test_padded_1d_matmul(device, side, has_program_config):
     output_tensor = ttnn.matmul(
         act,
         weight,
+        core_grid=None if has_program_config else ttnn.CoreGrid(x=4, y=4),
         program_config=program_config,
         compute_kernel_config=ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=False
@@ -1341,10 +1339,9 @@ def test_padded_1d_matmul(device, side, has_program_config):
     # Check that the tensors above and below the output are unchanged
     torch_output_tensor = torch.matmul(torch_act, torch_weight)
     output_tensor = ttnn.to_torch(output_tensor)
-    # assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     assert torch.all(lower == 2)
     assert torch.all(upper == 4)
-    # assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
 # fmt: off

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -20,6 +20,8 @@ void kernel_main() {
     uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
 
     // padding args (WRITER)
+    const uint32_t last_num_blocks_h_dim = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_last_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
@@ -140,12 +142,14 @@ void kernel_main() {
 
 #ifndef OUT_SHARDED
                 // WRITER
+                uint32_t num_blocks_h_dim_ = bh >= last_num_blocks_h_dim - 1 ? last_num_blocks_h_dim : num_blocks_h_dim;
+                uint32_t num_blocks_w_dim_ = bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
                 uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
                 uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
-                if (bh == num_blocks_h_dim - 1) {
+                if (bh == num_blocks_h_dim_ - 1) {
                     out_num_nonzero_subblocks_h_ = out_last_num_nonzero_subblocks_h;
                 }
-                if (bw == num_blocks_w_dim - 1) {
+                if (bw == num_blocks_w_dim_ - 1) {
                     out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
                 }
                 uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
@@ -157,10 +161,10 @@ void kernel_main() {
                         uint32_t out_subblock_h_ = out_subblock_h;
                         uint32_t out_subblock_w_ = out_subblock_w;
                         uint32_t subblock_tiles_addr_skip = 0;
-                        if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
+                        if (bh == num_blocks_h_dim_ - 1 && sbh == out_num_nonzero_subblocks_h_ - 1) {
                             out_subblock_h_ = out_last_subblock_h;
                         }
-                        if (bw == num_blocks_w_dim - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
                             out_subblock_w_ = out_last_subblock_w;
                             subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                         }
@@ -171,7 +175,9 @@ void kernel_main() {
                         for (uint32_t h = 0; h < out_subblock_h_; ++h) {
                             uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                             for (uint32_t w = 0; w < out_subblock_w_; ++w) {
-                                noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                if (bh < num_blocks_h_dim_ && bw < num_blocks_w_dim_) {
+                                    noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                }
 
                                 l1_read_addr += output_single_tile_size_bytes;
 
@@ -188,14 +194,14 @@ void kernel_main() {
                         out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                     }
                     // Pop fully padded subblocks along the row
-                    if (bw == num_blocks_w_dim - 1) {
+                    if (bw == num_blocks_w_dim_ - 1) {
                         cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);
                         cb_pop_front(cb_id_out0, padded_block_tiles_w_skip);
                     }
                     out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
                 }
                 // Pop row(s) of fully padded subblocks
-                if (bh == num_blocks_h_dim - 1) {
+                if (bh == num_blocks_h_dim_ - 1) {
                     cb_wait_front(cb_id_out0, padded_block_tiles_h_skip);
                     cb_pop_front(cb_id_out0, padded_block_tiles_h_skip);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -28,6 +28,7 @@ void kernel_main() {
     // padding args (READER)
     const uint32_t last_block_w = get_arg_val<uint32_t>(rt_args_idx++);
     // padding args (WRITER)
+    const uint32_t last_num_blocks_w_dim = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_num_nonzero_subblocks_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t out_last_subblock_h = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t padded_block_tiles_h_skip = get_arg_val<uint32_t>(rt_args_idx++);
@@ -420,9 +421,10 @@ void kernel_main() {
 
 #ifndef OUT_SHARDED
                 // WRITER
+                uint32_t num_blocks_w_dim_ = bw >= last_num_blocks_w_dim - 1 ? last_num_blocks_w_dim : num_blocks_w_dim;
                 uint32_t out_num_nonzero_subblocks_h_ = out_num_nonzero_subblocks_h;
                 uint32_t out_num_nonzero_subblocks_w_ = out_num_nonzero_subblocks_w;
-                if (bw == num_blocks_w_dim - 1) {
+                if (bw == num_blocks_w_dim_ - 1) {
                     out_num_nonzero_subblocks_w_ = out_last_num_nonzero_subblocks_w;
                 }
                 uint32_t out_tensor_sbh_start_tile_id = out_tensor_current_w_dim_block_tile_id;
@@ -437,7 +439,7 @@ void kernel_main() {
                         if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
                             out_subblock_h_ = out_last_subblock_h;
                         }
-                        if (bw == num_blocks_w_dim - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
                             out_subblock_w_ = out_last_subblock_w;
                             subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                         }
@@ -448,7 +450,9 @@ void kernel_main() {
                         for (uint32_t h = 0; h < out_subblock_h_; ++h) {
                             uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                             for (uint32_t w = 0; w < out_subblock_w_; ++w) {
-                                noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                if (bw < num_blocks_w_dim_) {
+                                    noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                }
 
                                 l1_read_addr += output_single_tile_size_bytes;
 
@@ -464,7 +468,7 @@ void kernel_main() {
                         out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                     }
                     // Pop fully padded subblocks along the row
-                    if (bw == num_blocks_w_dim - 1) {
+                    if (bw == num_blocks_w_dim_ - 1) {
                         cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);
                         cb_pop_front(cb_id_out0, padded_block_tiles_w_skip);
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -439,7 +439,7 @@ void kernel_main() {
                         if (bh == num_blocks_h_dim - 1 && sbh == out_num_nonzero_subblocks_h - 1) {
                             out_subblock_h_ = out_last_subblock_h;
                         }
-                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w - 1) {
+                        if (bw == num_blocks_w_dim_ - 1 && sbw == out_num_nonzero_subblocks_w_ - 1) {
                             out_subblock_w_ = out_last_subblock_w;
                             subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -941,7 +941,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
                 writer_runtime_args[0] = src_buffer_b->address();
                 writer_runtime_args[6] = dst_buffer->address();
                 if (bias_tensor.has_value()) {
-                    writer_runtime_args[17] = (*bias_buffer)->address();
+                    writer_runtime_args[18] = (*bias_buffer)->address();
                 }
             }
 
@@ -1657,7 +1657,7 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
                 sender_writer_runtime_args[0] = src_buffer_b->address();
                 sender_writer_runtime_args[6] = dst_buffer->address();
                 if (bias_tensor.has_value()) {
-                    sender_writer_runtime_args[17] = (*bias_buffer)->address();
+                    sender_writer_runtime_args[18] = (*bias_buffer)->address();
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1063,6 +1063,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                 }
 
                 if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
+                    uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
                     vc = vc == 3 ? 0 : vc + 1;
                     mm_in1_sender_writer_args.push_back(vc);
 
@@ -1121,7 +1122,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                             worker_core_stride = stride;
                         }
                     }
-                    mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + 20, num_iter);
+                    mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
                 }
                 if (fuse_op) {
                     fused_op_signaler->push_matmul_fused_op_rt_args(mm_in1_sender_writer_args, true);
@@ -1268,7 +1269,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                 writer_runtime_args[0] = src_buffer_b->address();
                 writer_runtime_args[6] = dst_buffer->address();
                 if (bias_tensor.has_value()) {
-                    writer_runtime_args[17] = (*bias_buffer)->address();
+                    writer_runtime_args[18] = (*bias_buffer)->address();
                 }
             }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17491#event-16386901268)

### Problem description
sometimes the matmul has less out-blocks for the last core on row/col, we need to add some re-calc logic to get the correct last num_blocks_h and num_blocks_w for the last core. 

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/13460386767/job/37614401925
- [x] blackhole https://github.com/tenstorrent/tt-metal/actions/runs/13461943909
