### PR TITLE
Extend the capabilities of the graph tooling to include extra information of the ttnn operations

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -5,6 +5,8 @@ set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_cq_multi_dev.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_capture_arguments_morehdot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_capture_arguments_transpose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_query_op_constraints.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_query_op_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reflect.cpp

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
@@ -28,9 +28,11 @@ TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
     auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
     auto operations = ttnn::graph::extract_arguments(trace);
 
-    EXPECT_EQ(operations[0].size(), 6);
+    auto operation1 = operations[0];
+    EXPECT_EQ(operation1.operation_name, "ttnn::prim::moreh_dot");
+    EXPECT_EQ(operation1.arguments.size(), 6);
     EXPECT_EQ(
-        operations[0][0],
+        operation1.arguments[0],
         "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
         "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
         "32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_"
@@ -38,40 +40,44 @@ TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
         "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))");
     EXPECT_EQ(
-        operations[0][1],
+        operation1.arguments[1],
         "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
         "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
         "32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_"
         "shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
         "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))");
-    EXPECT_EQ(operations[0][2], "nullopt");
-    EXPECT_EQ(operations[0][3], "BFLOAT16");
-    EXPECT_EQ(operations[0][4], "nullopt");
+    EXPECT_EQ(operation1.arguments[2], "nullopt");
+    EXPECT_EQ(operation1.arguments[3], "BFLOAT16");
+    EXPECT_EQ(operation1.arguments[4], "nullopt");
     EXPECT_EQ(
-        operations[0][5],
+        operation1.arguments[5],
         "[ unsupported type , "
         "std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, "
         "ttnn::WormholeComputeKernelConfig>> const>]");
 
-    EXPECT_EQ(operations[1].size(), 2);
+    auto operation2 = operations[1];
+    EXPECT_EQ(operation2.operation_name, "MorehDotOperation");
+    EXPECT_EQ(operation2.arguments.size(), 2);
     EXPECT_EQ(
-        operations[1][0],
+        operation2.arguments[0],
         "[ unsupported type , "
         "std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::operation_attributes_t "
         "const>]");
     EXPECT_EQ(
-        operations[1][1],
+        operation2.arguments[1],
         "[ unsupported type , "
         "std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_args_t const>]");
 
-    EXPECT_EQ(operations[2].size(), 5);
-    EXPECT_EQ(operations[2][0], "Shape([1, 1, 1, 1])");
-    EXPECT_EQ(operations[2][1], "BFLOAT16");
-    EXPECT_EQ(operations[2][2], "Tile");
-    EXPECT_EQ(operations[2][3], "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]");
+    auto operation3 = operations[2];
+    EXPECT_EQ(operation3.operation_name, "tt::tt_metal::create_device_tensor");
+    EXPECT_EQ(operation3.arguments.size(), 5);
+    EXPECT_EQ(operation3.arguments[0], "Shape([1, 1, 1, 1])");
+    EXPECT_EQ(operation3.arguments[1], "BFLOAT16");
+    EXPECT_EQ(operation3.arguments[2], "Tile");
+    EXPECT_EQ(operation3.arguments[3], "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]");
     EXPECT_EQ(
-        operations[2][4],
+        operation3.arguments[4],
         "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::"
         "nullopt)");
 }

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "ttnn_test_fixtures.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_consts.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/moreh/moreh_dot/moreh_dot.hpp"
+#include <optional>
+#include <string>
+
+namespace ttnn::graph::arguments::test {
+
+class TestGraphCaptureArgumentsMorehDot : public TTNNFixtureWithTensor {
+protected:
+    tt::tt_metal::IGraphProcessor::RunMode Mode = tt::tt_metal::IGraphProcessor::RunMode::NORMAL;
+};
+
+TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
+    auto tt_input1 = CreateTensor();
+    auto tt_input2 = CreateTensor();
+    ttnn::graph::GraphProcessor::begin_graph_capture(Mode);
+    ttnn::operations::moreh::moreh_dot::MorehDot::invoke(
+        tt_input1, tt_input2, std::nullopt, DataType::BFLOAT16, std::nullopt, std::nullopt);
+    auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
+    auto operations = ttnn::graph::extract_arguments(trace);
+    /*
+        int i =0;
+        for(auto operation : operations)
+        {
+            std::cout << "operation: " <<  i << std::endl;
+
+            int j = 0;
+            for (auto argument : operation)
+            {
+                std::cout << "argument[" <<  j  << "]" << std::endl;
+                std::cout << argument << std::endl;
+                j++;
+            }
+
+            i++;
+        }
+    */
+
+    EXPECT_EQ(operations[0].size(), 6);
+    EXPECT_EQ(
+        operations[0][0],
+        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
+        "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_"
+        "shape={32, 32},face_shape={16, "
+        "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
+        "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))");
+    EXPECT_EQ(
+        operations[0][1],
+        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
+        "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_"
+        "shape={32, 32},face_shape={16, "
+        "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
+        "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))");
+    EXPECT_EQ(operations[0][2], "nullopt");
+    EXPECT_EQ(operations[0][3], "BFLOAT16");
+    EXPECT_EQ(operations[0][4], "nullopt");
+    EXPECT_EQ(
+        operations[0][5],
+        "[ unsupported type , "
+        "std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, "
+        "ttnn::WormholeComputeKernelConfig>> const>]");
+
+    EXPECT_EQ(operations[1].size(), 2);
+    EXPECT_EQ(
+        operations[1][0],
+        "[ unsupported type , "
+        "std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::operation_attributes_t "
+        "const>]");
+    EXPECT_EQ(
+        operations[1][1],
+        "[ unsupported type , "
+        "std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_args_t const>]");
+
+    EXPECT_EQ(operations[2].size(), 5);
+    EXPECT_EQ(operations[2][0], "Shape([1, 1, 1, 1])");
+    EXPECT_EQ(operations[2][1], "BFLOAT16");
+    EXPECT_EQ(operations[2][2], "Tile");
+    EXPECT_EQ(operations[2][3], "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]");
+    EXPECT_EQ(
+        operations[2][4],
+        "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::"
+        "nullopt)");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TestGraphCaptureArgumentsMorehDot_MorehDot,
+    TestGraphCaptureArgumentsMorehDot,
+    ::testing::Values(CreateTensorParameters{
+        .input_shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1, 32}),
+        .dtype = DataType::BFLOAT16,
+        .layout = TILE_LAYOUT,
+        .mem_cfg = L1_MEMORY_CONFIG}));
+}  // namespace ttnn::graph::arguments::test

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
@@ -14,21 +14,41 @@
 
 namespace ttnn::graph::arguments::test {
 
-class TestGraphCaptureArgumentsMorehDot : public TTNNFixtureWithTensor {
-protected:
-    tt::tt_metal::IGraphProcessor::RunMode Mode = tt::tt_metal::IGraphProcessor::RunMode::NORMAL;
-};
+class TestGraphCaptureArgumentsMorehDot : public TTNNFixtureWithTensor {};
 
 TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
     auto tt_input1 = CreateTensor();
     auto tt_input2 = CreateTensor();
-    ttnn::graph::GraphProcessor::begin_graph_capture(Mode);
-    ttnn::operations::moreh::moreh_dot::MorehDot::invoke(
-        tt_input1, tt_input2, std::nullopt, DataType::BFLOAT16, std::nullopt, std::nullopt);
+    ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NORMAL);
+    ttnn::moreh_dot(tt_input1, tt_input2, std::nullopt, DataType::BFLOAT16, std::nullopt, std::nullopt);
     auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
     auto operations = ttnn::graph::extract_arguments(trace);
 
