### PR TITLE
llama3: Enhance precision flexibility

### DIFF
--- a/models/demos/llama3/PERF.md
+++ b/models/demos/llama3/PERF.md
@@ -1,6 +1,6 @@
 # Llama 3 model performance and accuracy
 
-Performance collected from [demo/demo.py](demo/demo.py) and accuracy collected from [tests/test_llama_accuracy.py](tests/test_llama_accuracy.py). You can generate this table by running these tests with the `lt` tool (tell it to run `table`) and pressing `m` whilst in the results section to export to markdown.
+Performance collected from [demo/demo.py](demo/demo.py) and accuracy collected from [tests/test_llama_accuracy.py](tests/test_llama_accuracy.py). You can generate this table by running these tests with the `lt` tool (tell it to run `table` or `precision`) and pressing `m` whilst in the results section to export to markdown.
 
 Note that `test_llama_accuracy.py` parses the below to determine expected values +- 0.5.
 

--- a/models/demos/llama3/PERF.md
+++ b/models/demos/llama3/PERF.md
@@ -53,7 +53,7 @@ This configuration uses bfp4 MLP FF1+FF3 only for the 3.1-70B model.
 | 70b   | T3K    | 95        | 99        | 14.7          |
 | 70b   | TG     | 95        | 100       | 12.7          |
 
-## LlamaOptimizations.ff1_3_bfp4_lofi_ff2_bfp4_lofi
+## LlamaOptimizations.ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi
 
 | Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
 |-------|--------|-----------|-----------|---------------|
@@ -75,7 +75,7 @@ This configuration uses bfp4 MLP FF1+FF3 only for the 3.1-70B model.
 | 70b   | T3K    | N/A       | N/A       | N/A           |
 | 70b   | TG     | N/A       | N/A       | N/A           |
 
-## LlamaOptimizations.ff1_3_bfp4_lofi_ff2_bfp8_hifi2
+## LlamaOptimizations.ff1_bfp4_lofi_ff2_bfp8_ff3_bfp4_hifi2
 
 | Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
 |-------|--------|-----------|-----------|---------------|

--- a/models/demos/llama3/PERF.md
+++ b/models/demos/llama3/PERF.md
@@ -52,3 +52,201 @@ This configuration uses bfp4 MLP FF1+FF3 only for the 3.1-70B model.
 | 11b   | TG     | 88        | 100       | 29.5          |
 | 70b   | T3K    | 95        | 99        | 14.7          |
 | 70b   | TG     | 95        | 100       | 12.7          |
+
+## LlamaOptimizations.ff1_3_bfp4_lofi_ff2_bfp4_lofi
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 84        | 98        | 58.1          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bfp4_lofi_ff2_bfp8_hifi2
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 87        | 98        | 55.8          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bfp4_lofi_ff2_bf16_hifi4
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 84        | 98        | 53.0          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bfp8_hifi2_ff2_bfp4_lofi
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 86        | 98        | 56.9          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bfp8_hifi2_ff2_bfp8_hifi2
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 86        | 99        | 56.3          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bfp8_hifi2_ff2_bf16_hifi4
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 89        | 99        | 53.7          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bf16_hifi4_ff2_bfp4_lofi
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 85        | 98        | 51.6          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bf16_hifi4_ff2_bfp8_hifi2
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 88        | 98        | 53.0          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |
+
+## LlamaOptimizations.ff1_3_bf16_hifi4_ff2_bf16_hifi4
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b    | N150   | 0         | 0         | 0             |
+| 1b    | N300   | 90        | 99        | 50.7          |
+| 1b    | T3K    | N/A       | N/A       | N/A           |
+| 1b    | TG     | N/A       | N/A       | N/A           |
+| 3b    | N150   | N/A       | N/A       | N/A           |
+| 3b    | N300   | N/A       | N/A       | N/A           |
+| 3b    | T3K    | N/A       | N/A       | N/A           |
+| 3b    | TG     | N/A       | N/A       | N/A           |
+| 8b    | N150   | N/A       | N/A       | N/A           |
+| 8b    | N300   | N/A       | N/A       | N/A           |
+| 8b    | T3K    | N/A       | N/A       | N/A           |
+| 8b    | TG     | N/A       | N/A       | N/A           |
+| 11b   | N300   | N/A       | N/A       | N/A           |
+| 11b   | T3K    | N/A       | N/A       | N/A           |
+| 11b   | TG     | N/A       | N/A       | N/A           |
+| 70b   | T3K    | N/A       | N/A       | N/A           |
+| 70b   | TG     | N/A       | N/A       | N/A           |

