### PR TITLE
Remove work_executor.hpp from public API

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -9,7 +9,7 @@
 #include <utility>
 
 #include "hostdevcommon/common_values.hpp"
-#include "work_executor.hpp"
+#include "work_executor_types.hpp"
 #include "basic_allocator.hpp"
 #include "l1_banking_allocator.hpp"
 #include "data_types.hpp"

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -49,8 +49,8 @@ public:
     Device(const Device &other) = delete;
     Device& operator=(const Device &other) = delete;
 
-    Device(Device &&other) = default;
-    Device& operator=(Device &&other) = default;
+    Device(Device&& other);
+    Device& operator=(Device&& other);
 
     tt::ARCH arch() const override;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -9,7 +9,7 @@
 
 #include "device.hpp"
 #include "hostdevcommon/common_values.hpp"
-#include "work_executor.hpp"
+#include "work_executor_types.hpp"
 #include "basic_allocator.hpp"
 #include "l1_banking_allocator.hpp"
 #include "data_types.hpp"
@@ -160,8 +160,8 @@ public:
     void enable_async(bool enable) override;
     void force_enable_async(bool enable);
     void synchronize() override;
-    WorkExecutorMode get_worker_mode() override { return work_executor_.get_worker_mode(); }
-    bool is_worker_queue_empty() const override { return work_executor_.worker_queue.empty(); }
+    WorkExecutorMode get_worker_mode() override;
+    bool is_worker_queue_empty() const override;
 
     void push_work(std::function<void()> work, bool blocking) override;
 
@@ -249,7 +249,7 @@ private:
 
     // Work Executor for this device - can asynchronously process host side work for
     // all tasks scheduled on this device
-    WorkExecutor work_executor_;
+    std::shared_ptr<WorkExecutor> work_executor_;
     uint32_t worker_thread_core_ = 0;
     uint32_t completion_queue_reader_core_ = 0;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -249,7 +249,7 @@ private:
 
     // Work Executor for this device - can asynchronously process host side work for
     // all tasks scheduled on this device
-    std::shared_ptr<WorkExecutor> work_executor_;
+    std::unique_ptr<WorkExecutor> work_executor_;
     uint32_t worker_thread_core_ = 0;
     uint32_t completion_queue_reader_core_ = 0;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;

