### PR TITLE
enable -O3 compile for 1D fabric

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -90,7 +90,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize(
     "expected_bw",
-    [5.65],
+    [6.5],
 )
 def test_fabric_edm_mcast_bw(
     num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw
@@ -117,7 +117,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize(
     "expected_bw",
-    [7.13],
+    [7.5],
 )
 def test_fabric_edm_unicast_bw(
     num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
why go slow (-Os) when you can go fast (-O3)? make 1D fabric go brrrr

### What's changed
Swith to -O3 to get a roughly 13% perf bump (as measured by mcast perf test at 4K packet size)



### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13531048676
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
