### PR TITLE
#0: remove sync_events from api

### DIFF
--- a/tt_metal/api/tt-metalium/build.hpp
+++ b/tt_metal/api/tt-metalium/build.hpp
@@ -199,9 +199,4 @@ void jit_build_subset(const JitBuildStateSubset& builds, const JitBuildSettings*
 
 void launch_build_step(const std::function<void()>& build_func, std::vector<std::shared_future<void>>& events);
 
-inline void sync_build_step(std::vector<std::shared_future<void>>& events) {
-    for (auto& f : events) {
-        f.get();
-    }
-}
 }  // namespace tt::tt_metal

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -28,6 +28,16 @@ namespace fs = std::filesystem;
 using namespace std;
 using namespace tt;
 
+namespace {
+
+void sync_events(auto& events) {
+    for (auto& f : events) {
+        f.get();
+    }
+}
+
+}  // namespace
+
 namespace tt::tt_metal {
 
 static std::string get_string_aliased_arch_lowercase(tt::ARCH arch) {
@@ -660,7 +670,8 @@ void JitBuildState::compile(const string& log_file, const string& out_dir, const
             events);
     }
 
-    sync_build_step(events);
+    sync_events(events);
+
     if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
         dump_kernel_defines_and_args(env_.get_out_kernel_root_path());
     }
@@ -762,7 +773,8 @@ void jit_build_set(const JitBuildStateSet& build_set, const JitBuildSettings* se
         auto& build = build_set[i];
         launch_build_step([build, settings] { build->build(settings); }, events);
     }
-    sync_build_step(events);
+
+    sync_events(events);
 }
 
 void jit_build_subset(const JitBuildStateSubset& build_subset, const JitBuildSettings* settings) {
@@ -772,7 +784,8 @@ void jit_build_subset(const JitBuildStateSubset& build_subset, const JitBuildSet
         auto& build = build_subset.build_ptr[i];
         launch_build_step([build, settings] { build->build(settings); }, events);
     }
-    sync_build_step(events);
+
+    sync_events(events);
 }
 
 void launch_build_step(const std::function<void()>& build_func, std::vector<std::shared_future<void>>& events) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This is an internal function

### What's changed
Delete it from the api directory

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
