### PR TITLE
#17725: Update SD test parametrizations to use chosen WH sharding schemes 

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/parameterizations.py
+++ b/models/demos/wormhole/stable_diffusion/tests/parameterizations.py
@@ -20,7 +20,7 @@ CROSS_UP_BLOCKS_HIDDEN_STATES_INFO = (
 )
 
 # hidden states info, attention head dim, block (up/down/min), block index, attention index
-TRANSFORMER_PARAMETRIZATIONS = (
+TRANSFORMER_PARAMETERIZATIONS = (
     (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[0] + (40, "down", 0, 0)),
     (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[0] + (40, "down", 0, 1)),
     (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[1] + (80, "down", 1, 0)),

--- a/models/demos/wormhole/stable_diffusion/tests/parametrizations.py
+++ b/models/demos/wormhole/stable_diffusion/tests/parametrizations.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+# shape, shard_layout, shard end core, shard shape, attention head dim
+CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO = (
+    ([2, 320, 64, 64], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (4, 7), (1024, 64)),
+    ([2, 640, 32, 32], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (4, 7), (256, 128)),
+    ([2, 1280, 16, 16], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (7, 7), (64, 160)),
+)
+
+DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO = ([2, 1280, 8, 8], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (7, 3), (32, 160))
+
+CROSS_UP_BLOCKS_HIDDEN_STATES_INFO = (
+    ([2, 1280, 16, 16], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (7, 7), (64, 160)),
+    ([2, 640, 32, 32], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (4, 7), (256, 128)),
+    ([2, 320, 64, 64], ttnn.TensorMemoryLayout.BLOCK_SHARDED, (4, 7), (1024, 64)),
+)
+
+# hidden states info, attention head dim, block (up/down/min), block index, attention index
+TRANSFORMER_PARAMETRIZATIONS = (
+    (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[0] + (40, "down", 0, 0)),
+    (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[0] + (40, "down", 0, 1)),
+    (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[1] + (80, "down", 1, 0)),
+    (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[1] + (80, "down", 1, 1)),
+    (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[2] + (160, "down", 2, 0)),
+    (CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[2] + (160, "down", 2, 1)),
+    (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO + (160, "mid", 0, 0)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[0] + (160, "up", 1, 0)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[0] + (160, "up", 1, 1)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[0] + (160, "up", 1, 2)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[1] + (80, "up", 2, 0)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[1] + (80, "up", 2, 1)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[1] + (80, "up", 2, 2)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[2] + (40, "up", 3, 0)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[2] + (40, "up", 3, 1)),
+    (CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[2] + (40, "up", 3, 2)),
+)

--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -18,7 +18,7 @@ from models.utility_functions import (
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 
 
 @skip_for_grayskull()
@@ -26,7 +26,7 @@ from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSF
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
-    TRANSFORMER_PARAMETRIZATIONS,
+    TRANSFORMER_PARAMETERIZATIONS,
 )
 def test_basic_transformer_block_512x512(
     device,

--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -15,58 +15,52 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import (
     skip_for_grayskull,
 )
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    preprocess_and_push_input_to_device,
+)
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
-    "N, C, H, W, index, attention_head_dim",
-    [
-        (
-            1,
-            2,
-            4096,
-            320,
-            3,
-            40,
-        ),
-        (
-            1,
-            2,
-            1024,
-            640,
-            2,
-            80,
-        ),
-        (
-            1,
-            2,
-            256,
-            1280,
-            1,
-            160,
-        ),
-        (
-            1,
-            2,
-            64,
-            1280,
-            1,
-            160,
-        ),
-    ],
+    "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
+    TRANSFORMER_PARAMETRIZATIONS,
 )
-def test_basic_transformer_block_512x512(device, model_name, N, C, H, W, index, attention_head_dim):
+def test_basic_transformer_block_512x512(
+    device,
+    model_name,
+    input_shape,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    attention_head_dim,
+    block,
+    block_index,
+    attention_index,
+):
     torch.manual_seed(0)
+
+    N, C, H, W = input_shape
 
     pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
     model = pipe.unet
     model.eval()
     config = model.config
-    basic_transformer = pipe.unet.up_blocks[index].attentions[1].transformer_blocks[0]
 
-    hidden_states_shape = torch.Size([N, C, H, W])
+    if block == "up":
+        basic_transformer = pipe.unet.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "down":
+        basic_transformer = pipe.unet.down_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "mid":
+        basic_transformer = pipe.unet.mid_block.attentions[0].transformer_blocks[0]
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: basic_transformer, custom_preprocessor=custom_preprocessor, device=device
+    )
+
+    hidden_states_shape = torch.Size(input_shape)
     hidden_states = torch.rand(hidden_states_shape) * 0.01
     encoder_hidden_states_shape = [1, 2, 77, 768]
     encoder_hidden_states = torch.rand(encoder_hidden_states_shape)
