### PR TITLE
Aczajkowski/16670 topk op fix

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tensix_dest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tiles.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_raise_wait.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_config_register.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_noc_sanitize_delays.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_config_register.cpp
@@ -1,0 +1,595 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <unordered_set>
+#include <iostream>
+
+#include <tt-metalium/bfloat16.hpp>
+#include "debug_tools_fixture.hpp"
+#include "gtest/gtest.h"
+#include "debug_tools_test_utils.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking dprint
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+// Register names
+#define ALU_CONFIG 0
+#define UNPACK_TILE_DESCRIPTOR 1
+#define UNPACK_CONFIG 2
+#define PACK_CONFIG 3
+#define RELU_CONFIG 4
+#define DEST_RD_CTRL 5
+#define PACK_EDGE_OFFSET 6
+#define PACK_COUNTERS 7
+#define PACK_STRIDES 8
+
+// Type of prints
+const std::unordered_set<std::string> format_fields = {"ALU_FORMAT_SPEC_REG0_SrcA", "ALU_FORMAT_SPEC_REG1_SrcB",
+    "ALU_FORMAT_SPEC_REG2_Dstacc", "in_data_format", "out_data_format"};
+const std::unordered_set<std::string> decimal_fields = {
+    "blobs_per_xy_plane",
+    "x_dim",
+    "y_dim",
+    "z_dim",
+    "w_dim",
+    "blobs_y_start",
+    "digest_size",
+    "upsample_rate",
+    "shift_amount",
+    "fifo_size",
+    "row_ptr_section_size",
+    "exp_section_size",
+    "pack_per_xy_plane",
+    "downsample_shift_count",
+    "exp_threshold",
+    "STACC_RELU_ReluThreshold",
+    "pack_reads_per_xy_plane",
+    "pack_xys_per_til",
+    "pack_per_xy_plane_offset",
+    "sub_l1_tile_header_size",
+    "add_tile_header_size"};
+
+// ALU CONFIG
+const std::vector<std::string> field_names_alu_config_all = {
+    "ALU_ROUNDING_MODE_Fpu_srnd_en",
+    "ALU_ROUNDING_MODE_Gasket_srnd_en",
+    "ALU_ROUNDING_MODE_Packer_srnd_en",
+    "ALU_ROUNDING_MODE_Padding",
+    "ALU_ROUNDING_MODE_GS_LF",
+    "ALU_ROUNDING_MODE_Bfp8_HF",
+    "ALU_FORMAT_SPEC_REG0_SrcAUnsigned",
+    "ALU_FORMAT_SPEC_REG0_SrcBUnsigned",
+    "ALU_FORMAT_SPEC_REG0_SrcA",
+    "ALU_FORMAT_SPEC_REG1_SrcB",
+    "ALU_FORMAT_SPEC_REG2_Dstacc",
+    "ALU_ACC_CTRL_Fp32_enabled",
+    "ALU_ACC_CTRL_SFPU_Fp32_enabled",
+    "ALU_ACC_CTRL_INT8_math_enabled"};
+const std::vector<uint32_t> field_values_alu_config_all = {1, 0, 1, 15, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1};
+
+// PACK_EDGE_OFFSET
+const std::vector<std::string> field_names_pack_edge_offset_all = {
+    "mask",
+    "mode",
+    "tile_row_set_select_pack0",
+    "tile_row_set_select_pack1",
+    "tile_row_set_select_pack2",
+    "tile_row_set_select_pack3",
+    "reserved"};
+const std::vector<uint32_t> field_values_pack_edge_offset_all = {16, 1, 0, 1, 2, 3, 0};
+
+// PACK_COUNTERS
+const std::vector<std::string> field_names_pack_counters_all = {
+    "pack_per_xy_plane",
+    "pack_reads_per_xy_plane",
+    "pack_xys_per_til",
+    "pack_yz_transposed",
+    "pack_per_xy_plane_offset"};
+const std::vector<uint32_t> field_values_pack_counters_all = {4, 8, 2, 0, 6};
+
+// RELU_CONFIG
+const std::vector<std::string> field_names_relu_config_all = {
+    "ALU_ACC_CTRL_Zero_Flag_disabled_src",
+    "ALU_ACC_CTRL_Zero_Flag_disabled_dst",
+    "STACC_RELU_ApplyRelu",
+    "STACC_RELU_ReluThreshold",
+    "DISABLE_RISC_BP_Disable_main",
+    "DISABLE_RISC_BP_Disable_trisc",
+    "DISABLE_RISC_BP_Disable_ncrisc",
+    "DISABLE_RISC_BP_Disable_bmp_clear_main",
+    "DISABLE_RISC_BP_Disable_bmp_clear_trisc",
+    "DISABLE_RISC_BP_Disable_bmp_clear_ncrisc"};
+const std::vector<uint32_t> field_values_relu_config_all = {0, 0, 1, 8, 0, 0, 0, 0, 0, 0};
+
+// PACK_DEST_RD_CTRL
+const std::vector<std::string> field_names_dest_rd_ctrl_all = {
+    "PCK_DEST_RD_CTRL_Read_32b_data",
+    "PCK_DEST_RD_CTRL_Read_unsigned",
+    "PCK_DEST_RD_CTRL_Read_int8",
+    "PCK_DEST_RD_CTRL_Round_10b_mant",
+    "PCK_DEST_RD_CTRL_Reserved"};
+const std::vector<uint32_t> field_values_dest_rd_ctrl_all = {1, 0, 1, 1, 0};
+
+// UNPACK TILE DESCRIPTOR
+const std::vector<std::string> field_names_unpack_tile_descriptor_grayskull = {
+    "in_data_format",
+    "uncompressed",
+    "reserved_0",
+    "blobs_per_xy_plane",
+    "reserved_1",
+    "x_dim",
+    "y_dim",
+    "z_dim",
+    "w_dim",
+    "blobs_y_start",
+    "digest_type",
+    "digest_size"};
+const std::vector<uint32_t> field_values_unpack_tile_descriptor_grayskull = {5, 1, 2, 10, 7, 2, 4, 8, 16, 32, 0, 0};
+
+// UNPACK CONFIG
+const std::vector<std::string> field_names_unpack_config_grayskull = {
+    "out_data_format",
+    "throttle_mode",
+    "context_count",
+    "haloize_mode",
+    "tileize_mode",
+    "force_shared_exp",
+    "reserved_0",
+    "upsample_rate",
+    "upsample_and_interlave",
+    "shift_amount",
+    "uncompress_cntx0_3",
+    "reserved_1",
+    "uncompress_cntx4_7",
+    "reserved_2",
+    "limit_addr",
+    "fifo_size"};
+const std::vector<uint32_t> field_values_unpack_config_grayskull = {0, 1, 2, 0, 1, 0, 0, 3, 0, 16, 5, 0, 2, 0, 28, 29};
+
+// PACK CONFIG
+const std::vector<std::string> field_names_pack_config_grayskull = {
+    "row_ptr_section_size",
+    "exp_section_size",
+    "l1_dest_addr",
+    "uncompress",
+    "add_l1_dest_addr_offset",
+    "reserved_0",
+    "out_data_format",
+    "in_data_format",
+    "reserved_1",
+    "src_if_sel",
+    "pack_per_xy_plane",
+    "l1_src_addr",
+    "downsample_mask",
+    "downsample_shift_count",
+    "read_mode",
+    "exp_threshold_en",
+    "reserved_2",
+    "exp_threshold"};
+const std::vector<uint32_t> field_values_pack_config_grayskull = {
+    12, 24, 16, 0, 1, 0, 5, 5, 0, 1, 0, 8, 12, 4, 0, 1, 0, 12};
+
+// UNPACK TILE DESCRIPTOR
+const std::vector<std::string> field_names_unpack_tile_descriptor_wormhole_or_blackhole = {
+    "in_data_format",
+    "uncompressed",
+    "reserved_0",
+    "blobs_per_xy_plane",
+    "reserved_1",
+    "x_dim",
+    "y_dim",
+    "z_dim",
+    "w_dim",
+    "blobs_y_start_lo",
+    "blobs_y_start_hi",
+    "digest_type",
+    "digest_size"};
+const std::vector<uint32_t> field_values_unpack_tile_descriptor_wormhole_or_blackhole = {
+    5, 1, 0, 10, 7, 2, 4, 8, 16, 32, 0, 0, 0};
+
+// UNPACK CONFIG
+const std::vector<std::string> field_names_unpack_config_wormhole_or_blackhole = {
+    "out_data_format",
+    "throttle_mode",
+    "context_count",
+    "haloize_mode",
+    "tileize_mode",
+    "unpack_src_reg_set_update",
+    "unpack_if_sel",
+    "upsample_rate",
+    "reserved_1",
+    "upsample_and_interlave",
+    "shift_amount",
+    "uncompress_cntx0_3",
+    "unpack_if_sel_cntx0_3",
+    "force_shared_exp",
+    "reserved_2",
+    "uncompress_cntx4_7",
+    "unpack_if_sel_cntx4_7",
+    "reserved_3",
+    "limit_addr",
+    "reserved_4",
+    "fifo_size",
+    "reserved_5"};
+const std::vector<uint32_t> field_values_unpack_config_wormhole_or_blackhole = {0, 1, 2, 0, 1, 1, 0, 3,  0, 0,  16,
+                                                                                5, 6, 0, 0, 2, 3, 0, 28, 0, 29, 0};
+
+const std::vector<std::string> field_names_pack_config_blackhole = {
+    "row_ptr_section_size",
+    "exp_section_size",
+    "l1_dest_addr",
+    "uncompress",
+    "add_l1_dest_addr_offset",
+    "disable_pack_zero_flag",
+    "reserved_0",
+    "out_data_format",
+    "in_data_format",
+    "dis_shared_exp_assembler",
+    "auto_set_last_pacr_intf_sel",
+    "enable_out_fifo",
+    "sub_l1_tile_header_size",
+    "src_if_sel",
+    "pack_start_intf_pos",
+    "all_pack_disable_zero_compress_ovrd",
+    "add_tile_header_size",
+    "pack_dis_y_pos_start_offset",
+    "l1_src_addr"};
+const std::vector<uint32_t> field_values_pack_config_blackhole = {
+    12, 24, 16, 0, 1, 1, 0, 5, 5, 0, 0, 1, 0, 1, 2, 0, 1, 0, 8};
+// PACK CONFIG
+const std::vector<std::string> field_names_pack_config_wormhole = {
+    "row_ptr_section_size",
+    "exp_section_size",
+    "l1_dest_addr",
+    "uncompress",
+    "add_l1_dest_addr_offset",
+    "reserved_0",
+    "out_data_format",
+    "in_data_format",
+    "reserved_1",
+    "src_if_sel",
+    "pack_per_xy_plane",
+    "l1_src_addr",
+    "downsample_mask",
+    "downsample_shift_count",
+    "read_mode",
+    "exp_threshold_en",
+    "pack_l1_acc_disable_pack_zero_flag",
+    "reserved_2",
+    "exp_threshold"};
+const std::vector<uint32_t> field_values_pack_config_wormhole = {
+    12, 24, 16, 0, 1, 0, 5, 5, 0, 1, 0, 8, 12, 4, 0, 1, 2, 0, 12};
+
+// Configuration for Data Flow Test involving Reader, Datacopy, and Writer
+struct ConfigRegPrintTestConfig {
+    CoreCoord core = {};
+    std::string write_kernel;
+    std::string print_kernel;
+    int num_of_registers;
+    std::vector<std::string> field_names;
+    std::vector<uint32_t> field_values;
+    uint32_t register_name;
+};
+
+// Dprints data format as string given an uint
+static std::string data_format_to_string(uint8_t data_format) {
+    switch (data_format) {
+        case (uint8_t) DataFormat::Float32:
+            return "Float32";
+        case (uint8_t) DataFormat::Float16:
+            return "Float16";
+        case (uint8_t) DataFormat::Bfp8:
+            return "Bfp8";
+        case (uint8_t) DataFormat::Bfp4:
+            return "Bfp4";
+        case (uint8_t) DataFormat::Bfp2:
+            return "Bfp2";
+        case (uint8_t) DataFormat::Float16_b:
+            return "Float16_b";
+        case (uint8_t) DataFormat::Bfp8_b:
+            return "Bfp8_b";
+        case (uint8_t) DataFormat::Bfp4_b:
+            return "Bfp4_b";
+        case (uint8_t) DataFormat::Bfp2_b:
+            return "Bfp2_b";
+        case (uint8_t) DataFormat::Lf8:
+            return "Lf8";
+        case (uint8_t) DataFormat::Int8:
+            return "Int8";
+        case (uint8_t) DataFormat::UInt8:
+            return "UInt8";
+        case (uint8_t) DataFormat::UInt16:
+            return "UInt16";
+        case (uint8_t) DataFormat::Int32:
+            return "Int32";
+        case (uint8_t) DataFormat::UInt32:
+            return "UInt32";
+        case (uint8_t) DataFormat::Tf32:
+            return "Tf32";
+        default:
+            return "INVALID DATA FORMAT";
+    }
+}
+
+static std::string int_to_hex(int value) {
+    std::stringstream ss;
+    ss << std::hex << value; // Convert to hexadecimal
+    return ss.str();
+}
+
+// Prepares the compute kernel with the specified program and test configuration
+static KernelHandle prepare_writer(tt_metal::Program& program, const ConfigRegPrintTestConfig& config) {
+    return tt_metal::CreateKernel(
+        program,
+        config.write_kernel,
+        config.core,
+        tt_metal::ComputeConfig{
+            .compile_args = { config.register_name }});
+}
+
+static std::string generate_golden_output(const std::vector<std::string>& field_names, const std::vector<uint32_t>& values, uint num_of_registers, uint32_t register_name) {
+    std::string golden_output;
+    bool multiple_registers = num_of_registers > 1;
+    for (uint reg_id = 1; reg_id <= num_of_registers; reg_id++) {
+        if (multiple_registers) golden_output += "REG_ID: " + std::to_string(reg_id) + "\n";
+        for (size_t i = 0; i < field_names.size(); i++) {
+            if (field_names[i] == "blobs_y_start_lo") continue;
+            if (field_names[i] == "blobs_y_start_hi") {
+                uint32_t val = (values[i] << 16) | values[i-1];
+                golden_output += "blobs_y_start: " + std::to_string(val) + "\n";
+                continue;
+            }
+            if (format_fields.find(field_names[i]) != format_fields.end())
+                golden_output += field_names[i] + ": " + data_format_to_string(values[i]) + "\n";
+            else if (decimal_fields.find(field_names[i]) != format_fields.end())
+                golden_output += field_names[i] + ": " + std::to_string(values[i]) + "\n";
+            else {
+                golden_output += field_names[i] + ": 0x" + int_to_hex(values[i]) + "\n";
+            }
+
+            if (register_name == PACK_EDGE_OFFSET && reg_id > 1) break;
+        }
+        if (reg_id != num_of_registers) golden_output += "\n";
+    }
+    return golden_output;
+}
+
+static void print_config_reg(
+    DPrintFixture* fixture, tt_metal::IDevice* device, const ConfigRegPrintTestConfig& config) {
+    // Create program
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    // Prepare write kernel
+    auto write_kernel = prepare_writer(program, config);
+
+    // Generate golden output
+    std::string golden_output = generate_golden_output(config.field_names, config.field_values, config.num_of_registers, config.register_name);
+
+    // Run the program
+    fixture->RunProgram(device, program);
+
+    // Check the print log against golden output.
+    EXPECT_TRUE(FilesMatchesString(DPrintFixture::dprint_file_name, golden_output));
+}
+
+TEST_F(DPrintFixture, ConfigRegAluTestPrint) {
+    std::vector<std::string> field_names_alu_config = field_names_alu_config_all;
+    std::vector<uint32_t> field_values_alu_config = field_values_alu_config_all;
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = 1,
+        .field_names = field_names_alu_config,
+        .field_values = field_values_alu_config,
+        .register_name = ALU_CONFIG};
+
+    if (this->arch_ == ARCH::GRAYSKULL) {
+        GTEST_SKIP() << "Printing ALU CONFIG is not supported on grayskull.";
+    }
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegTileDescriptorTestPrint) {
+    // Setup test configuration
+
+    std::vector<std::string> field_names_unpack_tile_descriptor;
+    std::vector<uint32_t> field_values_unpack_tile_descriptor;
+
+    if (this->arch_ == ARCH::GRAYSKULL) {
+        field_names_unpack_tile_descriptor = field_names_unpack_tile_descriptor_grayskull;
+        field_values_unpack_tile_descriptor = field_values_unpack_tile_descriptor_grayskull;
+    } else {
+        field_names_unpack_tile_descriptor = field_names_unpack_tile_descriptor_wormhole_or_blackhole;
+        field_values_unpack_tile_descriptor = field_values_unpack_tile_descriptor_wormhole_or_blackhole;
+    }
+
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = 2,
+        .field_names = field_names_unpack_tile_descriptor,
+        .field_values = field_values_unpack_tile_descriptor,
+        .register_name = UNPACK_TILE_DESCRIPTOR};
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegUnpackTestPrint) {
+    std::vector<std::string> field_names_unpack_config;
+    std::vector<uint32_t> field_values_unpack_config;
+
+    if (this->arch_ == ARCH::GRAYSKULL) {
+        field_names_unpack_config = field_names_unpack_config_grayskull;
+        field_values_unpack_config = field_values_unpack_config_grayskull;
+    } else {
+        field_names_unpack_config = field_names_unpack_config_wormhole_or_blackhole;
+        field_values_unpack_config = field_values_unpack_config_wormhole_or_blackhole;
+    }
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = 2,
+        .field_names = field_names_unpack_config,
+        .field_values = field_values_unpack_config,
+        .register_name = UNPACK_CONFIG};
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegPackTestPrint) {
+    std::vector<std::string> field_names_pack_config;
+    std::vector<uint32_t> field_values_pack_config;
+
+    if (this->arch_ == ARCH::GRAYSKULL) {
+        field_names_pack_config = field_names_pack_config_grayskull;
+        field_values_pack_config = field_values_pack_config_grayskull;
+    } else if (this->arch_ == ARCH::WORMHOLE_B0) {
+        field_names_pack_config = field_names_pack_config_wormhole;
+        field_values_pack_config = field_values_pack_config_wormhole;
+    } else {
+        field_names_pack_config = field_names_pack_config_blackhole;
+        field_values_pack_config = field_values_pack_config_blackhole;
+    }
+
+    int num_of_registers;
+    if (this->arch_ == ARCH::BLACKHOLE) {
+        num_of_registers = 1;
+    } else {
+        num_of_registers = 4;
+    }
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = num_of_registers,
+        .field_names = field_names_pack_config,
+        .field_values = field_values_pack_config,
+        .register_name = PACK_CONFIG};
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegReluTestPrint) {
+    std::vector<std::string> field_names_relu_config = field_names_relu_config_all;
+    std::vector<uint32_t> field_values_relu_config = field_values_relu_config_all;
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = 1,
+        .field_names = field_names_relu_config,
+        .field_values = field_values_relu_config,
+        .register_name = RELU_CONFIG};
+
+    if (this->arch_ == ARCH::GRAYSKULL) {
+        GTEST_SKIP() << "Printing RELU CONFIG is not supported on grayskull.";
+    }
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegDestRdCtrlTestPrint) {
+    std::vector<std::string> field_names_dest_rd_ctrl = field_names_dest_rd_ctrl_all;
+    std::vector<uint32_t> field_values_dest_rd_ctrl = field_values_dest_rd_ctrl_all;
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = 1,
+        .field_names = field_names_dest_rd_ctrl,
+        .field_values = field_values_dest_rd_ctrl,
+        .register_name = DEST_RD_CTRL};
+
+    if (this->arch_ == ARCH::GRAYSKULL) {
+        GTEST_SKIP() << "Printing DEST RD CTRL is not supported on grayskull.";
+    }
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegPackEdgeOffsetTestPrint) {
+    std::vector<std::string> field_names_pack_edge_offset = field_names_pack_edge_offset_all;
+    std::vector<uint32_t> field_values_pack_edge_offset = field_values_pack_edge_offset_all;
+
+    int num_of_registers;
+    if (this->arch_ == ARCH::BLACKHOLE) {
+        num_of_registers = 1;
+    } else {
+        num_of_registers = 4;
+    }
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = num_of_registers,
+        .field_names = field_names_pack_edge_offset,
+        .field_values = field_values_pack_edge_offset,
+        .register_name = PACK_EDGE_OFFSET};
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}
+
+TEST_F(DPrintFixture, ConfigRegPackCountersTestPrint) {
+    std::vector<std::string> field_names_pack_counters = field_names_pack_counters_all;
+    std::vector<uint32_t> field_values_pack_counters = field_values_pack_counters_all;
+
+    int num_of_registers;
+    if (this->arch_ == ARCH::BLACKHOLE) {
+        num_of_registers = 1;
+    } else {
+        num_of_registers = 4;
+    }
+
+    // Setup test configuration
+    ConfigRegPrintTestConfig test_config = {
+        .core = CoreCoord(0, 0),
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .num_of_registers = num_of_registers,
+        .field_names = field_names_pack_counters,
+        .field_values = field_values_pack_counters,
+        .register_name = PACK_COUNTERS};
+
+    // Run the test on the device
+    this->RunTestOnDevice(
+        [&](DPrintFixture* fixture, IDevice* device) { print_config_reg(fixture, device, test_config); },
+        this->devices_[0]);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "debug/dprint_tensix_pack.h"
+#include "debug/dprint_tensix_unpack.h"
+
+#include <array>
+
+// Register names
+#define ALU_CONFIG 0
+#define UNPACK_TILE_DESCRIPTOR 1
+#define UNPACK_CONFIG 2
+#define PACK_CONFIG 3
+#define RELU_CONFIG 4
+#define DEST_RD_CTRL 5
+#define PACK_EDGE_OFFSET 6
+#define PACK_COUNTERS 7
+#define PACK_STRIDES 8
+
+namespace NAMESPACE {
+#if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+void generate_alu_config(ckernel::unpacker::alu_config_t& config) {
+   config.ALU_ROUNDING_MODE_Fpu_srnd_en = 1;
+   config.ALU_ROUNDING_MODE_Gasket_srnd_en = 0;
+   config.ALU_ROUNDING_MODE_Packer_srnd_en = 1;
+   config.ALU_ROUNDING_MODE_Padding = 15;
+   config.ALU_ROUNDING_MODE_GS_LF = 0;
+   config.ALU_ROUNDING_MODE_Bfp8_HF = 1;
+   config.ALU_FORMAT_SPEC_REG0_SrcAUnsigned = 1;
+   config.ALU_FORMAT_SPEC_REG0_SrcBUnsigned = 0;
+   config.ALU_FORMAT_SPEC_REG0_SrcA = 0;
+   config.ALU_FORMAT_SPEC_REG1_SrcB = 1;
+   config.ALU_FORMAT_SPEC_REG2_Dstacc = 0;
+   config.ALU_ACC_CTRL_Fp32_enabled = 0;
+   config.ALU_ACC_CTRL_SFPU_Fp32_enabled = 0;
+   config.ALU_ACC_CTRL_INT8_math_enabled = 1;
+}
+#endif
+
+void generate_unpack_tile_descriptor(ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+   tile_descriptor.in_data_format = 5;
+   tile_descriptor.uncompressed = 1;
+   tile_descriptor.reserved_0 = 0;
+   tile_descriptor.blobs_per_xy_plane = 10;
+   tile_descriptor.reserved_1 = 7;
+   tile_descriptor.x_dim = 2;
+   tile_descriptor.y_dim = 4;
+   tile_descriptor.z_dim = 8;
+   tile_descriptor.w_dim = 16;
+#ifdef ARCH_GRAYSKULL
+   tile_descriptor.blobs_y_start = 32;
+#else // ARCH_WORMHOLE or ARCH_BLACKHOLE
+   tile_descriptor.blobs_y_start_lo = 32;
+   tile_descriptor.blobs_y_start_hi = 0;
+#endif
+   tile_descriptor.digest_type = 0;
+   tile_descriptor.digest_size = 0;
+}
+
+void generate_unpack_config(ckernel::unpacker::unpack_config_t& config) {
+   config.out_data_format = 0;
+   config.throttle_mode = 1;
+   config.context_count = 2;
+   config.haloize_mode = 0;
+   config.tileize_mode = 1;
+   config.upsample_rate = 3;
+   config.reserved_1 = 0;
+   config.upsamle_and_interlave = 0;
+   config.shift_amount = 16;
+   config.uncompress_cntx0_3 = 5;
+   config.force_shared_exp = 0;
+   config.reserved_2 = 0;
+   config.uncompress_cntx4_7 = 2;
+   config.limit_addr = 28;
+   config.fifo_size = 29;
+
+#ifdef ARCH_GRAYSKULL
+   config.reserved_0 = 0;
+#else // ARCH_WORMHOLE or ARCH_BLACKHOLE
+   config.reserved_3 = 0;
+   config.reserved_4 = 0;
+   config.reserved_5 = 0;
+   config.unpack_if_sel_cntx0_3 = 6;
+   config.unpack_if_sel_cntx4_7 = 3;
+   config.unpack_src_reg_set_update = 1;
+   config.unpack_if_sel = 0;
+#endif
+}
+
+void generate_pack_config(ckernel::packer::pack_config_t& config) {
+   config.row_ptr_section_size = 12;
+   config.exp_section_size = 24;
+   config.l1_dest_addr = 16;
+   config.uncompress = 0;
+   config.add_l1_dest_addr_offset = 1;
+   config.reserved_0 = 0;
+   config.out_data_format = 5;
+   config.in_data_format = 5;
+   config.src_if_sel = 1;
+   config.l1_src_addr = 8;
+#if defined(ARCH_WORMHOLE) or defined(ARCH_GRAYSKULL)
+   config.reserved_1 = 0;
+   config.pack_per_xy_plane = 0;
+   config.downsample_mask = 12;
+   config.downsample_shift_count = 4;
+   config.read_mode = 0;
+   config.exp_threshold_en = 1;
+#ifdef ARCH_WORMHOLE
+   config.pack_l1_acc_disable_pack_zero_flag = 2;
+#endif
+   config.reserved_2 = 0;
+   config.exp_threshold = 12;
+#endif
+#ifdef ARCH_BLACKHOLE
+   config.disable_pack_zero_flag = 1;
+   config.dis_shared_exp_assembler = 0;
+   config.auto_set_last_pacr_intf_sel = 0;
+   config.enable_out_fifo = 1;
+   config.sub_l1_tile_header_size = 0;
+   config.pack_start_intf_pos = 2;
+   config.all_pack_disable_zero_compress_ovrd = 0;
+   config.add_tile_header_size = 1;
+   config.pack_dis_y_pos_start_offset = 0;
+#endif
+}
+
+#if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+void generate_relu_config(ckernel::packer::relu_config_t& config) {
+    config.ALU_ACC_CTRL_Zero_Flag_disabled_src = 0;
+    config.ALU_ACC_CTRL_Zero_Flag_disabled_dst = 0;
+    config.STACC_RELU_ApplyRelu = 1;
+    config.STACC_RELU_ReluThreshold = 8;
+    config.DISABLE_RISC_BP_Disable_main = 0;
+    config.DISABLE_RISC_BP_Disable_trisc = 0;
+    config.DISABLE_RISC_BP_Disable_ncrisc = 0;
+    config.DISABLE_RISC_BP_Disable_bmp_clear_main = 0;
+    config.DISABLE_RISC_BP_Disable_bmp_clear_trisc = 0;
+    config.DISABLE_RISC_BP_Disable_bmp_clear_ncrisc = 0;
+}
+#endif
+
+#if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+void generate_dest_rd_ctrl(ckernel::packer::dest_rd_ctrl_t& dest) {
+   dest.PCK_DEST_RD_CTRL_Read_32b_data = 1;
+   dest.PCK_DEST_RD_CTRL_Read_unsigned = 0;
+   dest.PCK_DEST_RD_CTRL_Read_int8 = 1;
+   dest.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
+   dest.PCK_DEST_RD_CTRL_Reserved = 0;
+}
+#endif
+
+void generate_pack_edge_offset(ckernel::packer::pck_edge_offset_t& edge) {
+   edge.mask = 16;
+   edge.mode = 1;
+   edge.tile_row_set_select_pack0 = 0;
+   edge.tile_row_set_select_pack1 = 1;
+   edge.tile_row_set_select_pack2 = 2;
+   edge.tile_row_set_select_pack3 = 3;
+   edge.reserved = 0;
+}
+
+void generate_pack_counters(ckernel::packer::pack_counters_t& counter) {
+   counter.pack_per_xy_plane = 4;
+   counter.pack_reads_per_xy_plane = 8;
+   counter.pack_xys_per_til = 2;
+   counter.pack_yz_transposed = 0;
+   counter.pack_per_xy_plane_offset = 6;
+}
+
+#if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+void write_alu_config(volatile uint tt_reg_ptr* cfg, uint32_t address, const ckernel::unpacker::alu_config_u &config) {
+   cfg[address] = config.val;
+}
+#endif
+
+void write_unpack_tile_descriptor(volatile uint tt_reg_ptr* cfg, uint32_t address, uint num_of_words, const ckernel::unpacker::unpack_tile_descriptor_u &tile_descriptor) {
+   for (uint i = 0; i < num_of_words; i++)
+      cfg[address + i] = tile_descriptor.val[i];
+}
+
+void write_unpack_config(volatile uint tt_reg_ptr* cfg, uint32_t address, uint num_of_words, const ckernel::unpacker::unpack_config_u &config) {
+   for (uint i = 0; i < num_of_words; i++)
+      cfg[address + i] = config.val[i];
+}
+
+void write_pack_config(volatile uint tt_reg_ptr* cfg, uint32_t address, uint num_of_words, const ckernel::packer::pack_config_u &config) {
+   for (uint i = 0; i < num_of_words; i++)
+      cfg[address + i] = config.val[i];
+}
+
+#if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+void write_relu_config(volatile uint tt_reg_ptr* cfg, uint32_t address, uint num_of_words, const ckernel::packer::relu_config_u &config) {
+   for (uint i = 0; i < num_of_words; i++)
+      cfg[address + i] = config.val[i];
+}
+#endif
+
+#if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+void write_dest_rd_ctrl(volatile uint tt_reg_ptr* cfg, uint32_t address, const ckernel::packer::dest_rd_ctrl_u &dest) {
+   cfg[address] = dest.val;
+}
+#endif
+
+void write_pack_edge_offset(volatile uint tt_reg_ptr* cfg, uint32_t address, const ckernel::packer::pck_edge_offset_u &edge) {
+   cfg[address] = edge.val;
+}
+
+void write_pack_counters(volatile uint tt_reg_ptr* cfg, uint32_t address, const ckernel::packer::pack_counters_u &counter) {
+   cfg[address] = counter.val;
+}
+
+void MAIN {
+   uint32_t register_name = get_compile_time_arg_val(0);
+
+   // Get pointer to registers for current state ID
+   volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
+
+   switch (register_name) {
+      #if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+      case ALU_CONFIG:
+         ckernel::unpacker::alu_config_u alu_config;
+         generate_alu_config(alu_config.f);
+         ckernel::unpacker::alu_config_u alu_config_original;
+         alu_config_original.f = ckernel::unpacker::read_alu_config();
+         write_alu_config(cfg, ALU_ROUNDING_MODE_Fpu_srnd_en_ADDR32, alu_config);
+         dprint_tensix_alu_config();
+         write_alu_config(cfg, ALU_ROUNDING_MODE_Fpu_srnd_en_ADDR32, alu_config_original);
+         break;
+      #endif
+      case UNPACK_TILE_DESCRIPTOR:
+         ckernel::unpacker::unpack_tile_descriptor_u tile_descriptor;
+         generate_unpack_tile_descriptor(tile_descriptor.f);
+         std::array<ckernel::unpacker::unpack_tile_descriptor_t, ckernel::unpacker::NUM_UNPACKERS> tile_descriptor_vec;
+         tile_descriptor_vec = ckernel::unpacker::read_unpack_tile_descriptor();
+         write_unpack_tile_descriptor(cfg, THCON_SEC0_REG0_TileDescriptor_ADDR32, 4, tile_descriptor);
+         write_unpack_tile_descriptor(cfg, THCON_SEC1_REG0_TileDescriptor_ADDR32, 4, tile_descriptor);
+         dprint_tensix_unpack_tile_descriptor();
+         tile_descriptor.f = tile_descriptor_vec[0];
+         write_unpack_tile_descriptor(cfg, THCON_SEC0_REG0_TileDescriptor_ADDR32, 4, tile_descriptor);
+         tile_descriptor.f = tile_descriptor_vec[1];
+         write_unpack_tile_descriptor(cfg, THCON_SEC1_REG0_TileDescriptor_ADDR32, 4, tile_descriptor);
+         break;
+      case UNPACK_CONFIG:
+         uint num_of_words_unpack_config;
+      #ifdef ARCH_GRAYSKULL
+         num_of_words_unpack_config = 3;
+      #else
+         num_of_words_unpack_config = 4;
+      #endif
+         ckernel::unpacker::unpack_config_u unpack_config;
+         generate_unpack_config(unpack_config.f);
+         std::array<ckernel::unpacker::unpack_config_t, ckernel::unpacker::NUM_UNPACKERS> unpack_config_vec;
+         unpack_config_vec = ckernel::unpacker::read_unpack_config();
+         write_unpack_config(cfg, THCON_SEC0_REG2_Out_data_format_ADDR32, num_of_words_unpack_config, unpack_config);
+         write_unpack_config(cfg, THCON_SEC1_REG2_Out_data_format_ADDR32, num_of_words_unpack_config, unpack_config);
+         dprint_tensix_unpack_config();
+         unpack_config.f = unpack_config_vec[0];
+         write_unpack_config(cfg, THCON_SEC0_REG2_Out_data_format_ADDR32, num_of_words_unpack_config, unpack_config);
+         unpack_config.f = unpack_config_vec[1];
+         write_unpack_config(cfg, THCON_SEC1_REG2_Out_data_format_ADDR32, num_of_words_unpack_config, unpack_config);
+         break;
+      case PACK_CONFIG:
+         uint num_of_words_pack_config;
+      #ifdef ARCH_BLACKHOLE
+         num_of_words_pack_config = 3;
+      #else
+         num_of_words_pack_config = 4;
+      #endif
+         ckernel::packer::pack_config_u pack_config;
+         generate_pack_config(pack_config.f);
+         std::array<ckernel::packer::pack_config_t, ckernel::packer::NUM_PACKERS> pack_config_vec;
+         pack_config_vec = ckernel::packer::read_pack_config();
+         write_pack_config(cfg, THCON_SEC0_REG1_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+      #if defined(ARCH_GRAYSKULL) or defined(ARCH_WORMHOLE)
+         write_pack_config(cfg, THCON_SEC0_REG8_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+         write_pack_config(cfg, THCON_SEC1_REG1_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+         write_pack_config(cfg, THCON_SEC1_REG8_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+      #endif
+         dprint_tensix_pack_config();
+         pack_config.f = pack_config_vec[0];
+         write_pack_config(cfg, THCON_SEC0_REG1_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+      #if defined(ARCH_GRAYSKULL) or defined(ARCH_WORMHOLE)
+         pack_config.f = pack_config_vec[1];
+         write_pack_config(cfg, THCON_SEC0_REG8_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+         pack_config.f = pack_config_vec[2];
+         write_pack_config(cfg, THCON_SEC1_REG1_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+         pack_config.f = pack_config_vec[3];
+         write_pack_config(cfg, THCON_SEC1_REG8_Row_start_section_size_ADDR32, num_of_words_pack_config, pack_config);
+      #endif
+         break;
+      #if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+      case RELU_CONFIG:
+         ckernel::packer::relu_config_u relu_config;
+         generate_relu_config(relu_config.r);
+         ckernel::packer::relu_config_u relu_config_original;
+         relu_config_original.r = ckernel::packer::read_relu_config();
+         write_relu_config(cfg, ALU_ACC_CTRL_Zero_Flag_disabled_src_ADDR32, 1, relu_config);
+         dprint_tensix_pack_relu_config();
+         write_relu_config(cfg, ALU_ACC_CTRL_Zero_Flag_disabled_src_ADDR32, 1, relu_config_original);
+         break;
+      #endif
+      #if defined(ARCH_WORMHOLE) or defined(ARCH_BLACKHOLE)
+      case DEST_RD_CTRL:
+         ckernel::packer::dest_rd_ctrl_u dest;
+         generate_dest_rd_ctrl(dest.f);
+         ckernel::packer::dest_rd_ctrl_u dest_original;
+         dest_original.f = ckernel::packer::read_dest_rd_ctrl();
+         write_dest_rd_ctrl(cfg, PCK_DEST_RD_CTRL_Read_32b_data_ADDR32, dest);
+         dprint_tensix_dest_rd_ctrl();
+         write_dest_rd_ctrl(cfg, PCK_DEST_RD_CTRL_Read_32b_data_ADDR32, dest_original);
+         break;
+      #endif
+      case PACK_EDGE_OFFSET:
+         ckernel::packer::pck_edge_offset_u edge;
+         generate_pack_edge_offset(edge.f);
+         std::array<ckernel::packer::pck_edge_offset_t, ckernel::packer::NUM_PACKERS> edge_vec;
+         edge_vec = ckernel::packer::read_pack_edge_offset();
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC0_mask_ADDR32, edge);
+      #if defined(ARCH_GRAYSKULL) or defined(ARCH_WORMHOLE)
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC1_mask_ADDR32, edge);
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC2_mask_ADDR32, edge);
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC3_mask_ADDR32, edge);
+      #endif
+         dprint_tensix_pack_edge_offset();
+         edge.f = edge_vec[0];
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC0_mask_ADDR32, edge);
+      #if defined(ARCH_GRAYSKULL) or defined(ARCH_WORMHOLE)
+         edge.f = edge_vec[1];
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC1_mask_ADDR32, edge);
+         edge.f = edge_vec[2];
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC2_mask_ADDR32, edge);
+         edge.f = edge_vec[3];
+         write_pack_edge_offset(cfg, PCK_EDGE_OFFSET_SEC3_mask_ADDR32, edge);
+      #endif
+         break;
+      case PACK_COUNTERS:
+         ckernel::packer::pack_counters_u counter;
+         generate_pack_counters(counter.f);
+         std::array<ckernel::packer::pack_counters_t, ckernel::packer::NUM_PACKERS> counter_vec;
+         counter_vec = ckernel::packer::read_pack_counters();
+         write_pack_counters(cfg, PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32, counter);
+      #if defined(ARCH_GRAYSKULL) or defined(ARCH_WORMHOLE)
+         write_pack_counters(cfg, PACK_COUNTERS_SEC1_pack_per_xy_plane_ADDR32, counter);
+         write_pack_counters(cfg, PACK_COUNTERS_SEC2_pack_per_xy_plane_ADDR32, counter);
+         write_pack_counters(cfg, PACK_COUNTERS_SEC3_pack_per_xy_plane_ADDR32, counter);
+      #endif
+         dprint_tensix_pack_counters();
+         counter.f = counter_vec[0];
+         write_pack_counters(cfg, PACK_COUNTERS_SEC0_pack_per_xy_plane_ADDR32, counter);
+      #if defined(ARCH_GRAYSKULL) or defined(ARCH_WORMHOLE)
+         counter.f = counter_vec[1];
+         write_pack_counters(cfg, PACK_COUNTERS_SEC1_pack_per_xy_plane_ADDR32, counter);
+         counter.f = counter_vec[2];
+         write_pack_counters(cfg, PACK_COUNTERS_SEC2_pack_per_xy_plane_ADDR32, counter);
+         counter.f = counter_vec[3];
+         write_pack_counters(cfg, PACK_COUNTERS_SEC3_pack_per_xy_plane_ADDR32, counter);
+      #endif
+         break;
+   }
+}
+}  // namespace NAMESPACE

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -203,6 +203,153 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@pytest.mark.parametrize("dim1", [1])
+@pytest.mark.parametrize("dim2", [50257])
+@pytest.mark.parametrize("dim", [1])
+@pytest.mark.parametrize("k", [50])
+@pytest.mark.parametrize("largest", [True])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
+    torch.manual_seed(2005)
+    shape = [dim1, dim2]
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(shape, dtype=torch_dtype)
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=dim, largest=largest, sorted=True)
+
+    desired_shape = [dim1, dim2]
+    desired_shape[dim] = k
+
+    assert list(ttnn_topk_values.shape) == desired_shape
+    assert list(ttnn_topk_indices.shape) == desired_shape
+
+    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_values = 0.99
+    else:
+        pcc_values = 1.0
+
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # rounding may also cause more ties than expected
+    # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
+    # use cosine similarity on the gathered indices as this will show the top elements are all about the same
+    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
+    cosine = torch.nn.CosineSimilarity(dim=dim)
+    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
+
+    assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
+    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+
+
+@pytest.mark.parametrize("dim1", [1])
+@pytest.mark.parametrize("dim2", [1])
+@pytest.mark.parametrize("dim3", [8])
+@pytest.mark.parametrize("dim4", [256])
+@pytest.mark.parametrize("dim5", [64])
+# @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4]) transpose cannot handle N-D tensor for all dims
+@pytest.mark.parametrize("dim", [3, 4])
+@pytest.mark.parametrize("k", [17, 32, 64])
+@pytest.mark.parametrize("largest", [True])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_5d_topk(device, dim1, dim2, dim3, dim4, dim5, dim, k, largest, dtype):
+    torch.manual_seed(2005)
+    shape = [dim1, dim2, dim3, dim4, dim5]
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(shape, dtype=torch_dtype)
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=dim, largest=largest, sorted=True)
+
+    desired_shape = [dim1, dim2, dim3, dim4, dim5]
+    desired_shape[dim] = k
+
+    assert list(ttnn_topk_values.shape) == desired_shape
+    assert list(ttnn_topk_indices.shape) == desired_shape
+
+    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_values = 0.99
+    else:
+        pcc_values = 1.0
+
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # rounding may also cause more ties than expected
+    # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
+    # use cosine similarity on the gathered indices as this will show the top elements are all about the same
+    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
+    cosine = torch.nn.CosineSimilarity(dim=dim)
+    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
+
+    assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
+    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+
+
+@pytest.mark.parametrize("dim1", [1])
+@pytest.mark.parametrize("dim2", [1])
+@pytest.mark.parametrize("dim3", [8])
+@pytest.mark.parametrize("dim4", [1])
+@pytest.mark.parametrize("dim5", [128])
+@pytest.mark.parametrize("dim6", [64])
+# @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5]) transpose cannot handle N-D tensor for all dims
+@pytest.mark.parametrize("dim", [4, 5])
+@pytest.mark.parametrize("k", [50, 64])
+@pytest.mark.parametrize("largest", [True])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_6d_topk(device, dim1, dim2, dim3, dim4, dim5, dim6, dim, k, largest, dtype):
+    torch.manual_seed(2005)
+    shape = [dim1, dim2, dim3, dim4, dim5, dim6]
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(shape, dtype=torch_dtype)
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=dim, largest=largest, sorted=True)
+
+    desired_shape = [dim1, dim2, dim3, dim4, dim5, dim6]
+    desired_shape[dim] = k
+
+    assert list(ttnn_topk_values.shape) == desired_shape
+    assert list(ttnn_topk_indices.shape) == desired_shape
+
+    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_values = 0.99
+    else:
+        pcc_values = 1.0
+
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # rounding may also cause more ties than expected
+    # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
+    # use cosine similarity on the gathered indices as this will show the top elements are all about the same
+    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
+    cosine = torch.nn.CosineSimilarity(dim=dim)
+    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
+
+    assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
+    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+
+
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [31])
 @pytest.mark.parametrize("w", [32])

