### PR TITLE
Allow users to specify build optimization level

### DIFF
--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
+#include <string_view>
 #include <vector>
 #include <map>
 #include <variant>
@@ -176,7 +177,11 @@ class DataMovementKernel : public Kernel {
 
     void process_defines(const std::function<void (const string& define, const string &value)>) const override;
 
-   private:
+    std::string_view get_compiler_opt_level() const override;
+
+    std::string_view get_linker_opt_level() const override;
+
+private:
     const DataMovementConfig config_;
 
     uint8_t expected_num_binaries() const override;
@@ -204,7 +209,11 @@ class EthernetKernel : public Kernel {
 
     void process_defines(const std::function<void(const string &define, const string &value)>) const override;
 
-   private:
+    std::string_view get_compiler_opt_level() const override;
+
+    std::string_view get_linker_opt_level() const override;
+
+private:
     const EthernetConfig config_;
 
     uint8_t expected_num_binaries() const override;
@@ -233,7 +242,11 @@ class ComputeKernel : public Kernel {
 
     void process_defines(const std::function<void (const string& define, const string &value)>) const override;
 
-   private:
+    std::string_view get_compiler_opt_level() const override;
+
+    std::string_view get_linker_opt_level() const override;
+
+private:
     const ComputeConfig config_;
 
     uint8_t expected_num_binaries() const override;

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,18 @@ namespace tt::tt_metal {
 
 using KernelHandle = std::uint32_t;
 
+// Option that controls compiler optimization level
+enum class KernelBuildOptLevel : uint8_t {
+    O1,     // Level 1 optimization. Same as O.
+    O2,     // Level 2 optimization. Turns on all flags specified by O1.
+    O3,     // Level 3 optimizaiton. Turns on all flags specified by O2.
+    O0,     // Reduce compilation time and make debugging produce the expected results.
+    Os,     // Optimize for size. Enables O2 optimizations except for those that increase binary size.
+    Ofast,  // Enable all O3 and non standard optimizations.
+    Og,     // Optimize for debugging.
+    Oz,     // Aggresively optimize for size rather than speed.
+};
+
 struct DataMovementConfig {
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0;  // For data transfer kernels: NCRISC & BRISC
     NOC noc = NOC::RISCV_0_default;
@@ -24,6 +36,8 @@ struct DataMovementConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
+    // Kernel optimization level
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
 };
 
 struct ReaderDataMovementConfig : public DataMovementConfig {
@@ -46,6 +60,8 @@ struct ComputeConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
+    // Kernel optimization level
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::O3;
 };
 
 struct EthernetConfig {
@@ -57,6 +73,8 @@ struct EthernetConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
+    // Kernel optimization level
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -15,15 +15,14 @@ namespace tt::tt_metal {
 
 using KernelHandle = std::uint32_t;
 
-// Option that controls compiler optimization level
+// Option that controls build optimization level
 enum class KernelBuildOptLevel : uint8_t {
-    O1,     // Level 1 optimization. Same as O.
-    O2,     // Level 2 optimization. Turns on all flags specified by O1.
-    O3,     // Level 3 optimizaiton. Turns on all flags specified by O2.
+    O1,     // Turns on level 1 optimization. Same as O.
+    O2,     // Turns on level 2 optimization and also all flags specified by O1.
+    O3,     // Turns on level 3 optimization and also all flags specified by O2.
     O0,     // Reduce compilation time and make debugging produce the expected results.
-    Os,     // Optimize for size. Enables O2 optimizations except for those that increase binary size.
-    Ofast,  // Enable all O3 and non standard optimizations.
-    Og,     // Optimize for debugging.
+    Os,     // Optimize for size and also O2 optimizations except for those that increase binary size.
+    Ofast,  // Turns on level O3 and also non standard optimizations.
     Oz,     // Aggresively optimize for size rather than speed.
 };
 
@@ -36,7 +35,7 @@ struct DataMovementConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
-    // Kernel optimization level
+    // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
 };
 
@@ -60,7 +59,7 @@ struct ComputeConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
-    // Kernel optimization level
+    // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::O3;
 };
 
@@ -73,7 +72,7 @@ struct EthernetConfig {
     // Each unique combination of defines will produce a unique compiled instantiation
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
-    // Kernel optimization level
+    // Set the compiler and linker optimization level
     KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
 };
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1,16 +1,19 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <kernel.hpp>
+#include <kernel_types.hpp>
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
+#include <magic_enum/magic_enum.hpp>
 #include <set>
 
 #include <build.hpp>
 #include "llrt.hpp"
+#include <string_view>
 #include <tt_metal.hpp>
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/kernel.hpp"
@@ -105,7 +108,7 @@ CoreType Kernel::get_kernel_core_type() const {
     return CoreType::WORKER;
 }
 
-const string &Kernel::get_full_kernel_name() const { return this->kernel_full_name_; }
+const std::string& Kernel::get_full_kernel_name() const { return this->kernel_full_name_; }
 
 void Kernel::add_defines(const std::map<std::string, std::string>& defines) {
     this->defines_.insert(defines.begin(), defines.end());
@@ -140,6 +143,24 @@ void EthernetKernel::process_defines(
     // pass default noc mode as eth does not need it, just for compile to pass
     callback("NOC_MODE", std::to_string(NOC_MODE::DM_DEDICATED_NOC));
 }
+
+std::string_view DataMovementKernel::get_compiler_opt_level() const {
+    return magic_enum::enum_name(this->config_.opt_level);
+}
+
+std::string_view DataMovementKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
+
+std::string_view ComputeKernel::get_compiler_opt_level() const {
+    return magic_enum::enum_name(this->config_.opt_level);
+}
+
+std::string_view ComputeKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
+
+std::string_view EthernetKernel::get_compiler_opt_level() const {
+    return magic_enum::enum_name(this->config_.opt_level);
+}
+
+std::string_view EthernetKernel::get_linker_opt_level() const { return this->get_compiler_opt_level(); }
 
 void Kernel::process_compile_time_args(const std::function<void(int i, uint32_t value)> callback) const {
     for (int i = 0; i < this->compile_time_args_.size(); i++) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -252,10 +252,12 @@ void JitBuildState::finish_init() {
 JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :
     JitBuildState(env, build_config) {
     TT_ASSERT(this->core_id_ >= 0 && this->core_id_ < 2, "Invalid data movement processor");
-
+    this->lflags_ = env.lflags_;
+    this->cflags_ = env.cflags_;
+    this->default_compile_opt_level_ = "Os";
+    this->default_linker_opt_level_ = "Os";
     this->out_path_ = this->is_fw_ ? env_.out_firmware_root_ : env_.out_kernel_root_;
-
-    this->cflags_ = env_.cflags_ + "-Os " + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
+    this->cflags_ = env_.cflags_ + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
     this->includes_ = env_.includes_ + "-I " + env_.root_ + "tt_metal/hw/firmware/src " + "-I " + env_.root_ +
                       "tt_metal/hw/ckernels/" + env.arch_name_ + "/metal/common " + "-I " + env_.root_ +
                       "tt_metal/hw/ckernels/" + env.arch_name_ + "/metal/llk_io ";
@@ -264,8 +266,6 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuil
 
     uint32_t l1_cache_disable_mask = tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(
         tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
-
-    this->lflags_ = env_.lflags_ + "-Os ";
 
     switch (this->core_id_) {
         case 0:
@@ -324,10 +324,11 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuil
 JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :
     JitBuildState(env, build_config) {
     TT_ASSERT(this->core_id_ >= 0 && this->core_id_ < 3, "Invalid compute processor");
-
+    this->lflags_ = env.lflags_;
+    this->cflags_ = env.cflags_;
+    this->default_compile_opt_level_ = "O3";
+    this->default_linker_opt_level_ = "O3";
     this->out_path_ = this->is_fw_ ? env_.out_firmware_root_ : env_.out_kernel_root_;
-
-    this->cflags_ = env_.cflags_ + "-O3 ";
 
     this->defines_ = env_.defines_;
     uint32_t l1_cache_disable_mask = tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(
@@ -352,8 +353,6 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
     } else {
         this->srcs_.push_back("tt_metal/hw/firmware/src/trisck.cc");
     }
-
-    this->lflags_ = env_.lflags_ + "-O3 ";
 
     switch (this->core_id_) {
         case 0:
@@ -416,6 +415,10 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
 JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :
     JitBuildState(env, build_config) {
     TT_ASSERT(this->core_id_ >= 0 && this->core_id_ < 1, "Invalid active ethernet processor");
+    this->lflags_ = env.lflags_;
+    this->cflags_ = env.cflags_;
+    this->default_compile_opt_level_ = "Os";
+    this->default_linker_opt_level_ = "Os";
     this->out_path_ = this->is_fw_ ? env_.out_firmware_root_ : env_.out_kernel_root_;
 
     this->includes_ = env_.includes_ + "-I " + env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ +
@@ -437,8 +440,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
     switch (build_class) {
         case 0: {
             this->target_name_ = "active_erisc";
-            this->cflags_ =
-                env_.cflags_ + "-Os " + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
+            this->cflags_ = env_.cflags_ + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
 
             this->defines_ +=
                 "-DCOMPILE_FOR_ERISC "
@@ -452,7 +454,6 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
             } else {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/active_erisck.cc");
             }
-            this->lflags_ = env_.lflags_ + "-Os ";
 
             if (this->is_fw_) {
                 this->lflags_ +=
@@ -466,7 +467,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
         }
         case 1: {
             this->target_name_ = "erisc";
-            this->cflags_ = env_.cflags_ + "-Os -fno-delete-null-pointer-checks ";
+            this->cflags_ = env_.cflags_ + " -fno-delete-null-pointer-checks ";
 
             this->defines_ +=
                 "-DCOMPILE_FOR_ERISC "
@@ -489,10 +490,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
             } else {
                 linker_str = "tt_metal/hw/toolchain/erisc-b0-kernel.ld ";
             }
-            this->lflags_ = env_.lflags_ +
-                            "-Os "
-                            "-L" +
-                            env_.root_ +
+            this->lflags_ = env_.lflags_ + "-L" + env_.root_ +
                             "/tt_metal/hw/toolchain "
                             "-T" +
                             env_.root_ + linker_str;
@@ -513,6 +511,10 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
 JitBuildIdleEthernet::JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :
     JitBuildState(env, build_config) {
     TT_ASSERT(this->core_id_ >= 0 && this->core_id_ < 2, "Invalid idle ethernet processor");
+    this->lflags_ = env.lflags_;
+    this->cflags_ = env.cflags_;
+    this->default_compile_opt_level_ = "Os";
+    this->default_linker_opt_level_ = "Os";
     this->out_path_ = this->is_fw_ ? env_.out_firmware_root_ : env_.out_kernel_root_;
 
     this->includes_ = env_.includes_ + "-I " + env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ +
@@ -530,8 +532,7 @@ JitBuildIdleEthernet::JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuil
     switch (this->core_id_) {
         case 0: {
             this->target_name_ = "idle_erisc";
-            this->cflags_ =
-                env_.cflags_ + "-Os " + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
+            this->cflags_ = env_.cflags_ + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
 
             this->defines_ +=
                 "-DCOMPILE_FOR_IDLE_ERISC=0 "
@@ -545,7 +546,6 @@ JitBuildIdleEthernet::JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuil
             } else {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/idle_erisck.cc");
             }
-            this->lflags_ = env_.lflags_ + "-Os ";
 
             if (this->is_fw_) {
                 this->lflags_ +=
@@ -559,8 +559,7 @@ JitBuildIdleEthernet::JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuil
         }
         case 1: {
             this->target_name_ = "slave_idle_erisc";
-            this->cflags_ =
-                env_.cflags_ + "-Os " + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
+            this->cflags_ = env_.cflags_ + "-fno-tree-loop-distribute-patterns ";  // don't use memcpy for cpy loops
             this->defines_ +=
                 "-DCOMPILE_FOR_IDLE_ERISC=1 "
                 "-DERISC "
@@ -571,7 +570,6 @@ JitBuildIdleEthernet::JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuil
             } else {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/idle_erisck.cc");
             }
-            this->lflags_ = env_.lflags_ + "-Os ";
             if (this->is_fw_) {
                 this->lflags_ +=
                     "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_slave_ierisc.ld ";
@@ -609,9 +607,11 @@ void JitBuildState::compile_one(
     // ZoneScoped;
     fs::create_directories(out_dir);
 
-    // Add kernel specific defines
+    string cmd{"cd " + out_dir + " && " + env_.gpp_};
     string defines = this->defines_;
-    if (settings != nullptr) {
+
+    if (settings) {
+        // Append user args
         if (process_defines_at_compile) {
             settings->process_defines([&defines](const string& define, const string& value) {
                 defines += "-D" + define + "='" + value + "' ";
@@ -621,15 +621,17 @@ void JitBuildState::compile_one(
         settings->process_compile_time_args([&defines](int i, uint32_t value) {
             defines += "-DKERNEL_COMPILE_TIME_ARG_" + to_string(i) + "=" + to_string(value) + " ";
         });
+
+        cmd += fmt::format("-{} ", settings->get_compiler_opt_level());
+    } else {
+        cmd += fmt::format("-{} ", this->default_compile_opt_level_);
     }
 
-    string cmd;
-    cmd = "cd " + out_dir + " && ";
-    cmd += env_.gpp_;
+    // Append common args provided by the build state
     cmd += this->cflags_;
-    cmd += defines;
     cmd += this->includes_;
-    cmd += "-c -o " + obj + " " + src;
+    cmd += "-c -o " + obj + " " + src + " ";
+    cmd += defines;
 
     log_debug(tt::LogBuildKernels, "    g++ compile cmd: {}", cmd);
 
@@ -659,18 +661,16 @@ void JitBuildState::compile(const string& log_file, const string& out_dir, const
     }
 }
 
-void JitBuildState::link(const string& log_file, const string& out_dir) const {
+void JitBuildState::link(const string& log_file, const string& out_dir, const JitBuildSettings* settings) const {
     // ZoneScoped;
+    string cmd{"cd " + out_dir + " && " + env_.gpp_};
     string lflags = this->lflags_;
     if (tt::llrt::RunTimeOptions::get_instance().get_build_map_enabled()) {
         lflags += "-Wl,-Map=" + out_dir + "linker.map ";
     }
 
-    string cmd;
-    cmd = "cd " + out_dir + " && ";
-    cmd += env_.gpp_;
-    cmd += lflags;
-    cmd += this->link_objs_;
+    // Append user args
+    cmd += fmt::format("-{} ", settings ? settings->get_linker_opt_level() : this->default_linker_opt_level_);
 
     if (!this->is_fw_) {
         string weakened_elf_name =
@@ -678,6 +678,9 @@ void JitBuildState::link(const string& log_file, const string& out_dir) const {
         cmd += "-Wl,--just-symbols=" + weakened_elf_name + " ";
     }
 
+    // Append common args provided by the build state
+    cmd += lflags;
+    cmd += this->link_objs_;
     cmd += "-o " + out_dir + this->target_name_ + ".elf";
     log_debug(tt::LogBuildKernels, "    g++ link cmd: {}", cmd);
     if (!tt::utils::run_command(cmd, log_file, false)) {
@@ -731,9 +734,8 @@ void JitBuildState::build(const JitBuildSettings* settings) const {
     if (fs::exists(log_file)) {
         std::remove(log_file.c_str());
     }
-
     compile(log_file, out_dir, settings);
-    link(log_file, out_dir);
+    link(log_file, out_dir, settings);
     if (this->is_fw_) {
         weaken(log_file, out_dir);
     }

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
+#include "tt-metalium/kernel_types.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -28,7 +29,8 @@ int main(int argc, char** argv) {
             .math_fidelity = MathFidelity::HiFi4,
             .fp32_dest_acc_en = false,
             .math_approx_mode = false,
-            .compile_args = compute_kernel_args});
+            .compile_args = compute_kernel_args,
+            .opt_level = KernelBuildOptLevel::O3});
 
     // Configure Program and Start Program Execution on Device
 


### PR DESCRIPTION
### Ticket
#7449 

### Problem description
Compute kernels are hardcoded to `O3`. Other kernels are hardcoded to`Os`.
Users can't benefit from potentially "free" optimization wins because the optimization flag to build their kernels is hardcoded to `Os`.

### What's changed
Add `opt_level` to kernel config structs. Default to `O3 (compute)` and `Os (data movement, ethernet)` if not specified.

Example: The user can specify the data movement kernel to be built with `O3` optimization. If this flag isn't specified, it will use the default which is `Os`.

```c++
    KernelHandle void_dataflow_kernel_noc0_id = CreateKernel(
        program,
        "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
        core,
        DataMovementConfig{
            .processor = DataMovementProcessor::RISCV_0,
            .noc = NOC::RISCV_0_default,
            .opt_level = KernelBuildOptLevel::O3
    });
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes --- same as main
https://github.com/tenstorrent/tt-metal/actions/runs/13518124178
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/13518134596
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
TGG: https://github.com/tenstorrent/tt-metal/actions/runs/13518130484
