### PR TITLE
#0: Add low latency mode to EDM

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -18,8 +18,8 @@ static constexpr bool enable_any_synchronization = enable_start_synchronization 
 
 FORCE_INLINE void line_sync(
     FabricConnectionManager& fabric_connection,
-    volatile tt::fabric::PacketHeader* mcast_fwd_packet_header,
-    volatile tt::fabric::PacketHeader* mcast_bwd_packet_header,
+    volatile PACKET_HEADER_TYPE* mcast_fwd_packet_header,
+    volatile PACKET_HEADER_TYPE* mcast_bwd_packet_header,
     size_t sync_bank_addr,
     size_t sync_noc_x,
     size_t sync_noc_y,
@@ -33,7 +33,7 @@ FORCE_INLINE void line_sync(
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
         print_pkt_header(mcast_fwd_packet_header);
         fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
-            (uint32_t)mcast_fwd_packet_header, sizeof(tt::fabric::PacketHeader));
+            (uint32_t)mcast_fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
     }
 
     if (fabric_connection.has_backward_connection()) {
@@ -41,7 +41,7 @@ FORCE_INLINE void line_sync(
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         print_pkt_header(mcast_bwd_packet_header);
         fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
-            (uint32_t)mcast_bwd_packet_header, sizeof(tt::fabric::PacketHeader));
+            (uint32_t)mcast_bwd_packet_header, sizeof(PACKET_HEADER_TYPE));
     }
     noc_semaphore_inc(get_noc_addr(sync_noc_x, sync_noc_y, sync_bank_addr), 1);
     if (sync_noc_x == my_x[0] && sync_noc_y == my_y[0]) {
@@ -98,11 +98,11 @@ void kernel_main() {
     const auto source_l1_buffer_address = get_write_ptr(source_l1_cb_index);
     const auto packet_header_buffer_address = get_write_ptr(packet_header_cb);
 
-    auto* mcast_fwd_packet_header = reinterpret_cast<PacketHeader*>(packet_header_buffer_address);
+    auto* mcast_fwd_packet_header = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address);
     auto* mcast_bwd_packet_header =
-        reinterpret_cast<PacketHeader*>(packet_header_buffer_address + sizeof(tt::fabric::PacketHeader));
+        reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
     auto* unicast_packet_header =
-        reinterpret_cast<PacketHeader*>(packet_header_buffer_address + sizeof(tt::fabric::PacketHeader) * 2);
+        reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE) * 2);
     mcast_fwd_packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_fwd_hops)});
     mcast_bwd_packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_bwd_hops)});
 
@@ -146,7 +146,7 @@ void kernel_main() {
                 fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
                     source_l1_buffer_address, packet_payload_size_bytes);
                 fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
