### PR TITLE
#0: Update BN read write Kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -54,8 +54,8 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
-    constexpr size_t num_reader_args = 11;
-    constexpr size_t num_writer_args = 14;
+    constexpr size_t num_reader_args = 9;
+    constexpr size_t num_writer_args = 12;
     constexpr size_t num_kernel_args = 3;
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
         const auto& core = cores[i];
@@ -87,9 +87,7 @@ void set_or_update_runtime_arguments(
             aHt * aWt * aC * (aN > 1),
             aHt * aWt * (aC > 1),
             cN,
-            cC,
-            cHt,
-            cWt};
+            cC};
         handle_args(program, reader_kernel_id, core, reader_runtime_args);
 
         const auto weight_addr = weight_has_value ? weight_tensor->buffer()->address() : 0;
@@ -106,9 +104,7 @@ void set_or_update_runtime_arguments(
             bHt * bWt * bC * (bN > 1),
             bHt * bWt * (bC > 1),
             cN,
-            cC,
-            cHt,
-            cWt};
+            cC};
         handle_args(program, writer_kernel_id, core, writer_runtime_args);
 
         auto counter = start_tile_id % cHtWt;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -18,6 +18,12 @@ void kernel_main() {
     uint32_t c_stride = get_arg_val<uint32_t>(6);
     uint32_t N = get_arg_val<uint32_t>(7);
     uint32_t C = get_arg_val<uint32_t>(8);
+    uint32_t n_stride_stat = get_arg_val<uint32_t>(9);
+    uint32_t c_stride_stat = get_arg_val<uint32_t>(10);
+    uint32_t batch_var_addr = get_arg_val<uint32_t>(11);   // batch_var
+    uint32_t weight_addr = get_arg_val<uint32_t>(12);      // weight
+    uint32_t bias_addr = get_arg_val<uint32_t>(13);        // bias
+    uint32_t batch_mean_addr = get_arg_val<uint32_t>(14);  // batch_mean
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 
@@ -54,12 +60,92 @@ void kernel_main() {
     // Input tile offset
     uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
 
+    // Inputs stats offset
+    uint32_t tile_offset_stat = start_n * n_stride_stat + start_c * c_stride_stat;
+    uint32_t next_batch_shift_stat = n_stride_stat - c_stride_stat * C;
+
     uint32_t next_channel_shift = c_stride - HtWt;
     uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    // batch_mean
+    constexpr auto cb_id_batch_mean = get_compile_time_arg_val(12);
+    constexpr bool batch_mean_is_dram = get_compile_time_arg_val(11) == 1;
+    const uint32_t batch_mean_tile_bytes = get_tile_size(cb_id_batch_mean);
+    const DataFormat batch_mean_data_format = get_dataformat(cb_id_batch_mean);
+
+    const InterleavedAddrGenFast<batch_mean_is_dram> batch_mean = {
+        .bank_base_address = batch_mean_addr,
+        .page_size = batch_mean_tile_bytes,
+        .data_format = batch_mean_data_format};
+
+    // batch_var
+    constexpr auto cb_id_batch_var = get_compile_time_arg_val(4);
+    constexpr bool batch_var_is_dram = get_compile_time_arg_val(3) == 1;
+    const uint32_t batch_var_tile_bytes = get_tile_size(cb_id_batch_var);
+    const DataFormat batch_var_data_format = get_dataformat(cb_id_batch_var);
+
+    const InterleavedAddrGenFast<batch_var_is_dram> batch_var = {
+        .bank_base_address = batch_var_addr, .page_size = batch_var_tile_bytes, .data_format = batch_var_data_format};
+
+    // weight
+    constexpr auto cb_id_weight = get_compile_time_arg_val(6);
+    constexpr bool weight_is_dram = get_compile_time_arg_val(5) == 1;
+    const uint32_t weight_tile_bytes = get_tile_size(cb_id_weight);
+    const DataFormat weight_data_format = get_dataformat(cb_id_weight);
+
+    const InterleavedAddrGenFast<weight_is_dram> weight = {
+        .bank_base_address = weight_addr, .page_size = weight_tile_bytes, .data_format = weight_data_format};
+
+    constexpr bool weight_has_value = get_compile_time_arg_val(7) == 1;
+
+    // bias
+    constexpr auto cb_id_bias = get_compile_time_arg_val(8);
+    constexpr bool bias_is_dram = get_compile_time_arg_val(9) == 1;
+    const uint32_t bias_tile_bytes = get_tile_size(cb_id_bias);
+    const DataFormat bias_data_format = get_dataformat(cb_id_bias);
+
+    const InterleavedAddrGenFast<bias_is_dram> bias = {
+        .bank_base_address = bias_addr, .page_size = bias_tile_bytes, .data_format = bias_data_format};
+
+    constexpr bool bias_has_value = get_compile_time_arg_val(10) == 1;
 
     uint32_t num_tiles_read = 0;
     for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
+            // read a tile from batch_mean
+            cb_reserve_back(cb_id_batch_mean, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_batch_mean);
+            noc_async_read_tile(tile_offset_stat, batch_mean, l1_write_addr);
+            noc_async_read_barrier();
+            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_batch_mean);
+            cb_push_back(cb_id_batch_mean, onetile);
+
+            // read a tile from batch variance
+            cb_reserve_back(cb_id_batch_var, onetile);
+            uint32_t l1_batch_var_write_addr = get_write_ptr(cb_id_batch_var);
+            noc_async_read_tile(tile_offset_stat, batch_var, l1_batch_var_write_addr);
+            noc_async_read_barrier();
+            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_batch_var);
+            cb_push_back(cb_id_batch_var, onetile);
+
+            if constexpr (weight_has_value) {  // read a tile from weight tensor
+                cb_reserve_back(cb_id_weight, onetile);
+                uint32_t l1_weight_write_addr = get_write_ptr(cb_id_weight);
+                noc_async_read_tile(tile_offset_stat, weight, l1_weight_write_addr);
+                noc_async_read_barrier();
+                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_weight);
+                cb_push_back(cb_id_weight, onetile);
+            }
+
+            if constexpr (bias_has_value) {  // read a tile from bias tensor
+                cb_reserve_back(cb_id_bias, onetile);
+                uint32_t l1_bias_write_addr = get_write_ptr(cb_id_bias);
+                noc_async_read_tile(tile_offset_stat, bias, l1_bias_write_addr);
+                noc_async_read_barrier();
+                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_bias);
+                cb_push_back(cb_id_bias, onetile);
+            }
+
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
                 cb_reserve_back(cb_id_src, onetile);
                 uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
