### PR TITLE
#17477: Finalize adoption of ND `MeshShape` in Metal and TTNN.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -256,7 +256,7 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(2, 2),
         **updated_device_params,
-        offset=ttnn.MeshOffset(0, 1),
+        offset=ttnn.MeshCoordinate(0, 1),
     )
     mesh_device.reshape(ttnn.MeshShape(1, 4))
 

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -129,7 +129,7 @@ TEST_F(MeshBufferTestT3000, Deallocation) {
 TEST(MeshBufferTest, DeallocationWithoutMeshDevice) {
     for (int i = 0; i < 100; i++) {
         auto config =
-            MeshDeviceConfig{.mesh_shape = SimpleMeshShape(1, 1), .offset = std::nullopt, .physical_device_ids = {}};
+            MeshDeviceConfig{.mesh_shape = MeshShape(1, 1), .offset = std::nullopt, .physical_device_ids = {}};
         auto mesh_device =
             MeshDevice::create(config, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreType::WORKER);
 
@@ -148,7 +148,7 @@ TEST(MeshBufferTest, DeallocationWithoutMeshDevice) {
 TEST(MeshBufferTest, DeallocationWithMeshDeviceClosed) {
     for (int i = 0; i < 100; i++) {
         auto config =
-            MeshDeviceConfig{.mesh_shape = SimpleMeshShape(1, 1), .offset = std::nullopt, .physical_device_ids = {}};
+            MeshDeviceConfig{.mesh_shape = MeshShape(1, 1), .offset = std::nullopt, .physical_device_ids = {}};
         auto mesh_device =
             MeshDevice::create(config, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreType::WORKER);
 

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -73,14 +73,13 @@ bool is_tgg_system() {
 }
 
 ttnn::MeshShape get_mesh_shape() {
-    ttnn::MeshShape shape;
     if (is_tg_system()) {
-        shape = {8, 4};
+        return ttnn::MeshShape{8, 4};
+    } else if (is_tgg_system()) {
+        return ttnn::MeshShape{8, 8};
     } else {
-        TT_FATAL(is_tgg_system(), "Unsupported Galaxy system");
-        shape = {8, 8};
+        TT_THROW("Unsupported Galaxy system");
     }
-    return shape;
 }
 
 void validate_num_tunnels_and_tunnel_depth() {
@@ -212,7 +211,7 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
     auto view = ttnn::MeshDeviceView(*mesh);
     std::vector<IDevice*> ring_devices = view.get_devices_on_row(0);  // Tunnel 0
     std::vector<IDevice*> ring_devices_1 =
-        view.get_devices_on_column(mesh_shape.num_cols - 1);  // Orthogonal to tunnel .. no deadlocks
+        view.get_devices_on_column(mesh_shape[1] - 1);  // Orthogonal to tunnel .. no deadlocks
     ring_devices_1 = std::vector<IDevice*>(ring_devices_1.begin() + 1, ring_devices_1.end());
     std::vector<IDevice*> ring_devices_2 =
         view.get_devices_on_row(7);  // Tunnel 7 .. potential deadlocks with lack of buffering

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -32,7 +32,7 @@ int main() {
     const size_t num_targets = 32;
     const float noise = 0.0F;
     const bool bias = true;
-    ttml::autograd::ctx().set_mesh_shape({1, 2});
+    ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
 
     auto training_params = ttml::datasets::MakeRegressionParams{
         .n_samples = training_samples_count,

--- a/tt-train/sources/examples/mnist_mlp/main.cpp
+++ b/tt-train/sources/examples/mnist_mlp/main.cpp
@@ -67,7 +67,7 @@ TrainingConfig parse_config(const YAML::Node &yaml_config) {
 void initialize_device(bool enable_tp) {
     if (enable_tp) {
         // we support only N300 for now
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 }
 

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -97,6 +97,6 @@ std::unique_ptr<ttml::schedulers::LRSchedulerBase> create_warmup_with_linear_sch
 void initialize_device(bool ddp) {
     if (ddp) {
         // currently supports only N300 device
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
     }
 }

--- a/tt-train/sources/ttml/autograd/auto_context.hpp
+++ b/tt-train/sources/ttml/autograd/auto_context.hpp
@@ -59,7 +59,7 @@ private:
     GradMode m_grads_mode = GradMode::ENABLED;
 
     Graph m_graph;
-    tt::tt_metal::distributed::MeshShape m_mesh_shape = {1, 1};
+    tt::tt_metal::distributed::MeshShape m_mesh_shape = tt::tt_metal::distributed::MeshShape(1, 1);
     std::unique_ptr<core::MeshDevice> m_device;
 
     friend class tt::stl::Indestructible<AutoContext>;

--- a/tt-train/sources/ttml/core/distributed_mapping.hpp
+++ b/tt-train/sources/ttml/core/distributed_mapping.hpp
@@ -34,7 +34,7 @@ protected:
     tt::tt_metal::distributed::MeshShape m_mesh_shape;
 
     size_t get_num_devices() const {
-        return m_mesh_shape.num_rows * m_mesh_shape.num_cols;
+        return m_mesh_shape.mesh_size();
     }
 };
 
@@ -90,8 +90,8 @@ public:
             throw std::invalid_argument("ShardTensor2dMesh requires at least one dimension to shard");
         }
 
-        int rows = Base::m_mesh_shape.num_rows;
-        int cols = Base::m_mesh_shape.num_cols;
+        int rows = Base::m_mesh_shape[0];
+        int cols = Base::m_mesh_shape[1];
         auto row_dim = m_dims.first;
         auto col_dim = m_dims.second;
 
@@ -138,8 +138,8 @@ public:
     std::unordered_map<std::string, std::string> config_impl() const {
         return {
             {"strategy", "shard_2d"},
-            {"mesh_shape_y", std::to_string(Base::m_mesh_shape.num_rows)},
-            {"mesh_shape_x", std::to_string(Base::m_mesh_shape.num_cols)}};
+            {"mesh_shape_y", std::to_string(Base::m_mesh_shape[0])},
+            {"mesh_shape_x", std::to_string(Base::m_mesh_shape[1])}};
     }
 
 private:
@@ -153,16 +153,16 @@ public:
     ConcatMesh2dToTensor(
         tt::tt_metal::distributed::MeshShape mesh_shape, const tt::tt_metal::distributed::MeshShape& dims) :
         Base(std::move(mesh_shape)), m_dims(dims) {
-        if (m_dims.num_rows == m_dims.num_cols) {
+        if (m_dims[0] == m_dims[1]) {
             throw std::invalid_argument("Dimensions in 'dims' must be different");
         }
     }
 
     std::vector<xt::xarray<T>> compose_impl(const std::vector<xt::xarray<T>>& tensors) const {
-        int rows = Base::m_mesh_shape.num_rows;
-        int cols = Base::m_mesh_shape.num_cols;
-        size_t row_dim = m_dims.num_rows;
-        size_t col_dim = m_dims.num_cols;
+        int rows = Base::m_mesh_shape[0];
+        int cols = Base::m_mesh_shape[1];
+        size_t row_dim = m_dims[0];
+        size_t col_dim = m_dims[1];
 
         std::vector<xt::xarray<T>> row_concatenated;
         row_concatenated.reserve(static_cast<size_t>(rows));

--- a/tt-train/tests/core/distributed_test.cpp
+++ b/tt-train/tests/core/distributed_test.cpp
@@ -12,6 +12,7 @@
 namespace {
 
 using ::testing::SizeIs;
+using ::tt::tt_metal::distributed::MeshShape;
 
 template <typename T>
 class MeshOpsTest : public ::testing::Test {
@@ -23,7 +24,7 @@ using TestTypes = ::testing::Types<uint32_t, float>;
 TYPED_TEST_SUITE(MeshOpsTest, TestTypes);
 
 TYPED_TEST(MeshOpsTest, ShardXTensorToMeshBasicShard) {
-    tt::tt_metal::distributed::MeshShape mesh_shape = {1, 4};
+    MeshShape mesh_shape{1, 4};
 
     // A simple 1D tensor to shard across 4 devices
     auto tensor = xt::arange<TypeParam>(8);  // [0,...,7]
@@ -40,7 +41,7 @@ TYPED_TEST(MeshOpsTest, ShardXTensorToMeshBasicShard) {
 
 TYPED_TEST(MeshOpsTest, ShardTensor2dMeshTwoDimSharding) {
     // Mesh shape: 2x2, total 4 devices
-    tt::tt_metal::distributed::MeshShape mesh_shape = {2, 2};
+    MeshShape mesh_shape{2, 2};
 
     // Create a 2D tensor shape: (4,4)
     auto tensor = xt::arange<TypeParam>(16).reshape({4, 4});
@@ -58,8 +59,8 @@ TYPED_TEST(MeshOpsTest, ShardTensor2dMeshTwoDimSharding) {
 }
 
 TYPED_TEST(MeshOpsTest, ReplicateXTensorToMeshReplication) {
-    tt::tt_metal::distributed::MeshShape mesh_shape = {2, 2};
-    int num_devices = mesh_shape.num_rows * mesh_shape.num_cols;  // 4
+    MeshShape mesh_shape{2, 2};
+    int num_devices = mesh_shape.mesh_size();  // 4
 
     auto tensor = xt::arange<TypeParam>(4);  // [0,1,2,3]
 
@@ -73,7 +74,7 @@ TYPED_TEST(MeshOpsTest, ReplicateXTensorToMeshReplication) {
 }
 
 TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
-    tt::tt_metal::distributed::MeshShape mesh_shape = {2, 2};
+    MeshShape mesh_shape{2, 2};
 
     // Create shards that would come from a 4x4 tensor:
     // Expected final tensor:
@@ -90,7 +91,7 @@ TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
 
     std::vector<xt::xarray<TypeParam>> shards = {top_left, top_right, bot_left, bot_right};
 
-    ttml::core::ConcatMesh2dToTensor<TypeParam> composer(mesh_shape, {0, 1});
+    ttml::core::ConcatMesh2dToTensor<TypeParam> composer(mesh_shape, MeshShape{0, 1});
     auto composed = composer.compose(shards);
 
     xt::xarray<TypeParam> expected = {
@@ -103,7 +104,7 @@ TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
 }
 
 TYPED_TEST(MeshOpsTest, ConcatMeshToXTensorOneDimConcatenation) {
-    tt::tt_metal::distributed::MeshShape mesh_shape = {1, 3};
+    MeshShape mesh_shape{1, 3};
 
     // Create a few shards: [0,1], [2,3], [4,5]
     xt::xarray<TypeParam> s1 = {TypeParam(0), TypeParam(1)};
@@ -120,7 +121,7 @@ TYPED_TEST(MeshOpsTest, ConcatMeshToXTensorOneDimConcatenation) {
 }
 
 TYPED_TEST(MeshOpsTest, VectorMeshToXTensorVectorReturn) {
-    tt::tt_metal::distributed::MeshShape mesh_shape = {2, 2};
+    MeshShape mesh_shape{2, 2};
     ttml::core::VectorMeshToXTensor<TypeParam> vectorComposer(mesh_shape);
 
     std::vector<xt::xarray<TypeParam>> shards = {
@@ -134,7 +135,7 @@ TYPED_TEST(MeshOpsTest, VectorMeshToXTensorVectorReturn) {
 }
 
 TYPED_TEST(MeshOpsTest, ConcatenateSameParametersAsCompose) {
-    tt::tt_metal::distributed::MeshShape mesh_shape = {1, 3};
+    MeshShape mesh_shape{1, 3};
 
     // Create a few shards: [0,1], [2,3], [4,5]
     xt::xarray<TypeParam> s1 = {TypeParam(0), TypeParam(1)};

--- a/tt-train/tests/core/distributed_test.cpp
+++ b/tt-train/tests/core/distributed_test.cpp
@@ -11,8 +11,8 @@
 
 namespace {
 
+using MetalMeshShape = ::tt::tt_metal::distributed::MeshShape;
 using ::testing::SizeIs;
-using ::tt::tt_metal::distributed::MeshShape;
 
 template <typename T>
 class MeshOpsTest : public ::testing::Test {
@@ -24,7 +24,7 @@ using TestTypes = ::testing::Types<uint32_t, float>;
 TYPED_TEST_SUITE(MeshOpsTest, TestTypes);
 
 TYPED_TEST(MeshOpsTest, ShardXTensorToMeshBasicShard) {
-    MeshShape mesh_shape{1, 4};
+    MetalMeshShape mesh_shape{1, 4};
 
     // A simple 1D tensor to shard across 4 devices
     auto tensor = xt::arange<TypeParam>(8);  // [0,...,7]
@@ -41,7 +41,7 @@ TYPED_TEST(MeshOpsTest, ShardXTensorToMeshBasicShard) {
 
 TYPED_TEST(MeshOpsTest, ShardTensor2dMeshTwoDimSharding) {
     // Mesh shape: 2x2, total 4 devices
-    MeshShape mesh_shape{2, 2};
+    MetalMeshShape mesh_shape{2, 2};
 
     // Create a 2D tensor shape: (4,4)
     auto tensor = xt::arange<TypeParam>(16).reshape({4, 4});
@@ -59,7 +59,7 @@ TYPED_TEST(MeshOpsTest, ShardTensor2dMeshTwoDimSharding) {
 }
 
 TYPED_TEST(MeshOpsTest, ReplicateXTensorToMeshReplication) {
-    MeshShape mesh_shape{2, 2};
+    MetalMeshShape mesh_shape{2, 2};
     int num_devices = mesh_shape.mesh_size();  // 4
 
     auto tensor = xt::arange<TypeParam>(4);  // [0,1,2,3]
@@ -74,7 +74,7 @@ TYPED_TEST(MeshOpsTest, ReplicateXTensorToMeshReplication) {
 }
 
 TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
-    MeshShape mesh_shape{2, 2};
+    MetalMeshShape mesh_shape{2, 2};
 
     // Create shards that would come from a 4x4 tensor:
     // Expected final tensor:
@@ -91,7 +91,7 @@ TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
 
     std::vector<xt::xarray<TypeParam>> shards = {top_left, top_right, bot_left, bot_right};
 
-    ttml::core::ConcatMesh2dToTensor<TypeParam> composer(mesh_shape, MeshShape{0, 1});
+    ttml::core::ConcatMesh2dToTensor<TypeParam> composer(mesh_shape, MetalMeshShape{0, 1});
     auto composed = composer.compose(shards);
 
     xt::xarray<TypeParam> expected = {
@@ -104,7 +104,7 @@ TYPED_TEST(MeshOpsTest, ConcatMesh2dToTensorRecomposition) {
 }
 
 TYPED_TEST(MeshOpsTest, ConcatMeshToXTensorOneDimConcatenation) {
-    MeshShape mesh_shape{1, 3};
+    MetalMeshShape mesh_shape{1, 3};
 
     // Create a few shards: [0,1], [2,3], [4,5]
     xt::xarray<TypeParam> s1 = {TypeParam(0), TypeParam(1)};
@@ -121,7 +121,7 @@ TYPED_TEST(MeshOpsTest, ConcatMeshToXTensorOneDimConcatenation) {
 }
 
 TYPED_TEST(MeshOpsTest, VectorMeshToXTensorVectorReturn) {
-    MeshShape mesh_shape{2, 2};
+    MetalMeshShape mesh_shape{2, 2};
     ttml::core::VectorMeshToXTensor<TypeParam> vectorComposer(mesh_shape);
 
     std::vector<xt::xarray<TypeParam>> shards = {
@@ -135,7 +135,7 @@ TYPED_TEST(MeshOpsTest, VectorMeshToXTensorVectorReturn) {
 }
 
 TYPED_TEST(MeshOpsTest, ConcatenateSameParametersAsCompose) {
-    MeshShape mesh_shape{1, 3};
+    MetalMeshShape mesh_shape{1, 3};
 
     // Create a few shards: [0,1], [2,3], [4,5]
     xt::xarray<TypeParam> s1 = {TypeParam(0), TypeParam(1)};

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -23,7 +23,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -34,7 +34,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -37,7 +37,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -29,7 +29,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -27,7 +27,7 @@ protected:
         if (!check_board_is_n300()) {
             GTEST_SKIP() << "Skipping N300 specific tests";
         }
-        ttml::autograd::ctx().set_mesh_shape({1, 2});
+        ttml::autograd::ctx().set_mesh_shape(tt::tt_metal::distributed::MeshShape(1, 2));
         ttml::autograd::ctx().open_device();
     }
 

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -113,7 +113,7 @@ private:
         DeviceAddr device_local_size,
         MeshDevice* mesh_device,
         std::shared_ptr<Buffer> backing_buffer) :
-        buffers_(SimpleMeshShape(mesh_device->shape()), nullptr),
+        buffers_(MeshShape(mesh_device->shape()), nullptr),
         config_(config),
         device_local_config_(device_local_config),
         mesh_device_(mesh_device->shared_from_this()),
@@ -128,7 +128,7 @@ private:
         DeviceAddr address,
         DeviceAddr device_local_size,
         MeshDevice* mesh_device) :
-        buffers_(SimpleMeshShape(mesh_device->shape()), /*fill_value=*/nullptr),
+        buffers_(MeshShape(mesh_device->shape()), /*fill_value=*/nullptr),
         config_(config),
         device_local_config_(device_local_config),
         mesh_device_(mesh_device->shared_from_this()),

--- a/tt_metal/api/tt-metalium/mesh_config.hpp
+++ b/tt_metal/api/tt-metalium/mesh_config.hpp
@@ -15,16 +15,6 @@ using DeviceIds = std::vector<int>;
 using MeshDeviceID = int;
 using chip_id_t = int;
 
-struct MeshOffset {
-    size_t row = 0;
-    size_t col = 0;
-};
-
-struct MeshShape {
-    size_t num_rows = 0;
-    size_t num_cols = 0;
-};
-
 /**
  * @brief Defines the organization of physical devices in a user-defined MeshDevice.
  *
@@ -40,7 +30,7 @@ struct MeshShape {
  */
 
 struct MeshDeviceConfig {
-    SimpleMeshShape mesh_shape{0, 0};
+    MeshShape mesh_shape{0, 0};
     std::optional<MeshCoordinate> offset;
     std::vector<chip_id_t> physical_device_ids{};
 };

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -57,7 +57,6 @@ private:
 
     std::shared_ptr<ScopedDevices> scoped_devices_;
     MeshDeviceID mesh_id_;
-    MeshShape mesh_shape_;
     std::unique_ptr<MeshDeviceView> view_;
     std::vector<std::shared_ptr<MeshDevice>>
         submeshes_;                          // Parent owns submeshes and is responsible for their destruction
@@ -75,7 +74,6 @@ private:
 public:
     MeshDevice(
         std::shared_ptr<ScopedDevices> scoped_devices,
-        const MeshShape& mesh_shape,
         std::unique_ptr<MeshDeviceView> mesh_device_view,
         std::weak_ptr<MeshDevice> parent_mesh = {});
     ~MeshDevice() override;
@@ -217,15 +215,19 @@ public:
     // Returns the devices in the mesh in row-major order.
     std::vector<IDevice*> get_devices() const;
     IDevice* get_device(chip_id_t physical_device_id) const;
-    IDevice* get_device(size_t row_idx, size_t col_idx) const;
     IDevice* get_device(const MeshCoordinate& coord) const;
 
     const DeviceIds get_device_ids() const;
 
     size_t num_devices() const;
+
+    // The following methods assume 2D mesh, and throw if the mesh is not 2D.
+    // TODO: #17477 - Remove the methods that assume 2D mesh.
     size_t num_rows() const;
     size_t num_cols() const;
-    MeshShape shape() const;
+    IDevice* get_device(size_t row_idx, size_t col_idx) const;
+
+    const MeshShape& shape() const;
 
     // Reshapes the logical mesh and re-maps the physical devices to the new logical coordinates.
     // Reshaping Rules:
@@ -251,7 +253,7 @@ public:
     std::vector<std::shared_ptr<MeshDevice>> get_submeshes() const;
 
     std::shared_ptr<MeshDevice> create_submesh(
-        const MeshShape& submesh_shape, const MeshOffset& offset = MeshOffset{0, 0});
+        const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset = std::nullopt);
 
     std::vector<std::shared_ptr<MeshDevice>> create_submeshes(const MeshShape& submesh_shape);
 

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -53,13 +53,13 @@ public:
 
     // Get devices spanning the region defined by `range` in row-major order with start/end coordinates inclusive
     [[nodiscard]] DeviceView get_devices(const MeshCoordinateRange& range) const;
-    [[nodiscard]] DeviceView get_devices(const SimpleMeshShape& submesh_shape) const;
+    [[nodiscard]] DeviceView get_devices(const MeshShape& submesh_shape) const;
     [[nodiscard]] DeviceView get_devices() const;
     [[nodiscard]] size_t num_devices() const;
 
     [[nodiscard]] bool empty() const noexcept;
     [[nodiscard]] size_t size() const noexcept;
-    [[nodiscard]] SimpleMeshShape shape() const noexcept;
+    [[nodiscard]] const MeshShape& shape() const noexcept;
     [[nodiscard]] bool contains(const MeshCoordinate& coord) const noexcept;
     [[nodiscard]] IDevice* get_device(const MeshCoordinate& coord) const;
     [[nodiscard]] const IDevice* at(const MeshCoordinate& coord) const noexcept;
@@ -77,7 +77,7 @@ public:
     // Throws if the `coord` is out of bounds of this view.
     [[nodiscard]] chip_id_t find_device_id(const MeshCoordinate& coord) const;
 
-    // TODO: Remove the methods that assume 2D mesh.
+    // TODO: #17477 - Remove the methods that assume 2D mesh.
     [[nodiscard]] bool is_mesh_2d() const;
     [[nodiscard]] size_t num_rows() const;
     [[nodiscard]] size_t num_cols() const;
@@ -95,6 +95,7 @@ public:
     // The current support only provides left-to-right and right-to-left snaking of the line.
     //
     // Important: these utilities currently only support 2D meshes.
+    // TODO: #17477 - Remove the methods that assume 2D mesh.
     [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(size_t length, const Shape2D& mesh_shape);
     [[nodiscard]] static std::vector<MeshCoordinate> get_ring_coordinates(
         const Shape2D& ring_shape, const Shape2D& mesh_shape);
@@ -106,7 +107,7 @@ private:
     std::unordered_map<chip_id_t, MeshCoordinate> device_coordinates_;
 
     // Set if the view is 2D to enable row/col APIs, otherwise nullopt.
-    // TODO: remove this?
+    // TODO: #17477 - Remove this?
     std::optional<Shape2D> shape_2d_;
 };
 

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -31,7 +31,7 @@ public:
     SystemMesh& operator=(SystemMesh&&) = delete;
 
     // Returns the shape of the system mesh
-    const SimpleMeshShape& get_shape() const;
+    const MeshShape& get_shape() const;
 
     // Returns the physical device ID for a given logical row and column index
     chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;

--- a/tt_metal/distributed/coordinate_translation.hpp
+++ b/tt_metal/distributed/coordinate_translation.hpp
@@ -19,6 +19,6 @@ using CoordinateTranslationMap = std::unordered_map<MeshCoordinate, PhysicalCoor
 // Returns a translation map between logical coordinates in logical ND space
 // to the physical coordinates as defined by the UMD layer.
 // TODO: #17477 - Return MeshContainer<PhysicalCoordinate> that contains everything we need.
-const std::pair<CoordinateTranslationMap, SimpleMeshShape>& get_system_mesh_coordinate_translation_map();
+const std::pair<CoordinateTranslationMap, MeshShape>& get_system_mesh_coordinate_translation_map();
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -434,7 +434,6 @@ void MeshCommandQueue::enqueue_read_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    const auto [num_rows, num_cols] = buffer->device()->shape();
     for (const auto& shard_data_transfer : shard_data_transfers) {
         auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
         read_shard_from_device(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -23,6 +23,8 @@
 #include <sub_device_types.hpp>
 
 #include <hal.hpp>
+#include <mesh_coord.hpp>
+#include <small_vector.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -110,11 +112,9 @@ IDevice* MeshDevice::reference_device() const { return this->get_devices().at(0)
 
 MeshDevice::MeshDevice(
     std::shared_ptr<ScopedDevices> mesh_handle,
-    const MeshShape& mesh_shape,
     std::unique_ptr<MeshDeviceView> mesh_device_view,
     std::weak_ptr<MeshDevice> parent_mesh) :
     scoped_devices_(std::move(mesh_handle)),
-    mesh_shape_(mesh_shape),
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
     parent_mesh_(std::move(parent_mesh)) {}
@@ -126,82 +126,89 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> l1_bank_remap) {
-    // TODO: #17477 Extend to ND.
-    TT_FATAL(config.mesh_shape.dims() == 2, "Mesh shape must be 2D");
-    auto mesh_shape_2d = MeshShape{config.mesh_shape[0], config.mesh_shape[1]};
-
     auto scoped_devices = std::make_shared<ScopedDevices>(
         l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, config);
     MeshContainer<IDevice*> devices(config.mesh_shape, scoped_devices->root_devices());
     auto mesh_device = std::make_shared<MeshDevice>(
-        std::move(scoped_devices),
-        mesh_shape_2d,
-        std::make_unique<MeshDeviceView>(devices),
-        std::weak_ptr<MeshDevice>());
+        std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::weak_ptr<MeshDevice>());
 
     mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
     return mesh_device;
 }
 
-std::shared_ptr<MeshDevice> MeshDevice::create_submesh(const MeshShape& submesh_shape, const MeshOffset& offset) {
-    if (submesh_shape.num_rows <= 0 || submesh_shape.num_cols <= 0) {
-        TT_THROW(
-            "Invalid submesh shape: ({}, {}). Both dimensions must be positive.",
-            submesh_shape.num_rows,
-            submesh_shape.num_cols);
-    }
+std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
+    const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset) {
+    TT_FATAL(
+        std::all_of(submesh_shape.cbegin(), submesh_shape.cend(), [](size_t dim) { return dim > 0; }),
+        "Invalid submesh shape: ({}). All dimensions must be positive.",
+        submesh_shape);
+    TT_FATAL(
+        submesh_shape.dims() == view_->shape().dims(),
+        "Submesh shape {} and mesh device shape {} must have the same number of dimensions.",
+        submesh_shape,
+        view_->shape());
 
-    if (offset.row < 0 || offset.col < 0) {
-        TT_THROW("Invalid offset: ({}, {}). Offset must be non-negative.", offset.row, offset.col);
-    }
+    const MeshCoordinate offset_coord = [&offset, &submesh_shape]() {
+        if (offset.has_value()) {
+            TT_FATAL(
+                submesh_shape.dims() == offset->dims(),
+                "Submesh shape {} and offset {} must have the same number of dimensions.",
+                submesh_shape,
+                *offset);
+            return *offset;
+        } else {
+            return MeshCoordinate::zero_coordinate(submesh_shape.dims());
+        }
+    }();
 
-    if (offset.row + submesh_shape.num_rows > mesh_shape_.num_rows ||
-        offset.col + submesh_shape.num_cols > mesh_shape_.num_cols) {
-        TT_THROW(
-            "Submesh ({}x{}) with offset ({}, {}) does not fit within parent mesh ({}x{}).",
-            submesh_shape.num_rows,
-            submesh_shape.num_cols,
-            offset.row,
-            offset.col,
-            mesh_shape_.num_rows,
-            mesh_shape_.num_cols);
+    tt::stl::SmallVector<uint32_t> end_coords;
+    for (size_t i = 0; i < submesh_shape.dims(); i++) {
+        TT_FATAL(
+            offset_coord[i] + submesh_shape[i] - 1 < view_->shape()[i],
+            "Submesh shape {} and offset {} does not fit within parent mesh ({}).",
+            submesh_shape,
+            offset,
+            view_->shape());
+        end_coords.push_back(offset_coord[i] + submesh_shape[i] - 1);
     }
-
-    auto start_coordinate = MeshCoordinate{offset.row, offset.col};
-    auto end_coordinate =
-        MeshCoordinate{offset.row + submesh_shape.num_rows - 1, offset.col + submesh_shape.num_cols - 1};
+    auto end_coordinate = MeshCoordinate(end_coords);
 
     MeshContainer<IDevice*> submesh_devices_container(
-        submesh_shape, view_->get_devices(MeshCoordinateRange{start_coordinate, end_coordinate}));
+        submesh_shape, view_->get_devices(MeshCoordinateRange{offset_coord, end_coordinate}));
 
     auto submesh = std::make_shared<MeshDevice>(
-        scoped_devices_,
-        submesh_shape,
-        std::make_unique<MeshDeviceView>(submesh_devices_container),
-        shared_from_this());
+        scoped_devices_, std::make_unique<MeshDeviceView>(submesh_devices_container), shared_from_this());
 
     submeshes_.push_back(submesh);
-    log_trace(
-        LogMetal,
-        "Instantiating submesh {}: {}x{} with offset: {} {}",
-        submesh->id(),
-        submesh_shape.num_rows,
-        submesh_shape.num_cols,
-        offset.row,
-        offset.col);
+    log_trace(LogMetal, "Instantiating submesh {}: {} with offset: {}", submesh->id(), submesh_shape, offset);
     log_trace(LogMetal, "Submesh {} instantiated with {} devices", submesh->id(), submesh->get_devices().size());
-
     return submesh;
 }
 
 std::vector<std::shared_ptr<MeshDevice>> MeshDevice::create_submeshes(const MeshShape& submesh_shape) {
-    std::vector<std::shared_ptr<MeshDevice>> submeshes;
-    for (int row = 0; row < this->num_rows(); row += submesh_shape.num_rows) {
-        for (int col = 0; col < this->num_cols(); col += submesh_shape.num_cols) {
-            auto submesh = this->create_submesh(submesh_shape, MeshOffset{row, col});
-            submeshes.push_back(submesh);
-        }
+    // Calculate how many submeshes fit in each dimension.
+    tt::stl::SmallVector<uint32_t> steps;
+    for (size_t dim = 0; dim < shape().dims(); dim++) {
+        TT_FATAL(
+            shape()[dim] % submesh_shape[dim] == 0,
+            "Shape {} is not divisible by submesh shape {} along dimension {}",
+            shape(),
+            submesh_shape,
+            dim);
+        uint32_t num_steps = shape()[dim] / submesh_shape[dim];
+        steps.push_back(num_steps);
     }
+
+    // Stamp `submesh_shape` along each dimension, `steps` number of times.
+    std::vector<std::shared_ptr<MeshDevice>> submeshes;
+    for (const auto& step_position : MeshCoordinateRange(MeshShape(steps))) {
+        tt::stl::SmallVector<uint32_t> offset_coords;
+        for (size_t dim = 0; dim < submesh_shape.dims(); dim++) {
+            offset_coords.push_back(step_position[dim] * submesh_shape[dim]);
+        }
+        submeshes.push_back(create_submesh(submesh_shape, MeshCoordinate(offset_coords)));
+    }
+
     return submeshes;
 }
 
@@ -251,11 +258,11 @@ tt::ARCH MeshDevice::arch() const {
         scoped_devices_->root_devices(), [](const auto& device) { return device->arch(); });
 }
 
-size_t MeshDevice::num_rows() const { return mesh_shape_.num_rows; }
+size_t MeshDevice::num_rows() const { return view_->num_rows(); }
 
-size_t MeshDevice::num_cols() const { return mesh_shape_.num_cols; }
+size_t MeshDevice::num_cols() const { return view_->num_cols(); }
 
-MeshShape MeshDevice::shape() const { return mesh_shape_; }
+const MeshShape& MeshDevice::shape() const { return view_->shape(); }
 
 std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_shape) const {
     // MeshDeviceView requires devices to be provided as a 1D array in row-major order for the target mesh shape.
@@ -281,7 +288,7 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
 
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
     // However, going from a Line mesh to an MxN mesh is not always possible.
-    if (new_shape.num_rows == 1 || new_shape.num_cols == 1) {
+    if (is_line_topology(new_shape)) {
         return view_->get_line_devices();
     }
 
@@ -292,14 +299,10 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
         if (physical_device_id_to_linearized_index.find(new_physical_device_ids[i]) ==
             physical_device_id_to_linearized_index.end()) {
             TT_THROW(
-                "User has requested a reshape of the MeshDevice to shape: {}x{}, but it is not possible to form a "
-                "physically connected mesh of {}x{} grid with the opened devices from the original shape: {}x{}.",
-                new_shape.num_rows,
-                new_shape.num_cols,
-                new_shape.num_rows,
-                new_shape.num_cols,
-                this->num_rows(),
-                this->num_cols());
+                "User has requested a reshape of the MeshDevice to shape: {}, but it is not possible to form a "
+                "physically connected mesh grid with the opened devices from the original shape: {}.",
+                new_shape,
+                view_->shape());
         }
     }
 
@@ -312,13 +315,11 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
 
 void MeshDevice::reshape(const MeshShape& new_shape) {
     TT_FATAL(
-        new_shape.num_rows * new_shape.num_cols == this->num_devices(),
+        new_shape.mesh_size() == this->num_devices(),
         "New shape must have the same number of devices as current shape");
 
     MeshContainer<IDevice*> devices(new_shape, this->get_row_major_devices(new_shape));
     auto new_view = std::make_unique<MeshDeviceView>(devices);
-
-    mesh_shape_ = new_shape;
     view_ = std::move(new_view);
 }
 

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -37,7 +37,7 @@ MeshDeviceView::MeshDeviceView(const MeshContainer<IDevice*>& devices) : devices
 }
 
 MeshDeviceView::MeshDeviceView(const MeshDevice& mesh_device) :
-    MeshDeviceView(MeshContainer<IDevice*>(SimpleMeshShape(mesh_device.shape()), mesh_device.get_devices())) {}
+    MeshDeviceView(MeshContainer<IDevice*>(MeshShape(mesh_device.shape()), mesh_device.get_devices())) {}
 
 MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshCoordinateRange& range) const {
     DeviceView devices_in_region;
@@ -47,7 +47,7 @@ MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshCoordinateRange
     return devices_in_region;
 }
 
-MeshDeviceView::DeviceView MeshDeviceView::get_devices(const SimpleMeshShape& submesh_shape) const {
+MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshShape& submesh_shape) const {
     return get_devices(MeshCoordinateRange(submesh_shape));
 }
 
@@ -91,7 +91,7 @@ std::vector<std::vector<IDevice*>> MeshDeviceView::get_column_views() const {
 
 bool MeshDeviceView::empty() const noexcept { return devices_.shape().mesh_size() == 0; }
 size_t MeshDeviceView::size() const noexcept { return devices_.shape().mesh_size(); }
-SimpleMeshShape MeshDeviceView::shape() const noexcept { return devices_.shape(); }
+const MeshShape& MeshDeviceView::shape() const noexcept { return devices_.shape(); }
 
 bool MeshDeviceView::contains(const MeshCoordinate& coord) const noexcept {
     return devices_.coord_range().contains(coord);

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -111,12 +111,7 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
         }
     }();
 
-    const bool line_topology = [&config]() {
-        const int non_unit_dims =
-            std::count_if(config.mesh_shape.cbegin(), config.mesh_shape.cend(), [](int dim) { return dim != 1; });
-        return non_unit_dims <= 1;
-    }();
-    if (line_topology) {
+    if (is_line_topology(config.mesh_shape)) {
         TT_FATAL(
             std::all_of(system_offset.coords().begin(), system_offset.coords().end(), [](int dim) { return dim == 0; }),
             "Offsets are unsupported for a line mesh");

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -16,7 +16,7 @@ namespace tt::tt_metal::distributed {
 
 class SystemMesh::Impl {
 private:
-    SimpleMeshShape logical_mesh_shape_;
+    MeshShape logical_mesh_shape_;
     CoordinateTranslationMap logical_to_physical_coordinates_;
     std::unordered_map<MeshCoordinate, chip_id_t> logical_to_device_id_;
     std::unordered_map<PhysicalCoordinate, chip_id_t> physical_coordinate_to_device_id_;
@@ -27,7 +27,7 @@ public:
 
     bool is_system_mesh_initialized() const;
     void initialize();
-    const SimpleMeshShape& get_shape() const;
+    const MeshShape& get_shape() const;
     std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;
     std::vector<chip_id_t> request_available_devices(const MeshDeviceConfig& config) const;
     chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
@@ -68,7 +68,7 @@ void SystemMesh::Impl::initialize() {
     }
 }
 
-const SimpleMeshShape& SystemMesh::Impl::get_shape() const { return logical_mesh_shape_; }
+const MeshShape& SystemMesh::Impl::get_shape() const { return logical_mesh_shape_; }
 
 chip_id_t SystemMesh::Impl::get_physical_device_id(const MeshCoordinate& coord) const {
     TT_FATAL(
@@ -206,7 +206,7 @@ chip_id_t SystemMesh::get_physical_device_id(const MeshCoordinate& coord) const 
     return pimpl_->get_physical_device_id(coord);
 }
 
-const SimpleMeshShape& SystemMesh::get_shape() const { return pimpl_->get_shape(); }
+const MeshShape& SystemMesh::get_shape() const { return pimpl_->get_shape(); }
 
 std::vector<chip_id_t> SystemMesh::request_available_devices(const MeshDeviceConfig& config) const {
     return pimpl_->request_available_devices(config);

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char** argv) {
     using namespace tt::tt_metal::distributed;
 
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 4)});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)});
     auto& cq = mesh_device->mesh_command_queue();
 
     // In a typical single-device fashion, instantiate a program with

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
     using namespace tt::tt_metal::distributed;
     using tt::tt_metal::distributed::ShardedBufferConfig;
 
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 4)});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)});
     auto& cq = mesh_device->mesh_command_queue();
 
     // Define the shape of the shard and the distributed buffer.

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -85,7 +85,7 @@ Program CreateEltwiseAddProgram(
 // The example showcases TT-Metalium's ability to abstract away the complexity
 // of distributed memory management and compute.
 int main(int argc, char** argv) {
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(2, 4)});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)});
 
     // Define the global buffer shape and shard shape for distributed buffers
     auto shard_shape = Shape2D{32, 32};

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -25,12 +25,10 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t trace_region_size,
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
-    const MeshOffset& offset,
+    const std::optional<MeshCoordinate>& offset,
     const std::vector<int>& physical_device_ids) {
-    std::optional<MeshCoordinate> offset_opt =
-        offset.row != 0 || offset.col != 0 ? std::make_optional<MeshCoordinate>(offset.row, offset.col) : std::nullopt;
-    auto config = MeshDeviceConfig{
-        .mesh_shape = SimpleMeshShape(mesh_shape), .offset = offset_opt, .physical_device_ids = physical_device_ids};
+    auto config =
+        MeshDeviceConfig{.mesh_shape = mesh_shape, .offset = offset, .physical_device_ids = physical_device_ids};
     return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
 }
 
@@ -130,8 +128,7 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     auto num_devices = instance.get_shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
 
-    auto physical_device_ids =
-        instance.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = SimpleMeshShape(1, 8)});
+    auto physical_device_ids = instance.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = MeshShape(1, 8)});
     return physical_device_ids;
 }
 
@@ -154,7 +151,9 @@ std::vector<IDevice*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_
         return std::visit(
             tt::stl::overloaded{
                 [&](const ShardTensor2D& s) {
-                    return mesh_device.get_view().get_devices(MeshShape{s.shard_mesh.y, s.shard_mesh.x});
+                    const tt::tt_metal::distributed::MeshCoordinateRange range(
+                        MeshShape(s.shard_mesh.y, s.shard_mesh.x));
+                    return mesh_device.get_view().get_devices(range);
                 },
                 [&](const auto&) { return get_workers_for_tensor(mesh_device.get_devices()); }},
             host_storage.strategy);

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -18,7 +18,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t trace_region_size,
     size_t num_command_queues,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config,
-    const MeshOffset& offset = MeshOffset(0, 0),
+    const std::optional<MeshCoordinate>& offset = std::nullopt,
     const std::vector<int>& physical_device_ids = {});
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -5,9 +5,12 @@
 #include "ttnn/distributed/distributed_pybind.hpp"
 #include <pybind11/pytypes.h>
 
+#include <ostream>
+
 #include <tt-metalium/command_queue.hpp>
 #include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 
@@ -25,56 +28,80 @@ void py_module_types(py::module& module) {
     py::class_<MeshDevice, std::shared_ptr<MeshDevice>>(module, "MeshDevice");
     py::class_<MeshSubDeviceManagerId>(module, "MeshSubDeviceManagerId");
     py::class_<MeshShape>(module, "MeshShape", "Struct representing the shape of a mesh device.");
-    py::class_<MeshOffset>(module, "MeshOffset", "Struct representing the offset of a mesh device.");
+    py::class_<MeshCoordinate>(module, "MeshCoordinate", "Struct representing the coordinate of a mesh device.");
 }
 
 void py_module(py::module& module) {
+    // TODO: #17477 - Remove overloads that accept 'row' and 'col'. Instead, use generic ND terms.
     static_cast<py::class_<MeshShape>>(module.attr("MeshShape"))
         .def(
             py::init([](size_t num_rows, size_t num_cols) { return MeshShape(num_rows, num_cols); }),
-            "Constructor with specified number of rows and columns.",
+            "Constructor with the specified number of rows and columns.",
             py::arg("num_rows"),
             py::arg("num_cols"))
-        .def_readwrite("num_rows", &MeshShape::num_rows, "Number of rows in the mesh.")
-        .def_readwrite("num_cols", &MeshShape::num_cols, "Number of columns in the mesh.")
+        .def(
+            py::init([](size_t x, size_t y, size_t z) { return MeshShape(x, y, z); }),
+            "Constructor with the specified 3D shape.",
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z"))
+        .def(
+            py::init([](const std::vector<uint32_t>& shape) { return MeshShape(shape); }),
+            "Constructor with the specified ND shape.",
+            py::arg("shape"))
         .def(
             "__repr__",
             [](const MeshShape& ms) {
-                return "<MeshShape num_rows=" + std::to_string(ms.num_rows) +
-                       " num_cols=" + std::to_string(ms.num_cols) + ">";
+                std::ostringstream str;
+                str << ms;
+                return str.str();
             })
-        .def("__iter__", [](const MeshShape& ms) { return py::iter(py::make_tuple(ms.num_rows, ms.num_cols)); });
-    static_cast<py::class_<MeshOffset>>(module.attr("MeshOffset"))
         .def(
-            py::init([](size_t row, size_t col) { return MeshOffset(row, col); }),
+            "__iter__",
+            [](const MeshShape& ms) { return py::make_iterator(ms.view().begin(), ms.view().end()); },
+            py::keep_alive<0, 1>());
+    static_cast<py::class_<MeshCoordinate>>(module.attr("MeshCoordinate"))
+        .def(
+            py::init([](size_t row, size_t col) { return MeshCoordinate(row, col); }),
             "Constructor with specified row and column offsets.",
             py::arg("row"),
             py::arg("col"))
-        .def_readwrite("row", &MeshOffset::row, "Row offset in the mesh.")
-        .def_readwrite("col", &MeshOffset::col, "Column offset in the mesh.")
+        .def(
+            py::init([](size_t x, size_t y, size_t z) { return MeshCoordinate(x, y, z); }),
+            "Constructor with the specified 3D coordinate.",
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z"))
+        .def(
+            py::init([](const std::vector<uint32_t>& coords) { return MeshCoordinate(coords); }),
+            "Constructor with the specified ND coordinate.",
+            py::arg("coords"))
         .def(
             "__repr__",
-            [](const MeshOffset& mo) {
-                return "<MeshOffset row=" + std::to_string(mo.row) + " col=" + std::to_string(mo.col) + ">";
+            [](const MeshCoordinate& mc) {
+                std::ostringstream str;
+                str << mc;
+                return str.str();
             })
-        .def("__iter__", [](const MeshOffset& mo) { return py::iter(py::make_tuple(mo.row, mo.col)); });
+        .def(
+            "__iter__",
+            [](const MeshCoordinate& mc) { return py::make_iterator(mc.coords().begin(), mc.coords().end()); },
+            py::keep_alive<0, 1>());
 
     auto py_mesh_device = static_cast<py::class_<MeshDevice, std::shared_ptr<MeshDevice>>>(module.attr("MeshDevice"));
     py_mesh_device
         .def(
-            py::init([](const MeshShape& mesh_device_shape,
+            py::init([](const MeshShape& mesh_shape,
                         size_t l1_small_size,
                         size_t trace_region_size,
                         size_t num_command_queues,
                         const DispatchCoreConfig& dispatch_core_config,
-                        const MeshOffset& offset,
+                        const std::optional<MeshCoordinate>& offset,
                         const std::vector<chip_id_t>& physical_device_ids) {
                 return MeshDevice::create(
                     MeshDeviceConfig{
-                        .mesh_shape = SimpleMeshShape(mesh_device_shape),
-                        .offset = offset.row != 0 || offset.col != 0
-                                      ? std::make_optional<MeshCoordinate>(offset.row, offset.col)
-                                      : std::nullopt,
+                        .mesh_shape = mesh_shape,
+                        .offset = offset,
                         .physical_device_ids = physical_device_ids,
                     },
                     l1_small_size,

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
@@ -52,58 +52,58 @@ private:
 
 class ShardTensorTo2dMesh : public TensorToMesh {
 public:
-    ShardTensorTo2dMesh(const MeshShape& mesh_shape, const Shard2dConfig& config) :
-        mesh_shape_(mesh_shape), config_(config) {}
+    ShardTensorTo2dMesh(size_t mesh_rows, size_t mesh_cols, const Shard2dConfig& config) :
+        mesh_rows_(mesh_rows), mesh_cols_(mesh_cols), config_(config) {}
 
     std::vector<Tensor> map(const Tensor& tensor) const override {
-        const auto [rows, cols] = mesh_shape_;
         const auto [row_dim, col_dim] = config_;
 
         std::vector<Tensor> row_tensors;
 
         // Shard along rows
         if (!row_dim.has_value()) {
-            row_tensors.reserve(rows);
-            for (int i = 0; i < rows; ++i) {
+            row_tensors.reserve(mesh_rows_);
+            for (int i = 0; i < mesh_rows_; ++i) {
                 row_tensors.push_back(tensor);
             }
         } else {
-            row_tensors = experimental::xtensor::chunk(tensor, rows, *row_dim);
+            row_tensors = experimental::xtensor::chunk(tensor, mesh_rows_, *row_dim);
         }
 
         std::vector<Tensor> tensor_shards;
-        tensor_shards.reserve(rows * cols);
+        tensor_shards.reserve(mesh_rows_ * mesh_cols_);
         // Shard along columns
         if (!col_dim.has_value()) {
             for (const auto& t : row_tensors) {
-                for (int i = 0; i < cols; ++i) {
+                for (int i = 0; i < mesh_cols_; ++i) {
                     tensor_shards.push_back(t);
                 }
             }
         } else {
             for (const auto& t : row_tensors) {
-                auto col_chunks = experimental::xtensor::chunk(t, cols, *col_dim);
+                auto col_chunks = experimental::xtensor::chunk(t, mesh_cols_, *col_dim);
                 tensor_shards.insert(tensor_shards.end(), col_chunks.begin(), col_chunks.end());
             }
         }
 
         TT_FATAL(
-            static_cast<int>(tensor_shards.size()) == rows * cols,
+            static_cast<int>(tensor_shards.size()) == mesh_rows_ * mesh_cols_,
             "ShardTensorTo2dMesh: Sharding failed. Number of shards should match the product of the mesh "
             "dimensions. Size: {}, rows: {}, cols: {}",
             tensor_shards.size(),
-            rows,
-            cols);
+            mesh_rows_,
+            mesh_cols_);
 
         return tensor_shards;
     }
 
     tt::tt_metal::DistributedTensorConfig config() const override {
-        return DistributedTensorConfig{ShardTensor2D{ShardMesh{mesh_shape_.num_rows, mesh_shape_.num_cols}}};
+        return DistributedTensorConfig{ShardTensor2D{ShardMesh{mesh_rows_, mesh_cols_}}};
     }
 
 private:
-    MeshShape mesh_shape_;
+    size_t mesh_rows_ = 0;
+    size_t mesh_cols_ = 0;
     Shard2dConfig config_;
 };
 
@@ -121,18 +121,17 @@ private:
 
 class Concat2dMeshToTensor : public MeshToTensor {
 public:
-    Concat2dMeshToTensor(MeshDevice& mesh_device, const Concat2dConfig& config) :
-        mesh_shape_(mesh_device.shape()), config_(config) {}
+    Concat2dMeshToTensor(size_t mesh_rows, size_t mesh_cols, const Concat2dConfig& config) :
+        mesh_rows_(mesh_rows), mesh_cols_(mesh_cols), config_(config) {}
 
     Tensor compose(const std::vector<Tensor>& tensors) const override {
-        const auto [rows, cols] = mesh_shape_;
         const auto [row_dim, col_dim] = config_;
 
         std::vector<Tensor> row_concatenated;
-        row_concatenated.reserve(rows);
-        for (int i = 0; i < rows; ++i) {
-            auto row_start = tensors.begin() + i * cols;
-            auto row_end = row_start + cols;
+        row_concatenated.reserve(mesh_rows_);
+        for (int i = 0; i < mesh_rows_; ++i) {
+            auto row_start = tensors.begin() + i * mesh_cols_;
+            auto row_end = row_start + mesh_cols_;
             std::vector<Tensor> row_tensors(row_start, row_end);
             row_concatenated.push_back(experimental::xtensor::concat(row_tensors, col_dim));
         }
@@ -141,7 +140,8 @@ public:
     }
 
 private:
-    MeshShape mesh_shape_;
+    size_t mesh_rows_ = 0;
+    size_t mesh_cols_ = 0;
     Concat2dConfig config_;
 };
 
@@ -160,11 +160,13 @@ std::unique_ptr<TensorToMesh> shard_tensor_to_2d_mesh_mapper(
     TT_FATAL(
         config.row_dim.has_value() || config.col_dim.has_value(),
         "Sharding a tensor to 2D mesh requires at least one dimension to shard");
+    TT_FATAL(mesh_shape.dims() == 2, "Mesh shape is not 2D: {}", mesh_shape);
+    TT_FATAL(mesh_device.shape().dims() == 2, "Mesh device is not configured as a 2D mesh: {}", mesh_device.shape());
     TT_FATAL(
-        mesh_shape.num_rows <= mesh_device.shape().num_rows &&  //
-            mesh_shape.num_cols <= mesh_device.shape().num_cols,
+        mesh_shape[0] <= mesh_device.shape()[0] &&  //
+            mesh_shape[1] <= mesh_device.shape()[1],
         "Device mesh shape does not match the provided mesh shape.");
-    return std::make_unique<ShardTensorTo2dMesh>(mesh_shape, config);
+    return std::make_unique<ShardTensorTo2dMesh>(mesh_shape[0], mesh_shape[1], config);
 }
 
 std::unique_ptr<MeshToTensor> concat_mesh_to_tensor_composer(int dim) {
@@ -177,7 +179,8 @@ std::unique_ptr<MeshToTensor> concat_2d_mesh_to_tensor_composer(MeshDevice& mesh
         "Dimensions in 'dims' must be different; got row_dim: {}, col_dim: {}",
         config.row_dim,
         config.col_dim);
-    return std::make_unique<Concat2dMeshToTensor>(mesh_device, config);
+    TT_FATAL(mesh_device.shape().dims() == 2, "Mesh device is not configured as a 2D mesh: {}", mesh_device.shape());
+    return std::make_unique<Concat2dMeshToTensor>(mesh_device.shape()[0], mesh_device.shape()[1], config);
 }
 
 Tensor distribute_tensor(

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -13,9 +13,7 @@
 namespace ttnn::distributed {
 
 using MeshShape = tt::tt_metal::distributed::MeshShape;
-using SimpleMeshShape = tt::tt_metal::distributed::SimpleMeshShape;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
-using MeshOffset = tt::tt_metal::distributed::MeshOffset;
 using DeviceIds = tt::tt_metal::distributed::DeviceIds;
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using SystemMesh = tt::tt_metal::distributed::SystemMesh;
@@ -33,10 +31,8 @@ using ttnn::distributed::MeshCoordinate;
 using ttnn::distributed::MeshDevice;
 using ttnn::distributed::MeshDeviceConfig;
 using ttnn::distributed::MeshDeviceView;
-using ttnn::distributed::MeshOffset;
 using ttnn::distributed::MeshShape;
 using ttnn::distributed::MeshSubDeviceManagerId;
-using ttnn::distributed::SimpleMeshShape;
 using ttnn::distributed::SystemMesh;
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/tensor/storage.hpp"
+#include "tt-metalium/mesh_coord.hpp"
 
 namespace tt::tt_metal {
 
@@ -26,20 +27,19 @@ MultiDeviceStorage::MultiDeviceStorage(
     // tensor spec.
     //
     // For now, this code ensures MeshBuffer backed tensors are compatible with the rest of the ops infra.
-    const auto [num_rows, num_cols] = mesh_buffer->device()->shape();
+    const auto& mesh_shape = mesh_buffer->device()->shape();
+    distributed::MeshCoordinateRange range(mesh_shape);
 
-    ordered_device_ids.reserve(num_rows * num_cols);
-    buffers.reserve(num_rows * num_cols);
-    specs.reserve(num_rows * num_cols);
+    ordered_device_ids.reserve(mesh_shape.mesh_size());
+    buffers.reserve(mesh_shape.mesh_size());
+    specs.reserve(mesh_shape.mesh_size());
 
-    for (int row = 0; row < num_rows; ++row) {
-        for (int col = 0; col < num_cols; ++col) {
-            auto buffer = mesh_buffer->get_device_buffer(distributed::MeshCoordinate(row, col));
-            const int device_id = buffer->device()->id();
-            ordered_device_ids.push_back(device_id);
-            buffers.emplace(device_id, std::move(buffer));
-            specs.emplace(device_id, tensor_spec);
-        }
+    for (const auto& coord : range) {
+        auto buffer = mesh_buffer->get_device_buffer(coord);
+        const int device_id = buffer->device()->id();
+        ordered_device_ids.push_back(device_id);
+        buffers.emplace(device_id, std::move(buffer));
+        specs.emplace(device_id, tensor_spec);
     }
 }
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -156,7 +156,7 @@ from ttnn.types import (
     WormholeComputeKernelConfig,
     GrayskullComputeKernelConfig,
     MeshShape,
-    MeshOffset,
+    MeshCoordinate,
     UnaryWithParam,
     UnaryOpType,
     BinaryOpType,

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -138,7 +138,7 @@ def open_mesh_device(
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
     dispatch_core_config: ttnn.DispatchCoreConfig = ttnn.DispatchCoreConfig(),
-    offset: ttnn.MeshOffset = ttnn.MeshOffset(row=0, col=0),
+    offset: Optional[ttnn.MeshCoordinate] = None,
     physical_device_ids: List[int] = [],
 ):
     """
@@ -150,7 +150,7 @@ def open_mesh_device(
         trace_region_size (int, optional): Size of the trace region. Defaults to ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE.
         num_command_queues (int, optional): Number of command queues. Defaults to 1.
         dispatch_core_type (int, optional): Type of dispatch core. Defaults to DispatchCoreType.WORKER.
-        offset (ttnn.MeshOffset, optional): Offset in logical mesh coordinates for the mesh device. Defaults to (0, 0).
+        offset (ttnn.MeshCoordinate, optional): Offset in logical mesh coordinates for the mesh device. Defaults to None.
         physical_device_ids (List[int], optional): List of physical device IDs to use. Defaults to [].
 
     Returns:

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -65,7 +65,7 @@ class ShardStrategy(Enum):
 
 
 MeshShape = ttnn._ttnn.multi_device.MeshShape
-MeshOffset = ttnn._ttnn.multi_device.MeshOffset
+MeshCoordinate = ttnn._ttnn.multi_device.MeshCoordinate
 ShardOrientation = ttnn._ttnn.tensor.ShardOrientation
 ShardMode = ttnn._ttnn.tensor.ShardMode
 ShardSpec = ttnn._ttnn.tensor.ShardSpec


### PR DESCRIPTION
### Ticket
#17477

### Problem description
Continuing with adopting ND coordinate system in Metal and TTNN.

### What's changed
Remove the legacy `MeshShape`, and rename the new ND `SimpleMeshShape` to `MeshShape`:
* Remove last usages in `MeshDevice`, tensor libs, and tests.
* Remove `MeshOffset` and instead use `MeshCoordinate`.
* Add `is_line_topology`, `zero_coordinate`.
* Tests, tests, tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13490385633)
- [X] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13490397728)
- [X] New/Existing tests provide coverage for changes
