### PR TITLE
Enable Conv2d_Transposed tests for blackhole

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_conv_transpose2d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv_transpose2d.py
@@ -9,26 +9,11 @@ import pytest
 from models.utility_functions import (
     is_wormhole_b0,
     skip_for_grayskull,
-    is_grayskull,
-    is_wormhole_b0,
-    is_x2_harvested,
-    is_blackhole,
-    skip_for_blackhole,
-    is_blackhole,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 import ttnn
-import readline  # optional, will allow Up/Down/History in the console
-import code
 
 torch.set_printoptions(linewidth=400, profile="full", sci_mode=False)
-
-
-def drop_to_interpreter():
-    variables = globals().copy()
-    variables.update(locals())
-    shell = code.InteractiveConsole(variables)
-    shell.interact()
 
 
 def run_conv_transpose2d(
@@ -178,7 +163,6 @@ def run_conv_transpose2d(
     assert passing
 
 
-@skip_for_blackhole()
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 64 * 1024}], indirect=True)
 @pytest.mark.parametrize(
@@ -234,8 +218,8 @@ def test_simple_conv_t2d(
     shard_layout,
     mirror_kernel,
 ):
-    if device.core_grid.y != 8:
-        pytest.skip("Needs 8x8 Grid")
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 Grid for Wormhole_b0")
     run_conv_transpose2d(
         device,
         math_fidelity=ttnn.MathFidelity.HiFi4,


### PR DESCRIPTION
- removed `skip_for_blackhole()`
- removed unused code from `tests/ttnn/unit_tests/operations/test_conv_transpose2d.py`