### PR TITLE
#18148: Modify create_row_major_owned_buffer to directly return owned buffer if possible

### DIFF
--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -401,6 +401,12 @@ owned_buffer::Buffer<T> create_row_major_owned_buffer(
         return owned_buffer;
     }
 
+    // No modifications needed; direclty return buffer
+    if (tensor_spec.layout() == Layout::ROW_MAJOR and tensor_spec.logical_2d_shape() == tensor_spec.physical_shape()) {
+        return owned_buffer;
+    }
+
+    // TODO: Switch to use span in decode_tensor_data and avoid data copy here
     auto physical_data = owned_buffer.get();
 
     // See implementation for documentation


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18148)

### Problem description
Perf regressions with switching over to use `tensor.to_torch` in `ttnn.to_torch`. New `tensor.to_torch` does an unnecessary copy in `owned_buffer.get()`. 

### What's changed
Modify create_row_major_owned_buffer to directly return owned buffer if possible

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13509513753
  - [ ] TG demo: https://github.com/tenstorrent/tt-metal/actions/runs/13509520932
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
