### PR TITLE
#18206 Conv2d Block Sharded with ReLu

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -72,6 +72,7 @@ def run_conv(
     weight_mesh_mapper=None,
     output_mesh_composer=None,
     enable_split_reader=False,
+    activation="",
 ):
     if isinstance(device, ttnn.MeshDevice):
         assert input_mesh_mapper is not None, "Expected mesh mapper for input tensor when using device mesh"
@@ -102,6 +103,8 @@ def run_conv(
         dilation=(dilation, dilation),
         groups=groups,
     )
+    if activation == "relu":
+        torch_out_golden_tensor = torch.nn.functional.relu(torch_out_golden_tensor)
 
     reader_patterns_cache = {}
 
@@ -134,6 +137,7 @@ def run_conv(
         enable_split_reader=enable_split_reader,
         enable_subblock_padding=False,
         output_layout=output_layout,
+        activation=activation,
     )
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -2795,4 +2799,56 @@ def test_small_in_large_out_channels_auto_shard(device, torch_tensor_map):
         padding[1],
         None,
         auto_shard=True,
+    )
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "batch, input_channels, output_channels, input_height, input_width, kernel, stride, padding",
+    (
+        (1, 64, 64, 128, 128, (3, 3), (1, 1), (1, 1)),
+    ),
+)
+#fmt: on
+
+@pytest.mark.parametrize("shard_layout", [BS])
+@pytest.mark.parametrize("activation", ["relu"])
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384*2}], indirect=True)
+def test_block_sharding_relu_act_block_h(
+    device,
+    torch_tensor_map,
+    batch,
+    input_channels,
+    output_channels,
+    input_height,
+    input_width,
+    kernel,
+    stride,
+    padding,
+    shard_layout,
+    activation,
+):
+    config_override = {}
+    config_override["act_block_h"] = 32
+    run_conv(
+        device,
+        torch_tensor_map,
+        ttnn.MathFidelity.LoFi,
+        ttnn.bfloat16,
+        ttnn.bfloat16,
+        batch,
+        output_channels,
+        input_channels,
+        input_height,
+        input_width,
+        kernel[0],
+        kernel[1],
+        stride[0],
+        stride[1],
+        padding[0],
+        padding[1],
+        config_override=config_override,
+        shard_layout=shard_layout,
+        activation=activation,
     )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -445,6 +445,9 @@ void MAIN {
 
                 if constexpr (!tilize_in0) {
                     mm_block_init_short(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+#ifdef PACK_RELU
+                    PACK((llk_pack_relu_config(ReluType::NO_RELU)));
+#endif
                 }
             }
         }  // for in0_num_blocks_h


### PR DESCRIPTION
If Conv2d has fused Relu with blocks sharding
and activation block height override is used,
pcc would fail as state of the packer wan't
properly cleared (relu disabled) when compute
kernel starts processing new block.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18206)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13506981220) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/13506985950) CI passes (if applicable)
- [x] [(Single-card) Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/13506989571)
