### PR TITLE
#16643: Disabling dispatch posting atomic increments on blackhole

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -385,6 +385,15 @@ int main() {
     noc_local_state_init(noc_index);
     uint8_t prev_noc_mode = DM_DEDICATED_NOC;
 
+
+#if defined(ARCH_BLACKHOLE)
+    // When dispatch_s is on an ethernet core on blockhole, we've been seeing
+    // issues where posted atomic incremenets seem to fail to complete.
+    const bool post_atomic_increments = false;
+#else
+    const bool post_atomic_increments = true;
+#endif
+
     while (1) {
         init_sync_registers();
         reset_ncrisc_with_iram();
@@ -423,7 +432,7 @@ int main() {
                     1,
                     31 /*wrap*/,
                     false /*linked*/,
-                    true /*posted*/);
+                    post_atomic_increments /*posted*/);
             }
         }
 
@@ -550,7 +559,7 @@ int main() {
                     1,
                     31 /*wrap*/,
                     false /*linked*/,
-                    true /*posted*/);
+                    post_atomic_increments /*posted*/);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
         }

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -48,7 +48,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 256)
+#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 512)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 1536
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION


### Ticket
#16643

### Problem description
We seem to have NOC issues when posting atomic increments to ethernet cores on Blackhole.

### What's changed
Avoid posting atomic increments to the disaptcher on Blackhole. This may lead to a 250 cycle increase in GO message latency, worst-case.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
