### PR TITLE
#0: Fix dprint of edm packet header

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -38,7 +38,8 @@ FORCE_INLINE void print_pkt_hdr_routing_fields(volatile tt::fabric::LowLatencyPa
     #endif
 }
 
-FORCE_INLINE void print_pkt_header_noc_fields(volatile PACKET_HEADER_TYPE *const packet_start) {
+template <typename T>
+FORCE_INLINE void print_pkt_header_noc_fields(volatile T *const packet_start) {
 #ifdef DEBUG_PRINT_ENABLED
     switch (packet_start->noc_send_type) {
         case tt::fabric::NocSendType::NOC_UNICAST_WRITE: {
@@ -69,15 +70,15 @@ FORCE_INLINE void print_pkt_header(volatile tt::fabric::PacketHeader *const pack
 }
 
 FORCE_INLINE void print_pkt_header(volatile tt::fabric::LowLatencyPacketHeader *const packet_start) {
-    #ifdef DEBUG_PRINT_ENABLED
-        auto const& header = *packet_start;
-        DPRINT << "PKT: nsnd_t:" << (uint32_t) packet_start->noc_send_type <<
-            ", src_chip:" << (uint32_t) packet_start->src_ch_id <<
-            ", payload_size_bytes:" << (uint32_t) packet_start->payload_size_bytes << "\n";
-        print_pkt_hdr_routing_fields(packet_start);
-        print_pkt_header_noc_fields(packet_start);
-    #endif
-    }
+#ifdef DEBUG_PRINT_ENABLED
+    auto const& header = *packet_start;
+    DPRINT << "PKT: nsnd_t:" << (uint32_t) packet_start->noc_send_type <<
+        ", src_chip:" << (uint32_t) packet_start->src_ch_id <<
+        ", payload_size_bytes:" << (uint32_t) packet_start->payload_size_bytes << "\n";
+    print_pkt_hdr_routing_fields(packet_start);
+    print_pkt_header_noc_fields(packet_start);
+#endif
+}
 
 
 // Since we unicast to local, we must omit the packet header


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Dprint function for packet header needs to accept both header types, instead of using the defined PACKET_HEADER_TYPE

### What's changed
Template the dprint function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
