### PR TITLE
Lower profiler op-to-op overhead by send op times in batches

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -76,7 +76,8 @@ def get_function_name():
 
 
 @skip_for_grayskull()
-def test_multi_op():
+@pytest.mark.parametrize("experimental", [True, False])
+def test_multi_op(experimental):
     OP_COUNT = 1000
     RUN_COUNT = 2
     REF_COUNT_DICT = {
@@ -88,7 +89,11 @@ def test_multi_op():
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in REF_COUNT_DICT.keys()
 
+    if experimental:
+        os.environ["TT_METAL_PROFILER_EXPERIMENTAL"] = "1"
     devicesData = run_device_profiler_test(setupAutoExtract=True)
+    if experimental:
+        os.environ["TT_METAL_PROFILER_EXPERIMENTAL"] = "0"
 
     stats = devicesData["data"]["devices"]["0"]["cores"]["DEVICE"]["analysis"]
 

--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -109,6 +109,7 @@ class RunTimeOptions {
 
     bool profiler_enabled = false;
     bool profile_dispatch_cores = false;
+    bool profile_do_experimental = false;
     bool profiler_sync_enabled = false;
     bool profiler_buffer_usage_enabled = false;
 
@@ -285,6 +286,7 @@ public:
 
     inline bool get_profiler_enabled() { return profiler_enabled; }
     inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
+    inline bool get_profiler_do_experimental() { return profile_do_experimental; }
     inline bool get_profiler_sync_enabled() { return profiler_sync_enabled; }
     inline bool get_profiler_buffer_usage_enabled() { return profiler_buffer_usage_enabled; }
 

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #define PROFILER_OPT_DO_DISPATCH_CORES 2
+#define PROFILER_OPT_DO_EXPERIMENTAL 3
 
 namespace kernel_profiler {
 
@@ -40,8 +41,8 @@ enum ControlBuffer {
     DEVICE_BUFFER_END_INDEX_T0,
     DEVICE_BUFFER_END_INDEX_T1,
     DEVICE_BUFFER_END_INDEX_T2,
-    FW_RESET_H,
-    FW_RESET_L,
+    L1_HOST_SYNC_ADDRESS,
+    HOST_SYNC_TIMESTAMP,
     DRAM_PROFILER_ADDRESS,
     RUN_COUNTER,
     NOC_X,

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -17,6 +17,9 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint32_t core_flat_id __attribute__((used));
+    uint32_t profiler_core_count_per_dram __attribute__((used));
+    uint32_t dram_buffer_page_size __attribute__((used));
 }
 #endif
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -60,6 +60,9 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint32_t core_flat_id __attribute__((used));
+    uint32_t profiler_core_count_per_dram __attribute__((used));
+    uint32_t dram_buffer_page_size __attribute__((used));
 }
 #endif
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -57,6 +57,9 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint32_t core_flat_id __attribute__((used));
+    uint32_t profiler_core_count_per_dram __attribute__((used));
+    uint32_t dram_buffer_page_size __attribute__((used));
 }
 #endif
 
@@ -119,6 +122,7 @@ int main(int argc, char *argv[]) {
     // Need to save address to jump to after BRISC resumes NCRISC
     set_ncrisc_resume_addr();
 
+    DeviceProfilerInit();
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
         WAYPOINT("W");

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -100,6 +100,7 @@ int main(int argc, char *argv[]) {
 
     reset_cfg_state_id();
 
+    DeviceProfilerInit();
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
         WAYPOINT("W");

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This c-file's purpose is:
 // 1) include the generated list of kernels
 //      The files hold run_kernel() definition and inline kernel_main functions for every ckernel

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -134,6 +134,10 @@ void JitBuildEnv::init(
         } else {
             this->defines_ += "-DPROFILE_KERNEL=1 ";
         }
+
+        if (tt::llrt::RunTimeOptions::get_instance().get_profiler_do_experimental()) {
+            this->defines_ += "-DPROFILE_KERNEL_EXPERIMENTAL=1 ";
+        }
     }
 
     if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -58,6 +58,7 @@ RunTimeOptions::RunTimeOptions() {
     profiler_enabled = false;
     profile_dispatch_cores = false;
     profiler_sync_enabled = false;
+    profile_do_experimental = false;
     profiler_buffer_usage_enabled = false;
 #if defined(TRACY_ENABLE)
     const char* profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
@@ -70,6 +71,11 @@ RunTimeOptions::RunTimeOptions() {
         const char* profiler_sync_enabled_str = std::getenv("TT_METAL_PROFILER_SYNC");
         if (profiler_enabled && profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
             profiler_sync_enabled = true;
+        }
+        const char* profiler_experimental_enabled_str = std::getenv("TT_METAL_PROFILER_EXPERIMENTAL");
+        if (profiler_enabled && profiler_experimental_enabled_str != nullptr &&
+            profiler_experimental_enabled_str[0] == '1') {
+            profile_do_experimental = true;
         }
     }
     const char* profile_buffer_usage_str = std::getenv("TT_METAL_MEM_PROFILER");

--- a/tt_metal/tools/profiler/experimental/kernel_profiler_experimental.hpp
+++ b/tt_metal/tools/profiler/experimental/kernel_profiler_experimental.hpp
@@ -1,0 +1,410 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <climits>
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
+    defined(COMPILE_FOR_IDLE_ERISC)
+#include "risc_common.h"
+#include "dataflow_api.h"
+#else
+#include "ckernel.h"
+#endif
+
+#include "hostdevcommon/profiler_common.h"
+#include "risc_attribs.h"
+
+#include <dev_msgs.h>
+
+#define DO_PRAGMA(x) _Pragma(#x)
+
+#define Stringize(L) #L
+#define MakeString(M, L) M(L)
+#define $Line MakeString(Stringize, __LINE__)
+
+#define PROFILER_MSG __FILE__ "," $Line ",KERNEL_PROFILER"
+#define PROFILER_MSG_NAME(name) name "," PROFILER_MSG
+
+#define SrcLocNameToHash(name)                   \
+    DO_PRAGMA(message(PROFILER_MSG_NAME(name))); \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
+
+#if defined(PROFILE_KERNEL)
+
+namespace kernel_profiler {
+
+extern uint32_t wIndex;
+extern uint32_t time_out;
+extern uint32_t stackSize;
+
+extern uint32_t sums[SUM_COUNT];
+extern uint32_t sumIDs[SUM_COUNT];
+
+constexpr uint32_t PROFILER_PUSH_TIME_OUT = 100000;
+constexpr uint32_t NOC_PUSH_MARKER_COUNT = 2;
+constexpr int WALL_CLOCK_HIGH_INDEX = 1;
+constexpr int WALL_CLOCK_LOW_INDEX = 0;
+
+#if !defined(COMPILE_FOR_TRISC)
+extern uint32_t core_flat_id;
+extern uint32_t profiler_core_count_per_dram;
+extern uint32_t dram_buffer_page_size;
+#endif
+
+volatile tt_l1_ptr uint32_t* profiler_control_buffer =
+    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(GET_MAILBOX_ADDRESS_DEV(profiler.control_vector));
+
+volatile tt_l1_ptr uint32_t (*profiler_data_buffer)[kernel_profiler::PROFILER_L1_VECTOR_SIZE] =
+    reinterpret_cast<volatile tt_l1_ptr uint32_t (*)[kernel_profiler::PROFILER_L1_VECTOR_SIZE]>(
+        GET_MAILBOX_ADDRESS_DEV(profiler.buffer));
+
+#if defined(COMPILE_FOR_BRISC)
+constexpr uint32_t myRiscID = 0;
+#elif defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+constexpr uint32_t myRiscID = 0;
+#elif defined(COMPILE_FOR_NCRISC)
+constexpr uint32_t myRiscID = 1;
+#elif defined(COMPILE_FOR_TRISC) && COMPILE_FOR_TRISC == 0
+constexpr uint32_t myRiscID = 2;
+#elif defined(COMPILE_FOR_TRISC) && COMPILE_FOR_TRISC == 1
+constexpr uint32_t myRiscID = 3;
+#elif defined(COMPILE_FOR_TRISC) && COMPILE_FOR_TRISC == 2
+constexpr uint32_t myRiscID = 4;
+#endif
+
+constexpr uint32_t Hash32_CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261)) {
+    return n == 0 ? basis : Hash32_CT(str + 1, n - 1, (basis ^ str[0]) * UINT32_C(16777619));
+}
+
+template <size_t N>
+constexpr uint32_t Hash16_CT(const char (&s)[N]) {
+    auto res = Hash32_CT(s, N - 1);
+    return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
+}
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
+    defined(COMPILE_FOR_IDLE_ERISC)
+inline void __attribute__((always_inline)) noc_async_write_posted(
+    std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    WAYPOINT("NAWW");
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+    ncrisc_noc_fast_write_any_len<noc_mode>(
+        noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true, true);
+    WAYPOINT("NAWD");
+}
+#endif
+
+__attribute__((noinline)) void init_profiler(
+    uint16_t briscKernelID = 0, uint16_t ncriscKernelID = 0, uint16_t triscsKernelID = 0) {
+    wIndex = CUSTOM_MARKERS;
+    profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] = 0;
+    stackSize = 0;
+
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_BRISC)
+    uint32_t runCounter = profiler_control_buffer[RUN_COUNTER];
+    profiler_control_buffer[PROFILER_DONE] = 0;
+    if (runCounter == 0) {
+        for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID++) {
+            for (uint32_t i = ID_HH; i < GUARANTEED_MARKER_1_H; i++) {
+                profiler_data_buffer[riscID][i] = 0;
+            }
+        }
+
+        profiler_control_buffer[NOC_X] = my_x[0];
+        profiler_control_buffer[NOC_Y] = my_y[0];
+    }
+
+    for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID++) {
+        for (uint32_t i = GUARANTEED_MARKER_1_H; i < CUSTOM_MARKERS; i++) {
+            // TODO(MO): Clean up magic numbers
+            profiler_data_buffer[riscID][i] = 0x80000000;
+        }
+        profiler_data_buffer[riscID][ID_LL] =
+            (runCounter & 0xFFFF) | (profiler_data_buffer[riscID][ID_LL] & 0xFFFF0000);
+    }
+
+    while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
+
+    core_flat_id = profiler_control_buffer[FLAT_ID];
+    profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
+    dram_buffer_page_size = PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * profiler_core_count_per_dram;
+
+    profiler_data_buffer[myRiscID][ID_LH] = ((core_flat_id & 0xFF) << 3) | myRiscID;
+#endif
+}
+
+constexpr uint32_t get_const_id(uint32_t id, PacketTypes type) { return ((id & 0xFFFF) | ((type << 16) & 0x7FFFF)); }
+
+inline __attribute__((always_inline)) uint32_t get_id(uint32_t id, PacketTypes type) {
+    return ((id & 0xFFFF) | ((type << 16) & 0x7FFFF));
+}
+
+inline __attribute__((always_inline)) bool bufferHasRoom() {
+    return wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - (NOC_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE));
+}
+
+inline __attribute__((always_inline)) void mark_time_at_index_inlined(uint32_t index, uint32_t timer_id) {
+    volatile tt_reg_ptr uint32_t* p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L);
+    profiler_data_buffer[myRiscID][index] =
+        0x80000000 | ((timer_id & 0x7FFFF) << 12) | (p_reg[WALL_CLOCK_HIGH_INDEX] & 0xFFF);
+    profiler_data_buffer[myRiscID][index + 1] = p_reg[WALL_CLOCK_LOW_INDEX];
+}
+
+inline __attribute__((always_inline)) void mark_padding() {
+    if (wIndex < PROFILER_L1_VECTOR_SIZE) {
+        profiler_data_buffer[myRiscID][wIndex] = 0x80000000;
+        profiler_data_buffer[myRiscID][wIndex + 1] = 0;
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+    }
+}
+
+inline __attribute__((always_inline)) void mark_dropped_timestamps(uint32_t index) {
+    uint32_t curr = profiler_control_buffer[DROPPED_ZONES];
+    profiler_control_buffer[DROPPED_ZONES] = (1 << index) | curr;
+}
+
+inline __attribute__((always_inline)) void set_host_counter(uint32_t counterValue) {
+    for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID++) {
+        profiler_data_buffer[riscID][ID_LL] = (counterValue << 16) | (profiler_data_buffer[riscID][ID_LL] & 0xFFFF);
+    }
+}
+
+inline __attribute__((always_inline)) void set_profiler_zone_valid(bool condition) {
+    profiler_control_buffer[PROFILER_DONE] = !condition;
+}
+
+inline __attribute__((always_inline)) void risc_finished_profiling() {
+    for (uint32_t i = 0; i < (wIndex % NOC_ALIGNMENT_FACTOR); i++) {
+        mark_padding();
+    }
+    profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] = wIndex;
+}
+
+template <bool RECORD_ZONE = true>
+__attribute__((noinline)) void finish_profiler() {
+    if constexpr (RECORD_ZONE) {
+        SrcLocNameToHash("PROFILER-DRAM-PUSH");
+        mark_time_at_index_inlined(wIndex, hash);
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+
+        mark_time_at_index_inlined(wIndex, get_const_id(hash, ZONE_END));
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+    }
+    risc_finished_profiling();
+    profiler_control_buffer[PROFILER_DONE] = 1;
+#if !defined(COMPILE_FOR_TRISC)
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_BRISC)
+    for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID++)
+#elif defined(DISPATCH_KERNEL)
+    uint32_t riscID = myRiscID;
+    core_flat_id = profiler_control_buffer[FLAT_ID];
+    profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
+    dram_buffer_page_size = PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * profiler_core_count_per_dram;
+    profiler_data_buffer[myRiscID][ID_LH] = ((core_flat_id & 0xFF) << 3) | myRiscID;
+#else
+    uint32_t riscID = myRiscID;
+    return;
+#endif
+    {
+        int hostIndex = riscID;
+        int deviceIndex = DEVICE_BUFFER_END_INDEX_BR_ER + riscID;
+        if (profiler_control_buffer[deviceIndex]) {
+            uint32_t currEndIndex = profiler_control_buffer[deviceIndex] + profiler_control_buffer[hostIndex];
+
+            bool do_noc = false;
+            uint32_t dram_offset = 0;
+            uint32_t send_size = 0;
+            if (currEndIndex <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
+                dram_offset = (core_flat_id % profiler_core_count_per_dram) * MAX_RISCV_PER_CORE *
+                                  PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                              hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                              profiler_control_buffer[hostIndex] * sizeof(uint32_t);
+
+                send_size = profiler_control_buffer[deviceIndex] * sizeof(uint32_t);
+
+                do_noc = true;
+                profiler_control_buffer[hostIndex] = currEndIndex;
+            } else if (profiler_control_buffer[RUN_COUNTER] < 1) {
+                dram_offset = (core_flat_id % profiler_core_count_per_dram) * MAX_RISCV_PER_CORE *
+                                  PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                              hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC;
+
+                send_size = CUSTOM_MARKERS * sizeof(uint32_t);
+
+                do_noc = true;
+                mark_dropped_timestamps(hostIndex);
+            } else {
+                mark_dropped_timestamps(hostIndex);
+            }
+
+            if (do_noc) {
+                const InterleavedAddrGen<true> s = {
+                    .bank_base_address = profiler_control_buffer[DRAM_PROFILER_ADDRESS],
+                    .page_size = dram_buffer_page_size};
+
+                uint64_t dram_bank_dst_noc_addr =
+                    s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
+
+                noc_async_write_posted(
+                    reinterpret_cast<uint32_t>(profiler_data_buffer[hostIndex]), dram_bank_dst_noc_addr, send_size);
+            }
+            profiler_control_buffer[deviceIndex] = 0;
+        }
+    }
+
+    noc_async_posted_writes_flushed();
+    profiler_control_buffer[PROFILER_DONE] = 0;
+    wIndex = CUSTOM_MARKERS;
+#endif
+}
+
+void push_time_out() {
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_BRISC)
+    if (time_out++ > PROFILER_PUSH_TIME_OUT && wIndex > CUSTOM_MARKERS + PROFILER_L1_MARKER_UINT32_SIZE) {
+        time_out = 0;
+        finish_profiler();
+    }
+#endif
+}
+
+struct scopePush {
+    inline __attribute__((always_inline)) scopePush() {
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_BRISC)
+        uint32_t runCounter = profiler_control_buffer[RUN_COUNTER];
+        profiler_data_buffer[myRiscID][wIndex] = (runCounter & 0xFFFF) |
+                                                 ((((core_flat_id & 0xFF) << 3) | myRiscID) << 16) |
+                                                 ((runCounter & 0xF) << 27) | (0x1 << 31);
+#else
+        if (wIndex >= (PROFILER_L1_VECTOR_SIZE - (NOC_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE))) {
+            // This risc did request a noc push so wait until its data is pushed
+            while (profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] != 0) {
+            }
+            wIndex = CUSTOM_MARKERS;
+        } else if (profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] == 0) {
+            // This risc did not request a noc push but its data might have been sent so flush the buffer
+            wIndex = CUSTOM_MARKERS;
+        }
+#endif
+    }
+
+    inline __attribute__((always_inline)) ~scopePush() {
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_BRISC)
+        if (profiler_control_buffer[PROFILER_DONE] ||
+            wIndex >= (PROFILER_L1_VECTOR_SIZE - (NOC_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE))) {
+            // If any other risc has its buffer full or we are full
+            finish_profiler();
+        }
+#else
+        // Set control buffer index, in case B/NCRISC attempt to do a noc push
+        profiler_control_buffer[DEVICE_BUFFER_END_INDEX_BR_ER + myRiscID] = wIndex;
+        if (wIndex >= (PROFILER_L1_VECTOR_SIZE - (NOC_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE))) {
+            finish_profiler();
+        }
+#endif
+    }
+};
+
+template <uint32_t timer_id>
+struct profileScope {
+    bool start_marked = false;
+    inline __attribute__((always_inline)) profileScope() {
+        if (bufferHasRoom()) {
+            stackSize += PROFILER_L1_MARKER_UINT32_SIZE;
+            start_marked = true;
+            mark_time_at_index_inlined(wIndex, timer_id);
+            wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+        } else {
+#if defined(DISPATCH_KERNEL)
+            finish_profiler();
+#endif
+        }
+    }
+
+    inline __attribute__((always_inline)) ~profileScope() {
+        if (start_marked) {
+            mark_time_at_index_inlined(wIndex, get_const_id(timer_id, ZONE_END));
+            wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+            start_marked = false;
+            stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
+        }
+    }
+};
+
+template <uint32_t data_id>
+inline __attribute__((always_inline)) void timeStampedData(uint64_t data) {
+    if (bufferHasRoom()) {
+        mark_time_at_index_inlined(wIndex, get_const_id(data_id, TS_DATA));
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+        profiler_data_buffer[myRiscID][wIndex++] = data >> 32;
+        profiler_data_buffer[myRiscID][wIndex++] = (data << 32) >> 32;
+    }
+}
+
+inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
+    if (bufferHasRoom()) {
+        mark_time_at_index_inlined(wIndex, get_id(event_id, TS_EVENT));
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+    }
+}
+}  // namespace kernel_profiler
+
+#define DeviceTimestampedData(data_id, data)
+
+#define DeviceRecordEvent(event_id)
+
+#define DeviceValidateProfiler(condition) ;
+
+#define DeviceZoneScopedMainN(name)                                            \
+    kernel_profiler::scopePush scope_push = kernel_profiler::scopePush();      \
+    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
+
+#define DeviceZoneScopedMainChildN(name)                                       \
+    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
+
+#define DeviceZoneScopedN(name)                                                \
+    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+    kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
+
+#define DeviceZoneSetCounter(counter) ;
+
+#define DeviceZonesTimeoutPush() kernel_profiler::push_time_out();
+
+#define DeviceZoneScopedPush() kernel_profiler::scopePush scope_push = kernel_profiler::scopePush();
+
+#define DeviceProfilerInit() kernel_profiler::init_profiler();
+
+#else
+
+#define DeviceValidateProfiler(condition)
+
+#define DeviceZoneScopedMainN(name)
+
+#define DeviceZoneScopedPush()
+
+#define DeviceZoneScopedMainChildN(name)
+
+#define DeviceZoneScopedN(name)
+
+#define DeviceZoneSetCounter(counter)
+
+#define DeviceTimestampedData(data_id, data)
+
+#define DeviceRecordEvent(event_id)
+
+#define DeviceZonesTimeoutPush()
+
+#define DeviceProfilerInit()
+
+#endif
+
+#define DeviceZoneScopedSumN1(name)
+
+#define DeviceZoneScopedSumN2(name)

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#if defined(PROFILE_KERNEL_EXPERIMENTAL)
+
+#include "tt_metal/tools/profiler/experimental/kernel_profiler_experimental.hpp"
+
+#else
+
 #include <climits>
 
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
@@ -420,7 +426,7 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
     (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)) && \
     (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
 
-#define DeviceZoneScopedN(name)                                                         \
+#define DeviceZoneScopedN(name)                                                          \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                         \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));           \
     kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
@@ -465,6 +471,14 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 
 #define DeviceZoneSetCounter(counter) kernel_profiler::set_host_counter(counter);
 
+#define DeviceZoneScopedPush()
+
+#define DeviceZonesTimeoutPush()
+
+#define DeviceZonesPush()
+
+#define DeviceProfilerInit()
+
 #else
 
 #define DeviceValidateProfiler(condition)
@@ -485,4 +499,13 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 
 #define DeviceRecordEvent(event_id)
 
+#define DeviceZoneScopedPush()
+
+#define DeviceZonesTimeoutPush()
+
+#define DeviceZonesPush()
+
+#define DeviceProfilerInit()
+
+#endif
 #endif

--- a/tt_metal/tools/profiler/sync/sync_kernel.cpp
+++ b/tt_metal/tools/profiler/sync/sync_kernel.cpp
@@ -12,8 +12,8 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(((mailboxes_t*)MEM_MAILBOX_BASE)->profiler.control_vector);
 
     constexpr uint32_t briscIndex = 0;
-    volatile tt_l1_ptr uint32_t* briscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        &((mailboxes_t*)MEM_MAILBOX_BASE)->profiler.buffer[briscIndex][kernel_profiler::CUSTOM_MARKERS]);
+    volatile tt_l1_ptr uint32_t* briscBuffer =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(profiler_control_buffer[kernel_profiler::L1_HOST_SYNC_ADDRESS]);
 
     uint32_t syncTimeBufferIndex = 0;
 