--- a/models/demos/llama3/demo/demo.py
+++ b/models/demos/llama3/demo/demo.py
@@ -31,7 +31,8 @@ from models.demos.llama3.tt.model_config import TtModelArgs
 
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
-from models.demos.llama3.tt.model_config import LlamaOptimizations, LayerGroup, PrecisionSetting
+from models.demos.llama3.tt.model_config import LlamaOptimizations
+from models.demos.llama3.tests.optimizations_conf import precision_conf
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):
@@ -915,100 +916,7 @@ def run_llama3_demo(
 )
 @pytest.mark.parametrize(
     "optimizations",
-    [
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
-        ),
-        LlamaOptimizations.performance,
-        LlamaOptimizations.accuracy,
-    ],
+    precision_conf(),
 )
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(

--- a/models/demos/llama3/demo/demo.py
+++ b/models/demos/llama3/demo/demo.py
@@ -918,57 +918,93 @@ def run_llama3_demo(
     [
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
             ),
-            id="precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi",
+            id="precision_ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
             ),
-            id="precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2",
+            id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
             ),
-            id="precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4",
+            id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
             ),
-            id="precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi",
+            id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
             ),
-            id="precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2",
+            id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
             ),
-            id="precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4",
+            id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
             ),
-            id="precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi",
+            id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
             ),
-            id="precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2",
+            id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
             ),
-            id="precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4",
+            id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
         ),
         LlamaOptimizations.performance,
         LlamaOptimizations.accuracy,

--- a/models/demos/llama3/demo/demo.py
+++ b/models/demos/llama3/demo/demo.py
@@ -31,7 +31,7 @@ from models.demos.llama3.tt.model_config import TtModelArgs
 
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
-from models.demos.llama3.tt.model_config import LlamaOptimizations
+from models.demos.llama3.tt.model_config import LlamaOptimizations, LayerGroup, PrecisionSetting
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):
@@ -916,6 +916,60 @@ def run_llama3_demo(
 @pytest.mark.parametrize(
     "optimizations",
     [
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+            ),
+            id="precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+            ),
+            id="precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+            ),
+            id="precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+            ),
+            id="precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+            ),
+            id="precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+            ),
+            id="precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+            ),
+            id="precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+            ),
+            id="precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+            ),
+            id="precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4",
+        ),
         LlamaOptimizations.performance,
         LlamaOptimizations.accuracy,
     ],

--- a/models/demos/llama3/lt
+++ b/models/demos/llama3/lt
@@ -461,6 +461,9 @@ def main(stdscr):
                         if command_input == "table":
                             command_input = "accuracy,demo,accuracy-acc,demo-acc"
 
+                        if command_input == "precision":
+                            command_input = "accuracy,demo,accuracy-acc,demo-acc,accuracy-precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi,accuracy-precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2,accuracy-precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4,accuracy-precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi,accuracy-precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2,accuracy-precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4,accuracy-precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi,accuracy-precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2,accuracy-precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4,demo-precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi,demo-precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2,demo-precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4,demo-precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi,demo-precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2,demo-precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4,demo-precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi,demo-precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2,demo-precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4"
+
                         # Parse models, devices, and commands
                         models = parse_list(model_input)
                         devices = parse_list(device_input)
@@ -842,6 +845,24 @@ def run_entry_command(entry, screen_lock, output_entries, screen_needs_update):
         "model": "pytest models/demos/llama3/tests/test_llama_model.py -k 'performance-256 and full'",
         "model-quick": "pytest models/demos/llama3/tests/test_llama_model.py -k 'performance-256 and quick'",
         "model-prefill": "pytest models/demos/llama3/tests/test_llama_model_prefill.py -k performance-4096",
+        "accuracy-precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi and file'",
+        "accuracy-precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2 and file'",
+        "accuracy-precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4 and file'",
+        "accuracy-precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi and file'",
+        "accuracy-precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2 and file'",
+        "accuracy-precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4 and file'",
+        "accuracy-precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi and file'",
+        "accuracy-precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2 and file'",
+        "accuracy-precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k 'attention-precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4 and file'",
+        "demo-precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi and batch-1'",
+        "demo-precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2 and batch-1'",
+        "demo-precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4 and batch-1'",
+        "demo-precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi and batch-1'",
+        "demo-precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2 and batch-1'",
+        "demo-precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4 and batch-1'",
+        "demo-precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi and batch-1'",
+        "demo-precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2 and batch-1'",
+        "demo-precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4": "pytest models/demos/llama3/demo/demo.py -k 'precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4 and batch-1'",
         # Vision tests (require 11B weights)
         "vision-mlp": "pytest models/demos/llama3/tests/multimodal/test_llama_image_mlp.py",
         "vision-attn": "pytest models/demos/llama3/tests/multimodal/test_llama_image_attention.py",
@@ -1172,7 +1193,7 @@ def get_help_text(current_line, num_input_fields, num_output_entries):
     elif current_line <= num_input_fields - 1:
         return "Enter: Next field | ↑↓: Navigate fields | Esc: Exit"
     else:
