### PR TITLE
Add tests that exploit multiple queues for multiple devices

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -48,6 +48,11 @@ add_executable(unit_tests_ttnn_fabric_edm ${TTNN_FABRIC_EDM_SRC})
 add_executable(unit_tests_ttnn_tensor ${TTNN_TENSOR_UNIT_TESTS_SRC})
 add_executable(test_multi_device ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_device.cpp)
 add_executable(galaxy_unit_tests_ttnn ${CMAKE_CURRENT_SOURCE_DIR}/test_ccl_on_galaxy.cpp)
+add_executable(
+    test_ccl_multi_cq_multi_device
+    ${CMAKE_CURRENT_SOURCE_DIR}/multi_thread/test_ccl_multi_cq_multi_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/multi_thread/test_utils.cpp
+)
 
 # Set up properties for all targets
 setup_ttnn_test_target(unit_tests_ttnn)
@@ -56,3 +61,4 @@ setup_ttnn_test_target(unit_tests_ttnn_fabric_edm)
 setup_ttnn_test_target(unit_tests_ttnn_tensor)
 setup_ttnn_test_target(test_multi_device)
 setup_ttnn_test_target(galaxy_unit_tests_ttnn)
+setup_ttnn_test_target(test_ccl_multi_cq_multi_device)

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "test_utils.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+#include <cmath>
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+#include <future>
+#include <memory>
+
+#define BOOST_ASIO_HAS_STD_INVOKE_RESULT
+#include <boost/asio/thread_pool.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/lockfree/queue.hpp>
+
+#include "ttnn/async_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp"
+#include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "ttnn/operations/ccl/erisc_datamover_builder.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/event.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_device_view.hpp>
+
+#include "gtest/gtest.h"
+
+namespace ttnn::distributed::test {
+
+using namespace tt;
+using namespace tt_metal;
+
+using tt::tt_metal::distributed::MeshCoordinate;
+using tt::tt_metal::distributed::MeshDevice;
+using tt::tt_metal::distributed::MeshDeviceConfig;
+using tt::tt_metal::distributed::MeshDeviceView;
+using tt::tt_metal::distributed::MeshShape;
+
+TEST_F(T3kMultiDeviceMultiQueueFixture, AsyncExecutionWorksCQ0) {
+    const size_t dim = 0;
+    const size_t num_links = 1;
+    constexpr auto layout = Layout::TILE;
+    constexpr size_t test_expected_num_devices = 4;
+
+    MeshDevice* mesh_device = this->mesh_device_.get();
+    mesh_device->enable_async(true);
+    mesh_device->enable_program_cache();
+
+    auto view = mesh_device->get_view();
+
+    // build a line of devices
+    std::vector<IDevice*> devices = {
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3))};
+    const size_t num_devices = devices.size();
+    TT_FATAL(
+        test_expected_num_devices == num_devices,
+        "Expected {} devices but got {}",
+        test_expected_num_devices,
+        num_devices);
+
+    // FABRIC setup
+    const bool enable_persistent_fabric = true;
+
+    std::vector<Program> dummy_worker_programs;
+    std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
+    std::optional<std::vector<Program>> fabric_programs;
+    std::vector<Program*> fabric_program_ptrs;
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
+    setup_test_with_persistent_fabric(
+        devices,
+        dummy_worker_programs,
+        subdevice_managers,
+        fabric_programs,
+        fabric_program_ptrs,
+        fabric_handle,
+        enable_persistent_fabric,
+        num_links);
+
+    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
+    auto
+        [from_remote_multi_device_global_semaphore,
+         to_remote_multi_device_global_semaphore,
+         multi_device_global_semaphore] = create_global_semaphores(this->mesh_device_, devices[0]);
+
+    const int batch_size = 8;
+    const int sequence_length = 1024;
+    const int embedding_dim = 768;
+
+    const ttnn::Shape input_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const auto num_elems = input_shape.volume();
+    auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
+    auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
+
+    uint8_t op_cq_id = 0;  // operation command queue id
+    boost::asio::thread_pool pool(devices.size());
+
+    for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
+        log_info(LogTest, "Running outer loop {}", outer_loop);
+        std::vector<Tensor> device_tensors(devices.size());
+
+        int dev_idx = 0;
+        log_info(LogTest, "Enqueue Operations before AllGather", outer_loop);
+        std::vector<std::future<void>> futures;
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto promise = std::make_shared<std::promise<void>>();
+            futures.push_back(promise->get_future());
+            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+                // Generate input data for each device
+                for (int j = 0; j < num_elems; j++) {
+                    host_data[j] = bfloat16(static_cast<float>(dev_idx));
+                }
+
+                TensorSpec tensor_spec(
+                    input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+                auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor input_tensor = Tensor(input_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
+
+                // Enqueue write_buffer to the read/write command queue and record the event
+                ttnn::write_buffer(ttnn::QueueId(op_cq_id), input_tensor, {host_data});
+
+                // Enqueue multiple operations to the operation command queue
+                // Set output_tensor into device_tensor for allreduce
+                device_tensors[dev_idx] = dispatch_ops_to_device(device, input_tensor, ttnn::QueueId(op_cq_id));
+
+                promise->set_value();
+            });
+            // If you remove below comment (perform sleep), the final output value will be correct.
+            // std::this_thread::sleep_for(std::chrono::seconds(1));
+            dev_idx++;
+        }
+
+        // Wait for all tasks to complete
+        for (auto& future : futures) {
+            future.wait();
+        }
+
+        log_info(LogTest, "Enqueue AllGather", outer_loop);
+        // Create a multi-device tensor for allgather
+        const Tensor mesh_tensor_for_ag = ttnn::distributed::aggregate_as_tensor(device_tensors, AllGatherTensor{});
+
+        // Enqueue the all_gather_async operation on each device.
+        // It does not support command queue ID as a parameter and internally uses command queue 0.
+        const Tensor gathered_tensor = ttnn::experimental::all_gather_async(
+            mesh_tensor_for_ag,
+            0,
+            multi_device_global_semaphore,
+            1,
+            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            ttnn::ccl::Topology::Linear,
+            SubDeviceId(0),
+            true);
+
+        log_info(LogTest, "EnqueueReadBuffer", outer_loop);
+        // Read the values from each device and compare them with the results calculated on the host
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto device_tensor = ttnn::distributed::get_device_tensor(gathered_tensor, device);
+            boost::asio::post(pool, [&, i, device, num_elems, device_tensor]() mutable {
+                auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.volume()]);
+                ttnn::read_buffer(ttnn::QueueId(op_cq_id), device_tensor, {output_data});
+
+                for (int j = 0; j < device_tensor.volume(); j++) {
+                    int base = j / num_elems;  // dev_idx
+                    ASSERT_EQ(output_data[j].to_float(), (-1.0 * base * 32.0 + 128));
+                }
+                log_info(LogTest, "Device{} Compare Success", device->id(), outer_loop);
+            });
+        }
+    }
+
+    pool.join();
+
+    if (enable_persistent_fabric) {
+        persistent_fabric_teardown_sequence(
+            devices, subdevice_managers, fabric_handle.value(), tt::fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+    }
+    for (auto device : devices) {
+        ttnn::queue_synchronize(device->command_queue(op_cq_id));
+    }
+
+    log_info(tt::LogTest, "Finished");
+}
+
+TEST_F(T3kMultiDeviceMultiQueueFixture, AsyncExecutionWorksCQ0CQ1) {
+    const size_t dim = 0;
+    const size_t num_links = 1;
+    constexpr auto layout = Layout::TILE;
+    constexpr size_t test_expected_num_devices = 4;
+
+    MeshDevice* mesh_device = this->mesh_device_.get();
+    mesh_device->enable_async(true);
+    mesh_device->enable_program_cache();
+
+    auto view = mesh_device->get_view();
+
+    // build a line of devices
+    std::vector<IDevice*> devices = {
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3))};
+    const size_t num_devices = devices.size();
+    TT_FATAL(
+        test_expected_num_devices == num_devices,
+        "Expected {} devices but got {}",
+        test_expected_num_devices,
+        num_devices);
+
+    // FABRIC setup
+    const bool enable_persistent_fabric = true;
+
+    std::vector<Program> dummy_worker_programs;
+    std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
+    std::optional<std::vector<Program>> fabric_programs;
+    std::vector<Program*> fabric_program_ptrs;
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
+    setup_test_with_persistent_fabric(
+        devices,
+        dummy_worker_programs,
+        subdevice_managers,
+        fabric_programs,
+        fabric_program_ptrs,
+        fabric_handle,
+        enable_persistent_fabric,
+        num_links);
+
+    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
+    auto
+        [from_remote_multi_device_global_semaphore,
+         to_remote_multi_device_global_semaphore,
+         multi_device_global_semaphore] = create_global_semaphores(this->mesh_device_, devices[0]);
+
+    const int batch_size = 8;
+    const int sequence_length = 1024;
+    const int embedding_dim = 768;
+
+    const ttnn::Shape input_shape = ttnn::Shape{1, batch_size, sequence_length, embedding_dim};
+    const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const auto num_elems = input_shape.volume();
+    auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
+    auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[num_elems]);
+
+    uint8_t ccl_cq_id = 0;  // ccl operation command queue id
+    uint8_t op_cq_id = 1;   // device operation, read/write command queue id
+
+    boost::asio::thread_pool pool(devices.size());
+
+    for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
+        log_info(LogTest, "Running outer loop {}", outer_loop);
+        std::vector<Tensor> device_tensors(devices.size());
+
+        int dev_idx = 0;
+        log_info(LogTest, "Enqueue Operations before AllGather", outer_loop);
+        std::vector<std::future<void>> futures;
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto promise = std::make_shared<std::promise<void>>();
+            futures.push_back(promise->get_future());
+            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+                // Generate input data for each device
+                for (int j = 0; j < num_elems; j++) {
+                    host_data[j] = bfloat16(static_cast<float>(dev_idx));
+                }
+
+                TensorSpec tensor_spec(
+                    input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
+                auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor input_tensor = Tensor(input_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
+
+                // Enqueue write_buffer to the operation`s command queue and record the event
+                ttnn::write_buffer(ttnn::QueueId(op_cq_id), input_tensor, {host_data});
+
+                // Enqueue multiple operations to the operation command queue
+                // Set output_tensor into device_tensor for allgather
+                device_tensors[dev_idx] = dispatch_ops_to_device(device, input_tensor, ttnn::QueueId(op_cq_id));
+
+                auto operation_event = std::make_shared<Event>();
+                ttnn::record_event(device->command_queue(op_cq_id), operation_event);
+                // Enqueue the task waiting for the operation_event to the ccl`s command queue
+                ttnn::wait_for_event(device->command_queue(ccl_cq_id), operation_event);
+
+                promise->set_value();
+            });
+            dev_idx++;
+        }
+
+        // Wait for all tasks to complete
+        for (auto& future : futures) {
+            future.wait();
+        }
+
+        log_info(LogTest, "Enqueue AllGather", outer_loop);
+        // Create a multi-device tensor for allgather
+        const Tensor mesh_tensor_for_ag = ttnn::distributed::aggregate_as_tensor(device_tensors, AllGatherTensor{});
+
+        // Enqueue the all_gather_async operation on each device.
+        // It does not support command queue ID as a parameter and internally uses command queue 0.
+        const Tensor gathered_tensor = ttnn::experimental::all_gather_async(
+            mesh_tensor_for_ag,
+            0,
+            multi_device_global_semaphore,
+            1,
+            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            ttnn::ccl::Topology::Linear,
+            SubDeviceId(0),
+            true);
+
+        futures.clear();  // Clear futures for the next set of tasks
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto promise = std::make_shared<std::promise<void>>();
+            futures.push_back(promise->get_future());
+            boost::asio::post(pool, [&, dev_idx, device, promise]() mutable {
+                auto ccl_event = std::make_shared<Event>();
+                ttnn::record_event(device->command_queue(ccl_cq_id), ccl_event);
+                // Enqueue the task waiting for the operation_event to the ccl`s command queue
+                ttnn::wait_for_event(device->command_queue(op_cq_id), ccl_event);
+
+                promise->set_value();
+            });
+            dev_idx++;
+        }
+
+        // Wait for all tasks to complete
+        for (auto& future : futures) {
+            future.wait();
+        }
+
+        log_info(LogTest, "EnqueueReadBuffer", outer_loop);
+        // Read the values from each device and compare them with the results calculated on the host
+        for (size_t i = 0; i < devices.size(); ++i) {
+            auto device = devices[i];
+            auto device_tensor = ttnn::distributed::get_device_tensor(gathered_tensor, device);
+
+            boost::asio::post(pool, [&, i, device, num_elems, device_tensor]() mutable {
+                auto output_data = std::shared_ptr<bfloat16[]>(new bfloat16[device_tensor.volume()]);
+                ttnn::read_buffer(ttnn::QueueId(op_cq_id), device_tensor, {output_data});
+
+                for (int j = 0; j < device_tensor.volume(); j++) {
+                    int base = j / num_elems;  // dev_idx
+                    ASSERT_EQ(output_data[j].to_float(), (-1.0 * base * 32.0 + 128));
+                }
+                log_info(LogTest, "Device{} Compare Success", device->id(), outer_loop);
+            });
+        }
+    }
+
+    pool.join();
+
+    if (enable_persistent_fabric) {
+        persistent_fabric_teardown_sequence(
+            devices, subdevice_managers, fabric_handle.value(), tt::fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+    }
+    for (auto device : devices) {
+        ttnn::queue_synchronize(device->command_queue(op_cq_id));
+    }
+
+    log_info(tt::LogTest, "Finished");
+}
+
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "test_utils.hpp"
+
+namespace ttnn::distributed::test {
+
+static constexpr size_t TEST_WORKERS_SUBDEVICE_INDEX = 0;
+static constexpr size_t TEST_EDM_FABRIC_SUBDEVICE_INDEX = 1;
+
+using namespace tt;
+using namespace tt_metal;
+
+Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id) {
+    using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::UnaryWithParam;
+
+    Tensor output_tensor = ttnn::mul_sfpu(cq_id, input_tensor, 2);
+    for (int i = 0; i < 3; i++) {
+        output_tensor = ttnn::neg(cq_id, output_tensor);
+        output_tensor = ttnn::neg(cq_id, output_tensor);
+        output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
+    }
+    output_tensor = ttnn::neg(cq_id, output_tensor);
+    output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
+    output_tensor = ttnn::add_sfpu(cq_id, output_tensor, 128);
+    return output_tensor;
+}
+
+SubdeviceInfo create_subdevices(const std::vector<IDevice*>& devices) {
+    SubdeviceInfo subdevice_info;
+    std::unordered_map<chip_id_t, SubDeviceManagerId> sub_device_manager_ids;
+    for (auto device : devices) {
+        const auto& tensix_sub_device =
+            tt_metal::SubDevice(std::array{device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0})});
+        const auto& eth_sub_device = tt_metal::SubDevice(
+            std::array{CoreRangeSet(), device->worker_cores(HalProgrammableCoreType::ACTIVE_ETH, SubDeviceId{0})});
+        subdevice_info.sub_device_managers.insert(
+            {device->id(), device->create_sub_device_manager({tensix_sub_device, eth_sub_device}, 0)});
+        device->load_sub_device_manager(subdevice_info.sub_device_managers.at(device->id()));
+        subdevice_info.worker_subdevice_id.insert(
+            {device->id(), device->get_sub_device_ids().at(TEST_WORKERS_SUBDEVICE_INDEX)});
+        subdevice_info.fabric_subdevice_id.insert(
+            {device->id(), device->get_sub_device_ids().at(TEST_EDM_FABRIC_SUBDEVICE_INDEX)});
+        device->set_sub_device_stall_group({subdevice_info.worker_subdevice_id.at(device->id())});
+    }
+
+    return subdevice_info;
+}
+
+void build_and_enqueue(const std::vector<IDevice*>& devices, std::vector<Program>& programs, bool enqueue_only) {
+    TT_FATAL(
+        devices.size() == programs.size(),
+        "Number of devices must match number of programs when calling build_and_enqueue in test");
+    if (!enqueue_only) {
+        for (size_t i = 0; i < devices.size(); i++) {
+            tt::tt_metal::detail::CompileProgram(devices[i], programs[i]);
+        }
+    }
+    for (size_t i = 0; i < devices.size(); i++) {
+        tt_metal::EnqueueProgram(devices[i]->command_queue(), programs[i], false);
+    }
+}
+
+void setup_test_with_persistent_fabric(
+    const std::vector<IDevice*>& devices,
+    std::vector<Program>& programs,
+    std::optional<SubdeviceInfo>& subdevice_managers,
+    std::optional<std::vector<Program>>& fabric_programs,
+    std::vector<Program*>& fabric_program_ptrs,
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface>& line_fabric,
+    bool enable_persistent_fabric,
+    std::optional<size_t> num_links) {
+    if (enable_persistent_fabric) {
+        log_info(tt::LogTest, "Enabling persistent fabric");
+        fabric_programs = std::vector<Program>(devices.size());
+        subdevice_managers = create_subdevices(devices);
+        std::transform(
+            fabric_programs->begin(), fabric_programs->end(), std::back_inserter(fabric_program_ptrs), [](auto& p) {
+                return &p;
+            });
+    } else {
+        std::transform(
+            programs.begin(), programs.end(), std::back_inserter(fabric_program_ptrs), [](auto& p) { return &p; });
+    }
+
+    line_fabric = ttnn::ccl::EdmLineFabricOpInterface(
+        devices, fabric_program_ptrs, enable_persistent_fabric, num_links.value_or(1));
+    line_fabric->set_firmware_context_switch_interval(0);
+
+    if (enable_persistent_fabric) {
+        TT_FATAL(fabric_programs.has_value(), "Fabric programs must be set if fabric is enabled");
+        TT_FATAL(devices.size() == fabric_programs->size(), "Number of devices must match number of programs");
+
+        log_info(tt::LogTest, "Building EDM kernels");
+        line_fabric->build_kernels();
+        build_and_enqueue(devices, *fabric_programs);
+    }
+}
+
+void persistent_fabric_teardown_sequence(
+    const std::vector<IDevice*>& devices,
+    std::optional<SubdeviceInfo>& subdevice_managers,
+    ttnn::ccl::EdmLineFabricOpInterface& line_fabric,
+    tt::fabric::TerminationSignal termination_mode) {
+    log_info("Tearing down fabric");
+
+    // Wait for workers to finish
+    auto d0_worker_subdevice = devices[0]->get_sub_device_ids()[TEST_WORKERS_SUBDEVICE_INDEX];
+    tt_metal::Finish(devices[0]->command_queue(), {subdevice_managers->worker_subdevice_id.at(devices[0]->id())});
+
+    // Teardown the fabric
+    line_fabric.teardown_from_host(termination_mode);
+
+    // wait for fabric teardown to finish
+    std::ranges::for_each(devices, [&](IDevice* d) {
+        tt_metal::Finish(d->command_queue(), {subdevice_managers->fabric_subdevice_id.at(d->id())});
+    });
+}
+
+std::tuple<
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore>
+create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, IDevice* device) {
+    auto from_remote_multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        mesh_device.get(),
+        device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        0,                             // initial value
+        tt::tt_metal::BufferType::L1,  // buffer type
+        10                             // attempts
+    );
+
+    auto to_remote_multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        mesh_device.get(),
+        device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        0,                             // initial value
+        tt::tt_metal::BufferType::L1,  // buffer type
+        10                             // attempts
+    );
+
+    auto multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+        mesh_device.get(),
+        device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+        0,                             // initial value
+        tt::tt_metal::BufferType::L1,  // buffer type
+        10                             // attempts
+    );
+
+    return {
+        from_remote_multi_device_global_semaphore,
+        to_remote_multi_device_global_semaphore,
+        multi_device_global_semaphore};
+}
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/async_runtime.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include <tt-metalium/mesh_device.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/ccl/erisc_datamover_builder.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp"
+#include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+
+namespace ttnn::distributed::test {
+
+using namespace tt;
+using namespace tt_metal;
+
+Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id);
+
+struct SubdeviceInfo {
+    std::unordered_map<chip_id_t, SubDeviceManagerId> sub_device_managers;
+    std::unordered_map<chip_id_t, SubDeviceId> worker_subdevice_id;
+    std::unordered_map<chip_id_t, SubDeviceId> fabric_subdevice_id;
+};
+
+SubdeviceInfo create_subdevices(const std::vector<IDevice*>& devices);
+
+void build_and_enqueue(const std::vector<IDevice*>& devices, std::vector<Program>& programs, bool enqueue_only = false);
+
+void setup_test_with_persistent_fabric(
+    const std::vector<IDevice*>& devices,
+    std::vector<Program>& programs,
+    std::optional<SubdeviceInfo>& subdevice_managers,
+    std::optional<std::vector<Program>>& fabric_programs,
+    std::vector<Program*>& fabric_program_ptrs,
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface>& line_fabric,
+    bool enable_persistent_fabric,
+    std::optional<size_t> num_links = std::nullopt);
+
+void persistent_fabric_teardown_sequence(
+    const std::vector<IDevice*>& devices,
+    std::optional<SubdeviceInfo>& subdevice_managers,
+    ttnn::ccl::EdmLineFabricOpInterface& line_fabric,
+    tt::fabric::TerminationSignal termination_mode = tt::fabric::TerminationSignal::GRACEFULLY_TERMINATE);
+
+std::tuple<
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore,
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore>
+create_global_semaphores(std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, IDevice* device);
+
+}  // namespace ttnn::distributed::test


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18497