--- a/tests/ttnn/unit_tests/operations/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/test_topk.py
@@ -12,19 +12,22 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import skip_for_grayskull
 
 
-def run_topk_test(N, C, H, W, k, largest, dtype, device):
+def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device):
     torch.manual_seed(2005)
     shape = [N, C, H, W]
     torch_dtype = torch.bfloat16
 
-    input = torch.randn(shape, dtype=torch_dtype)
-    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=-1, largest=largest, sorted=True)
+    input = torch.randn(shape, dtype=torch_dtype) * 0.9
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=sorted)
 
     ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
-    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=largest, sorted=True)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=dim, largest=largest, sorted=sorted)
 
-    assert list(ttnn_topk_values.padded_shape) == [N, C, H, k]
-    assert list(ttnn_topk_indices.padded_shape) == [N, C, H, k]
+    desired_shape = [N, C, H, W]
+    desired_shape[dim] = k
+
+    assert list(ttnn_topk_values.shape) == desired_shape
+    assert list(ttnn_topk_indices.shape) == desired_shape
 
     ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
     ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
@@ -39,10 +42,10 @@ def run_topk_test(N, C, H, W, k, largest, dtype, device):
     # but the values associated with the indices should be the same
     # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
     # rounding may also cause more ties than expected
-    # the bigger we get, the tighter the distribution of the top 32 elements, so the pcc will be worse as stability/rounding will cause more ties
+    # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
     # use cosine similarity on the gathered indices as this will show the top elements are all about the same
-    ttnn_torch_gather_from_indices = torch.gather(input, -1, ttnn_torch_indices.to(torch.int64))
-    cosine = torch.nn.CosineSimilarity(dim=-1)
+    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
+    cosine = torch.nn.CosineSimilarity(dim=dim)
     ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
 
     assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
@@ -64,15 +67,39 @@ def run_topk_test(N, C, H, W, k, largest, dtype, device):
     ],
 )
 @pytest.mark.parametrize(
-    "N, C, H, W, k,",
+    "N, C, H, W, dim, k",
     (
-        (1, 1, 32, 64, 32),
-        (1, 1, 32, 8192, 32),
-        (1, 1, 2048, 64, 32),
-        (1, 1, 32, 32768, 32),
-        (1, 1, 8192, 64, 32),
+        (1, 1, 32, 8192, 3, 50),  # passed
+        (1, 1, 64, 64, 2, 32),  # passed
+        (1, 1, 64, 64, 2, 64),  # passed
+        (1, 1, 32, 8192, 3, 50),  # passed
+        (1, 2048, 1, 64, 1, 32),  # skipped?
+        (1, 1, 32, 64, 3, 2),  # passed
+        (1, 1, 32, 64, 3, 4),  # passed
+        (1, 1, 32, 8192, 3, 6),  # passed
+        (1, 2048, 1, 64, 1, 8),  # passed
+        (1, 1, 32, 32768, 3, 16),
     ),
 )
