### PR TITLE
Bump UMD, rename P150A to P150

### DIFF
--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -215,7 +215,7 @@ void metal_SocDescriptor::update_pcie_cores(const BoardType& board_type) {
         case UNKNOWN: {  // Workaround for BHs running FW that does not return board type in the cluster yaml
             this->pcie_cores = {CoreCoord(11, 0)};
         } break;
-        case P150A: {
+        case P150: {
             this->pcie_cores = {CoreCoord(2, 0)};
         } break;
         default: TT_THROW("Need to update PCIe core assignment for new Blackhole type, file issue to abhullar");


### PR DESCRIPTION
### Ticket

/

### Problem description

Board type was named P150A. It should be named just P150, just to describe base architecture, since we have other specific P150 boards (A, C, ...)

### What's changed
Rename board type P150A to P150.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
