### PR TITLE
Refactor sliding window shard boundary and tensor metadata types

### DIFF
--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -56,7 +56,7 @@ uint32_t compare_conv_out_with_golden(
 // It is ok to use pad_metadata since its correctness is validated in other test cases.
 uint32_t validate_generate_halo_kernel_config(
     tt::tt_metal::IDevice* device,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries,
+    const std::vector<ShardBoundary>& shard_boundaries,
     const std::tuple<vector<vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>>&
         halo_kernel_config,
     const vector<bool>& pad_metadata,

--- a/ttnn/cpp/ttnn/operations/sliding_window/reference_sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/reference_sliding_window.hpp
@@ -44,7 +44,7 @@ owned_buffer::Buffer<bfloat16> conv_using_op_trace_metadata(
 owned_buffer::Buffer<bfloat16> conv_using_shard_boundaries(
     const owned_buffer::Buffer<bfloat16>& input_padded_tensor_buf,
     const std::vector<float>& filter_vector,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries,
+    const std::vector<ShardBoundary>& shard_boundaries,
     uint32_t stride_h,
     uint32_t stride_w,
     uint32_t padded_input_h,
@@ -60,7 +60,7 @@ owned_buffer::Buffer<bfloat16> conv_using_sliding_window_op_config(
     const owned_buffer::Buffer<bfloat16>& input_padded_tensor_buf,
     const std::vector<float>& filter_vector,
     const std::vector<uint32_t>& op_trace_metadata,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries,
+    const std::vector<ShardBoundary>& shard_boundaries,
     const std::vector<std::vector<uint16_t>>& sharded_input_top_left_indices,
     uint32_t input_h,
     uint32_t input_w,
@@ -72,23 +72,22 @@ owned_buffer::Buffer<bfloat16> conv_using_sliding_window_op_config(
     uint32_t out_tensor_size);
 
 // Calculate Padding using tensor metadata.
-std::vector<bool> pad_metadata_from_tensor_metadata(const std::vector<std::pair<bool, uint32_pair_t>>& tensor_metadata);
+std::vector<bool> pad_metadata_from_tensor_metadata(const std::vector<PixelMetadata>& tensor_metadata);
 
 // Calculate Indices of pads in padded input buffer using halo kernel config's flattened pad config.
 std::vector<uint32_t> pad_indices_from_flattened_pad_config(
-    const std::vector<std::vector<uint16_t>>& flattened_pad_config,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries);
+    const std::vector<std::vector<uint16_t>>& flattened_pad_config, const std::vector<ShardBoundary>& shard_boundaries);
 
 // Calculate Indices of valid inputs in padded input buffer using halo kernel config's flattened local configs.
 std::vector<uint32_t> input_indices_from_flattened_local_config(
     const std::vector<std::vector<uint16_t>>& flattened_local_config,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries);
+    const std::vector<ShardBoundary>& shard_boundaries);
 
 // Calculate Indices of valid inputs in padded input buffer using halo kernel config's flattened remote configs.
 std::vector<uint32_t> input_indices_from_flattened_remote_config(
     tt::tt_metal::IDevice* device,
     const std::vector<std::vector<uint16_t>>& flattened_remote_config,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries,
+    const std::vector<ShardBoundary>& shard_boundaries,
     bool remote_read = false,
     bool is_block_sharded = false,
     bool transpose_mcast = false);

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -84,28 +84,43 @@ struct SlidingWindowConfig {
     uint32_t get_output_shard_y(bool snap_to_tile = false) const;
 };  // struct SlidingWindowConfig
 
+struct Range {
+    uint32_t start{0};
+    uint32_t end{0};
+};
+
+struct ShardBoundary {
+    Range output_range;
+    Range input_range;
+};
+
+struct PixelMetadata {
+    bool is_pad{false};
+    uint32_t src_core_id{0};
+    uint32_t src_local_idx{0};
+};
+
 std::vector<bool> generate_pad_metadata(const SlidingWindowConfig& config);
 std::vector<uint32_t> generate_op_trace_metadata(const SlidingWindowConfig& config);
-std::vector<std::pair<uint32_pair_t, uint32_pair_t>> generate_shard_boundaries(
+std::vector<ShardBoundary> generate_shard_boundaries(
     const SlidingWindowConfig& config, const std::vector<uint32_t>& op_trace_metadata);
-std::vector<std::pair<bool, uint32_pair_t>> generate_tensor_metadata(
+std::vector<PixelMetadata> generate_tensor_metadata(
     const std::vector<bool>& pad_metadata,
     const SlidingWindowConfig& config,
     uint32_t reshard_num_cores_nhw = 0,
     bool is_in_tiled = true);
-uint32_t generate_max_out_nsticks_per_core(
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries);
+uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& shard_boundaries);
 std::tuple<std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>>
 generate_halo_kernel_config_tensors(
-    const std::vector<std::pair<bool, uint32_pair_t>>& tensor_metadata,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries,
+    const std::vector<PixelMetadata>& tensor_metadata,
+    const std::vector<ShardBoundary>& shard_boundaries,
     bool is_block_sharded,
     bool transpose_mcast,
     bool remote_read,
     tt::tt_metal::IDevice* device);
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
-    const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries,
+    const std::vector<ShardBoundary>& shard_boundaries,
     bool pad_tile = false,
     bool pad_cores = false);
 std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input);
@@ -143,5 +158,11 @@ struct fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig> : f
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::ParallelConfig> : formatter<string_view> {
     auto format(const ttnn::operations::sliding_window::ParallelConfig& t, fmt::format_context& ctx) const
+        -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<ttnn::operations::sliding_window::ShardBoundary> : formatter<string_view> {
+    auto format(const ttnn::operations::sliding_window::ShardBoundary& t, fmt::format_context& ctx) const
         -> format_context::iterator;
 };


### PR DESCRIPTION
### Summary
This change updates the sliding window config tensor generation to use structs instead of tuples to improve readability and type safety. Specifically, this PR introduces `ShardBoundary` and `PixelMetadata` types to replace the old tuple-based data structures.

No meaningful performance improvement/regression is expected for this change.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13552597580