### PR TITLE
Buffer/MeshBuffer unification draft

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -172,14 +172,14 @@ TEST_P(DeviceLocalMeshBufferShardingTest, ShardingTest) {
     std::vector<uint32_t> src_vec(buf_size / sizeof(uint32_t), 0);
     std::iota(src_vec.begin(), src_vec.end(), 0);
 
-    for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
-        for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+    for (std::size_t logical_x = 0; logical_x < buf->mesh_device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < buf->mesh_device()->num_rows(); logical_y++) {
             WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, Coordinate(logical_y, logical_x));
         }
     }
 
-    for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
-        for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+    for (std::size_t logical_x = 0; logical_x < buf->mesh_device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < buf->mesh_device()->num_rows(); logical_y++) {
             std::vector<uint32_t> dst_vec = {};
             ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, Coordinate(logical_y, logical_x));
             EXPECT_EQ(dst_vec, src_vec);
@@ -302,14 +302,14 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
 
             std::vector<uint32_t> src_vec(num_random_tiles * single_tile_size / sizeof(uint32_t), 0);
             std::iota(src_vec.begin(), src_vec.end(), i);
-            for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
-                for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+            for (std::size_t logical_x = 0; logical_x < buf->mesh_device()->num_cols(); logical_x++) {
+                for (std::size_t logical_y = 0; logical_y < buf->mesh_device()->num_rows(); logical_y++) {
                     WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, Coordinate(logical_y, logical_x));
                 }
             }
 
