### PR TITLE
Add a ThreadPool class backed by boost::asio::thread_pool for TT-Mesh

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -466,5 +466,65 @@ TEST_F(MeshBufferTestSuite, ColMajorShardingAndReplication) {
     }
 }
 
+TEST_F(MeshBufferTestSuite, MultiShardReadWrite) {
+    constexpr uint32_t NUM_ITERS = 50;
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", 0);
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+
+    std::uniform_int_distribution<int> gen_num_datums(32, 128);
+    std::mt19937 rng(seed);
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size,
+        .buffer_type = BufferType::DRAM,
+        .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+        .bottom_up = true};
+
+    distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
+
+    uint32_t rows = mesh_device_->num_rows();
+    uint32_t cols = mesh_device_->num_cols();
+    uint32_t num_devices = rows * cols;
+
+    for (auto shard_orientation : {ShardOrientation::COL_MAJOR, ShardOrientation::ROW_MAJOR}) {
+        for (int i = 0; i < NUM_ITERS; i++) {
+            Shape2D global_buffer_shape = {
+                gen_num_datums(rng) * constants::TILE_HEIGHT * rows,
+                gen_num_datums(rng) * constants::TILE_WIDTH * cols};
+            Shape2D shard_shape = {global_buffer_shape.height() / rows, global_buffer_shape.width() / cols};
+            uint32_t global_buffer_size = global_buffer_shape.height() * global_buffer_shape.width() * sizeof(uint32_t);
+            ShardedBufferConfig sharded_config{
+                .global_size = global_buffer_size,
+                .global_buffer_shape = global_buffer_shape,
+                .shard_shape = shard_shape,
+                .shard_orientation = shard_orientation,
+            };
+            auto mesh_buffer = MeshBuffer::create(sharded_config, per_device_buffer_config, mesh_device_.get());
+
+            std::vector<uint32_t> src_vec =
+                std::vector<uint32_t>(global_buffer_size / num_devices / sizeof(uint32_t), 0);
+            std::iota(src_vec.begin(), src_vec.end(), i);
+            std::unordered_map<distributed::MeshCoordinate, std::vector<uint32_t>> dst_vec = {};
+            std::vector<MeshCommandQueue::ShardDataTransfer> input_shards = {};
+            std::vector<MeshCommandQueue::ShardDataTransfer> output_shards = {};
+
+            for (auto& coord : coord_range) {
+                input_shards.push_back({coord, src_vec.data()});
+            }
+            for (auto& coord : coord_range) {
+                dst_vec[coord] = std::vector<uint32_t>(global_buffer_size / num_devices / sizeof(uint32_t), 0);
+                output_shards.push_back({coord, dst_vec[coord].data()});
+            }
+
+            mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
+            mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+
+            for (auto& dst : dst_vec) {
+                EXPECT_EQ(dst.second, src_vec);
+            }
+        }
+    }
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed::test

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -15,7 +15,11 @@
 #include "mesh_trace.hpp"
 #include "mesh_trace_id.hpp"
 
-namespace tt::tt_metal::distributed {
+namespace tt::tt_metal {
+
+class ThreadPool;
+
+namespace distributed {
 
 class MeshEvent;
 struct MeshReadEventDescriptor;
@@ -111,9 +115,15 @@ private:
     CoreCoord dispatch_core_;
     CoreType dispatch_core_type_ = CoreType::WORKER;
     std::queue<std::shared_ptr<MeshReadEventDescriptor>> event_descriptors_;
+    // MeshCommandQueues and the MeshDevice share the thread-pool
+    std::shared_ptr<ThreadPool> thread_pool_;
 
 public:
-    MeshCommandQueue(MeshDevice* mesh_device, uint32_t id);
+    MeshCommandQueue(MeshDevice* mesh_device, uint32_t id, std::shared_ptr<ThreadPool>& thread_pool);
+
+    MeshCommandQueue(const MeshCommandQueue& other) = delete;
+    MeshCommandQueue& operator=(const MeshCommandQueue& other) = delete;
+
     MeshDevice* device() const { return mesh_device_; }
     uint32_t id() const { return id_; }
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_[index]; };
@@ -167,4 +177,6 @@ public:
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking);
 };
 