--- a/tt_metal/api/tt-metalium/work_executor_types.hpp
+++ b/tt_metal/api/tt-metalium/work_executor_types.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt {
+
+enum class WorkExecutorMode {
+    SYNCHRONOUS = 0,
+    ASYNCHRONOUS = 1,
+};
+
+enum class WorkerState {
+    RUNNING = 0,
+    TERMINATE = 1,
+    IDLE = 2,
+};
+
+class WorkExecutor;
+
+}  // namespace tt

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(
     PUBLIC
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal
+        ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(

--- a/tt_metal/common/work_executor.hpp
+++ b/tt_metal/common/work_executor.hpp
@@ -15,6 +15,7 @@
 
 #include "env_lib.hpp"
 #include "multi_producer_single_consumer_queue.hpp"
+#include "work_executor_types.hpp"
 #include "tracy/Tracy.hpp"
 
 #if defined(TRACY_ENABLE)
@@ -26,17 +27,6 @@
 #endif
 
 namespace tt {
-
-enum class WorkExecutorMode {
-    SYNCHRONOUS = 0,
-    ASYNCHRONOUS = 1,
-};
-
-enum class WorkerState {
-    RUNNING = 0,
-    TERMINATE = 1,
-    IDLE = 2,
-};
 
 inline void set_device_thread_affinity(std::thread& thread_, int cpu_core_for_worker) {
     // Bind a device worker/reader thread to a CPU core, determined using round-robin.

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -37,6 +37,8 @@
 #include "impl/dispatch/hardware_command_queue.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 
+#include "work_executor.hpp"
+
 namespace tt {
 
 namespace tt_metal {
@@ -50,8 +52,10 @@ Device::Device(
     bool minimal,
     uint32_t worker_thread_core,
     uint32_t completion_queue_reader_core) :
-    id_(device_id), worker_thread_core_(worker_thread_core), completion_queue_reader_core_(completion_queue_reader_core), work_executor_(worker_thread_core, device_id)
-{
+    id_(device_id),
+    worker_thread_core_(worker_thread_core),
+    completion_queue_reader_core_(completion_queue_reader_core),
+    work_executor_(std::make_shared<WorkExecutor>(worker_thread_core, device_id)) {
     ZoneScoped;
     update_dispatch_cores_for_multi_cq_eth_dispatch();
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, minimal);
@@ -954,7 +958,7 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
         return true;
 
     // Mark initialized before compiling and sending dispatch kernels to device because compilation expects device to be initialized
-    this->work_executor_.initialize();
+    this->work_executor_->initialize();
     this->initialized_ = true;
 
     return true;
@@ -968,7 +972,7 @@ void Device::push_work(std::function<void()> work, bool blocking) {
         }
         return;
     }
-    this->work_executor_.push_work(std::move(work), blocking);
+    this->work_executor_->push_work(std::move(work), blocking);
 }
 
 bool Device::close() {
@@ -984,7 +988,7 @@ bool Device::close() {
         hw_command_queue->terminate();
     }
 
-    this->work_executor_.reset();
+    this->work_executor_->reset();
     tt_metal::detail::DumpDeviceProfileResults(this, ProfilerDumpState::LAST_CLOSE_DEVICE);
 
     sub_device_manager_tracker_.reset(nullptr);
@@ -1248,12 +1252,10 @@ void Device::synchronize() {
         log_warning("Attempting to synchronize Device {} which is not initialized. Ignoring...", this->id_);
         return;
     }
-    this->work_executor_.synchronize();
+    this->work_executor_->synchronize();
 }
 
-void Device::set_worker_mode(const WorkExecutorMode& mode) {
-    this->work_executor_.set_worker_mode(mode);
-}
+void Device::set_worker_mode(const WorkExecutorMode& mode) { this->work_executor_->set_worker_mode(mode); }
 
 void Device::enable_async(bool enable) {
     if (enable) {
@@ -1271,7 +1273,8 @@ void Device::force_enable_async(bool enable) {
     // This is required for checking if a call is made from an application thread or a worker thread.
     // See InWorkerThread().
     if (enable) {
-        tt::DevicePool::instance().register_worker_thread_for_device(this, this->work_executor_.get_worker_thread_id());
+        tt::DevicePool::instance().register_worker_thread_for_device(
+            this, this->work_executor_->get_worker_thread_id());
     } else {
         tt::DevicePool::instance().unregister_worker_thread_for_device(this);
     }
@@ -1705,6 +1708,9 @@ float v1::GetSfpuNan(IDevice* device) { return tt::tt_metal::experimental::hal::
 float v1::GetSfpuInf(IDevice* device) { return tt::tt_metal::experimental::hal::get_inf(); }
 
 std::size_t v1::GetNumProgramCacheEntries(IDevice* device) { return device->num_program_cache_entries(); }
+
+tt::WorkExecutorMode Device::get_worker_mode() { return work_executor_->get_worker_mode(); }
+bool Device::is_worker_queue_empty() const { return work_executor_->worker_queue.empty(); }
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -55,7 +55,7 @@ Device::Device(
     id_(device_id),
     worker_thread_core_(worker_thread_core),
     completion_queue_reader_core_(completion_queue_reader_core),
-    work_executor_(std::make_shared<WorkExecutor>(worker_thread_core, device_id)) {
+    work_executor_(std::make_unique<WorkExecutor>(worker_thread_core, device_id)) {
     ZoneScoped;
     update_dispatch_cores_for_multi_cq_eth_dispatch();
     this->initialize(num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, minimal);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -43,6 +43,9 @@ namespace tt {
 
 namespace tt_metal {
 
+Device::Device(Device&& other) = default;
+Device& Device::operator=(Device&& other) = default;
+
 Device::Device(
     chip_id_t device_id,
     const uint8_t num_hw_cqs,

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -26,6 +26,8 @@
 
 #include "tt_cluster.hpp"
 
+#include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
+
 using namespace tt::tt_metal;
 
 namespace tt {

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -14,6 +14,8 @@
 
 #include "tt_cluster.hpp"
 
+#include "work_executor.hpp"
+
 // Because we are a Friend of Program, accessing Program::get_program_transfer_info() and Program::get_kernels_buffer()
 // MUST REMOVE
 #include <program_impl.hpp>

--- a/tt_metal/include/tt_metal/deprecated/device.hpp
+++ b/tt_metal/include/tt_metal/deprecated/device.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 
 #include <buffer_constants.hpp>
-#include <work_executor.hpp>
+#include <work_executor_types.hpp>
 #include <types.hpp>
 
 //==================================================

--- a/tt_metal/include/tt_metal/internal/device.hpp
+++ b/tt_metal/include/tt_metal/internal/device.hpp
@@ -8,7 +8,6 @@
 #include "types.hpp"
 #include <buffer_constants.hpp>
 #include <buffer.hpp>
-#include <work_executor.hpp>
 
 //==================================================
 //               DEVICE MANAGEMENT


### PR DESCRIPTION
### Problem description
Need to reduce surface area of tt_metal public APIs

### What's changed
Split `work_executor.hpp` into `work_executor_types.hpp` and `work_executor.hpp`.
The former can remain part of the public API, since its types are used in the interface.
The later is now moved to `tt_metal/common/`

`Device` class now maintains `WorkExecutor` as a `unique_ptr` class member.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13553542228) CI passes
- [x] New/Existing tests provide coverage for changes
