### PR TITLE
Some LightMetal Support for TTNN Round 2 (e2e binary capture+replay in ttnn tests)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from loguru import logger
 
 from tests.scripts.common import run_process_and_get_result
+from tests.scripts.common import get_updated_device_params
 
 
 @pytest.fixture(scope="function")
@@ -91,30 +92,6 @@ def get_tt_cache_path():
             return default_path
 
     return get_tt_cache_path_
-
-
-def get_dispatch_core_type():
-    import ttnn
-
-    # TODO: 11059 move dispatch_core_type to device_params when all tests are updated to not use WH_ARCH_YAML env flag
-    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
-    if ("WH_ARCH_YAML" in os.environ) and os.environ["WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
-        dispatch_core_type = ttnn.device.DispatchCoreType.ETH
-    return dispatch_core_type
-
-
-def get_updated_device_params(device_params):
-    import ttnn
-
-    dispatch_core_type = get_dispatch_core_type()
-    new_device_params = device_params.copy()
-    dispatch_core_axis = new_device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if ttnn.get_arch_name() == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
-    new_device_params["dispatch_core_config"] = dispatch_core_config
-    return new_device_params
 
 
 @pytest.fixture(scope="function")

--- a/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
+++ b/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
@@ -23,16 +23,24 @@ protected:
     bool replay_binary_;
     std::string trace_bin_path_;
     bool write_bin_to_disk_;
+    bool replay_manages_device_;
+    size_t trace_region_size_;
 
     void SetUp() override {
         this->validate_dispatch_mode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        TT_FATAL(!this->IsSlowDispatch(), "Test is running in slow dispatch mode, which is not supported.");
     }
 
     void CreateDeviceAndBeginCapture(
-        const size_t trace_region_size, const bool replay_binary = true, const std::string trace_bin_path = "") {
+        const size_t trace_region_size,
+        const bool replay_manages_device = false,
+        const bool replay_binary = true,
+        const std::string trace_bin_path = "") {
         // Skip writing to disk by default, unless user sets env var for local testing
         write_bin_to_disk_ = tt::parse_env("LIGHTMETAL_SAVE_BINARY", false);
+        replay_manages_device_ = replay_manages_device;
+        trace_region_size_ = trace_region_size;
 
         // If user didn't provide a specific trace bin path, set a default here based on test name
         if (trace_bin_path == "") {
@@ -41,7 +49,7 @@ protected:
             this->trace_bin_path_ = "/tmp/" + trace_filename;
         }
 
-        this->create_device(trace_region_size);
+        this->create_device(trace_region_size_);
         this->replay_binary_ = replay_binary && !tt::parse_env("LIGHTMETAL_DISABLE_RUN", false);
         // TODO (kmabee) - revisit placement. CreateDevice() path calls CreateKernel() on programs not
         // created with CreateProgram() traced API which leads to "program not in global_id map"
@@ -60,21 +68,27 @@ protected:
             binary.save_to_file(this->trace_bin_path_);
         }
 
-        if (!this->IsSlowDispatch()) {
-            tt::tt_metal::CloseDevice(this->device_);
-        }
+        tt::tt_metal::CloseDevice(this->device_);
 
         // We could gaurd this to not attempt to replay empty binary, and still allow test to pass
         // but, would rather catch the case if the feature gets disabled at compile time.
         if (replay_binary_) {
-            RunLightMetalBinary(std::move(binary));
+            if (replay_manages_device_) {
+                RunLightMetalBinary(std::move(binary), nullptr);
+            } else {
+                this->create_device(trace_region_size_);
+                RunLightMetalBinary(std::move(binary), this->device_);
+                tt::tt_metal::CloseDevice(this->device_);
+            }
         }
     }
 
     // Mimic the light-metal standalone run replay tool by executing the binary.