@@ -68,7 +154,9 @@ void kernel_main() {
                 cb_push_back(cb_id_src, onetile);
             }
             tile_offset += next_channel_shift;
+            tile_offset_stat += c_stride_stat;
         }
         tile_offset += next_batch_shift;
+        tile_offset_stat += next_batch_shift_stat;
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -8,68 +8,25 @@
 #include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);        // batch_mean
-    uint32_t batch_var_addr = get_arg_val<uint32_t>(1);  // batch_var
-    uint32_t weight_addr = get_arg_val<uint32_t>(2);     // weight
-    uint32_t bias_addr = get_arg_val<uint32_t>(3);       // bias
-    uint32_t dst_addr = get_arg_val<uint32_t>(4);        // output
-    uint32_t start_tile_id = get_arg_val<uint32_t>(5);
-    uint32_t num_tiles = get_arg_val<uint32_t>(6);
-    uint32_t HtWt = get_arg_val<uint32_t>(7);
-    uint32_t n_stride = get_arg_val<uint32_t>(8);
-    uint32_t c_stride = get_arg_val<uint32_t>(9);
-    uint32_t N = get_arg_val<uint32_t>(10);
-    uint32_t C = get_arg_val<uint32_t>(11);
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);  // output
+    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t HtWt = get_arg_val<uint32_t>(3);
+    uint32_t n_stride = get_arg_val<uint32_t>(4);
+    uint32_t c_stride = get_arg_val<uint32_t>(5);
+    uint32_t N = get_arg_val<uint32_t>(6);
+    uint32_t C = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t onetile = 1;
 
-    // batch_mean
-    constexpr auto cb_id_src = get_compile_time_arg_val(7);
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
-
     // output
