### PR TITLE
Generate multicast command for all kernels

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -461,7 +461,7 @@ TEST_F(DeviceFixture, TensixIllegallyModifyRTArgs) {
     }
 }
 
-TEST_F(DeviceFixture, TensixSetCommonRuntimeArgsMultipleKernelHandlesSameProgram) {
+TEST_F(DeviceFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto grid_size = this->devices_.at(id)->logical_grid_size();
         auto max_x = grid_size.x - 1;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -41,6 +41,15 @@ struct DummyProgramMultiCBConfig {
     uint32_t num_sems;
 };
 
+struct IncrementKernelsSet {
+    // Kernels that were created
+    std::vector<KernelHandle> kernel_handles;
+    // L1 address for unique args
+    uint32_t unique_args_addr;
+    // L1 address for common args
+    uint32_t common_args_addr;
+};
+
 namespace local_test_functions {
 
 void initialize_dummy_kernels(Program& program, const CoreRangeSet& cr_set) {
@@ -615,7 +624,179 @@ bool verify_rt_args(
     return pass;
 }
 
+// Returns L1 address for {unique RTA, common RTA}
+std::pair<uint32_t, uint32_t> get_args_addr(const IDevice* device, const tt::RISCV& riscv, bool idle_eth) {
+    uint32_t unique_args_addr;
+    uint32_t common_args_addr;
+    switch (riscv) {
+        case tt::RISCV::BRISC:
+            unique_args_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+            common_args_addr = unique_args_addr + 3 * 256 * sizeof(uint32_t);
+            break;
+        case tt::RISCV::NCRISC:
+            unique_args_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1) + 256 * sizeof(uint32_t);
+            common_args_addr = unique_args_addr + 4 * 256 * sizeof(uint32_t);
+            break;
+        case tt::RISCV::COMPUTE:
+            unique_args_addr =
+                device->allocator()->get_base_allocator_addr(HalMemType::L1) + 2 * 256 * sizeof(uint32_t);
+            common_args_addr = unique_args_addr + 5 * 256 * sizeof(uint32_t);
+            break;
+        case tt::RISCV::ERISC: {
+            HalProgrammableCoreType eth_core_type =
+                idle_eth ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
+            unique_args_addr = hal.get_dev_addr(eth_core_type, HalL1MemAddrType::UNRESERVED);
+            common_args_addr = unique_args_addr + 1 * 256 * sizeof(uint32_t);
+            break;
+        } break;
+        default: TT_THROW("Unsupported {} processor in get_args_addr.", riscv);
+    }
+    return {unique_args_addr, common_args_addr};
+}
+
+// Call CreateKernel for the program configs
+// Returns a struct with the kernel IDs, and L1 addresses to check CRTA/RTAs.
+IncrementKernelsSet create_increment_kernels(
+    const IDevice* device,
+    Program& program,
+    const std::vector<DummyProgramConfig>& program_configs,
+    const tt::RISCV& riscv,
+    uint32_t num_unique_rt_args,
+    uint32_t num_common_rt_args,
+    bool idle_eth = false) {
+    // Tell kernel how many unique and common RT args to expect. Will increment each.
+    std::vector<KernelHandle> kernels;
+    const auto [unique_args_addr, common_args_addr] = get_args_addr(device, riscv, idle_eth);
+    std::vector<uint32_t> compile_args{num_unique_rt_args, num_common_rt_args, unique_args_addr, common_args_addr};
+
+    // CreateKernel on each core range set
+    for (const auto& program_config : program_configs) {
+        const auto& cr_set = program_config.cr_set;
+        KernelHandle kernel_id;
+        switch (riscv) {
+            case tt::RISCV::BRISC:
+                kernel_id = CreateKernel(
+                    program,
+                    "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp",
+                    cr_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0,
+                        .noc = NOC::RISCV_0_default,
+                        .compile_args = compile_args,
+                    });
+                break;
+            case tt::RISCV::NCRISC:
+                kernel_id = CreateKernel(
+                    program,
+                    "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp",
+                    cr_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1,
+                        .noc = NOC::RISCV_1_default,
+                        .compile_args = compile_args,
+                    });
+                break;
+            case tt::RISCV::COMPUTE:
+                kernel_id = CreateKernel(
+                    program,
+                    "tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp",
+                    cr_set,
+                    tt::tt_metal::ComputeConfig{
+                        .compile_args = compile_args,
+                    });
+                break;
+            case tt::RISCV::ERISC: {
+                kernel_id = CreateKernel(
+                    program,
+                    "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp",
+                    cr_set,
+                    tt::tt_metal::EthernetConfig{
+                        .eth_mode = idle_eth ? Eth::IDLE : Eth::RECEIVER,
+                        .noc = NOC::NOC_0,
+                        .compile_args = compile_args,
+                    });
+            } break;
+            default: TT_THROW("Unsupported {} processor in test.", riscv);
+        }
+
+        kernels.push_back(kernel_id);
+    }
+
+    return IncrementKernelsSet{
+        .kernel_handles = kernels, .unique_args_addr = unique_args_addr, .common_args_addr = common_args_addr};
+}
+
 // Write unique and common RT args, increment in kernel, and verify correctness via readback.
+// Multiple program_configs may be provided to create multiple kernels on the same program.
+bool test_increment_runtime_args_sanity(
+    IDevice* device,
+    const std::vector<DummyProgramConfig>& program_configs,
+    uint32_t num_unique_rt_args,
+    uint32_t num_common_rt_args,
+    const tt::RISCV& riscv,
+    bool idle_eth = false) {
+    Program program;
+    bool pass = true;
+
+    auto configured_kernels = create_increment_kernels(
+        device, program, program_configs, riscv, num_unique_rt_args, num_common_rt_args, idle_eth);
+
+    // Args will be at this addr in L1
+    uint32_t unique_args_addr = configured_kernels.unique_args_addr;
+    uint32_t common_args_addr = configured_kernels.common_args_addr;
+
+    // Generate Runtime Args.
+    std::vector<uint32_t> unique_runtime_args;
+    for (uint32_t i = 0; i < num_unique_rt_args; i++) {
+        unique_runtime_args.push_back(i * 0x10101010);
+    }
+
+    // Generate Common Runtime Args.
+    std::vector<uint32_t> common_runtime_args;
+    for (uint32_t i = 0; i < num_common_rt_args; i++) {
+        common_runtime_args.push_back(1000 + 0x10101010);
+    }
+
+    // Call SetRuntimeArgs. Set for core ranges that are running the kernel
+    // zip the kernel_id and cr set from program_config
+    for (int i = 0; i < program_configs.size(); ++i) {
+        const auto& cr_set = program_configs[i].cr_set;
+        const auto& kernel_id = configured_kernels.kernel_handles[i];
+
+        SetRuntimeArgs(program, kernel_id, cr_set, unique_runtime_args);
+    }
+
+    // Call SetCommonRuntimeArgs for kernels. Does not take into account core range as it's common.
+    for (const auto& kernel_id : configured_kernels.kernel_handles) {
+        SetCommonRuntimeArgs(program, kernel_id, common_runtime_args);
+    }
+
+    // Compile and Launch the Program now.
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
+
+    // Read all cores for all kernels
+    constexpr uint32_t unique_arg_incr_val = 10;
+    constexpr uint32_t common_arg_incr_val = 100;
+    for (const auto& kernel_id : configured_kernels.kernel_handles) {
+        const auto& kernel = tt::tt_metal::detail::GetKernel(program, kernel_id);
+
+        for (auto& core_range : kernel->logical_coreranges()) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                    CoreCoord core_coord(x, y);
+                    pass &= verify_rt_args(
+                        true, device, core_coord, riscv, unique_args_addr, unique_runtime_args, unique_arg_incr_val);
+                    pass &= verify_rt_args(
+                        false, device, core_coord, riscv, common_args_addr, common_runtime_args, common_arg_incr_val);
+                }
+            }
+        }
+    }
+
+    return pass;
+}
+
 bool test_increment_runtime_args_sanity(
     IDevice* device,
     const DummyProgramConfig& program_config,
@@ -623,117 +804,13 @@ bool test_increment_runtime_args_sanity(
     uint32_t num_common_rt_args,
     const tt::RISCV& riscv,
     bool idle_eth = false) {
-    Program program;
-    bool pass = true;
-    CoreRangeSet cr_set = program_config.cr_set;
-
-    // Tell kernel how many unique and common RT args to expect. Will increment each.
-    vector<uint32_t> compile_args = {num_unique_rt_args, num_common_rt_args, 0, 0};
-
-    KernelHandle kernel_id = 0;
-    uint32_t unique_args_addr = 0;
-    uint32_t common_args_addr = 0;
-
-    switch (riscv) {
-        case tt::RISCV::BRISC:
-            unique_args_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-            common_args_addr = unique_args_addr + 3 * 256 * sizeof(uint32_t);
-            compile_args[2] = unique_args_addr;
-            compile_args[3] = common_args_addr;
-            kernel_id = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp",
-                cr_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_0,
-                    .noc = NOC::RISCV_0_default,
-                    .compile_args = compile_args,
-                });
-            break;
-        case tt::RISCV::NCRISC:
-            unique_args_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1) + 256 * sizeof(uint32_t);
-            common_args_addr = unique_args_addr + 4 * 256 * sizeof(uint32_t);
-            compile_args[2] = unique_args_addr;
-            compile_args[3] = common_args_addr;
-            kernel_id = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp",
-                cr_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_1,
-                    .noc = NOC::RISCV_1_default,
-                    .compile_args = compile_args,
-                });
-            break;
-        case tt::RISCV::COMPUTE:
-            unique_args_addr =
-                device->allocator()->get_base_allocator_addr(HalMemType::L1) + 2 * 256 * sizeof(uint32_t);
-            common_args_addr = unique_args_addr + 5 * 256 * sizeof(uint32_t);
-            compile_args[2] = unique_args_addr;
-            compile_args[3] = common_args_addr;
-            kernel_id = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp",
-                cr_set,
-                tt::tt_metal::ComputeConfig{
-                    .compile_args = compile_args,
-                });
-            break;
-        case tt::RISCV::ERISC: {
-            HalProgrammableCoreType eth_core_type =
-                idle_eth ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
-            unique_args_addr = hal.get_dev_addr(eth_core_type, HalL1MemAddrType::UNRESERVED);
-            common_args_addr = unique_args_addr + 1 * 256 * sizeof(uint32_t);
-            compile_args[2] = unique_args_addr;
-            compile_args[3] = common_args_addr;
-            kernel_id = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp",
-                cr_set,
-                tt::tt_metal::EthernetConfig{
-                    .eth_mode = idle_eth ? Eth::IDLE : Eth::RECEIVER,
-                    .noc = NOC::NOC_0,
-                    .compile_args = compile_args,
-                });
-        } break;
-        default: TT_THROW("Unsupported {} processor in test.", riscv);
-    }
-
-    const auto kernel = tt::tt_metal::detail::GetKernel(program, kernel_id);
-
-    // Unique Runtime Args.
-    std::vector<uint32_t> unique_runtime_args;
-    for (uint32_t i = 0; i < num_unique_rt_args; i++) {
-        unique_runtime_args.push_back(i);
-    }
-    SetRuntimeArgs(program, 0, cr_set, unique_runtime_args);
-
-    // Setup Common Runtime Args.
-    std::vector<uint32_t> common_runtime_args;
-    for (uint32_t i = 0; i < num_common_rt_args; i++) {
-        common_runtime_args.push_back(1000 + i);
-    }
-    SetCommonRuntimeArgs(program, 0, common_runtime_args);
-
-    // Compile and Launch the Program now.
-    EnqueueProgram(device->command_queue(), program, false);
-    Finish(device->command_queue());
-
-    constexpr uint32_t unique_arg_incr_val = 10;
-    constexpr uint32_t common_arg_incr_val = 100;
-    for (auto& core_range : kernel->logical_coreranges()) {
-        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                CoreCoord core_coord(x, y);
-                pass &= verify_rt_args(
-                    true, device, core_coord, riscv, unique_args_addr, unique_runtime_args, unique_arg_incr_val);
-                pass &= verify_rt_args(
-                    false, device, core_coord, riscv, common_args_addr, common_runtime_args, common_arg_incr_val);
-            }
-        }
-    }
-
-    return pass;
+    return test_increment_runtime_args_sanity(
+        device,
+        std::vector<DummyProgramConfig>{program_config},
+        num_unique_rt_args,
+        num_common_rt_args,
+        riscv,
+        idle_eth);
 }
 
 }  // namespace local_test_functions
