### PR TITLE
#0: Remove bit fields from edm packet header

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -90,7 +90,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize(
     "expected_bw",
-    [6.5],
+    [6.7],
 )
 def test_fabric_edm_mcast_bw(
     num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw
@@ -117,7 +117,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize(
     "expected_bw",
-    [7.5],
+    [8.4],
 )
 def test_fabric_edm_unicast_bw(
     num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Bit fields in packet header causes additional instructions like shifting.

### What's changed
Remove bit fields from packet header.
Unicast: 17.47 GB/s -> 17.74 GB/s
Mcast: 14.02 GB/s -> 14.12 GB/s

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
T3K nightly: https://github.com/tenstorrent/tt-metal/actions/runs/13547469910
Microbenchmarks: https://github.com/tenstorrent/tt-metal/actions/runs/13544943235
