### PR TITLE
new function to subtract two corerangesets

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_subtract_corerangeset_from_another.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_subtract_corerangeset_from_another.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import pytest
+
+
+import ttnn
+import pytest
+
+
+@pytest.mark.parametrize(
+    "base_ranges, subtract_ranges, expected_result",
+    [
+        # Test Case 1: Basic subtraction - remove a portion of a range
+        (
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 9))]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 9))]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 9)),
+                ]
+            ),
+        ),
+        # Test Case 2: Subtraction with no overlap - should return the original
+        (
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 9))]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(3, 9))]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 9))]),
+        ),
+        # Test Case 3: Subtraction with complete overlap - should return empty set
+        (
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(2, 2))]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(2, 2))]),
+            ttnn.CoreRangeSet([]),
+        ),
+        # Test Case 4: Multiple ranges in both sets
+        (
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(4, 9)),
+                ]
+            ),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 5))]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 6), ttnn.CoreCoord(1, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(4, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(3, 6), ttnn.CoreCoord(3, 9)),
+                ]
+            ),
+        ),
+        # Test Case 5: Partial overlaps across multiple ranges
+        (
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 9)),
+                ]
+            ),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 5), ttnn.CoreCoord(5, 5))]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(2, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 6), ttnn.CoreCoord(2, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(5, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 6), ttnn.CoreCoord(5, 9)),
+                ]
+            ),
+        ),
+        # Test Case 6: Empty base set
+        (
+            ttnn.CoreRangeSet([]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 9))]),
+            ttnn.CoreRangeSet([]),
+        ),
+        # Test Case 7: Empty subtract set
+        (
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 9))]),
+            ttnn.CoreRangeSet([]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 9))]),
+        ),
+    ],
+)
+def test_corerangeset_subtract(base_ranges, subtract_ranges, expected_result):
+    """
+    Test the CoreRangeSet::subtract method which removes the common ranges (intersection)
+    from the current CoreRangeSet.
+
+    Args:
+        base_ranges: The original CoreRangeSet
+        subtract_ranges: The CoreRangeSet to subtract from the original
+        expected_result: The expected result after subtraction
+    """
+    result = base_ranges.subtract(subtract_ranges)
+    assert result.to_json() == expected_result.to_json()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_subtract_corerangeset_from_another.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_subtract_corerangeset_from_another.py
@@ -6,10 +6,6 @@ import ttnn
 import pytest
 
 
