### PR TITLE
#14604: New Blackhole muladd features

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -21,8 +21,8 @@ set(TYPES
 
 include(FetchContent)
 set(SFPI_x86_64_Linux_RELEASE
-    "v6.2.0/sfpi-release.tgz"
-    "c546b57c3161b06d03de7473c4add5e5"
+    "v6.3.0/sfpi-release.tgz"
+    "df27df37f0b8782d0c09f43fd4d42cec"
 )
 if(DEFINED SFPI_${CMAKE_HOST_SYSTEM_PROCESSOR}_${CMAKE_HOST_SYSTEM_NAME}_RELEASE)
     set(SFPI_RELEASE "${SFPI_${CMAKE_HOST_SYSTEM_PROCESSOR}_${CMAKE_HOST_SYSTEM_NAME}_RELEASE}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14604

### Problem description
Blackhole adds negation to muladd operands.

### What's changed
Implement merging negation of muladd operands.
https://github.com/tenstorrent/sfpi/releases/tag/v6.3.0 gives examples

### Checklist
- [ Yes] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ Yes] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [Yes] New/Existing tests provide coverage for changes
