### PR TITLE
[skip ci] Remove old Llama test

### DIFF
--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "tg_llama3_70b_tests", arch: wormhole_b0, cmd: run_tg_llama3_70b_tests, timeout: 90, owner_id: U03FJB5TM5Y}, # Colman Glagovich
+          { name: "placeholder", arch: wormhole_b0, cmd: "echo 'Placeholder'", timeout: 90, owner_id: U03FJB5TM5Y}, # Colman Glagovich
         ]
     name: ${{ matrix.test-group.name }}
     env:


### PR DESCRIPTION
### Ticket
#17038 

### Problem description
A test got removed, but this one still referenced it.

### What's changed
Removed the test.  A replacement is forthcoming, so keeping the workflow.

### Checklist
- [x] TG Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13530511542)
