### PR TITLE
Overhaul Stable Diffusion 1.4 web demo

### DIFF
--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
@@ -26,4 +26,6 @@ The interface of this project is built with [Streamlit](https://streamlit.io). U
 
 The web demo utilizes a [Flask](https://flask.palletsprojects.com/en/3.0.x/) server. Use `pip install Flask` to install the Flask dependencies on your machine.
 
+The web demo utilizes a [Gunicorn](https://gunicorn.org) server to server a WSGI application. Use `pip install gunicorn==21.2.0` to install the Gunicorn dependencies on your machine.
+
 Use `python models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py` to run the web demo. It should automatically pop-up at this [address](http://localhost:8501) (localhost:8501).

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
@@ -25,7 +25,7 @@ For more information, refer [installation and build guide](https://github.com/te
 The interface of this project is built with [Streamlit](https://streamlit.io). The web server utilizes [Flask](https://flask.palletsprojects.com/en/3.0.x/) and a [Gunicorn](https://gunicorn.org) server to server a WSGI application.
 
 ### Install dependencies
-Use `pip install -r requirements.txt` to install the dependencies on your machine.
+Use `pip install -r models/demos/wormhole/stable_diffusion/demo/web_demo/requirements.txt` to install the dependencies on your machine.
 
 ### Invoke web demo
 Use `python models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py` to run the web demo. It should automatically pop-up at this [address](http://localhost:8501)(localhost:8501).

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
@@ -22,10 +22,10 @@ Stable Diffusion is a latent text-to-image diffusion model capable of generating
 To run the demo, make sure to build the project, activate the environment, and set the appropriate environment variables.
 For more information, refer [installation and build guide](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md).
 
-The interface of this project is built with [Streamlit](https://streamlit.io). Use `pip install streamlit` to install the Streamlit dependencies on your machine.
+The interface of this project is built with [Streamlit](https://streamlit.io). The web server utilizes [Flask](https://flask.palletsprojects.com/en/3.0.x/) and a [Gunicorn](https://gunicorn.org) server to server a WSGI application.
 
-The web demo utilizes a [Flask](https://flask.palletsprojects.com/en/3.0.x/) server. Use `pip install Flask` to install the Flask dependencies on your machine.
+### Install dependencies
+Use `pip install -r requirements.txt` to install the dependencies on your machine.
 
-The web demo utilizes a [Gunicorn](https://gunicorn.org) server to server a WSGI application. Use `pip install gunicorn==21.2.0` to install the Gunicorn dependencies on your machine.
-
-Use `python models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py` to run the web demo. It should automatically pop-up at this [address](http://localhost:8501) (localhost:8501).
+### Invoke web demo
+Use `python models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py` to run the web demo. It should automatically pop-up at this [address](http://localhost:8501)(localhost:8501).

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/conftest.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/conftest.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+
+# This will add a --port argument to pytest CLI
+def pytest_addoption(parser):
+    parser.addoption("--port", action="store", default=7000, help="Port to run the server")
+
+
+# Fixture to get the value of --port passed via pytest CLI
+@pytest.fixture
+def port(request):
+    return request.config.getoption("--port")

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
@@ -2,138 +2,113 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from flask import Flask, request, jsonify, send_from_directory, send_file, send_from_directory
-import json
+from flask import Flask, request, jsonify, send_from_directory
+from gunicorn.app.base import BaseApplication
+from http import HTTPStatus
+from models.demos.wormhole.stable_diffusion.demo.web_demo.task_queue import TaskQueue
+from models.demos.wormhole.stable_diffusion.demo.web_demo.sdserver import warmup_model
+from models.utility_functions import skip_for_grayskull
 import os
-import atexit
+import pytest
+from threading import Thread
+import time
+
 
 app = Flask(__name__)
+
+# Initialize the task queue
+task_queue = TaskQueue()
+
+
+# worker thread to process the task queue
+def create_worker():
+    try:
+        while True:
+            # get task if one exists, otherwise block
+            task_id = task_queue.get_task()
+            if task_id:
+                task_queue.process_task(task_id)
+    except Exception as error:
+        print(error)
 
 
 @app.route("/")
 def hello_world():
-    return "Hello, World!"
+    return jsonify({"message": "OK\n"}), 200
 
 
-@app.route("/submit", methods=["POST"])
-def submit():
-    data = request.get_json()
-    prompt = data.get("prompt")
-    print(prompt)
-
-    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
-
-    if not os.path.isfile(json_file_path):
-        with open(json_file_path, "w") as f:
-            json.dump({"prompts": []}, f)
-
-    with open(json_file_path, "r") as f:
-        prompts_data = json.load(f)
-
-    prompts_data["prompts"].append({"prompt": prompt, "status": "not generated"})
-
-    with open(json_file_path, "w") as f:
-        json.dump(prompts_data, f, indent=4)
-
-    return jsonify({"message": "Prompt received and added to queue."})
-
-
-@app.route("/update_status", methods=["POST"])
-def update_status():
+@app.route("/enqueue", methods=["POST"])
+def enqueue_prompt():
     data = request.get_json()
     prompt = data.get("prompt")
 
-    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+    if not prompt:
+        return jsonify({"error": "No prompt provided"}), HTTPStatus.BAD_REQUEST
 
-    with open(json_file_path, "r") as f:
-        prompts_data = json.load(f)
-
-    for p in prompts_data["prompts"]:
-        if p["prompt"] == prompt:
-            p["status"] = "generated"
-            break
-
-    with open(json_file_path, "w") as f:
-        json.dump(prompts_data, f, indent=4)
-
-    return jsonify({"message": "Prompt status updated to generated."})
+    # Enqueue the prompt and start processing
+    task_id = task_queue.enqueue_task(prompt)
+    return jsonify({"task_id": task_id, "status": "Enqueued"}), HTTPStatus.CREATED
 
 
-@app.route("/get_image", methods=["GET"])
-def get_image():
-    image_name = "interactive_512x512_ttnn.png"
-    directory = os.getcwd()  # Get the current working directory
-    return send_from_directory(directory, image_name)
+@app.route("/status/<task_id>", methods=["GET"])
+def get_task_status(task_id):
+    task_status = task_queue.get_task_status(task_id)
+    if not task_status:
+        return jsonify({"error": "Task not found"}), HTTPStatus.NOT_FOUND
+    return jsonify({"task_id": task_id, "status": task_status["status"]}), HTTPStatus.OK
 
 
-@app.route("/image_exists", methods=["GET"])
-def image_exists():
-    image_path = "interactive_512x512_ttnn.png"
-    if os.path.isfile(image_path):
-        return jsonify({"exists": True}), 200
-    else:
-        return jsonify({"exists": False}), 200
+@app.route("/fetch_image/<task_id>", methods=["GET"])
+def fetch_image(task_id):
+    task_status = task_queue.get_task_status(task_id)
+    if not task_status:
+        return jsonify({"error": "Task not found"}), HTTPStatus.NOT_FOUND
+
+    if task_status["status"] != "Completed":
+        return jsonify({"error": "Task not completed yet"}), HTTPStatus.BAD_REQUEST
+
+    image_path = task_status["image_path"]
+    directory = os.getcwd()  # get the current working directory
+    return send_from_directory(directory, image_path)
 
 
-@app.route("/clean_up", methods=["POST"])
-def clean_up():
-    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+class GunicornApp(BaseApplication):
+    def __init__(self, app):
+        self.app = app
+        super().__init__()
 
-    with open(json_file_path, "r") as f:
-        prompts_data = json.load(f)
+    def load(self):
+        return self.app
 
-    prompts_data["prompts"] = [p for p in prompts_data["prompts"] if p["status"] != "done"]
+    def load_config(self):
+        config = {
+            "bind": f"0.0.0.0:{7000}",  # Specify the binding address
+            "workers": 1,  # Number of Gunicorn workers
+            "reload": False,
+            "worker_class": "sync",
+            "post_worker_init": self.post_worker_init,
+            "timeout": 0,
+        }
 
-    with open(json_file_path, "w") as f:
-        json.dump(prompts_data, f, indent=4)
+        # Set the configurations for Gunicorn (optional but useful)
+        for key, value in config.items():
+            self.cfg.set(key, value)
 
-    return jsonify({"message": "Cleaned up done prompts."})
+    def post_worker_init(self, worker):
+        # all setup tasks and spinup background threads must be performed
+        # here as gunicorn spawns worker processes who must be the parent
+        # of all server threads
+        warmup_model()
 
-
-@app.route("/get_latest_time", methods=["GET"])
-def get_latest_time():
-    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
-
-    if not os.path.isfile(json_file_path):
-        return jsonify({"message": "No prompts found"}), 404
-
-    with open(json_file_path, "r") as f:
-        prompts_data = json.load(f)
-
-    # Filter prompts that have a total_acc time available
-    completed_prompts = [p for p in prompts_data["prompts"] if "total_acc" in p]
-
-    if not completed_prompts:
-        return jsonify({"message": "No completed prompts with time available"}), 404
-
-    # Get the latest prompt with total_acc
-    latest_prompt = completed_prompts[-1]  # Assuming prompts are in chronological order
-
-    return (
-        jsonify(
-            {
-                "prompt": latest_prompt["prompt"],
-                "total_acc": latest_prompt["total_acc"],
-                "batch_size": latest_prompt["batch_size"],
-                "steps": latest_prompt["steps"],
-            }
-        ),
-        200,
-    )
+        # run the model worker in a background thread
+        thread = Thread(target=create_worker)
+        thread.daemon = True
+        thread.start()
 
 
-def cleanup():
-    if os.path.isfile("models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"):
-        os.remove("models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json")
-        print(f"Deleted json")
-
-    if os.path.isfile("interactive_512x512_ttnn.png"):
-        os.remove("interactive_512x512_ttnn.png")
-        print(f"Deleted image")
-
-
-atexit.register(cleanup)
-
-
-if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+@skip_for_grayskull
+def test_app():
+    # Ensure the generated images directory exists
+    os.makedirs("generated_images", exist_ok=True)
+    gunicorn_app = GunicornApp(app)
+    gunicorn_app.run()

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
@@ -5,6 +5,7 @@
 from flask import Flask, request, jsonify, send_from_directory
 from gunicorn.app.base import BaseApplication
 from http import HTTPStatus
+from loguru import logger
 from models.demos.wormhole.stable_diffusion.demo.web_demo.task_queue import TaskQueue
 from models.demos.wormhole.stable_diffusion.demo.web_demo.model import warmup_model
 import os
@@ -28,7 +29,7 @@ def create_worker():
             if task_id:
                 task_queue.process_task(task_id)
     except Exception as error:
-        print(error)
+        logger.error(error)
 
 
 @app.route("/")

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
@@ -84,7 +84,8 @@ class GunicornApp(BaseApplication):
             "bind": f"0.0.0.0:{7000}",  # Specify the binding address
             "workers": 1,  # Number of Gunicorn workers
             "reload": False,
-            "worker_class": "sync",
+            "worker_class": "gthread",
+            "threads": 16,
             "post_worker_init": self.post_worker_init,
             "timeout": 0,
         }

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
@@ -7,7 +7,6 @@ from gunicorn.app.base import BaseApplication
 from http import HTTPStatus
 from models.demos.wormhole.stable_diffusion.demo.web_demo.task_queue import TaskQueue
 from models.demos.wormhole.stable_diffusion.demo.web_demo.sdserver import warmup_model
-from models.utility_functions import skip_for_grayskull
 import os
 import pytest
 from threading import Thread
@@ -106,7 +105,6 @@ class GunicornApp(BaseApplication):
         thread.start()
 
 
-@skip_for_grayskull
 def test_app():
     # Ensure the generated images directory exists
     os.makedirs("generated_images", exist_ok=True)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -235,6 +235,8 @@ def warmup_model():
     device_id = 0
     device_params = {"l1_small_size": 32768}
     dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
+    if ("WH_ARCH_YAML" in os.environ) and os.environ["WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
+        dispatch_core_type = ttnn.device.DispatchCoreType.ETH
     dispatch_core_axis = ttnn.DispatchCoreAxis.ROW
     dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
     device_params["dispatch_core_config"] = dispatch_core_config

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/model.py
@@ -205,7 +205,7 @@ def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
             ttnn_latents = ttnn_scheduler.step(noise_pred, t, ttnn_latents).prev_sample
             total_accum += time.time() - t0
             iter += 1
-        print(f"Time taken for {iter} iterations: total: {total_accum:.3f}")
+        logger.info(f"Time taken for {iter} iterations: total: {total_accum:.3f}")
 
         latents = ttnn.to_torch(ttnn_latents).to(torch.float32)
 

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/requirements.txt
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/requirements.txt
@@ -1,0 +1,2 @@
+gunicorn==21.2.0
+streamlit==1.40.1

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
@@ -151,9 +151,18 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
 
         ttnn_scheduler.set_timesteps(num_inference_steps)
 
-        with open(json_file_path, "r") as f:
-            data = json.load(f)
-            input_prompts = data["prompts"]
+        # attempt to read file multiple times as web server can write to the prompt queue
+        # while it is being read, leading to invalid JSON parsing
+        NUM_ATTEMPTS = 10
+        for _attempt in range(10):
+            try:
+                with open(json_file_path, "r") as f:
+                    data = json.load(f)
+                    input_prompts = data["prompts"]
+            except json.decoder.JSONDecodeError:
+                continue
+            else:
+                break
 
         new_prompt = ""
         currInd = 0

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
@@ -160,6 +160,7 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
                     data = json.load(f)
                     input_prompts = data["prompts"]
             except json.decoder.JSONDecodeError:
+                time.sleep(0.25)
                 continue
             else:
                 break

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
@@ -141,7 +141,6 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
 
     time_step = ttnn_scheduler.timesteps.tolist()
 
-    prevPrompt = ""
     json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
 
     while True:
@@ -179,11 +178,8 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
             time.sleep(5)
             continue
 
-        if new_prompt == prevPrompt:
-            continue
         elif len(new_prompt) > 0:
             input_prompt = [new_prompt]
-            prevPrompt = new_prompt
         if input_prompt[0] == "q":
             break
 

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
@@ -12,6 +12,7 @@ from loguru import logger
 from tqdm.auto import tqdm
 from datasets import load_dataset
 import os
+import string
 import time
 import random
 
@@ -62,7 +63,11 @@ def tt_guide(noise_pred, guidance_scale):  # will return latents
     return noise_pred
 
 
-def run_interactive_demo_inference(device, num_inference_steps, image_size=(256, 256)):
+# Global variable for the Stable Diffusion model pipeline
+model_pipeline = None
+
+
+def create_model_pipeline(device, num_inference_steps, image_size=(256, 256)):
     disable_persistent_kernel_cache()
     device.enable_program_cache()
 
@@ -141,54 +146,14 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
 
     time_step = ttnn_scheduler.timesteps.tolist()
 
-    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
-
-    while True:
-        while not os.path.exists(json_file_path):
-            print(f"Waiting for the file {json_file_path} to be created...")
-            time.sleep(5)
-
+    # Function to generate an image from the given prompt
+    def _model_pipeline(input_prompt):
         ttnn_scheduler.set_timesteps(num_inference_steps)
-
-        # attempt to read file multiple times as web server can write to the prompt queue
-        # while it is being read, leading to invalid JSON parsing
-        NUM_ATTEMPTS = 10
-        for _attempt in range(10):
-            try:
-                with open(json_file_path, "r") as f:
-                    data = json.load(f)
-                    input_prompts = data["prompts"]
-            except json.decoder.JSONDecodeError:
-                time.sleep(0.25)
-                continue
-            else:
-                break
-
-        new_prompt = ""
-        currInd = 0
-        for i in range(len(input_prompts)):
-            if input_prompts[i]["status"] == "not generated":
-                currInd = i
-                new_prompt = input_prompts[i]["prompt"]
-                input_prompts[i]["status"] = "generated"
-                break
-
-        if new_prompt == "":
-            print("No 'not generated' prompts found, waiting...")
-            time.sleep(5)
-            continue
-
-        elif len(new_prompt) > 0:
-            input_prompt = [new_prompt]
-        if input_prompt[0] == "q":
-            break
 
         experiment_name = f"interactive_{height}x{width}"
         logger.info(f"input prompt : {input_prompt}")
         batch_size = len(input_prompt)
-
-        with open(json_file_path, "w") as f:
-            json.dump({"prompts": input_prompts}, f, indent=4)
+        assert batch_size == 1
 
         ## First, we get the text_embeddings for the prompt. These embeddings will be used to condition the UNet model.
         # Tokenizer and Text Encoder
@@ -252,27 +217,33 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
         image = image.detach().cpu().permute(0, 2, 3, 1).numpy()
         images = (image * 255).round().astype("uint8")
         pil_images = [Image.fromarray(image) for image in images][0]
-        ttnn_output_path = f"{experiment_name}_ttnn.png"
-        pil_images.save(ttnn_output_path)
+        # Generate a random file name for the image
+        random_filename = "".join(random.choices(string.ascii_lowercase + string.digits, k=10)) + ".png"
+        image_path = os.path.join("generated_images", random_filename)
+        pil_images.save(image_path)
 
-        input_prompts[currInd]["status"] = "done"
-        input_prompts[currInd]["total_acc"] = total_accum
-        input_prompts[currInd]["batch_size"] = batch_size
-        input_prompts[currInd]["steps"] = num_inference_steps
+        return image_path
 
-        with open(json_file_path, "w") as f:
-            json.dump({"prompts": input_prompts}, f, indent=4)
+    # warmup model pipeline
+    _model_pipeline(["ship"])
+    global model_pipeline
+    model_pipeline = _model_pipeline
 
 
-@skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-@pytest.mark.parametrize(
-    "num_inference_steps",
-    ((50),),
-)
-@pytest.mark.parametrize(
-    "image_size",
-    ((512, 512),),
-)
-def test_interactive_demo(device, num_inference_steps, image_size):
-    return run_interactive_demo_inference(device, num_inference_steps, image_size)
+def warmup_model():
+    # create device, these constants are specific to n150 & n300
+    device_id = 0
+    device_params = {"l1_small_size": 32768}
+    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
+    dispatch_core_axis = ttnn.DispatchCoreAxis.ROW
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    device_params["dispatch_core_config"] = dispatch_core_config
+    device = ttnn.CreateDevice(device_id=device_id, **device_params)
+    device.enable_program_cache()
+    num_inference_steps = 50
+    image_size = (512, 512)
+    create_model_pipeline(device, num_inference_steps, image_size)
+
+
+def generate_image_from_prompt(prompt):
+    return model_pipeline([prompt])

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
@@ -1,8 +1,11 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
+from http import HTTPStatus
 import streamlit as st
+import sys
 import requests
 from PIL import Image
 import io
@@ -10,7 +13,11 @@ import time
 import os
 import json
 
-DOWNLOAD_PATH = os.path.join(os.path.expanduser("~"), "interactive_512x512_ttnn.png")
+
+# parse args
+parser = argparse.ArgumentParser(description="Streamlit app for Stable Diffusion")
+parser.add_argument("--port", type=int, default=7000, help="The port number the Streamlit server should run on")
+args = parser.parse_args()
 
 # Add space below the title
 st.title("TT Stable Diffusion Playground")
@@ -19,25 +26,21 @@ st.markdown("<br>", unsafe_allow_html=True)
 # Display an image logo at the end of the title
 
 # Popover for Device ID input
-with st.expander("Add Device ID"):
-    device_id = st.text_input("What's your device ID? 10.229.36.110")
+default_device_id = f"localhost:{args.port}"  # default URL
+with st.expander("Override API URL"):
+    device_id = st.text_input("What's your API URL? e.x. 10.229.36.110:5000")
+    device_id = device_id or default_device_id
 
 st.markdown("<br>", unsafe_allow_html=True)
 
 prompt = st.text_input("Enter your prompt:", "")
-
-curr = ""
 
 
 # Function to save image to Downloads and display it
 def save_and_display_image(image_data):
     try:
         image = Image.open(io.BytesIO(image_data))
-        image.save(DOWNLOAD_PATH)
-        if curr:  # Only add caption if curr is not an empty string
-            image_placeholder.image(image, caption=curr, use_column_width=True)
-        else:
-            image_placeholder.image(image, use_column_width=True)
+        image_placeholder.image(image, use_container_width=True)
     except Exception as e:
         st.error(f"Error processing image: {e}")
 
@@ -47,43 +50,35 @@ image_placeholder = st.empty()
 
 
 # Function to check and update the image
-def check_and_update_image(server_url):
-    global curr  # Make curr accessible to this function
+def check_and_update_image(server_url, task_id):
+    global curr
     try:
-        prompt_response = requests.get(f"{server_url}/get_latest_time")
-        image_response = requests.get(f"{server_url}/get_image")
-        if image_response.status_code == 200 and image_response.content:
+        status_response = requests.get(f"{server_url}/status/{task_id}")
+        if status_response.json().get("status") == "Completed":
+            image_response = requests.get(f"{server_url}/fetch_image/{task_id}")
             save_and_display_image(image_response.content)
-        if prompt_response.status_code == 200 and prompt_response.content:
-            decoded_string = prompt_response.content.decode("utf-8").strip()
-            parsed_data = json.loads(decoded_string)
-            total_acc = round(parsed_data.get("total_acc"), 2)
-            batch_size = round(parsed_data.get("batch_size"), 0)
-            steps = round(parsed_data.get("steps"), 0)
-            promp = parsed_data.get("prompt")
-            curr = f"{total_acc} seconds to generate '{promp}' with batch size of {batch_size} and {steps} steps"
-            print(curr)
+            return True
     except requests.exceptions.RequestException as e:
         st.error(f"Error connecting to the server: {e}")
 
 
-# Button to generate the image
-if st.button("Generate Image"):
+# generate image if prompt was entered
+if prompt:
     if not device_id:
         st.error("Please enter your device ID.")
     else:
-        SERVER_URL = f"http://{device_id}:5000"
+        SERVER_URL = f"http://{device_id}"
         with st.spinner("Running Stable Diffusion"):
             try:
                 data = {"prompt": prompt}
-                response = requests.post(f"{SERVER_URL}/submit", json=data)
-                if response.status_code != 200:
+                response = requests.post(f"{SERVER_URL}/enqueue", json=data, timeout=2)
+                if response.status_code != 201:
                     st.error(f"Error submitting prompt: {response.status_code} - {response.text}")
+                task_id = response.json().get("task_id")
             except requests.exceptions.RequestException as e:
                 st.error(f"Error connecting to the server: {e}")
             else:
-                while True:
-                    check_and_update_image(SERVER_URL)
+                while not (updated := check_and_update_image(SERVER_URL, task_id)):
                     time.sleep(2)
 
 hide_decoration_bar_style = """

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
@@ -20,6 +20,7 @@ parser.add_argument("--port", type=int, default=7000, help="The port number the 
 args = parser.parse_args()
 
 # Add space below the title
+st.set_page_config(page_title="Stable-Diffusion-1.4")
 st.title("TT Stable Diffusion Playground")
 st.markdown("<br>", unsafe_allow_html=True)
 

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/task_queue.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/task_queue.py
@@ -1,0 +1,42 @@
+import queue
+import uuid
+from models.demos.wormhole.stable_diffusion.demo.web_demo.sdserver import generate_image_from_prompt
+
+
+class TaskQueue:
+    def __init__(self):
+        self.tasks = {}
+        self.task_queue = queue.Queue()
+
+    def enqueue_task(self, prompt):
+        task_id = str(uuid.uuid4())
+        self.tasks[task_id] = {
+            "prompt": prompt,
+            "status": "Pending",
+            "image_path": None,
+        }
+
+        # Add the task to the queue for processing
+        self.task_queue.put(task_id)
+        return task_id
+
+    def get_task(self):
+        # Get the next task from the queue (this will block until there's a task)
+        return self.task_queue.get()
+
+    def process_task(self, task_id):
+        task = self.tasks[task_id]
+        task["status"] = "In Progress"
+
+        # Simulate image generation (you can replace this with actual image generation code)
+        print(f"Processing task {task_id} for prompt: {task['prompt']}")
+        image_path = generate_image_from_prompt(task["prompt"])
+
+        # Update task status and store image path
+        task["status"] = "Completed"
+        task["image_path"] = image_path
+
+        print(f"Task {task_id} completed, image saved at {image_path}")
+
+    def get_task_status(self, task_id):
+        return self.tasks.get(task_id)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/task_queue.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/task_queue.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from loguru import logger
 import queue
 import uuid
 from models.demos.wormhole.stable_diffusion.demo.web_demo.model import generate_image_from_prompt
@@ -33,14 +34,14 @@ class TaskQueue:
         task["status"] = "In Progress"
 
         # Simulate image generation (you can replace this with actual image generation code)
-        print(f"Processing task {task_id} for prompt: {task['prompt']}")
+        logger.info(f"Processing task {task_id} for prompt: {task['prompt']}")
         image_path = generate_image_from_prompt(task["prompt"])
 
         # Update task status and store image path
         task["status"] = "Completed"
         task["image_path"] = image_path
 
-        print(f"Task {task_id} completed, image saved at {image_path}")
+        logger.info(f"Task {task_id} completed, image saved at {image_path}")
 
     def get_task_status(self, task_id):
         return self.tasks.get(task_id)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/task_queue.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/task_queue.py
@@ -1,6 +1,10 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import queue
 import uuid
-from models.demos.wormhole.stable_diffusion.demo.web_demo.sdserver import generate_image_from_prompt
+from models.demos.wormhole.stable_diffusion.demo.web_demo.model import generate_image_from_prompt
 
 
 class TaskQueue:

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
@@ -31,28 +31,28 @@ def kill_port_5000():
     try:
         result = subprocess.check_output("lsof -i :5000 | grep LISTEN | awk '{print $2}'", shell=True)
         pid = int(result.strip())
-        print(f"Killing process {pid} using port 5000")
+        logger.info(f"Killing process {pid} using port 5000")
         os.kill(pid, signal.SIGTERM)
     except subprocess.CalledProcessError:
-        print("No process found using port 5000")
+        logger.error("No process found using port 5000")
     except Exception as e:
-        print(f"Error occurred: {e}")
+        logger.error(f"Error occurred: {e}")
 
 
 # Function to terminate both processes and kill port 5000
 def signal_handler(sig, frame):
-    print("Terminating processes...")
+    logger.info("Terminating processes...")
     process1.terminate()
     process2.terminate()
     kill_port_5000()
-    print("Processes terminated and port 5000 cleared.")
+    logger.info("Processes terminated and port 5000 cleared.")
     sys.exit(0)
 
 
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
-print("Running. Press Ctrl+C to stop.")
+logger.info("Running. Press Ctrl+C to stop.")
 try:
     process1.wait()
     process2.wait()

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
@@ -1,21 +1,29 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import subprocess
 import signal
 import sys
 import os
 
+# Create the argument parser
+parser = argparse.ArgumentParser(description="Stable Diffusion web demo")
+
+# Add the 'port' argument with a default value of 7000
+parser.add_argument("--port", type=int, default=7000, help="Port number to run the web demo on (default: 7000)")
+
+# Parse the command-line arguments
+args = parser.parse_args()
+
 # Two scripts to run
-script1 = "pytest models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py"
-script2 = "python3 models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py"
-script3 = "streamlit run models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py"
+script1 = f"pytest models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py --port {args.port} "
+script2 = f"streamlit run models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py -- --port {args.port}"
 
 # Start both scripts using subprocess
 process1 = subprocess.Popen(script1, shell=True)
 process2 = subprocess.Popen(script2, shell=True)
-process3 = subprocess.Popen(script3, shell=True)
 
 
 # Function to kill process using port 5000

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+from loguru import logger
 import subprocess
 import signal
 import sys


### PR DESCRIPTION
### Ticket
#18182 

### Problem description
See issue for problem description.

### What's changed
I have rewritten the web demo to:
- simplify dependency install process via use of `requirements.txt` file
- update `README.md` for simpler instructions
- use a Gunicorn WSGI server to serve the Flask backend
- perform model initialization after server instantiation to facilitate multi-threading of server workers (deal with complicated `pytest` and `gunicorn` thread interaction)
- compose `queue.Queue` to allow thread-safe transmission of data between Flask backend and model process
- overhaull Flask API to simplify user experience (`/enqueue -> /status/<task_id> -> /fetch_image/<task_id>`)
- update the `streamlit` app for simpler use
- allow customization of web demo's backend port number via CLI argument
