### PR TITLE
Make data movement kernels build at O2 by default

### DIFF
--- a/models/demos/bert_tiny/tests/test_performance.py
+++ b/models/demos/bert_tiny/tests/test_performance.py
@@ -119,7 +119,7 @@ def test_perf_device_bare_metal(batch_size, expected_perf):
     margin = 0.03
 
     if is_wormhole_b0():
-        expected_perf = 4114.8
+        expected_perf = 4439.2
     else:
         expected_perf = 3460.0
 

--- a/models/demos/bert_tiny/tests/test_performance.py
+++ b/models/demos/bert_tiny/tests/test_performance.py
@@ -119,7 +119,7 @@ def test_perf_device_bare_metal(batch_size, expected_perf):
     margin = 0.03
 
     if is_wormhole_b0():
-        expected_perf = 4439.2
+        expected_perf = 4475.2
     else:
         expected_perf = 3460.0
 

--- a/models/demos/distilbert/tests/test_perf_distilbert.py
+++ b/models/demos/distilbert/tests/test_perf_distilbert.py
@@ -154,7 +154,7 @@ def test_distilbert_perf_device(batch_size, test, reset_seeds):
     if is_grayskull():
         expected_perf = 57.3
     elif is_wormhole_b0():
-        expected_perf = 95.5
+        expected_perf = 97.0
 
     command = f"pytest tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert.py::test_distilbert_for_question_answering[sequence_size=768-batch_size=8-model_name=distilbert-base-uncased-distilled-squad]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
@@ -90,12 +90,12 @@ def test_device_perf_wh_bare_metal(
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, model_config_str, samples",
     (
-        ("prefill", 1, 128, 0, "BFLOAT16-DRAM", 2060),
-        ("prefill", 1, 1024, 0, "BFLOAT16-DRAM", 2890),
-        ("prefill", 1, 2048, 0, "BFLOAT16-DRAM", 2680),
-        ("decode", 32, 1, 128, "BFLOAT16-L1_SHARDED", 625),
-        ("decode", 32, 1, 1024, "BFLOAT16-L1_SHARDED", 568),
-        ("decode", 32, 1, 2047, "BFLOAT16-L1_SHARDED", 550),
+        ("prefill", 1, 128, 0, "BFLOAT16-DRAM", 2068),
+        ("prefill", 1, 1024, 0, "BFLOAT16-DRAM", 2895),
+        ("prefill", 1, 2048, 0, "BFLOAT16-DRAM", 2684),
+        ("decode", 32, 1, 128, "BFLOAT16-L1_SHARDED", 629),
+        ("decode", 32, 1, 1024, "BFLOAT16-L1_SHARDED", 572),
+        ("decode", 32, 1, 2047, "BFLOAT16-L1_SHARDED", 553),
     ),
 )
 @skip_for_grayskull()

--- a/models/demos/roberta/tests/test_perf_device_roberta.py
+++ b/models/demos/roberta/tests/test_perf_device_roberta.py
@@ -18,7 +18,7 @@ def test_perf_device_bare_metal(batch_size, test):
     subdir = "ttnn_roberta"
     num_iterations = 1
     margin = 0.03
-    expected_perf = 154.94 if is_grayskull() else 153.70
+    expected_perf = 154.94 if is_grayskull() else 153.9
 
     command = f"pytest tests/ttnn/integration_tests/roberta/test_ttnn_optimized_roberta.py::test_roberta_for_question_answering[{test}]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
+++ b/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
@@ -18,7 +18,7 @@ def test_perf_device_bare_metal(batch_size, test):
     subdir = "ttnn_squeezebert"
     num_iterations = 1
     margin = 0.03
-    expected_perf = 102.7 if is_grayskull() else 298.7
+    expected_perf = 102.7 if is_grayskull() else 299.7
 
     command = f"pytest tests/ttnn/integration_tests/squeezebert/test_ttnn_squeezebert.py::test_squeezebert_for_question_answering"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/wormhole/bert_tiny/tests/test_performance.py
