### PR TITLE
#0: Re-add "Move --exclude-warning-annotations to pytest.ini"

### DIFF
--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -52,14 +52,14 @@ jobs:
       matrix:
         os: ["${{ inputs.os }}"]
         test-group: [
-          {name: eager unit tests 1, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 1 --exclude-warning-annotations },
-          {name: eager unit tests 2, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 2 --exclude-warning-annotations },
-          {name: eager unit tests 3, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 3 --exclude-warning-annotations },
-          {name: eager unit tests 4, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 4 --exclude-warning-annotations },
-          {name: eager unit tests 5, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 5 --exclude-warning-annotations },
-          {name: eager unit tests 6, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 6 --exclude-warning-annotations },
-          {name: eager unit tests 7, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 7 --exclude-warning-annotations },
-          {name: sweep, cmd: pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/ -xvvv --exclude-warning-annotations },
+          {name: eager unit tests 1, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 1 },
+          {name: eager unit tests 2, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 2 },
+          {name: eager unit tests 3, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 3 },
+          {name: eager unit tests 4, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 4 },
+          {name: eager unit tests 5, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 5 },
+          {name: eager unit tests 6, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 6 },
+          {name: eager unit tests 7, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 7 },
+          {name: sweep, cmd: pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/ -xvvv },
         ]
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     env:

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -52,31 +52,31 @@ jobs:
         os: ["ubuntu-20.04"]
         test-group:
           - name: ttnn group 1
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 1 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode"
           - name: ttnn group 2
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 2 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 3 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 3 -m "not disable_fast_runtime_mode"
           - name: ttnn group 4
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 4 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 4 -m "not disable_fast_runtime_mode"
           - name: ttnn group 5
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 5 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 5 -m "not disable_fast_runtime_mode"
           - name: ttnn group 6
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 6 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 6 -m "not disable_fast_runtime_mode"
           - name: ttnn group 7
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 7 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 7 -m "not disable_fast_runtime_mode"
           - name: ttnn group 8
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 8 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 8 -m "not disable_fast_runtime_mode"
           - name: ttnn group 9
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 9 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 9 -m "not disable_fast_runtime_mode"
           - name: ttnn group 10
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 10 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 10 -m "not disable_fast_runtime_mode"
           - name: ttnn group 11
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 11 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 11 -m "not disable_fast_runtime_mode"
           - name: ttnn group 12
-            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --exclude-warning-annotations --group 12 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 12 -m "not disable_fast_runtime_mode"
           - name: ttnn fast runtime off
-            cmd: pytest tests/ttnn/unit_tests -xv --exclude-warning-annotations -m requires_fast_runtime_mode_off
+            cmd: pytest tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn example tests
             cmd: ./tests/scripts/run_ttnn_examples.sh

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 timeout = 300
 minversion = 7.2
-addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml
+addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml --exclude-warning-annotations
 empty_parameter_set_mark = skip
 markers =
     post_commit: mark tests to run on post-commit


### PR DESCRIPTION
### Ticket
Re-add https://github.com/tenstorrent/tt-metal/pull/18220

### Problem description
Warnings thrown by pytest inside profiler regressions show up as annotations in GHA after https://github.com/tenstorrent/tt-metal/pull/18106 because the tests run inside a bash script and don't have --exclude-warning-annotations set.

### What's changed
Add --exclude-warning-annotations to pytest.ini

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13509191145
- [ ] FYI to devs on slack to pick up new packages with ./create_venv.sh (this change makes `pytest-github-actions-annotate-failures` required, otherwise you will encounter the following error: `pytest: error: unrecognized arguments: --exclude-warning-annotations`)
