### PR TITLE
#0: Fix crash when gtest xml contains no tests

### DIFF
--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -264,5 +264,5 @@ def get_tests_from_test_report_path(test_report_path):
 
         return tests
     else:
-        logger.warning("XML is not pytest junit format (gtest?), skipping for now")
+        logger.warning("XML is not pytest junit or gtest format, or no tests were found in the XML, skipping for now")
         return []

--- a/infra/data_collection/junit_xml_utils.py
+++ b/infra/data_collection/junit_xml_utils.py
@@ -31,7 +31,7 @@ def sanity_check_test_xml_(root_element, is_pytest=True):
 
 
 def is_pytest_junit_xml(root_element):
-    is_pytest = root_element[0].get("name") == "pytest"
+    is_pytest = len(root_element) > 0 and root_element[0].get("name") == "pytest"
 
     if is_pytest:
         sanity_check_test_xml_(root_element)
@@ -40,7 +40,7 @@ def is_pytest_junit_xml(root_element):
 
 
 def is_gtest_xml(root_element):
-    is_gtest = root_element[0].get("name") != "pytest"
+    is_gtest = len(root_element) > 0 and root_element[0].get("name") != "pytest"
 
     if is_gtest:
         sanity_check_test_xml_(root_element, is_pytest=False)

--- a/infra/tests/_data/data_collection/cicd/all_post_commit_job_37712709106/distributed_unit_tests_wormhole_b0.xml
+++ b/infra/tests/_data/data_collection/cicd/all_post_commit_job_37712709106/distributed_unit_tests_wormhole_b0.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="0" failures="0" disabled="0" errors="0" time="0" timestamp="2025-02-24T13:27:42.985" name="AllTests">
+</testsuites>

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -1,6 +1,7 @@
 import pytest
 import pathlib
 
+from infra.data_collection.github import workflows
 from infra.data_collection.cicd import create_cicd_json_for_data_analysis
 from infra.data_collection.models import InfraErrorV1
 
@@ -224,3 +225,11 @@ def test_create_pipeline_json_for_gtest_testcases(workflow_run_gh_environment):
 
     # fails validation, job is expected be skipped
     assert len([x for x in pipeline.jobs if x.github_job_id == 37190219113]) == 0
+
+
+def test_empty_gtest_xml(workflow_run_gh_environment):
+    github_runner_environment = workflow_run_gh_environment
+    workflow_outputs_dir = pathlib.Path("tests/_data/data_collection/cicd/all_post_commit_job_37712709106/").resolve()
+    assert (
+        workflows.get_tests_from_test_report_path(workflow_outputs_dir / "distributed_unit_tests_wormhole_b0.xml") == []
+    )


### PR DESCRIPTION
### Ticket

### Problem description
Produce data flow started crashing due to an xml file where there are no tests ([job isn't running tests?](https://github.com/tenstorrent/tt-metal/actions/runs/13498939862/job/37712914831))
https://github.com/tenstorrent/tt-metal/actions/runs/13499985487/job/37715810765


### What's changed
Make sure that the length of the xml element tree has len > 0 before indexing into element 0

### Checklist
- [x] New/Existing tests provide coverage for changes
Rerun on existing failed run in fix branch: https://github.com/tenstorrent/tt-metal/actions/runs/13500449797/job/37717313193
Added unit test