### PR TITLE
Tightly Pack CB Indices for Reduce + Fused Ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -68,24 +68,24 @@ void MAIN {
 
     // input cbs
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_in = tt::CBIndex::c_29;
+    constexpr uint32_t cb_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
     constexpr uint32_t cb_scaler_global = tt::CBIndex::c_4;
     constexpr uint32_t cb_eps = tt::CBIndex::c_3;
     constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
+    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
 
     // interm cbs
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_x = tt::CBIndex::c_24;
-    constexpr uint32_t cb_xmm = tt::CBIndex::c_25;
+    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
+    constexpr uint32_t cb_x = tt::CBIndex::c_13;
+    constexpr uint32_t cb_xmm = tt::CBIndex::c_14;
     constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
     constexpr uint32_t cb_ex = tt::CBIndex::c_9;
     constexpr uint32_t cb_ex_external = tt::CBIndex::c_10;
     constexpr uint32_t cb_ex_global = num_cores_per_mcast_group == 1 ? cb_ex_partial : tt::CBIndex::c_15;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;
+    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_17;
 
     // interm cbs reuse
     constexpr uint32_t cb_fusion = cb_xmm;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -28,8 +28,8 @@ void kernel_main() {
     constexpr uint32_t cb_ex = tt::CBIndex::c_9;          // E[x] partial reduce
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;         // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
+    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);  // tile size

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -148,8 +148,8 @@ void kernel_main() {
     constexpr uint32_t cb_ex = tt::CBIndex::c_9;
     constexpr uint32_t cb_ex_external = tt::CBIndex::c_10;
     constexpr uint32_t cb_in0 = tt::CBIndex::c_0;  // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
+    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
     constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
     constexpr uint32_t cb_beta = tt::CBIndex::c_6;
     constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
+    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
 
     // constexpr uint32_t block_w = 4;
     const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -716,7 +716,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     }
 
     // in - stores tilized input
-    uint32_t in_cb_index = tt::CBIndex::c_29;
+    uint32_t in_cb_index = tt::CBIndex::c_1;
     tt::tt_metal::CircularBufferConfig in_cb_config =
         tt::tt_metal::CircularBufferConfig(in_CB_size, {{in_cb_index, in_data_format}})
             .set_page_size(in_cb_index, in_single_tile_size);
@@ -765,15 +765,15 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     }
     // input mask
     if (input_mask.has_value()) {
-        uint32_t in_mask_cb_index = tt::CBIndex::c_28;
+        uint32_t in_mask_cb_index = tt::CBIndex::c_7;
         tt::tt_metal::CircularBufferConfig in_mask_cb_config =
             tt::tt_metal::CircularBufferConfig(in_mask_CB_size, {{in_mask_cb_index, in_mask_cb_data_format}})
                 .set_page_size(in_mask_cb_index, in_mask_single_tile_size);
         auto cb_inz = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_mask_cb_config);
     }
     if (reader_repack_output) {
-        uint32_t repack_cb_index = tt::CBIndex::c_26;
-        uint32_t repack_out_cb_index = tt::CBIndex::c_31;
+        uint32_t repack_cb_index = tt::CBIndex::c_11;
+        uint32_t repack_out_cb_index = tt::CBIndex::c_12;
         std::map<uint8_t, tt::DataFormat> in0_out0_cb_data_format_spec{
             {repack_cb_index, in_data_format}, {repack_out_cb_index, in_data_format}};
         tt::tt_metal::CircularBufferConfig repack_cb_config =
@@ -783,13 +783,13 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         auto cb_inz = tt::tt_metal::CreateCircularBuffer(program, all_cores, repack_cb_config);
     }
     // x
-    uint32_t x_cb_index = tt::CBIndex::c_24;
+    uint32_t x_cb_index = tt::CBIndex::c_13;
     tt::tt_metal::CircularBufferConfig x_cb_config =
         tt::tt_metal::CircularBufferConfig(x_CB_size, {{x_cb_index, cb_data_format}})
             .set_page_size(x_cb_index, single_tile_size);
     auto cb_x = tt::tt_metal::CreateCircularBuffer(program, all_cores, x_cb_config);
     // xmm
-    uint32_t xmm_cb_index = tt::CBIndex::c_25;
+    uint32_t xmm_cb_index = tt::CBIndex::c_14;
     tt::tt_metal::CircularBufferConfig xmm_cb_config =
         tt::tt_metal::CircularBufferConfig(xmm_CB_size, {{xmm_cb_index, cb_data_format}})
             .set_page_size(xmm_cb_index, single_tile_size);
@@ -818,7 +818,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     auto cb_ex_global = tt::tt_metal::CreateCircularBuffer(program, all_cores, ex_global_cb_config);
     // ex2pe
     uint32_t cb_ex2pe_index;