-    auto operation1 = operations[0];
+    auto operation0 = operations[0];
+    EXPECT_EQ(operation0.operation_name, "ttnn::moreh_dot");
+    EXPECT_EQ(operation0.arguments.size(), 6);
+    EXPECT_EQ(
+        operation0.arguments[0],
+        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
+        "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_"
+        "shape={32, 32},face_shape={16, "
+        "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
+        "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))");
+    EXPECT_EQ(
+        operation0.arguments[1],
+        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
+        "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, "
+        "32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_"
+        "shape={32, 32},face_shape={16, "
+        "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
+        "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))");
+    EXPECT_EQ(operation0.arguments[2], "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]");
+    EXPECT_EQ(operation0.arguments[3], "BFLOAT16");
+    EXPECT_EQ(operation0.arguments[4], "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]");
+    EXPECT_EQ(operation0.arguments[5], "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]");
+
+    auto operation1 = operations[1];
     EXPECT_EQ(operation1.operation_name, "ttnn::prim::moreh_dot");
     EXPECT_EQ(operation1.arguments.size(), 6);
     EXPECT_EQ(
@@ -56,7 +76,7 @@ TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
         "std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, "
         "ttnn::WormholeComputeKernelConfig>> const>]");
 
-    auto operation2 = operations[1];
+    auto operation2 = operations[2];
     EXPECT_EQ(operation2.operation_name, "MorehDotOperation");
     EXPECT_EQ(operation2.arguments.size(), 2);
     EXPECT_EQ(
@@ -69,7 +89,7 @@ TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
         "[ unsupported type , "
         "std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_args_t const>]");
 
-    auto operation3 = operations[2];
+    auto operation3 = operations[3];
     EXPECT_EQ(operation3.operation_name, "tt::tt_metal::create_device_tensor");
     EXPECT_EQ(operation3.arguments.size(), 5);
     EXPECT_EQ(operation3.arguments[0], "Shape([1, 1, 1, 1])");
@@ -86,7 +106,7 @@ INSTANTIATE_TEST_SUITE_P(
     TestGraphCaptureArgumentsMorehDot_MorehDot,
     TestGraphCaptureArgumentsMorehDot,
     ::testing::Values(CreateTensorParameters{
-        .input_shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1, 32}),
+        .input_shape = ttnn::Shape({1, 1, 1, 32}),
         .dtype = DataType::BFLOAT16,
         .layout = TILE_LAYOUT,
         .mem_cfg = L1_MEMORY_CONFIG}));

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
@@ -27,23 +27,6 @@ TEST_P(TestGraphCaptureArgumentsMorehDot, MorehDot) {
         tt_input1, tt_input2, std::nullopt, DataType::BFLOAT16, std::nullopt, std::nullopt);
     auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
     auto operations = ttnn::graph::extract_arguments(trace);
