### PR TITLE
In Place Halo

### DIFF
--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -139,6 +139,7 @@ def create_unet_model_parameters(
     parameters.c8["use_activation_double_buffer"] = True
     parameters.c8["use_split_reader"] = True
     parameters.c8["input_channels_alignment"] = 16
+    parameters.c8["in_place"] = True
     parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -149,6 +149,7 @@ class UNetConv2D:
             output_layout=output_layout,
             input_channels_alignment=conv.input_channels_alignment if "input_channels_alignment" in conv else 32,
             reshard_if_not_optimal=reshard_if_not_optimal,
+            in_place=conv.in_place if "in_place" in conv else False,
         )
         self.compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -57,13 +57,14 @@ uint32_t compare_conv_out_with_golden(
 uint32_t validate_generate_halo_kernel_config(
     tt::tt_metal::IDevice* device,
     const std::vector<ShardBoundary>& shard_boundaries,
-    const std::tuple<vector<vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>>&
-        halo_kernel_config,
+    const std::
+        tuple<vector<vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, int>&
+            halo_kernel_config,
     const vector<bool>& pad_metadata,
     bool remote_read = false,
     bool is_block_sharded = false,
     bool transpose_mcast = false) {
-    auto [flattened_pad_config, flattened_local_config, flattened_remote_config] = halo_kernel_config;
+    auto [flattened_pad_config, flattened_local_config, flattened_remote_config, max_ref_size] = halo_kernel_config;
 
     uint32_t padded_input_tensor_buf_idx = 0;
     uint32_t invalid_pads = 0, invalid_indices = 0;

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -11,7 +11,13 @@ import math
 from models.utility_functions import is_wormhole_b0, is_grayskull, is_x2_harvested
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+import numpy as np
+import matplotlib.pyplot as plt
+import copy
+
 import ttnn
+
+output_shards = [[] for _ in range(64)]
 
 
 # Cache map used for torch tensor reuse - the tensor will not be generated if a tensor of the same dimensions has already been generated
@@ -45,6 +51,7 @@ def run_max_pool(
     memory_config=None,
     shard_scheme=None,
     ceil_mode=False,
+    in_place_halo=False,
 ):
     in_n, in_c, in_h, in_w = act_shape
     kernel_h, kernel_w = kernel_size
@@ -146,6 +153,18 @@ def run_max_pool(
         if in_c / cores_x < 16:
             pytest.skip("Block sharding requires large enough channels to shard (at least 16 per core)")
 
+    if in_place_halo == True:
+        if dtype == ttnn.bfloat8_b:
+            pytest.skip("In place halo not supported for BFP8_B")
+        if is_grayskull():
+            pytest.skip("In place halo not supported on Grayskull")
+        if (
+            kernel_size == (13, 13)
+            and in_c >= 640
+            and (shard_scheme == ttnn.TensorMemoryLayout.HEIGHT_SHARDED or shard_scheme == None)
+        ):
+            pytest.skip("This case runs out of memory with in place")
+
     torch.manual_seed(0)
     torch.set_printoptions(precision=3, sci_mode=False, linewidth=500, threshold=10000, edgeitems=32)
 
@@ -212,7 +231,40 @@ def run_max_pool(
         memory_config=memory_config,
         applied_shard_scheme=shard_scheme,
         ceil_mode=ceil_mode,
+        in_place_halo=in_place_halo,
     )
+
+    # for core_id in range(0, 64):
+    #     output_shard = torch.Tensor(ttnn.to_torch(output.extract_shard(core_id).pad_to_tile(0.0).cpu()))
+    #     output_shards[core_id].append(output_shard)
+    # if len(output_shards[0]) == 2:
+    #     for core_id in range(0, 64):
+    #         print(f"Core ID: {core_id}")
+    #         # coord = ttnn.CoreCoord(x, y)
+    #         gold_shard = output_shards[core_id][0]
+    #         opt_shard = output_shards[core_id][1]
+    #         diff = gold_shard[0][0] - opt_shard[0][0]
+
+    #         print(gold_shard[0, 0, :, :1])
+    #         print(opt_shard[0, 0, :, :1])
+    #         print("--")
+
+    #         diff = diff.to(torch.float32)
+    #         # Replace -inf with zeros only where both gold_shard[0][0] and opt_shard[0][0] are -inf
+    #         mask = (gold_shard[0][0] == -float("inf")) & (opt_shard[0][0] == -float("inf"))
+    #         diff = torch.where(mask, torch.tensor(0.0, dtype=diff.dtype), diff)
+
+    #         # Plot the difference
+    #         plt.imshow(diff[:, -32:], cmap="viridis")
+    #         plt.colorbar()
+    #         plt.title("Difference between output shards")
+
+    #         # Save the plot
+    #         filename = "output_shard_pics/output_shard_difference_core_" + str(core_id) + ".png"
+    #         plt.savefig(filename)
+
+    #         # Clear the plot to avoid overlap in subsequent runs
+    #         plt.clf()
 
     output_host = output.cpu()
     output_pytorch_padded = torch.Tensor(ttnn.to_torch(output_host))
@@ -310,7 +362,7 @@ def run_max_pool(
             [1, 640, 32, 32],
             [1, 576, 32, 32],
             [1, 384, 32, 32],
-            # C=16 test
+            # C=16 test2
             [1, 16, 10, 10],
         )
     ),
@@ -357,8 +409,15 @@ def run_max_pool(
         True,
     ],
 )
+@pytest.mark.parametrize(
+    "in_place_halo",
+    [
+        False,
+        True,
+    ],
+)
 def test_run_max_pool(
-    act_shape, kernel_size, padding, stride, dilation, device, torch_tensor_map, dtype, use_program_cache, ceil_mode
+    act_shape, kernel_size, padding, stride, dilation, device, torch_tensor_map, dtype, use_program_cache, ceil_mode, in_place_halo
 ):
     run_max_pool(
         act_shape,
@@ -371,6 +430,7 @@ def test_run_max_pool(
         dtype,
         shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ceil_mode=ceil_mode,
+        in_place_halo=in_place_halo,
     )
 
 
@@ -440,6 +500,13 @@ def test_run_max_pool(
         True,
     ],
 )
+@pytest.mark.parametrize(
+    "in_place_halo",
+    [
+        False,
+        True,
+    ],
+)
 def test_run_max_pool_width_shard(
     act_shape,
     kernel_size,
@@ -451,6 +518,7 @@ def test_run_max_pool_width_shard(
     dtype,
     use_program_cache,
     ceil_mode,
+    in_place_halo,
 ):
     run_max_pool(
         act_shape,
@@ -463,6 +531,7 @@ def test_run_max_pool_width_shard(
         dtype,
         shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ceil_mode=ceil_mode,
+        in_place_halo=in_place_halo,
     )
 
 
@@ -552,6 +621,13 @@ def test_run_max_pool_width_shard(
         True,
     ],
 )
+@pytest.mark.parametrize(
+    "in_place_halo",
+    [
+        False,
+        True,
+    ],
+)
 def test_run_max_pool_block_shard(
     act_shape,
     kernel_size,
@@ -563,6 +639,7 @@ def test_run_max_pool_block_shard(
     dtype,
     use_program_cache,
     ceil_mode,
+    in_place_halo,
 ):
     run_max_pool(
         act_shape,
@@ -575,6 +652,7 @@ def test_run_max_pool_block_shard(
         dtype,
         shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ceil_mode=ceil_mode,
+        in_place_halo=in_place_halo,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -73,6 +73,7 @@ def run_conv(
     output_mesh_composer=None,
     enable_split_reader=False,
     activation="",
+    in_place_halo=False,
 ):
     if isinstance(device, ttnn.MeshDevice):
         assert input_mesh_mapper is not None, "Expected mesh mapper for input tensor when using device mesh"
@@ -136,6 +137,7 @@ def run_conv(
         enable_act_double_buffer=False,
         enable_split_reader=enable_split_reader,
         enable_subblock_padding=False,
+        in_place=in_place_halo,
         output_layout=output_layout,
         activation=activation,
     )
@@ -1761,24 +1763,24 @@ def test_unet_conv_groups_2_wh(
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
-    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant",
+    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant, in_place_halo",
     (
-        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        (16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        (32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        # (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True), # OOM - need inplace convolution
-        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        # (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True), # OOM - need inplace convolution
-        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 2 * 32}, False),
+        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, True),
+        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, True),
+        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 2 * 32}, False, False),
     ),
 )
 @pytest.mark.parametrize(
@@ -1814,6 +1816,7 @@ def test_unet_conv_groups_4_6_wh(
     use_shallow_conv_variant,
     output_layout,
     groups,
+    in_place_halo,
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
@@ -1821,6 +1824,8 @@ def test_unet_conv_groups_4_6_wh(
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
+    if input_channels == 32 and input_height == 1056 and groups == 6:
+        pytest.skip("OOM, need fused untilize with halo")
     run_conv(
         device,
         torch_tensor_map,
@@ -1843,6 +1848,7 @@ def test_unet_conv_groups_4_6_wh(
         use_shallow_conv_variant=use_shallow_conv_variant,
         output_layout=output_layout,
         groups=groups,
+        in_place_halo=in_place_halo,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -181,7 +181,8 @@ Result conv2d(
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
                 0,
                 input_tensor_post_tm.memory_config(),
-                true);
+                true,
+                conv_config.in_place);
 
             if (conv_config.deallocate_activation) {
                 input_tensor_post_tm.deallocate(/*force*/ true);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -335,6 +335,7 @@ void py_bind_conv2d(py::module& module) {
             bool,
             bool,
             bool,
+            bool,
             bool>(),
         py::kw_only(),
         py::arg("dtype") = DataType::BFLOAT16,
@@ -354,7 +355,8 @@ void py_bind_conv2d(py::module& module) {
         py::arg("enable_act_double_buffer") = false,
         py::arg("enable_weights_double_buffer") = false,
         py::arg("enable_split_reader") = false,
-        py::arg("enable_subblock_padding") = false);
+        py::arg("enable_subblock_padding") = false,
+        py::arg("in_place") = false);
     py_conv_config.def_readwrite("dtype", &Conv2dConfig::dtype);
     py_conv_config.def_readwrite("weights_dtype", &Conv2dConfig::weights_dtype);
     py_conv_config.def_readwrite("activation", &Conv2dConfig::activation);
@@ -373,6 +375,7 @@ void py_bind_conv2d(py::module& module) {
     py_conv_config.def_readwrite("enable_weights_double_buffer", &Conv2dConfig::enable_weights_double_buffer);
     py_conv_config.def_readwrite("enable_split_reader", &Conv2dConfig::enable_split_reader);
     py_conv_config.def_readwrite("enable_subblock_padding", &Conv2dConfig::enable_subblock_padding);
+    py_conv_config.def_readwrite("in_place", &Conv2dConfig::in_place);
 
     py_conv_config.def("__repr__", [](const Conv2dConfig& config) { return fmt::format("{}", config); });
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -73,6 +73,10 @@ struct Conv2dConfig {
     bool enable_split_reader = false;
 
     bool enable_subblock_padding = false;
+
+    // Re-use input tensor storage when creating output tensor
+    bool in_place = false;
+
     static constexpr auto attribute_names = std::make_tuple(
         "dtype",
         "weights_dtype",
@@ -91,7 +95,8 @@ struct Conv2dConfig {
         "enable_act_double_buffer",
         "enable_weights_double_buffer",
         "enable_split_reader",
-        "enable_subblock_padding");
+        "enable_subblock_padding",
+        "in_place");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->dtype),
@@ -111,7 +116,8 @@ struct Conv2dConfig {
             std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_weights_double_buffer),
             std::cref(this->enable_split_reader),
-            std::cref(this->enable_subblock_padding));
+            std::cref(this->enable_subblock_padding),
+            std::cref(this->in_place));
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -44,7 +44,8 @@ Tensor Pool2DOp<pool_type>::invoke(
     std::array<uint32_t, 2> dilation,
     const std::optional<const MemoryConfig>& memory_config,
     const std::optional<const TensorMemoryLayout> applied_shard_scheme,
-    bool ceil_mode) {
+    bool ceil_mode,
+    bool in_place_halo) {
     sliding_window::SlidingWindowConfig sliding_window_config{
             .batch_size = batch_size,
             .input_hw = {input_h, input_w},
@@ -139,7 +140,8 @@ Tensor Pool2DOp<pool_type>::invoke(
         parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
         0,
         input_tensor_sharded.memory_config(),
-        is_out_tiled);
+        is_out_tiled,
+        in_place_halo);
 
     auto output_tensor = ttnn::prim::pool2d(
         queue_id,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -30,7 +30,8 @@ struct Pool2DOp {
         std::array<uint32_t, 2> dilation,
         const std::optional<const MemoryConfig>& memory_config = std::nullopt,
         const std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
-        bool ceil_mode = false);
+        bool ceil_mode = false,
+        bool in_place_halo = false);
 };
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -37,6 +37,7 @@ void bind_max_pool2d_operation(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
             applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
             ceil_mode (bool, optional): whether to use ceil mode for the output shape. Defaults to `False`.
+            in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
             queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
@@ -71,6 +72,7 @@ void bind_max_pool2d_operation(py::module& module) {
                                 memory_config=None,
                                 applied_shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                                 ceil_mode=False,
+                                in_place_halo=False,
                             )
 
         )doc",
@@ -88,6 +90,7 @@ void bind_max_pool2d_operation(py::module& module) {
                const std::optional<const MemoryConfig>& memory_config,
                const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
                bool ceil_mode,
+               bool in_place_halo,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
                     queue_id,
@@ -102,7 +105,8 @@ void bind_max_pool2d_operation(py::module& module) {
                     dilation,
                     memory_config,
                     applied_shard_scheme,
-                    ceil_mode);
+                    ceil_mode,
+                    in_place_halo);
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -117,6 +121,7 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("applied_shard_scheme") = std::nullopt,
             py::arg("ceil_mode") = false,
+            py::arg("in_place_halo") = false,
             py::arg("queue_id") = DefaultQueueId});
 }
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
 #include <array>
@@ -69,6 +70,11 @@ std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vec
         TT_FATAL(input_core_w == output_core_w, "Error");
     }
 
+    if (this->in_place_) {
+        tt::log_info(tt::LogAlways, "halo_device_operation - Using in-place mode so deallocating input buffer");
+        DeallocateBuffer(*input_tensor.buffer());
+    }
+
     auto out_mem_config = output_memory_config_;
     std::array<uint32_t, 2> shard_shape = {
         tt::div_up(output_shape[0] * output_shape[2], config_.num_cores_nhw),
@@ -96,11 +102,19 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
     auto tensor_metadata = sliding_window::generate_tensor_metadata(
         pad_metadata, config_, reshard_num_cores_nhw_, is_in_tiled || is_out_tiled_);
     auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
-        tensor_metadata, shard_boundaries, is_block_sharded, transpose_mcast_, remote_read_, device);
+        tensor_metadata,
+        shard_boundaries,
+        is_block_sharded,
+        transpose_mcast_,
+        remote_read_,
+        device,
+        max_out_nsticks_per_core_,
+        in_nsticks_per_core_);  // TODO: is this a valid way to get the input shard size?
 
     const auto& pad_config = std::get<0>(kernel_config);
     const auto& local_config = std::get<1>(kernel_config);
     const auto& remote_config = std::get<2>(kernel_config);
