### PR TITLE
#18150: Drop xmltodict from requirements-dev.txt and use built-in xml.etree instead

### DIFF
--- a/.github/scripts/data_analysis/print_gtest_annotations.py
+++ b/.github/scripts/data_analysis/print_gtest_annotations.py
@@ -5,15 +5,6 @@ import os
 from typing import Union
 
 
-def _guaranteed_list(x):
-    if not x:
-        return []
-    elif isinstance(x, list):
-        return x
-    else:
-        return [x]
-
-
 def _build_workflow_command(
     command_name: str,
     file: str,

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -5,7 +5,6 @@
 loguru
 
 # For github workflow unit test failure annotations
-xmltodict
 pytest-github-actions-annotate-failures==0.3.0
 
 # During dep resolution, black may install platformdirs >=4.0.0, which is


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/18150 and concerns from PR https://github.com/tenstorrent/tt-metal/pull/18251 

### Problem description
- pytest mysteriously crashes on tt-metal-ci-vm-24 when xmltodict is included in the dev env.

[From PR 18251]
- avoid installing infra deps each time we want to run the github action
- prevent situation where deps can be installed outside of a docker container due to running `pip install` directly

### What's changed
Remove `xmltodict` from `requirements-dev.txt`
Refactor github action script to use built-in `xml.etree.ElementTree` instead.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13526080092