-    /*
-        int i =0;
-        for(auto operation : operations)
-        {
-            std::cout << "operation: " <<  i << std::endl;
-
-            int j = 0;
-            for (auto argument : operation)
-            {
-                std::cout << "argument[" <<  j  << "]" << std::endl;
-                std::cout << argument << std::endl;
-                j++;
-            }
-
-            i++;
-        }
-    */
 
     EXPECT_EQ(operations[0].size(), 6);
     EXPECT_EQ(

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "ttnn_test_fixtures.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_consts.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include <optional>
+#include <string>
+
+namespace ttnn::graph::arguments::test {
+
+class TestGraphCaptureArgumentsTranspose : public TTNNFixtureWithTensor {
+protected:
+    tt::tt_metal::IGraphProcessor::RunMode Mode = tt::tt_metal::IGraphProcessor::RunMode::NORMAL;
+};
+
+TEST_P(TestGraphCaptureArgumentsTranspose, Transpose) {
+    auto tt_input = CreateTensor();
+    tt_input.reshape(ttnn::Shape{1, 2048, 4, 128});
+    ttnn::graph::GraphProcessor::begin_graph_capture(Mode);
+    ttnn::operations::data_movement::ExecuteTranspose::invoke(tt_input, 1, 2);
+    auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
+    auto operations = ttnn::graph::extract_arguments(trace);
+
+    EXPECT_EQ(operations[0].size(), 5);
+    EXPECT_EQ(
+        operations[0][0],
+        "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
+        "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 2048, "
+        "512]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile("
+        "tile_shape={32, 32},face_shape={16, "
+        "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
+        "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1]))))");
+    EXPECT_EQ(operations[0][1], "SmallVector([0, 2, 1, 3])");
+    EXPECT_EQ(
+        operations[0][2],
+        "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::"
+        "nullopt)");
+    EXPECT_EQ(operations[0][3], "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]");
+    EXPECT_EQ(operations[0][4], "0");
+
+    EXPECT_EQ(operations[1].size(), 2);
+    EXPECT_EQ(
+        operations[1][0],
+        "[ unsupported type , "
+        "std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::operation_attributes_t "
+        "const>]");
+    EXPECT_EQ(
+        operations[1][1],
+        "[ unsupported type , "
+        "std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::tensor_args_t const>]");
+
+    EXPECT_EQ(operations[2].size(), 5);
+    EXPECT_EQ(operations[2][0], "Shape([1, 2048, 1, 512])");
+    EXPECT_EQ(operations[2][1], "BFLOAT16");
+    EXPECT_EQ(operations[2][2], "Row Major");
+    EXPECT_EQ(operations[2][3], "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]");
+    EXPECT_EQ(
+        operations[2][4],
+        "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::"
+        "nullopt)");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TestGraphCaptureArgumentsTranspose_Transpose,
+    TestGraphCaptureArgumentsTranspose,
+    ::testing::Values(CreateTensorParameters{
+        .input_shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 2048, 512}),
+        .dtype = DataType::BFLOAT16,
+        .layout = ROW_MAJOR_LAYOUT,
+        .mem_cfg = L1_MEMORY_CONFIG}));
+}  // namespace ttnn::graph::arguments::test

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_transpose.cpp
@@ -27,41 +27,47 @@ TEST_P(TestGraphCaptureArgumentsTranspose, Transpose) {
     auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
     auto operations = ttnn::graph::extract_arguments(trace);
 
-    EXPECT_EQ(operations[0].size(), 5);
+    auto operation1 = operations[0];
+    EXPECT_EQ(operation1.operation_name, "ttnn::prim::permute");
+    EXPECT_EQ(operation1.arguments.size(), 5);
     EXPECT_EQ(
-        operations[0][0],
+        operation1.arguments[0],
         "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_"
         "type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 2048, "
         "512]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile("
         "tile_shape={32, 32},face_shape={16, "
         "16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type="
         "BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1]))))");
-    EXPECT_EQ(operations[0][1], "SmallVector([0, 2, 1, 3])");
+    EXPECT_EQ(operation1.arguments[1], "SmallVector([0, 2, 1, 3])");
     EXPECT_EQ(
-        operations[0][2],
+        operation1.arguments[2],
         "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::"
         "nullopt)");
-    EXPECT_EQ(operations[0][3], "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]");
-    EXPECT_EQ(operations[0][4], "0");
+    EXPECT_EQ(operation1.arguments[3], "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]");
+    EXPECT_EQ(operation1.arguments[4], "0");
 
-    EXPECT_EQ(operations[1].size(), 2);
+    auto operation2 = operations[1];
+    EXPECT_EQ(operation2.operation_name, "PermuteDeviceOperation");
+    EXPECT_EQ(operation2.arguments.size(), 2);
     EXPECT_EQ(
-        operations[1][0],
+        operation2.arguments[0],
         "[ unsupported type , "
         "std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::operation_attributes_t "
         "const>]");
     EXPECT_EQ(
-        operations[1][1],
+        operation2.arguments[1],
         "[ unsupported type , "
         "std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::tensor_args_t const>]");
 
-    EXPECT_EQ(operations[2].size(), 5);
-    EXPECT_EQ(operations[2][0], "Shape([1, 2048, 1, 512])");
-    EXPECT_EQ(operations[2][1], "BFLOAT16");
-    EXPECT_EQ(operations[2][2], "Row Major");
-    EXPECT_EQ(operations[2][3], "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]");
+    auto operation3 = operations[2];
+    EXPECT_EQ(operation3.operation_name, "tt::tt_metal::create_device_tensor");
+    EXPECT_EQ(operation3.arguments.size(), 5);
+    EXPECT_EQ(operation3.arguments[0], "Shape([1, 2048, 1, 512])");
+    EXPECT_EQ(operation3.arguments[1], "BFLOAT16");
+    EXPECT_EQ(operation3.arguments[2], "Row Major");
+    EXPECT_EQ(operation3.arguments[3], "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]");
     EXPECT_EQ(
-        operations[2][4],
+        operation3.arguments[4],
         "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::"
         "nullopt)");
 }

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -13,6 +13,8 @@
 
 #include "ttnn/device.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_impl.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/host_api.hpp>
 #include "hostdevcommon/common_values.hpp"
@@ -51,6 +53,26 @@ protected:
     }
 
     tt::tt_metal::IDevice& getDevice() { return *device_; }
+};
+
+struct CreateTensorParameters {
+    ttnn::Shape input_shape;
+    DataType dtype;
+    Layout layout;
+    MemoryConfig mem_cfg;
+};
+
+class TTNNFixtureWithTensor : public TTNNFixtureWithDevice, public testing::WithParamInterface<CreateTensorParameters> {
+protected:
+    [[nodiscard]] const Tensor CreateTensor() {
+        CreateTensorParameters params = GetParam();
+        TensorSpec tensor_spec(
+            params.input_shape, TensorLayout(params.dtype, PageConfig(params.layout), params.mem_cfg));
+        auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device_, tensor_spec);
+        auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+        Tensor input_tensor = Tensor(input_storage, params.input_shape, params.dtype, params.layout);
+        return std::move(input_tensor);
+    }
 };
 
 }  // namespace ttnn

--- a/tests/ttnn/unit_tests/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/test_graph_capture.py
@@ -35,3 +35,119 @@ def test_graph_capture(tmp_path, device, scalar, size, mode):
     ttnn.graph.pretty_print(captured_graph)
 
     ttnn.graph.visualize(captured_graph, file_name=tmp_path / pathlib.Path("graph.svg"))
