### PR TITLE
CCache kernel compilation support

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -108,7 +108,7 @@ void JitBuildEnv::init(
     this->out_firmware_root_ = this->out_root_ + to_string(build_key) + "/firmware/";
     this->out_kernel_root_ = this->out_root_ + to_string(build_key) + "/kernels/";
 
-    const static bool use_ccache = std::getenv("CCACHE_KERNEL_SUPPORT") != nullptr;
+    const static bool use_ccache = std::getenv("TT_METAL_CCACHE_KERNEL_SUPPORT") != nullptr;
     if (use_ccache) {
         this->gpp_ = "ccache ";
     } else {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -108,8 +108,15 @@ void JitBuildEnv::init(
     this->out_firmware_root_ = this->out_root_ + to_string(build_key) + "/firmware/";
     this->out_kernel_root_ = this->out_root_ + to_string(build_key) + "/kernels/";
 
+    const static bool use_ccache = std::getenv("CCACHE_KERNEL_SUPPORT") != nullptr;
+    if (use_ccache) {
+        this->gpp_ = "ccache ";
+    } else {
+        this->gpp_ = "";
+    }
+
     // Tools
-    this->gpp_ = this->root_ + "runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++ ";
+    this->gpp_ += this->root_ + "runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++ ";
 
     // Flags
     string common_flags;


### PR DESCRIPTION
Use CCACHE_KERNEL_SUPPORT env var to enable ccache for kernel compilation. This will improve JIT build times in cases when
cache is hot, and consequently improve runtime
performance of tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13498494297) CI passes
