### PR TITLE
Use direct-shard for BH in to_device function, remove i2s workaround.

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -361,7 +361,7 @@ def test_create_min_width_shard(
         )
 
     # BH does s2i and i2s inside of to_device and from_device as device ops
-    expected_entries = 1 if not is_blackhole() else 4 if overlap_coregrid else 5
+    expected_entries = 1 if not is_blackhole() else 3 if overlap_coregrid else 4
     assert device.num_program_cache_entries() == expected_entries
 
 

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -50,13 +50,7 @@ ttnn::Tensor squeeze_from_4D(const ttnn::Tensor& tensor, const int rank) {
 
 ttnn::Tensor to_device(
     const ttnn::Tensor& tensor, IDevice* device, const std::optional<MemoryConfig>& memory_config, QueueId cq_id) {
-    auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
-    if (mem_config.is_sharded() and (device->arch() == tt::ARCH::BLACKHOLE)) {
-        auto interleaved_tensor = tensor.to_device(device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
-        return ttnn::interleaved_to_sharded(ttnn::DefaultQueueId, interleaved_tensor, mem_config, std::nullopt);
-    } else {
-        return tensor.to_device(device, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG), cq_id);
-    }
+    return tensor.to_device(device, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG), cq_id);
 }
 
 ttnn::Tensor to_device(


### PR DESCRIPTION
### Ticket
#18144 (https://github.com/tenstorrent/tt-metal/issues/18144#issuecomment-2675053638)


### Problem description
BH used to call i2s to run sharding instead of direct sharding. I2S can't do DRAM sharding

### What's changed
Remove the workaround in to_device function, switch back to direct sharding.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. (https://github.com/tenstorrent/tt-metal/actions/runs/13508013932)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) (https://github.com/tenstorrent/tt-metal/actions/runs/13527025714)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