+    const auto& max_ref_size = std::get<3>(kernel_config);
 
     auto pad_config_tensor =
         sliding_window::construct_on_host_config_tensor(pad_config, this->config_, this->parallel_config_);
@@ -109,12 +123,32 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
     auto remote_config_tensor =
         sliding_window::construct_on_host_config_tensor(remote_config, this->config_, this->parallel_config_);
 
+    DataType type = input_tensor.get_dtype();
+    int num_cores = this->parallel_config_.grid.num_cores();
+    int num_cores_c = conv::get_num_cores_channels_from_parallel_config(this->parallel_config_);
+    int stick_size = input_tensor.get_padded_shape()[3] / num_cores_c;
+
     auto pad_config_device_tensor =
         sliding_window::move_config_tensor_to_device(pad_config_tensor, parallel_config_, is_block_sharded, device);
     auto local_config_device_tensor =
         sliding_window::move_config_tensor_to_device(local_config_tensor, parallel_config_, is_block_sharded, device);
     auto remote_config_device_tensor =
         sliding_window::move_config_tensor_to_device(remote_config_tensor, parallel_config_, is_block_sharded, device);
+
+    std::optional<Tensor> remote_temp_device_tensor;
+    if (max_ref_size > 0 && this->in_place_) {
+        // create the remote temp tensor, TODO do we need to vary this type for bfloat8?
+        int remote_temp_size = max_ref_size * stick_size * num_cores;
+        auto remote_temp_buffer = owned_buffer::create<bfloat16>(std::vector<bfloat16>(remote_temp_size));
+        ttnn::Shape remote_temp_shape = ttnn::Shape({num_cores, max_ref_size, stick_size});
+        Tensor remote_temp_tensor(OwnedStorage{remote_temp_buffer}, remote_temp_shape, type, Layout::ROW_MAJOR);
+
+        // move tensors to device
+        auto shard_shape = std::array<uint32_t, 2>({max_ref_size, stick_size});
+        ShardSpec shard_spec(parallel_config_.grid, shard_shape, ShardOrientation::ROW_MAJOR);
+        MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec};
+        remote_temp_device_tensor = remote_temp_tensor.to_device(device, memory_config);
+    }
 
     Program program = CreateProgram();
 