+++ b/models/demos/wormhole/bert_tiny/tests/test_performance.py
@@ -122,7 +122,7 @@ def test_perf_bert_tiny(
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        (16, 6800),
+        (16, 6825),
     ],
 )
 def test_perf_device_bare_metal(batch_size, expected_perf):

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -12,7 +12,7 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5255],
+        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5311.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -207,7 +207,7 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((9.5),),
+    ((9.8),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"

--- a/models/demos/yolov4/tests/test_perf_yolo.py
+++ b/models/demos/yolov4/tests/test_perf_yolo.py
@@ -125,7 +125,7 @@ def test_perf_device_bare_metal_yolov4(batch_size, model_name):
     num_iterations = 1
     margin = 0.03
 
-    expected_perf = 75
+    expected_perf = 77
     command = f"pytest tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py"
 
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -49,7 +49,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 2, 128, 25.0, 830.0),),
+    ((1, 2, 128, 25.0, 835.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -92,8 +92,8 @@ def test_unet_trace_perf(
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput, use_async_mode",
     (
-        (1, 2, 128, 25.0, 1220.0, True),
-        (1, 2, 128, 25.0, 1650.0, False),
+        (1, 2, 128, 25.0, 1500.0, True),
+        (1, 2, 128, 25.0, 1660.0, False),
     ),
 )
 def test_unet_trace_perf_multi_device(

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -92,7 +92,7 @@ def test_unet_trace_perf(
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput, use_async_mode",
     (
-        (1, 2, 128, 25.0, 1500.0, True),
+        (1, 2, 128, 25.0, 1450.0, True),
         (1, 2, 128, 25.0, 1660.0, False),
     ),
 )

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -564,7 +564,8 @@ void configure_kernel_variant(
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = my_noc_index,
             .compile_args = compile_args,
-            .defines = defines});
+            .defines = defines,
+            .opt_level = KernelBuildOptLevel::Os});
 }
 
 // Specific to this test. This test doesn't use Buffers, and for Storage cores in L1 that have 2 banks, they are

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -36,7 +36,7 @@ struct DataMovementConfig {
     // This file is then automatically included in the generated compiled kernel files
     std::map<std::string, std::string> defines;
     // Set the compiler and linker optimization level
-    KernelBuildOptLevel opt_level = KernelBuildOptLevel::Os;
+    KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2;
 };
 
 struct ReaderDataMovementConfig : public DataMovementConfig {

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -40,11 +40,17 @@ struct DataMovementConfig {
 };
 
 struct ReaderDataMovementConfig : public DataMovementConfig {
-    ReaderDataMovementConfig(std::vector<uint32_t> compile_args = {}, std::map<std::string, std::string> defines = {});
+    ReaderDataMovementConfig(
+        std::vector<uint32_t> compile_args = {},
+        std::map<std::string, std::string> defines = {},
+        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2);
 };
 
 struct WriterDataMovementConfig : public DataMovementConfig {
-    WriterDataMovementConfig(std::vector<uint32_t> compile_args = {}, std::map<std::string, std::string> defines = {});
+    WriterDataMovementConfig(
+        std::vector<uint32_t> compile_args = {},
+        std::map<std::string, std::string> defines = {},
+        KernelBuildOptLevel opt_level = KernelBuildOptLevel::O2);
 };
 
 struct ComputeConfig {

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -7,6 +7,7 @@
 #include <tt_metal.hpp>
 #include "dprint_server.hpp"
 
+#include "kernel_types.hpp"
 #include "prefetch.hpp"
 #include "dispatch.hpp"
 #include "dispatch_s.hpp"
@@ -134,7 +135,8 @@ void FDKernel::configure_kernel_variant(
                                            : tt::tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = noc_selection_.non_dispatch_noc,
                 .compile_args = compile_args,
-                .defines = defines});
+                .defines = defines,
+                .opt_level = KernelBuildOptLevel::Os});
     } else {
         tt::tt_metal::CreateKernel(
             *program_,
@@ -144,6 +146,7 @@ void FDKernel::configure_kernel_variant(
                 .eth_mode = is_active_eth_core ? Eth::SENDER : Eth::IDLE,
                 .noc = noc_selection_.non_dispatch_noc,
                 .compile_args = compile_args,
-                .defines = defines});
+                .defines = defines,
+                .opt_level = KernelBuildOptLevel::Os});
     }
 }

--- a/tt_metal/impl/kernels/kernel_types.cpp
+++ b/tt_metal/impl/kernels/kernel_types.cpp
@@ -10,21 +10,23 @@
 namespace tt::tt_metal {
 
 ReaderDataMovementConfig::ReaderDataMovementConfig(
-    std::vector<uint32_t> compile_args, std::map<std::string, std::string> defines) :
+    std::vector<uint32_t> compile_args, std::map<std::string, std::string> defines, KernelBuildOptLevel opt_level) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch()),
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
         .compile_args = std::move(compile_args),
-        .defines = std::move(defines)} {}
+        .defines = std::move(defines),
+        .opt_level = opt_level} {}
 
 WriterDataMovementConfig::WriterDataMovementConfig(
-    std::vector<uint32_t> compile_args, std::map<std::string, std::string> defines) :
+    std::vector<uint32_t> compile_args, std::map<std::string, std::string> defines, KernelBuildOptLevel opt_level) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_0,
         .noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch()),
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
         .compile_args = std::move(compile_args),
-        .defines = std::move(defines)} {}
+        .defines = std::move(defines),
+        .opt_level = opt_level} {}
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -56,11 +56,12 @@ Fold::MultiCore::cached_program_t fold_multi_core(
     auto cb_dst0 = CreateCircularBuffer(program, all_cores, dst_cb_config);
 
     // Setup kernel
+    // Set build optimization level to Os. O2 was slower.
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
         all_cores,
-        WriterDataMovementConfig({cb_src0_index, cb_dst0_index}));
+        WriterDataMovementConfig({cb_src0_index, cb_dst0_index}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
 
     // Writer run-time args
     SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_op_multi_core.cpp
@@ -56,7 +56,7 @@ cached_program_t fold_multi_core(const Tensor& input, const Tensor& output, uint
         program,
         "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2s_row_major.cpp",
         all_cores,
-        WriterDataMovementConfig({cb_src0_index, cb_dst0_index}));
+        WriterDataMovementConfig({cb_src0_index, cb_dst0_index}, {}, tt::tt_metal::KernelBuildOptLevel::Os));
 
     // Writer run-time args
     SetRuntimeArgs(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Currently Compute kernels build at O3 and Data movement kernels build at Os
- We should make data movement kernels build at at least O2

### What's changed
- Change default for Data movement config to O2
- FD2 and FD tests -- kept at Os
- NOTE: Multicore Fold op kept at Os. Used by resnet

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/13540511373/job/37840734705
Single Device Perf
https://github.com/tenstorrent/tt-metal/actions/runs/13584879293
Single Card Demo
https://github.com/tenstorrent/tt-metal/actions/runs/13594610401
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/13594659247
TG/TGG
https://github.com/tenstorrent/tt-metal/actions/runs/13533072675
BH
https://github.com/tenstorrent/tt-metal/actions/runs/13549512017