### PR TITLE
#18306: Use write barriers instead of flushes for BH

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -237,17 +237,18 @@ void kernel_main() {
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
                 // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
                 // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
-                // be sent in order they are issued
-                noc_async_writes_flushed();
-#endif
 
                 // We should also multicast VALID flag to destinations for receiver semaphore
                 noc_semaphore_set_multicast_loopback_src(
                     act_mcast_sender_semaphore_valid_addr,
                     act_mcast_receiver_semaphore_noc_addr,
                     act_mcast_num_cores + 1);
+
+#ifdef ARCH_BLACKHOLE
+                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
+                // be sent in order they are issued
+                noc_async_write_barrier();
+#endif
 
                 noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
             } else {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -256,7 +256,7 @@ void kernel_main() {
                         // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
                         // which means data could be changed before
                         //  write is issued.
-                        noc_async_writes_flushed();
+                        noc_async_write_barrier();
 #endif
 
                     } else if constexpr (core_in_in0_receiver_mcast_grid) {


### PR DESCRIPTION
### Ticket
#18306

### Problem description
On Blackhole, watcher reports ncrisc_noc_nonposted_writes_flushed assert for matmul and conv2d reader kernels of Stable Diffusion 1.4 ops.

### What's changed
- Using barriers instead
- Moved barrier in the conv reader after all noc multicast set calls

### Checklist
Post commit BH: https://github.com/tenstorrent/tt-metal/actions/runs/13527488470
