### PR TITLE
Enable FD + 2D Fabric on all systems

### DIFF
--- a/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
+++ b/tech_reports/TT-Distributed/TT-Distributed-Architecture-1219.md
@@ -2296,9 +2296,6 @@ CoreCoord Device::grid_size() const;
 // Get the Tensix Grid Size for this device. Queries SOC Descriptor + harvesting info + system type.
 CoreCoord Device::logical_grid_size() const;
 
-// Get the devices connected to this device. Relies on UMD for the cluster descriptor
-std::unordered_set<chip_id_t> Device::get_ethernet_connected_device_ids();
-
 // Get the worker core grid-size on this device. Queries SOC Descriptor + harvesting info + system type + core descriptor.
 CoreCoord Device::compute_with_storage_grid_size() const;
 

--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -22,6 +22,7 @@ cd $TT_METAL_HOME
 echo "Running fabric unit tests now...";
 
 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricFixture.*"
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricFixture.*"
 
 #############################################
 # FABRIC SANITY TESTS                       #

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -45,6 +45,7 @@ run_t3000_ttfabric_tests() {
   echo "LOG_METAL: Running run_t3000_ttfabric_tests"
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*T3k*
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricFixture.*"
+  ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricFixture.*"
   # Unicast tests
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -115,6 +115,7 @@ run_tg_tests() {
     echo "LOG_FABRIC: running run_tg_fabric_tests"
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricFixture.*"
     # Unicast tests
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -40,10 +40,10 @@ protected:
 
     void SetUp() override {
         slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (!slow_dispatch_) {
-            tt::log_info(
-                tt::LogTest, "Fabric test suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
-            GTEST_SKIP();
+        if (slow_dispatch_) {
+            tt::log_info(tt::LogTest, "Running fabric api tests with slow dispatch");
+        } else {
+            tt::log_info(tt::LogTest, "Running fabric api tests with fast dispatch");
         }
         // Set up all available devices
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -52,10 +52,28 @@ protected:
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::tt_metal::detail::InitializeFabricSetting(tt::tt_metal::detail::FabricSetting::FABRIC);
+        tt::tt_metal::detail::InitializeFabricConfig(tt::FabricConfig::FABRIC_2D);
         devices_map_ = tt::tt_metal::detail::CreateDevices(ids);
         for (auto& [id, device] : devices_map_) {
             devices_.push_back(device);
+        }
+    }
+    void RunProgramNonblocking(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program) {
+        if (this->slow_dispatch_) {
+            tt::tt_metal::detail::LaunchProgram(device, program, false);
+        } else {
+            tt::tt_metal::CommandQueue& cq = device->command_queue();
+            tt::tt_metal::EnqueueProgram(cq, program, false);
+        }
+    }
+    void WaitForSingleProgramDone(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program) {
+        if (this->slow_dispatch_) {
+            // Wait for the program to finish
+            tt::tt_metal::detail::WaitProgramDone(device, program);
+        } else {
+            // Wait for all programs on cq to finish
+            tt::tt_metal::CommandQueue& cq = device->command_queue();
+            tt::tt_metal::Finish(cq);
         }
     }
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -152,10 +152,10 @@ TEST_F(FabricFixture, TestAsyncWrite) {
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    tt_metal::detail::LaunchProgram(receiver_device, receiver_program, false);
-    tt_metal::detail::LaunchProgram(sender_device, sender_program, false);
-    tt_metal::detail::WaitProgramDone(sender_device, sender_program);
-    tt_metal::detail::WaitProgramDone(receiver_device, receiver_program);
+    this->RunProgramNonblocking(receiver_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(receiver_device, receiver_program);
 
     // Validate the data received by the receiver
     std::vector<uint32_t> received_buffer_data;
@@ -302,10 +302,10 @@ TEST_F(FabricFixture, TestAtomicInc) {
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    tt_metal::detail::LaunchProgram(receiver_device, receiver_program, false);
-    tt_metal::detail::LaunchProgram(sender_device, sender_program, false);
-    tt_metal::detail::WaitProgramDone(sender_device, sender_program);
-    tt_metal::detail::WaitProgramDone(receiver_device, receiver_program);
+    this->RunProgramNonblocking(receiver_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(receiver_device, receiver_program);
 
     // Validate the data received by the receiver
     std::vector<uint32_t> received_buffer_data;
@@ -469,10 +469,10 @@ TEST_F(FabricFixture, TestAsyncWriteAtomicInc) {
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    tt_metal::detail::LaunchProgram(receiver_device, receiver_program, false);
-    tt_metal::detail::LaunchProgram(sender_device, sender_program, false);
-    tt_metal::detail::WaitProgramDone(sender_device, sender_program);
-    tt_metal::detail::WaitProgramDone(receiver_device, receiver_program);
+    this->RunProgramNonblocking(receiver_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(receiver_device, receiver_program);
 
     // Validate the data received by the receiver
     std::vector<uint32_t> received_buffer_data;
@@ -586,7 +586,7 @@ TEST_F(FabricFixture, TestAsyncWriteMulticast) {
             };
             tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
-            tt_metal::detail::LaunchProgram(receiver_device, receiver_program, false);
+            this->RunProgramNonblocking(receiver_device, receiver_program);
             receiver_programs.push_back(std::move(receiver_program));
             receiver_buffers.push_back(std::move(receiver_buffer));
         }
@@ -676,12 +676,12 @@ TEST_F(FabricFixture, TestAsyncWriteMulticast) {
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    tt_metal::detail::LaunchProgram(sender_device, sender_program, false);
-    tt_metal::detail::WaitProgramDone(sender_device, sender_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
     for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
         for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
             auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_ids[i]);
-            tt_metal::detail::WaitProgramDone(receiver_device, receiver_programs[i]);
+            this->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
         }
     }
 
@@ -799,7 +799,7 @@ TEST_F(FabricFixture, TestAsyncWriteMulticastMultidirectional) {
             };
             tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
-            tt_metal::detail::LaunchProgram(receiver_device, receiver_program, false);
+            this->RunProgramNonblocking(receiver_device, receiver_program);
             receiver_programs.push_back(std::move(receiver_program));
             receiver_buffers.push_back(std::move(receiver_buffer));
         }
@@ -894,12 +894,12 @@ TEST_F(FabricFixture, TestAsyncWriteMulticastMultidirectional) {
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    tt_metal::detail::LaunchProgram(sender_device, sender_program, false);
-    tt_metal::detail::WaitProgramDone(sender_device, sender_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
     for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
         for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
             auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_ids[i]);
-            tt_metal::detail::WaitProgramDone(receiver_device, receiver_programs[i]);
+            this->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -236,6 +236,7 @@ int main(int argc, char** argv) {
             std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
             "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
         auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(tg_mesh_graph_desc_path.string());
+        control_plane->configure_routing_tables();
 
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id_l >= num_devices) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -137,8 +137,10 @@ typedef struct test_board {
             throw std::runtime_error("Odd number of chips detected, not supported currently");
         }
 
-        if (metal_fabric_init_level != 0) {
-            tt::tt_metal::detail::InitializeFabricSetting(tt::tt_metal::detail::FabricSetting::FABRIC);
+        if (metal_fabric_init_level == 0) {
+            tt::tt_metal::detail::InitializeFabricConfig(tt::FabricConfig::CUSTOM);
+        } else if (metal_fabric_init_level == 1) {
+            tt::tt_metal::detail::InitializeFabricConfig(tt::FabricConfig::FABRIC_2D);
         }
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         if (metal_fabric_init_level == 0) {
@@ -299,8 +301,8 @@ typedef struct test_board {
         // for each physical chip id, store the neighbors
         // TDOD: update the logic to find inter-mesh neighbors
         for (auto chip_id : physical_chip_ids) {
-            auto neighbors = tt::Cluster::instance().get_ethernet_connected_device_ids(chip_id);
-            for (auto neighbor : neighbors) {
+            auto neighbors = tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(chip_id);
+            for (const auto& [neighbor, cores] : neighbors) {
                 // only append valid chip IDs since the neighbors could include mmio chips (wh galaxy) or
                 // could be outside of the board type (in case of partial galaxy configurations)
                 if (is_valid_chip_id(neighbor)) {
@@ -502,13 +504,12 @@ typedef struct test_device {
         core_range_end_virtual = device_handle->worker_core_from_logical_core(CoreCoord(7, 7));
 
         // populate router cores
-        auto neighbors = tt::Cluster::instance().get_ethernet_connected_device_ids(physical_chip_id);
-        for (auto neighbor : neighbors) {
-            if (!(board_handle->is_valid_chip_id(neighbor))) {
+        auto neighbors = tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(device_handle->id());
+        for (const auto& [neighbor_chip, connected_logical_cores] : neighbors) {
+            if (!(board_handle->is_valid_chip_id(neighbor_chip))) {
                 continue;
             }
 
-            auto connected_logical_cores = device_handle->get_ethernet_sockets(neighbor);
             for (auto logical_core : connected_logical_cores) {
                 router_logical_cores.push_back(logical_core);
                 router_virtual_cores.push_back(device_handle->ethernet_core_from_logical_core(logical_core));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -143,6 +143,7 @@ typedef struct test_board {
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         if (metal_fabric_init_level == 0) {
             _init_control_plane(mesh_graph_descriptor);
+            control_plane->configure_routing_tables();
         } else {
             control_plane = tt::DevicePool::instance().get_control_plane();
         }

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -52,6 +52,8 @@ class ControlPlane {
 
        routing_plane_id_t get_routing_plane_id(chan_id_t eth_chan_id) const;
 
+       size_t get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t chip_id) const;
+
    private:
        std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
        std::vector<std::vector<chip_id_t>> logical_mesh_chip_id_to_physical_chip_id_mapping_;

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -36,11 +36,9 @@ public:
     DevicePool(DevicePool&& other) noexcept = delete;
 
     static DevicePool& instance() noexcept {
-        TT_ASSERT((_inst != nullptr) and (_inst->initialized), "Trying to get DevicePool without initializing it");
+        TT_ASSERT(_inst != nullptr, "Trying to get DevicePool without initializing it");
         return *_inst;
     }
-
-    static void initialize_fabric_setting(detail::FabricSetting fabric_setting) noexcept;
 
     static void initialize(
         const std::vector<chip_id_t>& device_ids,
@@ -81,10 +79,7 @@ private:
     bool skip_remote_devices;
     std::unordered_set<uint32_t> firmware_built_keys;
 
-    detail::FabricSetting fabric_setting = detail::FabricSetting::DEFAULT;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane;
-
-    bool initialized = false;
 
     // Determine which CPU cores the worker threads need to be placed on for each device
     std::unordered_map<uint32_t, uint32_t> worker_thread_to_cpu_core_map;

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -13,6 +13,7 @@
 #include "dispatch_core_manager.hpp"
 #include "buffer.hpp"
 #include "profiler.hpp"
+#include "llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal {
 inline namespace v0 {
@@ -23,15 +24,13 @@ class IDevice;
 
 namespace detail {
 
-enum class FabricSetting { DISABLED = 0, FABRIC = 1, EDM = 2, DEFAULT = 3 };
-
 bool DispatchStateCheck(bool isFastDispatch);
 
 bool InWorkerThread();
 inline bool InMainThread() { return not InWorkerThread(); }
 
-// Call before CreateDevices to enable fabric, which uses all ethernet cores and some tensix cores
-void InitializeFabricSetting(detail::FabricSetting fabric_setting);
+// Call before CreateDevices to enable fabric, which uses all free ethernet cores
+void InitializeFabricConfig(FabricConfig fabric_config);
 
 std::map<chip_id_t, IDevice*> CreateDevices(
     // TODO: delete this in favour of DevicePool
@@ -165,7 +164,7 @@ void CompileProgram(IDevice* device, Program& program, bool fd_bootloader_mode =
  * | program             | The program holding the runtime args                                   | const Program & | |
  * Yes      |
  */
-void WriteRuntimeArgsToDevice(IDevice* device, Program& program);
+void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloader_mode = false);
 
 // Configures a given device with a given program.
 // - Loads all kernel binaries into L1s of assigned Tensix cores

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -33,10 +33,3 @@ target_precompile_headers(
 )
 
 target_compile_options(fabric PRIVATE -Wno-int-to-pointer-cast)
-
-#set_target_properties(
-#    fabric
-#    PROPERTIES
-#        INSTALL_RPATH
-#            "${PROJECT_BINARY_DIR}/lib"
-#)

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -52,7 +52,6 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     this->routing_table_generator_->print_routing_tables();
 
     this->initialize_from_mesh_graph_desc_file(mesh_graph_desc_file);
-    this->configure_routing_tables();
 
     // Printing, only enabled with log_debug
     this->print_ethernet_channels();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -943,8 +943,8 @@ void Device::init_fabric() {
 
     program_dispatch::finalize_program_offsets(*fabric_program_, this);
 
-    detail::WriteRuntimeArgsToDevice(this, *fabric_program_);
-    detail::ConfigureDeviceWithProgram(this, *fabric_program_);
+    detail::WriteRuntimeArgsToDevice(this, *fabric_program_, this->using_fast_dispatch());
+    detail::ConfigureDeviceWithProgram(this, *fabric_program_, this->using_fast_dispatch());
 
     // Note: the l1_barrier below is needed to be sure writes to cores that
     // don't get the GO mailbox (eg, storage cores) have all landed

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -406,8 +406,12 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 
     // TODO: add handling of EDM
     if (this->fabric_setting == detail::FabricSetting::FABRIC) {
-        // Initialize control plane, which writes routing tables to all ethernet cores
+        // Initialize control plane, does not configure kernels/routing tables
+        // We always need a control plane for mapping of logical devices to physical devices
+        // TODO: add single device support
         _inst->initialize_control_plane();
+        // write routing tables to all ethernet cores
+        this->control_plane->configure_routing_tables();
     }
     this->using_fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
     if (this->using_fast_dispatch) {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -196,14 +196,6 @@ void DevicePool::init_profiler_devices() const {
 #endif
 }
 
-void DevicePool::initialize_fabric_setting(detail::FabricSetting fabric_setting) noexcept {
-    if (_inst == nullptr) {
-        static DevicePool device_pool{};
-        _inst = &device_pool;
-    }
-    _inst->fabric_setting = fabric_setting;
-}
-
 void DevicePool::initialize(
     const std::vector<chip_id_t>& device_ids,
     const uint8_t num_hw_cqs,
@@ -232,7 +224,6 @@ void DevicePool::initialize(
     // modifying the state of this instance, for example those responsible for
     // (un)registering worker threads, can only be called in the creation thread
     _inst->device_pool_creation_thread_id = std::this_thread::get_id();
-    _inst->initialized = true;
 
     // Never skip for TG Cluster
     bool skip = not tt::Cluster::instance().is_galaxy_cluster();
@@ -292,7 +283,8 @@ void DevicePool::initialize_device(IDevice* dev) const {
     watcher_attach(dev);
 
     // TODO: add handling of EDM
-    if (this->fabric_setting == detail::FabricSetting::FABRIC) {
+    if (tt::Cluster::instance().get_fabric_config() == FabricConfig::FABRIC_2D) {
+        // Initialize fabric on mmio device
         dev->init_fabric();
     }
 
@@ -393,19 +385,17 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
     // Only can launch Fabric if all devices are active
-    if (this->fabric_setting == detail::FabricSetting::FABRIC) {
+    if (tt::Cluster::instance().get_fabric_config() == FabricConfig::FABRIC_2D) {
         for (int i = 0; i < tt::Cluster::instance().number_of_devices(); i++) {
             if (not _inst->is_device_active(i)) {
                 // Fabric currently requires all devices to be active
-                log_warning(tt::LogMetal, "Fabric is disabled because device {} is not active", i);
-                this->fabric_setting = detail::FabricSetting::DISABLED;
-                break;
+                log_fatal(tt::LogMetal, "Fabric is being used but {} is not active", i);
             }
         }
     }
 
     // TODO: add handling of EDM
-    if (this->fabric_setting == detail::FabricSetting::FABRIC) {
+    if (tt::Cluster::instance().get_fabric_config() == FabricConfig::FABRIC_2D) {
         // Initialize control plane, does not configure kernels/routing tables
         // We always need a control plane for mapping of logical devices to physical devices
         // TODO: add single device support
@@ -420,15 +410,23 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 }
 
 void DevicePool::wait_for_fabric_master_router_sync() const {
-    if (this->fabric_setting == detail::FabricSetting::FABRIC) {
+    if (tt::Cluster::instance().get_fabric_config() == FabricConfig::FABRIC_2D) {
         auto fabric_router_sync_sem_addr =
             hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
         std::vector<std::uint32_t> master_router_status{0};
         for (const auto& dev : this->get_all_active_devices()) {
-            auto fabric_master_router_core = *dev->get_active_ethernet_cores().begin();  // TODO: get this from a
-                                                                                         // manager
-            std::uint32_t num_routers = dev->get_active_ethernet_cores().size();
+            if (tt::Cluster::instance().get_fabric_ethernet_channels(dev->id()).empty()) {
+                continue;
+            }
+            tt_fabric::chan_id_t fabric_master_router_chan =
+                *(tt::Cluster::instance().get_fabric_ethernet_channels(dev->id()).begin());
+            CoreCoord virtual_eth_core =
+                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+            auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
+
+            auto [mesh_id, chip_id] = this->control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
+            auto num_routers = this->control_plane->get_num_active_fabric_routers(mesh_id, chip_id);
             while (master_router_status[0] != num_routers) {
                 tt_metal::detail::ReadFromDeviceL1(
                     dev,
@@ -642,13 +640,16 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
     }
 
     // Terminate fabric routers
-    if (this->fabric_setting == detail::FabricSetting::FABRIC) {
+    if (tt::Cluster::instance().get_fabric_config() == FabricConfig::FABRIC_2D) {
         std::vector<uint32_t> master_router_terminate(1, 0);
         auto fabric_router_sync_sem_addr =
             hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         for (const auto& dev : this->get_all_active_devices()) {
-            auto fabric_master_router_core = *dev->get_active_ethernet_cores().begin();  // TODO: get this from a
-                                                                                         // manager
+            tt_fabric::chan_id_t fabric_master_router_chan =
+                *(tt::Cluster::instance().get_fabric_ethernet_channels(dev->id()).begin());
+            CoreCoord virtual_eth_core =
+                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+            auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
             tt_metal::detail::WriteToDeviceL1(
                 dev, fabric_master_router_core, fabric_router_sync_sem_addr, master_router_terminate, CoreType::ETH);
         }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -89,7 +89,7 @@ inline std::string get_soc_description_file(
 }  // namespace
 namespace tt {
 
-const Cluster &Cluster::instance() {
+Cluster& Cluster::instance() {
     static Cluster inst;
     return inst;
 }
@@ -131,6 +131,8 @@ void Cluster::detect_arch_and_target() {
 bool Cluster::is_galaxy_cluster() const { return this->cluster_type_ == ClusterType::TG; }
 
 ClusterType Cluster::get_cluster_type() const { return this->cluster_type_; }
+
+FabricConfig Cluster::get_fabric_config() const { return this->fabric_config_; }
 
 BoardType Cluster::get_board_type(chip_id_t chip_id) const {
   return this->cluster_desc_->get_board_type(chip_id);
@@ -328,6 +330,7 @@ Cluster::~Cluster() {
     this->device_to_host_mem_channel_.clear();
     this->device_eth_routing_info_.clear();
     this->tunnels_from_mmio_device.clear();
+    this->ethernet_sockets_.clear();
 }
 
 std::unordered_map<chip_id_t, eth_coord_t> Cluster::get_user_chip_ethernet_coordinates() const {
@@ -896,7 +899,7 @@ std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_device_ids(chip_id
     const auto &connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
     for (const auto &[other_chip_id, eth_cores] : connected_chips) {
         for (const auto &eth_core : eth_cores) {
-            if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::IDLE) {
+            if (this->device_eth_routing_info_.at(chip_id).at(eth_core) != EthRouterMode::BI_DIR_TUNNELING) {
                 device_ids.insert(other_chip_id);
             }
         }
@@ -932,6 +935,38 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
         }
     }
     return active_ethernet_cores;
+}
+
+void Cluster::initialize_fabric_config(FabricConfig fabric_config) {
+    this->fabric_config_ = fabric_config;
+    if (fabric_config != FabricConfig::DISABLED) {
+        this->reserve_ethernet_cores_for_fabric_routers();
+    }
+}
+
+void Cluster::reserve_ethernet_cores_for_fabric_routers() {
+    for (const auto& [chip_id, eth_cores] : this->device_eth_routing_info_) {
+        for (const auto& [eth_core, mode] : eth_cores) {
+            if (mode == EthRouterMode::IDLE) {
+                this->device_eth_routing_info_[chip_id][eth_core] = EthRouterMode::FABRIC_ROUTER;
+            }
+        }
+    }
+    // Update sockets to reflect fabric routing
+    this->ethernet_sockets_.clear();
+}
+
+std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(chip_id_t chip_id) const {
+    std::set<tt_fabric::chan_id_t> fabric_ethernet_channels;
+    const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
+    for (const auto& [other_chip_id, eth_cores] : connected_chips) {
+        for (const auto& eth_core : eth_cores) {
+            if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
+                fabric_ethernet_channels.insert(this->get_soc_desc(chip_id).logical_eth_core_to_chan_map.at(eth_core));
+            }
+        }
+    }
+    return fabric_ethernet_channels;
 }
 
 std::unordered_set<CoreCoord> Cluster::get_inactive_ethernet_cores(chip_id_t chip_id) const {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -7,24 +7,20 @@
 #include <cstdint>
 #include <functional>
 
-#include "metal_soc_descriptor.h"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/metal_soc_descriptor.h>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/fabric_host_interface.h>
 #include "umd/device/device_api_metal.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
 
-#include "dev_msgs.h"
+#include <tt-metalium/dev_msgs.h>
 
-#include "hal.hpp"
+#include <tt-metalium/hal.hpp>
 
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 
 using tt_target_dram = std::tuple<int, int, int>;
-
-enum EthRouterMode : uint32_t {
-    IDLE = 0,
-    BI_DIR_TUNNELING = 1,
-};
 
 namespace tt {
 
@@ -45,6 +41,14 @@ enum class ClusterType : std::uint8_t {
     TG = 4,      // Will be deprecated
 };
 
+enum class EthRouterMode : uint32_t {
+    IDLE = 0,
+    BI_DIR_TUNNELING = 1,
+    FABRIC_ROUTER = 2,
+};
+
+enum class FabricConfig { DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4 };
+
 class Cluster {
 public:
     Cluster& operator=(const Cluster&) = delete;
@@ -52,7 +56,7 @@ public:
     Cluster(const Cluster&) = delete;
     Cluster(Cluster&& other) noexcept = delete;
 
-    static const Cluster& instance();
+    static Cluster& instance();
 
     // For TG Galaxy systems, mmio chips are gateway chips that are only used for dispatc, so user_devices are meant for
     // user facing host apis
@@ -254,6 +258,8 @@ public:
         return this->tunnels_from_mmio_device.at(mmio_chip_id);
     }
 
+    void initialize_fabric_config(FabricConfig fabric_config);
+
     // Returns whether we are running on Galaxy.
     bool is_galaxy_cluster() const;
 
@@ -261,6 +267,11 @@ public:
     BoardType get_board_type(chip_id_t chip_id) const;
 
     ClusterType get_cluster_type() const;
+
+    FabricConfig get_fabric_config() const;
+
+    // Get all fabric ethernet cores
+    std::set<tt_fabric::chan_id_t> get_fabric_ethernet_channels(chip_id_t chip_id) const;
 
     bool is_worker_core(const CoreCoord& core, chip_id_t chip_id) const;
     bool is_ethernet_core(const CoreCoord& core, chip_id_t chip_id) const;
@@ -322,6 +333,11 @@ private:
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     ClusterType cluster_type_ = ClusterType::INVALID;
+
+    // Reserves all free ethernet cores for fabric routers
+    void reserve_ethernet_cores_for_fabric_routers();
+
+    FabricConfig fabric_config_ = FabricConfig::DISABLED;
 
     // Tunnels setup in cluster
     std::map<chip_id_t, std::vector<std::vector<chip_id_t>>> tunnels_from_mmio_device = {};

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -351,8 +351,8 @@ bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t 
     return true;
 }
 
-void InitializeFabricSetting(detail::FabricSetting fabric_setting) {
-    tt::DevicePool::initialize_fabric_setting(detail::FabricSetting::FABRIC);
+void InitializeFabricConfig(FabricConfig fabric_config) {
+    tt::Cluster::instance().initialize_fabric_config(fabric_config);
 }
 
 std::map<chip_id_t, IDevice*> CreateDevices(
@@ -803,10 +803,10 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootl
     return pass;
 }
 
-void WriteRuntimeArgsToDevice(IDevice* device, Program& program) {
+void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloader_mode) {
     ZoneScoped;
     auto device_id = device->id();
-    detail::DispatchStateCheck(false);
+    detail::DispatchStateCheck(fd_bootloader_mode);
 
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18011)

### Problem description
Missing support for FD and Fabric co-existing.

### What's changed
- Enable partial Fabric
- Add bookkeeping of fabric routers to Cluster
- Add FabricFixture FD tests to CI

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
