### PR TITLE
#0: Improve error messages in Tensor storage classes

### DIFF
--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -330,7 +330,7 @@ struct MultiDeviceStorage {
         TT_ASSERT(
             buffer_it->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffer_it;
+        return *buffer_it;
     }
 
     inline std::shared_ptr<Buffer>& get_buffer_for_device(IDevice* device) {

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -328,18 +328,19 @@ struct MultiDeviceStorage {
         auto buffer_it = buffers.find(device->id());
         TT_FATAL(buffer_it != buffers.end(), "Buffer not found for device {}", device->id());
         TT_ASSERT(
-            buffer_it->device() == device,
+            buffer_it->second->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
         return buffer_it->second;
     }
 
     inline std::shared_ptr<Buffer>& get_buffer_for_device(IDevice* device) {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        TT_FATAL(buffers.find(device->id()) != buffers.end(), "Buffer not found for device {}", device->id());
+        auto buffer_it = buffers.find(device->id());
+        TT_FATAL(buffer_it != buffers.end(), "Buffer not found for device {}", device->id());
         TT_ASSERT(
-            buffers.at(device->id())->device() == device,
+            buffer_it->second->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffers.at(device->id());
+        return buffer_it->second;
     }
 
     inline std::shared_ptr<Buffer> get_buffer_for_device_id(uint32_t device_id) const {
@@ -349,8 +350,9 @@ struct MultiDeviceStorage {
 
     inline TensorSpec get_tensor_spec_for_device(IDevice* device) const {
         std::lock_guard<std::mutex> lock(shape_mtx);
-        TT_FATAL(specs.find(device->id()) != specs.end(), "Shape not found for device {}", device->id());
-        return specs.at(device->id());
+        auto spec_it = specs.find(device->id());
+        TT_FATAL(spec_it != specs.end(), "Shape not found for device {}", device->id());
+        return spec_it->second;
     }
 
     inline uint32_t num_buffers() const {

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -200,7 +200,7 @@ struct MultiDeviceHostStorage {
 
     TensorSpec get_tensor_spec(int spec_index) const {
         std::lock_guard<std::mutex> lock(mtx);
-        TT_ASSERT(spec_index < specs.size(), "Spec for device {} not found in spec list, was buffer added?", spec_index);
+        TT_ASSERT(spec_index < specs.size(), "Spec for device {} not found in spec list, were buffer and spec added?", spec_index);
         return specs[spec_index];
     }
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -200,7 +200,7 @@ struct MultiDeviceHostStorage {
 
     TensorSpec get_tensor_spec(int spec_index) const {
         std::lock_guard<std::mutex> lock(mtx);
-        TT_ASSERT(spec_index < specs.size(), "Buffer not found for device {}", spec_index);
+        TT_ASSERT(spec_index < specs.size(), "Spec for device {} not found in spec list, was buffer added?", spec_index);
         return specs[spec_index];
     }
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -330,7 +330,7 @@ struct MultiDeviceStorage {
         TT_ASSERT(
             buffer_it->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return *buffer_it;
+        return buffer_it->second;
     }
 
     inline std::shared_ptr<Buffer>& get_buffer_for_device(IDevice* device) {

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -325,11 +325,12 @@ struct MultiDeviceStorage {
 
     inline std::shared_ptr<Buffer> get_buffer_for_device(IDevice* device) const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        TT_FATAL(buffers.find(device->id()) != buffers.end(), "Buffer not found for device {}", device->id());
+        auto buffer_it = buffers.find(device->id());
+        TT_FATAL(buffer_it != buffers.end(), "Buffer not found for device {}", device->id());
         TT_ASSERT(
-            buffers.at(device->id())->device() == device,
+            buffer_it->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffers.at(device->id());
+        return buffer_it;
     }
 
     inline std::shared_ptr<Buffer>& get_buffer_for_device(IDevice* device) {

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -188,13 +188,13 @@ struct MultiDeviceHostStorage {
 
     OwnedBuffer get_buffer(int buffer_index) const {
         std::lock_guard<std::mutex> lock(mtx);
-        TT_ASSERT(buffer_index < buffers.size(), "Buffer not found for buffer_index {}", buffer_index);
+        TT_FATAL(buffer_index < buffers.size(), "Buffer not found for buffer_index {}", buffer_index);
         return buffers[buffer_index];
     }
 
     OwnedBuffer& get_buffer(int buffer_index) {
         std::lock_guard<std::mutex> lock(mtx);
-        TT_ASSERT(buffer_index < buffers.size(), "Buffer not found for buffer_index {}", buffer_index);
+        TT_FATAL(buffer_index < buffers.size(), "Buffer not found for buffer_index {}", buffer_index);
         return buffers[buffer_index];
     }
 
@@ -325,7 +325,7 @@ struct MultiDeviceStorage {
 
     inline std::shared_ptr<Buffer> get_buffer_for_device(IDevice* device) const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        TT_ASSERT(buffers.find(device->id()) != buffers.end(), "Buffer not found for device {}", device->id());
+        TT_FATAL(buffers.find(device->id()) != buffers.end(), "Buffer not found for device {}", device->id());
         TT_ASSERT(
             buffers.at(device->id())->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
@@ -334,7 +334,7 @@ struct MultiDeviceStorage {
 
     inline std::shared_ptr<Buffer>& get_buffer_for_device(IDevice* device) {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        TT_ASSERT(buffers.find(device->id()) != buffers.end(), "Buffer not found for device {}", device->id());
+        TT_FATAL(buffers.find(device->id()) != buffers.end(), "Buffer not found for device {}", device->id());
         TT_ASSERT(
             buffers.at(device->id())->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
@@ -348,7 +348,7 @@ struct MultiDeviceStorage {
 
     inline TensorSpec get_tensor_spec_for_device(IDevice* device) const {
         std::lock_guard<std::mutex> lock(shape_mtx);
-        TT_ASSERT(specs.find(device->id()) != specs.end(), "Shape not found for device {}", device->id());
+        TT_FATAL(specs.find(device->id()) != specs.end(), "Shape not found for device {}", device->id());
         return specs.at(device->id());
     }
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -200,7 +200,7 @@ struct MultiDeviceHostStorage {
 
     TensorSpec get_tensor_spec(int spec_index) const {
         std::lock_guard<std::mutex> lock(mtx);
-        TT_ASSERT(spec_index < specs.size(), "Spec for device {} not found in spec list, were buffer and spec added?", spec_index);
+        TT_FATAL(spec_index < specs.size(), "Spec for device {} not found in spec list", spec_index);
         return specs[spec_index];
     }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue: N/A

### Problem description
An error was a little unclear and potentially misleading and some breaking errors were marked as assert rather than fatal. 

### What's changed
Reworded and changed a spec assert to a TT_FATAL making the problem more clear for users who run into this error in the future. 
Changed some buffer checks to FATAL. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13537003520/job/37858354651
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