-    void RunLightMetalBinary(LightMetalBinary&& binary) {
-        tt::tt_metal::LightMetalReplay lm_replay(std::move(binary));
-        if (!lm_replay.execute_binary()) {
+    // Note: Replay tool will open device if nullptr is provided.
+    void RunLightMetalBinary(LightMetalBinary&& binary, IDevice* device) {
+        tt::tt_metal::LightMetalReplay lm_replay(std::move(binary), device);
+        bool success = lm_replay.execute_binary();
+        if (!success) {
             FAIL() << "Light Metal Binary failed to execute or encountered errors.";
         } else {
             log_info(tt::LogMetalTrace, "Light Metal Binary executed successfully!");

--- a/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
+++ b/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
@@ -12,7 +12,7 @@
 #include <circular_buffer_constants.h>
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "lightmetal/lightmetal_replay.hpp"
+#include <tt-metalium/lightmetal_replay.hpp>
 #include "command_queue_fixture.hpp"
 #include <lightmetal_binary.hpp>
 
@@ -83,11 +83,11 @@ protected:
         }
     }
 
-    // Mimic the light-metal standalone run replay tool by executing the binary.
+    // Mimic the light-metal standalone run replay tool by running the binary.
     // Note: Replay tool will open device if nullptr is provided.
     void RunLightMetalBinary(LightMetalBinary&& binary, IDevice* device) {
         tt::tt_metal::LightMetalReplay lm_replay(std::move(binary), device);
-        bool success = lm_replay.execute_binary();
+        bool success = lm_replay.run();
         if (!success) {
             FAIL() << "Light Metal Binary failed to execute or encountered errors.";
         } else {

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -308,6 +308,13 @@ TEST_F(LightMetalBasicTest, SingleRISCDataMovementRtArgsPerCoreVec) {
     SingleRISCDataMovement_test(device_, true);
 }
 
+// Same as above but let replay library manage open/close device instead of user (test), for coverage.
+TEST_F(LightMetalBasicTest, SingleRISCDataMovementReplayManageDevice) {
+    const bool replay_manage_device = true;
+    CreateDeviceAndBeginCapture(4096, replay_manage_device);
+    SingleRISCDataMovement_test(device_, false);
+}
+
 // Test simple case of 3 riscs used for datamovement and compute works for trace + replay.
 TEST_F(LightMetalBasicTest, ThreeRISCDataMovementCompute) {
     CreateDeviceAndBeginCapture(4096);

--- a/tests/ttnn/unit_tests/light_metal/conftest.py
+++ b/tests/ttnn/unit_tests/light_metal/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from types import ModuleType
+from loguru import logger
+import pytest
+import ttnn
+
+from tests.scripts.common import get_updated_device_params
+
+
+# A fixture for device reset. Borrows same logic to close and open device from device fixture.
+# Useful if test needs to reset device in middle (ie. between capture and replay of light metal binary)
+@pytest.fixture(scope="function")
+def reset_device(request, device_params):
+    def _reset_device(device):
+        """Closes and reopens the device to ensure a fresh state."""
+        ttnn.DumpDeviceProfiler(device)
+        ttnn.synchronize_device(device)
+        ttnn.close_device(device)
+
+        # Reopen a new device instance
+        device_id = request.config.getoption("device_id")
+        request.node.pci_ids = [ttnn.GetPCIeDeviceID(device_id)]
+
+        num_devices = ttnn.GetNumPCIeDevices()
+        assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
+        updated_device_params = get_updated_device_params(device_params)
+        new_device = ttnn.CreateDevice(device_id=device_id, **updated_device_params)
+        ttnn.SetDefaultDevice(device)
+        return new_device
+
+    yield _reset_device  # Provides function to test

--- a/tt_metal/api/tt-metalium/lightmetal_replay.hpp
+++ b/tt_metal/api/tt-metalium/lightmetal_replay.hpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 #include <optional>
-#include <lightmetal_binary.hpp>
+#include <tt-metalium/lightmetal_binary.hpp>
 
 #include <tt-metalium/device.hpp>
 
@@ -56,10 +56,10 @@ public:
     // Constructor that initializes the class with a binary blob and transfers ownership of the blob.
     explicit LightMetalReplay(LightMetalBinary&& binary, IDevice* device = nullptr);
 
-    // Execute the stored LightMetal binary by looping over all commands, and execting them.
+    // Run the stored LightMetal binary by looping over all commands, and executing them.
     // Returns true if passed.  Currently has no side-effects/artifacts returned to user,
     // may change in the future.
-    bool execute_binary();
+    bool run();
 
 private:
     // Executor functions for all traced host API calls (commands)

--- a/tt_metal/impl/lightmetal/lightmetal_replay.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay.cpp
@@ -104,7 +104,8 @@ std::shared_ptr<RuntimeArgs> LightMetalReplay::rt_args_from_flatbuffer(
 // LightMetalReplay Class           //
 //////////////////////////////////////
 
-LightMetalReplay::LightMetalReplay(LightMetalBinary&& binary) : binary_(std::move(binary)), fb_binary_(nullptr) {
+LightMetalReplay::LightMetalReplay(LightMetalBinary&& binary, IDevice* device) :
+    binary_(std::move(binary)), fb_binary_(nullptr), device_(device) {
     if (binary_.is_empty()) {
         log_warning(tt::LogMetalTrace, "Empty LightMetalBinary provided to LightMetalReplay.");
     }
@@ -227,8 +228,10 @@ void LightMetalReplay::remove_cb_handle_from_map(uint32_t global_id) { cb_handle
 //////////////////////////////////////
 
 // TODO (kmabee) - Hardcode for now, eventually capture/replay "systemdesc" from binary.
+// Alternatively, user can manage device open/close and pass to replay library.
 void LightMetalReplay::setup_devices() {
     log_debug(tt::LogMetalTrace, "LightMetalReplay(setup_devices) - Using hardcoded CreateDevices() as temp hack.");
+    TT_FATAL(!device_, "Device already setup in LightMetalReplay, no need to call setup_devices()");
     const size_t trace_region_size = 4096;  // Default is 0
     const int device_id = 0;
     const auto dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
@@ -694,6 +697,8 @@ bool LightMetalReplay::execute_binary() {
         return false;
     }
 
+    const bool replay_manages_device = device_ == nullptr;
+
     try {
         const auto* trace_descs = fb_binary_->trace_descriptors();
         const auto* commands = fb_binary_->commands();
@@ -702,12 +707,16 @@ bool LightMetalReplay::execute_binary() {
             return false;
         }
 
-        setup_devices();
         log_info(
             tt::LogMetalTrace,
-            "Running LightMetal Binary with {} cmds, {} traces.",
+            "Running LightMetal Binary with {} cmds, {} traces. ManageDevice: {}",
             commands->size(),
-            trace_descs->size());
+            trace_descs->size(),
+            replay_manages_device);
+
+        if (replay_manages_device) {
+            setup_devices();
+        }
 
         // Just loop over all commands, and execute. This is purposely kept simple for prototyping v0.
         // TODO (kmabee) - should expand to cover, multiple devices, cqs, etc.
@@ -719,13 +728,18 @@ bool LightMetalReplay::execute_binary() {
         }
 
         clear_object_maps();
-        close_devices();
+
+        if (replay_manages_device) {
+            close_devices();
+        }
 
         return true;
     } catch (const std::exception& e) {
-        clear_object_maps();
-        close_devices();
         log_fatal(e.what());
+        clear_object_maps();
+        if (replay_manages_device) {
+            close_devices();
+        }
         return false;
     }
 }

--- a/tt_metal/impl/lightmetal/lightmetal_replay.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay.cpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/device_impl.hpp>
-#include "lightmetal/lightmetal_replay.hpp"
+#include <tt-metalium/lightmetal_replay.hpp>
 #include "flatbuffer/base_types_from_flatbuffer.hpp"
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
@@ -691,7 +691,7 @@ void LightMetalReplay::execute(const ::tt::tt_metal::flatbuffer::LightMetalCompa
 }
 
 // Main entry point to execute a light metal binary blob, return true if pass.
-bool LightMetalReplay::execute_binary() {
+bool LightMetalReplay::run() {
     if (!fb_binary_) {
         std::cerr << "Cannot Replay empty/uninitialized Light Metal Binary." << std::endl;
         return false;

--- a/tt_metal/impl/lightmetal/lightmetal_replay.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay.hpp
@@ -54,7 +54,7 @@ inline namespace v0 {
 class LightMetalReplay {
 public:
     // Constructor that initializes the class with a binary blob and transfers ownership of the blob.
-    explicit LightMetalReplay(LightMetalBinary&& binary);
+    explicit LightMetalReplay(LightMetalBinary&& binary, IDevice* device = nullptr);
 
     // Execute the stored LightMetal binary by looping over all commands, and execting them.
     // Returns true if passed.  Currently has no side-effects/artifacts returned to user,

--- a/tt_metal/tools/lightmetal_runner/lightmetal_runner.cpp
+++ b/tt_metal/tools/lightmetal_runner/lightmetal_runner.cpp
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "impl/lightmetal/lightmetal_replay.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/assert.hpp>
-#include <lightmetal_binary.hpp>
+#include <tt-metalium/lightmetal_replay.hpp>
+#include <tt-metalium/lightmetal_binary.hpp>
 
 using namespace tt;
 
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
     auto binary = tt::tt_metal::LightMetalBinary::load_from_file(binary_filename);
     tt::tt_metal::LightMetalReplay lm_replay(std::move(binary));
 
-    if (!lm_replay.execute_binary()) {
+    if (!lm_replay.run()) {
         log_fatal("Light Metal Binary {} failed to execute or encountered errors.", binary_filename);
         return 1;
     } else {

--- a/ttnn/cpp/pybind11/core.hpp
+++ b/ttnn/cpp/pybind11/core.hpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/core.hpp"
 #include "tt-metalium/lightmetal_binary.hpp"
+#include "tt-metalium/lightmetal_replay.hpp"
 
 namespace py = pybind11;
 
@@ -43,6 +44,16 @@ void py_module(py::module& module) {
         .def("is_empty", &LightMetalBinary::is_empty)
         .def("save_to_file", &LightMetalBinary::save_to_file)
         .def_static("load_from_file", &LightMetalBinary::load_from_file);
+
+    py::class_<tt::tt_metal::LightMetalReplay>(module, "LightMetalReplay")
+        .def_static(
+            "create",
+            [](LightMetalBinary binary, IDevice* device = nullptr) {
+                return std::make_unique<tt::tt_metal::LightMetalReplay>(std::move(binary), device);
+            },
+            py::arg("binary"),
+            py::arg("device") = nullptr)
+        .def("run", &tt::tt_metal::LightMetalReplay::run);
 
     module.def("get_memory_config", &ttnn::get_memory_config);
     module.def("light_metal_begin_capture", &LightMetalBeginCapture);

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -230,6 +230,7 @@ from ttnn.core import (
     get_memory_config,
     light_metal_begin_capture,
     light_metal_end_capture,
+    LightMetalReplay,
     create_sharded_memory_config,
     create_sharded_memory_config_,
     dump_memory_config,

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -45,6 +45,9 @@ get_memory_config = ttnn._ttnn.core.get_memory_config
 light_metal_begin_capture = ttnn._ttnn.core.light_metal_begin_capture
 light_metal_end_capture = ttnn._ttnn.core.light_metal_end_capture
 
+# Add LightMetalReplay binding
+LightMetalReplay = ttnn._ttnn.core.LightMetalReplay
+
 
 def num_cores_to_corerangeset(
     target_num_cores: int,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18145

### Problem description

Add e2e capture+replay support for lightmetal in TTNN tests. This won't close ticket above, but step toward increasing coverage in TTNN.

### What's changed

Goal of this PR is just to add LightMetalBinary replay support in TTNN unit tests (so they are e2e capture+replay) just like was already in tt-metal unit tests. 3 things needed to do it I might squash before merge:
 
- Move lightmetal_replay.hpp out of tt_metal/impl into public API folder (avoids hacky includes to tt_metal/impl by TTNN)
- Allow user/test to manage device open/close when using LightMetalReplay instead of LightMetalReplay itself. Make that the default behavior used by TTNN and tt-metal fixtures, and add test to cover previous behavior to tt-metal suite (it still has some usefulness long term).
- pybind LightMetalReplay so it can be used in python ttnn test, and add reset_device fixture (used by tests) so that device can be closed and new one reopened before replaying the binary.  It's built from contents of original "device" fixture in terms of how it opens and closes device.  

While maybe not 100% neccessary with existing tests to close and re-open the device, this is consistent with the tt-metal fixture that does the same, and we figured it was safer/better-for-testing to have replay of binary start from freshly opened device than same device that previously ran same workload to generate binary.  ie, we want to ensure binary can be rereun from fresh device without issue.

I flagged hpp file move to public API folder to @blozano-tt and @ayerofieiev-tt already and idea.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
