### PR TITLE
Move TGG Unit Tests to 22.04

### DIFF
--- a/.github/workflows/tgg-unit-tests.yaml
+++ b/.github/workflows/tgg-unit-tests.yaml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
+      version: "22.04"
       build-wheel: true
   TGG-tests:
     needs: build-artifact


### PR DESCRIPTION
### Ticket
#14393

### Problem description
20.04 is going the way of the Dodo.

### What's changed
Flipped TGG-Unit to 22.04

### Checklist
- [x] TGG Unit [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13504215225)