@@ -918,6 +995,27 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanitySin
     for (IDevice* device : devices_) {
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device, dummy_program_config, 8, 8, tt::RISCV::COMPUTE));
+    }
+}
+
+// Test setting common runtime args across multiple kernel in the same program
+// This test will ensure a multicast (or unicast for eth) gets created for each time the
+// user calls SetCommonRuntimeArgs.
+TEST_F(CommandQueueSingleCardProgramFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
+    const CoreRange core_range_0(CoreCoord(1, 1), CoreCoord(2, 2));
+    const CoreRange core_range_1(CoreCoord(3, 3), CoreCoord(4, 4));
+
+    const CoreRangeSet core_range_set_0(std::vector{core_range_0});
+    const CoreRangeSet core_range_set_1(std::vector{core_range_1});
+
+    std::vector<DummyProgramConfig> configs{
+        {.cr_set = core_range_set_0},
+        {.cr_set = core_range_set_1},
+    };
+
+    for (IDevice* device : devices_) {
+        EXPECT_TRUE(
+            local_test_functions::test_increment_runtime_args_sanity(device, configs, 8, 8, tt::RISCV::COMPUTE));
     }
 }
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -280,6 +280,8 @@ uint32_t finalize_kernel_bins(
     return max_offset;
 }
 
