### PR TITLE
Use dedicated NoC cmd buf for EDM producer-sender path

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -93,7 +93,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize(
     "expected_bw",
-    [6.5],
+    [5.83],
 )
 def test_fabric_edm_mcast_bw(
     num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw
@@ -120,7 +120,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize(
     "expected_bw",
-    [7.5],
+    [7.41],
 )
 def test_fabric_edm_unicast_bw(
     num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -14,11 +14,11 @@ int main(int argc, char** argv) {
     std::size_t line_size = std::stoi(argv[arg_idx++]);
     std::size_t packet_payload_size_bytes = std::stoi(argv[arg_idx++]);
 
-    uint32_t test_expected_num_devices = 8;
-    if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
-        tt::log_warning("This test can only be run on T3000 devices");
-        return 1;
-    }
+    // uint32_t test_expected_num_devices = 8;
+    // if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
+    //     tt::log_warning("This test can only be run on T3000 devices");
+    //     return 1;
+    // }
 
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -74,7 +74,7 @@ public:
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ == 8 and tt::tt_metal::GetNumPCIeDevices() == 4) {
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumPCIeDevices() == 4) {
             mesh_device_ = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape{2, 4}});
 
             std::vector<chip_id_t> ids(num_devices_, 0);

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1925,6 +1925,38 @@ void noc_inline_dw_write(
     WAYPOINT("NWID");
 }
 
+FORCE_INLINE
+void noc_inline_dw_write_set_state(
+    uint64_t addr, uint8_t be = 0xF, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
+    WAYPOINT("NWIW");
+    DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
+
+    uint32_t noc_cmd_field = NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | NOC_CMD_CPY | NOC_CMD_WR |
+                             NOC_CMD_WR_INLINE | 0x0 | NOC_CMD_RESP_MARKED;
+
+    uint32_t be32 = be;
+    uint32_t be_shift = (addr & (NOC_WORD_BYTES - 1));
+    // If we're given a misaligned address, don't write to the bytes in the word below the address
+    be32 = (be32 << be_shift);
+
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, addr & 0xFFFFFFFF);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+    WAYPOINT("NWID");
+}
+
+FORCE_INLINE
+void noc_inline_dw_write_with_state(uint32_t val, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
+    WAYPOINT("NWIW");
+
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    WAYPOINT("NWID");
+}
+
 // clang-format off
 /**
  * The Tensix core executing this function call initiates an atomic increment

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1908,12 +1908,13 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
  */
 // clang-format on
 FORCE_INLINE
