### PR TITLE
[skip ci] Add workflow to delete pre-releases

### DIFF
--- a/.github/workflows/release-cleanup.yaml
+++ b/.github/workflows/release-cleanup.yaml
@@ -2,7 +2,7 @@ name: Release Cleanup
 
 on:
   schedule:
-    - cron: "0 0 * * *"  # Runs daily at midnight UTC
+    - cron: "0 7 * * *"  # Runs daily at midnight UTC
   workflow_dispatch:
     inputs:
       months_back:

--- a/.github/workflows/release-cleanup.yaml
+++ b/.github/workflows/release-cleanup.yaml
@@ -1,6 +1,7 @@
 name: Release Cleanup
 
 on:
+  pr:
   schedule:
     - cron: "0 7 * * *"  # Runs daily at midnight UTC
   workflow_dispatch:

--- a/.github/workflows/release-cleanup.yaml
+++ b/.github/workflows/release-cleanup.yaml
@@ -1,7 +1,6 @@
 name: Release Cleanup
 
 on:
-  pr:
   schedule:
     - cron: "0 7 * * *"  # Runs daily at midnight UTC
   workflow_dispatch:

--- a/.github/workflows/release-cleanup.yaml
+++ b/.github/workflows/release-cleanup.yaml
@@ -1,0 +1,46 @@
+name: Release Cleanup
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs daily at midnight UTC
+  workflow_dispatch:
+    inputs:
+      months_back:
+        description: "Number of months back to check for pre-releases"
+        required: false
+        default: "3"  # Default set to 3 months
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup old pre-releases
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const monthsBack = parseInt(core.getInput("months_back") || "3"); // Default to 3 months
+            const now = new Date();
+            const cutoffDate = new Date(now.setMonth(now.getMonth() - monthsBack));
+
+            // Retrieve all releases using pagination
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            for (const release of releases) {
+              if (release.prerelease && new Date(release.created_at) < cutoffDate) {
+                console.log(`Deleting pre-release: ${release.name || release.tag_name} (created at: ${release.created_at})`);
+
+                try {
+                  await github.rest.repos.deleteRelease({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    release_id: release.id,
+                  });
+                  console.log(`Successfully deleted release: ${release.name || release.tag_name}`);
+                } catch (releaseError) {
+                  console.error(`Failed to delete release ${release.name || release.tag_name}: ${releaseError.message}`);
+                }
+              }
+            }


### PR DESCRIPTION
### Problem description
Our release page is extremely cluttered with nightly pre-releases: https://github.com/tenstorrent/tt-metal/releases

We are using the release page as an artifactory.

It is extremely difficult to wade through the muck to find an actual release.

Compare our repo's release page to more mature github repos:
https://github.com/protocolbuffers/protobuf/releases
https://github.com/pytorch/pytorch/releases
https://github.com/tensorflow/tensorflow/releases

It has been argued that having a workflow to remove stale pre-release candidates from N months ago can help.

### What's changed
Add workflow to delete prereleases older than N months ago. Default is 3 months.