-        return "Enter: View log | Backspace/x: Cancel entry | X: Cancel all | r: Restart entry | p: Reparse log | ↑↓: Navigate entries | Esc: Exit"
+        return "Enter: View log | Backspace/x: Cancel entry | X: Cancel all | r: Restart entry | p: Reparse log | m: Export markdown | ↑↓: Navigate entries | Esc: Exit"
 
 
 def cancel_entry(entry):
@@ -1196,6 +1217,7 @@ def export_results_to_markdown(output_entries, stdscr):
     # Initialize ordered lists to maintain entry order
     perf_entries = []
     acc_entries = []
+    precision_entries = {}
 
     # Collect results from entries in their original order
     for entry in output_entries:
@@ -1239,6 +1261,28 @@ def export_results_to_markdown(output_entries, stdscr):
                         existing_entry[1:3] = [top1, top5]
                 else:
                     acc_entries.append([key, top1, top5, speed or "N/A"])
+            elif entry.command_name.startswith('demo-precision'):
+                # get speed from demo-precision entries
+                speed = entry.speed
+
+                setting = entry.command_name[len('demo-precision'):]
+                if setting not in precision_entries:
+                    precision_entries[setting] = {key: ['N/A', 'N/A', speed or 'N/A']}
+                else:
+                    precision_entries[setting][key][-1] = speed or 'N/A'
+            elif entry.command_name.startswith('accuracy-precision'):
+                # get accuracy from accuracy-precision entries
+                top1, top5 = "N/A", "N/A"
+                if entry.pcc:
+                    match = re.match(r"(\d+)\s*\|\s*(\d+)", entry.pcc)
+                    if match:
+                        top1, top5 = match.group(1), match.group(2)
+
+                setting = entry.command_name[len('accuracy-precision'):]
+                if setting not in precision_entries:
+                    precision_entries[setting] = {key: [top1, top5, 'N/A']}
+                else:
+                    precision_entries[setting][key][1:3] = [top1, top5]
 
     # Create markdown content
     markdown_lines = [
@@ -1273,15 +1317,43 @@ def export_results_to_markdown(output_entries, stdscr):
         (model, device), top1, top5, speed = entry
         markdown_lines.append(f"| {model} | {device} | {top1} | {top5} | {speed} |")
 
+    # add precision tables
+    for setting, entries in precision_entries.items():
+        markdown_lines.extend(
+            [
+                "",
+                f"## LlamaOptimizations.{setting}",
+                "",
+                "| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |",
+                "|-------|--------|-----------|-----------|---------------|",
+            ]
+        )
+        for key, entry in entries.items():
+            model, device = key
+            top1, top5, speed = entry
+            markdown_lines.append(f"| {model} | {device} | {top1} | {top5} | {speed} |")
+
     # Write to PERF.md
     with open("PERF.md", "w") as f:
         f.write("\n".join(markdown_lines) + "\n")
 
     # Clear screen and show message
     stdscr.clear()
-    stdscr.addstr(0, 0, "\n".join(markdown_lines))
-    stdscr.addstr(len(markdown_lines) + 2, 0, f"Table written to {os.path.abspath('PERF.md')}")
-    stdscr.addstr(len(markdown_lines) + 3, 0, "Press any key to return...")
+
+    # display 'PERF.md' using less
+    # Save current terminal state
+    curses.def_prog_mode()
+    # Exit curses temporarily
+    curses.endwin()
+    # Run less command
+    os.system(f"less -R PERF.md")
+    # Resume curses
+    curses.reset_prog_mode()
+    stdscr.refresh()
+
+    # display helpful message at the bottom of the screen
+    stdscr.addstr(0, 0, f"Table written to {os.path.abspath('PERF.md')}")
+    stdscr.addstr(1, 0, "Press any key to return...")
     stdscr.refresh()
 
     # Temporarily make getch() blocking

--- a/models/demos/llama3/tests/optimizations_conf.py
+++ b/models/demos/llama3/tests/optimizations_conf.py
@@ -2,101 +2,106 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from models.demos.llama3.tt.model_config import LlamaOptimizations, LayerGroup, PrecisionSetting
+from models.demos.llama3.tt.model_config import DecodersPrecision, LlamaOptimizations, LayerGroup, PrecisionSetting
 
 
 def precision_conf():
+    num_decoders = 32
+
     return [
         pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
+            DecodersPrecision(
+                num_decoders,
+                LlamaOptimizations(
+                    {
+                        LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                        LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                        LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                    }
+                ),
             ),
             id="precision_ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi",
         ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
-        ),
-        pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
-        pytest.param(LlamaOptimizations.performance, id="performance"),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+        #             LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+        #             LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+        #         }
+        #     ),
+        #     id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+        #             LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+        #             LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+        #         }
+        #     ),
+        #     id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+        #             LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+        #             LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+        #         }
+        #     ),
+        #     id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+        #             LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+        #             LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+        #         }
+        #     ),
+        #     id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+        #             LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+        #             LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+        #         }
+        #     ),
+        #     id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+        #             LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+        #             LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+        #         }
+        #     ),
+        #     id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+        #             LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+        #             LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+        #         }
+        #     ),
+        #     id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
+        # ),
+        # pytest.param(
+        #     LlamaOptimizations(
+        #         {
+        #             LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+        #             LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+        #             LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+        #         }
+        #     ),
+        #     id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
+        # ),
+        pytest.param(DecodersPrecision(num_decoders, LlamaOptimizations.accuracy()), id="accuracy"),
+        pytest.param(DecodersPrecision(num_decoders, LlamaOptimizations.performance()), id="performance"),
     ]

