### PR TITLE
add extra guard on connection management for 1D fabric kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -660,6 +660,44 @@ FORCE_INLINE void receiver_forward_packet(
     }
 }
 
+template <uint8_t SENDER_NUM_BUFFERS>
+FORCE_INLINE void check_worker_connections(
+    tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS> &local_sender_channel_worker_interface,
+    bool &channel_connection_established,
+    bool &did_something
+) {
+    if (!channel_connection_established) {
+        // Can get rid of one of these two checks if we duplicate the logic above here in the function
+        // and depending on which of the two versions we are in (the connected version or disconnected version)
+        // We also check if the interface has a teardown request in case worker
+        // 1. opened connection
+        // 2. sent of all packets (EDM sender channel was sufficiently empty)
+        // 3. closed the connection
+        //
+        // In such a case like that, we still want to formally teardown the connection to keep things clean
+        bool connect_requested = local_sender_channel_worker_interface.connection_is_live() ||
+                                local_sender_channel_worker_interface.has_worker_teardown_request();
+        if (connect_requested) {
+            // if constexpr (enable_fabric_counters) {
+            //     sender_channel_counters->add_connection();
+            // }
+            did_something = true;
+            channel_connection_established = true;
+            local_sender_channel_worker_interface.cache_producer_noc_addr();
+            if constexpr (enable_first_level_ack) {
+                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(local_sender_channel_worker_interface.local_ackptr.get_ptr());
+            } else {
+                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(local_sender_channel_worker_interface.local_rdptr.get_ptr());
+            }
+        }
+    } else if (local_sender_channel_worker_interface.has_worker_teardown_request()) {
+        did_something = true;
+        channel_connection_established = false;
+        local_sender_channel_worker_interface.teardown_connection(
+            local_sender_channel_worker_interface.local_rdptr.get_ptr());
+    }
+}
+
 ////////////////////////////////////
 ////////////////////////////////////
 //  Main Control Loop
@@ -733,35 +771,9 @@ FORCE_INLINE bool run_sender_channel_step(
     }
 
 
-    if (!channel_connection_established) {
-        // Can get rid of one of these two checks if we duplicate the logic above here in the function
-        // and depending on which of the two versions we are in (the connected version or disconnected version)
-        // We also check if the interface has a teardown request in case worker
-        // 1. opened connection
-        // 2. sent of all packets (EDM sender channel was sufficiently empty)
-        // 3. closed the connection
-        //
-        // In such a case like that, we still want to formally teardown the connection to keep things clean
-        bool connect_requested = local_sender_channel_worker_interface.connection_is_live() ||
-                                 local_sender_channel_worker_interface.has_worker_teardown_request();
-        if (connect_requested) {
-            if constexpr (enable_fabric_counters) {
-                sender_channel_counters->add_connection();
-            }
-            did_something = true;
-            channel_connection_established = true;
-            local_sender_channel_worker_interface.cache_producer_noc_addr();
-            if constexpr (enable_first_level_ack) {
-                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(local_sender_channel_worker_interface.local_ackptr.get_ptr());
-            } else {
-                local_sender_channel_worker_interface.update_worker_copy_of_read_ptr(local_sender_channel_worker_interface.local_rdptr.get_ptr());
-            }
-        }
-    } else if (local_sender_channel_worker_interface.has_worker_teardown_request()) {
-        did_something = true;
-        channel_connection_established = false;
-        local_sender_channel_worker_interface.teardown_connection(
-            local_sender_channel_worker_interface.local_rdptr.get_ptr());
+    bool check_connection_status = !channel_connection_established || local_sender_channel_worker_interface.has_worker_teardown_request();
+    if (check_connection_status) {
+        check_worker_connections(local_sender_channel_worker_interface, channel_connection_established, did_something);
     }
 
     return did_something;


### PR DESCRIPTION
This change avoids cascading conditionals for a in frequent operation (adding or acknowledging a connection teardown request).

Leads to a modest perf bump:
BASELINE @ 4k packet size
mcast -> 13.81 GB/s
unicast -> 17 GB/s

Extra guard around check_connection:
mcast -> 14 GB/s
unicast -> 17.5 GB/s

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13501242748
 - Same on main
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
