### PR TITLE
Enable multi-threading for MeshCQ based program dispatch, replicated and sharded IO

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -8,6 +8,7 @@ set(UNIT_TESTS_DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_allocator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_trace.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_thread_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
 )
 

--- a/tests/tt_metal/distributed/test_thread_pool.cpp
+++ b/tests/tt_metal/distributed/test_thread_pool.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt-metalium/thread_pool.hpp>
+
+namespace tt::tt_metal::distributed {
+namespace {
+
+// Stress test for thread pool used by TT-Mesh
+TEST(ThreadPoolTest, Stress) {
+    // Enqueue enough tasks to saturate the thread pool.
+    uint64_t NUM_ITERS = 1 << 18;
+    ThreadPool thread_pool = ThreadPool();
+    // Increment this once for each task in the thread pool.
+    // Use this to verify that tasks actually executed.
+    std::atomic<uint64_t> counter = 0;
+    auto incrementer_fn = std::make_shared<std::function<void()>>([&counter]() {
+        counter++;
+        // Sleep every 10 iterations to slow down the workers - allows
+        // the thread pool to get saturated
+        if (counter.load() % 10 == 0) {
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+    });
+    for (std::size_t iter = 0; iter < NUM_ITERS; iter++) {
+        thread_pool.enqueue([incrementer_fn]() mutable { (*incrementer_fn)(); });
+    }
+
+    thread_pool.barrier();
+    EXPECT_EQ(counter.load(), NUM_ITERS);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -13,6 +13,7 @@
 #include "mesh_device.hpp"
 #include "mesh_workload.hpp"
 #include "mesh_trace.hpp"
+#include <tt-metalium/thread_pool.hpp>
 
 namespace tt::tt_metal::distributed {
 
@@ -110,9 +111,11 @@ private:
     CoreCoord dispatch_core_;
     CoreType dispatch_core_type_ = CoreType::WORKER;
     std::queue<std::shared_ptr<MeshReadEventDescriptor>> event_descriptors_;
+    // The MeshCQ is provided a reference to a thread-pool currently owned by the MeshDevice
+    ThreadPool& thread_pool_;
 
 public:
-    MeshCommandQueue(MeshDevice* mesh_device, uint32_t id);
+    MeshCommandQueue(MeshDevice* mesh_device, uint32_t id, ThreadPool& thread_pool);
     MeshDevice* device() const { return mesh_device_; }
     uint32_t id() const { return id_; }
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_[index]; };

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#include <tt-metalium/thread_pool.hpp>
 
 #include "device.hpp"
 
@@ -64,6 +65,8 @@ private:
     std::vector<std::unique_ptr<MeshCommandQueue>> mesh_command_queues_;
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     std::unordered_map<MeshTraceId, std::shared_ptr<MeshTraceBuffer>> trace_buffer_pool_;
+    // Thread-Pool used to parallelize dispatch to the Virtual Mesh
+    ThreadPool thread_pool_;
     uint32_t trace_buffers_size_ = 0;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;

--- a/tt_metal/api/tt-metalium/thread_pool.hpp
+++ b/tt_metal/api/tt-metalium/thread_pool.hpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <thread>
+#include <mutex>
+#include <semaphore>
+#include <functional>
+#include <future>
+#include <memory>
+
+class ThreadPool {
+public:
+    explicit ThreadPool(size_t thread_count = std::thread::hardware_concurrency());
+    ~ThreadPool();
+
+    template <class F>
+    void enqueue(F&& f) {
+        // Bind the function to a packaged_task
+        auto task = std::packaged_task<void()>(std::forward<F>(f));
+        tasks_.push(std::move(task));  // Move the task directly into queue
+        task_semaphore.release();      // Notify a worker that a task is available
+        // Light-Weight counter increment to track the number of tasks in flight
+        // Need this because a counting_semaphore does not allow querying state
+        counter++;
+    }
+    void barrier() const noexcept;
+
+    std::size_t num_threads() const noexcept;
+
+private:
+    class WorkerQueue {
+    public:
+        WorkerQueue();
+        void push(std::packaged_task<void()>&& task);
+        std::packaged_task<void()>&& pop();
+        bool empty() const;
+
+    private:
+        struct Node {
+            // Use packaged_task, since it is
+            // move only. Forces us to ensure
+            // that tasks are enqueued in a
+            // light-weight manner
+            std::packaged_task<void()> data;
+            Node* next = nullptr;
+        };
+
+        std::atomic<Node*> head;
+        std::atomic<Node*> tail;
+
+        Node* pop_head();
+        // Statically allocated ring buffer containing
+        // node objects, which contain handles to data
+        // and another node object to traverse ring buffer.
+        const static uint32_t ring_buffer_size = 32768;
+        Node ring_buffer[ring_buffer_size];
+    };
+
+    // Worker threads backing the pool
+    std::vector<std::thread> workers_;
+    // Task queue
+    WorkerQueue tasks_;
+    // Mutex to synchronize workers when reading
+    // from task queue
+    std::mutex mutex_;
+    // Counting Semaphore used by main thread to
+    // notify workers when a task is available
+    std::counting_semaphore<> task_semaphore{0};
+    // Atomic counter used by workers to notify
+    // main thread when all tasks are complete
+    std::atomic<int> counter = 0;
+    bool shutdown_;
+};

--- a/tt_metal/api/tt-metalium/thread_pool.hpp
+++ b/tt_metal/api/tt-metalium/thread_pool.hpp
@@ -20,9 +20,7 @@ public:
 
     template <class F>
     void enqueue(F&& f) {
-        // Bind the function to a packaged_task
-        auto task = std::packaged_task<void()>(std::forward<F>(f));
-        tasks_.push(std::move(task));  // Move the task directly into queue
+        tasks_.push(std::move(f));     // Move the task directly into queue
         task_semaphore_.release();     // Notify a worker that a task is available
         // Light-Weight counter increment to track the number of tasks in flight
         // Need this because a counting_semaphore does not allow querying state
@@ -36,17 +34,13 @@ private:
     class WorkerQueue {
     public:
         WorkerQueue();
-        void push(std::packaged_task<void()>&& task);
-        std::packaged_task<void()>&& pop();
+        void push(std::function<void()>&& task);
+        std::function<void()>&& pop();
         bool empty() const;
 
     private:
         struct Node {
-            // Use packaged_task, since it is
-            // move only. Forces us to ensure
-            // that tasks are enqueued in a
-            // light-weight manner
-            std::packaged_task<void()> data;
+            std::function<void()> data;
             Node* next = nullptr;
         };
 

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
         tt_backend_api_types.cpp
         utils.cpp
         work_split.cpp
+        thread_pool.cpp
 )
 
 target_include_directories(

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -48,7 +48,7 @@ ThreadPool::WorkerQueue::Node* ThreadPool::WorkerQueue::pop_head() {
 
 ThreadPool::ThreadPool(size_t thread_count) : shutdown_(false) {
     workers_.reserve(thread_count);
-
+    application_thread_id_ = std::this_thread::get_id();
     for (size_t i = 0; i < thread_count; ++i) {
         workers_.emplace_back([this] {
             while (true) {

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/thread_pool.hpp>
+
+ThreadPool::WorkerQueue::WorkerQueue() {
+    // Initialize ring buffer for traversal. Each node points to the subsequent node, except for the last one, which
+    // points to the head.
+    for (int node_idx = 0; node_idx < ring_buffer_size; node_idx++) {
+        (node_idx < ring_buffer_size - 1) ? ring_buffer[node_idx].next = (&ring_buffer[node_idx + 1])
+                                          : ring_buffer[node_idx].next = &(ring_buffer[0]);
+    }
+    // Initialize head and tail ptrs to start of ring buffer.
+    this->head = ring_buffer;
+    this->tail = ring_buffer;
+}
+
+void ThreadPool::WorkerQueue::push(std::packaged_task<void()>&& task) {
+    // Stall condition: this push will update the tail (wptr)
+    // to match the location of head (rptr). The current push can
+    // thus overwrite data that's being read. Stall until head
+    // has progressed (data has been read).
+    // A stall is only required when the ring_buffer backing the queue
+    // is full. Realistically, this should never happen, given the size
+    while (tail.load()->next == head.load());
+    tail.load()->data = std::move(task);
+    tail.store(tail.load()->next);
+}
+
+std::packaged_task<void()>&& ThreadPool::WorkerQueue::pop() {
+    ThreadPool::WorkerQueue::Node* oldHead = pop_head();
+    return std::move(oldHead->data);
+}
+
+bool ThreadPool::WorkerQueue::empty() const { return head.load() == tail.load(); }
+
+ThreadPool::WorkerQueue::Node* ThreadPool::WorkerQueue::pop_head() {
+    ThreadPool::WorkerQueue::Node* oldHead = head.load();
+    if (oldHead == tail.load()) {
+        return nullptr;  // Queue is empty
+    }
+    head.store(oldHead->next);
+    return oldHead;
+}
+
+ThreadPool::ThreadPool(size_t thread_count) : shutdown_(false) {
+    workers_.reserve(thread_count);
+
+    for (size_t i = 0; i < thread_count; ++i) {
+        workers_.emplace_back([this] {
+            while (true) {
+                std::packaged_task<void()> task;  // Task container for this thread
+                {
+                    task_semaphore.acquire();  // Ensures 1:1 task to worker mapping
+                    if (shutdown_) {
+                        return;
+                    }
+                    // The lock free queue only allows a single reader/single writer
+                    // With multiple readers, we must use a lock to synchronize
+                    std::unique_lock<std::mutex> lock(mutex_);
+                    task = std::move(tasks_.pop());  // Move the packaged_task
+                }
+                task();     // Execute the packaged_task
+                counter--;  // Notify maibn thread that a task was completed
+            }
+        });
+    }
+}
+
+ThreadPool::~ThreadPool() {
+    shutdown_ = true;
+    // Notify all workers that a shutdown signal was sent
+    for (size_t i = 0; i < workers_.size(); ++i) {
+        task_semaphore.release();
+    }
+    for (std::thread& worker : workers_) {
+        worker.join();
+    }
+}
+
+void ThreadPool::barrier() const noexcept { while (counter); }
+
+std::size_t ThreadPool::num_threads() const noexcept { return workers_.size(); }

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -24,7 +24,8 @@ struct MeshReadEventDescriptor {
     LogicalDeviceRange device_range;
 };
 
-MeshCommandQueue::MeshCommandQueue(MeshDevice* mesh_device, uint32_t id) {
+MeshCommandQueue::MeshCommandQueue(MeshDevice* mesh_device, uint32_t id, ThreadPool& thread_pool) :
+    thread_pool_(thread_pool) {
     this->mesh_device_ = mesh_device;
     this->id_ = id;
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
@@ -380,15 +381,33 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
     bool blocking,
     std::optional<BufferRegion> region) {
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
-        for (std::size_t logical_x = device_range.start_coord.x; logical_x < device_range.end_coord.x + 1;
-             logical_x++) {
-            for (std::size_t logical_y = device_range.start_coord.y; logical_y < device_range.end_coord.y + 1;
-                 logical_y++) {
+        // Multi-Threaded writes are currently tuned for 8 chip systems. Performance sweeps on randomized shapes show
+        // that we get the best perf when assigning a device to a thread.
+        std::size_t num_rows = device_range.end_coord.y - device_range.start_coord.y + 1;
+        std::size_t num_cols = device_range.end_coord.x - device_range.start_coord.x + 1;
+        std::size_t num_devices = num_rows * num_cols;
+        std::size_t num_dispatch_threads = std::min(num_devices, thread_pool_.num_threads());
+        std::size_t num_devices_per_thread = num_devices / num_dispatch_threads;
+
+        TT_FATAL(num_devices_per_thread == 1, "Expected each thread to process a single device.");
+
+        auto dispatch_lambda = std::make_shared<std::function<void(uint32_t, uint32_t)>>(
+            [this, &buffer, host_data, &region](uint32_t logical_x, uint32_t logical_y) {
                 auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(logical_y, logical_x));
                 const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
                 this->write_shard_to_device(device_shard_view, host_data, buffer_region);
-            }
+            });
+
+        for (std::size_t thread_idx = 0; thread_idx < num_dispatch_threads; thread_idx++) {
+            thread_pool_.enqueue([dispatch_lambda,
+                                  thread_idx,
+                                  num_rows,
+                                  start_x = device_range.start_coord.x,
+                                  start_y = device_range.start_coord.y]() mutable {
+                (*dispatch_lambda)(start_x + thread_idx / num_rows, start_y + thread_idx % num_rows);
+            });
         }
+        thread_pool_.barrier();
     } else {
         this->write_sharded_buffer(buffer, host_data);
     }
@@ -416,13 +435,31 @@ void MeshCommandQueue::enqueue_write_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
-        write_shard_to_device(
-            device_shard_view,
-            shard_data_transfer.host_data,
-            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+
+    // Multi-Threaded writes are currently tuned for 8 chip systems. Performance sweeps on randomized shapes show
+    // that we get the best perf when assigning a device to a thread.
+    uint32_t num_dispatch_threads = std::min(thread_pool_.num_threads(), shard_data_transfers.size());
+    uint32_t num_shards_per_thread = shard_data_transfers.size() / num_dispatch_threads;
+
+    auto dispatch_lambda = std::make_shared<std::function<void(uint32_t)>>(
+        [this, &buffer, &shard_data_transfers, num_shards_per_thread](uint32_t shard_start_idx) {
+            for (uint32_t shard_idx = shard_start_idx; shard_idx < shard_start_idx + num_shards_per_thread;
+                 shard_idx++) {
+                auto& shard_data_transfer = shard_data_transfers[shard_idx];
+                auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
+                this->write_shard_to_device(
+                    device_shard_view,
+                    shard_data_transfer.host_data,
+                    shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+            }
+        });
+
+    for (std::size_t thread_idx = 0; thread_idx < num_dispatch_threads; thread_idx++) {
+        thread_pool_.enqueue([dispatch_lambda, thread_idx, num_shards_per_thread]() mutable {
+            (*dispatch_lambda)(thread_idx* num_shards_per_thread);
+        });
     }
+    thread_pool_.barrier();
     if (blocking) {
         this->finish();
     }
@@ -434,13 +471,31 @@ void MeshCommandQueue::enqueue_read_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
-        read_shard_from_device(
-            device_shard_view,
-            shard_data_transfer.host_data,
-            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+
+    // Multi-Threaded reads are currently tuned for 8 chip systems. Performance sweeps on randomized shapes show
+    // that we get the best perf when assigning a device to a thread.
+    uint32_t num_dispatch_threads = std::min(thread_pool_.num_threads(), shard_data_transfers.size());
+    uint32_t num_shards_per_thread = shard_data_transfers.size() / num_dispatch_threads;
+
+    auto dispatch_lambda = std::make_shared<std::function<void(uint32_t)>>(
+        [this, &buffer, &shard_data_transfers, num_shards_per_thread](uint32_t shard_start_idx) {
+            for (uint32_t shard_idx = shard_start_idx; shard_idx < shard_start_idx + num_shards_per_thread;
+                 shard_idx++) {
+                auto& shard_data_transfer = shard_data_transfers[shard_idx];
+                auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
+                this->read_shard_from_device(
+                    device_shard_view,
+                    shard_data_transfer.host_data,
+                    shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+            }
+        });
+    for (std::size_t thread_idx = 0; thread_idx < num_dispatch_threads; thread_idx++) {
+        thread_pool_.enqueue([dispatch_lambda, thread_idx, num_shards_per_thread]() mutable {
+            (*dispatch_lambda)(thread_idx* num_shards_per_thread);
+        });
     }
+
+    thread_pool_.barrier();
 }
 
 void MeshCommandQueue::enqueue_record_event_helper(
@@ -576,21 +631,49 @@ void MeshCommandQueue::write_program_cmds_to_subgrid(
     bool stall_first,
     bool stall_before_program,
     std::unordered_set<uint32_t>& chip_ids_in_workload) {
+    // Multi-Threaded program dispatch is current tuned for data-parallel workloads on
+    // 8 chip systems. Performance sweeps on randomized workloads show that we get the
+    // best perf when assigning a column to a thread.
+    std::size_t num_columns = (sub_grid.end_coord.x - sub_grid.start_coord.x + 1);
+    std::size_t num_dispatch_threads = std::min(num_columns, thread_pool_.num_threads());
+    std::size_t num_columns_per_thread = num_columns / num_dispatch_threads;
+
     auto dispatch_core_config = DispatchQueryManager::instance().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    auto dispatch_core_type = dispatch_core_config.get_core_type();
+
+    auto dispatch_lambda = std::make_shared<std::function<void(uint32_t)>>([dispatch_core_type,
+                                                                            &program_cmd_seq,
+                                                                            &sub_grid,
+                                                                            stall_first,
+                                                                            stall_before_program,
+                                                                            num_columns_per_thread,
+                                                                            this](uint32_t start_x) {
+        for (std::size_t logical_x = start_x; logical_x < start_x + num_columns_per_thread; logical_x++) {
+            for (std::size_t logical_y = sub_grid.start_coord.y; logical_y < sub_grid.end_coord.y + 1; logical_y++) {
+                program_dispatch::write_program_command_sequence(
+                    program_cmd_seq,
+                    mesh_device_->get_device(logical_y, logical_x)->sysmem_manager(),
+                    id_,
+                    dispatch_core_type,
+                    stall_first,
+                    stall_before_program);
+            }
+        }
+    });
+
+    for (std::size_t thread_idx = 0; thread_idx < num_dispatch_threads; thread_idx++) {
+        thread_pool_.enqueue(
+            [dispatch_lambda, thread_idx, num_columns_per_thread, start = sub_grid.start_coord.x]() mutable {
+                (*dispatch_lambda)(start + thread_idx * num_columns_per_thread);
+            });
+    }
 
     for (std::size_t logical_x = sub_grid.start_coord.x; logical_x < sub_grid.end_coord.x + 1; logical_x++) {
         for (std::size_t logical_y = sub_grid.start_coord.y; logical_y < sub_grid.end_coord.y + 1; logical_y++) {
-            program_dispatch::write_program_command_sequence(
-                program_cmd_seq,
-                this->mesh_device_->get_device(logical_y, logical_x)->sysmem_manager(),
-                id_,
-                dispatch_core_type,
-                stall_first,
-                stall_before_program);
-            chip_ids_in_workload.insert(this->mesh_device_->get_device(logical_y, logical_x)->id());
+            chip_ids_in_workload.insert(mesh_device_->get_device(logical_y, logical_x)->id());
         }
     }
+    thread_pool_.barrier();
 }
 
 void MeshCommandQueue::write_go_signal_to_unused_sub_grids(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -117,7 +117,8 @@ MeshDevice::MeshDevice(
     scoped_devices_(std::move(mesh_handle)),
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
-    parent_mesh_(std::move(parent_mesh)) {}
+    parent_mesh_(std::move(parent_mesh)),
+    thread_pool_(view_->shape().mesh_size()) {}
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,
@@ -642,7 +643,7 @@ bool MeshDevice::initialize(
     mesh_command_queues_.reserve(this->num_hw_cqs());
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(std::make_unique<MeshCommandQueue>(this, cq_id));
+            mesh_command_queues_.push_back(std::make_unique<MeshCommandQueue>(this, cq_id, thread_pool_));
         }
     }
     return true;


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
Dispatch across multiple physical devices is currently single threaded in the TT-Mesh Infra.
In preparation for TTNN integration/performance parity, we must rely on multi-threading to parallelize program dispatch and IO (the latter can become a critical performance bottleneck).

### What's changed
- Add a `ThreadPool` class, backed by a statically allocated lock-free-queue
- Use this thread-pool to parallelize program dispatch, replicated and sharded reads/writes
- The current implementation is tuned on T3K (see results here: https://docs.google.com/spreadsheets/d/1kHjwl1aaiT1Z4bbqGoAfdlhX31AKUA7_LjQbPrmARVQ/edit?gid=0#gid=0)
- Thread Affinities are not currently set for thread pool workers
- Performance scaling is sub-linear: requires more investigation. This will be done as part of TTNN performance bringup with end to end tests, depending on the fraction of time spent on TT-Mesh host dispatch

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
