### PR TITLE
Fix distributed tensor test

### DIFF
--- a/tests/ttnn/distributed/test_tensor_parallel_example_T3000.py
+++ b/tests/ttnn/distributed/test_tensor_parallel_example_T3000.py
@@ -35,7 +35,7 @@ def test_tensor_parallel_falcon_mlp():
         pytest.skip()
 
     mesh_device = ttnn.open_mesh_device(
-        ttnn.MeshShape(2, 4),
+        ttnn.MeshShape(1, 8),
     )
 
     # Set PyTorch seed for reproducibility


### PR DESCRIPTION
### Problem description
There was a failing ttnn distributed test:

```
2025-02-26T15:45:04.6748241Z FAILED tests/ttnn/distributed/test_tensor_parallel_example_T3000.py::test_tensor_parallel_falcon_mlp - RuntimeError: TT_FATAL @ /work/tt_metal/llrt/tt_cluster.cpp:965: local_ethernet_sockets.find(remote_chip) != local_ethernet_sockets.end()
2025-02-26T15:45:04.6749364Z info:
2025-02-26T15:45:04.6749611Z Device 4 is not connected to Device 7
```

### What's changed
Test no longer fails

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
