### PR TITLE
#0: Fix produce data crash when job is stuck in pending state

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -192,7 +192,9 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations):
 
     name = github_job["name"]
 
-    assert github_job["status"] == "completed", f"{github_job_id} is not completed"
+    if github_job["status"] != "completed":
+        logger.warning(f"{github_job_id} is not completed, skipping this job")
+        return None
 
     # Best effort card type getting
 
@@ -286,9 +288,10 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations):
 
 
 def get_job_rows_from_github_info(github_pipeline_json, github_jobs_json, github_job_id_to_annotations):
-    return list(
+    job_rows = list(
         map(lambda job: get_job_row_from_github_job(job, github_job_id_to_annotations), github_jobs_json["jobs"])
     )
+    return [x for x in job_rows if x is not None]
 
 
 def get_github_partial_benchmark_json_filenames():


### PR DESCRIPTION
### Ticket
...

### Problem description
Fix crash in produce data: https://github.com/tenstorrent/tt-metal/actions/runs/13518418725/job/37810462342#step:10:494
```
get_job_row_from_github_job
    assert github_job["status"] == "completed", f"{github_job_id} is not completed"
AssertionError: 37759949624 is not completed
```

`build-deploy-docs` can sometimes be left in a pending status when cancelled:
https://github.com/tenstorrent/tt-metal/actions/runs/13514047027/job/37759949624

This causes the produce data flow to trip an assert that only completed jobs are to be processed.

### What's changed
Downgrade assert to warning and skip the job if its not completed instead of exiting.

### Checklist
- [x] New/Existing tests provide coverage for changes
Rerun of failed workflow in fix branch
https://github.com/tenstorrent/tt-metal/actions/runs/13530691987