@@ -22,26 +22,26 @@ void kernel_main() {
     while (syncTimeBufferIndex < FIRST_READ_COUNT) {
         uint32_t deviceTime = p_reg[kernel_profiler::WALL_CLOCK_LOW_INDEX];
 
-        uint32_t hostTime = profiler_control_buffer[kernel_profiler::FW_RESET_L];
+        uint32_t hostTime = profiler_control_buffer[kernel_profiler::HOST_SYNC_TIMESTAMP];
         if (hostTime > 0) {
             briscBuffer[syncTimeBufferIndex++] = p_reg[kernel_profiler::WALL_CLOCK_HIGH_INDEX];
             briscBuffer[syncTimeBufferIndex++] = deviceTime;
             briscBuffer[syncTimeBufferIndex++] = deviceTime;
             briscBuffer[syncTimeBufferIndex++] = hostTime;
-            profiler_control_buffer[kernel_profiler::FW_RESET_L] = 0;
+            profiler_control_buffer[kernel_profiler::HOST_SYNC_TIMESTAMP] = 0;
         }
     }
 
     {
-        DeviceZoneScopedMainChildN("SYNC-LOOP");
+        DeviceZoneScopedN("SYNC-LOOP");
         while (syncTimeBufferIndex < ((SAMPLE_COUNT + 1) * 2)) {
             uint32_t deviceTime = p_reg[kernel_profiler::WALL_CLOCK_LOW_INDEX];
 
-            uint32_t hostTime = profiler_control_buffer[kernel_profiler::FW_RESET_L];
+            uint32_t hostTime = profiler_control_buffer[kernel_profiler::HOST_SYNC_TIMESTAMP];
             if (hostTime > 0) {
                 briscBuffer[syncTimeBufferIndex++] = deviceTime;
                 briscBuffer[syncTimeBufferIndex++] = hostTime;
-                profiler_control_buffer[kernel_profiler::FW_RESET_L] = 0;
+                profiler_control_buffer[kernel_profiler::HOST_SYNC_TIMESTAMP] = 0;
             }
         }
     }

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -106,8 +106,15 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     if (!tt::llrt::RunTimeOptions::get_instance().get_profiler_sync_enabled()) {
         return;
     }
+
     auto device_id = device->id();
     auto core = device->worker_core_from_logical_core(logical_core);
+
+    profiler_msg_t* profiler_msg = device->get_dev_addr<profiler_msg_t*>(core, HalL1MemAddrType::PROFILER);
+    uint32_t addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+    uint64_t control_l1_addr =
+        reinterpret_cast<uint64_t>(&profiler_msg->control_vector[kernel_profiler::L1_HOST_SYNC_ADDRESS]);
+    tt::Cluster::instance().write_reg(&addr, tt_cxy_pair(device_id, core), control_l1_addr);
 
     deviceHostTimePair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
     smallestHostime.emplace(device_id, 0);
@@ -145,8 +152,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     const int64_t hostStartTime = TracyGetCpuTime();
     std::vector<int64_t> writeTimes(sampleCount);
 
-    profiler_msg_t* profiler_msg = device->get_dev_addr<profiler_msg_t*>(core, HalL1MemAddrType::PROFILER);
-    uint64_t control_addr = reinterpret_cast<uint64_t>(&profiler_msg->control_vector[kernel_profiler::FW_RESET_L]);
+    uint64_t control_addr =
+        reinterpret_cast<uint64_t>(&profiler_msg->control_vector[kernel_profiler::HOST_SYNC_TIMESTAMP]);
     for (int i = 0; i < sampleCount; i++) {
         ZoneScopedC(tracy::Color::Tomato2);
         std::this_thread::sleep_for(std::chrono::milliseconds(millisecond_wait));
@@ -170,7 +177,6 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     double writeOverhead = (double)writeSum / sampleCount;
 
     constexpr uint32_t briscIndex = 0;
-    uint64_t addr = reinterpret_cast<uint64_t>(&profiler_msg->buffer[briscIndex][kernel_profiler::CUSTOM_MARKERS]);
 
     std::vector<std::uint32_t> sync_times =
         tt::llrt::read_hex_vec_from_core(device_id, core, addr, (sampleCount + 1) * 2 * sizeof(uint32_t));


### PR DESCRIPTION
### Ticket
#16561 

### Problem description
Profiler noc-push overhead is becoming significant after all the dispatch improvements 

### What's changed
This PR introduces a new profiling method where L1 profiler data are only sent to DRAM when the buffer is full. This is unlike before where at then end of each iteration of BRISC loop, L1 data were sent. 

This PR brings phase 1 described in the issue.

At the moment this profiling method is hidden behind a envvar as not all current profiler features are available on it:

In addition to the other profiler envvars, including `TT_METAL_DEVICE_PROFILER`, you have to set `TT_METAL_PROFILER_EXPERIMENTAL=1`.

Measurements suggest that op-to-op profiler overhead is now at 80-90 cycles. Depending on how many zone scopes are uses every 120 op a noc push is done.

### Checklist
- [ ] [All post commit]
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/13723991496)
- [ ] [uBenchmark]
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