-}  // namespace tt::tt_metal::distributed
+}  // namespace distributed
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -21,6 +21,7 @@
 namespace tt::tt_metal {
 
 class SubDeviceManagerTracker;
+class ThreadPool;
 
 namespace distributed {
 
@@ -65,6 +66,7 @@ private:
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     std::unordered_map<MeshTraceId, std::shared_ptr<MeshTraceBuffer>> trace_buffer_pool_;
     uint32_t trace_buffers_size_ = 0;
+    std::shared_ptr<ThreadPool> thread_pool_;
     std::recursive_mutex push_work_mutex_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
         tt_backend_api_types.cpp
         utils.cpp
         work_split.cpp
+        thread_pool.cpp
 )
 
 target_include_directories(

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <boost/asio.hpp>
+#include <future>
+#include <iostream>
+
+#include "tt_metal/common/thread_pool.hpp"
+
+namespace tt::tt_metal {
+
+namespace detail {
+
+class BoostThreadPool : public ThreadPool {
+public:
+    BoostThreadPool(size_t thread_count) : pool_(thread_count) {
+        // Given the current use case, we don't expect to
+        // enqueue more tasks than the number of threads.
+        // Add a factor of safety and modify as needed.
+        futures_.reserve(thread_count * 4);
+    }
+
+    ~BoostThreadPool() noexcept override = default;
+
+    void enqueue(std::function<void()>&& f) override {
+        std::packaged_task<void()> task(std::move(f));
+        futures_.push_back(task.get_future());
+        boost::asio::post(pool_, [executor = std::move(task)]() mutable { executor(); });
+    }
+
+    void wait() override {
+        for (auto& future : futures_) {
+            future.get();
+        }
+        futures_.clear();
+    }
+
+private:
+    boost::asio::thread_pool pool_;
+    std::vector<std::future<void>> futures_;
+};
+
+}  // namespace detail
+
+std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads) {
+    return std::make_shared<detail::BoostThreadPool>(num_threads);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <thread>
+
+namespace tt::tt_metal {
+
+class ThreadPool {
+public:
+    virtual ~ThreadPool() = default;
+    virtual void enqueue(std::function<void()>&& f) = 0;
+    virtual void wait() = 0;
+};
+
+std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -15,7 +15,7 @@
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-
+#include "tt_metal/common/thread_pool.hpp"
 #include "tt_cluster.hpp"
 
 namespace tt::tt_metal::distributed {
@@ -25,7 +25,8 @@ struct MeshReadEventDescriptor {
     MeshCoordinateRange device_range;
 };
 
-MeshCommandQueue::MeshCommandQueue(MeshDevice* mesh_device, uint32_t id) {
+MeshCommandQueue::MeshCommandQueue(MeshDevice* mesh_device, uint32_t id, std::shared_ptr<ThreadPool>& thread_pool) :
+    thread_pool_(thread_pool) {
     this->mesh_device_ = mesh_device;
     this->id_ = id;
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
@@ -388,14 +389,24 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
     bool blocking,
     std::optional<BufferRegion> region) {
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
+        // Multi-Threaded writes supported for Replicated buffers.
+        // Currently not supported when doing TT-Mesh Native sharding, since we
+        // rely on TTNN to perform sharding and call enqueue_write_shards
+        auto dispatch_lambda =
+            std::function<void(MeshCoordinate)>([this, &buffer, host_data, &region](MeshCoordinate&& coord) {
+                auto device_shard_view = buffer.get_device_buffer(coord);
+                const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
+                this->write_shard_to_device(device_shard_view, host_data, buffer_region);
+            });
+
         for (const auto& coord : device_range) {
-            auto device_shard_view = buffer.get_device_buffer(coord);
-            const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
-            this->write_shard_to_device(device_shard_view, host_data, buffer_region);
+            thread_pool_->enqueue([&dispatch_lambda, coord]() { dispatch_lambda(std::move(coord)); });
         }
+        thread_pool_->wait();
     } else {
         this->write_sharded_buffer(buffer, host_data);
     }
+
     if (blocking) {
         this->finish();
     }
@@ -420,13 +431,22 @@ void MeshCommandQueue::enqueue_write_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
-        write_shard_to_device(
-            device_shard_view,
-            shard_data_transfer.host_data,
-            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+
+    auto dispatch_lambda =
+        std::function<void(uint32_t)>([&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
+            auto& shard_data_transfer = shard_data_transfers[shard_idx];
+            auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
+            this->write_shard_to_device(
+                device_shard_view,
+                shard_data_transfer.host_data,
+                shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+        });
+
+    for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
+        thread_pool_->enqueue([&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); });
     }
+    thread_pool_->wait();
+
     if (blocking) {
         this->finish();
     }
@@ -438,12 +458,23 @@ void MeshCommandQueue::enqueue_read_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
-        read_shard_from_device(
-            device_shard_view,
-            shard_data_transfer.host_data,
-            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+    auto dispatch_lambda =
+        std::function<void(uint32_t)>([&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
+            auto& shard_data_transfer = shard_data_transfers[shard_idx];
+            auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
+            read_shard_from_device(
+                device_shard_view,
+                shard_data_transfer.host_data,
+                shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+        });
+
+    for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
+        thread_pool_->enqueue([&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); });
+    }
+    thread_pool_->wait();
+
+    if (blocking) {
+        this->finish();
     }
 }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -21,6 +21,7 @@
 #include <sub_device_manager_tracker.hpp>
 #include <sub_device_manager.hpp>
 #include <sub_device_types.hpp>
+#include "tt_metal/common/thread_pool.hpp"
 
 #include <hal.hpp>
 #include <mesh_coord.hpp>
@@ -117,7 +118,8 @@ MeshDevice::MeshDevice(
     scoped_devices_(std::move(mesh_handle)),
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
-    parent_mesh_(std::move(parent_mesh)) {}
+    parent_mesh_(std::move(parent_mesh)),
+    thread_pool_(create_boost_thread_pool(view_->shape().mesh_size())) {}
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,
@@ -651,7 +653,7 @@ bool MeshDevice::initialize(
     mesh_command_queues_.reserve(this->num_hw_cqs());
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(std::make_unique<MeshCommandQueue>(this, cq_id));
+            mesh_command_queues_.push_back(std::make_unique<MeshCommandQueue>(this, cq_id, thread_pool_));
         }
     }
     return true;

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -128,8 +128,8 @@ int main(int argc, char** argv) {
     // Initialize command queue ids used for data movement and workload dispatch
     constexpr uint8_t data_movement_cq_id = 1;
     constexpr uint8_t workload_cq_id = 0;
-    auto data_movement_cq = mesh_device->mesh_command_queue(data_movement_cq_id);
-    auto workload_cq = mesh_device->mesh_command_queue(workload_cq_id);
+    auto& data_movement_cq = mesh_device->mesh_command_queue(data_movement_cq_id);
+    auto& workload_cq = mesh_device->mesh_command_queue(workload_cq_id);
 
     // =========== Step 1: Initialize and load two SubDevices ===========
     // Each SubDevice contains a single core. This SubDevice configuration is loaded on each physical device


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TT-Mesh needs a thread-pool to parallelize dispatch.

### What's changed
- Follow up, based on the discussion in: https://github.com/tenstorrent/tt-metal/pull/18270.
- Starting with a Boost back thread-pool implementation and limiting its usage to `MeshBuffer` Reads and Writes.
- Additional dispatch steps can be parallelized/additional thread-pool impls can be explored once we start measuring end to end performance.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