@@ -123,14 +157,18 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         input_tensor,
         pad_val_,
         config_.num_cores_nhw,
+        config_.num_cores_c,
         max_out_nsticks_per_core_,
         pad_config_device_tensor,
         local_config_device_tensor,
         remote_config_device_tensor,
+        remote_temp_device_tensor ? std::optional<std::reference_wrapper<const Tensor>>(*remote_temp_device_tensor)
+                                  : std::nullopt,
         remote_read_,
         transpose_mcast_,
         output_tensor,
-        /*capture_buffers=*/true)};
+        /*capture_buffers=*/true,
+        this->in_place_)};
 }
 
 Tensor halo_op(
@@ -141,7 +179,8 @@ Tensor halo_op(
     bool transpose_mcast,
     uint32_t reshard_num_cores_nhw,
     const MemoryConfig& output_memory_config,
-    bool is_out_tiled) {
+    bool is_out_tiled,
+    bool in_place) {
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Halo expects sharded input tensor");
     TT_FATAL(
         input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
@@ -159,7 +198,8 @@ Tensor halo_op(
          transpose_mcast,
          reshard_num_cores_nhw,
          output_memory_config,
-         is_out_tiled](
+         is_out_tiled,
+         in_place](
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
@@ -177,10 +217,19 @@ Tensor halo_op(
 
         uint32_t max_out_nsticks_per_core =
             HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
+        uint32_t in_nsticks_per_core = input_tensor.memory_config().shard_spec->shape[0];
         ParallelConfig p_config;
         p_config.grid = input_tensor.shard_spec().value().grid;
         p_config.shard_scheme = input_tensor.memory_config().memory_layout;
         p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
+
+        if (in_place && in_nsticks_per_core > max_out_nsticks_per_core) {
+            tt::log_info(
+                tt::LogAlways,
+                "halo_device_operation - in place operation is not supported for parameterizations with "
+                "input shard size larger than output shard size, falling back to normal operation");
+            in_place = false;
+        }
 
         return operation::run(
             HaloDeviceOperation{
@@ -191,8 +240,10 @@ Tensor halo_op(
                 .transpose_mcast_ = transpose_mcast,
                 .reshard_num_cores_nhw_ = reshard_num_cores_nhw,
                 .max_out_nsticks_per_core_ = max_out_nsticks_per_core,
+                .in_nsticks_per_core_ = in_nsticks_per_core,
                 .output_memory_config_ = output_memory_config,
-                .is_out_tiled_ = is_out_tiled},
+                .is_out_tiled_ = is_out_tiled,
+                .in_place_ = in_place},
             {input_tensor});
     };
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -23,8 +23,10 @@ struct HaloDeviceOperation {
     bool transpose_mcast_;
     uint32_t reshard_num_cores_nhw_;
     uint32_t max_out_nsticks_per_core_;
+    uint32_t in_nsticks_per_core_;
     tt::tt_metal::MemoryConfig output_memory_config_;
     bool is_out_tiled_;
+    bool in_place_;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
@@ -41,7 +43,8 @@ struct HaloDeviceOperation {
         "reshard_num_cores_nhw_",
         "max_out_nsticks_per_core_",
         "output_memory_config_",
-        "is_out_tiled_");
+        "is_out_tiled_",
+        "in_place_");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(config_),
@@ -52,7 +55,8 @@ struct HaloDeviceOperation {
             std::cref(reshard_num_cores_nhw_),
             std::cref(max_out_nsticks_per_core_),
             std::cref(output_memory_config_),
-            std::cref(is_out_tiled_));
+            std::cref(is_out_tiled_),
+            std::cref(in_place_));
     }
 };
 
@@ -64,7 +68,8 @@ Tensor halo_op(
     bool transpose_mcast = true,
     uint32_t reshard_num_cores_nhw = 0,
     const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    bool is_out_tiled = true);
+    bool is_out_tiled = true,
+    bool in_place = false);
 
 }  // namespace halo
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -89,18 +89,18 @@ void kernel_main() {
     constexpr uint32_t padding_config_cb_id = get_compile_time_arg_val(0);  // has untilized input shard
     constexpr uint32_t local_config_cb_id = get_compile_time_arg_val(1);    // has untilized input shard
     constexpr uint32_t remote_config_cb_id = get_compile_time_arg_val(2);   // has untilized input shard
-    constexpr uint32_t src_cb_id = get_compile_time_arg_val(3);             // has untilized input shard
-    constexpr uint32_t in_cb_id = get_compile_time_arg_val(4);              // has untilized input shard
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(5);     // output shard with padding and halo goes here
-    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(6);     // cb for const pad val buffer
-    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(7);   // pad value to fill pad buffer with
-    constexpr uint32_t in_nsticks = get_compile_time_arg_val(8);    // number of sticks
-    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(9);  // stick size in bytes (post untilize)
-    constexpr uint32_t is_block_sharded = get_compile_time_arg_val(10);
-    constexpr uint32_t remote_read = get_compile_time_arg_val(11);
-    constexpr bool is_col_major = get_compile_time_arg_val(12) == 1;
-    constexpr uint32_t is_width_sharded = get_compile_time_arg_val(13);
-    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(14);
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(4);             // has untilized input shard
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(5);              // has untilized input shard
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(6);      // output shard with padding and halo goes here
+    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(7);      // cb for const pad val buffer
+    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(8);    // pad value to fill pad buffer with
+    constexpr uint32_t in_nsticks = get_compile_time_arg_val(9);     // number of sticks
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(10);  // stick size in bytes (post untilize)
+    constexpr uint32_t is_block_sharded = get_compile_time_arg_val(11);
+    constexpr uint32_t remote_read = get_compile_time_arg_val(12);
+    constexpr bool is_col_major = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t is_width_sharded = get_compile_time_arg_val(14);
+    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(15);
 
     constexpr uint32_t elem_nbytes = sizeof(uint16_t);
     constexpr uint16_t pad_core_id = 0xFFFF;
@@ -120,7 +120,6 @@ void kernel_main() {
         uint32_t padding_config_l1_addr = get_read_ptr(padding_config_cb_id);
         volatile tt_l1_ptr uint16_t* config_data =
             reinterpret_cast<volatile tt_l1_ptr uint16_t*>(padding_config_l1_addr);
-        // print_data_u16(padding_config_l1_addr, 1, 16);
         const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
         const uint32_t dst_base_addr = out_base_l1_addr;
         uint16_t nsticks = 1;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+#define ENABLE_DEBUG 1
+
+#if ENABLE_DEBUG
+#include "debug/dprint.h"
+#include "debug/dprint_pages.h"
+#endif
+
+// Fill an L1 buffer with the given val
+inline bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
+    // simplest impl:
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(begin_addr);
+    for (uint32_t i = 0; i < n; ++i) {
+        ptr[i] = val;
+    }
+    return true;
+}
+
+template <
+    uint32_t stick_nbytes,
+    uint32_t input_aligned_page_size,
+    bool is_block_sharded,
+    bool is_width_sharded,
+    bool is_read,
+    bool is_col_major>
+void copy_sticks_async_temp_write(
+    const tt_l1_ptr uint16_t* config_data,
+    const uint16_t my_noc_x,
+    const uint16_t my_noc_y,
+    const uint32_t in_base_l1_addr,
+    const uint32_t out_base_l1_addr,
+    const uint32_t noc_00_x,
+    const uint32_t noc_00_y,
+    const uint32_t semaphore_addr = 0) {
+    int i = 0;
+    int length = config_data[i + 2];
+
+    const uint64_t base_addr = get_noc_addr(my_noc_x, my_noc_y, out_base_l1_addr);
+    uint64_t dst_addr = base_addr;
+
+    while (length) {
+        length = config_data[i + 2];
+        i += 3;
+        for (uint16_t j = 0; j < length; j += 3) {
+            uint16_t src_local_idx = config_data[i + j + 0];
+            uint16_t nsticks = config_data[i + j + 2];
+            uint32_t size = nsticks * stick_nbytes;
+            uint32_t src_offset = src_local_idx * input_aligned_page_size;
+
+            uint32_t src_addr = in_base_l1_addr + src_offset;
+            if constexpr (stick_nbytes == input_aligned_page_size) {
+                noc_async_write(src_addr, dst_addr, size);
+                dst_addr += size;
+            } else {
+                for (uint16_t k = 0; k < nsticks; k++) {
+                    noc_async_write(src_addr, dst_addr, stick_nbytes);
+                    dst_addr += stick_nbytes;
+                    src_addr += input_aligned_page_size;
+                }
+            }
+        }
+
+        i += length;
+    }
+}
+
+template <
+    uint32_t stick_nbytes,
+    uint32_t input_aligned_page_size,
+    bool is_block_sharded,
+    bool is_width_sharded,
+    bool is_read,
+    bool is_col_major>
+void copy_sticks_async_temp_read(
+    const tt_l1_ptr uint16_t* config_data,
+    const uint16_t my_noc_x,
+    const uint16_t my_noc_y,
+    const uint32_t in_base_l1_addr,
+    const uint32_t out_base_l1_addr,
+    const uint32_t noc_00_x,
+    const uint32_t noc_00_y,
+    const uint32_t semaphore_addr = 0) {
+    int i = 0;
+    int length = config_data[i + 2];
+
+    uint64_t src_addr = in_base_l1_addr;
+
+    while (length) {
+        uint16_t noc_x = ((is_block_sharded && !is_col_major) || is_width_sharded) ? my_noc_x : config_data[i + 0];
+        uint16_t noc_y = ((is_block_sharded && is_col_major) || is_width_sharded) ? my_noc_y : config_data[i + 1];
+        length = config_data[i + 2];
+        i += 3;
+        const uint64_t base_addr = get_noc_addr(noc_x, noc_y, out_base_l1_addr);
+        for (uint16_t j = 0; j < length; j += 3) {
+            uint16_t dst_local_idx = config_data[i + j + 1];
+            uint16_t nsticks = config_data[i + j + 2];
+            uint32_t size = nsticks * stick_nbytes;
+            uint32_t dst_offset = dst_local_idx * stick_nbytes;
+
+            uint64_t dst_addr = base_addr + dst_offset;
+            if constexpr (stick_nbytes == input_aligned_page_size) {
+                noc_async_write(src_addr, dst_addr, size);
+                src_addr += size;
+            } else {
+                for (uint16_t k = 0; k < nsticks; k++) {
+                    noc_async_write(src_addr, dst_addr, stick_nbytes);
+                    dst_addr += stick_nbytes;
+                    src_addr += stick_nbytes;
+                }
+            }
+        }
+
+        i += length;
+    }
+}
+
+template <
+    uint32_t stick_nbytes,
+    uint32_t input_aligned_page_size,
+    bool is_block_sharded,
+    bool is_width_sharded,
+    bool is_read,
+    bool is_col_major>
+void copy_sticks_async(
+    const tt_l1_ptr uint16_t* config_data,
+    const uint16_t my_noc_x,
+    const uint16_t my_noc_y,
+    const uint32_t in_base_l1_addr,
+    const uint32_t out_base_l1_addr,
+    const uint32_t in_out_buffer_start_delta) {
+    int i = 0;
+    int length = config_data[i + 2];
+
+    while (length) {
+        length = config_data[i + 2];
+        i += 3;
+        const uint64_t base_addr = get_noc_addr(my_noc_x, my_noc_y, out_base_l1_addr);
+        const uint64_t base_addr_src = get_noc_addr(my_noc_x, my_noc_y, in_base_l1_addr);
+        for (uint16_t j = 0; j < length; j += 3) {
+            uint16_t src_local_idx = config_data[i + j + 0];
+            uint16_t dst_local_idx = config_data[i + j + 1];
+            uint16_t nsticks = config_data[i + j + 2];
+            uint32_t size = nsticks * stick_nbytes;
+            uint32_t dst_offset = dst_local_idx * stick_nbytes;
+            uint32_t src_offset = src_local_idx * input_aligned_page_size;
+
+            uint64_t dst_addr = base_addr + dst_offset;
+            uint32_t src_addr = in_base_l1_addr + src_offset;
+
+            bool is_forward_copy = dst_local_idx > src_local_idx + in_out_buffer_start_delta &&
+                                   dst_local_idx <= src_local_idx + in_out_buffer_start_delta + nsticks;
+            bool is_overlap_copy = (dst_local_idx > src_local_idx + in_out_buffer_start_delta &&
+                                    dst_local_idx <= src_local_idx + in_out_buffer_start_delta + nsticks) ||
+                                   (dst_local_idx + nsticks >= src_local_idx + in_out_buffer_start_delta &&
+                                    dst_local_idx + nsticks < src_local_idx + in_out_buffer_start_delta + nsticks);
+            if (is_overlap_copy) {      // dst and src data overlaps, stick by stick copy is necessary
+                if (is_forward_copy) {  // dst data is being moved "in front" of the source data, reverse
+                                        // ordering of stick by stick copy is necessary
+                    for (int16_t k = nsticks - 1; k >= 0; k--) {
+                        noc_async_write(src_addr + k * stick_nbytes, dst_addr + k * stick_nbytes, stick_nbytes);
+                    }
+                } else {
+                    for (uint16_t k = 0; k < nsticks; k++) {
+                        noc_async_write(src_addr + k * stick_nbytes, dst_addr + k * stick_nbytes, stick_nbytes);
+                    }
+                }
+            } else {
+                noc_async_write(src_addr, dst_addr, size);
+            }
+        }
+
+        i += length;
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t padding_config_cb_id = get_compile_time_arg_val(0);  // has untilized input shard
+    constexpr uint32_t local_config_cb_id = get_compile_time_arg_val(1);    // has untilized input shard
+    constexpr uint32_t remote_config_cb_id = get_compile_time_arg_val(2);   // has untilized input shard
+    constexpr uint32_t remote_temp_cb_id = get_compile_time_arg_val(3);     // has untilized input shard
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(4);             // has untilized input shard
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(5);              // has untilized input shard
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(6);      // output shard with padding and halo goes here
+    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(7);      // cb for const pad val buffer
+    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(8);    // pad value to fill pad buffer with
+    constexpr uint32_t in_nsticks = get_compile_time_arg_val(9);     // number of sticks
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(10);  // stick size in bytes (post untilize)
+    constexpr uint32_t is_block_sharded = get_compile_time_arg_val(11);
+    constexpr uint32_t remote_read = get_compile_time_arg_val(12);
+    constexpr bool is_col_major = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t is_width_sharded = get_compile_time_arg_val(14);
+    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t noc_00_x = get_compile_time_arg_val(16);
+    constexpr uint32_t noc_00_y = get_compile_time_arg_val(17);
+    constexpr uint32_t num_cores_nhw = get_compile_time_arg_val(18);
+    constexpr uint32_t num_cores_c = get_compile_time_arg_val(19);
+    constexpr uint32_t num_cores_x = get_compile_time_arg_val(20);
+    constexpr uint32_t semaphore_id = get_compile_time_arg_val(21);
+    constexpr uint32_t max_out_nsticks_per_core = get_compile_time_arg_val(22);
+
+    constexpr uint32_t num_cores = num_cores_nhw * num_cores_c;
+
+    constexpr uint32_t elem_nbytes = sizeof(uint16_t);
+    constexpr uint16_t pad_core_id = 0xFFFF;
+
+    const uint16_t my_noc_x = NOC_X(my_x[noc_index]);
+    const uint16_t my_noc_y = NOC_Y(my_y[noc_index]);
+    const uint32_t in_base_l1_addr = get_read_ptr(in_cb_id);
+    const uint32_t out_base_l1_addr = get_write_ptr(out_cb_id);
+
+    // input shards
+    if constexpr (local_config_cb_id) {
+        cb_reserve_back(src_cb_id, in_nsticks);
+        cb_push_back(src_cb_id, in_nsticks);
+    }
+
+    uint32_t semaphore_addr = 0;
+    semaphore_addr = get_semaphore(semaphore_id);
+
+    cb_wait_front(in_cb_id, in_nsticks);  // make sure untilized data is available
+    if constexpr (remote_config_cb_id && remote_temp_cb_id) {
+        const uint32_t temp_base_l1_addr = get_write_ptr(remote_temp_cb_id);
+        uint32_t config_data_l1_addr = get_read_ptr(remote_config_cb_id);
+        const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+        copy_sticks_async_temp_write<
+            stick_nbytes,
+            input_aligned_page_size,
+            is_block_sharded,
+            is_width_sharded,
+            remote_read,
+            is_col_major>(
+            config_data, my_noc_x, my_noc_y, in_base_l1_addr, temp_base_l1_addr, noc_00_x, noc_00_y, semaphore_addr);
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+
+    if constexpr (local_config_cb_id) {
+        const int32_t in_out_buffer_start_delta = max_out_nsticks_per_core - in_nsticks;
+        uint32_t config_data_l1_addr = get_read_ptr(local_config_cb_id);
+        const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+        copy_sticks_async<
+            stick_nbytes,
+            input_aligned_page_size,
+            is_block_sharded,
+            is_width_sharded,
+            false,
+            is_col_major>(
+            config_data, my_noc_x, my_noc_y, in_base_l1_addr, out_base_l1_addr, in_out_buffer_start_delta);
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+    for (uint16_t noc = 0; noc < num_cores; ++noc) {
+        uint16_t noc_x = noc % num_cores_x;
+        uint16_t noc_y = noc / num_cores_x;
+        const uint64_t ref_semaphore_noc_addr = get_noc_addr(noc_x + noc_00_x, noc_y + noc_00_y, semaphore_addr);
+        noc_semaphore_inc(ref_semaphore_noc_addr, 1);
+    }
+
+    if constexpr (padding_config_cb_id) {
+        const uint64_t my_semaphore_noc_addr = get_noc_addr(my_noc_x, my_noc_y, semaphore_addr);
+        volatile tt_l1_ptr uint32_t* my_semaphore_noc_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(my_semaphore_noc_addr);
+        noc_semaphore_wait(my_semaphore_noc_addr_ptr, 2 * num_cores);
+
+        // construct the pad stick in its buffer
+        cb_reserve_back(pad_cb_id, 1);
+        const uint16_t pad_val = pad_val_u32;
+        fill_with_val(get_write_ptr(pad_cb_id), stick_nbytes / elem_nbytes, pad_val);
+        cb_push_back(pad_cb_id, 1);
+
+        uint32_t padding_config_l1_addr = get_read_ptr(padding_config_cb_id);
+        volatile tt_l1_ptr uint16_t* config_data =
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(padding_config_l1_addr);
+        const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
+        const uint32_t dst_base_addr = out_base_l1_addr;
+        uint16_t nsticks = 1;
+        for (uint16_t j = 0; nsticks; j += 2) {
+            uint16_t dst_local_idx = config_data[j + 0];
+            nsticks = config_data[j + 1];
+
+            uint64_t dst_addr = dst_base_addr + dst_local_idx * stick_nbytes;
+            for (uint16_t k = 0; k < nsticks; ++k) {
+                noc_async_read(padding_l1_addr, dst_addr, stick_nbytes);
+                dst_addr += stick_nbytes;
+            }
+        }
+    }
+
+    if constexpr (remote_config_cb_id && remote_temp_cb_id) {
+        const uint64_t my_semaphore_noc_addr = get_noc_addr(my_noc_x, my_noc_y, semaphore_addr);
+        volatile tt_l1_ptr uint32_t* my_semaphore_noc_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(my_semaphore_noc_addr);
+        noc_semaphore_wait(my_semaphore_noc_addr_ptr, 2 * num_cores);
+
+        const uint32_t temp_base_l1_addr = get_read_ptr(remote_temp_cb_id);
+        uint32_t config_data_l1_addr = get_read_ptr(remote_config_cb_id);
+        const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+        copy_sticks_async_temp_read<
+            stick_nbytes,
+            input_aligned_page_size,
+            is_block_sharded,
+            is_width_sharded,
+            remote_read,
+            is_col_major>(config_data, my_noc_x, my_noc_y, temp_base_l1_addr, out_base_l1_addr, noc_00_x, noc_00_y);
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_op.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_op.cpp
@@ -5,6 +5,7 @@
 #include "untilize_with_halo_v2_op.hpp"
 
 #include "ttnn/run_operation.hpp"
+#include <optional>
 #include <tt-metalium/work_split.hpp>
 #include "untilize_with_halo_v2_program_factory.hpp"
 
@@ -86,10 +87,12 @@ operation::ProgramWithCallbacks UntilizeWithHaloV2::create_program(
         input_tensor,
         pad_val_,
         ncores_nhw_,
+        ncores_c_,
         max_out_nsticks_per_core_,
         padding_config,
         local_config,
         remote_config,
+        std::nullopt,
         remote_read_,
         transpose_mcast_,
         output_tensor,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_op.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_op.hpp
@@ -15,6 +15,7 @@ namespace ttnn::operations::data_movement {
 struct UntilizeWithHaloV2 {
     const uint32_t pad_val_;
     const uint32_t ncores_nhw_;
+    const uint32_t ncores_c_;
     const uint32_t max_out_nsticks_per_core_;
     const tt::tt_metal::MemoryConfig out_mem_config_;
     const bool remote_read_;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
@@ -284,10 +284,9 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     reader_ct_args[3] = 0;
 
     KernelHandle reader_kernel_id1 = CreateKernel(
-        program,ß
-        in_place
-            ? "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp"
-            : "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp",
+        program,
+        in_place ? "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp"
+                 : "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp",
         all_cores,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_ct_args});

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp
@@ -13,14 +13,17 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     const Tensor& input_tensor,
     const uint32_t pad_val,
     const uint32_t ncores_nhw,
+    const uint32_t ncores_c,
     const uint32_t max_out_nsticks_per_core,
     const Tensor& padding_config,
     const Tensor& local_config,
     const Tensor& remote_config,
+    std::optional<std::reference_wrapper<const Tensor>> remote_temp,
     const bool remote_read,
     const bool transpose_mcast,
     Tensor& output_tensor,
-    const bool capture_buffers);  // Used by halo op to cache internally created config buffers with the program
-                                  // Untilize with Halo V2 op takes them as inputs from the user, so doesn't capture
+    const bool capture_buffers,
+    bool in_place = false);  // Used by halo op to cache internally created config buffers with the program
+                             // Untilize with Halo V2 op takes them as inputs from the user, so doesn't capture
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
@@ -16,7 +16,8 @@ Tensor HaloOperation::invoke(
     bool transpose_mcast,
     uint32_t reshard_num_cores_nhw,
     const MemoryConfig& output_memory_config,
-    bool is_out_tiled) {
+    bool is_out_tiled,
+    bool in_place) {
     return halo_op(
         input_tensor,
         config,
@@ -25,6 +26,7 @@ Tensor HaloOperation::invoke(
         transpose_mcast,
         reshard_num_cores_nhw,
         std::move(output_memory_config),
-        is_out_tiled);
+        is_out_tiled,
+        in_place);
 }
 };  // namespace ttnn::operations::sliding_window::halo

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -19,8 +19,9 @@ struct HaloOperation {
         bool remote_read = false,
         bool transpose_mcast = true,
         uint32_t reshard_num_cores_nhw = 0,
-        const MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        bool is_out_tiled = true);
+        const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        bool is_out_tiled = true,
+        bool in_place = false);
 
     // invoke can be overloaded as many times as needed to provide all desired APIs
 };

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -110,20 +110,26 @@ std::vector<PixelMetadata> generate_tensor_metadata(
     uint32_t reshard_num_cores_nhw = 0,
     bool is_in_tiled = true);
 uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& shard_boundaries);
-std::tuple<std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>>
+std::tuple<
+    std::vector<std::vector<uint16_t>>,
+    std::vector<std::vector<uint16_t>>,
+    std::vector<std::vector<uint16_t>>,
+    int>
 generate_halo_kernel_config_tensors(
     const std::vector<PixelMetadata>& tensor_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool is_block_sharded,
     bool transpose_mcast,
     bool remote_read,
-    tt::tt_metal::IDevice* device);
+    tt::tt_metal::IDevice* device,
+    uint32_t max_out_nsticks_per_core = INT_MAX,
+    uint32_t in_nsticks_per_core = 0);
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool pad_tile = false,
     bool pad_cores = false);