-                    (uint32_t)mcast_fwd_packet_header, sizeof(tt::fabric::PacketHeader));
+                    (uint32_t)mcast_fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
             }
 
             if (fabric_connection.has_backward_connection()) {
@@ -157,7 +157,7 @@ void kernel_main() {
                 fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
                     source_l1_buffer_address, packet_payload_size_bytes);
                 fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
-                    (uint32_t)mcast_bwd_packet_header, sizeof(tt::fabric::PacketHeader));
+                    (uint32_t)mcast_bwd_packet_header, sizeof(PACKET_HEADER_TYPE));
             }
             {
                 noc_async_writes_flushed();
@@ -174,8 +174,7 @@ void kernel_main() {
         fabric_conn.wait_for_empty_write_slot();
         fabric_conn.send_payload_without_header_non_blocking_from_address(
             source_l1_buffer_address, packet_payload_size_bytes);
-        fabric_conn.send_payload_blocking_from_address(
-            (uint32_t)unicast_packet_header, sizeof(tt::fabric::PacketHeader));
+        fabric_conn.send_payload_blocking_from_address((uint32_t)unicast_packet_header, sizeof(PACKET_HEADER_TYPE));
     }
 
     if (enable_finish_synchronization) {

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_reader.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_reader.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
         uint32_t pages_to_read = std::min<uint32_t>(pages_per_edm_buffer, num_pages_to_read_total - num_pages_read);
         cb_reserve_back(cb_id_in0, pages_to_read);
         uint32_t local_l1_read_addr = get_write_ptr(cb_id_in0);
-        local_l1_read_addr += sizeof(tt::fabric::PacketHeader);
+        local_l1_read_addr += sizeof(PACKET_HEADER_TYPE);
 
         for (uint32_t p = 0; p < pages_to_read; ++p) {
             uint64_t src_noc_addr = get_noc_addr(num_pages_read + p, source_address_generator);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_erisc_datamover_sender_worker_sender.cpp
@@ -122,9 +122,9 @@ void kernel_main() {
 
         // bit of a hack to extract X/Y
         const auto dest_noc_address = get_noc_addr(p, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
-        const size_t packet_size = page_size + sizeof(tt::fabric::PacketHeader);
+        const size_t packet_size = page_size + sizeof(PACKET_HEADER_TYPE);
         auto packet_addr = get_read_ptr(cb_id_in0);
-        auto* packet_header = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_addr);
+        auto* packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_addr);
         if constexpr (mcast_mode) {
             packet_header
                 ->to_chip_multicast(
@@ -145,7 +145,7 @@ void kernel_main() {
     if constexpr (!mcast_mode) {
         sender.wait_for_empty_write_slot();
 
-        auto& packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(a_packet_header_addr);
+        auto& packet_header = *reinterpret_cast<PACKET_HEADER_TYPE*>(a_packet_header_addr);
         ASSERT(*last_message_semaphore_address == 0);
         uint64_t last_message_semaphore_noc0_addr =
             safe_get_noc_addr(my_x[0], my_y[0], (uint32_t)last_message_semaphore_address, 0);

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/fabric_worker_sender_multi_input.cpp
@@ -52,10 +52,10 @@ auto forward_to_fabric_from_cb(
 
     // bit of a hack to extract X/Y
     const auto noc0_dest_address = get_noc_addr(current_page, dest_addr_gen, 0, NORMALIZED_NOC_INDEX);
-    const size_t packet_size = page_size + sizeof(tt::fabric::PacketHeader);
+    const size_t packet_size = page_size + sizeof(PACKET_HEADER_TYPE);
 
     auto packet_addr = get_read_ptr(cb_id);
-    auto &packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(packet_addr);
+    auto& packet_header = *reinterpret_cast<PACKET_HEADER_TYPE*>(packet_addr);
     if constexpr (mcast_mode) {
         packet_header
             .to_chip_multicast(tt::fabric::MulticastRoutingCommandHeader{config.mcast.distance, config.mcast.range})
@@ -182,7 +182,7 @@ void kernel_main() {
     sender.wait_for_empty_write_slot();
 
     constexpr size_t kLoopbackNumHopsToMyChip = 2;
-    auto &packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(a_packet_header_addr);
+    auto& packet_header = *reinterpret_cast<PACKET_HEADER_TYPE*>(a_packet_header_addr);
     ASSERT(*last_message_semaphore_address == 0);
     packet_header.reserved = 0xE;
     packet_header.reserved2 = 0xFFFF;

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/test_kernels.common.hpp
@@ -29,13 +29,14 @@ bool terminate_fabric_endpoints_farthest_to_nearest (
                 get_noc_addr(edm_noc_x, edm_noc_y, termination_addr),
                 tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE);
         } else {
-            auto &packet_header = *reinterpret_cast<tt::fabric::PacketHeader*>(a_packet_header_addr);
-            reinterpret_cast<volatile uint32_t*>(a_packet_header_addr)[sizeof(tt::fabric::PacketHeader) >> 2] = tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE;
+            auto& packet_header = *reinterpret_cast<PACKET_HEADER_TYPE*>(a_packet_header_addr);
+            reinterpret_cast<volatile uint32_t*>(a_packet_header_addr)[sizeof(PACKET_HEADER_TYPE) >> 2] =
+                tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE;
             sender.wait_for_empty_write_slot();
             packet_header.to_chip_unicast(static_cast<uint8_t>(distance))
                 .to_noc_unicast_write(
                     tt::fabric::NocUnicastCommandHeader{termination_sig_noc_addr},
-                    sizeof(tt::fabric::PacketHeader) + sizeof(uint32_t));
+                    sizeof(PACKET_HEADER_TYPE) + sizeof(uint32_t));
             sender.send_payload_blocking_from_address(a_packet_header_addr, packet_header.get_payload_size_including_header());
             noc_async_writes_flushed();
         }

--- a/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/kernel_writers.hpp
@@ -28,7 +28,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     uint32_t payload_size_bytes) {
     const size_t payload_l1_address = l1_read_addr;
 
-    auto pkt_hdr = reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr);
+    auto pkt_hdr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
 #ifdef DEBUG_PRINT_ENABLED
     pkt_hdr->reserved2 = my_chip_id;
 #endif
@@ -44,7 +44,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
             pkt_hdr->to_chip_unicast(unicast_args.distance_in_hops);
             fabric_conn.wait_for_empty_write_slot();
             fabric_conn.send_payload_without_header_non_blocking_from_address(l1_read_addr, payload_size_bytes);
-            fabric_conn.send_payload_flush_blocking_from_address((uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+            fabric_conn.send_payload_flush_blocking_from_address((uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
         } break;
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_MULTICAST: {
             noc_async_write(
@@ -57,7 +57,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
                 fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
                     l1_read_addr, payload_size_bytes);
                 fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-                    (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+                    (uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
             }
 
             if (fabric_connection.has_backward_connection()) {
@@ -67,7 +67,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
                 fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
                     l1_read_addr, payload_size_bytes);
                 fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
-                    (uint32_t)pkt_hdr, sizeof(tt::fabric::PacketHeader));
+                    (uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
             }
         } break;
         default: {
@@ -87,8 +87,8 @@ FORCE_INLINE void write_payload_then_advance_read_address(
     size_t& l1_read_addr,
     size_t payload_size_bytes) {
     static_assert(
-        ((sizeof(tt::fabric::PacketHeader) - 1) & sizeof(tt::fabric::PacketHeader)) == 0,
-        "sizeof(sizeof(tt::fabric::PacketHeader)) is not a power of two which violates the below assertion");
+        is_power_of_2(sizeof(PACKET_HEADER_TYPE)),
+        "sizeof(tt::fabric::PacketHeader) is not a power of two which violates the below assertion");
 
     switch (current_cmd_header.dest_type) {
         case ttnn::ccl::cmd::CclCommandDestType::CHIP_UNICAST: [[fallthrough]];

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader.cpp
@@ -162,7 +162,7 @@ void kernel_main() {
             for (uint32_t p = 0; p < command_tensor.worker_pages_per_slice; p += packet_size_in_pages) {
                 cb_reserve_back(cb_id, packet_size_in_pages);
                 const uint32_t local_l1_scratch_buffer_address =
-                    get_write_ptr(cb_id) + sizeof(tt::fabric::PacketHeader);
+                    get_write_ptr(cb_id) + sizeof(PACKET_HEADER_TYPE);
 
                 uint32_t n_pages = std::min(packet_size_in_pages, command_tensor.worker_pages_per_slice - p);
                 ASSERT(command_tensor.worker_start_offset_in_slice.w == 0);

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_writer.cpp
@@ -125,7 +125,7 @@ void kernel_main() {
     //    out when we start enabling other modes
     const size_t packet_size_in_pages = get_arg_val<uint32_t>(arg_idx++);
     const size_t payload_page_size = get_arg_val<uint32_t>(arg_idx++);
-    const size_t l1_scratch_page_size = payload_page_size + sizeof(tt::fabric::PacketHeader);
+    const size_t l1_scratch_page_size = payload_page_size + sizeof(PACKET_HEADER_TYPE);
     const size_t forward_direction_num_hops = get_arg_val<uint32_t>(arg_idx++);
     const size_t backward_direction_num_hops = get_arg_val<uint32_t>(arg_idx++);
     const bool has_forward_fabric_connection = get_arg_val<uint32_t>(arg_idx++) != 0;
@@ -248,7 +248,7 @@ void kernel_main() {
         DPRINT << "ccl_send_writer Sending payload completion sync signals\n";
         ASSERT(some_buffering_addr != 0);
         some_buffering_addr =
-            (some_buffering_addr + (sizeof(tt::fabric::PacketHeader))) & ~(sizeof(tt::fabric::PacketHeader) - 1);
+            (some_buffering_addr + (sizeof(PACKET_HEADER_TYPE))) & ~(sizeof(PACKET_HEADER_TYPE) - 1);
 
         mcast_sync_signal_to_addr(
             some_buffering_addr,

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -326,7 +326,7 @@ private:
     FORCE_INLINE void send_packet_header_and_notify_fabric(uint32_t source_address) {
         uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
 
-        send_chunk_from_address<blocking_mode>(source_address, 1, sizeof(tt::fabric::PacketHeader), buffer_address);
+        send_chunk_from_address<blocking_mode>(source_address, 1, sizeof(PACKET_HEADER_TYPE), buffer_address);
         post_send_payload_increment_pointers();
     }
 
@@ -335,23 +335,23 @@ private:
         uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
 
         // skip past the first part of the buffer which will be occupied by the packet header
-        send_chunk_from_address<blocking_mode>(source_address, 1, size_bytes, buffer_address + sizeof(tt::fabric::PacketHeader));
+        send_chunk_from_address<blocking_mode>(source_address, 1, size_bytes, buffer_address + sizeof(PACKET_HEADER_TYPE));
     }
     template <ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_from_address_impl(uint32_t source_address, size_t size_bytes) {
         uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
 
         ASSERT(size_bytes <= this->buffer_size_bytes);
-        ASSERT(tt::fabric::is_valid(*const_cast<tt::fabric::PacketHeader*>(
-            reinterpret_cast<volatile tt::fabric::PacketHeader*>(source_address))));
+        ASSERT(tt::fabric::is_valid(*const_cast<PACKET_HEADER_TYPE*>(
+            reinterpret_cast<volatile PACKET_HEADER_TYPE*>(source_address))));
         send_chunk_from_address<blocking_mode>(source_address, 1, size_bytes, buffer_address);
         post_send_payload_increment_pointers();
     }
     template <ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_from_address_with_trid_impl(uint32_t source_address, size_t size_bytes, uint8_t trid) {
         ASSERT(size_bytes <= this->buffer_size_bytes);
-        ASSERT(tt::fabric::is_valid(*const_cast<tt::fabric::PacketHeader*>(
-            reinterpret_cast<volatile tt::fabric::PacketHeader*>(source_address))));
+        ASSERT(tt::fabric::is_valid(*const_cast<PACKET_HEADER_TYPE*>(
+            reinterpret_cast<volatile PACKET_HEADER_TYPE*>(source_address))));
         send_chunk_from_address_with_trid<blocking_mode>(source_address, 1, size_bytes, this->edm_buffer_addr, trid, this->edm_noc_cmd_buf);
         post_send_payload_increment_pointers();
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
@@ -104,23 +104,147 @@ union NocCommandFields{
 static_assert(sizeof(NocCommandFields) <= 16, "CommandFields size is not 16 bytes");
 
 // TODO: wrap this in a debug version that holds type info so we can assert for field/command/
-struct PacketHeader {
+template <typename Derived>
+struct PacketHeaderBase {
+    NocCommandFields command_fields; // size = 16B due to uint64_t alignment
+    uint16_t payload_size_bytes;
     // TODO: trim this down noc_send_type 2 bits (4 values):
     //   -> unicast_write, mcast_write, unicast_seminc, mcast_seminc
     // For now, kept it separate so I could do reads which would be handled differently
     // but for our purposes we shouldn't need read so we should be able to omit the support
     NocSendType noc_send_type : 3;
+    // ChipSendType only used by PacketHeader, but keep here for now for bit-fields
     ChipSendType chip_send_type : 1;
-
     // Used only by the EDM sender and receiver channels. Populated by EDM sender channel to
     // indicate to the receiver channel what channel was the source of this packet. Reserved
     // otherwise.
     uint8_t src_ch_id : 4;
 
-    RoutingFields routing_fields;
-    uint16_t payload_size_bytes; // excludes header size
-    NocCommandFields command_fields; // size = 16B due to uint64_t alignment
+    // Returns size of payload in bytes - TODO: convert to words (4B)
+    size_t get_payload_size_excluding_header() volatile const {
+        return this->payload_size_bytes;
+    }
 
+    inline size_t get_payload_size_including_header() volatile const {
+        return get_payload_size_excluding_header() + sizeof(Derived);
+    }
+
+    // Setters for noc_send_type, routing_fields, and command_fields
+    inline void set_noc_send_type(NocSendType &type) { this->noc_send_type = type; }
+    inline void set_command_fields(NocCommandFields &fields) { this->command_fields = fields; }
+
+    inline Derived &to_chip_unicast(uint8_t distance_in_hops) {
+        static_cast<Derived*>(this)->to_chip_unicast_impl(distance_in_hops);
+        return *static_cast<Derived*>(this);
+    }
+
+    inline Derived &to_chip_multicast(MulticastRoutingCommandHeader const &mcast_routing_command_header) {
+        static_cast<Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
+        return *static_cast<Derived*>(this);
+    }
+
+    inline Derived &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) {
+        this->noc_send_type = NOC_UNICAST_WRITE;
+        this->command_fields.unicast_write = noc_unicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
+        return *static_cast<Derived*>(this);
+    }
+
+    inline Derived &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write = noc_unicast_command_header;
+        this->payload_size_bytes = 0;
+        return *static_cast<Derived*>(this);
+    }
+
+    inline Derived &to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
+        this->noc_send_type = NOC_MULTICAST_WRITE;
+        this->command_fields.mcast_write = noc_multicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
+        return *static_cast<Derived*>(this);
+    }
+
+    inline Derived &to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) {
+        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
+        this->command_fields.unicast_seminc = noc_unicast_atomic_inc_command_header;
+        this->payload_size_bytes = 0;
+        return *static_cast<Derived*>(this);
+    }
+
+    inline Derived &to_noc_multicast_atomic_inc(
+        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) {
+        this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
+        this->command_fields.mcast_seminc = noc_multicast_atomic_inc_command_header;
+        this->payload_size_bytes = payload_size_bytes;
+        return *static_cast<Derived*>(this);
+    }
+
+    inline volatile Derived* to_chip_unicast(uint8_t distance_in_hops) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_unicast_impl(distance_in_hops);
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline volatile Derived* to_chip_multicast(MulticastRoutingCommandHeader const &mcast_routing_command_header) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline volatile Derived* to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) volatile {
+        this->noc_send_type = NOC_UNICAST_WRITE;
+        this->command_fields.unicast_write.noc_address = noc_unicast_command_header.noc_address;
+        this->payload_size_bytes = payload_size_bytes;
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline volatile Derived* to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) volatile {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write.noc_address = noc_unicast_command_header.noc_address;
+        this->command_fields.unicast_inline_write.value = noc_unicast_command_header.value;
+        this->payload_size_bytes = 0;
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline volatile Derived* to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) volatile {
+        this->noc_send_type = NOC_MULTICAST_WRITE;
+        this->command_fields.mcast_write.mcast_rect_size_x = noc_multicast_command_header.mcast_rect_size_x;
+        this->command_fields.mcast_write.mcast_rect_size_y = noc_multicast_command_header.mcast_rect_size_y;
+        this->command_fields.mcast_write.noc_x_start = noc_multicast_command_header.noc_x_start;
+        this->command_fields.mcast_write.noc_y_start = noc_multicast_command_header.noc_y_start;
+        this->payload_size_bytes = payload_size_bytes;
+        this->command_fields.mcast_write.address = noc_multicast_command_header.address;
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline volatile Derived* to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) volatile {
+        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
+        this->command_fields.unicast_seminc.noc_address = noc_unicast_atomic_inc_command_header.noc_address;
+        this->command_fields.unicast_seminc.val = noc_unicast_atomic_inc_command_header.val;
+        this->command_fields.unicast_seminc.wrap = noc_unicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = 0;
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline volatile Derived *to_noc_multicast_atomic_inc(
+        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) volatile {
+        this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
+        this->command_fields.mcast_seminc.address = noc_multicast_atomic_inc_command_header.address;
+        this->command_fields.mcast_seminc.noc_x_start = noc_multicast_atomic_inc_command_header.noc_x_start;
+        this->command_fields.mcast_seminc.noc_y_start = noc_multicast_atomic_inc_command_header.noc_y_start;
+        this->command_fields.mcast_seminc.size_x = noc_multicast_atomic_inc_command_header.size_x;
+        this->command_fields.mcast_seminc.size_y = noc_multicast_atomic_inc_command_header.size_y;
+        this->command_fields.mcast_seminc.val = noc_multicast_atomic_inc_command_header.val;
+        this->command_fields.mcast_seminc.wrap = noc_multicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = payload_size_bytes;
+        return static_cast<volatile Derived*>(this);
+    }
+
+    inline void set_src_ch_id(uint8_t ch_id) volatile {
+        this->src_ch_id = ch_id;
+    }
+};
+
+struct PacketHeader : public PacketHeaderBase<PacketHeader> {
+    RoutingFields routing_fields;
     // Sort of hack to work-around DRAM read alignment issues that must be 32B aligned
     // To simplify worker kernel code, we for now decide to pad up the packet header
     // to 32B so the user can simplify shift into their CB chunk by sizeof(tt::fabric::PacketHeader)
@@ -132,123 +256,40 @@ struct PacketHeader {
     uint32_t padding0;
     uint32_t padding1;
 
+    private:
+
+    inline static uint32_t calculate_chip_unicast_routing_fields_value(uint8_t distance_in_hops) {
+        return RoutingFields::LAST_CHIP_IN_MCAST_VAL | distance_in_hops;
+    }
+    inline static uint32_t calculate_chip_multicast_routing_fields_value(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
+        return ((static_cast<uint8_t>(chip_multicast_command_header.range_hops) << RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH)) | static_cast<uint8_t>(chip_multicast_command_header.start_distance_in_hops);
+    }
+
+    public:
+
+    // Setters for PacketHeader-specific fields
     inline void set_chip_send_type(ChipSendType &type) { this->chip_send_type = type; }
-    inline void set_noc_send_type(NocSendType &type) { this->noc_send_type = type; }
+
     inline void set_routing_fields(RoutingFields &fields) { this->routing_fields = fields; }
-    inline void set_command_fields(NocCommandFields &fields) { this->command_fields = fields; }
 
-    // Returns size of payload in bytes - TODO: convert to words (4B)
-    size_t get_payload_size_excluding_header() volatile const {
-        return this->payload_size_bytes;
-    }
-    inline size_t get_payload_size_including_header() volatile const {
-        return get_payload_size_excluding_header() + sizeof(PacketHeader);
-    }
-
-    inline PacketHeader &to_chip_unicast(uint8_t distance_in_hops) {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) {
         this->chip_send_type = CHIP_UNICAST;
-        this->routing_fields.value = RoutingFields::LAST_CHIP_IN_MCAST_VAL | distance_in_hops;
-        return *this;
+        this->routing_fields.value = PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline PacketHeader &to_chip_multicast(MulticastRoutingCommandHeader const &chip_multicast_command_header) {
+    inline void to_chip_multicast_impl(MulticastRoutingCommandHeader const &chip_multicast_command_header) {
         this->chip_send_type = CHIP_MULTICAST;
-        this->routing_fields.value = ((static_cast<uint8_t>(chip_multicast_command_header.range_hops) << RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH)) | static_cast<uint8_t>(chip_multicast_command_header.start_distance_in_hops);
-        return *this;
+        this->routing_fields.value = PacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
 
-    inline PacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) {
-        this->noc_send_type = NOC_UNICAST_WRITE;
-        this->command_fields.unicast_write = noc_unicast_command_header;
-        this->payload_size_bytes = payload_size_bytes;
-        return *this;
-    }
-    inline PacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) {
-        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
-        this->command_fields.unicast_inline_write = noc_unicast_command_header;
-        this->payload_size_bytes = 0;
-        return *this;
-    }
-    inline PacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
-        this->noc_send_type = NOC_MULTICAST_WRITE;
-        this->command_fields.mcast_write = noc_multicast_command_header;
-        this->payload_size_bytes = payload_size_bytes;
-        return *this;
-    }
-    inline PacketHeader &to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) {
-        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
-        this->command_fields.unicast_seminc = noc_unicast_atomic_inc_command_header;
-        this->payload_size_bytes = 0;
-        return *this;
-    }
-    inline PacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
-        #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-        ASSERT(false);
-        while (1) {};
-        #endif
-        this->payload_size_bytes = payload_size_bytes;
-        return *this;
-    }
-
-    inline volatile PacketHeader *to_chip_unicast(uint8_t distance_in_hops) volatile {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
         this->chip_send_type = CHIP_UNICAST;
-        this->routing_fields.value = RoutingFields::LAST_CHIP_IN_MCAST_VAL | distance_in_hops;
-        return this;
+        this->routing_fields.value = PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline volatile PacketHeader *to_chip_multicast(MulticastRoutingCommandHeader const &chip_multicast_command_header) volatile {
+    inline void to_chip_multicast_impl(MulticastRoutingCommandHeader const &chip_multicast_command_header) volatile{
         this->chip_send_type = CHIP_MULTICAST;
-        this->routing_fields.value = (static_cast<uint8_t>(chip_multicast_command_header.range_hops) << RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH) | chip_multicast_command_header.start_distance_in_hops;
-        return this;
+        this->routing_fields.value = PacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
-    inline volatile PacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) volatile {
-        this->noc_send_type = NOC_UNICAST_WRITE;
-        this->command_fields.unicast_write.noc_address = noc_unicast_command_header.noc_address;
-        this->payload_size_bytes = payload_size_bytes;
-
-        return this;
-    }
-    inline volatile PacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) volatile {
-        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
-        this->command_fields.unicast_inline_write.noc_address = noc_unicast_command_header.noc_address;
-        this->command_fields.unicast_inline_write.value = noc_unicast_command_header.value;
-        this->payload_size_bytes = 0;
-        return *this;
-    }
-    inline volatile PacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) volatile {
-        this->noc_send_type = NOC_MULTICAST_WRITE;
-        this->command_fields.mcast_write.mcast_rect_size_x = noc_multicast_command_header.mcast_rect_size_x;
-        this->command_fields.mcast_write.mcast_rect_size_y = noc_multicast_command_header.mcast_rect_size_y;
-        this->command_fields.mcast_write.noc_x_start = noc_multicast_command_header.noc_x_start;
-        this->command_fields.mcast_write.noc_y_start = noc_multicast_command_header.noc_y_start;
-        this->payload_size_bytes = payload_size_bytes;
-        this->command_fields.mcast_write.address = noc_multicast_command_header.address;
-
-        return this;
-    }
-    inline volatile PacketHeader *to_noc_unicast_atomic_inc(
-        NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) volatile {
-        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
-        this->command_fields.unicast_seminc.noc_address = noc_unicast_atomic_inc_command_header.noc_address;
-        this->command_fields.unicast_seminc.val = noc_unicast_atomic_inc_command_header.val;
-        this->command_fields.unicast_seminc.wrap = noc_unicast_atomic_inc_command_header.wrap;
-        this->payload_size_bytes = 0;
-
-        return this;
-    }
-    inline volatile PacketHeader *to_noc_multicast_atomic_inc(
-        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) volatile {
-        this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
-        this->command_fields.mcast_seminc.address = noc_multicast_atomic_inc_command_header.address;
-        this->command_fields.mcast_seminc.noc_x_start = noc_multicast_atomic_inc_command_header.noc_x_start;
-        this->command_fields.mcast_seminc.noc_y_start = noc_multicast_atomic_inc_command_header.noc_y_start;
-        this->command_fields.mcast_seminc.size_x = noc_multicast_atomic_inc_command_header.size_x;
-        this->command_fields.mcast_seminc.size_y = noc_multicast_atomic_inc_command_header.size_y;
-        this->command_fields.mcast_seminc.val = noc_multicast_atomic_inc_command_header.val;
-        this->command_fields.mcast_seminc.wrap = noc_multicast_atomic_inc_command_header.wrap;
-        this->payload_size_bytes = payload_size_bytes;
-
-        return this;
-    }
-    inline void set_src_ch_id(uint8_t ch_id) volatile { this->src_ch_id = ch_id; }
 };
 
 struct LowLatencyRoutingFields {
@@ -263,179 +304,59 @@ struct LowLatencyRoutingFields {
     uint32_t value;
 };
 
-// TODO: wrap this in a debug version that holds type info so we can assert for field/command/
-struct LowLatencyPacketHeader {
-    // TODO: trim this down noc_send_type 2 bits (4 values):
-    //   -> unicast_write, mcast_write, unicast_seminc, mcast_seminc
-    // For now, kept it separate so I could do reads which would be handled differently
-    // but for our purposes we shouldn't need read so we should be able to omit the support
-    NocSendType noc_send_type : 4;
-
-    // Used only by the EDM sender and receiver channels. Populated by EDM sender channel to
-    // indicate to the receiver channel what channel was the source of this packet. Reserved
-    // otherwise.
-    uint8_t src_ch_id : 4;
-
+struct LowLatencyPacketHeader : public PacketHeaderBase<LowLatencyPacketHeader> {
+    uint8_t padding0;
     LowLatencyRoutingFields routing_fields;
-    uint16_t payload_size_bytes; // excludes header size
-    NocCommandFields command_fields; // size = 16B due to uint64_t alignment
+    uint32_t padding1;
 
-    // Sort of hack to work-around DRAM read alignment issues that must be 32B aligned
-    // To simplify worker kernel code, we for now decide to pad up the packet header
-    // to 32B so the user can simplify shift into their CB chunk by sizeof(tt::fabric::PacketHeader)
-    // and automatically work around the DRAM read alignment bug.
-    //
-    // Future changes will remove this padding and require the worker kernel to be aware of this bug
-    // and pad their own CBs conditionally when reading from DRAM. It'll be up to the users to
-    // manage this complexity.
+    private:
 
-    inline void set_noc_send_type(NocSendType &type) { this->noc_send_type = type; }
-    inline void set_routing_fields(LowLatencyRoutingFields &fields) { this->routing_fields = fields; }
-    inline void set_command_fields(NocCommandFields &fields) { this->command_fields = fields; }
-
-    // Returns size of payload in bytes - TODO: convert to words (4B)
-    size_t get_payload_size_excluding_header() volatile const {
-        return this->payload_size_bytes;
-    }
-    inline size_t get_payload_size_including_header() volatile const {
-        return get_payload_size_excluding_header() + sizeof(LowLatencyPacketHeader);
-    }
-
-    inline LowLatencyPacketHeader& to_chip_unicast(uint8_t distance_in_hops) {
+    inline static uint32_t calculate_chip_unicast_routing_fields_value(uint8_t distance_in_hops) {
         // Example of unicast 3 hops away
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
         // Last line will do 0b01 << 4 = 0b010000. This means that on the 3rd chip, we will write only
         // Together this means the final encoding is 0b011010
-        this->routing_fields.value =
+        return
             (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
             (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
-        return *this;
     }
-    inline LowLatencyPacketHeader& to_chip_multicast(
+    inline static uint32_t calculate_chip_multicast_routing_fields_value(
         const MulticastRoutingCommandHeader& chip_multicast_command_header) {
-
         // Example of starting 3 hops away mcasting to 2 chips
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
         // Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 = 0b110000. This means starting from the 3rd chip, we will write and forward once
         // Last line will do 0b01 << 6 = 0b01000000. This means that on the 5th chip, we will write only
         // Together this means the final encoding is 0b01111010
-        this->routing_fields.value =
+        return
             (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
             (LowLatencyRoutingFields::WR_AND_FWD_FIELD & ((1 << (chip_multicast_command_header.range_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1) <<
             ((chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH)) |
             (LowLatencyRoutingFields::WRITE_ONLY << (chip_multicast_command_header.start_distance_in_hops + chip_multicast_command_header.range_hops - 2) * LowLatencyRoutingFields::FIELD_WIDTH);
-        return *this;
     }
 
-    inline LowLatencyPacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) {
-        this->noc_send_type = NOC_UNICAST_WRITE;
-        this->command_fields.unicast_write = noc_unicast_command_header;
-        this->payload_size_bytes = payload_size_bytes;
-        return *this;
-    }
-    inline LowLatencyPacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) {
-        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
-        this->command_fields.unicast_inline_write = noc_unicast_command_header;
-        this->payload_size_bytes = 0;
-        return *this;
-    }
-    inline LowLatencyPacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
-        this->noc_send_type = NOC_MULTICAST_WRITE;
-        this->command_fields.mcast_write = noc_multicast_command_header;
-        this->payload_size_bytes = payload_size_bytes;
-        return *this;
-    }
-    inline LowLatencyPacketHeader &to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) {
-        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
-        this->command_fields.unicast_seminc = noc_unicast_atomic_inc_command_header;
-        this->payload_size_bytes = 0;
-        return *this;
-    }
-    inline LowLatencyPacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
-        #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-        ASSERT(false);
-        while (1) {};
-        #endif
-        this->payload_size_bytes = payload_size_bytes;
-        return *this;
+    public:
+
+    // Specialized implementations for LowLatencyPacketHeader
+    inline void set_routing_fields(LowLatencyRoutingFields &fields) {
+        this->routing_fields = fields;
     }
 
-    inline volatile LowLatencyPacketHeader* to_chip_unicast(uint8_t distance_in_hops) volatile {
-        // Example of unicast 3 hops away
-        // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
-        // Last line will do 0b01 << 4 = 0b010000. This means that on the 3rd chip, we will write only
-        // Together this means the final encoding is 0b011010
-        this->routing_fields.value =
-            (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
-            (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
-        return this;
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) {
+        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline volatile LowLatencyPacketHeader* to_chip_multicast(
+    inline void to_chip_multicast_impl(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
+        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
+    }
+
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
+        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
+    }
+    inline void to_chip_multicast_impl(
         const MulticastRoutingCommandHeader& chip_multicast_command_header) volatile {
-        // Example of starting 3 hops away mcasting to 2 chips
-        // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
-        // Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 = 0b110000. This means starting from the 3rd chip, we will write and forward once
-        // Last line will do 0b01 << 6 = 0b01000000. This means that on the 5th chip, we will write only
-        // Together this means the final encoding is 0b01111010
-        this->routing_fields.value =
-            (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
-            (LowLatencyRoutingFields::WR_AND_FWD_FIELD & ((1 << (chip_multicast_command_header.range_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1) <<
-            ((chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH)) |
-            (LowLatencyRoutingFields::WRITE_ONLY << (chip_multicast_command_header.start_distance_in_hops + chip_multicast_command_header.range_hops - 2) * LowLatencyRoutingFields::FIELD_WIDTH);
-        return this;
+        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
-    inline volatile LowLatencyPacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) volatile {
-        this->noc_send_type = NOC_UNICAST_WRITE;
-        this->command_fields.unicast_write.noc_address = noc_unicast_command_header.noc_address;
-        this->payload_size_bytes = payload_size_bytes;
-
-        return this;
-    }
-    inline volatile LowLatencyPacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) volatile {
-        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
-        this->command_fields.unicast_inline_write.noc_address = noc_unicast_command_header.noc_address;
-        this->command_fields.unicast_inline_write.value = noc_unicast_command_header.value;
-        this->payload_size_bytes = 0;
-        return *this;
-    }
-    inline volatile LowLatencyPacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) volatile {
-        this->noc_send_type = NOC_MULTICAST_WRITE;
-        this->command_fields.mcast_write.mcast_rect_size_x = noc_multicast_command_header.mcast_rect_size_x;
-        this->command_fields.mcast_write.mcast_rect_size_y = noc_multicast_command_header.mcast_rect_size_y;
-        this->command_fields.mcast_write.noc_x_start = noc_multicast_command_header.noc_x_start;
-        this->command_fields.mcast_write.noc_y_start = noc_multicast_command_header.noc_y_start;
-        this->payload_size_bytes = payload_size_bytes;
-        this->command_fields.mcast_write.address = noc_multicast_command_header.address;
-
-        return this;
-    }
-    inline volatile LowLatencyPacketHeader *to_noc_unicast_atomic_inc(
-        NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) volatile {
-        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
-        this->command_fields.unicast_seminc.noc_address = noc_unicast_atomic_inc_command_header.noc_address;
-        this->command_fields.unicast_seminc.val = noc_unicast_atomic_inc_command_header.val;
-        this->command_fields.unicast_seminc.wrap = noc_unicast_atomic_inc_command_header.wrap;
-        this->payload_size_bytes = 0;
-
-        return this;
-    }
-    inline volatile LowLatencyPacketHeader *to_noc_multicast_atomic_inc(
-        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) volatile {
-        this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
-        this->command_fields.mcast_seminc.address = noc_multicast_atomic_inc_command_header.address;
-        this->command_fields.mcast_seminc.noc_x_start = noc_multicast_atomic_inc_command_header.noc_x_start;
-        this->command_fields.mcast_seminc.noc_y_start = noc_multicast_atomic_inc_command_header.noc_y_start;
-        this->command_fields.mcast_seminc.size_x = noc_multicast_atomic_inc_command_header.size_x;
-        this->command_fields.mcast_seminc.size_y = noc_multicast_atomic_inc_command_header.size_y;
-        this->command_fields.mcast_seminc.val = noc_multicast_atomic_inc_command_header.val;
-        this->command_fields.mcast_seminc.wrap = noc_multicast_atomic_inc_command_header.wrap;
-        this->payload_size_bytes = payload_size_bytes;
-
-        return this;
-    }
-    inline void set_src_ch_id(uint8_t ch_id) volatile { this->src_ch_id = ch_id; }
 };
-
 
 // TODO: When we remove the 32B padding requirement, reduce to 16B size check
 static_assert(sizeof(PacketHeader) == 32, "sizeof(PacketHeader) is not equal to 32B");

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp
@@ -89,11 +89,11 @@ struct NocMulticastAtomicIncCommandHeader {
     uint8_t size_x;
     uint8_t size_y;
 };
-static_assert(sizeof(NocUnicastCommandHeader) == 8, "NocUnicastCommandHeader size is not 1 byte");
-static_assert(sizeof(NocMulticastCommandHeader) == 8, "NocMulticastCommandHeader size is not 1 byte");
-static_assert(sizeof(NocUnicastInlineWriteCommandHeader) == 16, "NocMulticastCommandHeader size is not 1 byte");
-static_assert(sizeof(NocUnicastAtomicIncCommandHeader) == 16, "NocUnicastCommandHeader size is not 1 byte");
-static_assert(sizeof(NocMulticastAtomicIncCommandHeader) == 12, "NocAtomicIncCommandHeader size is not 1 byte");
+static_assert(sizeof(NocUnicastCommandHeader) == 8, "NocUnicastCommandHeader size is not 8 bytes");
+static_assert(sizeof(NocMulticastCommandHeader) == 8, "NocMulticastCommandHeader size is not 8 bytes");
+static_assert(sizeof(NocUnicastInlineWriteCommandHeader) == 16, "NocMulticastCommandHeader size is not 16 bytes");
+static_assert(sizeof(NocUnicastAtomicIncCommandHeader) == 16, "NocUnicastCommandHeader size is not 16 bytes");
+static_assert(sizeof(NocMulticastAtomicIncCommandHeader) == 12, "NocAtomicIncCommandHeader size is not 12 bytes");
 union NocCommandFields{
     NocUnicastCommandHeader unicast_write;
     NocUnicastInlineWriteCommandHeader unicast_inline_write;
@@ -251,11 +251,208 @@ struct PacketHeader {
     inline void set_src_ch_id(uint8_t ch_id) volatile { this->src_ch_id = ch_id; }
 };
 
+struct LowLatencyRoutingFields {
+    static constexpr uint32_t FIELD_WIDTH = 2;
+    static constexpr uint32_t FIELD_MASK = 0b11;
+    static constexpr uint32_t NOOP = 0b00;
+    static constexpr uint32_t WRITE_ONLY = 0b01;
+    static constexpr uint32_t FORWARD_ONLY = 0b10;
+    static constexpr uint32_t WRITE_AND_FORWARD = 0b11;
+    static constexpr uint32_t FWD_ONLY_FIELD = 0xAAAAAAAA;
+    static constexpr uint32_t WR_AND_FWD_FIELD = 0xFFFFFFFF;
+    uint32_t value;
+};
+
+// TODO: wrap this in a debug version that holds type info so we can assert for field/command/
+struct LowLatencyPacketHeader {
+    // TODO: trim this down noc_send_type 2 bits (4 values):
+    //   -> unicast_write, mcast_write, unicast_seminc, mcast_seminc
+    // For now, kept it separate so I could do reads which would be handled differently
+    // but for our purposes we shouldn't need read so we should be able to omit the support
+    NocSendType noc_send_type : 4;
+
+    // Used only by the EDM sender and receiver channels. Populated by EDM sender channel to
+    // indicate to the receiver channel what channel was the source of this packet. Reserved
+    // otherwise.
+    uint8_t src_ch_id : 4;
+
+    LowLatencyRoutingFields routing_fields;
+    uint16_t payload_size_bytes; // excludes header size
+    NocCommandFields command_fields; // size = 16B due to uint64_t alignment
+
+    // Sort of hack to work-around DRAM read alignment issues that must be 32B aligned
+    // To simplify worker kernel code, we for now decide to pad up the packet header
+    // to 32B so the user can simplify shift into their CB chunk by sizeof(tt::fabric::PacketHeader)
+    // and automatically work around the DRAM read alignment bug.
+    //
+    // Future changes will remove this padding and require the worker kernel to be aware of this bug
+    // and pad their own CBs conditionally when reading from DRAM. It'll be up to the users to
+    // manage this complexity.
+
+    inline void set_noc_send_type(NocSendType &type) { this->noc_send_type = type; }
+    inline void set_routing_fields(LowLatencyRoutingFields &fields) { this->routing_fields = fields; }
+    inline void set_command_fields(NocCommandFields &fields) { this->command_fields = fields; }
+
+    // Returns size of payload in bytes - TODO: convert to words (4B)
+    size_t get_payload_size_excluding_header() volatile const {
+        return this->payload_size_bytes;
+    }
+    inline size_t get_payload_size_including_header() volatile const {
+        return get_payload_size_excluding_header() + sizeof(LowLatencyPacketHeader);
+    }
+
+    inline LowLatencyPacketHeader& to_chip_unicast(uint8_t distance_in_hops) {
+        // Example of unicast 3 hops away
+        // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
+        // Last line will do 0b01 << 4 = 0b010000. This means that on the 3rd chip, we will write only
+        // Together this means the final encoding is 0b011010
+        this->routing_fields.value =
+            (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
+            (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
+        return *this;
+    }
+    inline LowLatencyPacketHeader& to_chip_multicast(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
+
+        // Example of starting 3 hops away mcasting to 2 chips
+        // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
+        // Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 = 0b110000. This means starting from the 3rd chip, we will write and forward once
+        // Last line will do 0b01 << 6 = 0b01000000. This means that on the 5th chip, we will write only
+        // Together this means the final encoding is 0b01111010
+        this->routing_fields.value =
+            (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
+            (LowLatencyRoutingFields::WR_AND_FWD_FIELD & ((1 << (chip_multicast_command_header.range_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1) <<
+            ((chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH)) |
+            (LowLatencyRoutingFields::WRITE_ONLY << (chip_multicast_command_header.start_distance_in_hops + chip_multicast_command_header.range_hops - 2) * LowLatencyRoutingFields::FIELD_WIDTH);
+        return *this;
+    }
+
+    inline LowLatencyPacketHeader &to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) {
+        this->noc_send_type = NOC_UNICAST_WRITE;
+        this->command_fields.unicast_write = noc_unicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
+        return *this;
+    }
+    inline LowLatencyPacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write = noc_unicast_command_header;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline LowLatencyPacketHeader &to_noc_multicast_write(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
+        this->noc_send_type = NOC_MULTICAST_WRITE;
+        this->command_fields.mcast_write = noc_multicast_command_header;
+        this->payload_size_bytes = payload_size_bytes;
+        return *this;
+    }
+    inline LowLatencyPacketHeader &to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) {
+        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
+        this->command_fields.unicast_seminc = noc_unicast_atomic_inc_command_header;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline LowLatencyPacketHeader &to_noc_multicast_atomic_inc(NocMulticastAtomicIncCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) {
+        #if defined(KERNEL_BUILD) || defined(FW_BUILD)
+        ASSERT(false);
+        while (1) {};
+        #endif
+        this->payload_size_bytes = payload_size_bytes;
+        return *this;
+    }
+
+    inline volatile LowLatencyPacketHeader* to_chip_unicast(uint8_t distance_in_hops) volatile {
+        // Example of unicast 3 hops away
+        // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
+        // Last line will do 0b01 << 4 = 0b010000. This means that on the 3rd chip, we will write only
+        // Together this means the final encoding is 0b011010
+        this->routing_fields.value =
+            (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
+            (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
+        return this;
+    }
+    inline volatile LowLatencyPacketHeader* to_chip_multicast(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header) volatile {
+        // Example of starting 3 hops away mcasting to 2 chips
+        // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice (forward to neighbor is not encoded in the field)
+        // Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 = 0b110000. This means starting from the 3rd chip, we will write and forward once
+        // Last line will do 0b01 << 6 = 0b01000000. This means that on the 5th chip, we will write only
+        // Together this means the final encoding is 0b01111010
+        this->routing_fields.value =
+            (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
+            (LowLatencyRoutingFields::WR_AND_FWD_FIELD & ((1 << (chip_multicast_command_header.range_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1) <<
+            ((chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH)) |
+            (LowLatencyRoutingFields::WRITE_ONLY << (chip_multicast_command_header.start_distance_in_hops + chip_multicast_command_header.range_hops - 2) * LowLatencyRoutingFields::FIELD_WIDTH);
+        return this;
+    }
+    inline volatile LowLatencyPacketHeader *to_noc_unicast_write(NocUnicastCommandHeader const &noc_unicast_command_header, size_t payload_size_bytes) volatile {
+        this->noc_send_type = NOC_UNICAST_WRITE;
+        this->command_fields.unicast_write.noc_address = noc_unicast_command_header.noc_address;
+        this->payload_size_bytes = payload_size_bytes;
+
+        return this;
+    }
+    inline volatile LowLatencyPacketHeader &to_noc_unicast_inline_write(NocUnicastInlineWriteCommandHeader const &noc_unicast_command_header) volatile {
+        this->noc_send_type = NOC_UNICAST_INLINE_WRITE;
+        this->command_fields.unicast_inline_write.noc_address = noc_unicast_command_header.noc_address;
+        this->command_fields.unicast_inline_write.value = noc_unicast_command_header.value;
+        this->payload_size_bytes = 0;
+        return *this;
+    }
+    inline volatile LowLatencyPacketHeader *to_noc_multicast(NocMulticastCommandHeader const &noc_multicast_command_header, size_t payload_size_bytes) volatile {
+        this->noc_send_type = NOC_MULTICAST_WRITE;
+        this->command_fields.mcast_write.mcast_rect_size_x = noc_multicast_command_header.mcast_rect_size_x;
+        this->command_fields.mcast_write.mcast_rect_size_y = noc_multicast_command_header.mcast_rect_size_y;
+        this->command_fields.mcast_write.noc_x_start = noc_multicast_command_header.noc_x_start;
+        this->command_fields.mcast_write.noc_y_start = noc_multicast_command_header.noc_y_start;
+        this->payload_size_bytes = payload_size_bytes;
+        this->command_fields.mcast_write.address = noc_multicast_command_header.address;
+
+        return this;
+    }
+    inline volatile LowLatencyPacketHeader *to_noc_unicast_atomic_inc(
+        NocUnicastAtomicIncCommandHeader const &noc_unicast_atomic_inc_command_header) volatile {
+        this->noc_send_type = NOC_UNICAST_ATOMIC_INC;
+        this->command_fields.unicast_seminc.noc_address = noc_unicast_atomic_inc_command_header.noc_address;
+        this->command_fields.unicast_seminc.val = noc_unicast_atomic_inc_command_header.val;
+        this->command_fields.unicast_seminc.wrap = noc_unicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = 0;
+
+        return this;
+    }
+    inline volatile LowLatencyPacketHeader *to_noc_multicast_atomic_inc(
+        NocMulticastAtomicIncCommandHeader const &noc_multicast_atomic_inc_command_header, size_t payload_size_bytes) volatile {
+        this->noc_send_type = NOC_MULTICAST_ATOMIC_INC;
+        this->command_fields.mcast_seminc.address = noc_multicast_atomic_inc_command_header.address;
+        this->command_fields.mcast_seminc.noc_x_start = noc_multicast_atomic_inc_command_header.noc_x_start;
+        this->command_fields.mcast_seminc.noc_y_start = noc_multicast_atomic_inc_command_header.noc_y_start;
+        this->command_fields.mcast_seminc.size_x = noc_multicast_atomic_inc_command_header.size_x;
+        this->command_fields.mcast_seminc.size_y = noc_multicast_atomic_inc_command_header.size_y;
+        this->command_fields.mcast_seminc.val = noc_multicast_atomic_inc_command_header.val;
+        this->command_fields.mcast_seminc.wrap = noc_multicast_atomic_inc_command_header.wrap;
+        this->payload_size_bytes = payload_size_bytes;
+
+        return this;
+    }
+    inline void set_src_ch_id(uint8_t ch_id) volatile { this->src_ch_id = ch_id; }
+};
+
 
 // TODO: When we remove the 32B padding requirement, reduce to 16B size check
 static_assert(sizeof(PacketHeader) == 32, "sizeof(PacketHeader) is not equal to 32B");
+// Host code still hardcoded to sizeof(PacketHeader) so we need to keep this check
+static_assert(sizeof(LowLatencyPacketHeader) == sizeof(PacketHeader), "sizeof(LowLatencyPacketHeader) is not equal to 32B");
 
 static constexpr size_t header_size_bytes = sizeof(PacketHeader);
+
+#define FABRIC_LOW_LATENCY_MODE 1
+
+#if defined FABRIC_LOW_LATENCY_MODE and FABRIC_LOW_LATENCY_MODE == 1
+#define PACKET_HEADER_TYPE tt::fabric::LowLatencyPacketHeader
+#define ROUTING_FIELDS_TYPE tt::fabric::LowLatencyRoutingFields
+#else
+#define PACKET_HEADER_TYPE tt::fabric::PacketHeader
+#define ROUTING_FIELDS_TYPE tt::fabric::RoutingFields
+#endif
 
 
 } // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header_validate.hpp
@@ -16,4 +16,9 @@ FORCE_INLINE bool is_valid(PacketHeader const& packet_header) {
     return (packet_header.chip_send_type <= CHIP_SEND_TYPE_LAST) && (packet_header.noc_send_type <= NOC_SEND_TYPE_LAST);
 }
 
+FORCE_INLINE void validate(const LowLatencyPacketHeader& packet_header) {}
+FORCE_INLINE bool is_valid(const LowLatencyPacketHeader& packet_header) {
+    return (packet_header.noc_send_type <= NOC_SEND_TYPE_LAST);
+}
+
 }  // namespace tt::fabric

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -32,7 +32,13 @@ FORCE_INLINE void print_pkt_hdr_routing_fields(volatile tt::fabric::PacketHeader
 #endif
 }
 
-FORCE_INLINE void print_pkt_header_noc_fields(volatile tt::fabric::PacketHeader *const packet_start) {
+FORCE_INLINE void print_pkt_hdr_routing_fields(volatile tt::fabric::LowLatencyPacketHeader *const packet_start) {
+    #ifdef DEBUG_PRINT_ENABLED
+        DPRINT << "ROUTE:" << packet_start->routing_fields.value << "\n";
+    #endif
+}
+
+FORCE_INLINE void print_pkt_header_noc_fields(volatile PACKET_HEADER_TYPE *const packet_start) {
 #ifdef DEBUG_PRINT_ENABLED
     switch (packet_start->noc_send_type) {
         case tt::fabric::NocSendType::NOC_UNICAST_WRITE: {
@@ -62,12 +68,23 @@ FORCE_INLINE void print_pkt_header(volatile tt::fabric::PacketHeader *const pack
 #endif
 }
 
+FORCE_INLINE void print_pkt_header(volatile tt::fabric::LowLatencyPacketHeader *const packet_start) {
+    #ifdef DEBUG_PRINT_ENABLED
+        auto const& header = *packet_start;
+        DPRINT << "PKT: nsnd_t:" << (uint32_t) packet_start->noc_send_type <<
+            ", src_chip:" << (uint32_t) packet_start->src_ch_id <<
+            ", payload_size_bytes:" << (uint32_t) packet_start->payload_size_bytes << "\n";
+        print_pkt_hdr_routing_fields(packet_start);
+        print_pkt_header_noc_fields(packet_start);
+    #endif
+    }
+
 
 // Since we unicast to local, we must omit the packet header
 FORCE_INLINE void execute_chip_unicast_to_local_chip(
-    volatile tt::fabric::PacketHeader *const packet_start, uint16_t payload_size_bytes, uint32_t transaction_id) {
+    volatile PACKET_HEADER_TYPE *const packet_start, uint16_t payload_size_bytes, uint32_t transaction_id) {
     auto const& header = *packet_start;
-    uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(tt::fabric::PacketHeader);
+    uint32_t payload_start_address = reinterpret_cast<size_t>(packet_start) + sizeof(PACKET_HEADER_TYPE);
 
     tt::fabric::NocSendType noc_send_type = packet_start->noc_send_type;
     switch (noc_send_type) {
@@ -116,6 +133,10 @@ FORCE_INLINE void update_packet_header_for_next_hop(volatile tt::fabric::PacketH
     packet_header->routing_fields.value = cached_routing_fields.value - decrement_val;
 }
 
+FORCE_INLINE void update_packet_header_for_next_hop(volatile tt::fabric::LowLatencyPacketHeader * packet_header, tt::fabric::LowLatencyRoutingFields cached_routing_fields) {
+    packet_header->routing_fields.value >>= tt::fabric::LowLatencyRoutingFields::FIELD_WIDTH;
+}
+
 // This function forwards a packet to the downstream EDM channel for eventual sending
 // to the next chip in the line/ring
 //
@@ -127,9 +148,9 @@ FORCE_INLINE void update_packet_header_for_next_hop(volatile tt::fabric::PacketH
 // !!!WARNING!!!
 template <uint8_t NUM_SENDER_BUFFERS>
 FORCE_INLINE void forward_payload_to_downstream_edm(
-    volatile tt::fabric::PacketHeader *packet_header,
+    volatile PACKET_HEADER_TYPE *packet_header,
     uint16_t payload_size_bytes,
-    tt::fabric::RoutingFields cached_routing_fields,
+    ROUTING_FIELDS_TYPE cached_routing_fields,
     tt::fabric::EdmToEdmSender<NUM_SENDER_BUFFERS> &downstream_edm_interface,
     uint8_t transaction_id
     ) {
@@ -141,6 +162,6 @@ FORCE_INLINE void forward_payload_to_downstream_edm(
     update_packet_header_for_next_hop(packet_header, cached_routing_fields);
     downstream_edm_interface.send_payload_non_blocking_from_address_with_trid(
         reinterpret_cast<size_t>(packet_header),
-        payload_size_bytes + sizeof(tt::fabric::PacketHeader),
+        payload_size_bytes + sizeof(PACKET_HEADER_TYPE),
         transaction_id);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -64,12 +64,14 @@ class EthChannelBuffer final {
         return this->buffer_addresses[buffer_index];
     }
 
-    [[nodiscard]] FORCE_INLINE volatile PacketHeader *get_packet_header(BufferIndex const& buffer_index) const {
-        return reinterpret_cast<volatile PacketHeader *>(this->buffer_addresses[buffer_index]);
+    template <typename T>
+    [[nodiscard]] FORCE_INLINE volatile T *get_packet_header(BufferIndex const& buffer_index) const {
+        return reinterpret_cast<volatile T *>(this->buffer_addresses[buffer_index]);
     }
 
+    template <typename T>
     [[nodiscard]] FORCE_INLINE size_t get_payload_size(BufferIndex const& buffer_index) const {
-        return get_packet_header(buffer_index)->get_payload_size_including_header();
+        return get_packet_header<T>(buffer_index)->get_payload_size_including_header();
     }
     [[nodiscard]] FORCE_INLINE size_t get_channel_buffer_max_size_in_bytes(BufferIndex const& buffer_index) const {
         return this->buffer_size_in_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -94,10 +94,10 @@ void kernel_main() {
     DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
 
     // pre-populate packet headers
-    volatile tt::fabric::PacketHeader* pkt_hdr_forward =
-        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_forward);
-    volatile tt::fabric::PacketHeader* pkt_hdr_backward =
-        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_backward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
     pkt_hdr_forward->to_chip_multicast(
         tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
     pkt_hdr_backward->to_chip_multicast(
@@ -152,7 +152,7 @@ void kernel_main() {
     // 2. mcast output ready semaphore
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
-    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_seminc);
+    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
     pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
         out_ready_sem_noc_addr_in_pkt,
         static_cast<uint16_t>(1),  // increment 1
@@ -163,7 +163,7 @@ void kernel_main() {
         pkt_hdr->to_chip_multicast(
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
@@ -171,7 +171,7 @@ void kernel_main() {
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // increment locally
     uint64_t out_ready_sem_noc_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_post_binary_matmul_shape_writer.cpp
@@ -103,10 +103,10 @@ void kernel_main() {
     DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
 
     // pre-populate packet headers
-    volatile tt::fabric::PacketHeader* pkt_hdr_forward =
-        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_forward);
-    volatile tt::fabric::PacketHeader* pkt_hdr_backward =
-        reinterpret_cast<volatile tt::fabric::PacketHeader*>(packet_header_buffer_addr_backward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
     pkt_hdr_forward->to_chip_multicast(
         tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
     pkt_hdr_backward->to_chip_multicast(
@@ -158,7 +158,7 @@ void kernel_main() {
     }
 
     // 2. mcast output ready semaphore
-    auto* pkt_hdr = reinterpret_cast<tt::fabric::PacketHeader*>(packet_header_buffer_seminc);
+    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
     pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
@@ -171,7 +171,7 @@ void kernel_main() {
         pkt_hdr->to_chip_multicast(
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
@@ -179,7 +179,7 @@ void kernel_main() {
             tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(tt::fabric::PacketHeader));
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // increment locally
     uint64_t out_ready_sem_noc_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -12,8 +12,8 @@
 
 FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
     uint64_t noc0_dest_noc_addr,
-    volatile tt::fabric::PacketHeader* pkt_hdr_forward,
-    volatile tt::fabric::PacketHeader* pkt_hdr_backward,
+    volatile PACKET_HEADER_TYPE* pkt_hdr_forward,
+    volatile PACKET_HEADER_TYPE* pkt_hdr_backward,
     FabricConnectionManager& fabric_connection,
     size_t& l1_read_addr,
     uint32_t payload_size_bytes) {
@@ -29,7 +29,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
         fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
             l1_read_addr, payload_size_bytes);
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            (uint32_t)pkt_hdr_forward, sizeof(tt::fabric::PacketHeader));
+            (uint32_t)pkt_hdr_forward, sizeof(PACKET_HEADER_TYPE));
     }
 
     if (fabric_connection.has_backward_connection()) {
@@ -37,7 +37,7 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
         fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
             l1_read_addr, payload_size_bytes);
         fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
-            (uint32_t)pkt_hdr_backward, sizeof(tt::fabric::PacketHeader));
+            (uint32_t)pkt_hdr_backward, sizeof(PACKET_HEADER_TYPE));
     }
 
     noc_async_writes_flushed();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18184

### Problem description
Want to optimize decoding of packet header on the router side by encoding the pull routing path inside the packet header.

### What's changed
Add a new LowLatencyPacketHeader that encodes the full route in the header.
This simplifies router decode/update to anding to extract the current cmd, a switch statement to interpret the cmd, and a bit shift to update the route when forwarding.

With O3 compilation, perf improvements are as follows:
Unicast: ~15.42GB/s -> ~16.35GB/s
Multicast: ~12.7GB/s -> ~13.35GB/s

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13484988803
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
