### PR TITLE
Revert "Decouple control plane init and configuring routing tables"

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -236,7 +236,6 @@ int main(int argc, char** argv) {
             std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
             "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
         auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(tg_mesh_graph_desc_path.string());
-        control_plane->configure_routing_tables();
 
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id_l >= num_devices) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -143,7 +143,6 @@ typedef struct test_board {
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         if (metal_fabric_init_level == 0) {
             _init_control_plane(mesh_graph_descriptor);
-            control_plane->configure_routing_tables();
         } else {
             control_plane = tt::DevicePool::instance().get_control_plane();
         }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -52,6 +52,7 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     this->routing_table_generator_->print_routing_tables();
 
     this->initialize_from_mesh_graph_desc_file(mesh_graph_desc_file);
+    this->configure_routing_tables();
 
     // Printing, only enabled with log_debug
     this->print_ethernet_channels();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -403,12 +403,9 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     }
 
     // TODO: add handling of EDM
-    // Initialize control plane, does not configure kernels/routing tables
-    // We always need a control plane for mapping of logical devices to physical devices
-    _inst->initialize_control_plane();
     if (this->fabric_setting == detail::FabricSetting::FABRIC) {
-        // write routing tables to all ethernet cores
-        this->control_plane->configure_routing_tables();
+        // Initialize control plane, which writes routing tables to all ethernet cores
+        _inst->initialize_control_plane();
     }
     this->using_fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
     if (this->using_fast_dispatch) {


### PR DESCRIPTION
This reverts commit f0dd37751f8f03a7c8ebfce2c1238975d80ea00c.

### Ticket
Link to Github Issue

### Problem description
This change broke CI.

### What's changed
Revert.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