+
+
+def test_graph_capture_with_all_parameters(device):
+    # Create input tensor
+    torch_input = torch.rand((1, 1, 2048, 512), dtype=torch.bfloat16)
+
+    # TT operations
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    tt_input = tt_input.reshape(1, 2048, 4, 128)
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    ttnn.transpose(tt_input, 1, 2)
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    # ttnn:transpose
+    assert (
+        captured_graph[1]["arguments"]
+        == "[ \x00, std::__1::reference_wrapper<tt::stl::StrongType<unsigned char, ttnn::QueueIdTag>>],[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ 1, std::__1::reference_wrapper<long const>],[ 2, std::__1::reference_wrapper<long const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>],[ 0, std::__1::reference_wrapper<std::__1::optional<float> const>]"
+    )
+    # ttnn::prim::permute
+    assert (
+        captured_graph[4]["arguments"]
+        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ SmallVector([0, 2, 1, 3]), std::__1::reference_wrapper<tt::stl::SmallVector<unsigned int, 8ul>>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>],[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>],[ 0, std::__1::reference_wrapper<std::__1::optional<float> const>]"
+    )
+    # PermuteDeviceOperation
+    assert (
+        captured_graph[6]["arguments"]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::operation_attributes_t const>],[ unsupported type , std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::tensor_args_t const>]"
+    )
+    # tt::tt_metal::create_device_tensor
+    assert (
+        captured_graph[7]["arguments"]
+        == "[ Shape([1, 4, 2048, 128]), std::__1::reference_wrapper<tt::tt_metal::Shape const>],[ BFLOAT16, std::__1::reference_wrapper<tt::tt_metal::DataType>],[ Row Major, std::__1::reference_wrapper<tt::tt_metal::Layout>],[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>]"
+    )
+
+
+def test_graph_capture_without_memory_config(device):
+    # Create input tensor
+    input_shape = (1, 1, 1, 32)
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_other = torch.rand(input_shape, dtype=torch.bfloat16)
+
+    # TT operations
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+
+    tt_other = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    tt_out = ttnn.operations.moreh.dot(tt_input, tt_other, dtype=ttnn.bfloat16, output=None)
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    # ttnn::moreh_dot
+    assert (
+        captured_graph[1]["arguments"]
+        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Tensor> const>],[ BFLOAT16, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>],[ unsupported type , std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>> const>]"
+    )
+    # ttnn::prim::moreh_dot
+    assert (
+        captured_graph[6]["arguments"]
+        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Tensor> const>],[ BFLOAT16, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>],[ unsupported type , std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>> const>]"
+    )
+    # MorehDotOperation
+    assert (
+        captured_graph[9]["arguments"]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::operation_attributes_t const>],[ unsupported type , std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_args_t const>]"
+    )
+    # tt::tt_metal::create_device_tensor
+    assert (
+        captured_graph[10]["arguments"]
+        == "[ Shape([1, 1, 1, 1]), std::__1::reference_wrapper<tt::tt_metal::Shape const>],[ BFLOAT16, std::__1::reference_wrapper<tt::tt_metal::DataType>],[ Tile, std::__1::reference_wrapper<tt::tt_metal::Layout>],[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>]"
+    )
+
+
+def test_graph_capture_without_dtype(device):
+    torch_input = torch.randint(0, 100, (32, 32), dtype=torch.int32)
+    tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    tt_output = ttnn.moreh_full_like(tt_input, 3)
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    # ttnn::moreh_full_like
+    assert (
+        captured_graph[1]["arguments"]
+        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ unsupported type , std::__1::reference_wrapper<std::__1::variant<float, int>>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Layout> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>]"
+    )
+    # ttnn::prim::moreh_full_like
+    assert (
+        captured_graph[4]["arguments"]
+        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ unsupported type , std::__1::reference_wrapper<std::__1::variant<float, int> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Layout> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>]"
+    )
+    # FullLikeOperation
+    assert (
+        captured_graph[6]["arguments"]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::full_like::FullLikeOperation::operation_attributes_t const>],[ unsupported type , std::__1::reference_wrapper<ttnn::operations::full_like::FullLikeOperation::tensor_args_t const>]"
+    )
+    # tt::tt_metal::create_device_tensor
+    assert (
+        captured_graph[7]["arguments"]
+        == "[ Shape([32, 32]), std::__1::reference_wrapper<tt::tt_metal::Shape const>],[ INT32, std::__1::reference_wrapper<tt::tt_metal::DataType>],[ Tile, std::__1::reference_wrapper<tt::tt_metal::Layout>],[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>]"
+    )

--- a/tests/ttnn/unit_tests/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/test_graph_capture.py
@@ -55,25 +55,52 @@ def test_graph_capture_with_all_parameters(device):
     ttnn.transpose(tt_input, 1, 2)
     captured_graph = ttnn.graph.end_graph_capture()
 
+    node1 = captured_graph[1]["arguments"]
     # ttnn:transpose
+    assert node1[0] == "\x00"
     assert (
-        captured_graph[1]["arguments"]
-        == "[ \x00, std::__1::reference_wrapper<tt::stl::StrongType<unsigned char, ttnn::QueueIdTag>>],[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ 1, std::__1::reference_wrapper<long const>],[ 2, std::__1::reference_wrapper<long const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>],[ 0, std::__1::reference_wrapper<std::__1::optional<float> const>]"
+        node1[1]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1]))))"
     )
+    assert node1[2] == "1"
+    assert node1[3] == "2"
+    assert node1[4] == "nullopt"
+    assert node1[5] == "0"
+
     # ttnn::prim::permute
+    node4 = captured_graph[4]["arguments"]
     assert (
-        captured_graph[4]["arguments"]
-        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ SmallVector([0, 2, 1, 3]), std::__1::reference_wrapper<tt::stl::SmallVector<unsigned int, 8ul>>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>],[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>],[ 0, std::__1::reference_wrapper<std::__1::optional<float> const>]"
+        node4[0]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 2048, 4, 128]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=RowMajorPageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt),alignment=Alignment([1]))))"
     )
+    assert node4[1] == "SmallVector([0, 2, 1, 3])"
+    assert (
+        node4[2]
+        == "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)"
+    )
+    assert node4[3] == "[ unsupported type , std::__1::reference_wrapper<std::__1::nullopt_t const>]"
+    assert node4[4] == "0"
+
     # PermuteDeviceOperation
+    node6 = captured_graph[6]["arguments"]
     assert (
-        captured_graph[6]["arguments"]
-        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::operation_attributes_t const>],[ unsupported type , std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::tensor_args_t const>]"
+        node6[0]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::operation_attributes_t const>]"
     )
-    # tt::tt_metal::create_device_tensor
     assert (
-        captured_graph[7]["arguments"]
-        == "[ Shape([1, 4, 2048, 128]), std::__1::reference_wrapper<tt::tt_metal::Shape const>],[ BFLOAT16, std::__1::reference_wrapper<tt::tt_metal::DataType>],[ Row Major, std::__1::reference_wrapper<tt::tt_metal::Layout>],[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>]"
+        node6[1]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::data_movement::PermuteDeviceOperation::tensor_args_t const>]"
+    )
+
+    # tt::tt_metal::create_device_tensor
+    node7 = captured_graph[7]["arguments"]
+    assert node7[0] == "Shape([1, 4, 2048, 128])"
+    assert node7[1] == "BFLOAT16"
+    assert node7[2] == "Row Major"
+    assert node7[3] == "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]"
+    assert (
+        node7[4]
+        == "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt)"
     )
 
 
@@ -103,24 +130,61 @@ def test_graph_capture_without_memory_config(device):
     captured_graph = ttnn.graph.end_graph_capture()
 
     # ttnn::moreh_dot