--- a/models/demos/llama3/tests/optimizations_conf.py
+++ b/models/demos/llama3/tests/optimizations_conf.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from models.demos.llama3.tt.model_config import LlamaOptimizations, LayerGroup, PrecisionSetting
+
+
+def precision_conf():
+    return [
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
+            ),
+            id="precision_ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
+            ),
+            id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
+            ),
+            id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
+            ),
+            id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
+            ),
+            id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
+            ),
+            id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
+            ),
+            id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
+            ),
+            id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
+            ),
+            id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
+        ),
+        pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
+        pytest.param(LlamaOptimizations.performance, id="performance"),
+    ]

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -25,7 +25,7 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
     model_size = model_name.split("-")[1].lower()
 
     # Read PERF.md
-    perf_file = Path(__file__).parent.parent / "PERF_target.md"
+    perf_file = Path(__file__).parent.parent / "PERF.md"
     with open(perf_file, "r") as f:
         content = f.read()
 

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -13,14 +13,14 @@ from models.demos.llama3.tt.llama_common import (
     PagedAttentionConfig,
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
-from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations, DecodersPrecision
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.demos.llama3.demo.demo import preprocess_inputs_prefill
 from pathlib import Path
 from models.demos.llama3.tests.optimizations_conf import precision_conf
 
 
-def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: LlamaOptimizations):
+def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: DecodersPrecision):
     """Parse accuracy thresholds from PERF.md for the given model, optimization mode, and device."""
     # Get model size (e.g., "1b", "3b", etc.)
     model_size = model_name.split("-")[1].lower()
@@ -32,7 +32,8 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
 
     # Split into sections based on optimization mode
     sections = content.split("## ")
-    target_section = next(s for s in sections if s.startswith(f"LlamaOptimizations.{optimizations.__name__}\n"))
+    fist_decoder_conf = optimizations.decoder_optimizations[0]
+    target_section = next(s for s in sections if s.startswith(f"LlamaOptimizations.{fist_decoder_conf.__name__}\n"))
 
     # Parse the table and find the row for our model and device
     rows = [

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -75,57 +75,93 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
     [
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
             ),
-            id="precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi",
+            id="precision_ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
             ),
-            id="precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2",
+            id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
+                }
             ),
-            id="precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4",
+            id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
             ),
-            id="precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi",
+            id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
             ),
-            id="precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2",
+            id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
+                }
             ),
-            id="precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4",
+            id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
             ),
-            id="precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi",
+            id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
             ),
-            id="precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2",
+            id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
         ),
         pytest.param(
             LlamaOptimizations(
-                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+                {
+                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
+                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
+                }
             ),
-            id="precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4",
+            id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
         ),
         pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
         pytest.param(LlamaOptimizations.performance, id="performance"),

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -13,7 +13,7 @@ from models.demos.llama3.tt.llama_common import (
     PagedAttentionConfig,
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
-from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations, LayerGroup, PrecisionSetting
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.demos.llama3.demo.demo import preprocess_inputs_prefill
 from pathlib import Path
@@ -25,7 +25,7 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
     model_size = model_name.split("-")[1].lower()
 
     # Read PERF.md
-    perf_file = Path(__file__).parent.parent / "PERF.md"
+    perf_file = Path(__file__).parent.parent / "PERF_target.md"
     with open(perf_file, "r") as f:
         content = f.read()
 
@@ -73,6 +73,60 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
 @pytest.mark.parametrize(
     "optimizations",
     [
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+            ),
+            id="precision_ff1_3_bfp4_lofi_ff2_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+            ),
+            id="precision_ff1_3_bfp4_lofi_ff2_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+            ),
+            id="precision_ff1_3_bfp4_lofi_ff2_bf16_hifi4",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+            ),
+            id="precision_ff1_3_bfp8_hifi2_ff2_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+            ),
+            id="precision_ff1_3_bfp8_hifi2_ff2_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+            ),
+            id="precision_ff1_3_bfp8_hifi2_ff2_bf16_hifi4",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP4_LOFI}
+            ),
+            id="precision_ff1_3_bf16_hifi4_ff2_bfp4_lofi",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2}
+            ),
+            id="precision_ff1_3_bf16_hifi4_ff2_bfp8_hifi2",
+        ),
+        pytest.param(
+            LlamaOptimizations(
+                {LayerGroup.FF1_FF3: PrecisionSetting.BF16_HIFI4, LayerGroup.FF2: PrecisionSetting.BF16_HIFI4}
+            ),
+            id="precision_ff1_3_bf16_hifi4_ff2_bf16_hifi4",
+        ),
         pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
         pytest.param(LlamaOptimizations.performance, id="performance"),
     ],

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -13,10 +13,11 @@ from models.demos.llama3.tt.llama_common import (
     PagedAttentionConfig,
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
-from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations, LayerGroup, PrecisionSetting
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.demos.llama3.demo.demo import preprocess_inputs_prefill
 from pathlib import Path
+from models.demos.llama3.tests.optimizations_conf import precision_conf
 
 
 def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: LlamaOptimizations):
