### PR TITLE
#18199: Changed page size in upsample cb to fix alignment issue

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
@@ -4,6 +4,7 @@
 
 #include <math.h>
 
+#include "tt-metalium/hal.hpp"
 #include "upsample_op.hpp"
 #include "ttnn/operations/math.hpp"
 
@@ -39,7 +40,7 @@ operation::ProgramWithCallbacks upsample_single_core(
     // circulat buffer for input
     uint32_t src0_cb_index = CBIndex::c_0;
     uint32_t num_input_units = 2;
-    uint32_t aligned_input_unit_size = round_up_to_mul32(input_unit_size);
+    uint32_t aligned_input_unit_size = tt::round_up(input_unit_size, hal.get_alignment(HalMemType::DRAM));
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(
             num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})


### PR DESCRIPTION
### Ticket
Issue #18199

### Problem description
Address of page in CB in upsample op was 32B aligned, and that caused bad alignment read from DRAM.

### What's changed
Page size is resized to 64B.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/13544493368
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/13544507874 https://github.com/tenstorrent/tt-metal/actions/runs/13544522215
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
