### PR TITLE
#18150: Move xmltodict to requirements-infra.txt

### DIFF
--- a/.github/actions/generate-gtest-failure-message/action.yml
+++ b/.github/actions/generate-gtest-failure-message/action.yml
@@ -9,9 +9,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.8
+        cache: 'pip'
+        cache-dependency-path: 'infra/requirements-infra.txt'
     - name: Generate gtest failure messages
       id: generate-gtest-message
       shell: bash
       run: |
         set +e
+        pip install -r infra/requirements-infra.txt
         python3 .github/scripts/data_analysis/print_gtest_annotations.py ${{ inputs.path }}

--- a/infra/requirements-infra.txt
+++ b/infra/requirements-infra.txt
@@ -6,3 +6,5 @@ pydantic
 toolz
 defusedxml
 pytest
+# For github workflow gtest failure annotations
+xmltodict

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -4,8 +4,7 @@
 
 loguru
 
-# For github workflow unit test failure annotations
-xmltodict
+# For github workflow pytest failure annotations
 pytest-github-actions-annotate-failures==0.3.0
 
 # During dep resolution, black may install platformdirs >=4.0.0, which is


### PR DESCRIPTION
### Ticket
Resolves [18150](https://github.com/tenstorrent/tt-metal/issues/18150)

### Problem description
pytest mysteriously crashes on `tt-metal-ci-vm-24` when xmltodict is included in the dev env.

### What's changed
Move xmltodict to infra env instead.

### Checklist
- [ ] All-post-commit
https://github.com/tenstorrent/tt-metal/actions/runs/13508620542