### PR TITLE
Disables "should be migrated to C++" log messages

### DIFF
--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -803,8 +803,9 @@ def register_python_operation(
 
         if is_cpp_operation:
             raise RuntimeError(f"{function} is a C++ operation, but it is being registered as a Python operation")
-        elif not is_experimental and not is_method:
-            logger.debug(f"Should {python_fully_qualified_name} be migrated to C++?")
+        # Disabling for now (See GH issue #18386)
+        # elif not is_experimental and not is_method:
+        #     logger.debug(f"Should {python_fully_qualified_name} be migrated to C++?")
 
         operation_class = FastOperation if ttnn.CONFIG.enable_fast_runtime_mode else Operation
 


### PR DESCRIPTION
closes #18386

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18386)

### Problem description
Log messages about migrating Python methods to C++ are polluting the output. We do not plan to act on them in the short term, but will in the future.

### What's changed
The check that prints the message has been commented out, to be uncommented later.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
