### PR TITLE
Fix CMake version check to also scan tests

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -132,5 +132,4 @@ jobs:
       # TODO: Use a lukka/run-cmake with a preset after upgrading to a more modern CMake
       run: |
         echo "Checking compatibility with $(cmake --version)"
-        # FIXME: Why is HAVE_STD_REGEX needed? Clean up when we solve it.
-        cmake -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake -DHAVE_STD_REGEX=ON -B build .
+        cmake -D BUILD_PROGRAMMING_EXAMPLES=ON -D TT_METAL_BUILD_TESTS=ON -B build .


### PR DESCRIPTION
### Ticket
None

### Problem description
The CMake scan wasn't scanning the tests because they're off by default.

### What's changed
Enable some additional paths through the CMake files.
Dropped the toolchain because we can use the system defaults for our purposes.