-@pytest.mark.parametrize("largest", (True, False))
-def test_topk(N, C, H, W, k, largest, dtype, device):
-    run_topk_test(N, C, H, W, k, largest, dtype, device)
+@pytest.mark.parametrize(
+    "sorted",
+    [
+        True,
+        # False, Please refer to https://github.com/tenstorrent/tt-metal/issues/13235#issuecomment-2601432673
+    ],
+)
+@pytest.mark.parametrize(
+    "largest",
+    [
+        True,
+        # False, Waiting for Ata's patch to be merged
+    ],
+)
+def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device):
+    if dim == 0 or dim == 1:
+        # As of now, when we try to get top-k for dim = 0 or 1, we get following error from transpose_op.cpp's validate():
+        # input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32
+        # this is because, transpose.cpp always typecasts bf8 to bf16
+        # and when dim = 0 or 1, transpose converts it into TransposeOpDim::HC & this dim doesnt support bf16 or fp32
+        pytest.skip()
+    run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device)

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -84,11 +84,6 @@ CPMAddPackage(
         "XTENSOR_ENABLE_TESTS OFF"
 )
 
-CPMAddPackage(NAME Taskflow GITHUB_REPOSITORY taskflow/taskflow GIT_TAG v3.7.0 OPTIONS "TF_BUILD_TESTS OFF")
-if(Taskflow_ADDED AND NOT TARGET Taskflow::Taskflow)
-    add_library(Taskflow::Taskflow ALIAS Taskflow)
-endif()
-
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_cli11.cmake)
 
 # gersemi: off

--- a/tt_metal/hw/inc/debug/dprint_tensix.h
+++ b/tt_metal/hw/inc/debug/dprint_tensix.h
@@ -41,6 +41,63 @@ inline void dprint_array_with_data_type(uint32_t data_format, uint32_t* data, ui
            << ENDL();
 }
 
+// Dprints data format as string given an uint
+inline void dprint_data_format(uint8_t data_format) {
+    switch (data_format) {
+        case (uint8_t) DataFormat::Float32:
+            DPRINT << "Float32";
+            break;
+        case (uint8_t) DataFormat::Float16:
+            DPRINT << "Float16";
+            break;
+        case (uint8_t) DataFormat::Bfp8:
+            DPRINT << "Bfp8";
+            break;
+        case (uint8_t) DataFormat::Bfp4:
+            DPRINT << "Bfp4";
+            break;
+        case (uint8_t) DataFormat::Bfp2:
+            DPRINT << "Bfp2";
+            break;
+        case (uint8_t) DataFormat::Float16_b:
+            DPRINT << "Float16_b";
+            break;
+        case (uint8_t) DataFormat::Bfp8_b:
+            DPRINT << "Bfp8_b";
+            break;
+        case (uint8_t) DataFormat::Bfp4_b:
+            DPRINT << "Bfp4_b";
+            break;
+        case (uint8_t) DataFormat::Bfp2_b:
+            DPRINT << "Bfp2_b";
+            break;
+        case (uint8_t) DataFormat::Lf8:
+            DPRINT << "Lf8";
+            break;
+        case (uint8_t) DataFormat::Int8:
+            DPRINT << "Int8";
+            break;
+        case (uint8_t) DataFormat::UInt8:
+            DPRINT << "UInt8";
+            break;
+        case (uint8_t) DataFormat::UInt16:
+            DPRINT << "UInt16";
+            break;
+        case (uint8_t) DataFormat::Int32:
+            DPRINT << "Int32";
+            break;
+        case (uint8_t) DataFormat::UInt32:
+            DPRINT << "UInt32";
+            break;
+        case (uint8_t) DataFormat::Tf32:
+            DPRINT << "Tf32";
+            break;
+        default:
+            DPRINT << "INVALID DATA FORMAT";
+            break;
+    }
+}
+
 // if flag DEST_ACCESS_CFG_remap_addrs is enabled
 // destination register row identifiers are remmaped
 // bits 5:3 are rotated 543 -> 354
