### PR TITLE
#0: Fix test_all_gather_multiple_submeshes

### DIFF
--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -681,7 +681,7 @@ def test_all_gather_multiple_submeshes(mesh_device):
         pytest.skip()
 
     def model(submesh):
-        # Reshape to a linear mesh to enforce linearly connected topological order.
+        # Reshape to a 1x4 mesh to enforce ring connected topological order.
         submesh.reshape(ttnn.MeshShape(1, 4))
         full_tensor = torch.ones((1, 1, 32, 32 * submesh.get_num_devices()), dtype=torch.bfloat16)
         for i in range(submesh.get_num_devices()):

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -681,6 +681,8 @@ def test_all_gather_multiple_submeshes(mesh_device):
         pytest.skip()
 
     def model(submesh):
+        # Reshape to a linear mesh to enforce linearly connected topological order.
+        submesh.reshape(ttnn.MeshShape(1, 4))
         full_tensor = torch.ones((1, 1, 32, 32 * submesh.get_num_devices()), dtype=torch.bfloat16)
         for i in range(submesh.get_num_devices()):
             full_tensor[..., i * 32 : (i + 1) * 32] = i


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`test_all_gather_multiple_submeshes` is broken, as all gather OP assumes ring connected topology. Physical 2D mesh of devices is as follows (the first 2x2 submesh of T3K):
```
4 0
5 1
```
... which givers `4 0 5 1` row-major ordering, while all gather expects `4 0 1 5`.

### What's changed
Reshape submesh to `1x4` to force the the correct ordering.

### Checklist
- [X] Ran the test locally and confirmed it fixes the issue.
