### PR TITLE
#0: Support non-convex intersections between SubGrids when capturing MeshTrace commands

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -122,6 +122,22 @@ INSTANTIATE_TEST_SUITE_P(
     MeshTraceSweepTest,
     ::testing::Values(
         std::vector<std::vector<LogicalDeviceRange>>({
+            {LogicalDeviceRange({0, 0}, {3, 1})},  // Full grid
+            {LogicalDeviceRange({1, 0}, {1, 1})},  // Run on single center column
+            {LogicalDeviceRange({2, 0}, {2, 0})},  // Run on single device - top row, center
+            {LogicalDeviceRange({3, 1}, {3, 1})},  // Run on bottom right device
+            {LogicalDeviceRange({0, 0}, {0, 0})},  // Run on top left device
+            {LogicalDeviceRange({0, 0}, {3, 1})},  // Full grid
+        }),
+        std::vector<std::vector<LogicalDeviceRange>>({
+            {LogicalDeviceRange({0, 0}, {3, 1})},  // Full grid
+            {LogicalDeviceRange({1, 0}, {1, 1}),
+             LogicalDeviceRange({2, 0}, {2, 1}),
+             LogicalDeviceRange({3, 0}, {3, 1}),
+             LogicalDeviceRange({0, 0}, {0, 1})},                                      // Split grid into 4 columns
+            {LogicalDeviceRange({0, 0}, {3, 0}), LogicalDeviceRange({0, 1}, {3, 1})},  // Split grid into 2 rows
+        }),
+        std::vector<std::vector<LogicalDeviceRange>>({
             {LogicalDeviceRange({0, 0}, {3, 1})},                                      // Full grid
             {LogicalDeviceRange({0, 0}, {3, 0}), LogicalDeviceRange({0, 1}, {3, 1})},  // Split grid into 2 rows
             {LogicalDeviceRange({0, 0}, {1, 1}), LogicalDeviceRange({2, 0}, {3, 1})},  // Split grid into 2 columns
@@ -132,6 +148,20 @@ INSTANTIATE_TEST_SUITE_P(
              LogicalDeviceRange({1, 0}, {1, 1}),
              LogicalDeviceRange({2, 0}, {2, 1}),
              LogicalDeviceRange({3, 0}, {3, 1})},  // Split grid into 4 columns
+        }),
+        std::vector<std::vector<LogicalDeviceRange>>({
+            {LogicalDeviceRange({0, 0}, {3, 1})},  // Full grid
+            {LogicalDeviceRange({0, 0}, {0, 0}),
+             LogicalDeviceRange({1, 0}, {1, 0}),
+             LogicalDeviceRange({2, 0}, {2, 0}),
+             LogicalDeviceRange({3, 0}, {3, 0}),
+             LogicalDeviceRange({0, 1}, {0, 1}),
+             LogicalDeviceRange({1, 1}, {1, 1}),
+             LogicalDeviceRange({2, 1}, {2, 1}),
+             LogicalDeviceRange({3, 1}, {3, 1})},  // Run on individual devices
+            {LogicalDeviceRange({1, 0}, {2, 1})},  // Run on 2 center columns
+            {LogicalDeviceRange({2, 0}, {2, 1})},  // Run on single center column
+            {LogicalDeviceRange({1, 1}, {2, 1})},  // Run on 2 devices on the bottom row
         }),
         std::vector<std::vector<LogicalDeviceRange>>({
             {LogicalDeviceRange({0, 0}, {0, 1}),

--- a/tt_metal/api/tt-metalium/mesh_common.hpp
+++ b/tt_metal/api/tt-metalium/mesh_common.hpp
@@ -21,3 +21,4 @@ using MeshTraceId = tt::stl::StrongType<uint32_t, struct MeshTraceIdTag>;
 
 using DeviceCoord = CoreCoord;
 using LogicalDeviceRange = CoreRange;
+using LogicalDeviceRangeSet = CoreRangeSet;

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -46,8 +46,10 @@ void MeshTraceDescriptor::assemble_dispatch_commands(
                         std::make_move_iterator(program_cmds_vector.end()));
                 } else {
                     // Intersection is a subset of the originally placed program.
-                    auto compliment_ = convex_relative_complement(program.device_range, intersection);
-                    intermed_trace_data.push_back(MeshTraceData{compliment_, program.data});
+                    auto complement = relative_complement(program.device_range, intersection);
+                    for (auto& complement_range : complement.ranges()) {
+                        intermed_trace_data.push_back(MeshTraceData{complement_range, program.data});
+                    }
                     intermed_trace_data.push_back(MeshTraceData{intersection, program.data});
                     auto& intersection_data = intermed_trace_data.back().data;
                     intersection_data.insert(

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -80,15 +80,27 @@ void write_go_signal(
 bool is_row_major_intersection(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection) {
     return intersection.grid_size().x == parent.grid_size().x;
 }
+bool matching_dimensions(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection) {
+    auto intersection_grid_size = intersection.grid_size();
+    auto parent_grid_size = parent.grid_size();
+    return intersection_grid_size.x == parent_grid_size.x || intersection_grid_size.y == parent_grid_size.y;
+}
+
+bool matching_vertices(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection) {
+    return (intersection.start_coord.x == parent.start_coord.x && intersection.start_coord.y == parent.start_coord.y) ||
+           (intersection.end_coord.x == parent.end_coord.x && intersection.end_coord.y == parent.end_coord.y);
+}
+
+bool has_convex_relative_complement(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection) {
+    return matching_dimensions(parent, intersection) && matching_vertices(parent, intersection);
+}
 
 LogicalDeviceRange convex_relative_complement(
     const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection) {
     TT_FATAL(parent.contains(intersection), "Parent must contain intersection");
     auto intersection_grid_size = intersection.grid_size();
     auto parent_grid_size = parent.grid_size();
-    TT_FATAL(
-        intersection_grid_size.x == parent_grid_size.x || intersection_grid_size.y == parent_grid_size.y,
-        "Non convex grids not supported");
+    TT_FATAL(has_convex_relative_complement(parent, intersection), "Non convex grids not supported");
 
     if (is_row_major_intersection(parent, intersection)) {
         if (intersection.start_coord.y == parent.start_coord.y) {
@@ -107,6 +119,28 @@ LogicalDeviceRange convex_relative_complement(
                 {parent.start_coord.x, parent.start_coord.y}, {intersection.start_coord.x - 1, parent.end_coord.y});
         }
     }
+}
+
+LogicalDeviceRangeSet relative_complement(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection) {
+    TT_FATAL(parent.contains(intersection), "Parent must contain intersection");
+    if (has_convex_relative_complement(parent, intersection)) {
+        return convex_relative_complement(parent, intersection);
+    }
+    std::vector<LogicalDeviceRangeSet> relative_complement = {};
+    std::unordered_set<DeviceCoord> devices_in_intersection = {};
+    for (auto& intersection_device : intersection) {
+        devices_in_intersection.insert(intersection_device);
+    }
+    for (auto& parent_device : parent) {
+        if (devices_in_intersection.find(parent_device) == devices_in_intersection.end()) {
+            relative_complement.push_back(CoreRange(parent_device));
+        }
+    }
+    LogicalDeviceRangeSet merged_complement = relative_complement[0];
+    for (int i = 1; i < relative_complement.size(); i++) {
+        merged_complement = merged_complement.merge(relative_complement[i]);
+    }
+    return merged_complement;
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_workload_utils.hpp
+++ b/tt_metal/distributed/mesh_workload_utils.hpp
@@ -20,6 +20,6 @@ void write_go_signal(
     bool send_unicasts,
     int num_unicast_txns = -1);
 
-LogicalDeviceRange convex_relative_complement(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection);
+LogicalDeviceRangeSet relative_complement(const LogicalDeviceRange& parent, const LogicalDeviceRange& intersection);
 
 }  // namespace tt::tt_metal::distributed


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Existing implementation of `MeshTrace` relies on `convex_relative_complement` during trace command assembly. This requires the computed complement to be a convex grid.
- This is a strong assumption that may not always hold: example we run 2 MeshWorkloads; 1 with a single program broadcast to a rectangular grid and another with a unique program sent to each device. In this case, the relative complement of the entire grid with individual devices will be non-convex (requires more than one rectangular range to be fully described)

### What's changed
- Make `MeshTrace` rely on `relative_complement` (add functionality for this API) instead of `convex_relative_complement`
- Add tests for non-convex cases

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
