### PR TITLE
#0: show the kernel name when logging the size

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -401,7 +401,7 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         load_type);
     binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
-    log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, binary_size);
+    log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
@@ -424,7 +424,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
         load_type);
     binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
-    log_debug(LogLoader, "ERISC {} kernel binary size: {} in bytes", erisc_id, binary_size);
+    log_debug(LogLoader, "ERISC={}, name={}, size={} (bytes)", erisc_id, this->name(), binary_size);
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
@@ -442,7 +442,7 @@ void ComputeKernel::read_binaries(IDevice* device) {
             ll_api::memory::Loading::CONTIGUOUS_XIP);
         binaries.push_back(&binary_mem);
         uint32_t binary_size = binary_mem.get_packed_size();
-        log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", trisc_id + 2, binary_size);
+        log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", trisc_id + 2, this->name(), binary_size);
     }
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The log output for JITBuild is scrambled because the build uses
multiple threads.
- Can't tell which kernel the printed size corresponds to

### What's changed
Add the kernel name so we know which kernel the size is for

**Before**
```
                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes                 Loader | DEBUG    | RISC 0 kernel binary size: 400 in bytes
                 Loader | DEBUG    |                  Loader | DEBUG    |                  Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
RISC 0 kernel binary size: 5340 in bytes
                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
RISC 0 kernel binary size: 5340 in bytes                 Loader | DEBUG    |                  Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
                 Loader | DEBUG    |                  Loader | DEBUG    | 
RISC 0 kernel binary size: 5340 in bytes                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
RISC 0 kernel binary size: 5340 in bytes                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes                 Loader | DEBUG    | RISC 0 kernel binary size: 5340 in bytes
```

**After**
```
RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)                 Loader | DEBUG    |                  Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
                 Loader | DEBUG    | ERISC=0, name=tt_fabric_router, size=15008 (bytes)
                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)


                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)

                 Loader | DEBUG    | RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
RISC=0, name=tt_fabric_traffic_gen_tx, size=5340 (bytes)
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