-import ttnn
-import pytest
-
-
 @pytest.mark.parametrize(
     "base_ranges, subtract_ranges, expected_result",
     [

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -175,6 +175,10 @@ public:
     // code that uses this CoreRangeSet.
     CoreRangeSet merge_ranges() const;
 
+    // Subtract the common CoreRanges between this CoreRangeSet.
+    // A - (A n B)
+    CoreRangeSet subtract(const CoreRangeSet& other) const;
+
 private:
     void validate_no_overlap();
 

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -430,17 +430,20 @@ void CoreRangeSet::validate_no_overlap() {
 }
 
 CoreRangeSet CoreRangeSet::subtract(const CoreRangeSet& other) const {
+    const CoreRangeSet& this_merged = this->merge_ranges();
+    const CoreRangeSet& other_merged = other.merge_ranges();
+
     // Early returns for empty sets and non-intersecting sets
-    if (other.empty() || this->empty() || !this->intersects(other)) {
-        return this->empty() ? CoreRangeSet() : *this;
+    if (other_merged.empty() || this_merged.empty() || !this_merged.intersects(other_merged)) {
+        return this_merged.empty() ? CoreRangeSet() : *this;
     }
 
     std::vector<CoreRange> result_ranges;
 
-    for (const auto& current_range : this->ranges_) {
+    for (const auto& current_range : this_merged.ranges_) {
         std::vector<CoreRange> current_remaining = {current_range};
 
-        for (const auto& subtract_range : other.ranges_) {
+        for (const auto& subtract_range : other_merged.ranges_) {
             std::vector<CoreRange> new_remaining;
 
             for (const auto& remaining : current_remaining) {
@@ -450,7 +453,7 @@ CoreRangeSet CoreRangeSet::subtract(const CoreRangeSet& other) const {
                     continue;
                 }
 
-                CoreRange intersection = intersection_opt.value();
+                const CoreRange& intersection = intersection_opt.value();
 
                 if (remaining.start_coord.x < intersection.start_coord.x) {
                     CoreRange left{

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -429,6 +429,67 @@ void CoreRangeSet::validate_no_overlap() {
     }
 }
 
+CoreRangeSet CoreRangeSet::subtract(const CoreRangeSet& other) const {
+    // Early returns for empty sets and non-intersecting sets
+    if (other.empty() || this->empty() || !this->intersects(other)) {
+        return this->empty() ? CoreRangeSet() : *this;
+    }
+
+    std::vector<CoreRange> result_ranges;
+
+    for (const auto& current_range : this->ranges_) {
+        std::vector<CoreRange> current_remaining = {current_range};
+
+        for (const auto& subtract_range : other.ranges_) {
+            std::vector<CoreRange> new_remaining;
+
+            for (const auto& remaining : current_remaining) {
+                auto intersection_opt = remaining.intersection(subtract_range);
+                if (!intersection_opt.has_value()) {
+                    new_remaining.push_back(remaining);
+                    continue;
+                }
+
+                CoreRange intersection = intersection_opt.value();
+
+                if (remaining.start_coord.x < intersection.start_coord.x) {
+                    CoreRange left{
+                        remaining.start_coord, CoreCoord{intersection.start_coord.x - 1, remaining.end_coord.y}};
+                    new_remaining.push_back(left);
+                }
+
+                if (remaining.end_coord.x > intersection.end_coord.x) {
+                    CoreRange right{
+                        CoreCoord{intersection.end_coord.x + 1, remaining.start_coord.y}, remaining.end_coord};
+                    new_remaining.push_back(right);
+                }
+
+                if (remaining.start_coord.y < intersection.start_coord.y) {
+                    CoreRange bottom{
+                        CoreCoord{
+                            std::max(remaining.start_coord.x, intersection.start_coord.x), remaining.start_coord.y},
+                        CoreCoord{
+                            std::min(remaining.end_coord.x, intersection.end_coord.x), intersection.start_coord.y - 1}};
+                    new_remaining.push_back(bottom);
+                }
+
+                if (remaining.end_coord.y > intersection.end_coord.y) {
+                    CoreRange top{
+                        CoreCoord{
+                            std::max(remaining.start_coord.x, intersection.start_coord.x),
+                            intersection.end_coord.y + 1},
+                        CoreCoord{std::min(remaining.end_coord.x, intersection.end_coord.x), remaining.end_coord.y}};
+                    new_remaining.push_back(top);
+                }
+            }
+            current_remaining = new_remaining;
+        }
+        result_ranges.insert(result_ranges.end(), current_remaining.begin(), current_remaining.end());
+    }
+
+    return CoreRangeSet(std::move(result_ranges));
+}
+
 bool operator==(const CoreRangeSet& a, const CoreRangeSet& b) {
     if (a.ranges().size() == b.ranges().size()) {
         auto range_a = a.ranges();

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -435,7 +435,7 @@ CoreRangeSet CoreRangeSet::subtract(const CoreRangeSet& other) const {
 
     // Early returns for empty sets and non-intersecting sets
     if (other_merged.empty() || this_merged.empty() || !this_merged.intersects(other_merged)) {
-        return this_merged.empty() ? CoreRangeSet() : *this;
+        return this_merged;
     }
 
     std::vector<CoreRange> result_ranges;

--- a/ttnn/cpp/pybind11/tensor.cpp
+++ b/ttnn/cpp/pybind11/tensor.cpp
@@ -225,7 +225,9 @@ void tensor_mem_config_module(py::module& m_tensor) {
             "bounding_box",
             &CoreRangeSet::bounding_box,
             "Returns a CoreRange i.e. bounding box covering all the core ranges in the CoreRangeSet")
-        .def("num_cores", &CoreRangeSet::num_cores, "Returns total number of cores in the CoreRangeSet");
+        .def("num_cores", &CoreRangeSet::num_cores, "Returns total number of cores in the CoreRangeSet")
+        .def("subtract", &CoreRangeSet::subtract, "Subtract common CoreRanges from current i.e. it returns A - (AnB)");
+
 
     auto pyShardSpec = static_cast<py::class_<ShardSpec>>(m_tensor.attr("ShardSpec"));
     pyShardSpec


### PR DESCRIPTION
### Problem description
Added a helper function CoreRangeSet::subtract
This helps to subtract one CoreRangeSet from another.
Basically, it returns A - B = A - (A n B)

### What's changed
* Added a new function called subtract for CoreRangeSet class
* Added pybind for the same
* Added a unit test file
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13598958290) CI passes
- [x] New/Existing tests provide coverage for changes