+    node1 = captured_graph[1]["arguments"]
     assert (
-        captured_graph[1]["arguments"]
-        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Tensor> const>],[ BFLOAT16, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>],[ unsupported type , std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>> const>]"
+        node1[0]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))"
     )
+    assert (
+        node1[1]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))"
+    )
+    assert node1[2] == "nullopt"
+    assert node1[3] == "BFLOAT16"
+    assert node1[4] == "nullopt"
+    assert (
+        node1[5]
+        == "[ unsupported type , std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>> const>]"
+    )
+
     # ttnn::prim::moreh_dot
+    node6 = captured_graph[6]["arguments"]
     assert (
-        captured_graph[6]["arguments"]
-        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Tensor> const>],[ BFLOAT16, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>],[ unsupported type , std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>> const>]"
+        node6[0]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))"
     )
+    assert (
+        node6[1]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([1, 1, 1, 32]),tensor_layout=TensorLayout(dtype=BFLOAT16,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))"
+    )
+    assert node6[2] == "nullopt"
+    assert node6[3] == "BFLOAT16"
+    assert node6[4] == "nullopt"
+    assert (
+        node6[5]
+        == "[ unsupported type , std::__1::reference_wrapper<std::__1::optional<std::__1::variant<ttnn::GrayskullComputeKernelConfig, ttnn::WormholeComputeKernelConfig>> const>]"
+    )
+
     # MorehDotOperation
+    node9 = captured_graph[9]["arguments"]
     assert (
-        captured_graph[9]["arguments"]
-        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::operation_attributes_t const>],[ unsupported type , std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_args_t const>]"
+        node9[0]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::operation_attributes_t const>]"
     )
-    # tt::tt_metal::create_device_tensor
     assert (
-        captured_graph[10]["arguments"]
-        == "[ Shape([1, 1, 1, 1]), std::__1::reference_wrapper<tt::tt_metal::Shape const>],[ BFLOAT16, std::__1::reference_wrapper<tt::tt_metal::DataType>],[ Tile, std::__1::reference_wrapper<tt::tt_metal::Layout>],[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>]"
+        node9[1]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_args_t const>]"
+    )
+
+    # tt::tt_metal::create_device_tensor
+    node10 = captured_graph[10]["arguments"]
+    assert node10[0] == "Shape([1, 1, 1, 1])"
+    assert node10[1] == "BFLOAT16"
+    assert node10[2] == "Tile"
+    assert node10[3] == "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]"
+    assert (
+        node10[4]
+        == "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)"
     )
 
 
@@ -132,22 +196,45 @@ def test_graph_capture_without_dtype(device):
     captured_graph = ttnn.graph.end_graph_capture()
 
     # ttnn::moreh_full_like
+    node1 = captured_graph[1]["arguments"]
     assert (
-        captured_graph[1]["arguments"]
-        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ unsupported type , std::__1::reference_wrapper<std::__1::variant<float, int>>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Layout> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>]"
+        node1[0]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))"
     )
+    assert node1[1] == "[ unsupported type , std::__1::reference_wrapper<std::__1::variant<float, int>>]"
+    assert node1[2] == "nullopt"
+    assert node1[3] == "nullopt"
+    assert node1[4] == "nullopt"
+
     # ttnn::prim::moreh_full_like
+    node4 = captured_graph[4]["arguments"]
     assert (
-        captured_graph[4]["arguments"]
-        == "[ Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32])))), std::__1::reference_wrapper<tt::tt_metal::Tensor const>],[ unsupported type , std::__1::reference_wrapper<std::__1::variant<float, int> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::DataType> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::Layout> const>],[ nullopt, std::__1::reference_wrapper<std::__1::optional<tt::tt_metal::MemoryConfig> const>]"
+        node4[0]
+        == "Tensor(storage=DeviceStorage(memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)),tensor_spec=TensorSpec(logical_shape=Shape([32, 32]),tensor_layout=TensorLayout(dtype=INT32,page_config=PageConfig(config=TilePageConfig(tile=Tile(tile_shape={32, 32},face_shape={16, 16},num_faces=4))),memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt),alignment=Alignment([32, 32]))))"
     )
+    assert node4[1] == "[ unsupported type , std::__1::reference_wrapper<std::__1::variant<float, int> const>]"
+    assert node4[2] == "nullopt"
+    assert node4[3] == "nullopt"
+    assert node4[4] == "nullopt"
+
     # FullLikeOperation
+    node6 = captured_graph[6]["arguments"]
     assert (
-        captured_graph[6]["arguments"]
-        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::full_like::FullLikeOperation::operation_attributes_t const>],[ unsupported type , std::__1::reference_wrapper<ttnn::operations::full_like::FullLikeOperation::tensor_args_t const>]"
+        node6[0]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::full_like::FullLikeOperation::operation_attributes_t const>]"
     )
