### PR TITLE
Make profiler skip over active eth cores without links on BH

### DIFF
--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -351,6 +351,10 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
         chip_id_t device_id_receiver_curr = std::numeric_limits<chip_id_t>::max();
         while ((device_id_receiver != device_id_receiver_curr) and (eth_sender_core_iter != active_eth_cores.end())) {
             eth_sender_core = *eth_sender_core_iter;
+            if (not tt::Cluster::instance().is_ethernet_link_up(device_sender->id(), eth_sender_core)) {
+                eth_sender_core_iter++;
+                continue;
+            }
             std::tie(device_id_receiver_curr, eth_receiver_core) =
                 device_sender->get_connected_ethernet_core(eth_sender_core);
             eth_sender_core_iter++;
@@ -467,6 +471,9 @@ void ProfilerSync(ProfilerSyncState state) {
                 tt_xy_pair receiver_eth_core;
                 bool doSync = true;
                 for (auto& sender_eth_core : active_eth_cores) {
+                    if (not tt::Cluster::instance().is_ethernet_link_up(sender_device_id, sender_eth_core)) {
+                        continue;
+                    }
                     doSync = false;
                     std::tie(receiver_device_id, receiver_eth_core) =
                         sender_device->get_connected_ethernet_core(sender_eth_core);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
I broke profiler on BH with eth changes 

### What's changed
Skip over active eth cores that don't have any links when setting up profiler

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13577794628) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13577796086) CI passes 
