### PR TITLE
[UMD] Remove a couple of leftover usages of old soc descriptor API

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -317,7 +317,7 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
             const auto& physical_chip_id =
                 this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][src_chip_id];
             std::uint32_t num_ports_per_chip =
-                tt::Cluster::instance().get_soc_desc(physical_chip_id).ethernet_cores.size();
+                tt::Cluster::instance().get_soc_desc(physical_chip_id).get_cores(CoreType::ETH).size();
             this->intra_mesh_routing_tables_[mesh_id][src_chip_id].resize(
                 num_ports_per_chip);  // contains more entries than needed, this size is for all eth channels on chip
             for (int i = 0; i < num_ports_per_chip; i++) {
@@ -368,7 +368,7 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
             const auto& physical_chip_id =
                 this->logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
             std::uint32_t num_ports_per_chip =
-                tt::Cluster::instance().get_soc_desc(physical_chip_id).ethernet_cores.size();
+                tt::Cluster::instance().get_soc_desc(physical_chip_id).get_cores(CoreType::ETH).size();
             this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id].resize(
                 num_ports_per_chip);  // contains more entries than needed
             for (int i = 0; i < num_ports_per_chip; i++) {

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -21,7 +21,7 @@ void memset_dram(std::vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start
     const metal_SocDescriptor& sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
     for (uint32_t dram_view = 0; dram_view < sdesc.get_num_dram_views(); dram_view++) {
         for (uint32_t dram_src_subchannel_id = 0;
-             dram_src_subchannel_id < sdesc.dram_cores.at(sdesc.get_channel_for_dram_view(dram_view)).size();
+             dram_src_subchannel_id < sdesc.get_dram_cores().at(sdesc.get_channel_for_dram_view(dram_view)).size();
              dram_src_subchannel_id++) {
             tt::Cluster::instance().write_dram_vec(
                 mem_vec, tt_target_dram{chip_id, dram_view, dram_src_subchannel_id}, start_addr);


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/17002

### Problem description
A follow up from removing .dram_cores in https://github.com/tenstorrent/tt-metal/pull/17620 and removing eth_cores in https://github.com/tenstorrent/tt-metal/pull/17642

Not sure if I made mistake during merging changes, or if these changes happened in the meantime. With this changes, tt_metal builds with this UMD change which is the ultimate goal: https://github.com/tenstorrent/tt-umd/pull/509

### What's changed
- Changed .dram_cores with .get_dram_cores()
- Changed .ethernet_cores with .get_cores(CoreType::ETH)

### Checklist
All runs on brosko/umd_api_last_changes :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548653822
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548656443
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548658812
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/13548660915
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548663044
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548664896
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548666720
- [ ] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548669182
- [x] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548671739
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13548674558