@@ -197,3 +254,23 @@ void dprint_tensix_dest_reg(int tile_id = 0) {
         uint32_t reg_val = dbg_read_cfgreg(ckernel::dbg_cfgreg::bank, reg_field_name##_ADDR32); \
         DPRINT << #reg_field_name << " = " << HEX() << reg_val << ENDL();                       \
     }
+
+// Print the content of the register field given the value in the register.
+#define DPRINT_TENSIX_CONFIG_FIELD(reg_val, reg_field_name, name, printDec)                     \
+    {                                                                                           \
+        uint32_t field_value = (reg_val & reg_field_name##_MASK) >> reg_field_name##_SHAMT;     \
+        DPRINT << name << " = ";                                                                \
+        if (printDec) DPRINT << DEC();                                                          \
+        else DPRINT << "0x" << HEX();                                                           \
+        DPRINT << field_value << "; ";                                                          \
+    }
+
+inline void dprint_tensix_struct_field(uint32_t word, uint32_t mask, uint8_t shamt, const char* name, bool printDec = false)
+{
+    DPRINT << name << ": ";
+    if (printDec) DPRINT << DEC();
+    else {
+        DPRINT << "0x" << HEX();
+    }
+    DPRINT << ((word & mask) >> shamt) << ENDL();
+}

--- a/tt_metal/hw/inc/debug/dprint_tensix_pack.h
+++ b/tt_metal/hw/inc/debug/dprint_tensix_pack.h
@@ -1,0 +1,634 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+
+#include "dprint.h"
+#include "dprint_tensix.h"
+#include "cpack_common.h"
+
+// NOTE: FUNCTIONS WITHOUT HELPER SUFIX ARE INTENDED TO BE USED
+
+// PACK CONFIG
+
+// These function's argument should be return value of read_pack_config()
+
+inline void dprint_tensix_pack_config_row_ptr_section_size(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.row_ptr_section_size << ENDL();
+}
+
+inline void dprint_tensix_pack_config_exp_section_size(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.exp_section_size << ENDL();
+}
+
+inline void dprint_tensix_pack_config_l1_dest_addr(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.l1_dest_addr << ENDL();
+}
+
+inline void dprint_tensix_pack_config_uncompressed(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.uncompress << ENDL();
+}
+
+inline void dprint_tensix_pack_config_add_l1_dest_addr_offset(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.add_l1_dest_addr_offset << ENDL();
+}
+
+inline void dprint_tensix_pack_config_reserved_0(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_0 << ENDL();
+}
+
+inline void dprint_tensix_pack_config_out_data_format(const ckernel::packer::pack_config_t& config) {
+    dprint_data_format(config.out_data_format);
+    DPRINT << ENDL();
+}
+
+inline void dprint_tensix_pack_config_in_data_format(const ckernel::packer::pack_config_t& config) {
+    dprint_data_format(config.in_data_format);
+    DPRINT << ENDL();
+}
+
+#if defined(ARCH_GRAYSKULL) || defined(ARCH_WORMHOLE)
+inline void dprint_tensix_pack_config_reserved_1(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_1 << ENDL();
+}
+#endif
+
+inline void dprint_tensix_pack_config_src_if_sel(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.src_if_sel << ENDL();
+}
+
+#if defined(ARCH_GRAYSKULL) || defined(ARCH_WORMHOLE)
+inline void dprint_tensix_pack_config_pack_per_xy_plane(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.pack_per_xy_plane << ENDL();
+}
+#endif
+
+inline void dprint_tensix_pack_config_l1_src_addr(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.l1_src_addr << ENDL();
+}
+
+#if defined(ARCH_GRAYSKULL) || defined(ARCH_WORMHOLE)
+inline void dprint_tensix_pack_config_downsample_mask(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.downsample_mask << ENDL();
+}
+
+inline void dprint_tensix_pack_config_downsample_shift_count(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.downsample_shift_count << ENDL();
+}
+
+inline void dprint_tensix_pack_config_read_mode(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.read_mode << ENDL();
+}
+
+inline void dprint_tensix_pack_config_exp_threshold_en(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.exp_threshold_en << ENDL();
+}
+
+inline void dprint_tensix_pack_config_reserved_2(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_2 << ENDL();
+}
+
+inline void dprint_tensix_pack_config_exp_threshold(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.exp_threshold << ENDL();
+}
+#endif
+
+#ifdef ARCH_WORMHOLE
+inline void dprint_tensix_pack_config_l1_acc_disable_pack_zero_flag(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.pack_l1_acc_disable_pack_zero_flag << ENDL();
+}
+#endif
+
+#ifdef ARCH_BLACKHOLE
+inline void dprint_tensix_pack_config_disable_pack_zero_flag(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.disable_pack_zero_flag << ENDL();
+}
+
+inline void dprint_tensix_pack_config_dis_shared_exp_assembler(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.dis_shared_exp_assembler << ENDL();
+}
+
+inline void dprint_tensix_pack_config_auto_set_last_pacr_intf_sel(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.auto_set_last_pacr_intf_sel << ENDL();
+}
+
+inline void dprint_tensix_pack_config_enable_out_fifo(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.enable_out_fifo << ENDL();
+}
+
+inline void dprint_tensix_pack_config_sub_l1_tile_header_size(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.sub_l1_tile_header_size << ENDL();
+}
+
+inline void dprint_tensix_pack_config_pack_start_intf_pos(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.pack_start_intf_pos << ENDL();
+}
+
+inline void dprint_tensix_pack_config_all_pack_disable_zero_compress_ovrd(
+    const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.all_pack_disable_zero_compress_ovrd << ENDL();
+}
+
+inline void dprint_tensix_pack_config_add_tile_header_size(const ckernel::packer::pack_config_t& config) {
+    DPRINT << DEC() << config.add_tile_header_size << ENDL();
+}
+
+inline void dprint_tensix_pack_config_pack_dis_y_pos_start_offset(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.pack_dis_y_pos_start_offset << ENDL();
+}
+#endif
+
+#ifdef ARCH_GRAYSKULL
+
+inline void dprint_tensix_pack_config_helper(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "row_ptr_section_size: ";
+    dprint_tensix_pack_config_row_ptr_section_size(config);
+    DPRINT << "exp_section_size: ";
+    dprint_tensix_pack_config_exp_section_size(config);
+    DPRINT << "l1_dest_addr: ";
+    dprint_tensix_pack_config_l1_dest_addr(config);
+    DPRINT << "uncompress: ";
+    dprint_tensix_pack_config_uncompress(config);
+    DPRINT << "add_l1_dest_addr_offset: ";
+    dprint_tensix_pack_config_add_l1_dest_addr_offset(config);
+    DPRINT << "reserved_0: ";
+    dprint_tensix_pack_config_reserved_0(config);
+    DPRINT << "out_data_format: ";
+    dprint_tensix_pack_config_out_data_format(config);
+    DPRINT << "in_data_format: ";
+    dprint_tensix_pack_config_in_data_format(config);
+    DPRINT << "reserved_1: ";
+    dprint_tensix_pack_config_reserved_1(config);
+    DPRINT << "src_if_sel: ";
+    dprint_tensix_pack_config_src_if_sel(config);
+    DPRINT << "pack_per_xy_plane: ";
+    dprint_tensix_pack_config_pack_per_xy_plane(config);
+    DPRINT << "l1_src_addr: ";
+    dprint_tensix_pack_conifg_l1_src_addr(config);
+    DPRINT << "downsample_mask: ";
+    dprint_tensix_pack_config_downsample_mask(config);
+    DPRINT << "downsample_shift_count: ";
+    dprint_tensix_pack_config_downsample_shift_count(config);
+    DPRINT << "read_mode: ";
+    dprint_tensix_pack_config_read_mode(config);
+    DPRINT << "exp_threshold_en: ";
+    dprint_tensix_pack_config_exp_threshold_en(config);
+    DPRINT << "reserved_2: ";
+    dprint_tensix_pack_config_reserved_2(config);
+    DPRINT << "exp_threshold: ";
+    dprint_tensix_pack_config_exp_threshold(config);
+}
+
+#else  // ARCH_WORMHOLE or ARCH_BLACKHOLE
+
+#ifdef ARCH_WORMHOLE
+inline void dprint_tensix_pack_config_helper(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "row_ptr_section_size: ";
+    dprint_tensix_pack_config_row_ptr_section_size(config);
+    DPRINT << "exp_section_size: ";
+    dprint_tensix_pack_config_exp_section_size(config);
+    DPRINT << "l1_dest_addr: ";
+    dprint_tensix_pack_config_l1_dest_addr(config);
+    DPRINT << "uncompress: ";
+    dprint_tensix_pack_config_uncompressed(config);
+    DPRINT << "add_l1_dest_addr_offset: ";
+    dprint_tensix_pack_config_add_l1_dest_addr_offset(config);
+    DPRINT << "reserved_0: ";
+    dprint_tensix_pack_config_reserved_0(config);
+    DPRINT << "out_data_format: ";
+    dprint_tensix_pack_config_out_data_format(config);
+    DPRINT << "in_data_format: ";
+    dprint_tensix_pack_config_in_data_format(config);
+    DPRINT << "reserved_1: ";
+    dprint_tensix_pack_config_reserved_1(config);
+    DPRINT << "src_if_sel: ";
+    dprint_tensix_pack_config_src_if_sel(config);
+    DPRINT << "pack_per_xy_plane: ";
+    dprint_tensix_pack_config_pack_per_xy_plane(config);
+    DPRINT << "l1_src_addr: ";
+    dprint_tensix_pack_config_l1_src_addr(config);
+    DPRINT << "downsample_mask: ";
+    dprint_tensix_pack_config_downsample_mask(config);
+    DPRINT << "downsample_shift_count: ";
+    dprint_tensix_pack_config_downsample_shift_count(config);
+    DPRINT << "read_mode: ";
+    dprint_tensix_pack_config_read_mode(config);
+    DPRINT << "exp_threshold_en: ";
+    dprint_tensix_pack_config_exp_threshold_en(config);
+    DPRINT << "pack_l1_acc_disable_pack_zero_flag: ";
+    dprint_tensix_pack_config_l1_acc_disable_pack_zero_flag(config);
+    DPRINT << "reserved_2: ";
+    dprint_tensix_pack_config_reserved_2(config);
+    DPRINT << "exp_threshold: ";
+    dprint_tensix_pack_config_exp_threshold(config);
+}
+#endif  // ARCH_WORMHOLE
+
+#ifdef ARCH_BLACKHOLE
+inline void dprint_tensix_pack_config_helper(const ckernel::packer::pack_config_t& config) {
+    DPRINT << "row_ptr_section_size: ";
+    dprint_tensix_pack_config_row_ptr_section_size(config);
+    DPRINT << "exp_section_size: ";
+    dprint_tensix_pack_config_exp_section_size(config);
+    DPRINT << "l1_dest_addr: ";
+    dprint_tensix_pack_config_l1_dest_addr(config);
+    DPRINT << "uncompress: ";
+    dprint_tensix_pack_config_uncompressed(config);
+    DPRINT << "add_l1_dest_addr_offset: ";
+    dprint_tensix_pack_config_add_l1_dest_addr_offset(config);
+    DPRINT << "disable_pack_zero_flag: ";
+    dprint_tensix_pack_config_disable_pack_zero_flag(config);
+    DPRINT << "reserved_0: ";
+    dprint_tensix_pack_config_reserved_0(config);
+    DPRINT << "out_data_format: ";
+    dprint_tensix_pack_config_out_data_format(config);
+    DPRINT << "in_data_format: ";
+    dprint_tensix_pack_config_in_data_format(config);
+    DPRINT << "dis_shared_exp_assembler: ";
+    dprint_tensix_pack_config_dis_shared_exp_assembler(config);
+    DPRINT << "auto_set_last_pacr_intf_sel: ";
+    dprint_tensix_pack_config_auto_set_last_pacr_intf_sel(config);
+    DPRINT << "enable_out_fifo: ";
+    dprint_tensix_pack_config_enable_out_fifo(config);
+    DPRINT << "sub_l1_tile_header_size: ";
+    dprint_tensix_pack_config_sub_l1_tile_header_size(config);
+    DPRINT << "src_if_sel: ";
+    dprint_tensix_pack_config_src_if_sel(config);
+    DPRINT << "pack_start_intf_pos: ";
+    dprint_tensix_pack_config_pack_start_intf_pos(config);
+    DPRINT << "all_pack_disable_zero_compress_ovrd: ";
+    dprint_tensix_pack_config_all_pack_disable_zero_compress_ovrd(config);
+    DPRINT << "add_tile_header_size: ";
+    dprint_tensix_pack_config_add_tile_header_size(config);
+    DPRINT << "pack_dis_y_pos_start_offset: ";
+    dprint_tensix_pack_config_pack_dis_y_pos_start_offset(config);
+    DPRINT << "l1_src_addr: ";
+    dprint_tensix_pack_config_l1_src_addr(config);
+}
+#endif  // ARCH_BLACKHOLE
+
+// PACK RELU CONFIG
+
+// These functions' argument should be return value of read_relu_config()
+
+inline void dprint_tensix_pack_relu_config_alu_acc_ctrl_zero_flag_disabled_src(
+    const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ACC_CTRL_Zero_Flag_disabled_src << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_alu_acc_ctrl_zero_flag_disabled_dst(
+    const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ACC_CTRL_Zero_Flag_disabled_dst << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_stacc_relu_apply_relu(const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.STACC_RELU_ApplyRelu << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_stacc_relu_relu_threshold(const ckernel::packer::relu_config_t& config) {
+    DPRINT << DEC() << config.STACC_RELU_ReluThreshold << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_disable_risc_bp_disable_main(const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.DISABLE_RISC_BP_Disable_main << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_disable_risc_bp_disable_trisc(const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.DISABLE_RISC_BP_Disable_trisc << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_disable_risc_bp_disable_ncrisc(
+    const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.DISABLE_RISC_BP_Disable_ncrisc << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_disable_risc_bp_disable_bmp_clear_main(
+    const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.DISABLE_RISC_BP_Disable_bmp_clear_main << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_disable_risc_bp_disable_bmp_clear_trisc(
+    const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.DISABLE_RISC_BP_Disable_bmp_clear_trisc << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config_disable_risc_bp_disable_bmp_clear_ncrisc(
+    const ckernel::packer::relu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.DISABLE_RISC_BP_Disable_bmp_clear_ncrisc << ENDL();
+}
+
+inline void dprint_tensix_pack_relu_config() {
+    MATH(ckernel::packer::relu_config_t config = ckernel::packer::read_relu_config();
+
+         DPRINT << "ALU_ACC_CTRL_Zero_Flag_disabled_src: ";
+         dprint_tensix_pack_relu_config_alu_acc_ctrl_zero_flag_disabled_src(config);
+         DPRINT << "ALU_ACC_CTRL_Zero_Flag_disabled_dst: ";
+         dprint_tensix_pack_relu_config_alu_acc_ctrl_zero_flag_disabled_dst(config);
+         DPRINT << "STACC_RELU_ApplyRelu: ";
+         dprint_tensix_pack_relu_config_stacc_relu_apply_relu(config);
+         DPRINT << "STACC_RELU_ReluThreshold: ";
+         dprint_tensix_pack_relu_config_stacc_relu_relu_threshold(config);
+         DPRINT << "DISABLE_RISC_BP_Disable_main: ";
+         dprint_tensix_pack_relu_config_disable_risc_bp_disable_main(config);
+         DPRINT << "DISABLE_RISC_BP_Disable_trisc: ";
+         dprint_tensix_pack_relu_config_disable_risc_bp_disable_trisc(config);
+         DPRINT << "DISABLE_RISC_BP_Disable_ncrisc: ";
+         dprint_tensix_pack_relu_config_disable_risc_bp_disable_ncrisc(config);
+         DPRINT << "DISABLE_RISC_BP_Disable_bmp_clear_main: ";
+         dprint_tensix_pack_relu_config_disable_risc_bp_disable_bmp_clear_main(config);
+         DPRINT << "DISABLE_RISC_BP_Disable_bmp_clear_trisc: ";
+         dprint_tensix_pack_relu_config_disable_risc_bp_disable_bmp_clear_trisc(config);
+         DPRINT << "DISABLE_RISC_BP_Disable_bmp_clear_ncrisc: ";
+         dprint_tensix_pack_relu_config_disable_risc_bp_disable_bmp_clear_ncrisc(config);)
+}
+
+// PACK DEST RD CTRL
+
+// These functions' argument should be return value of read_dest_rd_ctrl()
+
+inline void dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_read_32b_data(
+    const ckernel::packer::dest_rd_ctrl_t& dest) {
+    DPRINT << "0x" << HEX() << dest.PCK_DEST_RD_CTRL_Read_32b_data << ENDL();
+}
+
+inline void dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_read_unsigned(
+    const ckernel::packer::dest_rd_ctrl_t& dest) {
+    DPRINT << "0x" << HEX() << dest.PCK_DEST_RD_CTRL_Read_unsigned << ENDL();
+}
+
+inline void dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_read_int8(const ckernel::packer::dest_rd_ctrl_t& dest) {
+    DPRINT << "0x" << HEX() << dest.PCK_DEST_RD_CTRL_Read_int8 << ENDL();
+}
+
+inline void dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_round_10b_mant(
+    const ckernel::packer::dest_rd_ctrl_t& dest) {
+    DPRINT << "0x" << HEX() << dest.PCK_DEST_RD_CTRL_Round_10b_mant << ENDL();
+}
+
+inline void dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_reserved(const ckernel::packer::dest_rd_ctrl_t& dest) {
+    DPRINT << "0x" << HEX() << dest.PCK_DEST_RD_CTRL_Reserved << ENDL();
+}
+
+// Printing dest control bits
+inline void dprint_tensix_dest_rd_ctrl() {
+    PACK(ckernel::packer::dest_rd_ctrl_t dest = ckernel::packer::read_dest_rd_ctrl();
+
+         DPRINT << "PCK_DEST_RD_CTRL_Read_32b_data: ";
+         dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_read_32b_data(dest);
+         DPRINT << "PCK_DEST_RD_CTRL_Read_unsigned: ";
+         dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_read_unsigned(dest);
+         DPRINT << "PCK_DEST_RD_CTRL_Read_int8: ";
+         dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_read_int8(dest);
+         DPRINT << "PCK_DEST_RD_CTRL_Round_10b_mant: ";
+         dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_round_10b_mant(dest);
+         DPRINT << "PCK_DEST_RD_CTRL_Reserved: ";
+         dprint_tensix_pack_dest_rd_ctrl_pck_dest_rd_ctrl_reserved(dest);)
+}
+
+#endif  // END OF ELSE
+
+// PACK STRIDES
+#ifdef ARCH_BLACKHOLE
+inline void dprint_tensix_pack_strides_x_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff, 0, "x_stride", true);  // decimal
+}
+
+inline void dprint_tensix_pack_strides_y_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff0000, 16, "y_stride", true);  // decimal
+}
+
+inline void dprint_tensix_pack_strides_z_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff, 0, "z_stride", true);  // decimal
+}
+
+inline void dprint_tensix_pack_strides_w_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff0000, 16, "w_stride", true);  // decimal
+}
+#else
+inline void dprint_tensix_pack_strides_x_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff, 0, "x_stride", true);  // decimal
+}
+
+inline void dprint_tensix_pack_strides_y_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff0000, 16, "y_stride", true);  // decimal
+}
+
+inline void dprint_tensix_pack_strides_z_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff, 0, "z_stride", true);  // decimal
+}
+
+inline void dprint_tensix_pack_strides_w_stride(const uint32_t& word) {
+    dprint_tensix_struct_field(word, 0xffff0000, 16, "w_stride", true);  // decimal
+}
+#endif
+
+// Printing packer strides
+inline void dprint_tensix_pack_strides_helper(uint reg_id, const volatile uint tt_reg_ptr* cfg) {
+    uint32_t reg_addr = 0;
+    switch (reg_id) {
+        case 1: reg_addr = PCK0_ADDR_CTRL_XY_REG_0_Xstride_ADDR32; break;
+        case 2: reg_addr = PCK0_ADDR_CTRL_XY_REG_1_Xstride_ADDR32; break;
+        default: DPRINT << "Aborting! Invalid register id (valid ids are between 1 and 2)" << ENDL(); break;
+    }
+
+    // word 0 xy_stride
+    uint32_t word = cfg[reg_addr];
+    dprint_tensix_pack_strides_x_stride(word);
+    dprint_tensix_pack_strides_y_stride(word);
+
+    // word 1 zw_stride
+    word = cfg[reg_addr + 1];
+    dprint_tensix_pack_strides_z_stride(word);
+    dprint_tensix_pack_strides_w_stride(word);
+}
+
+// PCK_EDGE_OFFSET
+
+// These function's argument should be return value of read_pack_edge_offset()
+
+inline void dprint_tensix_pack_edge_offset_mask(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.mask << ENDL();
+}
+
+inline void dprint_tensix_pack_edge_offset_mode(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.mode << ENDL();
+}
+
+inline void dprint_tensix_pack_edge_offset_tile_row_set_select_pack0(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.tile_row_set_select_pack0 << ENDL();
+}
+
+inline void dprint_tensix_pack_edge_offset_tile_row_set_select_pack1(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.tile_row_set_select_pack1 << ENDL();
+}
+
+inline void dprint_tensix_pack_edge_offset_tile_row_set_select_pack2(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.tile_row_set_select_pack2 << ENDL();
+}
+
+inline void dprint_tensix_pack_edge_offset_tile_row_set_select_pack3(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.tile_row_set_select_pack3 << ENDL();
+}
+
+inline void dprint_tensix_pack_edge_offset_reserved(const ckernel::packer::pck_edge_offset_t& edge) {
+    DPRINT << "0x" << HEX() << edge.reserved << ENDL();
+}
+
+// Printing packer edge offset
+inline void dprint_tensix_pack_edge_offset_helper(const ckernel::packer::pck_edge_offset_t& edge, uint reg_id) {
+    DPRINT << "mask: ";
+    dprint_tensix_pack_edge_offset_mask(edge);
+    if (reg_id == 1) {
+        DPRINT << "mode: ";
+        dprint_tensix_pack_edge_offset_mode(edge);
+        DPRINT << "tile_row_set_select_pack0: ";
+        dprint_tensix_pack_edge_offset_tile_row_set_select_pack0(edge);
+        DPRINT << "tile_row_set_select_pack1: ";
+        dprint_tensix_pack_edge_offset_tile_row_set_select_pack1(edge);
+        DPRINT << "tile_row_set_select_pack2: ";
+        dprint_tensix_pack_edge_offset_tile_row_set_select_pack2(edge);
+        DPRINT << "tile_row_set_select_pack3: ";
+        dprint_tensix_pack_edge_offset_tile_row_set_select_pack3(edge);
+        DPRINT << "reserved: ";
+        dprint_tensix_pack_edge_offset_reserved(edge);
+    }
+}
+
+// Choose what register you want printed with reg_id (1-4), 0 for all
+inline void dprint_tensix_pack_edge_offset(uint reg_id = 0) {
+    std::array<ckernel::packer::pck_edge_offset_t, ckernel::packer::NUM_PACKERS> edge_vec;
+    PACK(
+        edge_vec = ckernel::packer::read_pack_edge_offset();
+        if (reg_id >= 1 && reg_id <= ckernel::packer::NUM_PACKERS) {
+            if (ckernel::packer::NUM_PACKERS > 1) {
+                DPRINT << "REG_ID: " << reg_id << ENDL();
+            }
+            dprint_tensix_pack_edge_offset_helper(edge_vec[reg_id - 1], reg_id);
+        }
+        // Print all registers
+        else if (reg_id == 0) {
+            for (uint i = 1; i <= ckernel::packer::NUM_PACKERS; i++) {
+                if (ckernel::packer::NUM_PACKERS > 1) {
+                    DPRINT << "REG_ID: " << i << ENDL();
+                }
+                dprint_tensix_pack_edge_offset_helper(edge_vec[i - 1], i);
+                if (i != ckernel::packer::NUM_PACKERS) {
+                    DPRINT << ENDL();
+                }
+            }
+        } else DPRINT
+        << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND " << ckernel::packer::NUM_PACKERS << "."
+        << ENDL();)
+}
+
+// PACK COUNTERS
+
+// These functions' argument should be return value of read_pack_counters()
+
+inline void dprint_tensix_pack_counters_pack_per_xy_plane(const ckernel::packer::pack_counters_t& counters) {
+    DPRINT << DEC() << counters.pack_per_xy_plane << ENDL();
+}
+
+inline void dprint_tensix_pack_counters_pack_reads_per_xy_plane(const ckernel::packer::pack_counters_t& counters) {
+    DPRINT << DEC() << counters.pack_reads_per_xy_plane << ENDL();
+}
+
+inline void dprint_tensix_pack_counters_pack_xys_per_til(const ckernel::packer::pack_counters_t& counters) {
+    DPRINT << DEC() << counters.pack_xys_per_til << ENDL();
+}
+
+inline void dprint_tensix_pack_counters_pack_yz_transposed(const ckernel::packer::pack_counters_t& counters) {
+    DPRINT << "0x" << HEX() << counters.pack_yz_transposed << ENDL();
+}
+
+inline void dprint_tensix_pack_counters_pack_per_xy_plane_offset(const ckernel::packer::pack_counters_t& counters) {
+    DPRINT << DEC() << counters.pack_per_xy_plane_offset << ENDL();
+}
+
+// Printing packer counters
+inline void dprint_tensix_pack_counters_helper(const ckernel::packer::pack_counters_t& counters) {
+    DPRINT << "pack_per_xy_plane: ";
+    dprint_tensix_pack_counters_pack_per_xy_plane(counters);
+    DPRINT << "pack_reads_per_xy_plane: ";
+    dprint_tensix_pack_counters_pack_reads_per_xy_plane(counters);
+    DPRINT << "pack_xys_per_til: ";
+    dprint_tensix_pack_counters_pack_xys_per_til(counters);
+    DPRINT << "pack_yz_transposed: ";
+    dprint_tensix_pack_counters_pack_yz_transposed(counters);
+    DPRINT << "pack_per_xy_plane_offset: ";
+    dprint_tensix_pack_counters_pack_per_xy_plane_offset(counters);
+}
+
+// Choose what register you want printed with reg_id (1-4), 0 for all
+inline void dprint_tensix_pack_counters(uint reg_id = 0) {
+    std::array<ckernel::packer::pack_counters_t, ckernel::packer::NUM_PACKERS> counters_vec;
+    PACK(
+        counters_vec = ckernel::packer::read_pack_counters();
+        if (reg_id >= 1 && reg_id <= ckernel::packer::NUM_PACKERS) {
+            if (ckernel::packer::NUM_PACKERS > 1) {
+                DPRINT << "REG_ID: " << reg_id << ENDL();
+            }
+            dprint_tensix_pack_counters_helper(counters_vec[reg_id - 1]);
+        }
+        // Print all registers
+        else if (reg_id == 0) {
+            for (uint i = 1; i <= ckernel::packer::NUM_PACKERS; i++) {
+                if (ckernel::packer::NUM_PACKERS > 1) {
+                    DPRINT << "REG_ID: " << i << ENDL();
+                }
+                dprint_tensix_pack_counters_helper(counters_vec[i - 1]);
+                if (i != ckernel::packer::NUM_PACKERS) {
+                    DPRINT << ENDL();
+                }
+            }
+        } else DPRINT
+        << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND " << ckernel::packer::NUM_PACKERS << "."
+        << ENDL();)
+}
+
+// Choose what register you want by id (1-4). 0 for all.
+inline void dprint_tensix_pack_config(uint reg_id = 0) {
+    std::array<ckernel::packer::pack_config_t, ckernel::packer::NUM_PACKERS> config_vec;
+    MATH(
+        config_vec = ckernel::packer::read_pack_config(); if (reg_id >= 1 && reg_id <= ckernel::packer::NUM_PACKERS) {
+            if (ckernel::packer::NUM_PACKERS > 1) {
+                DPRINT << "REG_ID: " << reg_id << ENDL();
+            }
+            dprint_tensix_pack_config_helper(config_vec[reg_id - 1]);
+        } else if (reg_id == 0) for (uint i = 1; i <= ckernel::packer::NUM_PACKERS; i++) {
+            if (ckernel::packer::NUM_PACKERS > 1) {
+                DPRINT << "REG_ID: " << i << ENDL();
+            }
+            dprint_tensix_pack_config_helper(config_vec[i - 1]);
+            if (i != ckernel::packer::NUM_PACKERS) {
+                DPRINT << ENDL();
+            }
+        } else DPRINT << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND "
+                      << ckernel::packer::NUM_PACKERS << "." << ENDL();)
+}
+
+// Choose what register you want printed (1-2). 0 for all.
+inline void dprint_tensix_pack_strides(uint reg_id = 0) {
+    PACK(
+        // Get pointer to registers for current state ID
+        volatile uint tt_reg_ptr* cfg = get_cfg_pointer();
+
+        if (reg_id >= 1 && reg_id <= 2) {
+            DPRINT << "REG_ID: " << reg_id << ENDL();
+            dprint_tensix_pack_strides_helper(reg_id, cfg);
+        }
+        // Print all registers
+        else if (reg_id == 0) {
+            for (uint i = 1; i <= 2; i++) {
+                DPRINT << "REG_ID: " << i << ENDL();
+                dprint_tensix_pack_strides_helper(i, cfg);
+                if (i != 2) {
+                    DPRINT << ENDL();
+                }
+            }
+        } else DPRINT
+        << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND 2." << ENDL();)
+}

--- a/tt_metal/hw/inc/debug/dprint_tensix_unpack.h
+++ b/tt_metal/hw/inc/debug/dprint_tensix_unpack.h
@@ -1,0 +1,508 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+
+#include "dprint.h"
+#include "dprint_tensix.h"
+#include "cunpack_common.h"
+
+// NOTE: FUNCTIONS WITHOUT HELPER SUFIX ARE INTENDED TO BE USED
+
+// UNPACK TILE DESCRIPTOR
+
+// These function's argument should be return value of read_unpack_tile_descriptor()
+
+inline void dprint_tensix_unpack_tile_descriptor_in_data_format(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    dprint_data_format(tile_descriptor.in_data_format);
+    DPRINT << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_uncompressed(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << "0x" << HEX() << tile_descriptor.uncompressed << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_reserved_0(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << "0x" << HEX() << tile_descriptor.reserved_0 << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_blobs_per_xy_plane(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << DEC() << tile_descriptor.blobs_per_xy_plane << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_reserved_1(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << "0x" << HEX() << tile_descriptor.reserved_1 << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_x_dim(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << DEC() << tile_descriptor.x_dim << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_y_dim(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << DEC() << tile_descriptor.y_dim << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_z_dim(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << DEC() << tile_descriptor.z_dim << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_w_dim(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << DEC() << tile_descriptor.w_dim << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_blobs_y_start(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+#ifdef ARCH_GRAYSKULL
+    DPRINT << DEC() << tile_descriptor.blobs_y_start << ENDL();
+#else
+    DPRINT << DEC() << ((tile_descriptor.blobs_y_start_hi << 16) | tile_descriptor.blobs_y_start_lo) << ENDL();
+#endif
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_digest_type(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << "0x" << HEX() << tile_descriptor.digest_type << ENDL();
+}
+
+inline void dprint_tensix_unpack_tile_descriptor_digest_size(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << DEC() << tile_descriptor.digest_size << ENDL();
+}
+
+// UNPACK CONFIG
+
+// These function's argument should be return value of read_unpack_config()
+
+inline void dprint_tensix_unpack_config_out_data_format(const ckernel::unpacker::unpack_config_t& config) {
+    dprint_data_format(config.out_data_format);
+    DPRINT << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_throttle_mode(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.throttle_mode << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_context_count(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.context_count << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_haloize_mode(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.haloize_mode << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_tileize_mode(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.tileize_mode << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_force_shared_exp(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.force_shared_exp << ENDL();
+}
+
+#ifdef ARCH_GRAYSKULL
+inline void dprint_tensix_unpack_config_reserved_0(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_0 << ENDL();
+}
+#endif
+
+inline void dprint_tensix_unpack_config_upsample_rate(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << DEC() << config.upsample_rate << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_upsample_and_interlave(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.upsamle_and_interlave << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_shift_amount(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << DEC() << config.shift_amount << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_uncompress_cntx0_3(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.uncompress_cntx0_3 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_reserved_1(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_1 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_uncompress_cntx4_7(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.uncompress_cntx4_7 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_reserved_2(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_2 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_limit_addr(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.limit_addr << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_fifo_size(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << DEC() << config.fifo_size << ENDL();
+}
+
+#if defined(ARCH_WORMHOLE) || defined(ARCH_BLACKHOLE)
+inline void dprint_tensix_unpack_config_unpack_src_reg_set_update(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.unpack_src_reg_set_update << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_unpack_if_sel(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.unpack_if_sel << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_unpack_if_sel_cntx0_3(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.unpack_if_sel_cntx0_3 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_unpack_if_sel_cntx4_7(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.unpack_if_sel_cntx4_7 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_reserved_3(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_3 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_reserved_4(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_4 << ENDL();
+}
+
+inline void dprint_tensix_unpack_config_reserved_5(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "0x" << HEX() << config.reserved_5 << ENDL();
+}
+#endif
+
+// HARDWARE SPECIFIC FUNCTIONS
+
+#ifdef ARCH_GRAYSKULL
+inline void dprint_tensix_unpack_tile_descriptor_helper(
+    const ckernel::unpacker::tile_descriptor_t& tile_descriptor) {
+    DPRINT << "in_data_format: ";
+    dprint_tensix_unpack_tile_descriptor_in_data_format(tile_descriptor);
+    DPRINT << "uncompressed: ";
+    dprint_tensix_unpack_tile_descriptor_uncompressed(tile_descriptor);
+    DPRINT << "reserved_0: ";
+    dprint_tensix_unpack_tile_descriptor_reserved_0(tile_descriptor);
+    DPRINT << "blobs_per_xy_plane: " dprint_tensix_unpack_tile_descriptor_blobs_per_xy_plane(tile_descriptor);
+    DPRINT << "reserved_1: ";
+    dprint_tensix_unpack_tile_descriptor_reserved_1(tile_descriptor);
+    DPRINT << "x_dim: ";
+    dprint_tensix_unpack_tile_descriptor_x_dim(tile_descriptor);
+    DPRINT << "y_dim: ";
+    dprint_tensix_unpacK_tile_descriptor_y_dim(tile_descriptor);
+    DPRINT << "z_dim: ";
+    dprint_tensix_unpack_tile_descriptor_z_dim(tile_descriptor);
+    DPRINT << "w_dim: ";
+    dprint_tensix_unpack_tile_descriptor_w_dim(tile_descriptor);
+    DPRINT << "blobs_y_start: ";
+    dprint_tensix_unpack_tile_descriptor_blobs_y_start(tile_descriptor);
+    DPRINT << "digest_type: ";
+    dprint_tensix_unpack_tile_descriptor_digest_type(tile_descriptor);
+    DPRINT << "digest_size: ";
+    dprint_tensix_unpack_tile_descriptor_digest_type(tile_descriptor);
+}
+
+inline void dprint_tensix_unpack_tile_descriptor(uint reg_id = 0) {
+    std::array<ckernel::unpacker::unpack_tile_descriptor_t, ckernel::unpacker::NUM_UNPACKERS> tile_descriptor_vec;
+    UNPACK(
+    tile_descriptor_vec = ckernel::unpacker::read_unpack_tile_descriptor();
+    if (reg_id >= 1 && reg_id <= ckernel::unpacker::NUM_UNPACKERS) {
+        DPRINT << "REG_ID: " << reg_id << ENDL();
+        dprint_tensix_unpack_tile_descriptor_helper(tile_descriptor_vec[reg_id - 1]);
+    } else if (reg_id == 0) {
+        for (uint i = 1; i <= ckernel::unpacker::NUM_UNPACKERS; i++) {
+            DPRINT << "REG_ID: " << i << ENDL();
+            dprint_tensix_unpack_tile_descriptor_helper(tile_descriptor_vec[i - 1]);
+            if (i != ckernel::unpacker::NUM_UNPACKERS) {
+                DPRINT << ENDL();
+            }
+        }
+    } else {
+        DPRINT << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND " << ckernel::unpacker::NUM_UNPACKERS << "." << ENDL();
+    }
+    )
+}
+
+inline void dprint_tensix_unpack_config_helper(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "out_data_format: ";
+    dprint_tensix_unpack_config_out_data_format(config);
+    DPRINT << "throttle_mode: ";
+    dprint_tensix_unpack_config_throttle_mode(config);
+    DPRINT << "context_count: ";
+    dprint_tensix_unpack_config_context_count(config);
+    DPRINT << "haloize_mode: ";
+    dprint_tensix_unpack_config_haloize_mode(config);
+    DPRINT << "tileize_mode: ";
+    dprint_tensix_unpack_config_tileize_mode(config);
+    DPRINT << "force_shared_exp: ";
+    dprint_tensix_unpack_config_force_shared_exp(config) DPRINT << "reserved_0: ";
+    dprint_tensix_unpack_config_reserved_0(config);
+    DPRINT << "upsample_rate: ";
+    dprint_tensix_unpack_config_upsample_rate(config);
+    DPRINT << "upsamle_and_interlave: ";
+    dprint_tensix_unpack_config_upsample_and_interlave(config);
+    DPRINT << "shift_amount: ";
+    dprint_tensix_unpack_config_shift_amount(config);
+    DPRINT << "uncompress_cntx0_3: ";
+    dprint_tensix_unpack_config_uncompress_cntx0_3(config);
+    DPRINT << "reserved_1: ";
+    dprint_tensix_unpack_config_reserved_1(config);
+    DPRINT << "uncompress_cntx4_7: ";
+    dprint_tensix_unpack_config_uncompress_cntx4_7(config);
+    DPRINT << "reserved_2: ";
+    dprint_tensix_unpack_config_reserved_2(config);
+    DPRINT << "limit_addr: ";
+    dprint_tensix_unpack_config_limit_addr(config);
+    DPRINT << "fifo_size: ";
+    dprint_tensix_unpack_config_fifo_size(config);
+}
+
+inline void dprint_tensix_unpack_config(uint reg_id = 0) {
+    std::array<ckernel::unpacker::unpack_config_t, ckernel::unpacker::NUM_UNPACKERS> config_vec;
+    UNPACK(
+    config_vec = ckernel::unpacker::read_unpack_config();
+    if (reg_id >= 1 && reg_id <= ckernel::unpacker::NUM_UNPACKERS) {
+        DPRINT << "REG_ID: " << reg_id << ENDL();
+        dprint_tensix_unpack_config_helper(config_vec[reg_id - 1]);
+    } else if (reg_id == 0) {
+        for (uint i = 1; i <= ckernel::unpacker::NUM_UNPACKERS; i++) {
+            DPRINT << "REG_ID: " << i << ENDL();
+            dprint_tensix_unpack_config_helper(config_vec[i - 1]);
+            if (i != ckernel::unpacker::NUM_UNPACKERS) {
+                DPRINT << ENDL();
+            }
+        }
+    } else {
+        DPRINT << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND " << ckernel::unpacker::NUM_UNPACKERS << "." << ENDL();
+    }
+    )
+}
+
+#else  // ARCH_WORMHOLE or ARCH_BLACKHOLE
+inline void dprint_tensix_unpack_tile_descriptor_helper(
+    const ckernel::unpacker::unpack_tile_descriptor_t& tile_descriptor) {
+    DPRINT << "in_data_format: ";
+    dprint_tensix_unpack_tile_descriptor_in_data_format(tile_descriptor);
+    DPRINT << "uncompressed: ";
+    dprint_tensix_unpack_tile_descriptor_uncompressed(tile_descriptor);
+    DPRINT << "reserved_0: ";
+    dprint_tensix_unpack_tile_descriptor_reserved_0(tile_descriptor);
+    DPRINT << "blobs_per_xy_plane: ";
+    dprint_tensix_unpack_tile_descriptor_blobs_per_xy_plane(tile_descriptor);
+    DPRINT << "reserved_1: ";
+    dprint_tensix_unpack_tile_descriptor_reserved_1(tile_descriptor);
+    DPRINT << "x_dim: ";
+    dprint_tensix_unpack_tile_descriptor_x_dim(tile_descriptor);
+    DPRINT << "y_dim: ";
+    dprint_tensix_unpack_tile_descriptor_y_dim(tile_descriptor);
+    DPRINT << "z_dim: ";
+    dprint_tensix_unpack_tile_descriptor_z_dim(tile_descriptor);
+    DPRINT << "w_dim: ";
+    dprint_tensix_unpack_tile_descriptor_w_dim(tile_descriptor);
+    DPRINT << "blobs_y_start: ";
+    dprint_tensix_unpack_tile_descriptor_blobs_y_start(tile_descriptor);
+    DPRINT << "digest_type: ";
+    dprint_tensix_unpack_tile_descriptor_digest_type(tile_descriptor);
+    DPRINT << "digest_size: ";
+    dprint_tensix_unpack_tile_descriptor_digest_size(tile_descriptor);
+}
+
+// Choose which register you want (1-2). 0 for both.
+inline void dprint_tensix_unpack_tile_descriptor(uint reg_id = 0) {
+    std::array<ckernel::unpacker::unpack_tile_descriptor_t, ckernel::unpacker::NUM_UNPACKERS> tile_descriptor_vec;
+    UNPACK(
+    tile_descriptor_vec = ckernel::unpacker::read_unpack_tile_descriptor();
+    if (reg_id >= 1 && reg_id <= ckernel::unpacker::NUM_UNPACKERS) {
+        DPRINT << "REG_ID: " << reg_id << ENDL();
+        dprint_tensix_unpack_tile_descriptor_helper(tile_descriptor_vec[reg_id - 1]);
+    } else if (reg_id == 0) {
+        for (uint i = 1; i <= ckernel::unpacker::NUM_UNPACKERS; i++) {
+            DPRINT << "REG_ID: " << i << ENDL();
+            dprint_tensix_unpack_tile_descriptor_helper(tile_descriptor_vec[i - 1]);
+            if (i != ckernel::unpacker::NUM_UNPACKERS) {
+                DPRINT << ENDL();
+            }
+        }
+    } else {
+        DPRINT << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND " << ckernel::unpacker::NUM_UNPACKERS << "." << ENDL();
+    }
+    )
+}
+
+inline void dprint_tensix_unpack_config_helper(const ckernel::unpacker::unpack_config_t& config) {
+    DPRINT << "out_data_format: ";
+    dprint_tensix_unpack_config_out_data_format(config);
+    DPRINT << "throttle_mode: ";
+    dprint_tensix_unpack_config_throttle_mode(config);
+    DPRINT << "context_count: ";
+    dprint_tensix_unpack_config_context_count(config);
+    DPRINT << "haloize_mode: ";
+    dprint_tensix_unpack_config_haloize_mode(config);
+    DPRINT << "tileize_mode: ";
+    dprint_tensix_unpack_config_tileize_mode(config);
+    DPRINT << "unpack_src_reg_set_update: ";
+    dprint_tensix_unpack_config_unpack_src_reg_set_update(config);
+    DPRINT << "unpack_if_sel: ";
+    dprint_tensix_unpack_config_unpack_if_sel(config);
+    DPRINT << "upsample_rate: ";
+    dprint_tensix_unpack_config_upsample_rate(config);
+    DPRINT << "reserved_1: ";
+    dprint_tensix_unpack_config_reserved_1(config);
+    DPRINT << "upsample_and_interlave: ";
+    dprint_tensix_unpack_config_upsample_and_interlave(config);
+    DPRINT << "shift_amount: ";
+    dprint_tensix_unpack_config_shift_amount(config);
+    DPRINT << "uncompress_cntx0_3: ";
+    dprint_tensix_unpack_config_uncompress_cntx0_3(config);
+    DPRINT << "unpack_if_sel_cntx0_3: ";
+    dprint_tensix_unpack_config_unpack_if_sel_cntx0_3(config);
+    DPRINT << "force_shared_exp: ";
+    dprint_tensix_unpack_config_force_shared_exp(config);
+    DPRINT << "reserved_2: ";
+    dprint_tensix_unpack_config_reserved_2(config);
+    DPRINT << "uncompress_cntx4_7: ";
+    dprint_tensix_unpack_config_uncompress_cntx4_7(config);
+    DPRINT << "unpack_if_sel_cntx4_7: ";
+    dprint_tensix_unpack_config_unpack_if_sel_cntx4_7(config);
+    DPRINT << "reserved_3: ";
+    dprint_tensix_unpack_config_reserved_3(config);
+    DPRINT << "limit_addr: ";
+    dprint_tensix_unpack_config_limit_addr(config);
+    DPRINT << "reserved_4: ";
+    dprint_tensix_unpack_config_reserved_4(config);
+    DPRINT << "fifo_size: ";
+    dprint_tensix_unpack_config_fifo_size(config);
+    DPRINT << "reserved_5: ";
+    dprint_tensix_unpack_config_reserved_5(config);
+}
+
+// Choose which register you want (1-2). 0 for both.
+inline void dprint_tensix_unpack_config(uint reg_id = 0) {
+    std::array<ckernel::unpacker::unpack_config_t, ckernel::unpacker::NUM_UNPACKERS> config_vec;
+    UNPACK(
+    config_vec = ckernel::unpacker::read_unpack_config();
+    if (reg_id >= 1 && reg_id <= ckernel::unpacker::NUM_UNPACKERS) {
+        DPRINT << "REG_ID: " << reg_id << ENDL();
+        dprint_tensix_unpack_config_helper(config_vec[reg_id - 1]);
+    } else if (reg_id == 0) {
+        for (uint i = 1; i <= ckernel::unpacker::NUM_UNPACKERS; i++) {
+            DPRINT << "REG_ID: " << i << ENDL();
+            dprint_tensix_unpack_config_helper(config_vec[i - 1]);
+            if (i != ckernel::unpacker::NUM_UNPACKERS) {
+                DPRINT << ENDL();
+            }
+        }
+    } else {
+        DPRINT << "INVALID REGISTER ID! PLEASE CHOOSE A NUMBER BETWEEN 0 AND " << ckernel::unpacker::NUM_UNPACKERS << "." << ENDL();
+    }
+    )
+}
+
+// ALU CONFIG
+
+// These functions' argument should be return value of read_alu_config()
+
+inline void dprint_tensix_alu_config_alu_rounding_mode_fpu_srnd_en(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ROUNDING_MODE_Fpu_srnd_en << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_rounding_mode_gasket_srnd_en(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ROUNDING_MODE_Gasket_srnd_en << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_rounding_mode_packer_srnd_en(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ROUNDING_MODE_Packer_srnd_en << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_rounding_mode_padding(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ROUNDING_MODE_Padding << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_rounding_mode_gs_lf(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ROUNDING_MODE_GS_LF << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_rounding_mode_bfp8_hf(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ROUNDING_MODE_Bfp8_HF << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_format_spec_reg0_srcaunsigned(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_FORMAT_SPEC_REG0_SrcAUnsigned << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_format_spec_reg0_srcbunsigned(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_FORMAT_SPEC_REG0_SrcBUnsigned << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_format_spec_reg0_srca(const ckernel::unpacker::alu_config_t& config) {
+    dprint_data_format(config.ALU_FORMAT_SPEC_REG0_SrcA);
+    DPRINT << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_format_spec_reg1_srcb(const ckernel::unpacker::alu_config_t& config) {
+    dprint_data_format(config.ALU_FORMAT_SPEC_REG1_SrcB);
+    DPRINT << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_format_spec_reg2_dstacc(const ckernel::unpacker::alu_config_t& config) {
+    dprint_data_format(config.ALU_FORMAT_SPEC_REG2_Dstacc);
+    DPRINT << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_acc_ctrl_fp32_enabled(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ACC_CTRL_Fp32_enabled << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_acc_ctrl_sfpu_fp32_enabled(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ACC_CTRL_SFPU_Fp32_enabled << ENDL();
+}
+
+inline void dprint_tensix_alu_config_alu_acc_ctrl_int8_math_enabled(const ckernel::unpacker::alu_config_t& config) {
+    DPRINT << "0x" << HEX() << config.ALU_ACC_CTRL_INT8_math_enabled << ENDL();
+}
+
+// Print content of the register field by field.
+inline void dprint_tensix_alu_config() {
+    MATH(ckernel::unpacker::alu_config_t config = ckernel::unpacker::read_alu_config();
+
+         DPRINT << "ALU_ROUNDING_MODE_Fpu_srnd_en: ";
+         dprint_tensix_alu_config_alu_rounding_mode_fpu_srnd_en(config);
+         DPRINT << "ALU_ROUNDING_MODE_Gasket_srnd_en: ";
+         dprint_tensix_alu_config_alu_rounding_mode_gasket_srnd_en(config);
+         DPRINT << "ALU_ROUNDING_MODE_Packer_srnd_en: ";
+         dprint_tensix_alu_config_alu_rounding_mode_packer_srnd_en(config);
+         DPRINT << "ALU_ROUNDING_MODE_Padding: ";
+         dprint_tensix_alu_config_alu_rounding_mode_padding(config);
+         DPRINT << "ALU_ROUNDING_MODE_GS_LF: ";
+         dprint_tensix_alu_config_alu_rounding_mode_gs_lf(config);
+         DPRINT << "ALU_ROUNDING_MODE_Bfp8_HF: ";
+         dprint_tensix_alu_config_alu_rounding_mode_bfp8_hf(config);
+         DPRINT << "ALU_FORMAT_SPEC_REG0_SrcAUnsigned: ";
+         dprint_tensix_alu_config_alu_format_spec_reg0_srcaunsigned(config);
+         DPRINT << "ALU_FORMAT_SPEC_REG0_SrcBUnsigned: ";
+         dprint_tensix_alu_config_alu_format_spec_reg0_srcbunsigned(config);
+         DPRINT << "ALU_FORMAT_SPEC_REG0_SrcA: ";
+         dprint_tensix_alu_config_alu_format_spec_reg0_srca(config);
+         DPRINT << "ALU_FORMAT_SPEC_REG1_SrcB: ";
+         dprint_tensix_alu_config_alu_format_spec_reg1_srcb(config);
+         DPRINT << "ALU_FORMAT_SPEC_REG2_Dstacc: ";
+         dprint_tensix_alu_config_alu_format_spec_reg2_dstacc(config);
+         DPRINT << "ALU_ACC_CTRL_Fp32_enabled: ";
+         dprint_tensix_alu_config_alu_acc_ctrl_fp32_enabled(config);
+         DPRINT << "ALU_ACC_CTRL_SFPU_Fp32_enabled: ";
+         dprint_tensix_alu_config_alu_acc_ctrl_sfpu_fp32_enabled(config);
+         DPRINT << "ALU_ACC_CTRL_INT8_math_enabled: ";
+         dprint_tensix_alu_config_alu_acc_ctrl_int8_math_enabled(config);)
+}
+
+#endif  // END OF ELSE

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -373,6 +373,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/prod/prod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/topk.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/halo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/sliding_window.cpp

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -367,6 +367,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/prod/prod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/topk.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/halo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/sliding_window.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/operations/reduction/moe/moe_pybind.hpp"
 #include "ttnn/operations/reduction/prod/prod_pybind.hpp"
 #include "ttnn/operations/reduction/sampling/sampling_pybind.hpp"
+#include "ttnn/operations/reduction/topk/topk_pybind.hpp"
 
 namespace ttnn::operations::reduction {
 
@@ -33,6 +34,7 @@ void py_module(py::module& module) {
     detail::bind_reduction_moe_operation(module);
     detail::bind_reduction_prod_operation(module, ttnn::prod);
     detail::bind_reduction_sampling_operation(module);
+    detail::bind_reduction_topk_operation(module);
 }
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -15,6 +15,258 @@
 int32_t topk_replay_init = 0;
 
 namespace NAMESPACE {
+
+void process_tile_pair(
+    uint32_t left_ind,
+    uint32_t right_ind,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end,
+    bool ascending,
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t logk,
+    bool target_tiles_is_one) {
+    acquire_dst();
+
+    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+    copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
+    if (!target_tiles_is_one) {
+        copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+    }
+
+    // unpack indices into dest
+    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+    copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
+    if (!target_tiles_is_one) {
+        copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+    }
+
+    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+    // sort within the larger 32 values
+    ckernel::topk_rebuild(0, (uint32_t)ascending, m_iter, K, logk, target_tiles_is_one);
+
+    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
+    // values for topk, which was in input_dest_start
+    pack_reconfig_data_format(input_transposed_cb_index);
+    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+    if (!target_tiles_is_one) {
+        pack_tile<true>(input_dest_end, input_transposed_cb_index, right_ind);
+    }
+
+    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
+    // values for topk, which was in index_dest_start
+    pack_reconfig_data_format(index_transposed_cb_index);
+    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
+    if (!target_tiles_is_one) {
+        pack_tile<true>(index_dest_end, index_transposed_cb_index, right_ind);
+    }
+    release_dst();
+}
+
+void process_sequence(
+    uint32_t idx,
+    uint32_t tiles_per_seq,
+    uint32_t target_tiles,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end,
+    bool& ascending,
+    bool switch_dir,
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t logk,
+    uint32_t Wt) {
+    uint32_t sel_tile_id[2];
+    uint32_t sel_tile_id_ptr = 0;
+
+    for (uint32_t t = 0; t < tiles_per_seq; t++) {
+        uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
+        if (left_ind >= Wt) {
+            break;
+        }
+        sel_tile_id[sel_tile_id_ptr] = left_ind;
+        sel_tile_id_ptr++;
+        if (sel_tile_id_ptr == target_tiles) {
+            process_tile_pair(
+                sel_tile_id[0],
+                sel_tile_id[1],
+                input_transposed_cb_index,
+                index_transposed_cb_index,
+                input_dest_start,
+                input_dest_end,
+                index_dest_start,
+                index_dest_end,
+                ascending,
+                m_iter,
+                K,
+                logk,
+                target_tiles == 1);
+            sel_tile_id_ptr = 0;
+            ascending = switch_dir ? !ascending : ascending;
+        }
+    }
+}
+
+void process_tiles(
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t Wt,
+    uint32_t num_k_sequences,
+    uint32_t tiles_per_seq,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end) {
+    uint32_t dist = ((1 << m_iter) * K) >> 5;
+    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
+    for (uint32_t i = 0; i < num_k_sequences; i += seq_per_2tiles) {
+        for (uint32_t t = 0; t < tiles_per_seq; t++) {
+            uint32_t left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
+            uint32_t right_tile_id = left_tile_id + dist;
+            if (left_tile_id == right_tile_id) {
+                right_tile_id = left_tile_id + 1;
+            }
+
+            if (left_tile_id >= Wt || right_tile_id >= Wt) {
+                break;
+            }
+
+            acquire_dst();
+
+            copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+            copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
+            copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
+
+            // unpack indices into dest
+            copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+            copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
+            copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
+
+            // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+            ckernel::topk_merge(0, m_iter, K);
+
+            // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
+            // for topk, which was in input_dest_start
+            pack_reconfig_data_format(input_transposed_cb_index);
+            pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
+            pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
+
+            // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
+            // for topk, which was in index_dest_start
+            pack_reconfig_data_format(index_transposed_cb_index);
+            pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
+            pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
+            release_dst();
+        }
+    }
+}
+
+void process_iteration(
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t Wt,
+    uint32_t num_k_sequences,
+    uint32_t tiles_per_seq,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end,
+    bool largest,
+    bool switch_dir,
+    uint32_t logk) {
+    cb_wait_front(input_transposed_cb_index, Wt);
+    cb_wait_front(index_transposed_cb_index, Wt);
+
+    process_tiles(
+        m_iter,
+        K,
+        Wt,
+        num_k_sequences,
+        tiles_per_seq,
+        input_transposed_cb_index,
+        index_transposed_cb_index,
+        input_dest_start,
+        input_dest_end,
+        index_dest_start,
+        index_dest_end);
+
+    cb_reserve_back(input_transposed_cb_index, Wt);
+    cb_reserve_back(index_transposed_cb_index, Wt);
+
+    cb_pop_front(input_transposed_cb_index, Wt);
+    cb_pop_front(index_transposed_cb_index, Wt);
+
+    cb_push_back(input_transposed_cb_index, Wt);
+    cb_push_back(index_transposed_cb_index, Wt);
+
+    // we have decreased our search space by half
+    num_k_sequences = num_k_sequences >> 1;
+    int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
+    bool ascending = !largest;
+
+    cb_wait_front(input_transposed_cb_index, Wt);
+    cb_wait_front(index_transposed_cb_index, Wt);
+
+    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
+    for (uint32_t idx = 0; idx < num_k_sequences; idx += (seq_per_2tiles >> 1)) {
+        process_sequence(
+            idx,
+            tiles_per_seq,
+            target_tiles,
+            input_transposed_cb_index,
+            index_transposed_cb_index,
+            input_dest_start,
+            input_dest_end,
+            index_dest_start,
+            index_dest_end,
+            ascending,
+            switch_dir,
+            m_iter,
+            K,
+            logk,
+            Wt);
+    }
+
+    cb_reserve_back(input_transposed_cb_index, Wt);
+    cb_reserve_back(index_transposed_cb_index, Wt);
+
+    cb_pop_front(input_transposed_cb_index, Wt);
+    cb_pop_front(index_transposed_cb_index, Wt);
+
+    cb_push_back(input_transposed_cb_index, Wt);
+    cb_push_back(index_transposed_cb_index, Wt);
+}
+
+void transpose_and_pack(
+    uint32_t cb_index, uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Kt, uint32_t Wt) {
+    reconfig_data_format_srca(transposed_cb_index);
+    transpose_wh_init_short(transposed_cb_index);
+    pack_reconfig_data_format(transposed_cb_index);
+
+    cb_wait_front(transposed_cb_index, Kt);
+    for (uint32_t i = 0; i < Kt; ++i) {
+        acquire_dst();
+        cb_reserve_back(dest_cb_index, 1);
+        transpose_wh_tile(transposed_cb_index, i, 0);
+        pack_tile(0, dest_cb_index);
+        cb_push_back(dest_cb_index, 1);
+        release_dst();
+    }
+    cb_wait_front(transposed_cb_index, Wt);
+    cb_pop_front(transposed_cb_index, Wt);
+}
+
 void MAIN {
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
@@ -36,7 +288,7 @@ void MAIN {
     constexpr uint32_t index_dest_start = 2;
     constexpr uint32_t input_dest_end = 1;
     constexpr uint32_t index_dest_end = 3;
-    constexpr uint32_t tiles_per_seq = K >> 5 + K % 32;
+    constexpr uint32_t tiles_per_seq = (K >> 5) + (K % 32);
 
     int end_phase = (K <= 64) ? logk - 1 : 5;
     // init pack, compute and unpack
@@ -99,169 +351,31 @@ void MAIN {
         // pair. second iteration we compare 0th and 2nd tile, then 4th and 6th, etc. logNk iteration we compare 0th and
         // Wt/2 tile single buffer as we can pack tiles back in-place
         for (uint32_t m_iter = 0; m_iter < logNk; ++m_iter) {
-            cb_wait_front(input_transposed_cb_index, Wt);
-            cb_wait_front(index_transposed_cb_index, Wt);
-
-            uint32_t i = 0;
-            uint32_t dist = ((1 << m_iter) * K) >> 5;
-            uint32_t left_tile_id = 0;
-            while (i < num_k_sequences) {
-                for (uint32_t t = 0; t < tiles_per_seq; t++) {
-                    left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
-                    uint32_t right_tile_id = left_tile_id + dist;
-                    if (left_tile_id == right_tile_id) {
-                        right_tile_id = left_tile_id + 1;
-                    }
-
-                    if (left_tile_id >= Wt || right_tile_id >= Wt) {
-                        break;
-                    }
-
-                    acquire_dst();
-
-                    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                    copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
-                    copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
-
-                    // unpack indices into dest
-                    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                    copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
-                    copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
-
-                    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                    ckernel::topk_merge(0, m_iter, K);
-
-                    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
-                    // for topk, which was in input_dest_start
-                    pack_reconfig_data_format(input_transposed_cb_index);
-                    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
-                    pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
-
-                    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
-                    // for topk, which was in index_dest_start
-                    pack_reconfig_data_format(index_transposed_cb_index);
-                    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
-                    pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
-                    release_dst();
-                }
-                i += seq_per_2tiles;
-            }
-
-            cb_reserve_back(input_transposed_cb_index, Wt);
-            cb_reserve_back(index_transposed_cb_index, Wt);
-
-            cb_pop_front(input_transposed_cb_index, Wt);
-            cb_pop_front(index_transposed_cb_index, Wt);
-
-            cb_push_back(input_transposed_cb_index, Wt);
-            cb_push_back(index_transposed_cb_index, Wt);
-
-            // we have decreased our search space by half
-            num_k_sequences = num_k_sequences >> 1;
-            int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
-            uint32_t idx = 0;
-            int sel_tile_id[2];
-            int sel_tile_id_ptr = 0;
-            seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
-            bool a = !largest;
-
-            cb_wait_front(input_transposed_cb_index, Wt);
-            cb_wait_front(index_transposed_cb_index, Wt);
-
-            while (idx < num_k_sequences) {
-                for (uint32_t t = 0; t < tiles_per_seq; t++) {
-                    uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
-                    if (left_ind >= Wt) {
-                        break;
-                    }
-                    sel_tile_id[sel_tile_id_ptr] = left_ind;
-                    sel_tile_id_ptr++;
-                    if (sel_tile_id_ptr == target_tiles) {
-                        acquire_dst();
-
-                        copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                        copy_tile(input_transposed_cb_index, sel_tile_id[0], input_dest_start);
-                        if (target_tiles != 1) {
-                            copy_tile(input_transposed_cb_index, sel_tile_id[1], input_dest_end);
-                        }
-
-                        // unpack indices into dest
-                        copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                        copy_tile(index_transposed_cb_index, sel_tile_id[0], index_dest_start);
-                        if (target_tiles != 1) {
-                            copy_tile(index_transposed_cb_index, sel_tile_id[1], index_dest_end);
-                        }
-
-                        // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                        // sort within the larger 32 values
-                        ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, target_tiles == 1);
-
-                        // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
-                        // values for topk, which was in input_dest_start
-                        pack_reconfig_data_format(input_transposed_cb_index);
-                        pack_tile<true>(input_dest_start, input_transposed_cb_index, sel_tile_id[0]);
-                        if (target_tiles != 1) {
-                            pack_tile<true>(input_dest_end, input_transposed_cb_index, sel_tile_id[1]);
-                        }
-
-                        // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
-                        // values for topk, which was in index_dest_start
-                        pack_reconfig_data_format(index_transposed_cb_index);
-                        pack_tile<true>(index_dest_start, index_transposed_cb_index, sel_tile_id[0]);
-                        if (target_tiles != 1) {
-                            pack_tile<true>(index_dest_end, index_transposed_cb_index, sel_tile_id[1]);
-                        }
-                        release_dst();
-                        sel_tile_id_ptr = 0;
-                        a = switch_dir ? !a : a;
-                    }
-                }
-                idx += (seq_per_2tiles >> 1);
-            }
-
-            cb_reserve_back(input_transposed_cb_index, Wt);
-            cb_reserve_back(index_transposed_cb_index, Wt);
-
-            cb_pop_front(input_transposed_cb_index, Wt);
-            cb_pop_front(index_transposed_cb_index, Wt);
-
-            cb_push_back(input_transposed_cb_index, Wt);
-            cb_push_back(index_transposed_cb_index, Wt);
+            process_iteration(
+                m_iter,
+                K,
+                Wt,
+                num_k_sequences,
+                tiles_per_seq,
+                input_transposed_cb_index,
+                index_transposed_cb_index,
+                input_dest_start,
+                input_dest_end,
+                index_dest_start,
+                index_dest_end,
+                largest,
+                switch_dir,
+                logk);
         }
 
         constexpr uint32_t Kt = K % TILE_WIDTH == 0 ? K / TILE_WIDTH : K / TILE_WIDTH + 1;
 
         // transpose value tiles and pack into output buffer
-        reconfig_data_format_srca(input_transposed_cb_index);
-        transpose_wh_init_short(input_transposed_cb_index);
-        pack_reconfig_data_format(input_transposed_cb_index);
-        cb_wait_front(input_transposed_cb_index, Kt);
-        for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst();
-            cb_reserve_back(values_cb_index, 1);
-            transpose_wh_tile(input_transposed_cb_index, i, 0);
-            pack_tile(0, values_cb_index);
-            cb_push_back(values_cb_index, 1);
-            release_dst();
-        }
-        cb_wait_front(input_transposed_cb_index, Wt);
-        cb_pop_front(input_transposed_cb_index, Wt);
+        transpose_and_pack(values_cb_index, input_transposed_cb_index, values_cb_index, Kt, Wt);
 
         // transpose index tiles and pack into output buffer
-        reconfig_data_format_srca(index_transposed_cb_index);
-        transpose_wh_init_short(index_transposed_cb_index);
-        pack_reconfig_data_format(index_transposed_cb_index);
-        cb_wait_front(index_transposed_cb_index, Kt);
-        for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst();
-            cb_reserve_back(output_ind_cb_index, 1);
-            transpose_wh_tile(index_transposed_cb_index, i, 0);
-            pack_tile(0, output_ind_cb_index);
-            cb_push_back(output_ind_cb_index, 1);
-            release_dst();
-        }
-        cb_wait_front(index_transposed_cb_index, Wt);
-        cb_pop_front(index_transposed_cb_index, Wt);
+        transpose_and_pack(output_ind_cb_index, index_transposed_cb_index, output_ind_cb_index, Kt, Wt);
     }
 }
+
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -26,8 +26,9 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(7);
     constexpr uint32_t K = get_compile_time_arg_val(8);
     constexpr uint32_t logk = get_compile_time_arg_val(9);
-    constexpr uint32_t logWt = get_compile_time_arg_val(10);
+    constexpr uint32_t logNk = get_compile_time_arg_val(10);
     constexpr uint32_t largest = get_compile_time_arg_val(11);
+    constexpr uint32_t sorted = get_compile_time_arg_val(12);
 
     // dest indices for where to unpack the tiles for the llk
     // the input goes in index 0,1 and the index goes in index 2,3
@@ -35,14 +36,20 @@ void MAIN {
     constexpr uint32_t index_dest_start = 2;
     constexpr uint32_t input_dest_end = 1;
     constexpr uint32_t index_dest_end = 3;
+    constexpr uint32_t tiles_per_seq = K >> 5 + K % 32;
+
+    int end_phase = (K <= 64) ? logk - 1 : 5;
     // init pack, compute and unpack
 
     ckernel::topk_tile_init();
     transpose_wh_init(input_cb_index, input_transposed_cb_index);
 
+    bool switch_dir = (K == 64);
+    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
+
     for (uint32_t ht = 0; ht < Ht; ++ht) {
         bool ascending = !largest;
-        // bool ascending = false;
+
         cb_reserve_back(input_transposed_cb_index, Wt);
         cb_reserve_back(index_transposed_cb_index, Wt);
 
@@ -64,7 +71,7 @@ void MAIN {
             transpose_wh_tile(index_cb_index, 1, 3);
 
             // llk_topk_sort -> inplace
-            ckernel::topk_local_sort(0, (int)ascending, logk - 1);
+            ckernel::topk_local_sort(0, (int)ascending, end_phase);
 
             // pack value tiles into cb_intermed0
             pack_reconfig_data_format(input_transposed_cb_index);
@@ -79,51 +86,139 @@ void MAIN {
             cb_pop_front(input_cb_index, 2);
             cb_pop_front(index_cb_index, 2);
             release_dst();
+            ascending = switch_dir ? !ascending : ascending;
         }
 
         cb_push_back(input_transposed_cb_index, Wt);
         cb_push_back(index_transposed_cb_index, Wt);
 
+        uint32_t num_k_sequences = (Wt * 32) / K;
+
         // iterative divide and conquer on pairs of tiles (bitonic topk merge and rebuild)
         // first iteration we compare 0th and 1st tile, then 2nd and 3rd, etc. We get the sorted top 32 values in each
-        // pair. second iteration we compare 0th and 2nd tile, then 4th and 6th, etc. logWt iteration we compare 0th and
+        // pair. second iteration we compare 0th and 2nd tile, then 4th and 6th, etc. logNk iteration we compare 0th and
         // Wt/2 tile single buffer as we can pack tiles back in-place
-        for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
-            bool a = !largest;
-            // bool a = false;
+        for (uint32_t m_iter = 0; m_iter < logNk; ++m_iter) {
             cb_wait_front(input_transposed_cb_index, Wt);
             cb_wait_front(index_transposed_cb_index, Wt);
 
-            for (uint32_t left_ind = 0; left_ind < Wt - (1 << m_iter); left_ind += 2 << m_iter) {
-                uint32_t right_ind = left_ind + (1 << m_iter);
-                acquire_dst();
+            uint32_t i = 0;
+            uint32_t dist = ((1 << m_iter) * K) >> 5;
+            uint32_t left_tile_id = 0;
+            while (i < num_k_sequences) {
+                for (uint32_t t = 0; t < tiles_per_seq; t++) {
+                    left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
+                    uint32_t right_tile_id = left_tile_id + dist;
+                    if (left_tile_id == right_tile_id) {
+                        right_tile_id = left_tile_id + 1;
+                    }
 
-                copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
-                copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+                    if (left_tile_id >= Wt || right_tile_id >= Wt) {
+                        break;
+                    }
 
-                // unpack indices into dest
-                copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
-                copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+                    acquire_dst();
 
-                // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                ckernel::topk_merge<!largest>(0, m_iter, K);
-                // sort within the larger 32 values
-                ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, true);
+                    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                    copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
+                    copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
 
-                // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values for
-                // topk, which was in input_dest_start
-                pack_reconfig_data_format(input_transposed_cb_index);
-                pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+                    // unpack indices into dest
+                    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                    copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
+                    copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
 
-                // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for
-                // topk, which was in index_dest_start
-                pack_reconfig_data_format(index_transposed_cb_index);
-                pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-                release_dst();
-                a = !a;
+                    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                    ckernel::topk_merge(0, m_iter, K);
+
+                    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
+                    // for topk, which was in input_dest_start
+                    pack_reconfig_data_format(input_transposed_cb_index);
+                    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
+                    pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
+
+                    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
+                    // for topk, which was in index_dest_start
+                    pack_reconfig_data_format(index_transposed_cb_index);
+                    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
+                    pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
+                    release_dst();
+                }
+                i += seq_per_2tiles;
             }
+
+            cb_reserve_back(input_transposed_cb_index, Wt);
+            cb_reserve_back(index_transposed_cb_index, Wt);
+
+            cb_pop_front(input_transposed_cb_index, Wt);
+            cb_pop_front(index_transposed_cb_index, Wt);
+
+            cb_push_back(input_transposed_cb_index, Wt);
+            cb_push_back(index_transposed_cb_index, Wt);
+
+            // we have decreased our search space by half
+            num_k_sequences = num_k_sequences >> 1;
+            int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
+            uint32_t idx = 0;
+            int sel_tile_id[2];
+            int sel_tile_id_ptr = 0;
+            seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
+            bool a = !largest;
+
+            cb_wait_front(input_transposed_cb_index, Wt);
+            cb_wait_front(index_transposed_cb_index, Wt);
+
+            while (idx < num_k_sequences) {
+                for (uint32_t t = 0; t < tiles_per_seq; t++) {
+                    uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
+                    if (left_ind >= Wt) {
+                        break;
+                    }
+                    sel_tile_id[sel_tile_id_ptr] = left_ind;
+                    sel_tile_id_ptr++;
+                    if (sel_tile_id_ptr == target_tiles) {
+                        acquire_dst();
+
+                        copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                        copy_tile(input_transposed_cb_index, sel_tile_id[0], input_dest_start);
+                        if (target_tiles != 1) {
+                            copy_tile(input_transposed_cb_index, sel_tile_id[1], input_dest_end);
+                        }
+
+                        // unpack indices into dest
+                        copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                        copy_tile(index_transposed_cb_index, sel_tile_id[0], index_dest_start);
+                        if (target_tiles != 1) {
+                            copy_tile(index_transposed_cb_index, sel_tile_id[1], index_dest_end);
+                        }
+
+                        // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                        // sort within the larger 32 values
+                        ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, target_tiles == 1);
+
+                        // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
+                        // values for topk, which was in input_dest_start
+                        pack_reconfig_data_format(input_transposed_cb_index);
+                        pack_tile<true>(input_dest_start, input_transposed_cb_index, sel_tile_id[0]);
+                        if (target_tiles != 1) {
+                            pack_tile<true>(input_dest_end, input_transposed_cb_index, sel_tile_id[1]);
+                        }
+
+                        // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
+                        // values for topk, which was in index_dest_start
+                        pack_reconfig_data_format(index_transposed_cb_index);
+                        pack_tile<true>(index_dest_start, index_transposed_cb_index, sel_tile_id[0]);
+                        if (target_tiles != 1) {
+                            pack_tile<true>(index_dest_end, index_transposed_cb_index, sel_tile_id[1]);
+                        }
+                        release_dst();
+                        sel_tile_id_ptr = 0;
+                        a = switch_dir ? !a : a;
+                    }
+                }
+                idx += (seq_per_2tiles >> 1);
+            }
+
             cb_reserve_back(input_transposed_cb_index, Wt);
             cb_reserve_back(index_transposed_cb_index, Wt);
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -52,47 +52,15 @@ void MAIN {
     for (uint32_t ht = 0; ht < Ht; ++ht) {
         bool ascending = !largest;
 
-        cb_reserve_back(input_transposed_cb_index, Wt);
-        cb_reserve_back(index_transposed_cb_index, Wt);
-
-        // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
-        for (uint32_t wt = 0; wt < Wt; wt += 2) {
-            acquire_dst();
-            // local sort into k groups
-            cb_wait_front(input_cb_index, 2);
-            cb_wait_front(index_cb_index, 2);
-
-            reconfig_data_format_srca(input_cb_index);
-            transpose_wh_init_short(input_cb_index);
-            transpose_wh_tile(input_cb_index, 0, 0);
-            transpose_wh_tile(input_cb_index, 1, 1);
-
-            reconfig_data_format_srca(index_cb_index);
-            transpose_wh_init_short(index_cb_index);
-            transpose_wh_tile(index_cb_index, 0, 2);
-            transpose_wh_tile(index_cb_index, 1, 3);
-
-            // llk_topk_sort -> inplace
-            ckernel::topk_local_sort(0, (int)ascending, end_phase);
-
-            // pack value tiles into cb_intermed0
-            pack_reconfig_data_format(input_transposed_cb_index);
-            pack_tile(0, input_transposed_cb_index);
-            pack_tile(1, input_transposed_cb_index);
-
-            // pack index tiles into cb_intermed1
-            pack_reconfig_data_format(index_transposed_cb_index);
-            pack_tile(2, index_transposed_cb_index);
-            pack_tile(3, index_transposed_cb_index);
-
-            cb_pop_front(input_cb_index, 2);
-            cb_pop_front(index_cb_index, 2);
-            release_dst();
-            ascending = switch_dir ? !ascending : ascending;
-        }
-
-        cb_push_back(input_transposed_cb_index, Wt);
-        cb_push_back(index_transposed_cb_index, Wt);
+        process_and_sort_tiles(
+            input_cb_index,
+            index_cb_index,
+            input_transposed_cb_index,
+            index_transposed_cb_index,
+            Wt,
+            switch_dir,
+            ascending,
+            end_phase);
 
         uint32_t num_k_sequences = (Wt * 32) / K;
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -10,262 +10,13 @@
 #include "compute_kernel_api/reconfig_data_format.h"
 #include "compute_kernel_api/pack.h"
 
+#include "topk_common_funcs.hpp"
+
 // topk llk needs a global variable atm
 // this can only be removed once that's fixed
 int32_t topk_replay_init = 0;
 
 namespace NAMESPACE {
-
-void process_tile_pair(
-    uint32_t left_ind,
-    uint32_t right_ind,
-    uint32_t input_transposed_cb_index,
-    uint32_t index_transposed_cb_index,
-    uint32_t input_dest_start,
-    uint32_t input_dest_end,
-    uint32_t index_dest_start,
-    uint32_t index_dest_end,
-    bool ascending,
-    uint32_t m_iter,
-    uint32_t K,
-    uint32_t logk,
-    bool target_tiles_is_one) {
-    acquire_dst();
-
-    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-    copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
-    if (!target_tiles_is_one) {
-        copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
-    }
-
-    // unpack indices into dest
-    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-    copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
-    if (!target_tiles_is_one) {
-        copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
-    }
-
-    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-    // sort within the larger 32 values
-    ckernel::topk_rebuild(0, (uint32_t)ascending, m_iter, K, logk, target_tiles_is_one);
-
-    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
-    // values for topk, which was in input_dest_start
-    pack_reconfig_data_format(input_transposed_cb_index);
-    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
-    if (!target_tiles_is_one) {
-        pack_tile<true>(input_dest_end, input_transposed_cb_index, right_ind);
-    }
-
-    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
-    // values for topk, which was in index_dest_start
-    pack_reconfig_data_format(index_transposed_cb_index);
-    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-    if (!target_tiles_is_one) {
-        pack_tile<true>(index_dest_end, index_transposed_cb_index, right_ind);
-    }
-    release_dst();
-}
-
-void process_sequence(
-    uint32_t idx,
-    uint32_t tiles_per_seq,
-    uint32_t target_tiles,
-    uint32_t input_transposed_cb_index,
-    uint32_t index_transposed_cb_index,
-    uint32_t input_dest_start,
-    uint32_t input_dest_end,
-    uint32_t index_dest_start,
-    uint32_t index_dest_end,
-    bool& ascending,
-    bool switch_dir,
-    uint32_t m_iter,
-    uint32_t K,
-    uint32_t logk,
-    uint32_t Wt) {
-    uint32_t sel_tile_id[2];
-    uint32_t sel_tile_id_ptr = 0;
-
-    for (uint32_t t = 0; t < tiles_per_seq; t++) {
-        uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
-        if (left_ind >= Wt) {
-            break;
-        }
-        sel_tile_id[sel_tile_id_ptr] = left_ind;
-        sel_tile_id_ptr++;
-        if (sel_tile_id_ptr == target_tiles) {
-            process_tile_pair(
-                sel_tile_id[0],
-                sel_tile_id[1],
-                input_transposed_cb_index,
-                index_transposed_cb_index,
-                input_dest_start,
-                input_dest_end,
-                index_dest_start,
-                index_dest_end,
-                ascending,
-                m_iter,
-                K,
-                logk,
-                target_tiles == 1);
-            sel_tile_id_ptr = 0;
-            ascending = switch_dir ? !ascending : ascending;
-        }
-    }
-}
-
-void process_tiles(
-    uint32_t m_iter,
-    uint32_t K,
-    uint32_t Wt,
-    uint32_t num_k_sequences,
-    uint32_t tiles_per_seq,
-    uint32_t input_transposed_cb_index,
-    uint32_t index_transposed_cb_index,
-    uint32_t input_dest_start,
-    uint32_t input_dest_end,
-    uint32_t index_dest_start,
-    uint32_t index_dest_end) {
-    uint32_t dist = ((1 << m_iter) * K) >> 5;
-    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
-    for (uint32_t i = 0; i < num_k_sequences; i += seq_per_2tiles) {
-        for (uint32_t t = 0; t < tiles_per_seq; t++) {
-            uint32_t left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
-            uint32_t right_tile_id = left_tile_id + dist;
-            if (left_tile_id == right_tile_id) {
-                right_tile_id = left_tile_id + 1;
-            }
-
-            if (left_tile_id >= Wt || right_tile_id >= Wt) {
-                break;
-            }
-
-            acquire_dst();
-
-            copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-            copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
-            copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
-
-            // unpack indices into dest
-            copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-            copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
-            copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
-
-            // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-            ckernel::topk_merge(0, m_iter, K);
-
-            // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
-            // for topk, which was in input_dest_start
-            pack_reconfig_data_format(input_transposed_cb_index);
-            pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
-            pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
-
-            // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
-            // for topk, which was in index_dest_start
-            pack_reconfig_data_format(index_transposed_cb_index);
-            pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
-            pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
-            release_dst();
-        }
-    }
-}
-
-void process_iteration(
-    uint32_t m_iter,
-    uint32_t K,
-    uint32_t Wt,
-    uint32_t num_k_sequences,
-    uint32_t tiles_per_seq,
-    uint32_t input_transposed_cb_index,
-    uint32_t index_transposed_cb_index,
-    uint32_t input_dest_start,
-    uint32_t input_dest_end,
-    uint32_t index_dest_start,
-    uint32_t index_dest_end,
-    bool largest,
-    bool switch_dir,
-    uint32_t logk) {
-    cb_wait_front(input_transposed_cb_index, Wt);
-    cb_wait_front(index_transposed_cb_index, Wt);
-
-    process_tiles(
-        m_iter,
-        K,
-        Wt,
-        num_k_sequences,
-        tiles_per_seq,
-        input_transposed_cb_index,
-        index_transposed_cb_index,
-        input_dest_start,
-        input_dest_end,
-        index_dest_start,
-        index_dest_end);
-
-    cb_reserve_back(input_transposed_cb_index, Wt);
-    cb_reserve_back(index_transposed_cb_index, Wt);
-
-    cb_pop_front(input_transposed_cb_index, Wt);
-    cb_pop_front(index_transposed_cb_index, Wt);
-
-    cb_push_back(input_transposed_cb_index, Wt);
-    cb_push_back(index_transposed_cb_index, Wt);
-
-    // we have decreased our search space by half
-    num_k_sequences = num_k_sequences >> 1;
-    int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
-    bool ascending = !largest;
-
-    cb_wait_front(input_transposed_cb_index, Wt);
-    cb_wait_front(index_transposed_cb_index, Wt);
-
-    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
-    for (uint32_t idx = 0; idx < num_k_sequences; idx += (seq_per_2tiles >> 1)) {
-        process_sequence(
-            idx,
-            tiles_per_seq,
-            target_tiles,
-            input_transposed_cb_index,
-            index_transposed_cb_index,
-            input_dest_start,
-            input_dest_end,
-            index_dest_start,
-            index_dest_end,
-            ascending,
-            switch_dir,
-            m_iter,
-            K,
-            logk,
-            Wt);
-    }
-
-    cb_reserve_back(input_transposed_cb_index, Wt);
-    cb_reserve_back(index_transposed_cb_index, Wt);
-
-    cb_pop_front(input_transposed_cb_index, Wt);
-    cb_pop_front(index_transposed_cb_index, Wt);
-
-    cb_push_back(input_transposed_cb_index, Wt);
-    cb_push_back(index_transposed_cb_index, Wt);
-}
-
-void transpose_and_pack(
-    uint32_t cb_index, uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Kt, uint32_t Wt) {
-    reconfig_data_format_srca(transposed_cb_index);
-    transpose_wh_init_short(transposed_cb_index);
-    pack_reconfig_data_format(transposed_cb_index);
-
-    cb_wait_front(transposed_cb_index, Kt);
-    for (uint32_t i = 0; i < Kt; ++i) {
-        acquire_dst();
-        cb_reserve_back(dest_cb_index, 1);
-        transpose_wh_tile(transposed_cb_index, i, 0);
-        pack_tile(0, dest_cb_index);
-        cb_push_back(dest_cb_index, 1);
-        release_dst();
-    }
-    cb_wait_front(transposed_cb_index, Wt);
-    cb_pop_front(transposed_cb_index, Wt);
-}
 
 void MAIN {
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
@@ -288,8 +39,7 @@ void MAIN {
     constexpr uint32_t index_dest_start = 2;
     constexpr uint32_t input_dest_end = 1;
     constexpr uint32_t index_dest_end = 3;
-    constexpr uint32_t tiles_per_seq = (K >> 5) + (K % 32);
-
+    constexpr uint32_t tiles_per_seq = (K + 31) / 32;
     int end_phase = (K <= 64) ? logk - 1 : 5;
     // init pack, compute and unpack
 
@@ -365,16 +115,17 @@ void MAIN {
                 index_dest_end,
                 largest,
                 switch_dir,
-                logk);
+                logk,
+                seq_per_2tiles);
         }
 
         constexpr uint32_t Kt = K % TILE_WIDTH == 0 ? K / TILE_WIDTH : K / TILE_WIDTH + 1;
 
         // transpose value tiles and pack into output buffer
-        transpose_and_pack(values_cb_index, input_transposed_cb_index, values_cb_index, Kt, Wt);
+        transpose_and_pack(input_transposed_cb_index, values_cb_index, Kt, Wt);
 
         // transpose index tiles and pack into output buffer
-        transpose_and_pack(output_ind_cb_index, index_transposed_cb_index, output_ind_cb_index, Kt, Wt);
+        transpose_and_pack(index_transposed_cb_index, output_ind_cb_index, Kt, Wt);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 namespace NAMESPACE {
 void process_and_sort_tiles(
     uint32_t input_cb_index,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_common_funcs.hpp
@@ -1,0 +1,219 @@
+namespace NAMESPACE {
+void process_tile_pair(
+    uint32_t left_ind,
+    uint32_t right_ind,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end,
+    bool ascending,
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t logk,
+    bool target_tiles_is_one) {
+    acquire_dst();
+
+    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+    copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
+    if (!target_tiles_is_one) {
+        copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+    }
+
+    // unpack indices into dest
+    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+    copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
+    if (!target_tiles_is_one) {
+        copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+    }
+
+    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+    // sort within the larger 32 values
+    ckernel::topk_rebuild(0, (uint32_t)ascending, m_iter, K, logk, target_tiles_is_one);
+
+    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
+    // values for topk, which was in input_dest_start
+    pack_reconfig_data_format(input_transposed_cb_index);
+    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+    if (!target_tiles_is_one) {
+        pack_tile<true>(input_dest_end, input_transposed_cb_index, right_ind);
+    }
+
+    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
+    // values for topk, which was in index_dest_start
+    pack_reconfig_data_format(index_transposed_cb_index);
+    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
+    if (!target_tiles_is_one) {
+        pack_tile<true>(index_dest_end, index_transposed_cb_index, right_ind);
+    }
+    release_dst();
+}
+
+void process_tiles(
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t Wt,
+    uint32_t num_k_sequences,
+    uint32_t tiles_per_seq,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end,
+    int seq_per_2tiles) {
+    uint32_t dist = ((1 << m_iter) * K) >> 5;
+    for (uint32_t i = 0; i < num_k_sequences; i += seq_per_2tiles) {
+        for (uint32_t t = 0; t < tiles_per_seq; t++) {
+            uint32_t left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
+            uint32_t right_tile_id = left_tile_id + dist;
+            if (left_tile_id == right_tile_id) {
+                right_tile_id = left_tile_id + 1;
+            }
+
+            if (left_tile_id >= Wt || right_tile_id >= Wt) {
+                break;
+            }
+
+            acquire_dst();
+
+            copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+            copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
+            copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
+
+            // unpack indices into dest
+            copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+            copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
+            copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
+
+            // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+            ckernel::topk_merge(0, m_iter, K);
+
+            // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
+            // for topk, which was in input_dest_start
+            pack_reconfig_data_format(input_transposed_cb_index);
+            pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
+            pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
+
+            // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
+            // for topk, which was in index_dest_start
+            pack_reconfig_data_format(index_transposed_cb_index);
+            pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
+            pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
+            release_dst();
+        }
+    }
+}
+
+void process_iteration(
+    uint32_t m_iter,
+    uint32_t K,
+    uint32_t Wt,
+    uint32_t& num_k_sequences,
+    uint32_t tiles_per_seq,
+    uint32_t input_transposed_cb_index,
+    uint32_t index_transposed_cb_index,
+    uint32_t input_dest_start,
+    uint32_t input_dest_end,
+    uint32_t index_dest_start,
+    uint32_t index_dest_end,
+    bool largest,
+    bool switch_dir,
+    uint32_t logk,
+    int& seq_per_2tiles) {
+    cb_wait_front(input_transposed_cb_index, Wt);
+    cb_wait_front(index_transposed_cb_index, Wt);
+
+    process_tiles(
+        m_iter,
+        K,
+        Wt,
+        num_k_sequences,
+        tiles_per_seq,
+        input_transposed_cb_index,
+        index_transposed_cb_index,
+        input_dest_start,
+        input_dest_end,
+        index_dest_start,
+        index_dest_end,
+        seq_per_2tiles);
+
+    cb_reserve_back(input_transposed_cb_index, Wt);
+    cb_reserve_back(index_transposed_cb_index, Wt);
+
+    cb_pop_front(input_transposed_cb_index, Wt);
+    cb_pop_front(index_transposed_cb_index, Wt);
+
+    cb_push_back(input_transposed_cb_index, Wt);
+    cb_push_back(index_transposed_cb_index, Wt);
+
+    // we have decreased our search space by half
+    num_k_sequences = num_k_sequences >> 1;
+    int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
+
+    int sel_tile_id[2];
+    int sel_tile_id_ptr = 0;
+    seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
+    bool ascending = !largest;
+
+    cb_wait_front(input_transposed_cb_index, Wt);
+    cb_wait_front(index_transposed_cb_index, Wt);
+
+    for (uint32_t idx = 0; idx < num_k_sequences; idx += (seq_per_2tiles >> 1)) {
+        for (uint32_t t = 0; t < tiles_per_seq; t++) {
+            uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
+            if (left_ind >= Wt) {
+                break;
+            }
+            sel_tile_id[sel_tile_id_ptr] = left_ind;
+            sel_tile_id_ptr++;
+            if (sel_tile_id_ptr == target_tiles) {
+                process_tile_pair(
+                    sel_tile_id[0],
+                    sel_tile_id[1],
+                    input_transposed_cb_index,
+                    index_transposed_cb_index,
+                    input_dest_start,
+                    input_dest_end,
+                    index_dest_start,
+                    index_dest_end,
+                    ascending,
+                    m_iter,
+                    K,
+                    logk,
+                    target_tiles == 1);
+                sel_tile_id_ptr = 0;
+                ascending = switch_dir ? !ascending : ascending;
+            }
+        }
+    }
+
+    cb_reserve_back(input_transposed_cb_index, Wt);
+    cb_reserve_back(index_transposed_cb_index, Wt);
+
+    cb_pop_front(input_transposed_cb_index, Wt);
+    cb_pop_front(index_transposed_cb_index, Wt);
+
+    cb_push_back(input_transposed_cb_index, Wt);
+    cb_push_back(index_transposed_cb_index, Wt);
+}
+
+void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Kt, uint32_t Wt) {
+    reconfig_data_format_srca(transposed_cb_index);
+    transpose_wh_init_short(transposed_cb_index);
+    pack_reconfig_data_format(transposed_cb_index);
+
+    cb_wait_front(transposed_cb_index, Kt);
+    for (uint32_t i = 0; i < Kt; ++i) {
+        acquire_dst();
+        cb_reserve_back(dest_cb_index, 1);
+        transpose_wh_tile(transposed_cb_index, i, 0);
+        pack_tile(0, dest_cb_index);
+        cb_push_back(dest_cb_index, 1);
+        release_dst();
+    }
+    cb_wait_front(transposed_cb_index, Wt);
+    cb_pop_front(transposed_cb_index, Wt);
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -95,10 +95,9 @@ void MAIN {
             cb_wait_front(input_transposed_cb_index, Wt);
             cb_wait_front(index_transposed_cb_index, Wt);
 
-            uint32_t i = 0;
             uint32_t dist = ((1 << m_iter) * K) >> 5;
             uint32_t left_tile_id = 0;
-            while (i < num_k_sequences) {
+            for (uint32_t i = 0; i < num_k_sequences; i += seq_per_2tiles) {
                 for (uint32_t t = 0; t < tiles_per_seq; t++) {
                     left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
                     uint32_t right_tile_id = left_tile_id + dist;
@@ -137,7 +136,6 @@ void MAIN {
                     pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
                     release_dst();
                 }
-                i += seq_per_2tiles;
             }
 
             cb_reserve_back(input_transposed_cb_index, Wt);
@@ -153,7 +151,7 @@ void MAIN {
             // we have decreased our search space by half
             num_k_sequences = num_k_sequences >> 1;
             int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
-            uint32_t idx = 0;
+
             int sel_tile_id[2];
             int sel_tile_id_ptr = 0;
             seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
@@ -162,7 +160,7 @@ void MAIN {
             cb_wait_front(input_transposed_cb_index, Wt);
             cb_wait_front(index_transposed_cb_index, Wt);
 
-            while (idx < num_k_sequences) {
+            for (uint32_t idx = 0; idx < num_k_sequences; idx += (seq_per_2tiles >> 1)) {
                 for (uint32_t t = 0; t < tiles_per_seq; t++) {
                     uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
                     if (left_ind >= Wt) {
@@ -210,7 +208,6 @@ void MAIN {
                         a = switch_dir ? !a : a;
                     }
                 }
-                idx += (seq_per_2tiles >> 1);
             }
             cb_reserve_back(input_transposed_cb_index, Wt);
             cb_reserve_back(index_transposed_cb_index, Wt);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -30,6 +30,7 @@ void MAIN {
     constexpr uint32_t logk = get_compile_time_arg_val(10);
     constexpr uint32_t logWt = get_compile_time_arg_val(11);
     constexpr uint32_t largest = get_compile_time_arg_val(12);
+    constexpr uint32_t sorted = get_compile_time_arg_val(13);
 
     // dest indices for where to unpack the tiles for the llk
     // the input goes in index 0,1 and the index goes in index 2,3
@@ -37,8 +38,12 @@ void MAIN {
     constexpr uint32_t index_dest_start = 2;
     constexpr uint32_t input_dest_end = 1;
     constexpr uint32_t index_dest_end = 3;
-    // init pack, compute and unpack
 
+    constexpr uint32_t tiles_per_seq = K >> 5 + K % 32;
+    bool switch_dir = (K == 64);
+    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
+
+    // init pack, compute and unpack
     init_sfpu(input_cb_index, tt::CBIndex::c_16);
     ckernel::topk_tile_init();
 
@@ -58,9 +63,9 @@ void MAIN {
             copy_tile(input_cb_index, wt, 0);
             // pack value tiles into cb_intermed2
             pack_tile(0, input_transposed_cb_index);
-            cb_push_back(input_transposed_cb_index, 1);
             release_dst();
         }
+        cb_push_back(input_transposed_cb_index, Wt);
         cb_wait_front(input_transposed_cb_index, Wt);
         cb_pop_front(input_cb_index, Wt);
 
@@ -79,6 +84,8 @@ void MAIN {
         cb_wait_front(index_transposed_cb_index, Wt);
         cb_pop_front(index_cb_index, Wt);
 
+        uint32_t num_k_sequences = (Wt * 32) / K;
+
         // iterative divide and conquer on pairs of tiles (bitonic topk merge and rebuild)
         // first iteration we compare 0th and 1st tile, then 2nd and 3rd, etc. We get the sorted top 32 values in each
         // pair. second iteration we compare 0th and 2nd tile, then 4th and 6th, etc. logWt iteration we compare 0th and
@@ -87,37 +94,123 @@ void MAIN {
             bool direction = !largest;
             cb_wait_front(input_transposed_cb_index, Wt);
             cb_wait_front(index_transposed_cb_index, Wt);
-            uint32_t stride = 1 << m_iter;
-            for (uint32_t left_ind = 0; left_ind < Wt - stride; left_ind += 2 << m_iter) {
-                uint32_t right_ind = left_ind + stride;
-                acquire_dst();
 
-                // unpack values into dest
-                copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
-                copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+            uint32_t i = 0;
+            uint32_t dist = ((1 << m_iter) * K) >> 5;
+            uint32_t left_tile_id = 0;
+            while (i < num_k_sequences) {
+                for (uint32_t t = 0; t < tiles_per_seq; t++) {
+                    left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
+                    uint32_t right_tile_id = left_tile_id + dist;
+                    if (left_tile_id == right_tile_id) {
+                        right_tile_id = left_tile_id + 1;
+                    }
 
-                // unpack indices into dest
-                copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
-                copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+                    if (left_tile_id >= Wt || right_tile_id >= Wt) {
+                        break;
+                    }
 
-                // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                ckernel::topk_merge<!largest>(0, m_iter, K);
-                // sort within the larger 32 values
-                ckernel::topk_rebuild(0, (uint32_t)direction, m_iter, K, logk, true);
+                    acquire_dst();
 
-                // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values for
-                // topk, which was in input_dest_start
-                pack_reconfig_data_format(input_transposed_cb_index);
-                pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+                    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                    copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
+                    copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
 
-                // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for
-                // topk, which was in index_dest_start
-                pack_reconfig_data_format(index_transposed_cb_index);
-                pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-                release_dst();
-                direction = !direction;
+                    // unpack indices into dest
+                    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                    copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
+                    copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
+
+                    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                    ckernel::topk_merge(0, m_iter, K);
+
+                    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
+                    // for topk, which was in input_dest_start
+                    pack_reconfig_data_format(input_transposed_cb_index);
+                    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
+                    pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
+
+                    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
+                    // for topk, which was in index_dest_start
+                    pack_reconfig_data_format(index_transposed_cb_index);
+                    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
+                    pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
+                    release_dst();
+                }
+                i += seq_per_2tiles;
+            }
+
+            cb_reserve_back(input_transposed_cb_index, Wt);
+            cb_reserve_back(index_transposed_cb_index, Wt);
+
+            cb_pop_front(input_transposed_cb_index, Wt);
+            cb_pop_front(index_transposed_cb_index, Wt);
+
+            cb_push_back(input_transposed_cb_index, Wt);
+            cb_push_back(index_transposed_cb_index, Wt);
+            // print_all_tiles(input_transposed_cb_index, 0);
+
+            // we have decreased our search space by half
+            num_k_sequences = num_k_sequences >> 1;
+            int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
+            uint32_t idx = 0;
+            int sel_tile_id[2];
+            int sel_tile_id_ptr = 0;
+            seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
+            bool a = !largest;
+
+            cb_wait_front(input_transposed_cb_index, Wt);
+            cb_wait_front(index_transposed_cb_index, Wt);
+
+            while (idx < num_k_sequences) {
+                for (uint32_t t = 0; t < tiles_per_seq; t++) {
+                    uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
+                    if (left_ind >= Wt) {
+                        break;
+                    }
+                    sel_tile_id[sel_tile_id_ptr] = left_ind;
+                    sel_tile_id_ptr++;
+                    if (sel_tile_id_ptr == target_tiles) {
+                        acquire_dst();
+
+                        copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                        copy_tile(input_transposed_cb_index, sel_tile_id[0], input_dest_start);
+                        if (target_tiles != 1) {
+                            copy_tile(input_transposed_cb_index, sel_tile_id[1], input_dest_end);
+                        }
+
+                        // unpack indices into dest
+                        copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                        copy_tile(index_transposed_cb_index, sel_tile_id[0], index_dest_start);
+                        if (target_tiles != 1) {
+                            copy_tile(index_transposed_cb_index, sel_tile_id[1], index_dest_end);
+                        }
+
+                        // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                        // sort within the larger 32 values
+                        ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, target_tiles == 1);
+
+                        // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
+                        // values for topk, which was in input_dest_start
+                        pack_reconfig_data_format(input_transposed_cb_index);
+                        pack_tile<true>(input_dest_start, input_transposed_cb_index, sel_tile_id[0]);
+                        if (target_tiles != 1) {
+                            pack_tile<true>(input_dest_end, input_transposed_cb_index, sel_tile_id[1]);
+                        }
+
+                        // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
+                        // values for topk, which was in index_dest_start
+                        pack_reconfig_data_format(index_transposed_cb_index);
+                        pack_tile<true>(index_dest_start, index_transposed_cb_index, sel_tile_id[0]);
+                        if (target_tiles != 1) {
+                            pack_tile<true>(index_dest_end, index_transposed_cb_index, sel_tile_id[1]);
+                        }
+                        release_dst();
+                        sel_tile_id_ptr = 0;
+                        a = switch_dir ? !a : a;
+                    }
+                }
+                idx += (seq_per_2tiles >> 1);
             }
             cb_reserve_back(input_transposed_cb_index, Wt);
             cb_reserve_back(index_transposed_cb_index, Wt);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -11,11 +11,14 @@
 #include "compute_kernel_api/reconfig_data_format.h"
 #include "compute_kernel_api/pack.h"
 
+#include "topk_common_funcs.hpp"
+
 // topk llk needs a global variable atm
 // this can only be removed once that's fixed
 int32_t topk_replay_init = 0;
 
 namespace NAMESPACE {
+
 void MAIN {
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
@@ -39,7 +42,7 @@ void MAIN {
     constexpr uint32_t input_dest_end = 1;
     constexpr uint32_t index_dest_end = 3;
 
-    constexpr uint32_t tiles_per_seq = K >> 5 + K % 32;
+    constexpr uint32_t tiles_per_seq = (K + 31) / 32;
     bool switch_dir = (K == 64);
     int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
 
@@ -91,165 +94,29 @@ void MAIN {
         // pair. second iteration we compare 0th and 2nd tile, then 4th and 6th, etc. logWt iteration we compare 0th and
         // Wt/2 tile single buffer as we can pack tiles back in-place
         for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
-            bool direction = !largest;
-            cb_wait_front(input_transposed_cb_index, Wt);
-            cb_wait_front(index_transposed_cb_index, Wt);
-
-            uint32_t dist = ((1 << m_iter) * K) >> 5;
-            uint32_t left_tile_id = 0;
-            for (uint32_t i = 0; i < num_k_sequences; i += seq_per_2tiles) {
-                for (uint32_t t = 0; t < tiles_per_seq; t++) {
-                    left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
-                    uint32_t right_tile_id = left_tile_id + dist;
-                    if (left_tile_id == right_tile_id) {
-                        right_tile_id = left_tile_id + 1;
-                    }
-
-                    if (left_tile_id >= Wt || right_tile_id >= Wt) {
-                        break;
-                    }
-
-                    acquire_dst();
-
-                    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                    copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
-                    copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
-
-                    // unpack indices into dest
-                    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                    copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
-                    copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
-
-                    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                    ckernel::topk_merge(0, m_iter, K);
-
-                    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
-                    // for topk, which was in input_dest_start
-                    pack_reconfig_data_format(input_transposed_cb_index);
-                    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
-                    pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
-
-                    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
-                    // for topk, which was in index_dest_start
-                    pack_reconfig_data_format(index_transposed_cb_index);
-                    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
-                    pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
-                    release_dst();
-                }
-            }
-
-            cb_reserve_back(input_transposed_cb_index, Wt);
-            cb_reserve_back(index_transposed_cb_index, Wt);
-
-            cb_pop_front(input_transposed_cb_index, Wt);
-            cb_pop_front(index_transposed_cb_index, Wt);
-
-            cb_push_back(input_transposed_cb_index, Wt);
-            cb_push_back(index_transposed_cb_index, Wt);
-            // print_all_tiles(input_transposed_cb_index, 0);
-
-            // we have decreased our search space by half
-            num_k_sequences = num_k_sequences >> 1;
-            int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
-
-            int sel_tile_id[2];
-            int sel_tile_id_ptr = 0;
-            seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
-            bool a = !largest;
-
-            cb_wait_front(input_transposed_cb_index, Wt);
-            cb_wait_front(index_transposed_cb_index, Wt);
-
-            for (uint32_t idx = 0; idx < num_k_sequences; idx += (seq_per_2tiles >> 1)) {
-                for (uint32_t t = 0; t < tiles_per_seq; t++) {
-                    uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
-                    if (left_ind >= Wt) {
-                        break;
-                    }
-                    sel_tile_id[sel_tile_id_ptr] = left_ind;
-                    sel_tile_id_ptr++;
-                    if (sel_tile_id_ptr == target_tiles) {
-                        acquire_dst();
-
-                        copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                        copy_tile(input_transposed_cb_index, sel_tile_id[0], input_dest_start);
-                        if (target_tiles != 1) {
-                            copy_tile(input_transposed_cb_index, sel_tile_id[1], input_dest_end);
-                        }
-
-                        // unpack indices into dest
-                        copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                        copy_tile(index_transposed_cb_index, sel_tile_id[0], index_dest_start);
-                        if (target_tiles != 1) {
-                            copy_tile(index_transposed_cb_index, sel_tile_id[1], index_dest_end);
-                        }
-
-                        // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                        // sort within the larger 32 values
-                        ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, target_tiles == 1);
-
-                        // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
-                        // values for topk, which was in input_dest_start
-                        pack_reconfig_data_format(input_transposed_cb_index);
-                        pack_tile<true>(input_dest_start, input_transposed_cb_index, sel_tile_id[0]);
-                        if (target_tiles != 1) {
-                            pack_tile<true>(input_dest_end, input_transposed_cb_index, sel_tile_id[1]);
-                        }
-
-                        // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
-                        // values for topk, which was in index_dest_start
-                        pack_reconfig_data_format(index_transposed_cb_index);
-                        pack_tile<true>(index_dest_start, index_transposed_cb_index, sel_tile_id[0]);
-                        if (target_tiles != 1) {
-                            pack_tile<true>(index_dest_end, index_transposed_cb_index, sel_tile_id[1]);
-                        }
-                        release_dst();
-                        sel_tile_id_ptr = 0;
-                        a = switch_dir ? !a : a;
-                    }
-                }
-            }
-            cb_reserve_back(input_transposed_cb_index, Wt);
-            cb_reserve_back(index_transposed_cb_index, Wt);
-
-            cb_pop_front(input_transposed_cb_index, Wt);
-            cb_pop_front(index_transposed_cb_index, Wt);
-
-            cb_push_back(input_transposed_cb_index, Wt);
-            cb_push_back(index_transposed_cb_index, Wt);
+            process_iteration(
+                m_iter,
+                K,
+                Wt,
+                num_k_sequences,
+                tiles_per_seq,
+                input_transposed_cb_index,
+                index_transposed_cb_index,
+                input_dest_start,
+                input_dest_end,
+                index_dest_start,
+                index_dest_end,
+                largest,
+                switch_dir,
+                logk,
+                seq_per_2tiles);
         }
 
         // transpose value tiles and pack into output buffer
-        reconfig_data_format_srca(input_transposed_cb_index);
-        transpose_wh_init_short(input_transposed_cb_index);
-        pack_reconfig_data_format(input_transposed_cb_index);
-        cb_wait_front(input_transposed_cb_index, Kt);
-        for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst();
-            cb_reserve_back(values_cb_index, 1);
-            transpose_wh_tile(input_transposed_cb_index, i, 0);
-            pack_tile(0, values_cb_index);
-            cb_push_back(values_cb_index, 1);
-            release_dst();
-        }
-        cb_wait_front(input_transposed_cb_index, Wt);
-        cb_pop_front(input_transposed_cb_index, Wt);
+        transpose_and_pack(input_transposed_cb_index, values_cb_index, Kt, Wt);
 
         // transpose index tiles and pack into output buffer
-        reconfig_data_format_srca(index_transposed_cb_index);
-        transpose_wh_init_short(index_transposed_cb_index);
-        pack_reconfig_data_format(index_transposed_cb_index);
-        cb_wait_front(index_transposed_cb_index, Kt);
-        for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst();
-            cb_reserve_back(output_ind_cb_index, 1);
-            transpose_wh_tile(index_transposed_cb_index, i, 0);
-            pack_tile(0, output_ind_cb_index);
-            cb_push_back(output_ind_cb_index, 1);
-            release_dst();
-        }
-        cb_wait_front(index_transposed_cb_index, Wt);
-        cb_pop_front(index_transposed_cb_index, Wt);
+        transpose_and_pack(index_transposed_cb_index, output_ind_cb_index, Kt, Wt);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -15,6 +15,7 @@
 int32_t topk_replay_init = 0;
 
 namespace NAMESPACE {
+
 void MAIN {
     constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
@@ -29,6 +30,7 @@ void MAIN {
     constexpr uint32_t logk = get_compile_time_arg_val(10);
     constexpr uint32_t logWt = get_compile_time_arg_val(11);
     constexpr uint32_t largest = get_compile_time_arg_val(12);
+    constexpr uint32_t sorted = get_compile_time_arg_val(13);
 
     uint32_t direction_init = get_arg_val<uint32_t>(0);
 
@@ -38,12 +40,21 @@ void MAIN {
     constexpr uint32_t index_dest_start = 2;
     constexpr uint32_t input_dest_end = 1;
     constexpr uint32_t index_dest_end = 3;
+    constexpr uint32_t tiles_per_seq = K >> 5 + K % 32;
 
+    // we support K only up to 64
+    int end_phase = (K <= 64) ? logk - 1 : 5;
     // init pack, compute and unpack
+
     ckernel::topk_tile_init();
     transpose_wh_init(input_cb_index, input_transposed_cb_index);
 
+    bool switch_dir = (K == 64);
+    int seq_per_2tiles = std::max((2 * 32) / K, (uint32_t)2);
+
     for (uint32_t ht = 0; ht < Ht; ++ht) {
+        bool ascending = !largest;
+
         cb_reserve_back(input_transposed_cb_index, Wt);
         cb_reserve_back(index_transposed_cb_index, Wt);
 
@@ -65,7 +76,7 @@ void MAIN {
             transpose_wh_tile(index_cb_index, 1, 3);
 
             // llk_topk_sort -> inplace
-            ckernel::topk_local_sort(0, (int)direction_init, logk - 1);
+            ckernel::topk_local_sort(0, (int)ascending, end_phase);
 
             // pack value tiles into cb_intermed0
             pack_reconfig_data_format(input_transposed_cb_index);
@@ -80,50 +91,139 @@ void MAIN {
             cb_pop_front(input_cb_index, 2);
             cb_pop_front(index_cb_index, 2);
             release_dst();
+            ascending = switch_dir ? !ascending : ascending;
         }
 
         cb_push_back(input_transposed_cb_index, Wt);
         cb_push_back(index_transposed_cb_index, Wt);
+
+        uint32_t num_k_sequences = (Wt * 32) / K;
 
         // iterative divide and conquer on pairs of tiles (bitonic topk merge and rebuild)
         // first iteration we compare 0th and 1st tile, then 2nd and 3rd, etc. We get the sorted top 32 values in each
         // pair. second iteration we compare 0th and 2nd tile, then 4th and 6th, etc. logWt iteration we compare 0th and
         // Wt/2 tile single buffer as we can pack tiles back in-place
         for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
-            bool direction = direction_init;
             cb_wait_front(input_transposed_cb_index, Wt);
             cb_wait_front(index_transposed_cb_index, Wt);
-            uint32_t stride = 1 << m_iter;
-            for (uint32_t left_ind = 0; left_ind < Wt - stride; left_ind += 2 << m_iter) {
-                uint32_t right_ind = left_ind + stride;
-                acquire_dst();
 
-                copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
-                copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+            uint32_t i = 0;
+            uint32_t dist = ((1 << m_iter) * K) >> 5;
+            uint32_t left_tile_id = 0;
+            while (i < num_k_sequences) {
+                for (uint32_t t = 0; t < tiles_per_seq; t++) {
+                    left_tile_id = ((i * (1 << m_iter) * K) >> 5) + t;
+                    uint32_t right_tile_id = left_tile_id + dist;
+                    if (left_tile_id == right_tile_id) {
+                        right_tile_id = left_tile_id + 1;
+                    }
 
-                // unpack indices into dest
-                copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
-                copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+                    if (left_tile_id >= Wt || right_tile_id >= Wt) {
+                        break;
+                    }
 
-                // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
-                ckernel::topk_merge<!largest>(0, m_iter, K);
-                // sort within the larger 32 values
-                ckernel::topk_rebuild(0, (uint32_t)direction, m_iter, K, logk, true);
+                    acquire_dst();
 
-                // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values for
-                // topk, which was in input_dest_start
-                pack_reconfig_data_format(input_transposed_cb_index);
-                pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+                    copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                    copy_tile(input_transposed_cb_index, left_tile_id, input_dest_start);
+                    copy_tile(input_transposed_cb_index, right_tile_id, input_dest_end);
 
-                // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for
-                // topk, which was in index_dest_start
-                pack_reconfig_data_format(index_transposed_cb_index);
-                pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-                release_dst();
-                direction = !direction;
+                    // unpack indices into dest
+                    copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                    copy_tile(index_transposed_cb_index, left_tile_id, index_dest_start);
+                    copy_tile(index_transposed_cb_index, right_tile_id, index_dest_end);
+
+                    // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                    ckernel::topk_merge(0, m_iter, K);
+
+                    // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values
+                    // for topk, which was in input_dest_start
+                    pack_reconfig_data_format(input_transposed_cb_index);
+                    pack_tile<true>(input_dest_start, input_transposed_cb_index, left_tile_id);
+                    pack_tile<true>(input_dest_end, input_transposed_cb_index, right_tile_id);
+
+                    // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values
+                    // for topk, which was in index_dest_start
+                    pack_reconfig_data_format(index_transposed_cb_index);
+                    pack_tile<true>(index_dest_start, index_transposed_cb_index, left_tile_id);
+                    pack_tile<true>(index_dest_end, index_transposed_cb_index, right_tile_id);
+                    release_dst();
+                }
+                i += seq_per_2tiles;
             }
+
+            cb_reserve_back(input_transposed_cb_index, Wt);
+            cb_reserve_back(index_transposed_cb_index, Wt);
+
+            cb_pop_front(input_transposed_cb_index, Wt);
+            cb_pop_front(index_transposed_cb_index, Wt);
+
+            cb_push_back(input_transposed_cb_index, Wt);
+            cb_push_back(index_transposed_cb_index, Wt);
+
+            // we have decreased our search space by half
+            num_k_sequences = num_k_sequences >> 1;
+            int target_tiles = (Wt == 1 || ((num_k_sequences == 1) && (tiles_per_seq == 1))) ? 1 : 2;
+            uint32_t idx = 0;
+            int sel_tile_id[2];
+            int sel_tile_id_ptr = 0;
+            seq_per_2tiles = (seq_per_2tiles == 2) ? 2 : seq_per_2tiles >> 1;
+            bool a = direction_init;
+
+            cb_wait_front(input_transposed_cb_index, Wt);
+            cb_wait_front(index_transposed_cb_index, Wt);
+
+            while (idx < num_k_sequences) {
+                for (uint32_t t = 0; t < tiles_per_seq; t++) {
+                    uint32_t left_ind = ((idx * (1 << (m_iter + 1)) * K) >> 5) + t;
+                    if (left_ind >= Wt) {
+                        break;
+                    }
+                    sel_tile_id[sel_tile_id_ptr] = left_ind;
+                    sel_tile_id_ptr++;
+                    if (sel_tile_id_ptr == target_tiles) {
+                        acquire_dst();
+
+                        copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                        copy_tile(input_transposed_cb_index, sel_tile_id[0], input_dest_start);
+                        if (target_tiles != 1) {
+                            copy_tile(input_transposed_cb_index, sel_tile_id[1], input_dest_end);
+                        }
+
+                        // unpack indices into dest
+                        copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                        copy_tile(index_transposed_cb_index, sel_tile_id[0], index_dest_start);
+                        if (target_tiles != 1) {
+                            copy_tile(index_transposed_cb_index, sel_tile_id[1], index_dest_end);
+                        }
+
+                        // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                        // sort within the larger 32 values
+                        ckernel::topk_rebuild(0, (uint32_t)a, m_iter, K, logk, target_tiles == 1);
+
+                        // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32
+                        // values for topk, which was in input_dest_start
+                        pack_reconfig_data_format(input_transposed_cb_index);
+                        pack_tile<true>(input_dest_start, input_transposed_cb_index, sel_tile_id[0]);
+                        if (target_tiles != 1) {
+                            pack_tile<true>(input_dest_end, input_transposed_cb_index, sel_tile_id[1]);
+                        }
+
+                        // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32
+                        // values for topk, which was in index_dest_start
+                        pack_reconfig_data_format(index_transposed_cb_index);
+                        pack_tile<true>(index_dest_start, index_transposed_cb_index, sel_tile_id[0]);
+                        if (target_tiles != 1) {
+                            pack_tile<true>(index_dest_end, index_transposed_cb_index, sel_tile_id[1]);
+                        }
+                        release_dst();
+                        sel_tile_id_ptr = 0;
+                        a = switch_dir ? !a : a;
+                    }
+                }
+                idx += (seq_per_2tiles >> 1);
+            }
+
             cb_reserve_back(input_transposed_cb_index, Wt);
             cb_reserve_back(index_transposed_cb_index, Wt);
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -57,47 +57,15 @@ void MAIN {
     for (uint32_t ht = 0; ht < Ht; ++ht) {
         bool ascending = !largest;
 
-        cb_reserve_back(input_transposed_cb_index, Wt);
-        cb_reserve_back(index_transposed_cb_index, Wt);
-
-        // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
-        for (uint32_t wt = 0; wt < Wt; wt += 2) {
-            acquire_dst();
-            // transpose tiles and then local sort into k groups
-            cb_wait_front(input_cb_index, 2);
-            cb_wait_front(index_cb_index, 2);
-
-            reconfig_data_format_srca(input_cb_index);
-            transpose_wh_init_short(input_cb_index);
-            transpose_wh_tile(input_cb_index, 0, 0);
-            transpose_wh_tile(input_cb_index, 1, 1);
-
-            reconfig_data_format_srca(index_cb_index);
-            transpose_wh_init_short(index_cb_index);
-            transpose_wh_tile(index_cb_index, 0, 2);
-            transpose_wh_tile(index_cb_index, 1, 3);
-
-            // llk_topk_sort -> inplace
-            ckernel::topk_local_sort(0, (int)ascending, end_phase);
-
-            // pack value tiles into cb_intermed0
-            pack_reconfig_data_format(input_transposed_cb_index);
-            pack_tile(0, input_transposed_cb_index);
-            pack_tile(1, input_transposed_cb_index);
-
-            // pack index tiles into cb_intermed1
-            pack_reconfig_data_format(index_transposed_cb_index);
-            pack_tile(2, index_transposed_cb_index);
-            pack_tile(3, index_transposed_cb_index);
-
-            cb_pop_front(input_cb_index, 2);
-            cb_pop_front(index_cb_index, 2);
-            release_dst();
-            ascending = switch_dir ? !ascending : ascending;
-        }
-
-        cb_push_back(input_transposed_cb_index, Wt);
-        cb_push_back(index_transposed_cb_index, Wt);
+        process_and_sort_tiles(
+            input_cb_index,
+            index_cb_index,
+            input_transposed_cb_index,
+            index_transposed_cb_index,
+            Wt,
+            switch_dir,
+            ascending,
+            end_phase);
 
         uint32_t num_k_sequences = (Wt * 32) / K;
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -34,9 +34,9 @@ void kernel_main() {
     uint32_t final_indices_cb_addr = get_write_ptr(final_indices_cb_index);
 
     uint64_t noc_final_addr_values =
-        get_noc_addr(noc_final_x, noc_final_y, final_values_cb_addr) + start_wt * tile_bytes_values;
+        get_noc_addr(noc_final_x, noc_final_y, final_values_cb_addr) + start_wt * tile_bytes_values * Kt;
     uint64_t noc_value_addr_values =
-        get_noc_addr(noc_final_x, noc_final_y, final_indices_cb_addr) + start_wt * tile_bytes_ind;
+        get_noc_addr(noc_final_x, noc_final_y, final_indices_cb_addr) + start_wt * tile_bytes_ind * Kt;
 
     volatile tt_l1_ptr uint32_t* receiver_semaphore_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -12,7 +12,7 @@ static inline bool verify_available_cores(
     uint16_t min_dim,
     uint16_t max_dim,
     CoreCoord grid,
-    uint16_t k,
+    int32_t k,
     const uint32_t l1_size,
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
@@ -28,7 +28,8 @@ static inline bool verify_available_cores(
             (split_size / tt::constants::TILE_WIDTH) *
             (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
                                                   // as a matching set of indices, is processed by a core
-        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < l1_size && num_cores > 1) {
+        if (num_cores <= max_cores && (memory_cost_gather + (memory_cost_local * num_cores)) < (l1_size * num_cores) &&
+            num_cores > 1) {
             return true;
         }
     }
@@ -43,16 +44,12 @@ void TopK::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     auto input_shape = input_tensors.at(0).get_padded_shape();
     TT_FATAL(input_shape.rank() == 4, "Input shape must be 4D, got {}", input_shape.rank());
-    TT_FATAL(this->k == 32, "K must be equal to 32, pad with -infinity if necessary to get 32, got {}", this->k);
-    TT_FATAL(this->dim == -1 || this->dim == 3, "Only the last dim is supported right now, got {}", this->dim);
+    TT_FATAL(
+        this->k <= 64, "K must be less than or equal to 64, pad with +/-infinity if necessary but got {}", this->k);
 
     TT_FATAL(
         input_shape[-1] >= 64,
-        "Input shape inner dim {} must be a multiple of 64, pad with -infinity if necessary",
-        input_shape[-1]);
-    TT_FATAL(
-        (input_shape[-1] & (input_shape[-1] - 1)) == 0,
-        "Input shape inner dim {} must be a power of 2, pad with -infinity if necessary",
+        "Input shape inner dim {} must be a multiple of 64, pad with +/-infinity if necessary",
         input_shape[-1]);
     TT_FATAL(
         (input_shape[0] * input_shape[1] * input_shape[2]) % 32 == 0,
@@ -122,10 +119,10 @@ operation::ProgramWithCallbacks TopK::create_program(
     const auto& input_tensor = input_tensors.at(0);
     if (input_tensor.get_padded_shape()[dim] < topk_utils::multi_core_min_width) {
         return detail::topk_single_core_interleaved(
-            input_tensor, this->k, this->dim, this->largest, output_tensors.at(0), output_tensors.at(1));
+            input_tensor, this->k, this->dim, this->largest, this->sorted, output_tensors.at(0), output_tensors.at(1));
     } else {
         return detail::topk_multicore_interleaved(
-            input_tensor, this->k, this->dim, this->largest, output_tensors.at(0), output_tensors.at(1));
+            input_tensor, this->k, this->dim, this->largest, this->sorted, output_tensors.at(0), output_tensors.at(1));
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
@@ -12,7 +12,7 @@
 namespace ttnn::operations::reduction {
 
 struct TopK {
-    const uint16_t k;
+    const uint32_t k;
     const int8_t dim;
     const bool largest;
     const bool sorted;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -12,9 +12,10 @@ namespace ttnn::operations::reduction::detail {
 
 operation::ProgramWithCallbacks topk_single_core_interleaved(
     const Tensor& input_tensor,
-    const uint16_t k,
+    const int32_t k,
     const int8_t dim,
     const bool largest,
+    const bool sorted,
     Tensor& value_tensor,
     Tensor& index_tensor) {
     using namespace tt::constants;
@@ -56,7 +57,7 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core, input_cb_config);
 
     // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four
-    // tiles of space This CB carries the indices that are created in the reader kernel
+    // tiles of space. This CB carries the indices that are created in the reader kernel
     uint32_t index_cb_index = tt::CBIndex::c_1;
     tt::tt_metal::CircularBufferConfig index_input_intermed0_config =
         tt::tt_metal::CircularBufferConfig(cb_in_units * index_tile_size, {{index_cb_index, index_cb_data_format}})
@@ -135,8 +136,10 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
         Wt,
         k,
         (std::uint32_t)std::log2(k),
-        (std::uint32_t)std::log2(Wt),
-        largest};
+        (std::uint32_t)std::log2(input_shape[3] / k),
+        (std::uint32_t)largest,
+        (std::uint32_t)sorted,
+    };
     tt::tt_metal::KernelHandle topk_compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp",
@@ -180,7 +183,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
     uint16_t min_dim,
     uint16_t max_dim,
     CoreCoord grid,
-    uint16_t k,
+    int32_t k,
     const uint32_t l1_size,
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
@@ -196,8 +199,13 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
             (split_size / tt::constants::TILE_WIDTH) *
             (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
                                                   // as a matching set of indices, is processed by a core
-        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < l1_size && num_cores > 1) {
-            return {num_cores + 1, split_size, rem, num_cores * k};
+        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local * num_cores) < (l1_size * num_cores) &&
+            num_cores > 1) {
+            return {
+                num_cores + 1,
+                split_size,
+                rem,
+                num_cores * std::max(static_cast<uint32_t>(k), static_cast<uint32_t>(tt::constants::TILE_WIDTH))};
         }
     }
     return {max_cores + 1, width, 0, width * k};
@@ -209,9 +217,10 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
  */
 operation::ProgramWithCallbacks topk_multicore_interleaved(
     const Tensor& input_tensor,
-    const uint16_t k,
+    const int32_t k,
     const int8_t dim,
     const bool largest,
+    const bool sorted,
     Tensor& value_tensor,
     Tensor& index_tensor) {
     using namespace tt::constants;
@@ -411,7 +420,9 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         Kt,
         (std::uint32_t)std::log2(k),
         (std::uint32_t)std::log2(Wt_local),
-        largest};
+        (std::uint32_t)largest,
+        (std::uint32_t)sorted,
+    };
     tt::tt_metal::KernelHandle topk_compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp",
@@ -431,7 +442,9 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         Kt,
         (std::uint32_t)std::log2(k),
         (std::uint32_t)std::log2(Wt_final),
-        largest};
+        (std::uint32_t)largest,
+        (std::uint32_t)sorted,
+    };
 
     tt::tt_metal::KernelHandle topk_final_compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -440,7 +453,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         tt::tt_metal::ComputeConfig{.compile_args = compute_args_final});
 
     for (uint32_t core_h = 0; core_h < 1; core_h++) {
-        bool ascending = !largest;
+        bool ascending = false;
         for (uint32_t core_w = 0; core_w < num_cores - 1; core_w++) {
             CoreCoord core = {core_h, core_w};
             SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -9,9 +9,15 @@
 
 namespace ttnn::operations::reduction {
 
-int32_t get_nearest_power_of_2(int32_t k) {
+int32_t get_nearest_supported_shape(int32_t k) {
     // LLK only support k = 4, 8, 16, 32, 64
-    if (k <= 32) {
+    if (k <= 4) {
+        return 4;
+    } else if (k <= 8) {
+        return 8;
+    } else if (k <= 16) {
+        return 16;
+    } else if (k <= 32) {
         return 32;
     } else {
         return 64;
@@ -103,7 +109,7 @@ std::vector<Tensor> ExecuteTopK::invoke(
     auto input_memory_config = memory_config.value_or(input_tensor.memory_config());
 
     // K may not be power of 2
-    int32_t adjusted_k = get_nearest_power_of_2(k);
+    int32_t adjusted_k = get_nearest_supported_shape(k);
     // if dim is not last dimension, transpose it
     Tensor transposed_tensor = perform_transpose(input_tensor, is_dim_last_idx, dim, -1);
     // if input is not 4d, convert it to 4d

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -13,10 +13,6 @@ int32_t get_nearest_supported_shape(int32_t k) {
     // LLK only support k = 4, 8, 16, 32, 64
     if (k <= 4) {
         return 4;
-    } else if (k <= 8) {
-        return 8;
-    } else if (k <= 16) {
-        return 16;
     } else if (k <= 32) {
         return 32;
     } else {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk.hpp"
+#include <cstdint>
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+namespace ttnn::operations::reduction {
+
+int32_t get_nearest_power_of_2(int32_t k) {
+    // LLK only support k = 4, 8, 16, 32, 64
+    if (k <= 32) {
+        return 32;
+    } else {
+        return 64;
+    }
+}
+
+inline Tensor perform_transpose(
+    const Tensor& input_tensor, const bool is_dim_last_idx, const int8_t dim1 = -1, const int8_t dim2 = -1) {
+    return is_dim_last_idx ? input_tensor : ttnn::transpose(input_tensor, dim1, dim2, input_tensor.memory_config());
+}
+
+inline Tensor transform_to_4d_tensor(const Tensor& input_tensor, const bool is_rank_le_4d) {
+    return is_rank_le_4d ? ttnn::unsqueeze_to_4D(input_tensor) : data_movement::squeeze_from_ND_to_4D(input_tensor);
+}
+
+inline Tensor perform_padding(const Tensor& input_tensor, const bool largest) {
+    auto input_shape = input_tensor.get_padded_shape();
+    auto last_dim = input_shape[-1];
+    auto new_last_dim = tt::round_up(last_dim, tt::constants::TILE_WIDTH);
+    if (last_dim == new_last_dim) {
+        return input_tensor;
+    }
+    return ttnn::pad(
+        input_tensor,
+        tt::tt_metal::Array4D({input_shape[0], input_shape[1], input_shape[2], new_last_dim}),
+        tt::tt_metal::Array4D({0, 0, 0, 0}),
+        largest ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
+}
+
+// one stop for all transformations needed after executing top-k
+// do we need seperate function for each case? revisit this later
+std::vector<Tensor> post_topk_transform_tensor(
+    const Tensor& input_tensor,
+    std::vector<Tensor>& result,
+    const int8_t dim,
+    const bool is_dim_last_idx,
+    const int32_t k,
+    const int32_t adjusted_k,
+    const MemoryConfig& input_memory_config) {
+    TT_ASSERT(result[0].get_padded_shape().rank() == 4, "Output shape rank must be 4");
+    TT_ASSERT(result[1].get_padded_shape().rank() == 4, "Output shape rank must be 4");
+
+    auto input_shape = input_tensor.get_padded_shape();
+    const auto orig_rank = input_shape.rank();
+
+    // case 1 : K is not pow of 2
+    if (adjusted_k != k) {
+        auto output_shape = result[0].get_padded_shape();
+        ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+        ttnn::SmallVector<uint32_t> end_index = {output_shape[0], output_shape[1], output_shape[2], k};
+        result[0] = ttnn::slice(result[0], start_index, end_index, step, input_memory_config);
+        result[1] = ttnn::slice(result[1], start_index, end_index, step, input_memory_config);
+    }
+
+    // case 2 : rank is not 4
+    if (orig_rank < 4) {
+        result[0] = ttnn::squeeze_from_4D(result[0], orig_rank);
+        result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
+    } else if (orig_rank > 4) {
+        ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
+        result_shape[result_shape.size() - 1] = k;
+        result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});
+        result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
+    }
+
+    // case 3 : dim is not last index
+    if (!is_dim_last_idx) {
+        result[0] = ttnn::transpose(result[0], dim, -1, input_tensor.memory_config());
+        result[1] = ttnn::transpose(result[1], dim, -1, input_tensor.memory_config());
+    }
+
+    return result;
+}
+
+std::vector<Tensor> ExecuteTopK::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const int32_t k,
+    const int8_t dim,
+    const bool largest,
+    const bool sorted,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
+    auto rank = input_tensor.get_padded_shape().rank();
+    const bool is_dim_last_idx = (dim == -1 || dim == rank - 1);
+    const bool is_rank_le_4d = rank <= 4;
+
+    auto input_memory_config = memory_config.value_or(input_tensor.memory_config());
+
+    // K may not be power of 2
+    int32_t adjusted_k = get_nearest_power_of_2(k);
+    // if dim is not last dimension, transpose it
+    Tensor transposed_tensor = perform_transpose(input_tensor, is_dim_last_idx, dim, -1);
+    // if input is not 4d, convert it to 4d
+    Tensor transformed_tensor = transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
+    // add padding if needed
+    Tensor padded_tensor = perform_padding(transformed_tensor, largest);
+
+    auto output_tensor_vec = operation::run(
+        TopK{adjusted_k, -1, largest, sorted, input_memory_config},
+        {padded_tensor},
+        {},
+        optional_output_tensors.has_value() ? tuple_to_vector_optional(optional_output_tensors.value())
+                                            : std::vector<std::optional<Tensor>>{},
+        queue_id);
+
+    return post_topk_transform_tensor(
+        transposed_tensor, output_tensor_vec, dim, is_dim_last_idx, k, adjusted_k, input_memory_config);
+}
+
+auto ExecuteTopK::invoke(
+    const Tensor& input_tensor,
+    const int32_t k,
+    const int8_t dim,
+    const bool largest,
+    const bool sorted,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
+    return invoke(
+        DefaultQueueId, input_tensor, k, dim, largest, sorted, memory_config, std::move(optional_output_tensors));
+}
+
+}  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -26,31 +26,21 @@ struct ExecuteTopK {
     static inline std::vector<Tensor> invoke(
         QueueId queue_id,
         const Tensor& input_tensor,
-        const uint16_t k,
+        const int32_t k,
         const int8_t dim,
         const bool largest,
         const bool sorted,
         const std::optional<MemoryConfig>& memory_config,
-        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt) {
-        return operation::run(
-            TopK{k, dim, largest, sorted, memory_config.value_or(input_tensor.memory_config())},
-            {input_tensor},
-            {},
-            optional_output_tensors.has_value() ? tuple_to_vector_optional(optional_output_tensors.value())
-                                                : std::vector<std::optional<Tensor>>{},
-            queue_id);
-    }
+        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
 
-    static inline auto invoke(
+    static auto invoke(
         const Tensor& input_tensor,
-        const uint16_t k,
+        const int32_t k,
         const int8_t dim,
         const bool largest,
         const bool sorted,
         const std::optional<MemoryConfig>& memory_config,
-        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
-        return invoke(DefaultQueueId, input_tensor, k, dim, largest, sorted, memory_config, optional_output_tensors);
-    }
+        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
 
     static inline std::vector<Tensor> create_async_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.hpp
@@ -62,7 +62,7 @@ void bind_reduction_topk_operation(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const uint16_t k,
+               const uint32_t k,
                const int8_t dim,
                const bool largest,
                const bool sorted,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/16670

### Problem description
few flags & input combinations (k, largest, sorted) were not supported

### What's changed
Original code improperly formatted k in the main function and in the kernels.  The code also contained a lot of repetitive code doing the same thing. In the solution I fixed aforementioned bugs and refactored the code into reusable functions.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] New/Existing tests provide coverage for changes
