### PR TITLE
added template for binary functions

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/add_tiles.rst
@@ -2,6 +2,5 @@ add_tiles
 =========
 
 
-.. doxygenfunction:: add_tiles_init_nof()
 .. doxygenfunction:: add_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false)
 .. doxygenfunction:: add_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_op_init_funcs.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_op_init_funcs.rst
@@ -3,4 +3,4 @@ binary_init_funcs
 
 
 .. doxygenfunction:: binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb)
-.. doxygenfunction:: binary_op_specific_init(uint32_t icb0, uint32_t icb1)
+.. doxygenfunction:: binary_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/mul_tiles.rst
@@ -1,6 +1,5 @@
 mul_tiles
 =========
 
-.. doxygenfunction:: mul_tiles_init_f()
 .. doxygenfunction:: mul_tiles_init(uint32_t icb0, uint32_t icb1)
 .. doxygenfunction:: mul_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/sub_tiles.rst
@@ -1,6 +1,6 @@
 sub_tiles
 =========
 
-.. doxygenfunction:: sub_tiles_init_nof()
+
 .. doxygenfunction:: sub_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false)
 .. doxygenfunction:: sub_tiles( uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -22,7 +22,7 @@ void MAIN {
     constexpr auto cb_out1 = tt::CBIndex::c_17;  // Bfp8_b
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    add_tiles_init_nof();
+    binary_tiles_init<false, ELWADD>(cb_in0, cb_in1);
     for (uint32_t block = 0; block < num_tiles; ++block) {
         cb_wait_front(cb_in0, ublock_size_tiles);
         cb_wait_front(cb_in1, ublock_size_tiles);

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -26,9 +26,9 @@ void MAIN {
 
 #if not defined ELTWISE_DEST_REUSE_TYPE
 #ifdef FULL_INIT
-    binary_op_specific_init<true, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
+    binary_tiles_init<true, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
 #else
-    binary_op_specific_init<false, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
+    binary_tiles_init<false, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
 #endif
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -34,7 +34,7 @@ void MAIN {
     binary_op_init_common(cb_inp0, cb_inp1, cb_out0);
 
 #if not PRE_SCALE
-    binary_op_specific_init<false, ELTWISE_OP_TYPE>(cb_inp0, cb_inp1);
+    binary_tiles_init<false, ELTWISE_OP_TYPE>(cb_inp0, cb_inp1);
 #endif
 
 #ifdef PACK_RELU
@@ -110,7 +110,7 @@ void MAIN {
         cb_reserve_back(cb_out0, per_core_block_size);
 
 #if PRE_SCALE
-        binary_op_specific_init<true, ELTWISE_OP_TYPE>(cb_inp0, cb_inp1);
+        binary_tiles_init<true, ELTWISE_OP_TYPE>(cb_inp0, cb_inp1);
 #endif
 
         tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -44,7 +44,7 @@ ALWI void process_tile(
         cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
-        binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
@@ -85,7 +85,7 @@ void MAIN {
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
-    binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -29,7 +29,7 @@ void MAIN {
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
-    binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
@@ -42,7 +42,7 @@ void MAIN {
         cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
-        binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -28,7 +28,7 @@ void MAIN {
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
-    binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
     PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
@@ -41,7 +41,7 @@ void MAIN {
         cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
-        binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9037

### Problem description
Most of the logic to define the functions can be centralized in a single template

### What's changed
Created a template to define the functions
Implemented it
Plus, created two enums for readability 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
