### PR TITLE
Don't write fatal logs when any exception is thrown

### DIFF
--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -97,12 +97,10 @@ template <typename... Args>
     if constexpr (sizeof...(args) > 0) {
         trace_message_ss << "info:" << std::endl;
         trace_message_ss << fmt::format(args...) << std::endl;
-        log_fatal(args...);
     }
     trace_message_ss << "backtrace:\n";
     trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
     trace_message_ss << std::flush;
-    Logger::get().flush();
     if (std::getenv("TT_ASSERT_ABORT")) {
         abort();
     }

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -103,11 +103,12 @@ template <typename... Args>
     trace_message_ss << std::flush;
     if (std::getenv("TT_ASSERT_ABORT")) {
         log_fatal(args...);
+        Logger::get().flush();
         abort();
     } else {
-        log_info(args...);
+        log_debug(args...);
+        Logger::get().flush();
     }
-    Logger::get().flush();
     throw std::runtime_error(trace_message_ss.str());
 }
 

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -92,23 +92,25 @@ inline std::string backtrace_to_string(int size = 64, int skip = 2, const std::s
 template <typename... Args>
 [[noreturn]] void tt_throw_impl(
     char const* file, int line, char const* assert_type, char const* condition_str, Args const&... args) {
+    if (std::getenv("TT_ASSERT_ABORT")) {
+        if constexpr (sizeof...(args) > 0) {
+            log_fatal(args...);
+            Logger::get().flush();
+        }
+        abort();
+    }
+
     std::stringstream trace_message_ss = {};
     trace_message_ss << assert_type << " @ " << file << ":" << line << ": " << condition_str << std::endl;
     if constexpr (sizeof...(args) > 0) {
         trace_message_ss << "info:" << std::endl;
         trace_message_ss << fmt::format(args...) << std::endl;
+        log_debug(args...);
+        Logger::get().flush();
     }
     trace_message_ss << "backtrace:\n";
     trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
     trace_message_ss << std::flush;
-    if (std::getenv("TT_ASSERT_ABORT")) {
-        log_fatal(args...);
-        Logger::get().flush();
-        abort();
-    } else {
-        log_debug(args...);
-        Logger::get().flush();
-    }
     throw std::runtime_error(trace_message_ss.str());
 }
 

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -102,8 +102,12 @@ template <typename... Args>
     trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
     trace_message_ss << std::flush;
     if (std::getenv("TT_ASSERT_ABORT")) {
+        log_fatal(args...);
         abort();
+    } else {
+        log_info(args...);
     }
+    Logger::get().flush();
     throw std::runtime_error(trace_message_ss.str());
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18059

### Problem description
Currently we write FATAL logs on every invocation of TT_THROW, which creates strange logs for our users even the exception is caught and handled

### What's changed
Use `log_debug` instead of `log_fatal` when throwing an exception.
If the exception won't get caught, the user should still see the error with text in the logs.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13510968044)
- [x] New/Existing tests provide coverage for changes
