### PR TITLE
#17139: Fixed tranpose in llk_unpack_untilize_init

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -42,6 +42,8 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
     const std::uint32_t face_r_dim = 1;
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
+
     // Save state of unpacker config for quick restore
     TTI_RDCFG(
         p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -42,6 +42,7 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
     const std::uint32_t face_r_dim = 1;
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
+    // Disable transpose when unused
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
     // Save state of unpacker config for quick restore

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -42,6 +42,8 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
     const std::uint32_t face_r_dim = 1;
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
+
     // Save state of unpacker config for quick restore
     TTI_RDCFG(
         p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -42,6 +42,7 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
     const std::uint32_t face_r_dim = 1;
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
+    // Disable transpose when unused
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
 
     // Save state of unpacker config for quick restore

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -30,9 +30,6 @@ ALWI void transpose_with_untilize(uint32_t cb_tilize, uint32_t cb_untilize, uint
         cb_push_back(cb_untilize, Ht);
 
         // tilize
-        // need to add this hw config here, otherwise pcc is bad
-        UNPACK((llk_unpack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE>(cb_untilize)));
-        MATH((llk_math_hw_configure_disaggregated(cb_untilize, cb_untilize)));
         untilize_init_short(cb_untilize);
         cb_wait_front(cb_untilize, Ht);
         cb_reserve_back(cb_out, Ht);


### PR DESCRIPTION
### Ticket
#17139 

### Problem description
llk_unpack_untilize_init did not reset the transpose configuration, which created issues during kernel fusion where previous op used transposed data. 

### What's changed
Reset transpose configuration to 0 in both WH_B0 and BH. 
Removed the previous workaround which was slow.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [Link to Action](https://github.com/tenstorrent/tt-metal/actions/runs/13459409294)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) [Link to Action](https://github.com/tenstorrent/tt-metal/actions/runs/13459412316)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