@@ -72,100 +73,7 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
 )
 @pytest.mark.parametrize(
     "optimizations",
-    [
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bfp4_lofi_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bfp8_hifi2_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BFP4_LOFI,
-                }
-            ),
-            id="precision_ff1_bfp4_lofi_ff2_bf16_hifi4_ff3_bfp4_lofi",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bfp4_lofi_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bfp8_hifi2_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
-                }
-            ),
-            id="precision_ff1_bfp8_hifi2_ff2_bf16_hifi4_ff3_bfp8_hifi2",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BFP4_LOFI,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bfp4_lofi_ff3_bf16_hifi4",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bfp8_hifi2_ff3_bf16_hifi4",
-        ),
-        pytest.param(
-            LlamaOptimizations(
-                {
-                    LayerGroup.FF1: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF2: PrecisionSetting.BF16_HIFI4,
-                    LayerGroup.FF3: PrecisionSetting.BF16_HIFI4,
-                }
-            ),
-            id="precision_ff1_bf16_hifi4_ff2_bf16_hifi4_ff3_bf16_hifi4",
-        ),
-        pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
-        pytest.param(LlamaOptimizations.performance, id="performance"),
-    ],
+    precision_conf(),
 )
 @pytest.mark.parametrize(
     "paged_attention",

--- a/models/demos/llama3/tt/llama_mlp.py
+++ b/models/demos/llama3/tt/llama_mlp.py
@@ -45,17 +45,15 @@ class TtLlamaMLP(LightweightModule):
             cache_file_name=cache_name(name),
         )
 
-        self.layer_settings = self.args.optimizations.layer_settings
-
         # Sharded weights
         w1_dim = (-1, -2) if args.is_galaxy else (-2, -1)
         w2_dim = (-2, -1) if args.is_galaxy else (-1, -2)
 
         self.w1 = as_sharded_tensor(
-            "w1_sharded", self.layer_settings["w1"]["dtype"], dim=w1_dim
+            "w1_sharded", self.model_config["FF1_3_DTYPE"], dim=w1_dim
         )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
-        self.w2 = as_sharded_tensor("w2_sharded", self.layer_settings["w2"]["dtype"], dim=w2_dim)
-        self.w3 = as_sharded_tensor("w3_sharded", self.layer_settings["w3"]["dtype"], dim=w1_dim)
+        self.w2 = as_sharded_tensor("w2_sharded", self.model_config["FF2_DTYPE"], dim=w2_dim)
+        self.w3 = as_sharded_tensor("w3_sharded", self.model_config["FF1_3_DTYPE"], dim=w1_dim)
 
     def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
         """
@@ -89,7 +87,7 @@ class TtLlamaMLP(LightweightModule):
         w1_out = ttnn.linear(
             x,
             self.w1,
-            compute_kernel_config=self.layer_settings["w1"]["compute_kernel_config"],
+            compute_kernel_config=self.model_config["FF1_3_COMPUTE_KERNEL_CFG"],
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
             dtype=ttnn.bfloat8_b if TG else ttnn.bfloat16,
             program_config=pc_1,
@@ -99,7 +97,7 @@ class TtLlamaMLP(LightweightModule):
         w3_out = ttnn.linear(
             x,
             self.w3,
-            compute_kernel_config=self.layer_settings["w3"]["compute_kernel_config"],
+            compute_kernel_config=self.model_config["FF1_3_COMPUTE_KERNEL_CFG"],
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
             dtype=ttnn.bfloat8_b if TG else ttnn.bfloat16,
             program_config=pc_3,
@@ -181,7 +179,7 @@ class TtLlamaMLP(LightweightModule):
         w2_out = ttnn.linear(
             w2_in,
             self.w2,
-            compute_kernel_config=self.layer_settings["w2"]["compute_kernel_config"],
+            compute_kernel_config=self.model_config["FF2_COMPUTE_KERNEL_CFG"],
             dtype=self.args.ccl_dtype if TG else ttnn.bfloat16,
             program_config=pc_2,
             memory_config=(ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG)

--- a/models/demos/llama3/tt/llama_mlp.py
+++ b/models/demos/llama3/tt/llama_mlp.py
@@ -50,10 +50,10 @@ class TtLlamaMLP(LightweightModule):
         w2_dim = (-2, -1) if args.is_galaxy else (-1, -2)
 
         self.w1 = as_sharded_tensor(
-            "w1_sharded", self.model_config["FF1_3_DTYPE"], dim=w1_dim
+            "w1_sharded", self.model_config["FF1_DTYPE"], dim=w1_dim
         )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
         self.w2 = as_sharded_tensor("w2_sharded", self.model_config["FF2_DTYPE"], dim=w2_dim)
-        self.w3 = as_sharded_tensor("w3_sharded", self.model_config["FF1_3_DTYPE"], dim=w1_dim)
+        self.w3 = as_sharded_tensor("w3_sharded", self.model_config["FF3_DTYPE"], dim=w1_dim)
 
     def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
         """