-            for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
-                for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+            for (std::size_t logical_x = 0; logical_x < buf->mesh_device()->num_cols(); logical_x++) {
+                for (std::size_t logical_y = 0; logical_y < buf->mesh_device()->num_rows(); logical_y++) {
                     std::vector<uint32_t> dst_vec = {};
                     ReadShard(mesh_device_->mesh_command_queue(), dst_vec, buf, Coordinate(logical_y, logical_x));
                     EXPECT_EQ(dst_vec, src_vec);

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -47,8 +47,8 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
         EnqueueWaitForEvent(mesh_device_->mesh_command_queue(1), event);
 
         // Reads on CQ 1
-        for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
-            for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
+        for (std::size_t logical_x = 0; logical_x < buf->mesh_device()->num_cols(); logical_x++) {
+            for (std::size_t logical_y = 0; logical_y < buf->mesh_device()->num_rows(); logical_y++) {
                 readback_vecs.push_back({});
                 auto shard = buf->get_device_buffer(Coordinate(logical_y, logical_x));
                 ReadShard(

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -126,8 +126,8 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
                 device->id(), syncer_core_phys, std::vector<uint32_t>{1}, global_sem.address());
         }
         mesh_device_->reset_sub_device_stall_group();
-        for (std::size_t logical_x = 0; logical_x < output_buf->device()->num_cols(); logical_x++) {
-            for (std::size_t logical_y = 0; logical_y < output_buf->device()->num_rows(); logical_y++) {
+        for (std::size_t logical_x = 0; logical_x < output_buf->mesh_device()->num_cols(); logical_x++) {
+            for (std::size_t logical_y = 0; logical_y < output_buf->mesh_device()->num_rows(); logical_y++) {
                 std::vector<uint32_t> dst_vec;
                 ReadShard(mesh_device_->mesh_command_queue(), dst_vec, output_buf, Coordinate(logical_y, logical_x));
                 EXPECT_EQ(dst_vec, src_vec);

--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -47,7 +47,7 @@ TEST_F(DeviceSingleCardBufferFixture, TestL1BuffersAllocatedTopDown) {
             break;
         }
         auto buffer =
-            tt::tt_metal::Buffer::create(this->device_, buffer_size, buffer_size, tt::tt_metal::BufferType::L1);
+            tt::tt_metal::SingleBuffer::create(this->device_, buffer_size, buffer_size, tt::tt_metal::BufferType::L1);
         buffers.emplace_back(std::move(buffer));
         total_buffer_size += buffer_size;
         EXPECT_EQ(buffers.back()->address(), this->device_->l1_size_per_core() - total_buffer_size);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -232,7 +232,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitFor
         vector<vector<uint32_t>> srcs;
         for (uint i = 0; i < cqs.size(); i++) {
             uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
-            buffers.push_back(Buffer::create(this->device_, buf_size, config.page_size, config.buftype));
+            buffers.push_back(SingleBuffer::create(this->device_, buf_size, config.page_size, config.buftype));
             srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
             log_debug(tt::LogTest, "buf_idx: {} Doing Write to cq_id: {} of data: {}", buf_idx, i, srcs[i]);
             EnqueueWriteBuffer(cqs[i], *buffers[i], srcs[i], false);
@@ -300,7 +300,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitFor
             auto event = std::make_shared<Event>();
             vector<uint32_t> result;
 
-            buffers.push_back(Buffer::create(this->device_, buf_size, config.page_size, config.buftype));
+            buffers.push_back(SingleBuffer::create(this->device_, buf_size, config.page_size, config.buftype));
             srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
 
             // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
@@ -371,7 +371,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitFor
             vector<vector<uint32_t>> read_results;
             vector<std::shared_ptr<Buffer>> buffers;
 
-            buffers.push_back(Buffer::create(this->device_, buf_size, config.page_size, config.buftype));
+            buffers.push_back(SingleBuffer::create(this->device_, buf_size, config.page_size, config.buftype));
 
             // Number of write-read combos per buffer. Fewer make RAW race without events easier to hit.
             for (uint j = 0; j < num_wr_rd_per_buf; j++) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -34,7 +34,7 @@ TEST_F(CommandQueueEventFixture, TestEventsDataMovementWrittenToCompletionQueueI
 
         vector<std::shared_ptr<Buffer>> buffers;
         for (size_t i = 0; i < num_buffers; i++) {
-            buffers.push_back(Buffer::create(this->device_, page_size, page_size, BufferType::DRAM));
+            buffers.push_back(SingleBuffer::create(this->device_, page_size, page_size, BufferType::DRAM));
 
             if (data_movement_mode == DataMovementMode::WRITE) {
                 EnqueueWriteBuffer(this->device_->command_queue(), buffers.back(), page, true);
@@ -275,7 +275,7 @@ TEST_F(CommandQueueEventFixture, TestEventsMixedWriteBufferRecordWaitSynchronize
         EXPECT_EQ(event->cq_id, this->device_->command_queue().id());
         EXPECT_EQ(event->event_id, events_issued_per_cq + 1);  // Event ids start at 1
 
-        std::shared_ptr<Buffer> buf = Buffer::create(this->device_, page_size, page_size, BufferType::DRAM);
+        std::shared_ptr<Buffer> buf = SingleBuffer::create(this->device_, page_size, page_size, BufferType::DRAM);
         EnqueueWriteBuffer(this->device_->command_queue(), buf, page, true);
         EnqueueWaitForEvent(this->device_->command_queue(), event);
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -555,7 +555,7 @@ bool test_EnqueueWrap_on_EnqueueWriteBuffer(IDevice* device, CommandQueue& cq, c
     This just ensures we don't hang on the subsequent EnqueueWriteBuffer
     */
     size_t buf_size = config.num_pages * config.page_size;
-    auto buffer = Buffer::create(device, buf_size, config.page_size, config.buftype);
+    auto buffer = SingleBuffer::create(device, buf_size, config.page_size, config.buftype);
 
     vector<uint32_t> src(buf_size / sizeof(uint32_t), 0);
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -28,7 +28,7 @@ inline std::pair<std::shared_ptr<tt::tt_metal::Buffer>, std::vector<uint32_t>> E
     // This function just enqueues a buffer (which should be large in the config)
     // write as a precursor to testing the wrap mechanism
     size_t buf_size = config.num_pages * config.page_size;
-    auto buffer = Buffer::create(device, buf_size, config.page_size, config.buftype);
+    auto buffer = SingleBuffer::create(device, buf_size, config.page_size, config.buftype);
 
     std::vector<uint32_t> src =
         create_random_vector_of_bfloat16(buf_size, 100, std::chrono::system_clock::now().time_since_epoch().count());

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -88,8 +88,8 @@ vector<bool> blocking_flags = {kBlocking, kNonBlocking};
 
 TEST_F(MultiCommandQueueSingleDeviceTraceFixture, TensixEnqueueOneProgramTrace) {
     CreateDevice(2048);
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     CommandQueue& command_queue = this->device_->command_queue(0);
     CommandQueue& data_movement_queue = this->device_->command_queue(1);
@@ -129,8 +129,8 @@ TEST_F(MultiCommandQueueSingleDeviceTraceFixture, TensixEnqueueOneProgramTrace) 
 
 TEST_F(MultiCommandQueueSingleDeviceTraceFixture, TensixEnqueueOneProgramTraceLoops) {
     CreateDevice(4096);
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     CommandQueue& command_queue = this->device_->command_queue(0);
     CommandQueue& data_movement_queue = this->device_->command_queue(1);
@@ -180,8 +180,8 @@ TEST_F(MultiCommandQueueSingleDeviceTraceFixture, TensixEnqueueOneProgramTraceLo
 
 TEST_F(MultiCommandQueueSingleDeviceTraceFixture, TensixEnqueueOneProgramTraceBenchmark) {
     CreateDevice(6144);
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     constexpr bool kBlocking = true;
     constexpr bool kNonBlocking = false;
@@ -258,12 +258,12 @@ TEST_F(CommandQueueTraceFixture, TensixInstantiateTraceSanity) {
     CreateDevice(2048);
     CommandQueue& command_queue = this->device_->command_queue();
 
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
     vector<uint32_t> input_data(input->size() / sizeof(uint32_t), 0);
     for (uint32_t i = 0; i < input_data.size(); i++) {
         input_data[i] = i;
     }
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
     auto simple_program = std::make_shared<Program>(create_simple_unary_program(*input, *output));
     EnqueueProgram(command_queue, *simple_program, true);
     uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
@@ -288,8 +288,8 @@ TEST_F(CommandQueueTraceFixture, TensixInstantiateTraceSanity) {
 
 TEST_F(CommandQueueTraceFixture, TensixEnqueueProgramTraceCapture) {
     CreateDevice(2048);
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     CommandQueue& command_queue = this->device_->command_queue();
 
@@ -314,8 +314,8 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueProgramTraceCapture) {
     EnqueueProgram(command_queue, simple_program, false);
     EndTraceCapture(this->device_, command_queue.id(), tid);
     // Create and Enqueue a Program with a live trace to ensure that a warning is generated
-    auto input_temp = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output_temp = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input_temp = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output_temp = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
     Program simple_program_temp = create_simple_unary_program(*input_temp, *output_temp);
     EnqueueProgram(command_queue, simple_program_temp, true);
     // Run trace that can clobber the temporary buffers created above
@@ -331,8 +331,8 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueProgramTraceCapture) {
 
 TEST_F(CommandQueueTraceFixture, TensixEnqueueProgramDeviceCapture) {
     CreateDevice(2048);
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     CommandQueue& command_queue = this->device_->command_queue();
 
@@ -387,9 +387,9 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueTwoProgramTrace) {
     // Get command queue from device for this test, since its running in async mode
     CommandQueue& command_queue = this->device_->command_queue();
 
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto interm = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto interm = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     Program op0 = create_simple_unary_program(*input, *interm);
     Program op1 = create_simple_unary_program(*interm, *output);
@@ -462,8 +462,8 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueMultiProgramTraceBenchmark) {
     CreateDevice(6144);
     CommandQueue& command_queue = this->device_->command_queue();
 
-    auto input = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
-    auto output = Buffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto input = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
+    auto output = SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM);
 
     uint32_t num_loops = parse_env<int>("TT_METAL_TRACE_LOOPS", 4);
     uint32_t num_programs = parse_env<int>("TT_METAL_TRACE_PROGRAMS", 4);
@@ -476,7 +476,7 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueMultiProgramTraceBenchmark) {
     }
 
     for (int i = 0; i < num_programs; i++) {
-        interm_buffers.push_back(Buffer::create(this->device_, 2048, 2048, BufferType::DRAM));
+        interm_buffers.push_back(SingleBuffer::create(this->device_, 2048, 2048, BufferType::DRAM));
         if (i == 0) {
             programs.push_back(create_simple_unary_program(*input, *(interm_buffers[i])));
         } else if (i == (num_programs - 1)) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -474,17 +474,18 @@ bool matmul_multi_core_multi_dram(DispatchFixture* fixture, tt_metal::IDevice* d
     auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
 
-    auto activation_buffer = Buffer::create(device, activations.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
+    auto activation_buffer =
+        SingleBuffer::create(device, activations.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
     pass &= move_tiles_to_dram(device, activations, M, K, activation_buffer);
     auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
     auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
 
-    auto weight_buffer = Buffer::create(device, weights.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
+    auto weight_buffer = SingleBuffer::create(device, weights.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
     pass &= move_tiles_to_dram(device, weights, K, N, weight_buffer);
     log_debug(LogTest, "Copying inputs to dram complete");
 
-    auto out_buffer = Buffer::create(device, M * N * sizeof(uint32_t) * 32 * 32, 1024 * 2, BufferType::DRAM);
+    auto out_buffer = SingleBuffer::create(device, M * N * sizeof(uint32_t) * 32 * 32, 1024 * 2, BufferType::DRAM);
     uint32_t out_dram_addr = out_buffer->address();
 
     log_debug(LogTest, "Writing kernel runtime args to device");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
 
         // limit size of the L1 buffer to do not exceed global L1 size
         uint32_t l1_buffer_size = num_cores_r * num_cores_c * (num_tiles > 256 ? 256 : num_tiles) * page_size;
-        auto l1_buffer = tt_metal::Buffer::create(device, l1_buffer_size, page_size, tt_metal::BufferType::L1);
+        auto l1_buffer = tt_metal::SingleBuffer::create(device, l1_buffer_size, page_size, tt_metal::BufferType::L1);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
         }
 
         // Application setup
-        auto buffer = tt_metal::Buffer::create(
+        auto buffer = tt_metal::SingleBuffer::create(
             device, transfer_size, page_size, buffer_type == 0 ? tt_metal::BufferType::DRAM : tt_metal::BufferType::L1);
 
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -192,8 +192,8 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
             input_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        auto input_buffer =
-            Buffer::create(device, input_vec.size() * sizeof(uint32_t), single_tile_size, tt_metal::BufferType::DRAM);
+        auto input_buffer = SingleBuffer::create(
+            device, input_vec.size() * sizeof(uint32_t), single_tile_size, tt_metal::BufferType::DRAM);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -394,7 +394,7 @@ int main(int argc, char** argv) {
             input_vec = create_random_vector_of_bfloat16(input_size, 100, 1234);
         }
 
-        auto input_buffer = tt_metal::Buffer::create(
+        auto input_buffer = tt_metal::SingleBuffer::create(
             device, input_vec.size() * sizeof(uint32_t), single_tile_size, tt_metal::BufferType::DRAM);
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -577,7 +577,7 @@ int main(int argc, char** argv) {
             input_vec = create_random_vector_of_bfloat16(input_size, 100, 1234);
         }
 
-        auto input_buffer = tt_metal::Buffer::create(
+        auto input_buffer = tt_metal::SingleBuffer::create(
             device, input_vec.size() * sizeof(uint32_t), single_tile_size, tt_metal::BufferType::DRAM);
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv) {
         l1_buffers.reserve(l1_buffers_size);
         for (int r = 0; r < num_cores_r; ++r) {
             for (int c = 0; c < num_cores_c; ++c) {
-                l1_buffers.push_back(tt_metal::Buffer::create(
+                l1_buffers.push_back(tt_metal::SingleBuffer::create(
                     device, total_tiles_size_bytes, single_tile_size, tt_metal::BufferType::L1));
                 tt_metal::detail::WriteToBuffer(*l1_buffers[r * num_cores_c + c], packed_tensors[r * num_cores_c + c]);
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,320 +17,78 @@
 #include <variant>
 #include <vector>
 
-#include "bfloat16.hpp"
-#include "core_coord.hpp"
-#include "buffer_constants.hpp"
+#include "buffer_config.hpp"
 #include "sub_device_types.hpp"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/types/xy_pair.h"
 #include "concepts.hpp"
 #include "assert.hpp"
-#include <nlohmann/json.hpp>
-
-#include "hal.hpp"
 
 namespace tt::tt_metal {
 inline namespace v0 {
 
-class IDevice;
-
-}  // namespace v0
-
-class Allocator;
-
-struct ShardSpec {
-    /* The individual cores the shard grid is mapped to */
-    CoreRangeSet grid;
-
-    /* Canonical tensor shape where the depth dimensions ([:-2] are folded along y) */
-    std::array<uint32_t, 2> shape;
-
-    /* The sequence order of the grid cores that the shards are layed out onto. */
-    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
-
-    // In ShardMode::PHYSICAL, physical_shard_shape will always be std::nullopt
-    ShardMode mode = ShardMode::PHYSICAL;
-    std::optional<std::array<uint32_t, 2>> physical_shard_shape = std::nullopt;
-
-    ShardSpec(
-        const CoreRangeSet &core_sets_,
-        const std::array<uint32_t, 2> &shard_shape_,
-        const ShardOrientation &shard_orientation_ = ShardOrientation::ROW_MAJOR,
-        const ShardMode &shard_mode_ = ShardMode::PHYSICAL) :
-        grid(core_sets_), shape(shard_shape_), orientation(shard_orientation_), mode(shard_mode_), physical_shard_shape(std::nullopt) {
-    }
-
-    ShardSpec(
-        const CoreRangeSet &core_sets_,
-        const std::array<uint32_t, 2> &shard_shape_,
-        const std::array<uint32_t, 2> &physical_shard_shape_,
-        const ShardOrientation &shard_orientation_ = ShardOrientation::ROW_MAJOR) :
-        grid(core_sets_), shape(shard_shape_), orientation(shard_orientation_), mode(ShardMode::LOGICAL), physical_shard_shape(physical_shard_shape_) {
-        TT_FATAL(physical_shard_shape_[0] >= shard_shape_[0] and physical_shard_shape_[1] >= shard_shape_[1], "Physical shard shape ({}, {}) must be greater or equal to logical shard shape ({}, {})!", physical_shard_shape_[0], physical_shard_shape_[1], shard_shape_[0], shard_shape_[1]);
-    }
-
-    const uint32_t num_cores() const { return this->grid.num_cores(); }
-    const uint32_t numel() const { return this->shape[0] * this->shape[1]; }
-
-    bool operator==(const ShardSpec& other) const;
-    bool operator!=(const ShardSpec& other) const;
-
-    static constexpr auto attribute_names = std::forward_as_tuple("grid", "shape", "orientation", "mode", "physical_shard_shape");
-    constexpr auto attribute_values() const {
-        return std::forward_as_tuple(this->grid, this->shape, this->orientation, this->mode, this->physical_shard_shape);
-    }
-};
-
-std::ostream& operator<<(std::ostream& os, const ShardSpec& spec);
-
-struct ShardSpecBuffer {
-    ShardSpec tensor_shard_spec;
-    std::array<uint32_t, 2> page_shape;
-    std::array<uint32_t, 2> tensor2d_shape_in_pages;
-    ShardSpecBuffer(
-        const CoreRangeSet& core_sets_,
-        const std::array<uint32_t, 2>& shard_shape_,
-        const ShardOrientation& shard_orientation_,
-        const std::array<uint32_t, 2>& page_shape,
-        const std::array<uint32_t, 2>& tensor2d_shape_in_pages) :
-        tensor_shard_spec(core_sets_, shard_shape_, shard_orientation_) {
-        this->page_shape = page_shape;
-        this->tensor2d_shape_in_pages = tensor2d_shape_in_pages;
-    }
-    ShardSpecBuffer(
-        const ShardSpec& shard_spec,
-        const std::array<uint32_t, 2>& page_shape,
-        const std::array<uint32_t, 2>& tensor2d_shape_in_pages) :
-        tensor_shard_spec(shard_spec) {
-        this->page_shape = page_shape;
-        this->tensor2d_shape_in_pages = tensor2d_shape_in_pages;
-    }
-    CoreRangeSet grid() const { return tensor_shard_spec.grid; }
-    std::array<uint32_t, 2> shape() const { return tensor_shard_spec.shape; }
-    ShardOrientation orientation() const { return tensor_shard_spec.orientation; }
-    void set_shard_spec(const ShardSpec& shard_spec) { tensor_shard_spec = shard_spec; };
-
-    /* Shape in pages of the full shard */
-    std::array<uint32_t, 2> shape_in_pages() const;
-    DeviceAddr num_pages() const;
-};
-
-inline namespace v0 {
-
-struct BufferConfig {
-    IDevice *device;
-    DeviceAddr size;       // Size in bytes
-    DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
-    BufferType buffer_type;
-    TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED;
-};
-
-typedef BufferConfig InterleavedBufferConfig;
-
-// copied from above instead of using inheritance such that we can use
-// designator constructor
-struct ShardedBufferConfig {
-    IDevice *device;
-    DeviceAddr size;       // Size in bytes
-    DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
-    BufferType buffer_type = BufferType::L1;
-    TensorMemoryLayout buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED;
-    ShardSpecBuffer shard_parameters;
-};
-
-}  // namespace v0
-
-bool is_sharded(const TensorMemoryLayout &layout);
-
-struct BufferPageMapping {
-    std::vector<CoreCoord> all_cores_;
-    std::vector<uint32_t> core_bank_indices_;
-    std::vector<std::vector<uint32_t>> core_host_page_indices_;
-    std::vector<uint32_t> dev_page_to_core_mapping_;
-
-    // some dev pages don't have mapping to host (in case of padding)
-    std::vector<std::optional<uint32_t>> dev_page_to_host_page_mapping_;
-    std::vector<uint32_t> host_page_to_dev_page_mapping_;
-    std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
-    std::vector<uint32_t> host_page_to_local_shard_page_mapping_;
-    std::vector<std::array<uint32_t, 2>> core_shard_shape_;
-};
-
-inline namespace v0 {
-
-struct BufferRegion {
-    DeviceAddr offset = 0;
-    DeviceAddr size = 0;
-
-    BufferRegion() = delete;
-    BufferRegion(DeviceAddr offset, DeviceAddr size) : offset(offset), size(size) {}
-};
-
-class Buffer final {
-    struct Private { explicit Private() = default; };
-
-   public:
-    static std::shared_ptr<Buffer> create(
-        IDevice *device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
-        const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-    static std::shared_ptr<Buffer> create(
-        IDevice *device,
-        DeviceAddr address,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
-        const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-
-    Buffer(const Buffer &other) = delete;
-    Buffer &operator=(const Buffer &other) = delete;
-    Buffer(Buffer &&other) = delete;
-    Buffer &operator=(Buffer &&other) = delete;
-
-    IDevice* device() const { return device_; }
-    Allocator *allocator() const { return allocator_; }
-    DeviceAddr size() const { return size_; }
-    bool is_allocated() const;
+class Buffer {
+public:
+    Buffer() = default;
+    virtual ~Buffer() = default;
+    virtual IDevice* device() const = 0;
+    virtual Allocator* allocator() const = 0;
+    virtual DeviceAddr size() const = 0;
+    virtual bool is_allocated() const = 0;
 
     // Returns address of buffer in the first bank
-    uint32_t address() const;
+    virtual uint32_t address() const = 0;
 
-    DeviceAddr page_size() const;
-    void set_page_size(DeviceAddr page_size);
+    virtual DeviceAddr page_size() const = 0;
+    virtual void set_page_size(DeviceAddr page_size) = 0;
 
-    uint32_t num_pages() const;
-    uint32_t num_dev_pages() const;
+    virtual uint32_t num_pages() const = 0;
+    virtual uint32_t num_dev_pages() const = 0;
 
-    BufferType buffer_type() const { return buffer_type_; }
-    CoreType core_type() const;
+    virtual BufferType buffer_type() const = 0;
+    virtual CoreType core_type() const = 0;
 
-    bool is_l1() const;
-    bool is_dram() const;
-    bool is_trace() const;
+    virtual bool is_l1() const = 0;
+    virtual bool is_dram() const = 0;
+    virtual bool is_trace() const = 0;
 
-    bool is_valid_region(const BufferRegion& region) const;
-    bool is_valid_partial_region(const BufferRegion& region) const;
+    virtual bool is_valid_region(const BufferRegion& region) const = 0;
+    virtual bool is_valid_partial_region(const BufferRegion& region) const = 0;
 
-    TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
+    virtual TensorMemoryLayout buffer_layout() const = 0;
 
-    bool bottom_up() const { return bottom_up_; }
+    virtual bool bottom_up() const = 0;
 
-    uint32_t dram_channel_from_bank_id(uint32_t bank_id) const;
+    virtual uint32_t dram_channel_from_bank_id(uint32_t bank_id) const = 0;
 
-    CoreCoord logical_core_from_bank_id(uint32_t bank_id) const;
+    virtual CoreCoord logical_core_from_bank_id(uint32_t bank_id) const = 0;
 
-    DeviceAddr page_address(uint32_t bank_id, uint32_t page_index) const;
+    virtual DeviceAddr page_address(uint32_t bank_id, uint32_t page_index) const = 0;
 
-    DeviceAddr bank_local_page_address(uint32_t bank_id, uint32_t page_index) const;
-    uint32_t alignment() const;
-    DeviceAddr aligned_page_size() const;
-    DeviceAddr aligned_size() const;
-    DeviceAddr aligned_size_per_bank() const;
+    virtual DeviceAddr bank_local_page_address(uint32_t bank_id, uint32_t page_index) const = 0;
+    virtual uint32_t alignment() const = 0;
+    virtual DeviceAddr aligned_page_size() const = 0;
+    virtual DeviceAddr aligned_size() const = 0;
+    virtual DeviceAddr aligned_size_per_bank() const = 0;
 
     // SHARDED API STARTS HERE
     // TODO: WILL SEPARATE INTO SHARDED BUFFER CLASS
 
-    DeviceAddr sharded_page_address(uint32_t bank_id, uint32_t page_index) const;
+    virtual DeviceAddr sharded_page_address(uint32_t bank_id, uint32_t page_index) const = 0;
 
-    ShardSpecBuffer shard_spec() const;
-    void set_shard_spec(const ShardSpecBuffer& shard_spec);
+    virtual ShardSpecBuffer shard_spec() const = 0;
+    virtual void set_shard_spec(const ShardSpecBuffer& shard_spec) = 0;
 
-    std::optional<uint32_t> num_cores() const;
+    virtual std::optional<uint32_t> num_cores() const = 0;
 
-    const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
+    virtual const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping() = 0;
 
-    std::optional<SubDeviceId> sub_device_id() const { return sub_device_id_; }
-    std::optional<SubDeviceManagerId> sub_device_manager_id() const { return sub_device_manager_id_; }
+    virtual std::optional<SubDeviceId> sub_device_id() const = 0;
+    virtual std::optional<SubDeviceManagerId> sub_device_manager_id() const = 0;
 
-    size_t unique_id() const { return unique_id_; }
+    virtual size_t unique_id() const = 0;
 
-    Buffer(
-        IDevice* device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        TensorMemoryLayout buffer_layout,
-        const std::optional<ShardSpecBuffer>& shard_parameter,
-        std::optional<bool> bottom_up,
-        std::optional<SubDeviceId> sub_device_id,
-        bool owns_data,
-        Private);
-
-   private:
-    enum class AllocationStatus : uint8_t {
-        ALLOCATION_REQUESTED,
-        ALLOCATION_FAILED,
-        ALLOCATED,
-        DEALLOCATED,
-    };
-
-    void allocate_impl();
-
-    // Deallocate is allowed to be called multiple times on the same buffer
-    void deallocate();
-    static void deleter(Buffer* buffer);
-    void deallocate_impl();
-    friend void DeallocateBuffer(Buffer &buffer);
-
-    DeviceAddr translate_page_address(uint64_t offset, uint32_t bank_id) const;
-
-    IDevice* const device_;
-    const DeviceAddr size_; // Size in bytes
-    const BufferType buffer_type_;
-    const TensorMemoryLayout buffer_layout_;
-    const bool bottom_up_;
-    const std::optional<SubDeviceId> sub_device_id_;
-    const bool owns_data_;
-
-    std::optional<SubDeviceManagerId> sub_device_manager_id_;
-    Allocator * allocator_;
-
-    std::atomic<AllocationStatus> allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
-    DeviceAddr address_ = 0;
-    mutable std::mutex allocation_mutex_;
-    mutable std::condition_variable allocation_cv_;
-    // Used exclusively for is_allocated() method
-    std::atomic<bool> deallocation_requested_ = false;
-
-    // These members must be only accessed on the device worker thread
-    DeviceAddr page_size_; // Size of unit being interleaved. For non-interleaved buffers: size == page_size
-    std::optional<ShardSpecBuffer> shard_parameters_;
-    std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
-
-    std::weak_ptr<Buffer> weak_self;
-    size_t unique_id_ = 0;
-    static std::atomic<size_t> next_unique_id;
+    virtual void deallocate() = 0;
 };
-
-}  // namespace v0
-
-BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
-
-inline namespace v0 {
-
-using HostDataType = std::variant<
-    const std::shared_ptr<std::vector<uint8_t>>,
-    const std::shared_ptr<std::vector<uint16_t>>,
-    const std::shared_ptr<std::vector<int32_t>>,
-    const std::shared_ptr<std::vector<uint32_t>>,
-    const std::shared_ptr<std::vector<float>>,
-    const std::shared_ptr<std::vector<bfloat16>>,
-    const void *>;
-
 }  // namespace v0
 }  // namespace tt::tt_metal
-
-namespace tt::stl::json {
-template <>
-struct from_json_t<tt_metal::ShardSpec> {
-    tt_metal::ShardSpec operator()(const nlohmann::json &json_object) const;
-};
-}  // namespace tt::stl::json

--- a/tt_metal/api/tt-metalium/buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/buffer_config.hpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <nlohmann/json.hpp>
+
+#include "bfloat16.hpp"
+#include "core_coord.hpp"
+#include "buffer_constants.hpp"
+#include "hal.hpp"
+
+namespace tt::tt_metal {
+inline namespace v0 {
+
+class IDevice;
+
+}  // namespace v0
+
+class Allocator;
+
+bool is_sharded(const TensorMemoryLayout& layout);
+
+struct BufferPageMapping {
+    std::vector<CoreCoord> all_cores_;
+    std::vector<uint32_t> core_bank_indices_;
+    std::vector<std::vector<uint32_t>> core_host_page_indices_;
+    std::vector<uint32_t> dev_page_to_core_mapping_;
+
+    // some dev pages don't have mapping to host (in case of padding)
+    std::vector<std::optional<uint32_t>> dev_page_to_host_page_mapping_;
+    std::vector<uint32_t> host_page_to_dev_page_mapping_;
+    std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
+    std::vector<uint32_t> host_page_to_local_shard_page_mapping_;
+    std::vector<std::array<uint32_t, 2>> core_shard_shape_;
+};
+
+struct ShardSpec {
+    /* The individual cores the shard grid is mapped to */
+    CoreRangeSet grid;
+
+    /* Canonical tensor shape where the depth dimensions ([:-2] are folded along y) */
+    std::array<uint32_t, 2> shape;
+
+    /* The sequence order of the grid cores that the shards are layed out onto. */
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+
+    // In ShardMode::PHYSICAL, physical_shard_shape will always be std::nullopt
+    ShardMode mode = ShardMode::PHYSICAL;
+    std::optional<std::array<uint32_t, 2>> physical_shard_shape = std::nullopt;
+
+    ShardSpec(
+        const CoreRangeSet& core_sets_,
+        const std::array<uint32_t, 2>& shard_shape_,
+        const ShardOrientation& shard_orientation_ = ShardOrientation::ROW_MAJOR,
+        const ShardMode& shard_mode_ = ShardMode::PHYSICAL) :
+        grid(core_sets_),
+        shape(shard_shape_),
+        orientation(shard_orientation_),
+        mode(shard_mode_),
+        physical_shard_shape(std::nullopt) {}
+
+    ShardSpec(
+        const CoreRangeSet& core_sets_,
+        const std::array<uint32_t, 2>& shard_shape_,
+        const std::array<uint32_t, 2>& physical_shard_shape_,
+        const ShardOrientation& shard_orientation_ = ShardOrientation::ROW_MAJOR) :
+        grid(core_sets_),
+        shape(shard_shape_),
+        orientation(shard_orientation_),
+        mode(ShardMode::LOGICAL),
+        physical_shard_shape(physical_shard_shape_) {
+        TT_FATAL(
+            physical_shard_shape_[0] >= shard_shape_[0] and physical_shard_shape_[1] >= shard_shape_[1],
+            "Physical shard shape ({}, {}) must be greater or equal to logical shard shape ({}, {})!",
+            physical_shard_shape_[0],
+            physical_shard_shape_[1],
+            shard_shape_[0],
+            shard_shape_[1]);
+    }
+
+    const uint32_t num_cores() const { return this->grid.num_cores(); }
+    const uint32_t numel() const { return this->shape[0] * this->shape[1]; }
+
+    bool operator==(const ShardSpec& other) const;
+    bool operator!=(const ShardSpec& other) const;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("grid", "shape", "orientation", "mode", "physical_shard_shape");
+    constexpr auto attribute_values() const {
+        return std::forward_as_tuple(
+            this->grid, this->shape, this->orientation, this->mode, this->physical_shard_shape);
+    }
+};
+
+std::ostream& operator<<(std::ostream& os, const ShardSpec& spec);
+
+struct ShardSpecBuffer {
+    ShardSpec tensor_shard_spec;
+    std::array<uint32_t, 2> page_shape;
+    std::array<uint32_t, 2> tensor2d_shape_in_pages;
+    ShardSpecBuffer(
+        const CoreRangeSet& core_sets_,
+        const std::array<uint32_t, 2>& shard_shape_,
+        const ShardOrientation& shard_orientation_,
+        const std::array<uint32_t, 2>& page_shape,
+        const std::array<uint32_t, 2>& tensor2d_shape_in_pages) :
+        tensor_shard_spec(core_sets_, shard_shape_, shard_orientation_) {
+        this->page_shape = page_shape;
+        this->tensor2d_shape_in_pages = tensor2d_shape_in_pages;
+    }
+    ShardSpecBuffer(
+        const ShardSpec& shard_spec,
+        const std::array<uint32_t, 2>& page_shape,
+        const std::array<uint32_t, 2>& tensor2d_shape_in_pages) :
+        tensor_shard_spec(shard_spec) {
+        this->page_shape = page_shape;
+        this->tensor2d_shape_in_pages = tensor2d_shape_in_pages;
+    }
+    CoreRangeSet grid() const { return tensor_shard_spec.grid; }
+    std::array<uint32_t, 2> shape() const { return tensor_shard_spec.shape; }
+    ShardOrientation orientation() const { return tensor_shard_spec.orientation; }
+    void set_shard_spec(const ShardSpec& shard_spec) { tensor_shard_spec = shard_spec; };
+
+    /* Shape in pages of the full shard */
+    std::array<uint32_t, 2> shape_in_pages() const;
+    DeviceAddr num_pages() const;
+};
+
+inline namespace v0 {
+
+struct BufferConfig {
+    IDevice* device;
+    DeviceAddr size;       // Size in bytes
+    DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    BufferType buffer_type;
+    TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED;
+};
+
+typedef BufferConfig InterleavedBufferConfig;
+
+// copied from above instead of using inheritance such that we can use
+// designator constructor
+struct ShardedBufferConfig {
+    IDevice* device;
+    DeviceAddr size;       // Size in bytes
+    DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    BufferType buffer_type = BufferType::L1;
+    TensorMemoryLayout buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    ShardSpecBuffer shard_parameters;
+};
+
+struct BufferRegion {
+    DeviceAddr offset = 0;
+    DeviceAddr size = 0;
+
+    BufferRegion() = delete;
+    BufferRegion(DeviceAddr offset, DeviceAddr size) : offset(offset), size(size) {}
+};
+
+using HostDataType = std::variant<
+    const std::shared_ptr<std::vector<uint8_t>>,
+    const std::shared_ptr<std::vector<uint16_t>>,
+    const std::shared_ptr<std::vector<int32_t>>,
+    const std::shared_ptr<std::vector<uint32_t>>,
+    const std::shared_ptr<std::vector<float>>,
+    const std::shared_ptr<std::vector<bfloat16>>,
+    const void*>;
+
+}  // namespace v0
+
+}  // namespace tt::tt_metal
+
+namespace tt::stl::json {
+template <>
+struct from_json_t<tt_metal::ShardSpec> {
+    tt_metal::ShardSpec operator()(const nlohmann::json& json_object) const;
+};
+}  // namespace tt::stl::json

--- a/tt_metal/api/tt-metalium/single_buffer.hpp
+++ b/tt_metal/api/tt-metalium/single_buffer.hpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "buffer.hpp"
+
+namespace tt::tt_metal {
+
+inline namespace v0 {
+
+class SingleBuffer : public Buffer {
+    struct Private {
+        explicit Private() = default;
+    };
+
+public:
+    static std::shared_ptr<SingleBuffer> create(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
+        const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+    static std::shared_ptr<SingleBuffer> create(
+        IDevice* device,
+        DeviceAddr address,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
+        const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+
+    SingleBuffer(const SingleBuffer& other) = delete;
+    SingleBuffer& operator=(const SingleBuffer& other) = delete;
+    SingleBuffer(SingleBuffer&& other) = delete;
+    SingleBuffer& operator=(SingleBuffer&& other) = delete;
+
+    IDevice* device() const override { return device_; }
+    Allocator* allocator() const override { return allocator_; }
+    DeviceAddr size() const override { return size_; }
+    bool is_allocated() const override;
+
+    // Returns address of buffer in the first bank
+    uint32_t address() const override;
+
+    DeviceAddr page_size() const override;
+    void set_page_size(DeviceAddr page_size) override;
+
+    uint32_t num_pages() const override;
+    uint32_t num_dev_pages() const override;
+
+    BufferType buffer_type() const override { return buffer_type_; }
+    CoreType core_type() const override;
+
+    bool is_l1() const override;
+    bool is_dram() const override;
+    bool is_trace() const override;
+
+    bool is_valid_region(const BufferRegion& region) const override;
+    bool is_valid_partial_region(const BufferRegion& region) const override;
+
+    TensorMemoryLayout buffer_layout() const override { return buffer_layout_; }
+
+    bool bottom_up() const override { return bottom_up_; }
+
+    uint32_t dram_channel_from_bank_id(uint32_t bank_id) const override;
+
+    CoreCoord logical_core_from_bank_id(uint32_t bank_id) const override;
+
+    DeviceAddr page_address(uint32_t bank_id, uint32_t page_index) const override;
+
+    DeviceAddr bank_local_page_address(uint32_t bank_id, uint32_t page_index) const override;
+    uint32_t alignment() const override;
+    DeviceAddr aligned_page_size() const override;
+    DeviceAddr aligned_size() const override;
+    DeviceAddr aligned_size_per_bank() const override;
+
+    // SHARDED API STARTS HERE
+    // TODO: WILL SEPARATE INTO SHARDED BUFFER CLASS
+
+    DeviceAddr sharded_page_address(uint32_t bank_id, uint32_t page_index) const override;
+
+    ShardSpecBuffer shard_spec() const override;
+    void set_shard_spec(const ShardSpecBuffer& shard_spec) override;
+
+    std::optional<uint32_t> num_cores() const override;
+
+    const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping() override;
+
+    std::optional<SubDeviceId> sub_device_id() const override { return sub_device_id_; }
+    std::optional<SubDeviceManagerId> sub_device_manager_id() const override { return sub_device_manager_id_; }
+
+    size_t unique_id() const override { return unique_id_; }
+
+    // Deallocate is allowed to be called multiple times on the same buffer
+    void deallocate() override;
+
+    SingleBuffer(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        TensorMemoryLayout buffer_layout,
+        const std::optional<ShardSpecBuffer>& shard_parameter,
+        std::optional<bool> bottom_up,
+        std::optional<SubDeviceId> sub_device_id,
+        bool owns_data,
+        Private);
+
+private:
+    enum class AllocationStatus : uint8_t {
+        ALLOCATION_REQUESTED,
+        ALLOCATION_FAILED,
+        ALLOCATED,
+        DEALLOCATED,
+    };
+
+    void allocate_impl();
+
+    static void deleter(SingleBuffer* buffer);
+    void deallocate_impl();
+    friend void DeallocateBuffer(SingleBuffer& buffer);
+
+    DeviceAddr translate_page_address(uint64_t offset, uint32_t bank_id) const;
+
+    IDevice* const device_;
+    const DeviceAddr size_;  // Size in bytes
+    const BufferType buffer_type_;
+    const TensorMemoryLayout buffer_layout_;
+    const bool bottom_up_;
+    const std::optional<SubDeviceId> sub_device_id_;
+    const bool owns_data_;
+
+    std::optional<SubDeviceManagerId> sub_device_manager_id_;
+    Allocator* allocator_;
+
+    std::atomic<AllocationStatus> allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
+    DeviceAddr address_ = 0;
+    mutable std::mutex allocation_mutex_;
+    mutable std::condition_variable allocation_cv_;
+    // Used exclusively for is_allocated() method
+    std::atomic<bool> deallocation_requested_ = false;
+
+    // These members must be only accessed on the device worker thread
+    DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    std::optional<ShardSpecBuffer> shard_parameters_;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
+
+    std::weak_ptr<SingleBuffer> weak_self;
+    size_t unique_id_ = 0;
+    static std::atomic<size_t> next_unique_id;
+};
+
+}  // namespace v0
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -11,7 +11,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include "core_coord.hpp"
 #include "dispatch_core_manager.hpp"
-#include "buffer.hpp"
+#include "single_buffer.hpp"
 #include "profiler.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
     if (!address.has_value()) {
         // Rely on the MeshDevice allocator to provide the address for the entire mesh buffer.
         // The address provided to the backing buffer is used as the address for the MeshBuffer object.
-        std::shared_ptr<Buffer> backing_buffer = Buffer::create(
+        std::shared_ptr<Buffer> backing_buffer = SingleBuffer::create(
             mesh_device,
             device_local_size,
             device_local_config.page_size,
@@ -113,7 +113,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 
 void MeshBuffer::initialize_device_buffers() {
     auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
-        std::shared_ptr<Buffer> buffer = Buffer::create(
+        std::shared_ptr<Buffer> buffer = SingleBuffer::create(
             mesh_device_->get_device(coord),
             address_,
             device_local_size_,

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -245,8 +245,8 @@ void MeshCommandQueue::write_sharded_buffer(const MeshBuffer& buffer, const void
     auto num_shards_x = global_buffer_shape.width() / shard_shape.width();
     auto num_shards_y = global_buffer_shape.height() / shard_shape.height();
 
-    uint32_t num_devices_x = buffer.device()->num_cols();
-    uint32_t num_devices_y = buffer.device()->num_rows();
+    uint32_t num_devices_x = buffer.mesh_device()->num_cols();
+    uint32_t num_devices_y = buffer.mesh_device()->num_rows();
 
     uint32_t device_x = 0;
     uint32_t device_y = 0;
@@ -325,8 +325,8 @@ void MeshCommandQueue::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
     auto total_write_size_per_shard = single_write_size * shard_shape.height();
     auto num_shards_x = global_buffer_shape.width() / shard_shape.width();
     auto num_shards_y = global_buffer_shape.height() / shard_shape.height();
-    uint32_t num_devices_x = buffer.device()->num_cols();
-    uint32_t num_devices_y = buffer.device()->num_rows();
+    uint32_t num_devices_x = buffer.mesh_device()->num_cols();
+    uint32_t num_devices_y = buffer.mesh_device()->num_rows();
 
     uint32_t device_x = 0;
     uint32_t device_y = 0;
@@ -386,7 +386,8 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
 
 void MeshCommandQueue::enqueue_write_mesh_buffer(
     const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
-    LogicalDeviceRange mesh_device_extent({0, 0}, {buffer->device()->num_cols() - 1, buffer->device()->num_rows() - 1});
+    LogicalDeviceRange mesh_device_extent(
+        {0, 0}, {buffer->mesh_device()->num_cols() - 1, buffer->mesh_device()->num_rows() - 1});
     this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
 }
 
@@ -421,7 +422,7 @@ void MeshCommandQueue::enqueue_read_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    const auto [num_rows, num_cols] = buffer->device()->shape();
+    const auto [num_rows, num_cols] = buffer->mesh_device()->shape();
     for (const auto& shard_data_transfer : shard_data_transfers) {
         auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
         read_shard_from_device(

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -85,7 +85,7 @@ void MeshWorkload::load_binaries(MeshCommandQueue& mesh_cq) {
                 mesh_device->mesh_command_queue().enqueue_write_shard_to_sub_grid(
                     *kernel_bin_buf_view, program.get_program_transfer_info().binary_data.data(), device_range, false);
 
-                std::shared_ptr<Buffer> buffer_view = Buffer::create(
+                std::shared_ptr<Buffer> buffer_view = SingleBuffer::create(
                     mesh_device,
                     kernel_bin_buf_->address(),
                     kernel_bin_size,

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -5,6 +5,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer_types.cpp

--- a/tt_metal/impl/buffers/buffer_config.cpp
+++ b/tt_metal/impl/buffers/buffer_config.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <buffer_config.hpp>
+
+namespace tt::tt_metal {
+
+std::ostream& operator<<(std::ostream& os, const ShardSpec& spec) {
+    tt::stl::reflection::operator<<(os, spec);
+    return os;
+}
+
+bool is_sharded(const TensorMemoryLayout& layout) {
+    return (
+        layout == TensorMemoryLayout::HEIGHT_SHARDED || layout == TensorMemoryLayout::WIDTH_SHARDED ||
+        layout == TensorMemoryLayout::BLOCK_SHARDED);
+}
+
+bool ShardSpec::operator==(const ShardSpec&) const = default;
+bool ShardSpec::operator!=(const ShardSpec&) const = default;
+
+std::array<uint32_t, 2> ShardSpecBuffer::shape_in_pages() const {
+    auto height_in_pages = page_shape[0] == 0 ? 0 : tensor_shard_spec.shape[0] / page_shape[0];
+    auto width_in_pages = page_shape[1] == 0 ? 0 : tensor_shard_spec.shape[1] / page_shape[1];
+    return {height_in_pages, width_in_pages};
+}
+
+DeviceAddr ShardSpecBuffer::num_pages() const {
+    auto shape_in_pages_ = this->shape_in_pages();
+    return shape_in_pages_[0] * shape_in_pages_[1];
+}
+}  // namespace tt::tt_metal
+
+namespace tt::stl::json {
+tt_metal::ShardSpec from_json_t<tt_metal::ShardSpec>::operator()(const nlohmann::json& json_object) const {
+    const auto& shard_mode = from_json<tt_metal::ShardMode>(json_object.at("mode"));
+    const auto& physical_shard_shape =
+        from_json<std::optional<std::array<uint32_t, 2>>>(json_object.at("physical_shard_shape"));
+    if (physical_shard_shape.has_value()) {
+        TT_FATAL(
+            shard_mode == tt::tt_metal::ShardMode::LOGICAL,
+            "Physical shard shape can only be provided in logical sharding mode!");
+        return tt_metal::ShardSpec{
+            from_json<CoreRangeSet>(json_object.at("grid")),
+            from_json<std::array<uint32_t, 2>>(json_object.at("shape")),
+            physical_shard_shape.value(),
+            from_json<tt_metal::ShardOrientation>(json_object.at("orientation"))};
+    }
+    return tt_metal::ShardSpec{
+        from_json<CoreRangeSet>(json_object.at("grid")),
+        from_json<std::array<uint32_t, 2>>(json_object.at("shape")),
+        from_json<tt_metal::ShardOrientation>(json_object.at("orientation")),
+        shard_mode};
+}
+}  // namespace tt::stl::json

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -118,7 +118,7 @@ void CaptureCreateBuffer(const std::shared_ptr<Buffer>& buffer, const Interleave
 void CaptureDeallocateBuffer(Buffer& buffer) {
     auto& ctx = LightMetalCaptureContext::get();
 
-    // Kind of a workaround, but Program Binaries buffer is created via Buffer::create() but can be
+    // Kind of a workaround, but Program Binaries buffer is created via SingleBuffer::create() but can be
     // deallocated on Program destruction while capturing is still enabled depending on test structure (scope)
     // so let's just not capture these DeallocateBuffer() calls since they will occur on playback naturally.
     if (!ctx.is_in_map(&buffer)) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1300,7 +1300,14 @@ void detail::Program_::allocate_kernel_bin_buf_on_device(IDevice* device) {
     // We allocate program binaries top down to minimize fragmentation with other buffers in DRAM, which are typically allocated bottom up
     std::size_t binary_data_size_bytes = this->program_transfer_info.binary_data.size() * sizeof(uint32_t);
     if (this->kernels_buffer_.find(device->id()) == this->kernels_buffer_.end() and binary_data_size_bytes) {
-        std::shared_ptr<Buffer> kernel_bin_buf = Buffer::create(device, binary_data_size_bytes, HostMemDeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM, TensorMemoryLayout::INTERLEAVED, std::nullopt, false);
+        std::shared_ptr<Buffer> kernel_bin_buf = SingleBuffer::create(
+            device,
+            binary_data_size_bytes,
+            HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
+            BufferType::DRAM,
+            TensorMemoryLayout::INTERLEAVED,
+            std::nullopt,
+            false);
         this->kernels_buffer_[device->id()] = kernel_bin_buf;
     }
 }

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -94,7 +94,7 @@ void Trace::initialize_buffer(CommandQueue& cq, const std::shared_ptr<TraceBuffe
         trace_region_size);
     // Commit trace to device DRAM
     trace_buffer->buffer =
-        Buffer::create(cq.device(), padded_size, page_size, BufferType::TRACE, TensorMemoryLayout::INTERLEAVED);
+        SingleBuffer::create(cq.device(), padded_size, page_size, BufferType::TRACE, TensorMemoryLayout::INTERLEAVED);
     EnqueueWriteBuffer(cq, trace_buffer->buffer, trace_data, kBlocking);
     log_trace(
         LogMetalTrace,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1155,7 +1155,7 @@ GlobalSemaphore CreateGlobalSemaphore(
 
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-    auto buffer = Buffer::create(
+    auto buffer = SingleBuffer::create(
         config.device,
         config.size,
         config.page_size,
@@ -1169,7 +1169,7 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
     return buffer;
 }
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, DeviceAddr address) {
-    return Buffer::create(
+    return SingleBuffer::create(
         config.device,
         address,
         config.size,
@@ -1180,7 +1180,7 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, Devi
         std::nullopt);
 }
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, SubDeviceId sub_device_id) {
-    return Buffer::create(
+    return SingleBuffer::create(
         config.device,
         config.size,
         config.page_size,
@@ -1191,7 +1191,7 @@ std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config, SubD
         sub_device_id);
 }
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config) {
-    return Buffer::create(
+    return SingleBuffer::create(
         config.device,
         config.size,
         config.page_size,
@@ -1202,7 +1202,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config) {
         std::nullopt);
 }
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAddr address) {
-    return Buffer::create(
+    return SingleBuffer::create(
         config.device,
         address,
         config.size,
@@ -1214,7 +1214,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAd
         std::nullopt);
 }
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDeviceId sub_device_id) {
-    return Buffer::create(
+    return SingleBuffer::create(
         config.device,
         config.size,
         config.page_size,

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -26,7 +26,7 @@ MultiDeviceStorage::MultiDeviceStorage(
     // tensor spec.
     //
     // For now, this code ensures MeshBuffer backed tensors are compatible with the rest of the ops infra.
-    const auto [num_rows, num_cols] = mesh_buffer->device()->shape();
+    const auto [num_rows, num_cols] = mesh_buffer->mesh_device()->shape();
 
     ordered_device_ids.reserve(num_rows * num_cols);
     buffers.reserve(num_rows * num_cols);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -581,7 +581,7 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking) {
     TT_FATAL(tt::tt_metal::detail::InMainThread(), "to_host_mesh_tensor must be called from the main thread");
     const auto& storage = std::get<MultiDeviceStorage>(tensor.get_storage());
     const auto& mesh_buffer = storage.mesh_buffer;
-    ttnn::MeshDevice* device = mesh_buffer->device();
+    ttnn::MeshDevice* device = mesh_buffer->mesh_device();
     distributed::MeshCommandQueue& mesh_cq = device->mesh_command_queue();
     const auto [num_rows, num_cols] = device->shape();
     const auto num_buffers = storage.buffers.size();

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<Buffer> allocate_buffer_on_device(IDevice* device, const TensorS
     auto shard_spec_buffer = tensor_spec.compute_shard_spec_buffer();
     auto memory_config = tensor_spec.tensor_layout().get_memory_config();
 
-    return Buffer::create(
+    return SingleBuffer::create(
         device,
         buffer_size_bytes,
         page_size_bytes,


### PR DESCRIPTION
Preview of what a straight unification of Buffer/MeshBuffer might look like. End result is a new virtual Buffer class, with SingleBuffer (representing the existing version) and MeshBuffer sub-classes.

There's a whole bunch of public members present in Buffer that aren't currently present in MeshBuffer, need to discuss if these are something that we plan to add (see tracking spreadsheet).