-    # tt::tt_metal::create_device_tensor
     assert (
-        captured_graph[7]["arguments"]
-        == "[ Shape([32, 32]), std::__1::reference_wrapper<tt::tt_metal::Shape const>],[ INT32, std::__1::reference_wrapper<tt::tt_metal::DataType>],[ Tile, std::__1::reference_wrapper<tt::tt_metal::Layout>],[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>],[ MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt), std::__1::reference_wrapper<tt::tt_metal::MemoryConfig const>]"
+        node6[1]
+        == "[ unsupported type , std::__1::reference_wrapper<ttnn::operations::full_like::FullLikeOperation::tensor_args_t const>]"
+    )
+
+    # tt::tt_metal::create_device_tensor
+    node7 = captured_graph[7]["arguments"]
+    assert node7[0] == "Shape([32, 32])"
+    assert node7[1] == "INT32"
+    assert node7[2] == "Tile"
+    assert node7[3] == "[ unsupported type , std::__1::reference_wrapper<tt::tt_metal::v0::IDevice*>]"
+    assert (
+        node7[4]
+        == "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt)"
     )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -202,6 +202,7 @@ set(TTNN_BASE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_processor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_argument_serializer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_trace_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/creation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sharding_utilities.cpp

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
@@ -96,11 +96,9 @@ void GraphArgumentSerializer::register_type() {
         if (value.type() == typeid(std::reference_wrapper<T>)) {
             auto referenced_value = std::any_cast<std::reference_wrapper<T>>(value);
             oss << referenced_value.get();
-            std::cout << "Parsed: " << typeid(referenced_value).name() << std::endl;
         } else if (value.type() == typeid(std::reference_wrapper<const T>)) {
             auto referenced_value = std::any_cast<std::reference_wrapper<const T>>(value);
             oss << referenced_value.get();
-            std::cout << "Parsed: " << typeid(referenced_value).name() << std::endl;
         } else {
             oss << "Unable to parse";
         }

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "graph_argument_serializer.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::graph {
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout) {
+    switch (layout) {
+        case Layout::ROW_MAJOR: return os << "Row Major";
+        case Layout::TILE: return os << "Tile";
+        case Layout::INVALID: return os << "Invalid";
+        default: return os << "Unknown layout";
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const Tile& config) {
+    tt::stl::reflection::operator<<(os, config);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Tensor& tensor) {
+    tt::stl::reflection::operator<<(os, tensor);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const tt::stl::StrongType<unsigned char, ttnn::QueueIdTag>& h) {
+    return os << *h;
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::optional<T>& optional_value) {
+    if (optional_value.has_value()) {
+        os << optional_value.value();
+    } else {
+        os << "nullopt";
+    }
+    return os;
+}
+
+std::string graph_demangle(const char* name) {
+    int status = -4;
+    char* res = abi::__cxa_demangle(name, NULL, NULL, &status);
+    const char* const demangled_name = (status == 0) ? res : name;
+    std::string ret_val(demangled_name);
+    free(res);
+    return ret_val;
+}
+
+std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction>& GraphArgumentSerializer::registry() {
+    static std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction> map;
+    return map;
+}
+
+template <typename T, std::size_t N>
+void GraphArgumentSerializer::register_small_vector() {
+    registry()[typeid(std::reference_wrapper<tt::stl::SmallVector<T, N>>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<tt::stl::SmallVector<T, N>>>(value);
+        oss << referenced_value.get();
+        return oss.str();
+    };
+}
+
+template <typename T>
+void GraphArgumentSerializer::register_special_type() {
+    registry()[typeid(std::reference_wrapper<T>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<T>>(value);
+        oss << referenced_value.get();
+        return oss.str();
+    };
+}
+
+template <typename OptionalT>
+void GraphArgumentSerializer::register_optional_type() {
+    registry()[typeid(std::reference_wrapper<OptionalT>)] = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        auto referenced_value = std::any_cast<std::reference_wrapper<OptionalT>>(value);
+        auto& referenced_optional = referenced_value.get();
+        if (referenced_optional.has_value()) {
+            oss << *referenced_optional;
+        } else {
+            oss << "nullopt";
+        }
+
+        return oss.str();
+    };
+}
+
+template <typename T>
+void GraphArgumentSerializer::register_type() {
+    GraphArgumentSerializer::ConvertionFunction regular_function = [](const std::any& value) -> std::string {
+        std::ostringstream oss;
+        if (value.type() == typeid(std::reference_wrapper<T>)) {
+            auto referenced_value = std::any_cast<std::reference_wrapper<T>>(value);
+            oss << referenced_value.get();
+            std::cout << "Parsed: " << typeid(referenced_value).name() << std::endl;
+        } else if (value.type() == typeid(std::reference_wrapper<const T>)) {
+            auto referenced_value = std::any_cast<std::reference_wrapper<const T>>(value);
+            oss << referenced_value.get();
+            std::cout << "Parsed: " << typeid(referenced_value).name() << std::endl;
+        } else {
+            oss << "Unable to parse";
+        }
+
+        return oss.str();
+    };
+
+    // regular cases
+    registry()[typeid(std::reference_wrapper<T>)] = regular_function;
+    registry()[typeid(std::reference_wrapper<const T>)] = regular_function;
+    registry()[typeid(const std::reference_wrapper<T>)] = regular_function;
+
+    // Particular cases for optional
+    register_optional_type<std::optional<T>>();
+    register_optional_type<const std::optional<T>>();
+
+    // Handle complex types (feel free to add more in the future)
+    // Small vector
+    register_small_vector<T, 2>();
+    register_small_vector<T, 4>();
+    register_small_vector<T, 8>();
+    register_small_vector<T, 16>();
+}
+
+std::vector<std::string> GraphArgumentSerializer::to_list(const std::span<std::any>& span) {
+    std::vector<std::string> result;
+    for (const auto& element : span) {
+        if (!element.has_value()) {
+            result.push_back("[any, empty]");
+            continue;
+        }
+
+        auto it = registry().find(element.type());
+        if (it != registry().end()) {
+            result.push_back(it->second(element));
+        } else {
+            // for debugging reasons, I want to report the type that is not managed
+            std::ostringstream oss;
+            oss << "[ unsupported type" << " , ";
+            auto demangled_name = graph_demangle(element.type().name());
+            oss << demangled_name;
+            oss << "]";
+            result.push_back(oss.str());
+        }
+    }
+
+    return result;
+}
+
+void GraphArgumentSerializer::initialize() {
+    GraphArgumentSerializer::register_type<bool>();
+    GraphArgumentSerializer::register_type<int>();
+    GraphArgumentSerializer::register_type<uint>();
+    GraphArgumentSerializer::register_type<long>();
+    GraphArgumentSerializer::register_type<float>();
+    GraphArgumentSerializer::register_type<uint8_t>();
+    GraphArgumentSerializer::register_type<uint16_t>();
+    GraphArgumentSerializer::register_type<tt::tt_metal::DataType>();
+    GraphArgumentSerializer::register_type<tt::tt_metal::Layout>();
+    GraphArgumentSerializer::register_type<tt::tt_metal::MemoryConfig>();
+    GraphArgumentSerializer::register_type<tt::tt_metal::Shape>();
+    GraphArgumentSerializer::register_type<tt::tt_metal::Tensor>();
+    GraphArgumentSerializer::register_type<tt::tt_metal::Tile>();
+    GraphArgumentSerializer::register_special_type<tt::stl::StrongType<unsigned char, ttnn::QueueIdTag>>();
+}
+}  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
@@ -39,17 +39,23 @@ std::ostream& operator<<(std::ostream& os, const std::optional<T>& optional_valu
     return os;
 }
 
-std::string graph_demangle(const char* name) {
+std::string graph_demangle(const std::string_view& name) {
     int status = -4;
-    char* res = abi::__cxa_demangle(name, NULL, NULL, &status);
-    const char* const demangled_name = (status == 0) ? res : name;
+    char* res = abi::__cxa_demangle(name.data(), NULL, NULL, &status);
+    const char* const demangled_name = (status == 0) ? res : name.data();
     std::string ret_val(demangled_name);
     free(res);
     return ret_val;
 }
 
+GraphArgumentSerializer::GraphArgumentSerializer() { initialize(); }
+
+GraphArgumentSerializer* GraphArgumentSerializer::instance() {
+    static GraphArgumentSerializer* new_instance = new GraphArgumentSerializer();
+    return new_instance;
+}
+
 std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction>& GraphArgumentSerializer::registry() {
-    static std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction> map;
     return map;
 }
 

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
@@ -50,8 +50,8 @@ std::string graph_demangle(const std::string_view& name) {
 
 GraphArgumentSerializer::GraphArgumentSerializer() { initialize(); }
 
-GraphArgumentSerializer* GraphArgumentSerializer::instance() {
-    static GraphArgumentSerializer* new_instance = new GraphArgumentSerializer();
+GraphArgumentSerializer& GraphArgumentSerializer::instance() {
+    static GraphArgumentSerializer new_instance;
     return new_instance;
 }
 

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
@@ -15,12 +15,12 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout) {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const Tile& config) {
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tile& config) {
     tt::stl::reflection::operator<<(os, config);
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const Tensor& tensor) {
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tensor& tensor) {
     tt::stl::reflection::operator<<(os, tensor);
     return os;
 }

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.cpp
@@ -39,7 +39,7 @@ std::ostream& operator<<(std::ostream& os, const std::optional<T>& optional_valu
     return os;
 }
 
-std::string graph_demangle(const std::string_view& name) {
+std::string graph_demangle(const std::string_view name) {
     int status = -4;
     char* res = abi::__cxa_demangle(name.data(), NULL, NULL, &status);
     const char* const demangled_name = (status == 0) ? res : name.data();

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <any>
+#include <functional>
+#include <span>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+
+namespace ttnn::graph {
+std::string graph_demangle(const char* name);
+
+struct GraphArgumentSerializer {
+    using ConvertionFunction = std::function<std::string(const std::any&)>;
+
+    static std::unordered_map<std::type_index, ConvertionFunction>& registry();
+
+    template <typename T, std::size_t N>
+    static void register_small_vector();
+
+    // In case you don't care about all the variations of the type
+    // such as const T, const T&, T, T&, etc
+    template <typename T>
+    static void register_special_type();
+
+    template <typename T>
+    static void register_type();
+
+    template <typename OptionalT>
+    static void register_optional_type();
+
+    static std::vector<std::string> to_list(const std::span<std::any>& span);
+
+    static void initialize();
+};
+}  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
@@ -18,7 +18,7 @@ public:
     using ConvertionFunction = std::function<std::string(const std::any&)>;
     std::vector<std::string> to_list(const std::span<std::any>& span);
 
-    static GraphArgumentSerializer* instance();
+    static GraphArgumentSerializer& instance();
 
 private:
     GraphArgumentSerializer();

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 
 namespace ttnn::graph {
-std::string graph_demangle(const std::string_view& name);
+std::string graph_demangle(const std::string_view name);
 
 class GraphArgumentSerializer {
 public:

--- a/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_argument_serializer.hpp
@@ -11,29 +11,36 @@
 #include <unordered_map>
 
 namespace ttnn::graph {
-std::string graph_demangle(const char* name);
+std::string graph_demangle(const std::string_view& name);
 
-struct GraphArgumentSerializer {
+class GraphArgumentSerializer {
+public:
     using ConvertionFunction = std::function<std::string(const std::any&)>;
+    std::vector<std::string> to_list(const std::span<std::any>& span);
 
-    static std::unordered_map<std::type_index, ConvertionFunction>& registry();
+    static GraphArgumentSerializer* instance();
+
+private:
+    GraphArgumentSerializer();
+    std::unordered_map<std::type_index, ConvertionFunction>& registry();
 
     template <typename T, std::size_t N>
-    static void register_small_vector();
+    void register_small_vector();
 
     // In case you don't care about all the variations of the type
     // such as const T, const T&, T, T&, etc
     template <typename T>
-    static void register_special_type();
+    void register_special_type();
 
     template <typename T>
-    static void register_type();
+    void register_type();
 
     template <typename OptionalT>
-    static void register_optional_type();
+    void register_optional_type();
 
-    static std::vector<std::string> to_list(const std::span<std::any>& span);
+    void initialize();
 
-    static void initialize();
+private:
+    std::unordered_map<std::type_index, GraphArgumentSerializer::ConvertionFunction> map;
 };
 }  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/graph/graph_consts.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_consts.hpp
@@ -10,6 +10,7 @@ constexpr auto kNodeType = "node_type";
 constexpr auto kCounter = "counter";
 constexpr auto kConnections = "connections";
 constexpr auto kParams = "params";
+constexpr auto kArguments = "arguments";
 // params keys
 constexpr auto kName = "name";
 constexpr auto kInputs = "inputs";

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -192,15 +192,7 @@ void GraphProcessor::track_function_start(std::string_view function_name, std::s
     };
 
     std::vector<std::string> serialized_arguments;
-    try{
-        serialized_arguments = GraphArgumentSerializer::to_list(input_parameters);
-        for(auto item : serialized_arguments)
-            std::cout << item << std::endl;
-    } catch (const std::exception& e) {  // ✅ Catches std::runtime_error, std::bad_any_cast, etc.
-        std::cerr << "Exception: " << e.what() << std::endl;
-    } catch (...) {  // ✅ Catches anything else (segfaults, etc.)
-        std::cerr << "Unknown Exception occurred." << std::endl;
-    }
+    serialized_arguments = GraphArgumentSerializer::to_list(input_parameters);
 
     auto counter = graph.size();
     {

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -15,7 +15,7 @@
 #include <typeindex>
 #include <unordered_map>
 #include "ttnn/core.hpp"
-#pragma optimize("", off)
+
 using namespace tt::tt_metal;
 
 namespace {

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -88,9 +88,6 @@ GraphProcessor::GraphProcessor(RunMode mode) : run_mode(mode) {
     end_function_any_map[typeid(std::reference_wrapper<Tensor>)] = [ptr = this](const std::any& val) mutable {
         ptr->end_function_process_tensor(val);
     };
-
-    // Add all the elements in the map to handle different datatypes
-    TT_ASSERT(GraphArgumentSerializer::instance());
 }
 
 void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
@@ -192,7 +189,7 @@ void GraphProcessor::track_function_start(std::string_view function_name, std::s
     };
 
     std::vector<std::string> serialized_arguments;
-    serialized_arguments = GraphArgumentSerializer::instance()->to_list(input_parameters);
+    serialized_arguments = GraphArgumentSerializer::instance().to_list(input_parameters);
 
     auto counter = graph.size();
     {

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -90,7 +90,7 @@ GraphProcessor::GraphProcessor(RunMode mode) : run_mode(mode) {
     };
 
     // Add all the elements in the map to handle different datatypes
-    GraphArgumentSerializer::initialize();
+    TT_ASSERT(GraphArgumentSerializer::instance());
 }
 
 void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
@@ -192,7 +192,7 @@ void GraphProcessor::track_function_start(std::string_view function_name, std::s
     };
 
     std::vector<std::string> serialized_arguments;
-    serialized_arguments = GraphArgumentSerializer::to_list(input_parameters);
+    serialized_arguments = GraphArgumentSerializer::instance()->to_list(input_parameters);
 
     auto counter = graph.size();
     {

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -67,7 +67,7 @@ public:
         int counter = 0;
         std::string node_type;
         std::unordered_map<std::string, std::string> params;
-        std::string arguments;
+        std::vector<std::string> arguments;
         std::vector<int> connections;
     };
     using ProcessFunc = std::function<void(const std::any&)>;

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -67,6 +67,7 @@ public:
         int counter = 0;
         std::string node_type;
         std::unordered_map<std::string, std::string> params;
+        std::string arguments;
         std::vector<int> connections;
     };
     using ProcessFunc = std::function<void(const std::any&)>;

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
@@ -154,20 +154,21 @@ std::vector<std::string> extract_calltrace(const nlohmann::json& trace) {
     return op_calls;
 }
 
-std::vector<std::vector<std::string>> extract_arguments(const nlohmann::json& trace) {
-    std::vector<std::vector<std::string>> arguments;
+std::vector<OperationInfo> extract_arguments(const nlohmann::json& trace) {
+    std::vector<OperationInfo> operations;
     size_t i = 0;
-
     while (i < trace.size()) {
         const auto& v = trace[i];
         i++;
-
+        OperationInfo info;
         if (v[kArguments].size() > 0) {
-            arguments.push_back(v[kArguments]);
+            info.operation_name = v[kParams][kName];
+            info.arguments = v[kArguments];
+            operations.push_back(info);
         }
     }
 
-    return arguments;
+    return operations;
 }
 
 std::unordered_set<uint32_t> extract_output_tensors(const nlohmann::json& trace) {

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
@@ -154,6 +154,22 @@ std::vector<std::string> extract_calltrace(const nlohmann::json& trace) {
     return op_calls;
 }
 
+std::vector<std::vector<std::string>> extract_arguments(const nlohmann::json& trace) {
+    std::vector<std::vector<std::string>> arguments;
+    size_t i = 0;
+
+    while (i < trace.size()) {
+        const auto& v = trace[i];
+        i++;
+
+        if (v[kArguments].size() > 0) {
+            arguments.push_back(v[kArguments]);
+        }
+    }
+
+    return arguments;
+}
+
 std::unordered_set<uint32_t> extract_output_tensors(const nlohmann::json& trace) {
     // Lambda to find the last 'function_end' node
     auto find_function_end_node = [](const auto& trace) -> const nlohmann::json& {

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -11,6 +11,11 @@
 
 namespace ttnn::graph {
 
+struct OperationInfo {
+    std::string operation_name;
+    std::vector<std::string> arguments;
+};
+
 enum class ExecutionStatus { Success, Error };
 
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
@@ -24,7 +29,7 @@ std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohma
 
 std::vector<std::string> extract_calltrace(const nlohmann::json& trace);
 
-std::vector<std::vector<std::string>> extract_arguments(const nlohmann::json& trace);
+std::vector<OperationInfo> extract_arguments(const nlohmann::json& trace);
 
 std::unordered_set<uint32_t> extract_output_tensors(const nlohmann::json& trace);
 

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -24,6 +24,8 @@ std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohma
 
 std::vector<std::string> extract_calltrace(const nlohmann::json& trace);
 
+std::vector<std::vector<std::string>> extract_arguments(const nlohmann::json& trace);
+
 std::unordered_set<uint32_t> extract_output_tensors(const nlohmann::json& trace);
 
 struct TensorInfo {

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -18,7 +18,8 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_ty
         case DataType::UINT8: return os << "UINT8";
         case DataType::UINT16: return os << "UINT16";
         case DataType::INT32: return os << "INT32";
-        case DataType::INVALID: return os << "Invalid";
+        case DataType::INVALID:
+        default: return os << "Invalid";
     }
 }
 

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -8,6 +8,21 @@
 
 namespace tt::tt_metal {
 
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_type) {
+    switch (data_type) {
+        case DataType::BFLOAT16: return os << "BFLOAT16";
+        case DataType::FLOAT32: return os << "FLOAT32";
+        case DataType::UINT32: return os << "UINT32";
+        case DataType::BFLOAT8_B: return os << "BFLOAT8_B";
+        case DataType::BFLOAT4_B: return os << "BFLOAT4_B";
+        case DataType::UINT8: return os << "UINT8";
+        case DataType::UINT16: return os << "UINT16";
+        case DataType::INT32: return os << "INT32";
+        case DataType::INVALID: return os << "Invalid";
+        default: return os << "Unknown data type";
+    }
+}
+
 bool is_floating_point(DataType dtype) {
     switch (dtype) {
         case DataType::BFLOAT16:

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -19,7 +19,6 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_ty
         case DataType::UINT16: return os << "UINT16";
         case DataType::INT32: return os << "INT32";
         case DataType::INVALID: return os << "Invalid";
-        default: return os << "Unknown data type";
     }
 }
 

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -43,6 +43,8 @@ enum class DataType {
     INVALID = 8,
 };
 
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_type);
+
 template <typename T>
 consteval inline DataType convert_to_data_type() {
     if constexpr (std::is_same_v<T, uint8_t>) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18120

### Problem description
The org will be creating new operations and they need some tooling to identify what is actually being sent via TTNN, so we extended the graph solution to include extra information, in this case, the arguments of the ttnn calls

### What's changed
Extended the capabilities of the graph tool to add extra information for those vertex that include arguments, so whoever wants to use them, will have more information available

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
