### PR TITLE
 #18302: Fix the permissions missing in the docs wrapper workflow

### DIFF
--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -3,6 +3,10 @@ name: "[post-commit] Docs build and deploy to GitHub pages on main"
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  pages: write
+
 jobs:
   build-docker-artifact:
     uses: ./.github/workflows/build-docker-artifact.yaml


### PR DESCRIPTION
### Ticket
#18302

### Problem description

When @bkeith-TT  and I were re-deploying the docs back, the wrapper workflow did not have enough permissions to re-deploy the docs. Specifically, it was missing 
```
  id-token: write
```

### What's changed

Added the required permissions to the workflow.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