+// Compute relative offsets (wrt the start of the kernel config ring buffer) and sizes of all
+// program data structures in L1. Will be used when assembling dispatch commands for this program
 template <typename T>
 void finalize_program_offsets(T& workload, IDevice* device) {
     if (workload.is_finalized()) {
@@ -542,7 +544,7 @@ void assemble_runtime_args_commands(
     std::variant<std::vector<CQDispatchWritePackedMulticastSubCmd>, std::vector<CQDispatchWritePackedUnicastSubCmd>>
         common_sub_cmds;
     std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>> common_rt_data_and_sizes;
-    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> common_rt_args_data;
+    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> common_rt_args_data;  // Data per kernel group
 
     program_command_sequence.runtime_args_command_sequences = {};
     uint32_t command_count = 0;
@@ -581,6 +583,7 @@ void assemble_runtime_args_commands(
         if (common_size != 0) {
             uint32_t max_runtime_args_len = common_size / sizeof(uint32_t);
             const auto& common_rt_args = kernel->common_runtime_args();
+
             if (common_rt_args.size() > 0) {
                 CoreType core_type = hal.get_core_type(programmable_core_type_index);
                 if (core_type == CoreType::ETH) {
@@ -610,6 +613,8 @@ void assemble_runtime_args_commands(
         CoreType core_type = hal.get_core_type(index);
         uint32_t processor_classes = hal.get_processor_classes_count(index);
 
+        // Unique RTAs - Unicast
+        // Set by the user based on the kernel and core coord
         for (auto& kg : program.get_kernel_groups(index)) {
             if (kg->total_rta_size != 0) {
                 for (const CoreRange& core_range : kg->core_ranges.ranges()) {
@@ -668,12 +673,18 @@ void assemble_runtime_args_commands(
             }
         }
 
+        // Common RTAs
+        // Set by the user based on the kernel ID. All cores running that kernel ID will get these RTAs
+        // On ETH use unicast
         for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
+            const uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
             uint32_t common_size = program.get_program_config(index).crta_sizes[dispatch_class];
             if (common_size == 0) {
                 continue;
             }
-            for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
+
+            for (size_t kernel_index = 0; kernel_index < program.num_kernels(); kernel_index++) {
+                auto kernel_id = get_device_local_kernel_handle(kernel_index);
                 auto kernel = detail::GetKernel(program, kernel_id);
                 if (kernel->get_kernel_core_type() != core_type) {
                     continue;  // TODO: fixme, need list of kernels by core_typexdispatch_class
@@ -683,78 +694,79 @@ void assemble_runtime_args_commands(
                 }
 
                 const auto& common_rt_args = kernel->common_runtime_args();
-                if (common_rt_args.size() > 0) {
-                    common_rt_args_data.resize(common_rt_args_data.size() + 1);
-                    common_rt_data_and_sizes.resize(common_rt_data_and_sizes.size() + 1);
+                if (common_rt_args.empty()) {
+                    continue;
+                }
 
-                    TT_ASSERT(kernel->common_runtime_args_data().size() * sizeof(uint32_t) == common_size);
-                    TT_ASSERT(common_rt_args.size() * sizeof(uint32_t) <= common_size);
-                    common_rt_data_and_sizes.back().emplace_back(
-                        common_rt_args.data(), common_rt_args.size() * sizeof(uint32_t), common_size);
-                    common_rt_args_data.back().emplace_back(kernel->common_runtime_args_data());
+                common_rt_args_data.resize(common_rt_args_data.size() + 1);
+                common_rt_data_and_sizes.resize(common_rt_data_and_sizes.size() + 1);
 
-                    if (core_type == CoreType::ETH) {
-                        common_sub_cmds.emplace<std::vector<CQDispatchWritePackedUnicastSubCmd>>(
-                            std::vector<CQDispatchWritePackedUnicastSubCmd>());
-                        auto& unicast_sub_cmd =
-                            std::get<std::vector<CQDispatchWritePackedUnicastSubCmd>>(common_sub_cmds);
-                        unicast_sub_cmd.reserve(kernel->logical_cores().size());
-                        for (auto& core_coord : kernel->logical_cores()) {
-                            // can make a vector of unicast encodings here
-                            CoreCoord virtual_core_coords =
-                                device->virtual_core_from_logical_core(core_coord, CoreType::ETH);
-                            unicast_sub_cmd.emplace_back(CQDispatchWritePackedUnicastSubCmd{
-                                .noc_xy_addr = device->get_noc_unicast_encoding(noc_index, virtual_core_coords)});
-                        }
-                    } else {
-                        std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                            device->extract_dst_noc_multicast_info(kernel->logical_coreranges(), core_type);
-                        common_sub_cmds.emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
-                            std::vector<CQDispatchWritePackedMulticastSubCmd>());
-                        auto& multicast_sub_cmd =
-                            std::get<std::vector<CQDispatchWritePackedMulticastSubCmd>>(common_sub_cmds);
-                        multicast_sub_cmd.reserve(dst_noc_multicast_info.size());
-                        for (const auto& mcast_dests : dst_noc_multicast_info) {
-                            multicast_sub_cmd.emplace_back(CQDispatchWritePackedMulticastSubCmd{
-                                .noc_xy_addr = device->get_noc_multicast_encoding(
-                                    noc_index, std::get<CoreRange>(mcast_dests.first)),
-                                .num_mcast_dests = mcast_dests.second});
-                        }
+                TT_ASSERT(kernel->common_runtime_args_data().size() * sizeof(uint32_t) == common_size);
+                TT_ASSERT(common_rt_args.size() * sizeof(uint32_t) <= common_size);
+                common_rt_data_and_sizes.back().emplace_back(
+                    common_rt_args.data(), common_rt_args.size() * sizeof(uint32_t), common_size);
+                common_rt_args_data.back().emplace_back(kernel->common_runtime_args_data());
+
+                if (core_type == CoreType::ETH) {
+                    common_sub_cmds.emplace<std::vector<CQDispatchWritePackedUnicastSubCmd>>(
+                        std::vector<CQDispatchWritePackedUnicastSubCmd>());
+                    auto& unicast_sub_cmd = std::get<std::vector<CQDispatchWritePackedUnicastSubCmd>>(common_sub_cmds);
+                    unicast_sub_cmd.reserve(kernel->logical_cores().size());
+                    for (auto& core_coord : kernel->logical_cores()) {
+                        // can make a vector of unicast encodings here
+                        CoreCoord virtual_core_coords =
+                            device->virtual_core_from_logical_core(core_coord, CoreType::ETH);
+                        unicast_sub_cmd.emplace_back(CQDispatchWritePackedUnicastSubCmd{
+                            .noc_xy_addr = device->get_noc_unicast_encoding(noc_index, virtual_core_coords)});
+                    }
+                } else {
+                    std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
+                        device->extract_dst_noc_multicast_info(kernel->logical_coreranges(), core_type);
+                    common_sub_cmds.emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
+                        std::vector<CQDispatchWritePackedMulticastSubCmd>());
+                    auto& multicast_sub_cmd =
+                        std::get<std::vector<CQDispatchWritePackedMulticastSubCmd>>(common_sub_cmds);
+                    multicast_sub_cmd.reserve(dst_noc_multicast_info.size());
+                    for (const auto& mcast_dests : dst_noc_multicast_info) {
+                        multicast_sub_cmd.emplace_back(CQDispatchWritePackedMulticastSubCmd{
+                            .noc_xy_addr =
+                                device->get_noc_multicast_encoding(noc_index, std::get<CoreRange>(mcast_dests.first)),
+                            .num_mcast_dests = mcast_dests.second});
                     }
                 }
+
+                // Fill out the command for this kernel group and then reset the vectors for the next group
+                // NOTE: Common rtas are always expected to fit in one prefetch cmd
+                // TODO: use a linear write instead of a packed-write
+                std::visit(
+                    [&](auto&& sub_cmds) {
+                        generate_runtime_args_cmds(
+                            program_command_sequence.runtime_args_command_sequences,
+                            crta_offset,
+                            sub_cmds,
+                            common_rt_data_and_sizes,
+                            common_size / sizeof(uint32_t),
+                            common_rt_args_data,
+                            max_prefetch_command_size,
+                            packed_write_max_unicast_sub_cmds,
+                            true,
+                            core_type == CoreType::WORKER ? DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE
+                                                          : DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
+                        sub_cmds.clear();
+                    },
+                    common_sub_cmds);
+                common_rt_data_and_sizes.clear();
+                common_rt_args_data.clear();
             }
-
-            uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
-
-            // Common rtas are always expected to fit in one prefetch cmd
-            // TODO: use a linear write instead of a packed-write
-            std::visit(
-                [&](auto&& sub_cmds) {
-                    generate_runtime_args_cmds(
-                        program_command_sequence.runtime_args_command_sequences,
-                        crta_offset,
-                        sub_cmds,
-                        common_rt_data_and_sizes,
-                        common_size / sizeof(uint32_t),
-                        common_rt_args_data,
-                        max_prefetch_command_size,
-                        packed_write_max_unicast_sub_cmds,
-                        true,
-                        core_type == CoreType::WORKER ? DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE
-                                                      : DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
-                    sub_cmds.clear();
-                },
-                common_sub_cmds);
 
             for (auto& data_per_kernel : common_rt_data_and_sizes) {
                 for (auto& data_and_sizes : data_per_kernel) {
                     RecordDispatchData(program, DISPATCH_DATA_RTARGS, std::get<1>(data_and_sizes));
                 }
             }
-            common_rt_data_and_sizes.clear();
-            common_rt_args_data.clear();
         }
     }
+
     TT_ASSERT(
         command_count >= program_command_sequence.runtime_args_command_sequences.size(),
         "Incorrect number of commands reserved {}, final size {}. Vector reallocation causes cached addresses to be "
@@ -870,9 +882,9 @@ void assemble_device_commands(
         uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
         auto index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (const CoreRange& core_range : circular_buffers_unique_coreranges) {
-            const CoreCoord virtual_start =
+            const CoreCoord& virtual_start =
                 device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
-            const CoreCoord virtual_end =
+            const CoreCoord& virtual_end =
                 device->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
 
             const uint32_t num_receivers = core_range.size();

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -37,11 +37,6 @@ uint32_t configure_crta_offsets_for_kernel_groups(
     std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
     std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes);
 
-// Compute relative offsets (wrt the start of the kernel config ring buffer) and sizes of all
-// program data structures in L1. Will be used when assembling dispatch commands for this program
-template <typename T>
-void finalize_program_offsets(T& workload_type, IDevice* device);
-
 uint32_t finalize_rt_args(
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
@@ -81,9 +76,6 @@ void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDevi
 
 void assemble_runtime_args_commands(
     ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device);
-
-void assemble_device_commands(
-    ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device, SubDeviceId sub_device_id);
 
 void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr);
 
@@ -139,10 +131,6 @@ void set_go_signal_noc_data_on_dispatch(
     const vector_memcpy_aligned<uint32_t>& go_signal_noc_data,
     SystemMemoryManager& manager,
     uint8_t cq_id);
-
-template <typename WorkloadType, typename DeviceType>
-uint32_t program_base_addr_on_core(
-    WorkloadType& workload, DeviceType generic_device, HalProgrammableCoreType programmable_core_type);
 
 }  // namespace program_dispatch
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1392,6 +1392,7 @@ void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
                 if (kernel->get_kernel_core_type() != dispatch_core_type) {
                     return false;
                 }
+
                 return kernel->is_on_logical_core(dispatch_core);
             });
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18276)

### Problem description
Only 1 multicast command (or unicast, for ETH kernels) was being generated. Each call to `SetCommonRuntimeArgs` should make 1 multicast command to all cores for that kernel. Only FD impacted.

### What's changed
- Call `generate_runtime_args_cmds` for each group of common runtime args.
- Add SD and FD test case for how the issue was originally discovered. Calling `SetCommonRuntimeArgs` with different args on the same kernel + same program. Confirmed that this test fails without the updates to `generate_runtime_args_cmds`.
  - Other parts of the test: Updated patterns to use more bits to also check for any bits being possibly truncated.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
