### PR TITLE
#18058: Move init_sync_registers to TRISC0

### DIFF
--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -45,6 +45,7 @@ constexpr uint32_t RUN_SYNC_MSG_GO = 0x80;
 // Trigger loading CBs (and IRAM) before actually running the kernel.
 constexpr uint32_t RUN_SYNC_MSG_LOAD = 0x1;
 constexpr uint32_t RUN_SYNC_MSG_WAITING_FOR_RESET = 0x2;
+constexpr uint32_t RUN_SYNC_MSG_INIT_SYNC_REGISTERS = 0x3;
 constexpr uint32_t RUN_SYNC_MSG_DONE = 0;
 constexpr uint32_t RUN_SYNC_MSG_ALL_GO = 0x80808080;
 constexpr uint32_t RUN_SYNC_MSG_ALL_SLAVES_DONE = 0;

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -19,6 +19,7 @@
 #include "circular_buffer.h"
 #include "circular_buffer_init.h"
 #endif
+#include "circular_buffer_constants.h"
 // clang-format on
 
 #if defined(PROFILE_KERNEL)
@@ -75,6 +76,17 @@ constexpr bool cb_init_write = false;
 
 using namespace ckernel;
 
+void init_sync_registers() {
+    volatile tt_reg_ptr uint* tiles_received_ptr;
+    volatile tt_reg_ptr uint* tiles_acked_ptr;
+    for (uint32_t operand = 0; operand < NUM_CIRCULAR_BUFFERS; operand++) {
+        tiles_received_ptr = get_cb_tiles_received_ptr(operand);
+        tiles_received_ptr[0] = 0;
+        tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
+        tiles_acked_ptr[0] = 0;
+    }
+}
+
 int main(int argc, char *argv[]) {
     configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
@@ -92,6 +104,12 @@ int main(int argc, char *argv[]) {
     while (1) {
         WAYPOINT("W");
         while (*trisc_run != RUN_SYNC_MSG_GO) {
+            if constexpr (COMPILE_FOR_TRISC == 0) {
+                if (*trisc_run == RUN_SYNC_MSG_INIT_SYNC_REGISTERS) {
+                    init_sync_registers();
+                    *trisc_run = RUN_SYNC_MSG_DONE;
+                }
+            }
             invalidate_l1_cache();
         }
         DeviceZoneScopedMainN("TRISC-FW");

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -638,6 +638,8 @@ void WatcherDeviceReader::DumpRunState(CoreDescriptor& core, const launch_msg_t*
         code = 'L';
     } else if (state == RUN_SYNC_MSG_WAITING_FOR_RESET) {
         code = 'W';
+    } else if (state == RUN_SYNC_MSG_INIT_SYNC_REGISTERS) {
+        code = 'S';
     }
     if (code == 'U') {
         LogRunningKernels(core, launch_msg);


### PR DESCRIPTION
### Ticket
#18058

### Problem description
Initializing all the sync registers takes around 120 cycles on wormhole.

### What's changed
 By moving the work to TRISC0 (when it's already idle) we can cut the cost to BRISC by around 100 cycles.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