@@ -87,7 +87,7 @@ class TtLlamaMLP(LightweightModule):
         w1_out = ttnn.linear(
             x,
             self.w1,
-            compute_kernel_config=self.model_config["FF1_3_COMPUTE_KERNEL_CFG"],
+            compute_kernel_config=self.model_config["FF1_COMPUTE_KERNEL_CFG"],
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
             dtype=ttnn.bfloat8_b if TG else ttnn.bfloat16,
             program_config=pc_1,
@@ -97,7 +97,7 @@ class TtLlamaMLP(LightweightModule):
         w3_out = ttnn.linear(
             x,
             self.w3,
-            compute_kernel_config=self.model_config["FF1_3_COMPUTE_KERNEL_CFG"],
+            compute_kernel_config=self.model_config["FF3_COMPUTE_KERNEL_CFG"],
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
             dtype=ttnn.bfloat8_b if TG else ttnn.bfloat16,
             program_config=pc_3,

--- a/models/demos/llama3/tt/llama_mlp.py
+++ b/models/demos/llama3/tt/llama_mlp.py
@@ -45,17 +45,17 @@ class TtLlamaMLP(LightweightModule):
             cache_file_name=cache_name(name),
         )
 
-        self.four_bit_mlp = args.optimizations.bfp4_mlp
+        self.layer_settings = self.args.optimizations.layer_settings
 
         # Sharded weights
         w1_dim = (-1, -2) if args.is_galaxy else (-2, -1)
         w2_dim = (-2, -1) if args.is_galaxy else (-1, -2)
 
         self.w1 = as_sharded_tensor(
-            "w1_sharded", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
+            "w1_sharded", self.layer_settings["w1"]["dtype"], dim=w1_dim
         )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
-        self.w2 = as_sharded_tensor("w2_sharded", ttnn.bfloat8_b, dim=w2_dim)
-        self.w3 = as_sharded_tensor("w3_sharded", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim)
+        self.w2 = as_sharded_tensor("w2_sharded", self.layer_settings["w2"]["dtype"], dim=w2_dim)
+        self.w3 = as_sharded_tensor("w3_sharded", self.layer_settings["w3"]["dtype"], dim=w1_dim)
 
     def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
         """
@@ -89,9 +89,7 @@ class TtLlamaMLP(LightweightModule):
         w1_out = ttnn.linear(
             x,
             self.w1,
-            compute_kernel_config=self.args.compute_kernel_config_lofi
-            if self.four_bit_mlp
-            else self.args.compute_kernel_config_hifi2_fp16,
+            compute_kernel_config=self.layer_settings["w1"]["compute_kernel_config"],
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
             dtype=ttnn.bfloat8_b if TG else ttnn.bfloat16,
             program_config=pc_1,
@@ -101,9 +99,7 @@ class TtLlamaMLP(LightweightModule):
         w3_out = ttnn.linear(
             x,
             self.w3,
-            compute_kernel_config=self.args.compute_kernel_config_lofi
-            if self.four_bit_mlp
-            else self.args.compute_kernel_config_hifi2_fp16,
+            compute_kernel_config=self.layer_settings["w3"]["compute_kernel_config"],
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
             dtype=ttnn.bfloat8_b if TG else ttnn.bfloat16,
             program_config=pc_3,
@@ -185,7 +181,7 @@ class TtLlamaMLP(LightweightModule):
         w2_out = ttnn.linear(
             w2_in,
             self.w2,
-            compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
+            compute_kernel_config=self.layer_settings["w2"]["compute_kernel_config"],
             dtype=self.args.ccl_dtype if TG else ttnn.bfloat16,
             program_config=pc_2,
             memory_config=(ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG)

--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -31,8 +31,9 @@ class PrecisionSetting(Enum):
 
 
 class LayerGroup(Enum):
-    FF1_FF3 = "ff1_3"
+    FF1 = "ff1"
     FF2 = "ff2"
+    FF3 = "ff3"
 
 
 class LlamaOptimizations:
@@ -53,7 +54,7 @@ class LlamaOptimizations:
         """Configuration optimized for performance
         All models use bfp4 MLPs in this configuration
         """
-        inst = cls({LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI})
+        inst = cls({LayerGroup.FF1: PrecisionSetting.BFP4_LOFI, LayerGroup.FF3: PrecisionSetting.BFP4_LOFI})
         inst.__name__ = "performance"
         return inst
 
@@ -64,8 +65,9 @@ class LlamaOptimizations:
 
     def _default_layer_settings(self):
         return {
-            LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2,
+            LayerGroup.FF1: PrecisionSetting.BFP8_HIFI2,
             LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+            LayerGroup.FF3: PrecisionSetting.BFP8_HIFI2,
         }
 
 

--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -21,30 +21,75 @@ from typing import Tuple
 from models.utility_functions import nearest_32
 from pathlib import Path
 from tqdm import tqdm
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
 class LlamaOptimizations:
-    bfp4_mlp: bool
-    # Future fields will go here:
-    # bfp8_activations: bool
-    # bfp8_layernorm: bool
-    # bfp8_ccl: bool
+    def _default_layer_settings():
+        return {
+            "w1": {
+                "dtype": ttnn.bfloat8_b,
+                "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
+                    math_fidelity=ttnn.MathFidelity.HiFi2,
+                    math_approx_mode=False,
+                    fp32_dest_acc_en=False,
+                    packer_l1_acc=True,
+                ),
+            },
+            "w2": {
+                "dtype": ttnn.bfloat8_b,
+                "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
+                    math_fidelity=ttnn.MathFidelity.HiFi2,
+                    math_approx_mode=False,
+                    fp32_dest_acc_en=False,
+                    packer_l1_acc=True,
+                ),
+            },
+            "w3": {
+                "dtype": ttnn.bfloat8_b,
+                "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
+                    math_fidelity=ttnn.MathFidelity.HiFi2,
+                    math_approx_mode=False,
+                    fp32_dest_acc_en=False,
+                    packer_l1_acc=True,
+                ),
+            },
+        }
+
+    layer_settings: dict = field(default_factory=_default_layer_settings)
 
     @classmethod
     def accuracy(cls, model_name):
         """Configuration optimized for accuracy
         Only 3.1-70B uses bfp4 MLPs in this configuration
         """
-        return cls(bfp4_mlp=model_name == "3.1-70B")
+        if model_name == "3.1-70B":
+            return LlamaOptimizations.performance(model_name)
+
+        return cls()
 
     @classmethod
     def performance(cls, model_name):
         """Configuration optimized for performance
         All models use bfp4 MLPs in this configuration
         """
-        return cls(bfp4_mlp=True)
+        inst = cls()
+        inst.layer_settings["w1"]["dtype"] = ttnn.bfloat4_b
+        inst.layer_settings["w1"]["compute_kernel_config"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+        inst.layer_settings["w3"]["dtype"] = ttnn.bfloat4_b
+        inst.layer_settings["w3"]["compute_kernel_config"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+        return inst
 
 
 class TtModelArgs:
@@ -160,6 +205,7 @@ class TtModelArgs:
             raise ValueError(f"Unsupported LLAMA model: {LLAMA_DIR}")
 
         # Set the max number of tokens for each prefill chunk based on the model and device
+        # NOTE: chosen based on the DRAM that is availalbe; this could be affected by the data type of weights
         MAX_PREFILL_CHUNK_SIZES_DIV1024 = {
             "3.2-1B": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128},
             "3.2-3B": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128},
@@ -263,6 +309,7 @@ class TtModelArgs:
                 fp32_dest_acc_en=True,
                 packer_l1_acc=True,
             )
+            # NOTE: compute_kernel_config_sdpa seems not used in the any of the model files
             self.compute_kernel_config_sdpa = ttnn.WormholeComputeKernelConfig(
                 math_fidelity=ttnn.MathFidelity.HiFi4,
                 math_approx_mode=False,
@@ -354,17 +401,17 @@ class TtModelArgs:
                 m=min(seq_len, 1024),
                 k=self.dim // self.cluster_shape[0],
                 n=self.hidden_dim // self.cluster_shape[1],
-                grid_size=(8, min(min(seq_len, 1024) // 32, 4))
-                if self.is_galaxy
-                else ((8, 8) if seq_len >= 1024 else (8, 4)),
+                grid_size=(
+                    (8, min(min(seq_len, 1024) // 32, 4)) if self.is_galaxy else ((8, 8) if seq_len >= 1024 else (8, 4))
+                ),
             )
             self.model_config["PREFILL_MLP_W2_PRG_CONFIG"] = lambda seq_len: self.matmul_config(
                 m=min(seq_len, 1024),
                 k=self.hidden_dim // (self.cluster_shape[1] if self.is_galaxy else 1),
                 n=self.dim,
-                grid_size=(8, min(min(seq_len, 1024) // 32, 4))
-                if self.is_galaxy
-                else ((8, 8) if seq_len >= 1024 else (8, 4)),
+                grid_size=(
+                    (8, min(min(seq_len, 1024) // 32, 4)) if self.is_galaxy else ((8, 8) if seq_len >= 1024 else (8, 4))
+                ),
             )
 
             self.model_config["WO_PREFILL_PROGCFG"] = lambda seq_len: self.matmul_config(

--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -21,75 +21,52 @@ from typing import Tuple
 from models.utility_functions import nearest_32
 from pathlib import Path
 from tqdm import tqdm
-from dataclasses import dataclass, field
+from enum import Enum, auto
 
 
-@dataclass
+class PrecisionSetting(Enum):
+    BFP4_LOFI = "bfp4_lofi"
+    BFP8_HIFI2 = "bfp8_hifi2"
+    BF16_HIFI4 = "bf16_hifi4"
+
+
+class LayerGroup(Enum):
+    FF1_FF3 = "ff1_3"
+    FF2 = "ff2"
+
+
 class LlamaOptimizations:
-    def _default_layer_settings():
-        return {
-            "w1": {
-                "dtype": ttnn.bfloat8_b,
-                "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.MathFidelity.HiFi2,
-                    math_approx_mode=False,
-                    fp32_dest_acc_en=False,
-                    packer_l1_acc=True,
-                ),
-            },
-            "w2": {
-                "dtype": ttnn.bfloat8_b,
-                "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.MathFidelity.HiFi2,
-                    math_approx_mode=False,
-                    fp32_dest_acc_en=False,
-                    packer_l1_acc=True,
-                ),
-            },
-            "w3": {
-                "dtype": ttnn.bfloat8_b,
-                "compute_kernel_config": ttnn.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.MathFidelity.HiFi2,
-                    math_approx_mode=False,
-                    fp32_dest_acc_en=False,
-                    packer_l1_acc=True,
-                ),
-            },
-        }
-
-    layer_settings: dict = field(default_factory=_default_layer_settings)
-
     @classmethod
     def accuracy(cls, model_name):
         """Configuration optimized for accuracy
         Only 3.1-70B uses bfp4 MLPs in this configuration
         """
         if model_name == "3.1-70B":
-            return LlamaOptimizations.performance(model_name)
-
-        return cls()
+            inst = LlamaOptimizations.performance(model_name)
+        else:
+            inst = cls()
+        inst.__name__ = "accuracy"
+        return inst
 
     @classmethod
     def performance(cls, model_name):
         """Configuration optimized for performance
         All models use bfp4 MLPs in this configuration
         """
-        inst = cls()
-        inst.layer_settings["w1"]["dtype"] = ttnn.bfloat4_b
-        inst.layer_settings["w1"]["compute_kernel_config"] = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        )
-        inst.layer_settings["w3"]["dtype"] = ttnn.bfloat4_b
-        inst.layer_settings["w3"]["compute_kernel_config"] = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        )
+        inst = cls({LayerGroup.FF1_FF3: PrecisionSetting.BFP4_LOFI})
+        inst.__name__ = "performance"
         return inst
+
+    def __init__(self, layer2precision: dict = None):
+        self.layer_settings = self._default_layer_settings()
+        self.layer_settings.update(layer2precision or {})
+        self.__name__ = "_".join([f"{k.value}_{v.value}" for k, v in self.layer_settings.items()])
+
+    def _default_layer_settings(self):
+        return {
+            LayerGroup.FF1_FF3: PrecisionSetting.BFP8_HIFI2,
+            LayerGroup.FF2: PrecisionSetting.BFP8_HIFI2,
+        }
 
 
 class TtModelArgs:
@@ -317,8 +294,19 @@ class TtModelArgs:
                 packer_l1_acc=False,
             )
 
+            # Configure data precision and math fidelity for kernels
             self.model_config["COMPUTE_KERNEL_CONFIG_HIFI2"] = self.compute_kernel_config_hifi2
+            precision_setting_lookup = {
+                PrecisionSetting.BFP4_LOFI: (ttnn.bfloat4_b, self.compute_kernel_config_lofi),
+                PrecisionSetting.BFP8_HIFI2: (ttnn.bfloat8_b, self.compute_kernel_config_hifi2),
+                PrecisionSetting.BF16_HIFI4: (ttnn.bfloat16, self.compute_kernel_config_hifi4),
+            }
+            for layer, precision in self.optimizations.layer_settings.items():
+                dtype, kernel_cfg = precision_setting_lookup[precision]
+                self.model_config[f"{layer.value.upper()}_DTYPE"] = dtype
+                self.model_config[f"{layer.value.upper()}_COMPUTE_KERNEL_CFG"] = kernel_cfg
 
+            # Create memory config for sharded tensors
             residual_grid = self.dram_shard_core_grid_for_k(self.dim // self.num_devices)
             self.model_config["DECODE_RESIDUAL_MEMCFG"] = (
                 ttnn.L1_MEMORY_CONFIG  # FIXME: when residual add support typecasting for sharded tensors


### PR DESCRIPTION
### Problem description
Currently, in Llama3, all the decoders have the same computation precision. 
Ideally we would want to configure each layer individually to explore possible optimizations.

### What's changed
In this work-in-progress, based on @gwangTT branch, I enabled the option to change the precision between FF1 and FF3 in the decoders to have more flexibility.