### PR TITLE
[2D Fabric] Add sync b/w controller kernels for bidirectional ubench

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
@@ -5,8 +5,15 @@
 // clang-format off
 #include "dataflow_api.h"
 #include "debug/dprint.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_interface.h"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/common/kernel_utils.hpp"
 // clang-format on
+
+using namespace tt::tt_fabric;
+
+#define CONTROLLER_HANDSHAKE_START 0x4
+#define CONTROLLER_HANDSHAKE_END 0x8
 
 void kernel_main() {
     uint32_t rt_args_idx = 0;
@@ -16,6 +23,7 @@ void kernel_main() {
     uint32_t host_signal_address = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t num_mcast_dests = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t mcast_encoding = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t sync_with_remote = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
 
     // wait for sync from tx kernels
     while (*(volatile tt_l1_ptr uint32_t*)tx_signal_addr != num_tx_workers);
@@ -26,6 +34,55 @@ void kernel_main() {
 
     tt_l1_ptr uint32_t* mcast_sem = reinterpret_cast<tt_l1_ptr uint32_t*>(0x100000);
     *mcast_sem = 1;
+
+    if (sync_with_remote) {
+        uint32_t dest_device = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+        uint32_t remote_controller_noc_encoding = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+        uint32_t outbound_eth_chan = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+
+        uint32_t remote_notification_addr = host_signal_address + 16;
+        uint32_t pkt_hdr_address = remote_notification_addr + 16;
+        uint32_t payload_address = pkt_hdr_address + PACKET_HEADER_SIZE_BYTES;
+        uint32_t payload_size_bytes = 16;
+        uint32_t client_interface_addr = payload_address + payload_size_bytes;
+
+        volatile tt_l1_ptr uint32_t* data_buf = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(payload_address);
+        volatile tt_l1_ptr uint32_t* poll_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_notification_addr);
+
+        volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface =
+            reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
+
+        fabric_endpoint_init<RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
+
+        uint64_t dst_noc_addr = get_noc_addr_helper(remote_controller_noc_encoding, remote_notification_addr);
+
+        data_buf[0] = CONTROLLER_HANDSHAKE_START;
+        fabric_async_write<AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
+            client_interface,
+            0,
+            pkt_hdr_address,
+            dest_device >> 16,
+            dest_device & 0xFFFF,
+            dst_noc_addr,
+            payload_size_bytes + PACKET_HEADER_SIZE_BYTES);
+        fabric_wait_for_pull_request_flushed(client_interface);
+
+        while (*poll_addr != CONTROLLER_HANDSHAKE_START);
+
+        data_buf[0] = CONTROLLER_HANDSHAKE_END;
+        fabric_async_write<AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
+            client_interface,
+            0,
+            pkt_hdr_address,
+            dest_device >> 16,
+            dest_device & 0xFFFF,
+            dst_noc_addr,
+            payload_size_bytes + PACKET_HEADER_SIZE_BYTES);
+        fabric_wait_for_pull_request_flushed(client_interface);
+
+        while (*poll_addr != CONTROLLER_HANDSHAKE_END);
+    }
 
     // do a noc multicast to tx kernels
     uint64_t mcast_dest_addr = get_noc_addr_helper(mcast_encoding, tx_signal_addr);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -776,6 +776,9 @@ typedef struct test_traffic {
     uint32_t rx_buf_size;
     uint32_t num_links_to_use;
     uint32_t link_idx = 0;
+    bool sync_with_remote_controller_kernel = false;
+    uint32_t remote_controller_noc_encoding;
+    uint32_t remote_controller_mesh_chip_id;
 
     test_traffic(
         std::shared_ptr<test_device_t>& tx_device_,
@@ -834,6 +837,13 @@ typedef struct test_traffic {
         }
     }
 
+    void set_remote_controller(test_traffic& reverse_traffic) {
+        sync_with_remote_controller_kernel = true;
+        auto remote_tx_device = reverse_traffic.tx_device;
+        remote_controller_noc_encoding = remote_tx_device->get_noc_offset(reverse_traffic.controller_logical_core);
+        remote_controller_mesh_chip_id = remote_tx_device->mesh_chip_id;
+    }
+
     void create_kernels(
         std::vector<uint32_t>& tx_compile_args,
         std::vector<uint32_t>& rx_compile_args,
@@ -859,13 +869,21 @@ typedef struct test_traffic {
             // launch controller kernel
             // TODO: remove hardcoding
             std::vector<uint32_t> runtime_args = {
-                time_seed,            // 0: time based seed
-                num_tx_workers,       // 1: number of workers for mcast
-                tx_signal_address,    // 2: address to send signal on to workers
-                host_signal_address,  // 3: address to receive signal from host
-                64,                   // 4: num mcast dest
-                mcast_encoding,       // 5: mcast dest noc encoding
+                time_seed,                          // 0: time based seed
+                num_tx_workers,                     // 1: number of workers for mcast
+                tx_signal_address,                  // 2: address to send signal on to workers
+                host_signal_address,                // 3: address to receive signal from host
+                64,                                 // 4: num mcast dest
+                mcast_encoding,                     // 5: mcast dest noc encoding
+                sync_with_remote_controller_kernel  // 6: if need to sync with the remote controller kernel
             };
+
+            // if need to sync with remote controller
+            if (sync_with_remote_controller_kernel) {
+                runtime_args.push_back(remote_controller_mesh_chip_id);
+                runtime_args.push_back(remote_controller_noc_encoding);
+                runtime_args.push_back(std::get<0>(tx_workers[0]));
+            }
 
             // zero out the signal address
             tt::llrt::write_hex_vec_to_core(
@@ -874,6 +892,16 @@ typedef struct test_traffic {
             // zero out host sync address
             tt::llrt::write_hex_vec_to_core(
                 tx_device->physical_chip_id, controller_virtual_core, zero_buf, host_signal_address);
+
+            log_info(
+                LogTest,
+                "[Device: Phys: {}, Logical: {}] Controller running on: logical: x={},y={}; virtual: x={},y={}",
+                tx_device->physical_chip_id,
+                (uint32_t)tx_device->logical_chip_id,
+                controller_logical_core.x,
+                controller_logical_core.y,
+                controller_virtual_core.x,
+                controller_virtual_core.y);
 
             auto kernel = tt_metal::CreateKernel(
                 tx_device->program_handle,
@@ -1528,7 +1556,7 @@ int main(int argc, char **argv) {
                 target_address,
                 num_hops,
                 num_links);
-            fabric_traffic.push_back(traffic);
+            fabric_traffic.push_back(std::move(traffic));
 
             if (bidirectional_traffic) {
                 std::vector<std::shared_ptr<test_device_t>> rx_devices = {test_devices[tx_chip_id]};
@@ -1540,7 +1568,14 @@ int main(int argc, char **argv) {
                     target_address,
                     num_hops,
                     num_links);
-                fabric_traffic.push_back(traffic_r);
+                fabric_traffic.push_back(std::move(traffic_r));
+            }
+
+            if (bidirectional_traffic && benchmark_mode) {
+                auto& traffic_fwd = fabric_traffic.at(fabric_traffic.size() - 2);
+                auto& traffic_bwd = fabric_traffic.at(fabric_traffic.size() - 1);
+                traffic_fwd.set_remote_controller(traffic_bwd);
+                traffic_bwd.set_remote_controller(traffic_fwd);
             }
 
             num_allocated_devices += 1 + rx_chip_ids.size();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17573)

### Problem description
For bidirectional ubench, the respective controller kernels need to handshake before the tx kernels can start transmitting.

### What's changed
Add a handshake protocol b/w the controller kernels

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13559002772)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
