### PR TITLE
[skip ci] Run TGG Demo on 22.04

### DIFF
--- a/.github/workflows/tgg-demo-tests.yaml
+++ b/.github/workflows/tgg-demo-tests.yaml
@@ -11,6 +11,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
+      version: 22.04
   tgg-demo-tests:
     needs: build-artifact
     strategy:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14393

Problem description
20.04 is going the way of the Dodo.

What's changed
Flipped TGG-Unit to 22.04

Checklist
- [x] TGG Unit [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13507017565)