### PR TITLE
Remove autoformat argument from get_workers_for_op_output

### DIFF
--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -571,9 +571,7 @@ void validate_workers_and_storage(
 }
 
 std::vector<IDevice*> get_workers_for_op_output(
-    const std::vector<Tensor>& inputs,
-    const std::vector<std::optional<const Tensor>>& optional_inputs,
-    bool enable_autoformat_device) {
+    const std::vector<Tensor>& inputs, const std::vector<std::optional<const Tensor>>& optional_inputs) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     std::vector<IDevice*> workers_for_op = {};
     // Infer output workers from inputs. For multi-device tensors the number
@@ -598,18 +596,6 @@ std::vector<IDevice*> get_workers_for_op_output(
                     workers_for_op = workers;
                 }
             }
-        }
-    }
-    if (enable_autoformat_device) {
-        validate_workers_and_storage(inputs, optional_inputs, workers_for_op);
-        // Workers not specified - inputs are on host and not multi-device.
-        // Use the default device from autoformat.
-        if (not workers_for_op.size()) {
-            TT_FATAL(
-                AutoFormat::GetDefaultDevice(),
-                "Default device must be specified using AutoFormat::SetDefaultDevice, if workers are not specified for "
-                "inputs to op.");
-            workers_for_op = {AutoFormat::GetDefaultDevice()};
         }
     }
     return workers_for_op;

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -157,9 +157,7 @@ void launch_with_autoformat(
     const OptionalTensors& optional_output_tensors = {});
 
 std::vector<IDevice*> get_workers_for_op_output(
-    const std::vector<Tensor>& inputs,
-    const std::vector<std::optional<const Tensor>>& optional_inputs = {},
-    bool enable_autoformat_device = true);
+    const std::vector<Tensor>& inputs, const std::vector<std::optional<const Tensor>>& optional_inputs = {});
 
 namespace detail {
 IDevice* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors = {});


### PR DESCRIPTION
### Ticket

### Problem description
We're trying to simplify and remove autoformat

### What's changed
Removed enable_autoformat_device from get_workers_for_op_output in run_operation

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13446219871)
- [x] New/Existing tests provide coverage for changes