-    cb_ex2pe_index = tt::CBIndex::c_27;
+    cb_ex2pe_index = tt::CBIndex::c_17;
     tt::tt_metal::CircularBufferConfig ex2pe_cb_config =
         tt::tt_metal::CircularBufferConfig(ex2pe_CB_size, {{cb_ex2pe_index, cb_data_format}})
             .set_page_size(cb_ex2pe_index, single_tile_size);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -44,17 +44,17 @@ void MAIN {
 #else
     constexpr uint32_t cb_xmm = tt::CBIndex::c_24;  // x minus mean
 #endif
-    constexpr auto cb_ex = tt::CBIndex::c_25;      // E[x]
-    constexpr auto cb_ex2 = tt::CBIndex::c_26;     // E[(x-E[x])^2]
-    constexpr auto cb_xmm2 = tt::CBIndex::c_27;    // xmm^2
-    constexpr auto cb_ex2pe = tt::CBIndex::c_28;   // E[(x-E[x])^2]+eps
-    constexpr auto cb_fusion = tt::CBIndex::c_29;  // stream gamma/beta
+    constexpr auto cb_ex = tt::CBIndex::c_18;      // E[x]
+    constexpr auto cb_ex2 = tt::CBIndex::c_19;     // E[(x-E[x])^2]
+    constexpr auto cb_xmm2 = tt::CBIndex::c_20;    // xmm^2
+    constexpr auto cb_ex2pe = tt::CBIndex::c_21;   // E[(x-E[x])^2]+eps
+    constexpr auto cb_fusion = tt::CBIndex::c_22;  // stream gamma/beta
     constexpr auto scaler0 = 0;
 #ifdef FUSE_PRE_ADD
 #ifdef RMSNORM
     constexpr uint32_t cb_x = cb_xmm;
 #else
-    constexpr uint32_t cb_x = tt::CBIndex::c_30;
+    constexpr uint32_t cb_x = tt::CBIndex::c_23;
 #endif
 #else
     constexpr uint32_t cb_x = cb_in;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -67,7 +67,7 @@ void MAIN {
 #if defined RMSNORM and not defined FUSE_PRE_ADD
     constexpr uint32_t cb_xmm = cb_in0;  // x minus mean
 #else
-    constexpr uint32_t cb_xmm = tt::CBIndex::c_25;  // x minus mean
+    constexpr uint32_t cb_xmm = tt::CBIndex::c_18;  // x minus mean
 #endif
     constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;  // E[x] partial reduce
     constexpr uint32_t cb_ex = tt::CBIndex::c_9;          // E[x] global reduce
@@ -77,8 +77,8 @@ void MAIN {
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
     constexpr uint32_t cb_xmm2 = cb_x;                    // xmm^2
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;      // E[(x-E[x])^2]+eps
-    constexpr uint32_t cb_fusion = tt::CBIndex::c_25;     // stream gamma/beta
+    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_20;      // E[(x-E[x])^2]+eps
+    constexpr uint32_t cb_fusion = tt::CBIndex::c_18;     // stream gamma/beta
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
     binary_op_init_common(cb_in0, cb_in0, cb_x);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -68,12 +68,12 @@ void MAIN {
     constexpr uint32_t cb_ex = tt::CBIndex::c_9;              // E[x] global reduce
     constexpr uint32_t cb_ex2 = tt::CBIndex::c_12;            // E[x^2]
     constexpr uint32_t cb_stats = tt::CBIndex::c_7;           // E[(x-E[x])^2] global reduce
-    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_28;  // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;  // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;      // E[x] global reduce
-    constexpr uint32_t cb_reciprocal = tt::CBIndex::c_27;     // [E[x^2]-E[x]^2]+eps
-    constexpr uint32_t cb_fusion = tt::CBIndex::c_25;         // stream gamma/beta
+    constexpr uint32_t cb_reciprocal = tt::CBIndex::c_20;     // [E[x^2]-E[x]^2]+eps
+    constexpr uint32_t cb_fusion = tt::CBIndex::c_18;         // stream gamma/beta
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
-    constexpr uint32_t cb_var = tt::CBIndex::c_26;
+    constexpr uint32_t cb_var = tt::CBIndex::c_19;
     constexpr uint32_t cb_ex_sqr = tt::CBIndex::c_24;  // E[x]^2
 
 #ifdef RMSNORM
@@ -83,7 +83,7 @@ void MAIN {
 #else
     binary_op_init_common(cb_stats, cb_scaler_global, cb_stats_reduced);
     constexpr uint32_t stats_tiles = 2;
-    constexpr uint32_t cb_xmm = tt::CBIndex::c_25;  // x minus mean
+    constexpr uint32_t cb_xmm = tt::CBIndex::c_18;  // x minus mean
 #endif
 
     // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
     constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;  // E[(x-E[x])^2] partial reduce
     constexpr uint32_t cb_ex2 = tt::CBIndex::c_12;          // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;
+    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_20;
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);  // tile size

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
     constexpr uint32_t cb_ex_partial2 = tt::CBIndex::c_11;
     constexpr uint32_t cb_ex2 = tt::CBIndex::c_12;
     constexpr uint32_t cb_ex_external2 = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;
+    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_20;
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -20,7 +20,7 @@ void kernel_main() {
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
     const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(3);
 
-    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_28;  // [E[x], E[x^2]] local to sender
+    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;  // [E[x], E[x^2]] local to sender
     constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;      // [E[x], E[X^2]] global to all cores
 
     const uint64_t multicast_data_noc = get_noc_multicast_addr(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -17,9 +17,9 @@ void kernel_main() {
     uint32_t beta_addr = get_arg_val<uint32_t>(7);
     uint32_t b_addr = get_arg_val<uint32_t>(8);
 
-    constexpr uint32_t cb_id_in0 = 0, cb_id_in1 = 1;
-    constexpr uint32_t cb_id_gamma = 5;
-    constexpr uint32_t cb_id_beta = 6;
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0, cb_id_in1 = tt::CBIndex::c_1;
+    constexpr uint32_t cb_id_gamma = tt::CBIndex::c_5;
+    constexpr uint32_t cb_id_beta = tt::CBIndex::c_6;
 
     // ublocks size defined in tiles
     const uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
@@ -55,7 +55,7 @@ void kernel_main() {
 
     // Generate constant tiles for layernorm compute
     {
-        constexpr uint32_t cb_in_2 = 2;
+        constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         uint32_t scaler = get_arg_val<uint32_t>(4);
         generate_reduce_scaler(cb_in_2, scaler);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -17,9 +17,9 @@ void kernel_main() {
     uint32_t beta_addr = get_arg_val<uint32_t>(7);
     uint32_t b_addr = get_arg_val<uint32_t>(8);
 
-    constexpr uint32_t cb_id_in0 = 0, cb_id_in1 = 1;
-    constexpr uint32_t cb_id_gamma = 5;
-    constexpr uint32_t cb_id_beta = 6;
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0, cb_id_in1 = tt::CBIndex::c_1;
+    constexpr uint32_t cb_id_gamma = tt::CBIndex::c_5;
+    constexpr uint32_t cb_id_beta = tt::CBIndex::c_6;
 
     // ublocks size defined in tiles
     const uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
@@ -67,7 +67,7 @@ void kernel_main() {
 
     // Generate constant tiles for layernorm compute
     {
-        constexpr uint32_t cb_in_2 = 2;
+        constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         uint32_t scaler = get_arg_val<uint32_t>(4);
         generate_reduce_scaler(cb_in_2, scaler);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -12,7 +12,7 @@ void kernel_main() {
     constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t blk = get_compile_time_arg_val(1);  // needed for correctness of softmax/LN kernels
 
-    constexpr uint32_t cb_id_out0 = 16;
+    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -306,8 +306,8 @@ operation::ProgramWithCallbacks layernorm_multi_core(
     CreateCircularBuffer(program, all_cores, cb_out0_config);
     if (!rms_norm) {
         CircularBufferConfig cb_intermed1_config =
-            CircularBufferConfig(im1_t * single_tile_size, {{tt::CBIndex::c_25, cb_data_format}})
-                .set_page_size(tt::CBIndex::c_25, single_tile_size);
+            CircularBufferConfig(im1_t * single_tile_size, {{tt::CBIndex::c_18, cb_data_format}})
+                .set_page_size(tt::CBIndex::c_18, single_tile_size);
         CreateCircularBuffer(program, all_cores, cb_intermed1_config);
     }
     CircularBufferConfig cb_in2_config =
@@ -319,8 +319,8 @@ operation::ProgramWithCallbacks layernorm_multi_core(
             .set_page_size(tt::CBIndex::c_3, bfloat16_tile_size);
     CreateCircularBuffer(program, all_cores, cb_in3_config);
     CircularBufferConfig cb_intermed2_config =
-        CircularBufferConfig(im2_t * single_tile_size, {{tt::CBIndex::c_26, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_26, single_tile_size);
+        CircularBufferConfig(im2_t * single_tile_size, {{tt::CBIndex::c_19, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_19, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed2_config);
     if (!(rms_norm && !b.has_value())) {
         CircularBufferConfig cb_intermed0_config =
@@ -329,17 +329,17 @@ operation::ProgramWithCallbacks layernorm_multi_core(
         CreateCircularBuffer(program, all_cores, cb_intermed0_config);
     }
     CircularBufferConfig c_intermed3_config =
-        CircularBufferConfig(im3_t * single_tile_size, {{tt::CBIndex::c_27, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_27, single_tile_size);
+        CircularBufferConfig(im3_t * single_tile_size, {{tt::CBIndex::c_20, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_20, single_tile_size);
     CreateCircularBuffer(program, all_cores, c_intermed3_config);
     CircularBufferConfig c_intermed4_config =
-        CircularBufferConfig(im4_t * single_tile_size, {{tt::CBIndex::c_28, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_28, single_tile_size);
+        CircularBufferConfig(im4_t * single_tile_size, {{tt::CBIndex::c_21, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_21, single_tile_size);
     CreateCircularBuffer(program, all_cores, c_intermed4_config);
     if (gamma.has_value() || beta.has_value()) {
         CircularBufferConfig c_intermed5_config =
-            CircularBufferConfig(im5_t * single_tile_size, {{tt::CBIndex::c_29, cb_data_format}})
-                .set_page_size(tt::CBIndex::c_29, single_tile_size);
+            CircularBufferConfig(im5_t * single_tile_size, {{tt::CBIndex::c_22, cb_data_format}})
+                .set_page_size(tt::CBIndex::c_22, single_tile_size);
         CreateCircularBuffer(program, all_cores, c_intermed5_config);
     }
     if (gamma.has_value()) {
@@ -361,8 +361,8 @@ operation::ProgramWithCallbacks layernorm_multi_core(
         // used as x b is buffered into c_in1
         if (!rms_norm) {
             CircularBufferConfig c_intermed6_config =
-                CircularBufferConfig(im6_t * single_tile_size, {{tt::CBIndex::c_30, cb_data_format}})
-                    .set_page_size(tt::CBIndex::c_30, single_tile_size);
+                CircularBufferConfig(im6_t * single_tile_size, {{tt::CBIndex::c_23, cb_data_format}})
+                    .set_page_size(tt::CBIndex::c_23, single_tile_size);
             CreateCircularBuffer(program, all_cores, c_intermed6_config);
         }
         // c_in1 is input buffer for b
@@ -1298,7 +1298,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     auto cb_x = tt::tt_metal::CreateCircularBuffer(program, all_cores, x_cb_config);
     // xmm
     uint32_t xmm_cb_index;
-    xmm_cb_index = tt::CBIndex::c_25;
+    xmm_cb_index = tt::CBIndex::c_18;
     tt::tt_metal::CircularBufferConfig xmm_cb_config =
         tt::tt_metal::CircularBufferConfig(xmm_CB_size, {{xmm_cb_index, cb_data_format}})
             .set_page_size(xmm_cb_index, single_tile_size);
@@ -1349,7 +1349,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     auto cb_ex_global = tt::tt_metal::CreateCircularBuffer(program, all_cores, ex_global_cb_config);
     // ex2pe
     uint32_t cb_ex2pe_index;
-    cb_ex2pe_index = tt::CBIndex::c_27;
+    cb_ex2pe_index = tt::CBIndex::c_20;
     tt::tt_metal::CircularBufferConfig ex2pe_cb_config =
         tt::tt_metal::CircularBufferConfig(ex2pe_CB_size, {{cb_ex2pe_index, cb_data_format}})
             .set_page_size(cb_ex2pe_index, single_tile_size);
@@ -1367,14 +1367,14 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         cb_stats = tt::tt_metal::CreateCircularBuffer(program, sender_cores, stats_cb_config);
         // cb_stats_reduced
         uint32_t cb_stats_reduced_index;
-        cb_stats_reduced_index = tt::CBIndex::c_28;
+        cb_stats_reduced_index = tt::CBIndex::c_21;
         tt::tt_metal::CircularBufferConfig stats_reduced_cb_config =
             tt::tt_metal::CircularBufferConfig(stats_reduced_cb_size, {{cb_stats_reduced_index, cb_data_format}})
                 .set_page_size(cb_stats_reduced_index, single_tile_size);
         auto cb_stats_reduced = tt::tt_metal::CreateCircularBuffer(program, sender_cores, stats_reduced_cb_config);
 
         // cb_var
-        uint32_t cb_var_index = tt::CBIndex::c_26;
+        uint32_t cb_var_index = tt::CBIndex::c_19;
         tt::tt_metal::CircularBufferConfig cb_var_config =
             tt::tt_metal::CircularBufferConfig(ex_global_CB_size, {{cb_var_index, cb_data_format}})
                 .set_page_size(cb_var_index, single_tile_size);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -44,18 +44,18 @@ void MAIN {
     constexpr uint32_t cb_eps = tt::CBIndex::c_4;
     constexpr uint32_t cb_reduce = tt::CBIndex::c_5;
 
-    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out = tt::CBIndex::c_14;
 
-    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_24;   // [E(x**2), E(x)]
-    constexpr uint32_t cb_var_eps = tt::CBIndex::c_27;         // var + epsilon (or E(x**2) + epsilon)
-    constexpr uint32_t cb_recip_sqrt_var = tt::CBIndex::c_28;  // 1/sqrt(var+eps)
-    constexpr uint32_t cb_x_normed = tt::CBIndex::c_30;  // (x - E(x)) * 1/sqrt(var+eps) or x * 1/sqrt(E(x**2) + eps)
+    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_6;    // [E(x**2), E(x)]
+    constexpr uint32_t cb_var_eps = tt::CBIndex::c_9;          // var + epsilon (or E(x**2) + epsilon)
+    constexpr uint32_t cb_recip_sqrt_var = tt::CBIndex::c_10;  // 1/sqrt(var+eps)
+    constexpr uint32_t cb_x_normed = tt::CBIndex::c_12;  // (x - E(x)) * 1/sqrt(var+eps) or x * 1/sqrt(E(x**2) + eps)
 
-    constexpr uint32_t cb_var = tt::CBIndex::c_26;  // E(x**2) - E(x)**2 or E(x**2)
+    constexpr uint32_t cb_var = tt::CBIndex::c_8;  // E(x**2) - E(x)**2 or E(x**2)
 #ifndef RMSNORM
     // Layernorm-specific CBs
-    constexpr uint32_t cb_mean_squared = tt::CBIndex::c_25;  // E(x)**2
-    constexpr uint32_t cb_x_minus_mean = tt::CBIndex::c_29;  // x - E(x)
+    constexpr uint32_t cb_mean_squared = tt::CBIndex::c_7;   // E(x)**2
+    constexpr uint32_t cb_x_minus_mean = tt::CBIndex::c_11;  // x - E(x)
 
     constexpr uint32_t cb_norm_x_input = cb_x_minus_mean;
     constexpr uint32_t stats_tile_stride = 2;
@@ -68,7 +68,7 @@ void MAIN {
     constexpr uint32_t cb_beta = tt::CBIndex::c_3;
     uint32_t cb_times_gamma_out = cb_out;
     if constexpr (do_gamma and do_beta) {
-        cb_times_gamma_out = tt::CBIndex::c_31;
+        cb_times_gamma_out = tt::CBIndex::c_13;
     }
 
     binary_op_init_common(cb_inp, cb_inp, cb_stats_reduced);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -33,9 +33,9 @@ void MAIN {
     constexpr uint32_t cb_inp = tt::CBIndex::c_0;
     constexpr uint32_t cb_reduce = tt::CBIndex::c_1;
 
-    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out = tt::CBIndex::c_14;
 
-    constexpr uint32_t cb_x2 = tt::CBIndex::c_24;  // x**2
+    constexpr uint32_t cb_x2 = tt::CBIndex::c_6;  // x**2
 
     cb_wait_front(cb_reduce, 1);  // comes from the reader
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -16,7 +16,7 @@ void kernel_main() {
     constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t blk = get_compile_time_arg_val(1);  // needed for correctness of softmax/LN kernels
 
-    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out = tt::CBIndex::c_14;
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_out);
     const DataFormat data_format = get_dataformat(cb_out);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -349,55 +349,55 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
     // LN and RMS shared intermediates //
     // c_intermed0 -> [mean(x**2), mean(x)]
     CircularBufferConfig cb_intermed0_config =
-        CircularBufferConfig(intermed0_tiles * single_tile_size, {{tt::CBIndex::c_24, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_24, single_tile_size);
+        CircularBufferConfig(intermed0_tiles * single_tile_size, {{tt::CBIndex::c_6, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_6, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed0_config);
     // c_intermed2 -> var = mean(x**2) - mean(x)**2
     CircularBufferConfig cb_intermed2_config =
-        CircularBufferConfig(intermed2_tiles * single_tile_size, {{tt::CBIndex::c_26, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_26, single_tile_size);
+        CircularBufferConfig(intermed2_tiles * single_tile_size, {{tt::CBIndex::c_8, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_8, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed2_config);
     // c_intermed3 -> var + epsilon
     CircularBufferConfig cb_intermed3_config =
-        CircularBufferConfig(intermed3_tiles * single_tile_size, {{tt::CBIndex::c_27, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_27, single_tile_size);
+        CircularBufferConfig(intermed3_tiles * single_tile_size, {{tt::CBIndex::c_9, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_9, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed3_config);
     // c_intermed4 -> 1/sqrt(var + epsilon)
     CircularBufferConfig cb_intermed4_config =
-        CircularBufferConfig(intermed4_tiles * single_tile_size, {{tt::CBIndex::c_28, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_28, single_tile_size);
+        CircularBufferConfig(intermed4_tiles * single_tile_size, {{tt::CBIndex::c_10, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_10, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed4_config);
     // c_intermed6 -> (x - mean(x)) * 1/sqrt(var + epsilon)
     CircularBufferConfig cb_intermed6_config =
-        CircularBufferConfig(intermed6_tiles * single_tile_size, {{tt::CBIndex::c_30, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_30, single_tile_size);
+        CircularBufferConfig(intermed6_tiles * single_tile_size, {{tt::CBIndex::c_12, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_12, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed6_config);
 
     // LN-specific intermediates
     if (!is_rmsnorm) {
         // c_intermed1 -> mean(x)**2
         CircularBufferConfig cb_intermed1_config =
-            CircularBufferConfig(intermed1_tiles * single_tile_size, {{tt::CBIndex::c_25, cb_data_format}})
-                .set_page_size(tt::CBIndex::c_25, single_tile_size);
+            CircularBufferConfig(intermed1_tiles * single_tile_size, {{tt::CBIndex::c_7, cb_data_format}})
+                .set_page_size(tt::CBIndex::c_7, single_tile_size);
         CreateCircularBuffer(program, all_cores, cb_intermed1_config);
         // c_intermed5 -> x - mean(x)
         CircularBufferConfig cb_intermed5_config =
-            CircularBufferConfig(intermed5_tiles * single_tile_size, {{tt::CBIndex::c_29, cb_data_format}})
-                .set_page_size(tt::CBIndex::c_29, single_tile_size);
+            CircularBufferConfig(intermed5_tiles * single_tile_size, {{tt::CBIndex::c_11, cb_data_format}})
+                .set_page_size(tt::CBIndex::c_11, single_tile_size);
         CreateCircularBuffer(program, all_cores, cb_intermed5_config);
         if (beta.has_value()) {
             // Layernorm has gamma and beta so we need an extra intermediate buffer
             // c_intermed7 -> (x - mean(x)) * 1/sqrt(var + epsilon) * gamma
             CircularBufferConfig cb_intermed7_config =
-                CircularBufferConfig(intermed7_tiles * single_tile_size, {{tt::CBIndex::c_31, cb_data_format}})
-                    .set_page_size(tt::CBIndex::c_31, single_tile_size);
+                CircularBufferConfig(intermed7_tiles * single_tile_size, {{tt::CBIndex::c_13, cb_data_format}})
+                    .set_page_size(tt::CBIndex::c_13, single_tile_size);
             CreateCircularBuffer(program, all_cores, cb_intermed7_config);
         }
     }
 
     CircularBufferConfig cb_out0_config =
-        CircularBufferConfig(out0_tiles * out_single_tile_size, {{tt::CBIndex::c_16, out_data_format}})
-            .set_page_size(tt::CBIndex::c_16, out_single_tile_size);
+        CircularBufferConfig(out0_tiles * out_single_tile_size, {{tt::CBIndex::c_14, out_data_format}})
+            .set_page_size(tt::CBIndex::c_14, out_single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_out0_config);
 
     // Log all circular buffers with program.circular_buffers_on_corerange(all_cores), which returns

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -222,13 +222,13 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     // LN and RMS shared intermediates //
     // c_intermed0 -> xˆ2
     CircularBufferConfig cb_intermed0_config =
-        CircularBufferConfig(intermed0_tiles * single_tile_size, {{tt::CBIndex::c_24, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_24, single_tile_size);
+        CircularBufferConfig(intermed0_tiles * single_tile_size, {{tt::CBIndex::c_6, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_6, single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_intermed0_config);
 
     CircularBufferConfig cb_out0_config =
-        CircularBufferConfig(out0_tiles * out_single_tile_size, {{tt::CBIndex::c_16, out_data_format}})
-            .set_page_size(tt::CBIndex::c_16, out_single_tile_size);
+        CircularBufferConfig(out0_tiles * out_single_tile_size, {{tt::CBIndex::c_14, out_data_format}})
+            .set_page_size(tt::CBIndex::c_14, out_single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_out0_config);
 
     // Log all circular buffers with program.circular_buffers_on_corerange(all_cores), which returns

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -75,7 +75,7 @@ void MAIN {
     const uint32_t ndst = get_arg_val<uint32_t>(3);
     const uint32_t start_ht = get_arg_val<uint32_t>(4);
     const uint32_t mask_padded_data = get_arg_val<uint32_t>(5);
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_24);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_6);
 
     constexpr uint32_t onetile = 1;
     // reserve one tile for zeros on cb_in2
@@ -86,14 +86,14 @@ void MAIN {
     constexpr auto cb_fused_scale = tt::CBIndex::c_3;
     constexpr auto cb_fused_attn = tt::CBIndex::c_4;
     constexpr auto cb_mask_padded = tt::CBIndex::c_5;
-    constexpr auto cb_exps = tt::CBIndex::c_24;
-    constexpr auto cb_scale_mask = tt::CBIndex::c_27;
-    constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
+    constexpr auto cb_exps = tt::CBIndex::c_6;
+    constexpr auto cb_scale_mask = tt::CBIndex::c_9;
+    constexpr auto cb_recipsumexps = tt::CBIndex::c_7;
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    constexpr auto cb_out0 = tt::CBIndex::c_11;
 #ifdef NUMERIC_STABLE
-    constexpr auto cb_max = tt::CBIndex::c_26;
-    constexpr auto cb_x = tt::CBIndex::c_28;
+    constexpr auto cb_max = tt::CBIndex::c_8;
+    constexpr auto cb_x = tt::CBIndex::c_10;
 #else
     constexpr auto cb_x = cb_exps;
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -70,19 +70,19 @@ void MAIN {
     constexpr uint32_t subblock_w = get_compile_time_arg_val(2);
     constexpr uint32_t num_subblocks_w = get_compile_time_arg_val(3);
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_24);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_6);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     constexpr auto cb_bcast_scaler = tt::CBIndex::c_1;
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     constexpr auto cb_fused_attn = tt::CBIndex::c_3;
-    constexpr auto cb_exps = tt::CBIndex::c_24;
-    constexpr auto cb_recipsumexps = tt::CBIndex::c_25;
-    constexpr auto cb_scale_mask = tt::CBIndex::c_26;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    constexpr auto cb_exps = tt::CBIndex::c_6;
+    constexpr auto cb_recipsumexps = tt::CBIndex::c_7;
+    constexpr auto cb_scale_mask = tt::CBIndex::c_8;
+    constexpr auto cb_out0 = tt::CBIndex::c_11;
 #ifdef NUMERIC_STABLE
-    constexpr auto cb_max = tt::CBIndex::c_27;
-    constexpr auto cb_x = tt::CBIndex::c_28;
+    constexpr auto cb_max = tt::CBIndex::c_9;
+    constexpr auto cb_x = tt::CBIndex::c_10;
 #else
     constexpr auto cb_x = cb_exps;
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/reader_unary_interleaved_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/reader_unary_interleaved_sm.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
     const uint32_t Wt = get_arg_val<uint32_t>(5);
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t cb_id_in0 = 0, cb_id_in1 = 1;
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0, cb_id_in1 = tt::CBIndex::c_1;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
@@ -58,7 +58,7 @@ void kernel_main() {
 
     // TODO(AP): cleanup, probably with named args/param pack/reflection.
     {
-        constexpr uint32_t cb_in_2 = 2;
+        constexpr uint32_t cb_in_2 = tt::CBIndex::c_2;
         const uint32_t reduce_scaler = get_arg_val<uint32_t>(10);
         generate_reduce_scaler(cb_in_2, reduce_scaler);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
 
     constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
 
-    constexpr uint32_t cb_id_out0 = 16;
+    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_11;
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     const DataFormat data_format = get_dataformat(cb_id_out0);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -210,17 +210,17 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     auto c_in0_config = CircularBufferConfig(in0_t * in0_tile_size, {{tt::CBIndex::c_0, in0_cb_data_format}})
                             .set_page_size(tt::CBIndex::c_0, in0_tile_size);
     auto cb_in0_id = CreateCircularBuffer(program, all_device_cores, c_in0_config);
-    auto c_out0_config = CircularBufferConfig(out0_t * out0_tile_size, {{tt::CBIndex::c_16, out0_cb_data_format}})
-                             .set_page_size(tt::CBIndex::c_16, out0_tile_size);
+    auto c_out0_config = CircularBufferConfig(out0_t * out0_tile_size, {{tt::CBIndex::c_11, out0_cb_data_format}})
+                             .set_page_size(tt::CBIndex::c_11, out0_tile_size);
     auto cb_out0_id = CreateCircularBuffer(program, all_device_cores, c_out0_config);
-    auto c_intermed1_config = CircularBufferConfig(im1_t * im_tile_size, {{tt::CBIndex::c_25, im_cb_data_format}})
-                                  .set_page_size(tt::CBIndex::c_25, im_tile_size);
+    auto c_intermed1_config = CircularBufferConfig(im1_t * im_tile_size, {{tt::CBIndex::c_7, im_cb_data_format}})
+                                  .set_page_size(tt::CBIndex::c_7, im_tile_size);
     auto cb_intermed1_id = CreateCircularBuffer(program, all_device_cores, c_intermed1_config);
     auto c_in2_config = CircularBufferConfig(in2_t * scalar_tile_size, {{tt::CBIndex::c_2, scalar_cb_data_format}})
                             .set_page_size(tt::CBIndex::c_2, scalar_tile_size);
     auto cb_in2_id = CreateCircularBuffer(program, all_device_cores, c_in2_config);
-    auto c_intermed0_config = CircularBufferConfig(im0_t * im_tile_size, {{tt::CBIndex::c_24, im_cb_data_format}})
-                                  .set_page_size(tt::CBIndex::c_24, im_tile_size);
+    auto c_intermed0_config = CircularBufferConfig(im0_t * im_tile_size, {{tt::CBIndex::c_6, im_cb_data_format}})
+                                  .set_page_size(tt::CBIndex::c_6, im_tile_size);
     auto cb_intermed0_id = CreateCircularBuffer(program, all_device_cores, c_intermed0_config);
     std::optional<CBHandle> cb_intermed3_id;
     std::optional<CBHandle> cb_in3_id;
@@ -228,8 +228,8 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     std::optional<CBHandle> cb_in5_id;
     if (mask.has_value()) {
         CircularBufferConfig c_intermed3_config =
-            CircularBufferConfig(im3_t * im_tile_size, {{tt::CBIndex::c_27, im_cb_data_format}})
-                .set_page_size(tt::CBIndex::c_27, im_tile_size);
+            CircularBufferConfig(im3_t * im_tile_size, {{tt::CBIndex::c_9, im_cb_data_format}})
+                .set_page_size(tt::CBIndex::c_9, im_tile_size);
         cb_intermed3_id = CreateCircularBuffer(program, all_device_cores, c_intermed3_config);
         CircularBufferConfig c_in3_config =
             CircularBufferConfig(in3_t * scalar_tile_size, {{tt::CBIndex::c_3, scalar_cb_data_format}})
@@ -248,12 +248,12 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     std::optional<CBHandle> cb_intermed4_id;
     if (numeric_stable) {
         // cb_max
-        auto c_intermed2_config = CircularBufferConfig(im2_t * im_tile_size, {{tt::CBIndex::c_26, im_cb_data_format}})
-                                      .set_page_size(tt::CBIndex::c_26, im_tile_size);
+        auto c_intermed2_config = CircularBufferConfig(im2_t * im_tile_size, {{tt::CBIndex::c_8, im_cb_data_format}})
+                                      .set_page_size(tt::CBIndex::c_8, im_tile_size);
         cb_intermed2_id = CreateCircularBuffer(program, all_device_cores, c_intermed2_config);
         // cb_x
-        auto c_x_config = CircularBufferConfig(im4_t * im_tile_size, {{tt::CBIndex::c_28, im_cb_data_format}})
-                              .set_page_size(tt::CBIndex::c_28, im_tile_size);
+        auto c_x_config = CircularBufferConfig(im4_t * im_tile_size, {{tt::CBIndex::c_10, im_cb_data_format}})
+                              .set_page_size(tt::CBIndex::c_10, im_tile_size);
         cb_intermed4_id = CreateCircularBuffer(program, all_device_cores, c_x_config);
     }
 
@@ -771,8 +771,8 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     std::optional<CBHandle> cb_in3_id;
     if (mask.has_value()) {
         // im2
-        auto c_intermed2_config = CircularBufferConfig(im2_CB_size, {{tt::CBIndex::c_26, im_cb_data_format}})
-                                      .set_page_size(tt::CBIndex::c_26, im_tile_size);
+        auto c_intermed2_config = CircularBufferConfig(im2_CB_size, {{tt::CBIndex::c_8, im_cb_data_format}})
+                                      .set_page_size(tt::CBIndex::c_8, im_tile_size);
         cb_intermed2_id = CreateCircularBuffer(program, all_device_cores, c_intermed2_config);
         // in2 scale
         auto c_in2_config = CircularBufferConfig(in2_CB_size, {{tt::CBIndex::c_2, scale_cb_data_format}})
@@ -792,26 +792,26 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
         }
     }
     // out
-    auto c_out0_config = CircularBufferConfig(out_CB_size, {{tt::CBIndex::c_16, out0_cb_data_format}})
-                             .set_page_size(tt::CBIndex::c_16, out0_tile_size)
+    auto c_out0_config = CircularBufferConfig(out_CB_size, {{tt::CBIndex::c_11, out0_cb_data_format}})
+                             .set_page_size(tt::CBIndex::c_11, out0_tile_size)
                              .set_globally_allocated_address(*out0_buffer);
     auto cb_out0_id = CreateCircularBuffer(program, all_device_cores, c_out0_config);
     // im0 for exp(x)
-    auto c_intermed0_config = CircularBufferConfig(im0_CB_size, {{tt::CBIndex::c_24, im_cb_data_format}})
-                                  .set_page_size(tt::CBIndex::c_24, im_tile_size);
+    auto c_intermed0_config = CircularBufferConfig(im0_CB_size, {{tt::CBIndex::c_6, im_cb_data_format}})
+                                  .set_page_size(tt::CBIndex::c_6, im_tile_size);
     auto cb_intermed0_id = CreateCircularBuffer(program, all_device_cores, c_intermed0_config);
     // im1 for 1/sum(exp(x))
-    auto c_intermed1_config = CircularBufferConfig(im1_CB_size, {{tt::CBIndex::c_25, im_cb_data_format}})
-                                  .set_page_size(tt::CBIndex::c_25, im_tile_size);
+    auto c_intermed1_config = CircularBufferConfig(im1_CB_size, {{tt::CBIndex::c_7, im_cb_data_format}})
+                                  .set_page_size(tt::CBIndex::c_7, im_tile_size);
     auto cb_intermed1_id = CreateCircularBuffer(program, all_device_cores, c_intermed1_config);
     if (numeric_stable) {
         // cb_max
-        auto c_intermed3_config = CircularBufferConfig(max_CB_size, {{tt::CBIndex::c_27, im_cb_data_format}})
-                                      .set_page_size(tt::CBIndex::c_27, im_tile_size);
+        auto c_intermed3_config = CircularBufferConfig(max_CB_size, {{tt::CBIndex::c_9, im_cb_data_format}})
+                                      .set_page_size(tt::CBIndex::c_9, im_tile_size);
         auto cb_intermed3_id = CreateCircularBuffer(program, all_device_cores, c_intermed3_config);
         // cb_x
-        auto c_intermed4_config = CircularBufferConfig(x_CB_size, {{tt::CBIndex::c_28, im_cb_data_format}})
-                                      .set_page_size(tt::CBIndex::c_28, im_tile_size);
+        auto c_intermed4_config = CircularBufferConfig(x_CB_size, {{tt::CBIndex::c_10, im_cb_data_format}})
+                                      .set_page_size(tt::CBIndex::c_10, im_tile_size);
         auto cb_intermed4_id = CreateCircularBuffer(program, all_device_cores, c_intermed4_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -48,7 +48,7 @@ operation::ProgramWithCallbacks argmax_single_core(
             .set_page_size(src0_cb_index, aligned_input_unit_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t intermed0_cb_index = tt::CBIndex::c_24;
+    uint32_t intermed0_cb_index = tt::CBIndex::c_1;
     uint32_t num_intermed0_units = B * C * H;
     uint32_t aligned_intermed0_unit_size = num_intermed0_units * output_unit_size;
     tt::tt_metal::CircularBufferConfig intermed0_cb_config =
@@ -146,7 +146,7 @@ operation::ProgramWithCallbacks argmax_multi_core(
             .set_page_size(src0_cb_index, aligned_input_unit_size);
     auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t intermed0_cb_index = tt::CBIndex::c_24;
+    uint32_t intermed0_cb_index = tt::CBIndex::c_1;
     uint32_t num_intermed0_units = B * C * H;
     uint32_t aligned_intermed0_unit_size = num_intermed0_units * output_unit_size;
     tt::tt_metal::CircularBufferConfig intermed0_cb_config =
@@ -154,7 +154,7 @@ operation::ProgramWithCallbacks argmax_multi_core(
             .set_page_size(intermed0_cb_index, aligned_intermed0_unit_size);  /// page size shouldn't matter here
     auto cb_intermed0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, intermed0_cb_config);
 
-    uint32_t intermed1_cb_index = tt::CBIndex::c_8;
+    uint32_t intermed1_cb_index = tt::CBIndex::c_2;
     uint32_t num_intermed1_units = B * C * H;
     uint32_t aligned_intermed1_unit_size = round_up_to_mul32(num_intermed1_units * input_unit_size);
     tt::tt_metal::CircularBufferConfig intermed1_cb_config =
@@ -162,7 +162,7 @@ operation::ProgramWithCallbacks argmax_multi_core(
             .set_page_size(intermed1_cb_index, aligned_intermed1_unit_size);  /// page size shouldn't matter here
     auto cb_intermed1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, intermed1_cb_config);
 
-    uint32_t out0_cb_index = tt::CBIndex::c_16;
+    uint32_t out0_cb_index = tt::CBIndex::c_3;
     uint32_t num_out0_units = B * C * H;
     uint32_t aligned_out0_unit_size = num_out0_units * output_unit_size;
     tt::tt_metal::CircularBufferConfig out0_cb_config =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -13,7 +13,7 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
     uint32_t row_chunk = get_compile_time_arg_val(3);
 
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CB::c_out0);
+    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
 
     constexpr int onetile = 1;
@@ -45,9 +45,9 @@ void MAIN {
                 }
             }
             for (uint32_t i = wt; i < chunk_end; ++i) {
-                cb_reserve_back(tt::CB::c_out0, onetile);
-                pack_tile((i - wt), tt::CB::c_out0);
-                cb_push_back(tt::CB::c_out0, onetile);
+                cb_reserve_back(tt::CBIndex::c_3, onetile);
+                pack_tile((i - wt), tt::CBIndex::c_3);
+                cb_push_back(tt::CBIndex::c_3, onetile);
             }
             release_dst();
         }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -12,7 +12,7 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
@@ -30,9 +30,9 @@ void MAIN {
                 cb_pop_front(tt::CBIndex::c_0, onetile);
             }
         }
-        cb_reserve_back(tt::CBIndex::c_16, onetile);
-        pack_tile(reduce_dst_idx, tt::CBIndex::c_16);
-        cb_push_back(tt::CBIndex::c_16, onetile);
+        cb_reserve_back(tt::CBIndex::c_3, onetile);
+        pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
+        cb_push_back(tt::CBIndex::c_3, onetile);
         release_dst();
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -18,9 +18,9 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
 
 #ifndef REDUCE_ROW_SUM_VIA_MM
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #else
-    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
 #endif
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
@@ -43,9 +43,9 @@ void MAIN {
                 cb_pop_front(tt::CBIndex::c_0, onetile);
             }
 
-            cb_reserve_back(tt::CBIndex::c_16, onetile);
-            pack_tile(reduce_dst_idx, tt::CBIndex::c_16);
-            cb_push_back(tt::CBIndex::c_16, onetile);
+            cb_reserve_back(tt::CBIndex::c_3, onetile);
+            pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
+            cb_push_back(tt::CBIndex::c_3, onetile);
             release_dst();
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -96,7 +96,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
             .set_page_size(scaler_cb_index, scaler_single_tile_size);
     auto cb_scaler = tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
 
-    uint32_t output_cb_index = CBIndex::c_16;  // output operands start at index 16
+    uint32_t output_cb_index = CBIndex::c_3;
     CBHandle cb_output;
     if (out_sharded) {
         uint32_t num_output_tiles = output.shard_spec().value().numel() / TILE_HW;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -65,7 +65,7 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
             .set_page_size(CBIndex::c_2, scaler_single_tile_size);
     auto cb_scaler = tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t output_cb_index = tt::CBIndex::c_3;
     uint32_t num_output_tiles = 2;
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks reduce_single_core_hw(
             .set_page_size(CBIndex::c_2, scaler_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_scaler_config);
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t output_cb_index = tt::CBIndex::c_3;
     uint32_t num_output_tiles = 2;
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -96,54 +96,54 @@ operation::ProgramWithCallbacks moe_single_core_interleaved(
     // TOP K CBs
     // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four
     // tiles of space This CB carries the indices that are created in the reader kernel
-    uint32_t index_cb_index = tt::CBIndex::c_24;
+    uint32_t index_cb_index = tt::CBIndex::c_4;
     tt::tt_metal::CircularBufferConfig index_input_intermed0_config =
         tt::tt_metal::CircularBufferConfig(cb_in_units * index_tile_size, {{index_cb_index, index_cb_data_format}})
             .set_page_size(index_cb_index, index_tile_size);
     auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
 
     // Single buffered circular buffer that holds the transposed input tiles
-    uint32_t input_transposed_cb_index = tt::CBIndex::c_25;
+    uint32_t input_transposed_cb_index = tt::CBIndex::c_5;
     tt::tt_metal::CircularBufferConfig input_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
             .set_page_size(input_transposed_cb_index, input_tile_size);
     auto cb_input_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
 
     // Single buffered circular buffer that holds the transposed index tiles
-    uint32_t index_transposed_cb_index = tt::CBIndex::c_26;
+    uint32_t index_transposed_cb_index = tt::CBIndex::c_6;
     tt::tt_metal::CircularBufferConfig index_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
             .set_page_size(index_transposed_cb_index, index_tile_size);
     auto cb_index_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
 
     // topk values
-    uint32_t values_cb_index = tt::CBIndex::c_27;
+    uint32_t values_cb_index = tt::CBIndex::c_7;
     tt::tt_metal::CircularBufferConfig values_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
             .set_page_size(values_cb_index, value_tile_size);
     auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, values_cb_config);
 
     // topk indices
-    uint32_t output_ind_cb_index = tt::CBIndex::c_28;
+    uint32_t output_ind_cb_index = tt::CBIndex::c_8;
     tt::tt_metal::CircularBufferConfig output_ind_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
             .set_page_size(output_ind_cb_index, index_tile_size);
     auto cb_output_ind_tensor = tt::tt_metal::CreateCircularBuffer(program, core, output_ind_cb_config);
 
-    uint32_t cb_cur_max_index = tt::CBIndex::c_29;
+    uint32_t cb_cur_max_index = tt::CBIndex::c_9;
     tt::tt_metal::CircularBufferConfig cb_cur_max_config =
         tt::tt_metal::CircularBufferConfig(num_out_tiles * out_tile_size, {{cb_cur_max_index, out_cb_data_format}})
             .set_page_size(cb_cur_max_index, out_tile_size);
     auto cb_cur_max_tensor = tt::tt_metal::CreateCircularBuffer(program, core, cb_cur_max_config);
 
-    uint32_t cb_cur_sum_index = tt::CBIndex::c_30;
+    uint32_t cb_cur_sum_index = tt::CBIndex::c_10;
     tt::tt_metal::CircularBufferConfig cb_cur_sum_config =
         tt::tt_metal::CircularBufferConfig(num_out_tiles * out_tile_size, {{cb_cur_sum_index, out_cb_data_format}})
             .set_page_size(cb_cur_sum_index, out_tile_size);
     auto cb_cur_sum_tensor = tt::tt_metal::CreateCircularBuffer(program, core, cb_cur_sum_config);
 
     // OUTPUT CBs
-    uint32_t out_cb_index = tt::CBIndex::c_16;
+    uint32_t out_cb_index = tt::CBIndex::c_11;
     tt::tt_metal::CircularBufferConfig c_out0_config =
         tt::tt_metal::CircularBufferConfig(num_out_tiles * out_tile_size, {{out_cb_index, out_cb_data_format}})
             .set_page_size(out_cb_index, out_tile_size);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
@@ -15,50 +15,50 @@ void MAIN {
     constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_24, tt::CBIndex::c_16);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
     bool last_tile = false;
     bool once = true;
     for (uint32_t t = 0; t < num_tiles; t++) {
         if (t == (num_tiles - 1)) {
             last_tile = true;
         }
-        cb_reserve_back(tt::CBIndex::c_16, 1);
+        cb_reserve_back(tt::CBIndex::c_3, 1);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
             cb_wait_front(tt::CBIndex::c_0, 1);
             if (once) {
-                cb_reserve_back(tt::CBIndex::c_24, 1);
+                cb_reserve_back(tt::CBIndex::c_2, 1);
                 tile_regs_acquire();
                 copy_tile_to_dst_init_short(tt::CBIndex::c_0);
                 copy_tile(tt::CBIndex::c_0, 0, 0);  // copy from c_in[0] to DST[0]
                 tile_regs_commit();
                 tile_regs_wait();
                 if constexpr (num_tiles == 1) {
-                    pack_tile(0, tt::CBIndex::c_16);
+                    pack_tile(0, tt::CBIndex::c_3);
                 } else {
-                    pack_tile(0, tt::CBIndex::c_24);
-                    cb_push_back(tt::CBIndex::c_24, 1);
+                    pack_tile(0, tt::CBIndex::c_2);
+                    cb_push_back(tt::CBIndex::c_2, 1);
                 }
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                mul_tiles_init(tt::CBIndex::c_0, tt::CBIndex::c_24);
-                mul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_24, 0, 0, 0);
+                mul_tiles_init(tt::CBIndex::c_0, tt::CBIndex::c_2);
+                mul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, 0);
                 tile_regs_commit();
                 tile_regs_wait();
                 if (last_tile) {
-                    pack_tile(0, tt::CBIndex::c_16);
+                    pack_tile(0, tt::CBIndex::c_3);
                 } else {
-                    cb_pop_front(tt::CBIndex::c_24, 1);
-                    cb_reserve_back(tt::CBIndex::c_24, 1);
-                    pack_tile(0, tt::CBIndex::c_24);
-                    cb_push_back(tt::CBIndex::c_24, 1);
+                    cb_pop_front(tt::CBIndex::c_2, 1);
+                    cb_reserve_back(tt::CBIndex::c_2, 1);
+                    pack_tile(0, tt::CBIndex::c_2);
+                    cb_push_back(tt::CBIndex::c_2, 1);
                 }
                 tile_regs_release();
             }
             once = false;
             cb_pop_front(tt::CBIndex::c_0, 1);
         }
-        cb_push_back(tt::CBIndex::c_16, 1);
+        cb_push_back(tt::CBIndex::c_3, 1);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
@@ -14,14 +14,14 @@ void MAIN {
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     constexpr auto cb_in1 = tt::CBIndex::c_1;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
-    constexpr auto cb_intermed0 = tt::CBIndex::c_24;
+    constexpr auto cb_out0 = tt::CBIndex::c_3;
+    constexpr auto cb_intermed0 = tt::CBIndex::c_2;
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
     constexpr uint32_t first_tile = 0;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_3);
     cb_wait_front(cb_in1, onetile);
 
     for (uint32_t i = 0; i < num_output_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -33,11 +33,11 @@ operation::ProgramWithCallbacks prod_single_core(const Tensor& a, const Tensor& 
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     tt_metal::CircularBufferConfig cb_inter_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tt::CBIndex::c_24, cb_data_format}})
-            .set_page_size(tt::CBIndex::c_24, single_tile_size);
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tt::CBIndex::c_2, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_2, single_tile_size);
     auto cb_interm = tt_metal::CreateCircularBuffer(program, core, cb_inter_config);
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t output_cb_index = tt::CBIndex::c_3;
     uint32_t num_output_tiles = 2;
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -80,10 +80,10 @@ operation::ProgramWithCallbacks prod_nc_format(const Tensor& input, const Tensor
         all_cores,
         cb_data_format,
         {
-            {CBIndex::c_0, in0_t},         // input
-            {CBIndex::c_1, in1_t},         // zero
-            {CBIndex::c_24, intermed0_t},  // accumulated sum
-            {CBIndex::c_16, out0_t},       // output
+            {CBIndex::c_0, in0_t},        // input
+            {CBIndex::c_1, in1_t},        // zero
+            {CBIndex::c_2, intermed0_t},  // accumulated sum
+            {CBIndex::c_3, out0_t},       // output
         });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -95,7 +95,7 @@ operation::ProgramWithCallbacks prod_nc_format(const Tensor& input, const Tensor
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_is_dram, static_cast<uint32_t>(dim)};
 
     tt_metal::Buffer* output_buffer_type = output.buffer();
-    constexpr uint32_t cb_id_out = CBIndex::c_16;
+    constexpr uint32_t cb_id_out = CBIndex::c_3;
     bool output_is_dram = output_buffer_type->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)cb_id_out, (std::uint32_t)output_is_dram};
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -39,7 +39,7 @@ void MAIN {
     constexpr uint32_t index_dest_end = 3;
     // init pack, compute and unpack
 
-    init_sfpu(input_cb_index, tt::CBIndex::c_16);
+    init_sfpu(input_cb_index, tt::CBIndex::c_4);
     ckernel::topk_tile_init();
 
     for (uint32_t ht = 0; ht < Ht; ++ht) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     constexpr uint32_t Wt_final = get_compile_time_arg_val(7);
     constexpr uint32_t num_dests = get_compile_time_arg_val(8);
 
-    constexpr uint32_t final_values_cb_index = tt::CBIndex::c_26;
-    constexpr uint32_t final_indices_cb_index = tt::CBIndex::c_27;
+    constexpr uint32_t final_values_cb_index = tt::CBIndex::c_6;
+    constexpr uint32_t final_indices_cb_index = tt::CBIndex::c_7;
 
     volatile tt_l1_ptr uint32_t* receiver_semaphore_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -16,14 +16,14 @@ void kernel_main() {
     uint32_t start_ht = get_arg_val<uint32_t>(0);
     uint32_t start_wt = get_arg_val<uint32_t>(1);
 
-    constexpr uint32_t values_cb_index = tt::CBIndex::c_16;
-    constexpr uint32_t output_ind_cb_index = tt::CBIndex::c_17;
+    constexpr uint32_t values_cb_index = tt::CBIndex::c_4;
+    constexpr uint32_t output_ind_cb_index = tt::CBIndex::c_5;
 
-    constexpr uint32_t topk_local_values_cb_index = tt::CBIndex::c_24;
-    constexpr uint32_t topk_local_indices_cb_index = tt::CBIndex::c_25;
+    constexpr uint32_t topk_local_values_cb_index = tt::CBIndex::c_2;
+    constexpr uint32_t topk_local_indices_cb_index = tt::CBIndex::c_3;
 
-    constexpr uint32_t final_values_cb_index = tt::CBIndex::c_26;
-    constexpr uint32_t final_indices_cb_index = tt::CBIndex::c_27;
+    constexpr uint32_t final_values_cb_index = tt::CBIndex::c_6;
+    constexpr uint32_t final_indices_cb_index = tt::CBIndex::c_7;
 
     // can amortize the noc reads by doing them side by side for the two tensors
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -64,28 +64,28 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
 
     // Single buffered circular buffer that holds the transposed input tiles
-    uint32_t input_transposed_cb_index = tt::CBIndex::c_24;
+    uint32_t input_transposed_cb_index = tt::CBIndex::c_2;
     tt::tt_metal::CircularBufferConfig input_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
             .set_page_size(input_transposed_cb_index, input_tile_size);
     auto cb_input_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
 
     // Single buffered circular buffer that holds the transposed index tiles
-    uint32_t index_transposed_cb_index = tt::CBIndex::c_25;
+    uint32_t index_transposed_cb_index = tt::CBIndex::c_3;
     tt::tt_metal::CircularBufferConfig index_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
             .set_page_size(index_transposed_cb_index, index_tile_size);
     auto cb_index_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
 
     // Output topk values
-    uint32_t values_cb_index = tt::CBIndex::c_16;
+    uint32_t values_cb_index = tt::CBIndex::c_4;
     tt::tt_metal::CircularBufferConfig values_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
             .set_page_size(values_cb_index, value_tile_size);
     auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, values_cb_config);
 
     // Output topk indices
-    uint32_t output_ind_cb_index = tt::CBIndex::c_17;
+    uint32_t output_ind_cb_index = tt::CBIndex::c_5;
     tt::tt_metal::CircularBufferConfig output_ind_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
             .set_page_size(output_ind_cb_index, index_tile_size);
@@ -281,7 +281,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
 
     // Single buffered circular buffer that holds the transposed input tiles
-    uint32_t input_transposed_cb_index = tt::CBIndex::c_24;
+    uint32_t input_transposed_cb_index = tt::CBIndex::c_2;
     tt::tt_metal::CircularBufferConfig input_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(
             Wt_local * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
@@ -289,21 +289,21 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     auto cb_input_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
 
     // Single buffered circular buffer that holds the transposed index tiles
-    uint32_t index_transposed_cb_index = tt::CBIndex::c_25;
+    uint32_t index_transposed_cb_index = tt::CBIndex::c_3;
     tt::tt_metal::CircularBufferConfig index_transposed_cb_config =
         tt::tt_metal::CircularBufferConfig(
             Wt_local * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
             .set_page_size(index_transposed_cb_index, index_tile_size);
     auto cb_index_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
 
-    uint32_t gathered_values_cb_index = tt::CBIndex::c_26;
+    uint32_t gathered_values_cb_index = tt::CBIndex::c_6;
     tt::tt_metal::CircularBufferConfig gathered_values_cb_config =
         tt::tt_metal::CircularBufferConfig(
             Wt_final * value_tile_size, {{gathered_values_cb_index, value_cb_data_format}})
             .set_page_size(gathered_values_cb_index, value_tile_size);
     auto cb_gathered_topk_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, gathered_values_cb_config);
 
-    uint32_t gathered_indices_cb_index = tt::CBIndex::c_27;
+    uint32_t gathered_indices_cb_index = tt::CBIndex::c_7;
     tt::tt_metal::CircularBufferConfig gathered_indices_cb_config =
         tt::tt_metal::CircularBufferConfig(
             Wt_final * index_tile_size, {{gathered_indices_cb_index, index_cb_data_format}})
@@ -311,27 +311,27 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     auto cb_gathered_topk_indices_tensor =
         tt::tt_metal::CreateCircularBuffer(program, core, gathered_indices_cb_config);
 
-    uint32_t final_values_cb_index = tt::CBIndex::c_28;
+    uint32_t final_values_cb_index = tt::CBIndex::c_8;
     tt::tt_metal::CircularBufferConfig final_values_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt_final * value_tile_size, {{final_values_cb_index, value_cb_data_format}})
             .set_page_size(final_values_cb_index, value_tile_size);
     auto cb_final_topk_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, final_values_cb_config);
 
-    uint32_t final_indices_cb_index = tt::CBIndex::c_29;
+    uint32_t final_indices_cb_index = tt::CBIndex::c_9;
     tt::tt_metal::CircularBufferConfig final_indices_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt_final * index_tile_size, {{final_indices_cb_index, index_cb_data_format}})
             .set_page_size(final_indices_cb_index, index_tile_size);
     auto cb_final_topk_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, final_indices_cb_config);
 
     // Output topk values
-    uint32_t values_cb_index = tt::CBIndex::c_16;
+    uint32_t values_cb_index = tt::CBIndex::c_4;
     tt::tt_metal::CircularBufferConfig values_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
             .set_page_size(values_cb_index, value_tile_size);
     auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, values_cb_config);
 
     // Output topk indices
-    uint32_t output_ind_cb_index = tt::CBIndex::c_17;
+    uint32_t output_ind_cb_index = tt::CBIndex::c_5;
     tt::tt_metal::CircularBufferConfig output_ind_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
             .set_page_size(output_ind_cb_index, index_tile_size);


### PR DESCRIPTION
### Ticket
[#16957](https://github.com/tenstorrent/tt-metal/issues/16957)
[#16958](https://github.com/tenstorrent/tt-metal/issues/16958)

### Problem description
CB indices previously had requirements for the values, such as outputs beginning at 16. These requirements were relaxed but the kernel implementations remained faithful to them, which hurt dispatch performance by requiring additional indices to be initialised.

### What's changed
CB indices within the reduction and normalization ops are changed so that circular buffers use the next available index starting from 0. This will resolve #16957 and resolve #16958.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13577752538) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes ](https://github.com/tenstorrent/tt-metal/actions/runs/13577755233)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13592645262) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13592659010) 
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
