### PR TITLE
#13953: Incorrectly handled bfloat16 -0.0 in ttnn.signbit

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_signbit.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_signbit.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import random
+from functools import partial
+import ttnn
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import skip_for_blackhole
+
+mem_configs = [
+    ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+    ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [[1, 1, 32, 32]],
+    ],
+)
+@pytest.mark.parametrize(
+    "dst_mem_config",
+    mem_configs,
+)
+class TestSignbit:
+    def test_run_signbit_negative_zero(
+        self,
+        input_shapes,
+        dst_mem_config,
+        device,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ]
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update({"output_mem_config": dst_mem_config})
+        comparison_func = comparison_funcs.comp_equal
+
+        run_single_pytorch_test(
+            "eltwise-signbit",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    def test_run_signbit_op(
+        self,
+        input_shapes,
+        dst_mem_config,
+        device,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_constant, constant=-0.0), torch.bfloat16)
+        ]
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update({"output_mem_config": dst_mem_config})
+        comparison_func = comparison_funcs.comp_equal
+
+        run_single_pytorch_test(
+            "eltwise-signbit",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_signbit.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_signbit.py
@@ -35,7 +35,7 @@ mem_configs = [
     mem_configs,
 )
 class TestSignbit:
-    def test_run_signbit_negative_zero(
+    def test_run_signbit_op(
         self,
         input_shapes,
         dst_mem_config,
@@ -57,7 +57,7 @@ class TestSignbit:
             test_args,
         )
 
-    def test_run_signbit_op(
+    def test_run_signbit_negative_zero(
         self,
         input_shapes,
         dst_mem_config,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_signbit.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_signbit.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -10,14 +10,17 @@
  * LLK UNPACK A
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <
+    bool is_fp32_dest_acc_en = false,
+    StochRndType stoch_rnd_mode = StochRndType::None,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure(
     const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
     const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
 
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -25,11 +28,15 @@ inline void llk_unpack_A_hw_configure(
         unpA_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <
+    bool is_fp32_dest_acc_en = false,
+    StochRndType stoch_rnd_mode = StochRndType::None,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_A_params, within_face_16x16_transpose);
+    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+        &unpack_A_params, within_face_16x16_transpose);
 }
 
 template <

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -10,14 +10,17 @@
  * LLK UNPACK A
  *************************************************************************/
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <
+    bool is_fp32_dest_acc_en = false,
+    StochRndType stoch_rnd_mode = StochRndType::None,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure(
     const llk_unpack_A_params_t* unpack_A_params, const int within_face_16x16_transpose = 0) {
     const uint32_t unpA_operand_id = get_operand_id(unpack_A_params->unpA_operand);
     const uint32_t unpA_num_faces = get_operand_num_faces(unpA_operand_id);
     const uint32_t unpA_face_r_dim = get_operand_face_r_dim(unpA_operand_id);
 
-    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode>(
+    _llk_unpack_A_hw_configure_<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id],
         unpA_face_r_dim,
@@ -25,11 +28,15 @@ inline void llk_unpack_A_hw_configure(
         unpA_num_faces);
 }
 
-template <bool is_fp32_dest_acc_en = false, StochRndType stoch_rnd_mode = StochRndType::None>
+template <
+    bool is_fp32_dest_acc_en = false,
+    StochRndType stoch_rnd_mode = StochRndType::None,
+    bool disable_src_zero_flag = false>
 inline void llk_unpack_A_hw_configure_disaggregated(
     const std::uint32_t unpA_operand, const int within_face_16x16_transpose = 0) {
     const llk_unpack_A_params_t unpack_A_params = {.unpA_operand = unpA_operand};
-    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode>(&unpack_A_params, within_face_16x16_transpose);
+    llk_unpack_A_hw_configure<is_fp32_dest_acc_en, stoch_rnd_mode, disable_src_zero_flag>(
+        &unpack_A_params, within_face_16x16_transpose);
 }
 
 template <

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -15,7 +15,7 @@
 namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
-    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
+    UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, true>(icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13953)

### Problem description
`-0.0` Incorrectly handled as `0.0` in `ttnn.signbit`. bfloat16 data format should preserve `-0.0` values through the unpacker, math, packer pipeline. However, `-0.0` in bfloat16 format gets passed into the kernel as `0.0` and `signbit` reads this as a positive value.

The detailed reasoning is as follows. When unpacking to the Dest register, bfloat16 values are first packed into Src registers and then moved to Dest. When moving these values from Src, `-0.0` is interpreted as `0.0` and src zero flags are set. This leads to `-0.0` values not being moved, but instead, zeroes being written into relevant locations in Dest. 

### What's changed
Disabled src zero flags for eltwise unary/sfpu operations. `-0.0` values are now moved to Dest instead of written with zeroes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13592906337) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13592910095) CI passes (if applicable)