-    constexpr auto cb_id_dst = get_compile_time_arg_val(8);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr auto cb_id_dst = get_compile_time_arg_val(1);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const DataFormat dst_data_format = get_dataformat(cb_id_dst);
 
     const InterleavedAddrGenFast<dst_is_dram> dst = {
         .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
-
-    // batch_var
-    constexpr auto cb_id_batch_var = get_compile_time_arg_val(9);
-    constexpr bool batch_var_is_dram = get_compile_time_arg_val(2) == 1;
-    const uint32_t batch_var_tile_bytes = get_tile_size(cb_id_batch_var);
-    const DataFormat batch_var_data_format = get_dataformat(cb_id_batch_var);
-
-    const InterleavedAddrGenFast<batch_var_is_dram> batch_var = {
-        .bank_base_address = batch_var_addr, .page_size = batch_var_tile_bytes, .data_format = batch_var_data_format};
-
-    // weight
-    constexpr auto cb_id_weight = get_compile_time_arg_val(10);
-    constexpr bool weight_is_dram = get_compile_time_arg_val(3) == 1;
-    const uint32_t weight_tile_bytes = get_tile_size(cb_id_weight);
-    const DataFormat weight_data_format = get_dataformat(cb_id_weight);
-
-    const InterleavedAddrGenFast<weight_is_dram> weight = {
-        .bank_base_address = weight_addr, .page_size = weight_tile_bytes, .data_format = weight_data_format};
-
-    // bias
-    constexpr auto cb_id_bias = get_compile_time_arg_val(11);
-    constexpr bool bias_is_dram = get_compile_time_arg_val(4) == 1;
-    const uint32_t bias_tile_bytes = get_tile_size(cb_id_bias);
-    const DataFormat bias_data_format = get_dataformat(cb_id_bias);
-
-    const InterleavedAddrGenFast<bias_is_dram> bias = {
-        .bank_base_address = bias_addr, .page_size = bias_tile_bytes, .data_format = bias_data_format};
-
-    constexpr bool weight_has_value = get_compile_time_arg_val(5) == 1;
-    constexpr bool bias_has_value = get_compile_time_arg_val(6) == 1;
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;
@@ -84,40 +41,6 @@ void kernel_main() {
     uint32_t num_tiles_written = 0;
     for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
-            // read a tile from src
-            cb_reserve_back(cb_id_src, onetile);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-            noc_async_read_tile(tile_offset, src, l1_write_addr);
-            noc_async_read_barrier();
-            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
-            cb_push_back(cb_id_src, onetile);
-
-            // read a tile from batch variance
-            cb_reserve_back(cb_id_batch_var, onetile);
-            uint32_t l1_batch_var_write_addr = get_write_ptr(cb_id_batch_var);
-            noc_async_read_tile(tile_offset, batch_var, l1_batch_var_write_addr);
-            noc_async_read_barrier();
-            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_batch_var);
-            cb_push_back(cb_id_batch_var, onetile);
-
-            if constexpr (weight_has_value) {  // read a tile from weight tensor
-                cb_reserve_back(cb_id_weight, onetile);
-                uint32_t l1_weight_write_addr = get_write_ptr(cb_id_weight);
-                noc_async_read_tile(tile_offset, weight, l1_weight_write_addr);
-                noc_async_read_barrier();
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_weight);
-                cb_push_back(cb_id_weight, onetile);
-            }
-
-            if constexpr (bias_has_value) {  // read a tile from bias tensor
-                cb_reserve_back(cb_id_bias, onetile);
-                uint32_t l1_bias_write_addr = get_write_ptr(cb_id_bias);
-                noc_async_read_tile(tile_offset, bias, l1_bias_write_addr);
-                noc_async_read_barrier();
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_bias);
-                cb_push_back(cb_id_bias, onetile);
-            }
-
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // write a tile to dst
                 cb_wait_front(cb_id_dst, onetile);


### PR DESCRIPTION
### Ticket

### Problem description
The current BN implementation splits tensor reading between NCRISC (Input tensor) and BRISC (input stat tensor) , while BRISC also handles writing. This stalls BRISC from writing until compute is done, and also writes are more expensive. It also creates performance inconsistencies.

### What's changed
Moved all the input reads to reader file

Below is the performance graph taken for shape `[1, 2, 4104, 4104]` with `DRAM` memory configuration.
<img width="1189" alt="Screenshot 2025-03-10 at 8 24 08 AM" src="https://github.com/user-attachments/assets/3baaf9b2-35d3-4185-a909-01f6e093922b" />
[Perf report for BN - DRAM.pdf](https://github.com/user-attachments/files/19154983/Perf.report.for.BN.-.Copy.of.DRAM.pdf)
The main benefit shown in the report is the performance improvement in the BF16 data type. These improvements indicate that the code changes positively impacted the performance for BF16 data type

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13550979413)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13550981619)
- [x] Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) -  [Link to test](https://github.com/tenstorrent/tt-metal/actions/runs/13550983297/job/37920980365)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/13550984924)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/13550986441) - Same as in main
- [x] [Single-card Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/13550995763)