@@ -76,32 +70,37 @@ def test_basic_transformer_block_512x512(device, model_name, N, C, H, W, index, 
     cross_attention_kwargs = None
     class_labels = None
 
-    torch_output = basic_transformer(hidden_states.squeeze(0), encoder_hidden_states.squeeze(0))
+    torch_hidden_states = torch.permute(hidden_states, [0, 2, 3, 1])
+    torch_hidden_states = torch.reshape(torch_hidden_states, [N, H * W, C])
+    torch_output = basic_transformer(torch_hidden_states, encoder_hidden_states.squeeze(0))
 
-    parameters = preprocess_model_parameters(
-        initialize_model=lambda: basic_transformer, custom_preprocessor=custom_preprocessor, device=device
-    )
-    model = basic_transformer_block(device, parameters, seq_len=H)
+    model = basic_transformer_block(device, parameters, seq_len=H * W)
 
-    hidden_states = ttnn.from_torch(hidden_states, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
-    hidden_states = ttnn.to_device(hidden_states, device, memory_config=ttnn.L1_MEMORY_CONFIG)
     encoder_hidden_states = torch.nn.functional.pad(encoder_hidden_states, (0, 0, 0, 19))
     encoder_hidden_states = ttnn.from_torch(encoder_hidden_states, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
     encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
-    grid_sizes = {8192: (5, 8), 2048: (5, 8), 512: (8, 8), 128: (8, 4)}
-    hidden_states = ttnn.reshape(
-        hidden_states, [1, 1, hidden_states.shape[-3] * hidden_states.shape[-2], hidden_states.shape[-1]]
+    hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            shard_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
     )
 
-    grid_size = grid_sizes[hidden_states.shape[-2]]
-    hidden_states = ttnn.interleaved_to_sharded(
-        hidden_states,
-        grid_size,
-        [hidden_states.volume() // hidden_states.shape[-1] // grid_size[1], hidden_states.shape[-1] // grid_size[0]],
-        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
     ttnn_output = model(
         hidden_states=hidden_states,
         encoder_hidden_states=encoder_hidden_states,

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
@@ -12,96 +12,58 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_cross_attention i
     cross_attention,
 )
 from ttnn.model_preprocessing import preprocess_model_parameters
-from tests.ttnn.utils_for_testing import assert_with_pcc, comp_pcc
+from tests.ttnn.utils_for_testing import comp_pcc
 from models.utility_functions import (
     skip_for_grayskull,
 )
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    preprocess_and_push_input_to_device,
+)
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+@pytest.mark.parametrize("has_encoder_hidden_states", (True, False))
 @pytest.mark.parametrize(
-    "N, C, H, W, index, has_encoder_hidden_states",
-    [
-        (
-            1,
-            2,
-            4096,
-            320,
-            3,
-            True,
-        ),
-        (
-            1,
-            2,
-            4096,
-            320,
-            3,
-            False,
-        ),
-        (
-            1,
-            2,
-            1024,
-            640,
-            2,
-            True,
-        ),
-        (
-            1,
-            2,
-            1024,
-            640,
-            2,
-            False,
-        ),
-        (
-            1,
-            2,
-            256,
-            1280,
-            1,
-            True,
-        ),
-        (
-            1,
-            2,
-            256,
-            1280,
-            1,
-            False,
-        ),
-        (
-            1,
-            2,
-            64,
-            1280,
-            1,
-            True,
-        ),
-        (
-            1,
-            2,
-            64,
-            1280,
-            1,
-            False,
-        ),
-    ],
+    "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
+    TRANSFORMER_PARAMETRIZATIONS,
 )
-def test_cross_attention_512x512(device, model_name, N, C, H, W, index, has_encoder_hidden_states):
+def test_cross_attention_512x512(
+    device,
+    model_name,
+    input_shape,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    attention_head_dim,
+    has_encoder_hidden_states,
+    block,
+    block_index,
+    attention_index,
+):
     torch.manual_seed(0)
     device.enable_program_cache()
+
+    N, C, H, W = input_shape
 
     pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
     model = pipe.unet
     model.eval()
 
-    hidden_states_shape = torch.Size([N, C, H, W])
+    hidden_states_shape = torch.Size(input_shape)
     hidden_states = torch.rand(hidden_states_shape)
+
+    if block == "up":
+        basic_transformer = pipe.unet.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "down":
+        basic_transformer = pipe.unet.down_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "mid":
+        basic_transformer = pipe.unet.mid_block.attentions[0].transformer_blocks[0]
+
     if has_encoder_hidden_states:
-        cross_attn = pipe.unet.up_blocks[index].attentions[0].transformer_blocks[0].attn2
+        cross_attn = basic_transformer.attn2
 
         encoder_hidden_states_shape = torch.Size([1, 2, 77, 768])
         encoder_hidden_states = torch.rand(encoder_hidden_states_shape)
@@ -110,12 +72,14 @@ def test_cross_attention_512x512(device, model_name, N, C, H, W, index, has_enco
         ttnn_encoder_hidden_states = ttnn.from_torch(encoder_hidden_states, dtype=ttnn.bfloat16)
         ttnn_encoder_hidden_states = ttnn.to_device(ttnn_encoder_hidden_states, device)
     else:
-        cross_attn = pipe.unet.up_blocks[index].attentions[0].transformer_blocks[0].attn1
+        cross_attn = basic_transformer.attn1
         encoder_hidden_states = None
         ttnn_encoder_hidden_states = None
 
+    torch_hidden_states = torch.permute(hidden_states, [0, 2, 3, 1])
+    torch_hidden_states = torch.reshape(torch_hidden_states, [N, H * W, C])
     encoder_hidden_states = encoder_hidden_states.squeeze(0) if encoder_hidden_states is not None else None
-    torch_output = cross_attn(hidden_states.squeeze(0), encoder_hidden_states).unsqueeze(0)
+    torch_output = cross_attn(torch_hidden_states.squeeze(0), encoder_hidden_states).unsqueeze(0)
 
     parameters = preprocess_model_parameters(
         initialize_model=lambda: cross_attn, custom_preprocessor=custom_preprocessor, device=device
@@ -129,16 +93,33 @@ def test_cross_attention_512x512(device, model_name, N, C, H, W, index, has_enco
     else:
         ttnn_encoder_hidden_states = None
 
-    hidden_states = hidden_states.reshape(1, 1, N * C * H, W)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_hidden_states = ttnn.to_device(ttnn_hidden_states, device)
+    ttnn_hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            shard_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
 
-    model = cross_attention(device, parameters, seq_len=H)
+    model = cross_attention(device, parameters, seq_len=H * W)
     ttnn_output = model(
         ttnn_hidden_states,
         ttnn_encoder_hidden_states,
         attention_mask=None,
-        dim_head=W // 8,
+        dim_head=attention_head_dim,
     )
     ttnn_output = ttnn.to_torch(ttnn_output)
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
@@ -19,7 +19,7 @@ from models.utility_functions import (
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 
 
 @skip_for_grayskull()
@@ -28,7 +28,7 @@ from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSF
 @pytest.mark.parametrize("has_encoder_hidden_states", (True, False))
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
-    TRANSFORMER_PARAMETRIZATIONS,
+    TRANSFORMER_PARAMETERIZATIONS,
 )
 def test_cross_attention_512x512(
     device,

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -17,6 +17,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     preprocess_and_push_input_to_device,
     post_process_output_and_move_to_host,
 )
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.utility_functions import skip_for_grayskull, torch_random
 from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -25,13 +26,12 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
-    "hidden_states, shard_end_core, shard_shape",
-    [
-        ([2, 1280, 8, 8], (7, 3), (32, 160)),
-    ],
+    "hidden_states, shard_layout, shard_end_core, shard_shape", (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,)
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
-def test_cross_attention_midblock_512x512(reset_seeds, device, hidden_states, shard_end_core, shard_shape, temb):
+def test_cross_attention_midblock_512x512(
+    reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb
+):
     # Initialize PyTorch component
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
     unet = pipe.unet
@@ -70,7 +70,7 @@ def test_cross_attention_midblock_512x512(reset_seeds, device, hidden_states, sh
         device,
         hidden_states,
         memory_config=ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            shard_layout,
             ttnn.BufferType.L1,
             ttnn.ShardSpec(
                 ttnn.CoreRangeSet(

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -17,7 +17,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     preprocess_and_push_input_to_device,
     post_process_output_and_move_to_host,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 from models.utility_functions import skip_for_grayskull, torch_random
 from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -22,7 +22,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     preprocess_and_push_input_to_device,
     post_process_output_and_move_to_host,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 
 
 @skip_for_grayskull()

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -22,13 +22,16 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     preprocess_and_push_input_to_device,
     post_process_output_and_move_to_host,
 )
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-@pytest.mark.parametrize("hidden_states, shard_end_core, shard_shape", [([2, 1280, 8, 8], (7, 3), (32, 160))])
+@pytest.mark.parametrize(
+    "hidden_states, shard_layout, shard_end_core, shard_shape", (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,)
+)
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
-def test_downblock_512x512(reset_seeds, device, hidden_states, shard_end_core, shard_shape, temb):
+def test_downblock_512x512(reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb):
     # Initialize PyTorch component
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
     unet = pipe.unet
@@ -62,7 +65,7 @@ def test_downblock_512x512(reset_seeds, device, hidden_states, shard_end_core, s
         device,
         hidden_states,
         memory_config=ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            shard_layout,
             ttnn.BufferType.L1,
             ttnn.ShardSpec(
                 ttnn.CoreRangeSet(

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -22,7 +22,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     preprocess_and_push_input_to_device,
     post_process_output_and_move_to_host,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO
 
 
 @skip_for_grayskull()

--- a/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
@@ -8,59 +8,55 @@ import torch
 from diffusers import UNet2DConditionModel
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
-
-from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_feedforward import feedforward
 from models.utility_functions import torch_random
-
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import (
     skip_for_grayskull,
 )
+
+from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_feedforward import feedforward
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    preprocess_and_push_input_to_device,
+)
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
-    "N, C, H, W, index",
-    [
-        (
-            1,
-            2,
-            4096,
-            320,
-            3,
-        ),
-        (
-            1,
-            2,
-            1024,
-            640,
-            2,
-        ),
-        (
-            1,
-            2,
-            256,
-            1280,
-            1,
-        ),
-        (
-            1,
-            2,
-            64,
-            1280,
-            1,
-        ),
-    ],
+    "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
+    TRANSFORMER_PARAMETRIZATIONS,
 )
-def test_feedforward_512x512(device, model_name, N, C, H, W, index, reset_seeds):
-    input_shapes = (N, C, H, W)
+def test_feedforward_512x512(
+    device,
+    model_name,
+    input_shape,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    attention_head_dim,
+    block,
+    block_index,
+    attention_index,
+):
     model = UNet2DConditionModel.from_pretrained(model_name, subfolder="unet").eval()
-    ref_model = model.up_blocks[index].attentions[0].transformer_blocks[0].ff
+
+    if block == "up":
+        basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "down":
+        basic_transformer = model.down_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "mid":
+        basic_transformer = model.mid_block.attentions[0].transformer_blocks[0]
+
+    ref_model = basic_transformer.ff
     config = model.config
-    torch_hidden_states = torch_random(input_shapes, -0.1, 0.1, dtype=torch.float32)
+
+    N, C, H, W = input_shape
+    hidden_states = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_hidden_states = torch.permute(hidden_states, [0, 2, 3, 1])
+    torch_hidden_states = torch.reshape(torch_hidden_states, [N, H * W, C])
     torch_output = ref_model(torch_hidden_states)
 
     parameters = preprocess_model_parameters(
@@ -70,13 +66,29 @@ def test_feedforward_512x512(device, model_name, N, C, H, W, index, reset_seeds)
     )
     model = feedforward(device, parameters)
 
-    ttnn_hidden_state = torch_hidden_states.reshape(
-        (1, 1, torch_hidden_states.shape[-3] * torch_hidden_states.shape[-2], torch_hidden_states.shape[-1])
+    ttnn_hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            shard_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+        dtype=ttnn.bfloat16,
     )
-    ttnn_hidden_state = ttnn.from_torch(ttnn_hidden_state, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-    ttnn_hidden_state = ttnn.to_device(ttnn_hidden_state, device)
 
-    output = model(config, ttnn_hidden_state)
+    output = model(config, ttnn_hidden_states)
     output = ttnn.from_device(output)
     output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
     output = ttnn.to_torch(output)

--- a/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
@@ -19,7 +19,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_feedforward impor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 
 
 @skip_for_grayskull()
@@ -27,7 +27,7 @@ from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSF
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
-    TRANSFORMER_PARAMETRIZATIONS,
+    TRANSFORMER_PARAMETERIZATIONS,
 )
 def test_feedforward_512x512(
     device,

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -15,50 +15,50 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_geglu import gegl
 from models.utility_functions import torch_random, skip_for_grayskull
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    preprocess_and_push_input_to_device,
+)
+
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
-    "N, C, H, W, index",
-    [
-        (
-            1,
-            2,
-            4096,
-            320,
-            3,
-        ),
-        (
-            1,
-            2,
-            1024,
-            640,
-            2,
-        ),
-        (
-            1,
-            2,
-            256,
-            1280,
-            1,
-        ),
-        (
-            1,
-            2,
-            64,
-            1280,
-            1,
-        ),
-    ],
+    "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
+    TRANSFORMER_PARAMETRIZATIONS,
 )
-def test_geglu_512x512(device, model_name, N, C, H, W, index, reset_seeds):
-    input_shapes = (N, C, H, W)
+def test_geglu_512x512(
+    device,
+    model_name,
+    input_shape,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    attention_head_dim,
+    block,
+    block_index,
+    attention_index,
+):
     model = UNet2DConditionModel.from_pretrained(model_name, subfolder="unet").eval()
-    ref_model = model.up_blocks[index].attentions[0].transformer_blocks[0].ff.net[0]
+
+    if block == "up":
+        basic_transformer = model.up_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "down":
+        basic_transformer = model.down_blocks[block_index].attentions[attention_index].transformer_blocks[0]
+    elif block == "mid":
+        basic_transformer = model.mid_block.attentions[0].transformer_blocks[0]
+
+    ref_model = basic_transformer.ff.net[0]
     config = model.config
-    torch_hidden_states = torch_random(input_shapes, -1, 1, dtype=torch.float32)
+
+    N, C, H, W = input_shape
+
+    hidden_states = torch_random(input_shape, -1, 1, dtype=torch.float32)
+    torch_hidden_states = torch.permute(hidden_states, [0, 2, 3, 1])
+    torch_hidden_states = torch.reshape(torch_hidden_states, [N, H * W, C])
+
     torch_output = ref_model(torch_hidden_states)
 
     parameters = preprocess_model_parameters(
@@ -68,16 +68,32 @@ def test_geglu_512x512(device, model_name, N, C, H, W, index, reset_seeds):
     )
     model = geglu(device, parameters=parameters)
 
-    torch_hidden_states = torch_hidden_states.reshape(
-        1, 1, torch_hidden_states.shape[-3] * torch_hidden_states.shape[-2], torch_hidden_states.shape[-1]
+    ttnn_hidden_states = preprocess_and_push_input_to_device(
+        device,
+        hidden_states,
+        memory_config=ttnn.MemoryConfig(
+            shard_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+        dtype=ttnn.bfloat16,
     )
-    ttnn_hidden_state = ttnn.from_torch(torch_hidden_states, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-    ttnn_hidden_state = ttnn.to_device(ttnn_hidden_state, device)
 
-    output = model(config, ttnn_hidden_state)
+    output = model(config, ttnn_hidden_states)
     output = ttnn.from_device(output)
     output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
     output = ttnn.to_torch(output)
     output = output.reshape(1, 2, output.shape[-2] // 2, output.shape[-1])
 
-    assert_with_pcc(torch_output, output.to(torch_output.dtype), 0.99)
+    assert_with_pcc(torch_output, output.to(torch_output.dtype).squeeze(0), 0.99)

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -19,7 +19,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     preprocess_and_push_input_to_device,
 )
 
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 
 
 @skip_for_grayskull()
@@ -27,7 +27,7 @@ from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSF
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
-    TRANSFORMER_PARAMETRIZATIONS,
+    TRANSFORMER_PARAMETERIZATIONS,
 )
 def test_geglu_512x512(
     device,

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -15,7 +15,10 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_resnetblock2d_new_conv import resnetBlock2D
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import conv_cache
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    conv_cache,
+    preprocess_and_push_input_to_device,
+)
 
 
 def ttnn_to_torch(input):
@@ -28,43 +31,58 @@ def ttnn_to_torch(input):
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, in_channels, input_height, input_width, index1, index2, block_name, out_channels",
+    "batch_size, in_channels, input_height, input_width, memory_layout, buffer_type, shard_end_core, shard_shape, out_channels, use_in_shortcut, block_name, block_index, resnet_index",
     [
+        # fmt: off
         # down block 0
-        (2, 320, 64, 64, 0, 0, "down", 320),
-        (2, 320, 64, 64, 0, 1, "down", 320),
+        (2, 320, 64, 64, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, (7, 7), (128, 320), 320, False, "down", 0, 0),
+        (2, 320, 64, 64, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (4, 7), (1024, 64), 320, False, "down", 0, 1),
         # down block 1
-        (2, 320, 32, 32, 1, 0, "down", 640),
-        (2, 640, 32, 32, 1, 1, "down", 640),
+        (2, 320, 32, 32, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (4, 7), (256, 64), 640, True, "down", 1, 0),
+        (2, 640, 32, 32, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (4, 7), (256, 128), 640, False, "down", 1, 1),
         # down block 2
-        (2, 640, 16, 16, 2, 0, "down", 1280),
-        (2, 1280, 16, 16, 2, 1, "down", 1280),
+        (2, 640, 16, 16, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (4, 7), (64, 128), 1280, True, "down", 2, 0),
+        (2, 1280, 16, 16, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (7, 7), (64, 160), 1280, False, "down", 2, 1),
         # down block 3
-        (2, 1280, 8, 8, 3, 0, "down", 1280),
-        (2, 1280, 8, 8, 3, 1, "down", 1280),
+        (2, 1280, 8, 8, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (7, 3), (32, 160), 1280, None, "down", 3, 0),
+        (2, 1280, 8, 8, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (7, 3), (32, 160), 1280, None, "down", 3, 1),
         # mid
-        (2, 1280, 8, 8, 0, 0, "mid", 1280),
-        (2, 1280, 8, 8, 0, 1, "mid", 1280),
+        (2, 1280, 8, 8, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (7, 3), (32, 160), 1280, None, "mid", 0, 0),
+        (2, 1280, 8, 8, ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, (7, 3), (32, 160), 1280, None, "mid", 0, 1),
         # up block 0
-        (2, 2560, 8, 8, 0, 0, "up", 1280),
-        (2, 2560, 8, 8, 0, 1, "up", 1280),
-        (2, 2560, 8, 8, 0, 2, "up", 1280),
+        (2, 2560, 8, 8, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1, None, None, 1280, None, "up", 0, 0,),
+        (2, 2560, 8, 8, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1, None, None, 1280, None, "up", 0, 1),
+        (2, 2560, 8, 8, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1, None, None, 1280, None, "up", 0, 2),
         # up block 1
-        (2, 2560, 16, 16, 1, 0, "up", 1280),
-        (2, 2560, 16, 16, 1, 1, "up", 1280),
-        (2, 1920, 16, 16, 1, 2, "up", 1280),
+        (2, 2560, 16, 16, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 1280, None, "up", 1, 0),
+        (2, 2560, 16, 16, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 1280, None, "up", 1, 1),
+        (2, 1920, 16, 16, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 1280, None, "up", 1, 2),
         # up block 2
-        (2, 1920, 32, 32, 2, 0, "up", 640),
-        (2, 1280, 32, 32, 2, 1, "up", 640),
-        (2, 960, 32, 32, 2, 2, "up", 640),
+        (2, 1920, 32, 32, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 640, None, "up", 2, 0),
+        (2, 1280, 32, 32, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 640, None, "up", 2, 1),
+        (2, 960, 32, 32, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 640, None, "up", 2, 2),
         # up block 3
-        (2, 960, 64, 64, 3, 0, "up", 320),
-        (2, 640, 64, 64, 3, 1, "up", 320),
-        (2, 640, 64, 64, 3, 2, "up", 320),
+        (2, 960, 64, 64, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 320, None, "up", 3, 0),
+        (2, 640, 64, 64, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 320, None, "up", 3, 1),
+        (2, 640, 64, 64, ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None, None, 320, None, "up", 3, 2),
+        # fmt: on
     ],
 )
 def test_resnet_block_2d_512x512(
-    device, batch_size, in_channels, input_height, input_width, index1, index2, block_name, out_channels
+    device,
+    batch_size,
+    in_channels,
+    input_height,
+    input_width,
+    memory_layout,
+    buffer_type,
+    shard_end_core,
+    shard_shape,
+    out_channels,
+    use_in_shortcut,
+    block_name,
+    block_index,
+    resnet_index,
 ):
     load_from_disk = False
     if not load_from_disk:
@@ -80,14 +98,14 @@ def test_resnet_block_2d_512x512(
         )
 
         if block_name == "up":
-            parameters = parameters.up_blocks[index1].resnets[index2]
-            resnet = pipe.unet.up_blocks[index1].resnets[index2]
+            parameters = parameters.up_blocks[block_index].resnets[resnet_index]
+            resnet = pipe.unet.up_blocks[block_index].resnets[resnet_index]
         elif block_name == "down":
-            parameters = parameters.down_blocks[index1].resnets[index2]
-            resnet = pipe.unet.down_blocks[index1].resnets[index2]
+            parameters = parameters.down_blocks[block_index].resnets[resnet_index]
+            resnet = pipe.unet.down_blocks[block_index].resnets[resnet_index]
         else:
-            parameters = parameters.mid_block.resnets[index2]
-            resnet = pipe.unet.mid_block.resnets[index2]
+            parameters = parameters.mid_block.resnets[resnet_index]
+            resnet = pipe.unet.mid_block.resnets[resnet_index]
         torch.save(resnet, "resnet.pt")
         torch.save(config, "config.pt")
 
@@ -105,7 +123,6 @@ def test_resnet_block_2d_512x512(
     groups = 32
     time_embedding_norm = "default"
     output_scale_factor = 1
-    use_in_shortcut = None
     ########## end of residual block #############
     hidden_states_shape = [batch_size, in_channels, input_height, input_width]
     temb_shape = [1, 1, 2, 1280]
@@ -133,12 +150,31 @@ def test_resnet_block_2d_512x512(
         compute_kernel_config=compute_kernel_config,
     )
 
-    input = torch.permute(input, (0, 2, 3, 1))
-    input = ttnn.from_torch(input, ttnn.bfloat16)
-    input = ttnn.reshape(input, (1, 1, batch_size * input_height * input_width, in_channels))
+    memory_config = None
+    if memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED:
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+            buffer_type=buffer_type,
+        )
+    else:
+        memory_config = ttnn.MemoryConfig(
+            memory_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
 
-    input = ttnn.to_device(input, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    input = ttnn.to_layout(input, ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+    input = preprocess_and_push_input_to_device(device, input, memory_config=memory_config)
 
     temb = temb.permute(2, 0, 1, 3)  # pre-permute temb
     temb = ttnn.from_torch(temb, ttnn.bfloat16)

--- a/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
@@ -19,13 +19,13 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     post_process_output_and_move_to_host,
     preprocess_and_push_input_to_device,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import TRANSFORMER_PARAMETERIZATIONS
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
-    TRANSFORMER_PARAMETRIZATIONS,
+    TRANSFORMER_PARAMETERIZATIONS,
 )
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)

--- a/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
@@ -16,51 +16,32 @@ from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_p
 
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_transformer_2d_new_conv import transformer_2d_model
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
-    pre_process_input,
     post_process_output_and_move_to_host,
+    preprocess_and_push_input_to_device,
 )
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import TRANSFORMER_PARAMETRIZATIONS
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize(
-    "input_shape, index1, index2, attention_head_dim, block ",
-    [
-        (
-            (2, 320, 64, 64),
-            3,
-            2,
-            40,
-            "up",
-        ),
-        (
-            (2, 640, 32, 32),
-            1,
-            1,
-            80,
-            "down",
-        ),
-        (
-            (2, 1280, 16, 16),
-            2,
-            1,
-            160,
-            "down",
-        ),
-        (
-            (2, 1280, 8, 8),
-            2,
-            1,
-            160,
-            "down",
-        ),
-    ],
+    "input_shape, shard_layout, shard_end_core, shard_shape, attention_head_dim, block, block_index, attention_index",
+    TRANSFORMER_PARAMETRIZATIONS,
 )
 @pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_transformer_2d_model_512x512(
-    input_shape, index1, index2, block, attention_head_dim, model_name, device, reset_seeds
+    device,
+    model_name,
+    input_shape,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    attention_head_dim,
+    block,
+    block_index,
+    attention_index,
+    reset_seeds,
 ):
-    # TODO
     torch.manual_seed(0)
     encoder_hidden_states = [1, 2, 77, 768]
     timestep = (None,)
@@ -90,11 +71,11 @@ def test_transformer_2d_model_512x512(
     )
 
     if block == "up":
-        parameters = parameters.up_blocks[index1].attentions[index2]
-        transformer = pipe.unet.up_blocks[index1].attentions[index2]
+        parameters = parameters.up_blocks[block_index].attentions[attention_index]
+        transformer = pipe.unet.up_blocks[block_index].attentions[attention_index]
     elif block == "down":
-        parameters = parameters.down_blocks[index1].attentions[index2]
-        transformer = pipe.unet.down_blocks[index1].attentions[index2]
+        parameters = parameters.down_blocks[block_index].attentions[attention_index]
+        transformer = pipe.unet.down_blocks[block_index].attentions[attention_index]
     elif block == "mid":
         parameters = parameters.mid_block.attentions[0]
         transformer = pipe.unet.mid_block.attentions[0]
@@ -117,14 +98,25 @@ def test_transformer_2d_model_512x512(
     model = transformer_2d_model(
         device, parameters, input_shape[0], input_shape[2], input_shape[3], compute_kernel_config
     )
-    ttnn_hidden_state = pre_process_input(ttnn_hidden_state)
-    ttnn_hidden_state = ttnn.reshape(
-        ttnn_hidden_state,
-        (
-            1,
-            1,
-            ttnn_hidden_state.shape[0] * ttnn_hidden_state.shape[1] * ttnn_hidden_state.shape[2],
-            ttnn_hidden_state.shape[-1],
+
+    ttnn_hidden_state = preprocess_and_push_input_to_device(
+        device,
+        input,
+        memory_config=ttnn.MemoryConfig(
+            shard_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
         ),
     )
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -25,7 +25,7 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     preprocess_and_push_input_to_device,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 
 
 @skip_for_grayskull()

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -22,14 +22,22 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
     post_process_output_and_move_to_host,
     weight_to_bfp8,
 )
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    preprocess_and_push_input_to_device,
+)
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("res_hidden_states_tuple", [([2, 1280, 8, 8], [2, 1280, 8, 8], [2, 1280, 8, 8])])
-@pytest.mark.parametrize("hidden_states", [[2, 1280, 8, 8]])
+@pytest.mark.parametrize(
+    "hidden_states, shard_layout, shard_end_core, shard_shape", [DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO]
+)
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
-def test_upblock_512x512(reset_seeds, device, res_hidden_states_tuple, hidden_states, temb):
+def test_upblock_512x512(
+    reset_seeds, device, res_hidden_states_tuple, hidden_states, shard_layout, shard_end_core, shard_shape, temb
+):
     os.environ["SLOW_MATMULS"] = "1"
 
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
@@ -66,13 +74,26 @@ def test_upblock_512x512(reset_seeds, device, res_hidden_states_tuple, hidden_st
     # execute pytorch
     torch_output = unet_upblock(hidden_state, res_hidden_states_tuple, None, None)
 
-    hidden_state = ttnn.from_torch(hidden_state, ttnn.bfloat16)
-    hidden_state = ttnn.to_device(hidden_state, device, memory_config=ttnn.L1_MEMORY_CONFIG)
-    hidden_state = ttnn.permute(hidden_state, (0, 2, 3, 1))
-
-    hidden_state = ttnn.reshape(hidden_state, (1, 1, N * H * W, in_channels))
-
-    hidden_state = ttnn.to_layout(hidden_state, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    hidden_state = preprocess_and_push_input_to_device(
+        device,
+        hidden_state,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
 
     temb = temb.permute(2, 0, 1, 3)  # pre-permute temb
     temb = ttnn.from_torch(temb, ttnn.bfloat16)

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -17,8 +17,14 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
-    pre_process_input,
     post_process_output_and_move_to_host,
+)
+from models.demos.wormhole.stable_diffusion.tests.parametrizations import (
+    DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,
+    CROSS_UP_BLOCKS_HIDDEN_STATES_INFO,
+)
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
+    preprocess_and_push_input_to_device,
 )
 
 
@@ -31,22 +37,20 @@ def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
 
 @skip_for_grayskull()
 @pytest.mark.parametrize(
-    "batch_size, in_channels, input_height, input_width, index",
+    "input_shape, shard_layout, shard_end_core, shard_shape, index",
     [
-        (2, 1280, 8, 8, 0),
-        (2, 1280, 16, 16, 1),
-        (2, 640, 32, 32, 2),
+        DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO + (0,),
+        CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[0] + (1,),
+        CROSS_UP_BLOCKS_HIDDEN_STATES_INFO[1] + (2,),
     ],
 )
-@pytest.mark.parametrize("scale_factor", [2])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_upsample2d_512x512(device, scale_factor, batch_size, in_channels, input_height, input_width, index):
+def test_upsample2d_512x512(device, input_shape, shard_layout, shard_end_core, shard_shape, index):
     # setup pytorch model
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
 
     unet = pipe.unet
     unet.eval()
-    state_dict = unet.state_dict()
     unet_upblock = pipe.unet.up_blocks[index]
     resnet_upsampler = unet_upblock.upsamplers[0]
     reader_patterns_cache = {}
@@ -62,21 +66,40 @@ def test_upsample2d_512x512(device, scale_factor, batch_size, in_channels, input
         fp32_dest_acc_en=True,
         packer_l1_acc=False,
     )
+
+    batch_size, in_channels, input_height, input_width = input_shape
     model = upsample2d(
         device, parameters, reader_patterns_cache, batch_size, input_height, input_width, compute_kernel_config
     )
 
-    input_shape = batch_size, in_channels, input_height, input_width
     out_channels = in_channels
-
     input = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output = resnet_upsampler(input)
 
-    input = input.permute(0, 2, 3, 1)
-    input = input.reshape(1, 1, batch_size * input_height * input_width, in_channels)
-    tt_input_tensor = ttnn.from_torch(input, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+    ttnn_input = preprocess_and_push_input_to_device(
+        device,
+        input,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.MemoryConfig(
+            shard_layout,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet(
+                    {
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(shard_end_core[0], shard_end_core[1]),
+                        ),
+                    }
+                ),
+                shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
     tt_up = model(
-        tt_input_tensor,
+        ttnn_input,
         in_channels,
         out_channels,
     )

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -19,7 +19,7 @@ from models.utility_functions import torch_random
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     post_process_output_and_move_to_host,
 )
-from models.demos.wormhole.stable_diffusion.tests.parametrizations import (
+from models.demos.wormhole.stable_diffusion.tests.parameterizations import (
     DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,
     CROSS_UP_BLOCKS_HIDDEN_STATES_INFO,
 )


### PR DESCRIPTION
### Ticket
#17725

### Problem description
Some of the test parametrizations weren't targeting input memory configuration used in the model, or they didn't test cases from all unet blocks.

### What's changed
Tests parametrizations were updated - in parametrizations.py file I put data that is reused between different tests.

### Checklist
(Single card) Nightly ttnn and models pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/13566794814