### Problem description
I am trying to add tests that exploits multiple queues for multiple devices.
It describes how external users can use tt-metal in multi-chip environments.

For easy understanding, I consists two tests.
Below is the instructions to run the tests:
```
# Build
(python_env) user@ubuntu:~/tt-metal$./build_metal.sh --build-tests --debug --enable-ccache

# First test
(python_env) user@ubuntu:~/tt-metal$ ./build/test/ttnn/test_ccl_multi_cq_multi_device --gtest_filter="CclMultiQueueMultiDevice.AsyncExecutionWorksCQ0"

# Second test
(python_env) user@ubuntu:~/tt-metal$ ./build/test/ttnn/test_ccl_multi_cq_multi_device --gtest_filter="CclMultiQueueMultiDevice.AsyncExecutionWorksCQ0CQ1"
```

In the first test:
1. Multiple user threads are spawned. One for each device and there are total 4 devices.
2. Each spawned thread enqueues WriteBuffer to the corresponding device through command queue 0.
3. Then, the main thread calls AllGather.
4. Finally, the spawned user threads enqueue ReadBuffer through command queue 0.

In the second test:
1. Multiple user threads are spawned. One for each device and there are total 4 devices.
2. Each spawned thread enqueues WriteBuffer to the corresponding device through command queue 1.
3. Then, the main thread calls AllGather through command queue 0. Command queue 0 and 1 are synchronized by the event so that AllGather starts after all the WriteBuffer commands are finished.
4. Finally, the spawned user threads enqueue ReadBuffer through command queue 1. Again, command queue 0 and 1 are synchronized by the event so that ReadBuffer starts after the AllGather command is finished.

However, the problems in the above tests are that there are some bugs in the current tt-metal so the above tests do not guarantee correct output. For example, the first test outputs wrong result while the second test hangs on the WriteBuffer enqueueing.

In my opinion, I hope that your team will first refer to the behavior described in the two tests above and determine the direction of the design changes, and ultimately, I hope that the problems will be solved so that it can run smoothly without bugs when executed according to the above scenario.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
