### PR TITLE
[skip ci] Update t3000-unit-tests-impl.yaml

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -16,7 +16,7 @@ jobs:
         test-group: [
           { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 30, label: pipeline-functional, owner_id: ULMEPM2MA}, #Sean Nijjar
           { name: "t3k fabric tests", arch: wormhole_b0, cmd: run_t3000_ttfabric_tests, timeout: 30, label: pipeline-fabric, owner_id: UJ45FEC7M}, # Allan Liu
-          { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 120, label: pipeline-functional, owner_id: UBHPP2NDP}, #Joseph Chu
+          { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 120, label: pipeline-fabric, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 30, label: pipeline-functional, owner_id: UBHPP2NDP}, #Joseph Chu
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, label: pipeline-functional, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k llama3-small tests", arch: wormhole_b0, cmd: run_t3000_llama3-small_tests, timeout: 30, label: pipeline-functional, owner_id: U03PUAKE719},  #Miguel Tairum Cruz


### PR DESCRIPTION
Move failing T3K unit tests to the pool of golden T3K VMs. "pipeline-fabric" 