### PR TITLE
#17863: Remove pop for eps in BN

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -19,9 +19,7 @@ from models.utility_functions import skip_for_grayskull
     [
         *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
         *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
-        torch.Size([3, 1, 64, 120]),
-        torch.Size([3, 2, 64, 120]),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3], [1, 2, 3, 4])),
     ],
 )
 @pytest.mark.parametrize(
@@ -171,9 +169,7 @@ def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
     [
         *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
         *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
-        torch.Size([3, 1, 64, 120]),
-        torch.Size([3, 2, 64, 120]),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3], [1, 2, 3, 4])),
     ],
 )
 @pytest.mark.parametrize(
@@ -248,9 +244,7 @@ def test_batch_norm_fp32(
     [
         *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
         *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
-        torch.Size([3, 1, 64, 120]),
-        torch.Size([3, 2, 64, 120]),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3], [1, 2, 3, 4])),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -63,7 +63,6 @@ ALWI void batchnorm_bcast_tiles(
     // 1/(sqrt(batch_var + eps))
     cb_reserve_back(cb_den, onetile);
     cb_wait_front(cb_batch_var, onetile);
-    cb_wait_front(cb_eps, onetile);
 
     add_binary_tile_init();
     rsqrt_tile_init();
@@ -86,7 +85,6 @@ ALWI void batchnorm_bcast_tiles(
 
     cb_push_back(cb_den, onetile);
     cb_pop_front(cb_batch_var, onetile);
-    cb_pop_front(cb_eps, onetile);
 
     // (input - batch_mean)/(sqrt(batch_var + eps)) = result
     cb_wait_front(cb_den, onetile);
@@ -202,6 +200,10 @@ void MAIN {
 
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    constexpr uint32_t onetile = 1;
+    cb_wait_front(cb_eps, onetile);
+
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
         batchnorm_bcast_tiles(
             cb_bcast,
@@ -236,8 +238,5 @@ void MAIN {
             weight_has_value,
             bias_has_value);
     }
-
-    constexpr uint32_t onetile = 1;
-    constexpr int dst0 = 0;
 }
 }  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
#18332

### Problem description
Need to remove pop for eps value as it is a scalar const. Previously, `cb_eps` was being popped after the first iteration, requiring unnecessary repopulation. Removing the pop line ensures epsilon is read once and retained throughout iterations, preventing redundant operations.

### What's changed
Removal of pop_front for eps scalar value

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13499693686)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13499697318)
- [ ] Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) -  [Link to test](https://github.com/tenstorrent/tt-metal/actions/runs/13499702976)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/13499706954)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/13509644007)
- [ ] [Single-card Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/13499714894)