-void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF, uint8_t noc = noc_index) {
+void noc_inline_dw_write(
+    uint64_t addr, uint32_t val, uint8_t be = 0xF, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
     WAYPOINT("NWIW");
     DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
     noc_fast_write_dw_inline<proc_type, noc_mode>(
         noc,
-        write_at_cmd_buf,
+        cmd_buf,
         val,
         addr,
         be,  // byte-enable

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1246,11 +1246,13 @@ void kernel_main() {
         auto connection_worker_info_ptr = reinterpret_cast<volatile tt::fabric::EDMChannelWorkerLocationInfo *>(
             local_sender_connection_info_addresses[i]);
         connection_worker_info_ptr->edm_rdptr = 0;
+        uint8_t channel_worker_noc_cmd_buf = i == 0 ? write_at_cmd_buf : read_cmd_buf;
         new (&local_sender_channel_worker_interfaces[i]) tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>(
             connection_worker_info_ptr,
             reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
                 local_sender_flow_control_semaphores[i]),
-            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(connection_live_semaphore_ptr));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(connection_live_semaphore_ptr),
+            channel_worker_noc_cmd_buf);
     }
 
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1192,7 +1192,7 @@ void kernel_main() {
     }
     auto downstream_edm_noc_interface =
         has_downstream_edm_buffer_connection
-            ? tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>(
+            ? tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS, false, write_reg_cmd_buf, write_at_cmd_buf, noc_index>(
                  //persistent_mode -> hardcode to false because for EDM -> EDM
                  // connections we must always use semaphore lookup
                   false,
@@ -1208,7 +1208,7 @@ void kernel_main() {
                   reinterpret_cast<volatile uint32_t *const>(edm_forwarding_semaphore_address),
                   reinterpret_cast<volatile uint32_t *const>(edm_teardown_semaphore_address),
                   downstream_noc_interface_buffer_index_local_addr)
-            : tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>();
+            : tt::fabric::EdmToEdmSender<SENDER_NUM_BUFFERS, false, write_reg_cmd_buf, write_at_cmd_buf, noc_index>();
 
     auto local_receiver_channel = tt::fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>(
         local_receiver_channel_buffer_address,
@@ -1258,7 +1258,7 @@ void kernel_main() {
     // unroll the sender channels so we can pass in different
     // sender channel 0
     new (&local_sender_channel_worker_interfaces[0])
-        tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS, true, write_at_cmd_buf>(
+        tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS, false, write_at_cmd_buf, noc_index>(
             reinterpret_cast<volatile tt::fabric::EDMChannelWorkerLocationInfo *>(
                 local_sender_connection_info_addresses[0]),
             reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
@@ -1268,7 +1268,7 @@ void kernel_main() {
 
     // sender channel 1
     new (&local_sender_channel_worker_interfaces[1])
-        tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS, true, write_cmd_buf>(
+        tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS, false, write_at_cmd_buf, noc_index>(
             reinterpret_cast<volatile tt::fabric::EDMChannelWorkerLocationInfo *>(
                 local_sender_connection_info_addresses[1]),
             reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1246,14 +1246,36 @@ void kernel_main() {
         auto connection_worker_info_ptr = reinterpret_cast<volatile tt::fabric::EDMChannelWorkerLocationInfo *>(
             local_sender_connection_info_addresses[i]);
         connection_worker_info_ptr->edm_rdptr = 0;
-        uint8_t channel_worker_noc_cmd_buf = i == 0 ? write_at_cmd_buf : read_cmd_buf;
-        new (&local_sender_channel_worker_interfaces[i]) tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>(
-            connection_worker_info_ptr,
-            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
-                local_sender_flow_control_semaphores[i]),
-            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(connection_live_semaphore_ptr),
-            channel_worker_noc_cmd_buf);
+        // uint8_t channel_worker_noc_cmd_buf = i == 0 ? write_at_cmd_buf : read_cmd_buf;
+        // new (&local_sender_channel_worker_interfaces[i]) tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>(
+        //     connection_worker_info_ptr,
+        //     reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
+        //         local_sender_flow_control_semaphores[i]),
+        //     reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(connection_live_semaphore_ptr),
+        //     channel_worker_noc_cmd_buf);
     }
+
+    // unroll the sender channels so we can pass in different
+    // sender channel 0
+    new (&local_sender_channel_worker_interfaces[0])
+        tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS, true, write_at_cmd_buf>(
+            reinterpret_cast<volatile tt::fabric::EDMChannelWorkerLocationInfo *>(
+                local_sender_connection_info_addresses[0]),
+            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
+                local_sender_flow_control_semaphores[0]),
+            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
+                local_sender_connection_live_semaphore_addresses[0]));
+
+    // sender channel 1
+    new (&local_sender_channel_worker_interfaces[1])
+        tt::fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS, true, write_cmd_buf>(
+            reinterpret_cast<volatile tt::fabric::EDMChannelWorkerLocationInfo *>(
+                local_sender_connection_info_addresses[1]),
+            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
+                local_sender_flow_control_semaphores[1]),
+            reinterpret_cast<volatile tt_l1_ptr uint32_t *const>(
+                local_sender_connection_live_semaphore_addresses[1]));
+
 
 
     WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS> receiver_channel_trid_tracker;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -120,6 +120,7 @@ struct EdmChannelWorkerInterface {
         cached_worker_semaphore_address(0),
         remote_producer_wrptr(nullptr),
         connection_live_semaphore(nullptr),
+        edm_noc_cmd_buf(write_at_cmd_buf),
         local_wrptr(),
         local_ackptr(),
         local_rdptr() {}
@@ -133,11 +134,13 @@ struct EdmChannelWorkerInterface {
         // semaphore directly (saving on regenerating it each time)
         volatile EDMChannelWorkerLocationInfo *worker_location_info_ptr,
         volatile tt_l1_ptr uint32_t *const remote_producer_wrptr,
-        volatile tt_l1_ptr uint32_t *const connection_live_semaphore) :
+        volatile tt_l1_ptr uint32_t *const connection_live_semaphore,
+        uint32_t edm_noc_cmd_buf) :
         worker_location_info_ptr(worker_location_info_ptr),
         cached_worker_semaphore_address(0),
         remote_producer_wrptr(remote_producer_wrptr),
         connection_live_semaphore(connection_live_semaphore),
+        edm_noc_cmd_buf(edm_noc_cmd_buf),
         local_wrptr(),
         local_ackptr(),
         local_rdptr() {
@@ -161,7 +164,7 @@ struct EdmChannelWorkerInterface {
     }
 
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
-        noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val);
+        noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val, this->edm_noc_cmd_buf);
     }
 
     // Connection management methods
@@ -202,6 +205,9 @@ struct EdmChannelWorkerInterface {
     uint64_t cached_worker_semaphore_address = 0;
     volatile tt_l1_ptr uint32_t *const remote_producer_wrptr;
     volatile tt_l1_ptr uint32_t *const connection_live_semaphore;
+
+    // the cmd buffer is used for producer-sender path
+    uint8_t edm_noc_cmd_buf;
 
     ChannelBufferPointer<NUM_BUFFERS> local_wrptr;
     ChannelBufferPointer<NUM_BUFFERS> local_ackptr;

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -113,7 +113,7 @@ class EthChannelBuffer final {
 };
 
 
-template <uint8_t NUM_BUFFERS, bool USE_STATEFUL_NOC_API = false, uint8_t PTR_UPDATE_NOC_CMD_BUF = write_at_cmd_buf>
+template <uint8_t NUM_BUFFERS, bool USE_STATEFUL_NOC_API = false, uint8_t PTR_UPDATE_NOC_CMD_BUF = write_at_cmd_buf, uint8_t PTR_UPDATE_NOC_INDEX = noc_index>
 struct EdmChannelWorkerInterface {
     EdmChannelWorkerInterface() :
         worker_location_info_ptr(nullptr),
@@ -163,9 +163,9 @@ struct EdmChannelWorkerInterface {
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
         if constexpr (USE_STATEFUL_NOC_API) {
             // for producer-sender ack path use the other NoC, so they can be made stateful
-            noc_inline_dw_write_with_state(new_ptr_val, PTR_UPDATE_NOC_CMD_BUF, 1-noc_index);
+            noc_inline_dw_write_with_state(new_ptr_val, PTR_UPDATE_NOC_CMD_BUF, PTR_UPDATE_NOC_INDEX);
         } else {
-            noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val, 0xF, PTR_UPDATE_NOC_CMD_BUF, 1-noc_index);
+            noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val, 0xF, PTR_UPDATE_NOC_CMD_BUF, PTR_UPDATE_NOC_INDEX);
         }
     }
 
@@ -191,7 +191,7 @@ struct EdmChannelWorkerInterface {
             (uint32_t)worker_info.worker_xy.x,
             (uint32_t)worker_info.worker_xy.y,
             worker_info.worker_semaphore_address,
-            1-noc_index);
+            PTR_UPDATE_NOC_INDEX);
         this->cached_worker_semaphore_address = worker_semaphore_address;
         if constexpr (USE_STATEFUL_NOC_API) {
             noc_inline_dw_write_set_state(worker_semaphore_address, 0xF, PTR_UPDATE_NOC_CMD_BUF);

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -164,7 +164,8 @@ struct EdmChannelWorkerInterface {
     }
 
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
-        noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val, this->edm_noc_cmd_buf);
+        // for producer-sender ack path use the other NoC, so they can be made stateful
+        noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val, 0xF, this->edm_noc_cmd_buf, 1-noc_index);
     }
 
     // Connection management methods
@@ -184,10 +185,12 @@ struct EdmChannelWorkerInterface {
 
     FORCE_INLINE void cache_producer_noc_addr() {
         auto const &worker_info = *worker_location_info_ptr;
+        // for producer-sender ack path use the other NoC, so they can be made stateful
         uint64_t worker_semaphore_address = get_noc_addr(
             (uint32_t)worker_info.worker_xy.x,
             (uint32_t)worker_info.worker_xy.y,
-            worker_info.worker_semaphore_address);
+            worker_info.worker_semaphore_address,
+            1-noc_index);
         this->cached_worker_semaphore_address = worker_semaphore_address;
     }
 


### PR DESCRIPTION
Now we use dedicated cmd buf,  sender->edm receiver ack: at cmd buf, worker-sender: read cmd buf, edm receiver->sender: write_reg

perf: 
unicast: 7.1->7.4
mcast: 5.6->5.8

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] ubench
