### PR TITLE
Increase sem count from 8 to 16

### DIFF
--- a/tt_metal/api/tt-metalium/semaphore.hpp
+++ b/tt_metal/api/tt-metalium/semaphore.hpp
@@ -12,7 +12,7 @@ namespace tt {
 
 namespace tt_metal {
 
-constexpr std::uint32_t NUM_SEMAPHORES = 8;
+constexpr std::uint32_t NUM_SEMAPHORES = 16;
 
 class Semaphore {
 public:

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -33,7 +33,7 @@ struct address_map {
 
     // Kernel config buffer is WIP
     // Size is presently based on the old sizes of the RTAs + CB config + Sems
-    static constexpr std::int32_t ERISC_L1_KERNEL_CONFIG_SIZE = 96 * 4 + 8 * 16;
+    static constexpr std::int32_t ERISC_L1_KERNEL_CONFIG_SIZE = 96 * 4 + 16 * 16;
 
     // Base addresses
     static constexpr std::int32_t FIRMWARE_BASE = 0x9040;


### PR DESCRIPTION
### Ticket
- #18430

### Problem description
Max semaphore count of 8 has been reached, when bringing up a new CCL op. See #18217 for the new CCL op motivating this increase.

### What's changed
Increase max sem count from 8 to 16.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13636041502) CI passes
- [x] [T3k](https://github.com/tenstorrent/tt-metal/actions/runs/13637559960) CI passes
