### PR TITLE
#0: Suppress device init warnings after the first to avoid spam

### DIFF
--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -270,6 +270,8 @@ private:
     program_cache::detail::ProgramCache program_cache_;
 
     uint32_t trace_buffers_size_ = 0;
+    bool uninitialized_error_fired_ =
+        false;  // To avoid spam with warnings about calling Device methods when it's not initialized.
 };
 
 }  // namespace v0

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -961,7 +961,10 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
 
 void Device::push_work(std::function<void()> work, bool blocking) {
     if (not this->initialized_) {
-        log_warning("Attempting to push work to Device {} which is not initialized. Ignoring...", this->id_);
+        if (!uninitialized_error_fired_) {
+            log_fatal("Attempting to push work to Device {} which is not initialized. Ignoring...", this->id_);
+            uninitialized_error_fired_ = true;
+        }
         return;
     }
     this->work_executor_.push_work(std::move(work), blocking);


### PR DESCRIPTION
Devs are getting spammed with this warning message on T3K/TG when something goes wrong and work is still getting pushed, making debugging hard. Change to a fatal log to highlight the error, but make it only print once per device.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/13463586490
