### PR TITLE
Changed page size in upsample cb to fix alignment issue

### DIFF
--- a/tt_metal/api/tt-metalium/test_tiles.hpp
+++ b/tt_metal/api/tt-metalium/test_tiles.hpp
@@ -229,9 +229,11 @@ inline std::vector<T> untilize_nchw(
     return result;
 }
 
-inline std::uint32_t round_up_to_mul16(std::uint32_t val) { return ((val & 15) == 0) ? val : (val | 15)+1; }
+inline std::uint32_t round_up_to_mul16(std::uint32_t val) { return ((val & 15) == 0) ? val : (val | 15) + 1; }
 
-inline std::uint32_t round_up_to_mul32(std::uint32_t val) { return ((val & 31) == 0) ? val : (val | 31)+1; }
+inline std::uint32_t round_up_to_mul32(std::uint32_t val) { return ((val & 31) == 0) ? val : (val | 31) + 1; }
+
+inline std::uint32_t round_up_to_mul64(std::uint32_t val) { return ((val & 63) == 0) ? val : (val | 63) + 1; }
 
 inline std::uint32_t round_up_to_tile(int val, int tile_val) { return (val + tile_val - 1) & ~(tile_val - 1); }
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
@@ -39,7 +39,7 @@ operation::ProgramWithCallbacks upsample_single_core(
     // circulat buffer for input
     uint32_t src0_cb_index = CBIndex::c_0;
     uint32_t num_input_units = 2;
-    uint32_t aligned_input_unit_size = round_up_to_mul32(input_unit_size);
+    uint32_t aligned_input_unit_size = round_up_to_mul64(input_unit_size);
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(
             num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})


### PR DESCRIPTION
### Ticket
Issue #18199 

### Problem description
Address of page in CB in upsample op was 32B aligned, and that caused bad alignment read from DRAM.

### What's changed
Page size is resized to 64B.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/13543027028
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/13543039652 https://github.com/tenstorrent/tt-metal/actions/runs/13543034631
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
