### PR TITLE
#0: Better kernel encoding for MeshWorkload

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -82,7 +82,7 @@ void verify_cb_config(
     uint32_t cb_config_buffer_size =
         NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
-    for (const auto& device_range : workload.get_logical_device_ranges()) {
+    for (const auto& [device_range, _] : workload.get_programs()) {
         for (const auto& coord : device_range) {
             auto device = mesh_device->get_device(coord);
             uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
@@ -417,7 +417,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
     for (int iter = 0; iter < 100; iter++) {
         log_info(LogTest, "Run iter {}", iter);
         if (iter) {
-            auto& program = mesh_workload.get_program_on_device_range(devices_0);
+            auto& program = mesh_workload.get_programs().at(devices_0);
             auto& rtas = GetRuntimeArgs(program, reader_writer_kernel);
             for (auto core : full_grid) {
                 rtas[core.x][core.y].at(4) = ((iter % 2) + 1) * add_factor;
@@ -475,7 +475,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadCBUpdate) {
         CBConfig& cb_config = updated_cb_config_vector[cb_id];
         cb_config.num_pages *= 2;
         const uint32_t cb_size = cb_config.num_pages * cb_config.page_size;
-        UpdateCircularBufferTotalSize(mesh_workload.get_program_on_device_range(devices), cb_handles[cb_id], cb_size);
+        UpdateCircularBufferTotalSize(mesh_workload.get_programs().at(devices), cb_handles[cb_id], cb_size);
     }
     EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_workload, false);
     Finish(mesh_device_->mesh_command_queue());

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -46,7 +46,6 @@ private:
     std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
     std::vector<Semaphore> semaphores_;
     std::unordered_map<MeshCoordinateRange, Program> programs_;
-    std::vector<MeshCoordinateRange> logical_device_ranges_;
     bool finalized_ = false;
     std::unordered_map<MeshCoordinateRange, std::unordered_map<KernelHandle, RuntimeArgsPerCore>> runtime_args_;
     MeshCommandQueue* last_used_command_queue_ = nullptr;
@@ -62,9 +61,7 @@ public:
     // Main User-Facing API building blocks
     MeshWorkload();
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
-    const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const { return programs_; }
-    const std::vector<MeshCoordinateRange> get_logical_device_ranges() const { return logical_device_ranges_; }
-    Program& get_program_on_device_range(const MeshCoordinateRange& device_range) { return programs_.at(device_range); }
+    std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
 
     // For testing purposes only
     void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -111,8 +111,7 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
     // Iterate over all programs. Update dispatch commands per program to reflect
     // current device state. Write the finalized program command sequence to each
     // physical device tied to the program.
-    for (const auto& device_range : mesh_workload.get_logical_device_ranges()) {
-        auto& program = mesh_workload.get_program_on_device_range(device_range);
+    for (auto& [device_range, program] : mesh_workload.get_programs()) {
         auto& program_cmd_seq = mesh_workload.get_dispatch_cmds_for_program(program);
         program_dispatch::update_program_dispatch_commands(
             program,

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -378,8 +378,8 @@ void finalize_program_offsets(T& workload, IDevice* device) {
         if constexpr (std::is_same_v<T, Program>) {
             set_program_offsets_and_sizes(workload, index);
         } else {
-            for (const auto& device_range : workload.get_logical_device_ranges()) {
-                set_program_offsets_and_sizes(workload.get_program_on_device_range(device_range), index);
+            for (auto& [_, program] : workload.get_programs()) {
+                set_program_offsets_and_sizes(program, index);
             }
         }
     }
@@ -387,8 +387,8 @@ void finalize_program_offsets(T& workload, IDevice* device) {
     if constexpr (std::is_same_v<T, Program>) {
         set_program_attrs_across_core_types(workload);
     } else {
-        for (const auto& device_range : workload.get_logical_device_ranges()) {
-            set_program_attrs_across_core_types(workload.get_program_on_device_range(device_range));
+        for (auto& [_, program] : workload.get_programs()) {
+            set_program_attrs_across_core_types(program);
         }
     }
     workload.set_finalized();


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`MeshWorkload` currently encodes kernel handle by shifting `row` / `col` of the device range in the upper 16 bits. This won't work for ND coordinates.

### What's changed
Encoding can be simplified by offsetting the index of the device range.

### Checklist
- [X] New/Existing tests provide coverage for changes
  - [X] Ran tests for `MeshWorkload`.
