### PR TITLE
#0: Resolve clang-tidy errors in distributed programming example

### DIFF
--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -25,9 +25,9 @@ using namespace tt::tt_metal::distributed;
 // synchronization
 
 std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
-    std::shared_ptr<MeshBuffer> src0_buf,
-    std::shared_ptr<MeshBuffer> src1_buf,
-    std::shared_ptr<MeshBuffer> output_buf,
+    const std::shared_ptr<MeshBuffer>& src0_buf,
+    const std::shared_ptr<MeshBuffer>& src1_buf,
+    const std::shared_ptr<MeshBuffer>& output_buf,
     const SubDevice& sub_device_for_program,
     uint32_t num_tiles,
     uint32_t single_tile_size,


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
Distributed Trace programming example has clang tidy errors, causing CI to fail on main.

### What's changed
Resolve reported errors.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