-std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input);
+std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes = 0);
 Tensor construct_on_host_config_tensor(
     const std::vector<std::vector<uint16_t>>& config,
     const SlidingWindowConfig& sw_config,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14450)

### Problem description
Currently separate buffers are used for the input and output shards of the Halo Op.  This should be adjusted so the output shard contains the input shard, thereby making Halo an "in-place" operation.

### What's changed
- In place flags were added to Conv2D and Maxpool, setting these to true prompts deallocation of the sharded input tensor to prompt re-allocation with output size
- Scratch tensor/CB were created for temporary storage of remote sticks
- New in place version of halo gather kernel was implemented
- New kernel functions were implemented to copy remote sticks to/from scratch buffer
- Gather kernel was updated to perform remote / local data movement on same core to block local copies until after scratch writes with in place operation
- Semaphores are used to block remote / padding writes until after scratch and local writes are complete on all cores
- Existing kernel copy function was updated to perform stick by stick copy when input / output chunks overlap and to perform copy in reverse order when output data is moved “in front” of input data
- Local config was updated to reverse chunk order for “forward” copies where dst is greated than src
- Broad coverage is included in MaxPool unit test 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13647697630
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13661257530
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13661254479
- [x] [Nightly model and ttnn](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI Passes: https://github.com/tenstorrent/tt-metal/actions/runs/13646285048
- [x] New/Existing tests provide coverage for changes
