### PR TITLE
Stop using a symlinked directory in CI, it just creates problems

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -194,7 +194,7 @@ jobs:
 
           args_fixme=$([ "${{ inputs.skip-tt-train }}" = "true" ] && echo "--build-metal-tests --build-ttnn-tests --build-programming-examples" || echo "--build-all")
           echo "Args: ${args_fixme}"
-          build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --toolchain-path ${{ inputs.toolchain }} ${args_fixme} --enable-ccache --configure-only --cpm-use-local-packages"
+          build_command="./build_metal.sh --build-dir build --build-type ${{ inputs.build-type }} --toolchain-path ${{ inputs.toolchain }} ${args_fixme} --enable-ccache --configure-only --cpm-use-local-packages"
           echo "Build tracy: ${{ inputs.tracy }}"
           if [ "${{ inputs.tracy }}" = "true" ]; then
             build_command="$build_command --enable-profiler"

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -63,7 +63,6 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           cp ./build/tt-train/3rd_party/wandb-cpp/libwandbcpp.so build/lib/
-          find ./build -type f -name "*.tcl" -o -name "*.cmake" -exec sed -i "s|/work/build_Release|/work/build|g" {} +
           cd /work/build/tt-train
           ldd tests/ttml_tests || true
           ${{ matrix.test-group.cmd }}


### PR DESCRIPTION
### Problem description
build_metal.sh has some magic logic in it to pick a build directory name, and then it creates a symlink to that directory.
This creates a scenario where the absolute paths on build machines do not match the absolute paths on test machines.
This has been known to cause problems for doing things like running CTest, or generating code coverage.

### What's changed
Add --build-dir option so, CI or anyone can choose their own build directory.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13563310430) CI passes (to a good enough extent)
- [x] New/Existing tests provide coverage for changes
