### PR TITLE
#18475: Add blocking reads to the EventSync test

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -18,6 +18,7 @@
 namespace tt::tt_metal {
 namespace {
 
+using ::testing::Eq;
 using ::testing::FloatEq;
 using ::testing::Pointwise;
 using ::tt::tt_metal::is_tensor_on_device;
@@ -52,8 +53,9 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     const Tensor t0_host_tensor = Tensor::from_vector(t0_host_data, tensor_spec);
     const Tensor t1_host_tensor = Tensor::from_vector(t1_host_data, tensor_spec);
 
+    constexpr int kNumIterations = 100;
     std::thread t0([&]() {
-        for (int j = 0; j < 100; j++) {
+        for (int j = 0; j < kNumIterations; j++) {
             Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
             EXPECT_TRUE(is_tensor_on_device(t0_tensor));
             EXPECT_THAT(t0_tensor.to_vector<float>(), Pointwise(FloatEq(), t0_host_data));
@@ -61,7 +63,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     });
 
     std::thread t1([&]() {
-        for (int j = 0; j < 100; j++) {
+        for (int j = 0; j < kNumIterations; j++) {
             Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
             EXPECT_TRUE(is_tensor_on_device(t1_tensor));
             EXPECT_THAT(t1_tensor.to_vector<float>(), Pointwise(FloatEq(), t1_host_data));
@@ -88,7 +90,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
         .shard_spec = std::nullopt};
-    const TensorLayout tensor_layout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), mem_cfg);
+    const TensorLayout tensor_layout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR), mem_cfg);
     const TensorSpec tensor_spec(tensor_shape, tensor_layout);
 
     const ttnn::QueueId write_cq = ttnn::DefaultQueueId;
@@ -97,18 +99,19 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
     std::shared_ptr<Event> write_event = std::make_shared<Event>();
     std::shared_ptr<Event> read_event = std::make_shared<Event>();
 
-    std::vector<float> host_data(tensor_shape.volume());
-    std::iota(host_data.begin(), host_data.end(), 0);
     Tensor device_tensor = create_device_tensor(tensor_spec, device);
 
+    constexpr int kNumIterations = 100;
     std::thread t0([&]() {
-        for (int j = 0; j < 1000; j++) {
+        std::vector<uint32_t> host_data(tensor_shape.volume());
+        for (int j = 0; j < kNumIterations; j++) {
             if (j != 0) {
                 ttnn::event_synchronize(read_event);
             }
             read_event = std::make_shared<Event>();
 
             // Create tensor and transfer to device
+            std::iota(host_data.begin(), host_data.end(), j);
             const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
             memcpy(device->command_queue(*write_cq), device_tensor, host_tensor);
             EXPECT_TRUE(is_tensor_on_device(device_tensor));
@@ -118,14 +121,16 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
     });
 
     std::thread t1([&]() {
-        for (int j = 0; j < 1000; j++) {
+        std::vector<uint32_t> host_data(tensor_shape.volume());
+        for (int j = 0; j < kNumIterations; j++) {
             ttnn::event_synchronize(write_event);
             write_event = std::make_shared<Event>();
 
             // Read back from device and verify
-            const Tensor readback_tensor = device_tensor.cpu(/*blocking=*/false, read_cq);
+            const Tensor readback_tensor = device_tensor.cpu(/*blocking=*/true, read_cq);
             EXPECT_FALSE(is_tensor_on_device(readback_tensor));
-            EXPECT_THAT(readback_tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
+            std::iota(host_data.begin(), host_data.end(), j);
+            EXPECT_THAT(readback_tensor.to_vector<uint32_t>(), Pointwise(Eq(), host_data)) << "At iteration " << j;
 
             ttnn::record_event(device->command_queue(*read_cq), read_event);
         }

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -227,19 +227,19 @@ public:
     // ======================================================================================
     // Non-Blocking Getters. Query attributes directly, without waiting for worker completion
     // ======================================================================================
-    inline const Storage& storage() const { return this->tensor_attributes->storage; };
-    inline const ttnn::Shape& logical_shape() const { return this->tensor_attributes->tensor_spec.logical_shape(); };
-    inline const ttnn::Shape& padded_shape() const { return this->tensor_attributes->tensor_spec.padded_shape(); };
-    inline DataType dtype() const { return this->tensor_attributes->tensor_spec.tensor_layout().get_data_type(); };
-    inline Layout layout() const { return this->tensor_attributes->tensor_spec.tensor_layout().get_layout(); };
-    inline const TensorSpec& tensor_spec() const { return this->tensor_attributes->tensor_spec; }
+    const Storage& storage() const { return this->tensor_attributes->storage; };
+    const ttnn::Shape& logical_shape() const { return this->tensor_attributes->tensor_spec.logical_shape(); };
+    const ttnn::Shape& padded_shape() const { return this->tensor_attributes->tensor_spec.padded_shape(); };
+    DataType dtype() const { return this->tensor_attributes->tensor_spec.tensor_layout().get_data_type(); };
+    Layout layout() const { return this->tensor_attributes->tensor_spec.tensor_layout().get_layout(); };
+    const TensorSpec& tensor_spec() const { return this->tensor_attributes->tensor_spec; }
 
     // ======================================================================================
     //                                      Setters
     // ======================================================================================
-    inline void set_storage(const Storage& storage) { this->tensor_attributes->storage = storage; }
+    void set_storage(const Storage& storage) { this->tensor_attributes->storage = storage; }
     // We intend to remove this API once we migrate all ops to compute_output_specs, and provide TensorSpec at creation
-    inline void set_tensor_spec(const TensorSpec& tensor_spec) {
+    void set_tensor_spec(const TensorSpec& tensor_spec) {
         this->tensor_attributes->tensor_spec = tensor_spec;
         this->tensor_attributes->metadata_populated = true;
     }
@@ -322,7 +322,7 @@ public:
     std::vector<uint32_t> host_page_ordering();
 
     // Main Thread - Wait for all workers in this tensor to populate the entire tensor
-    inline void wait_for_tensor_data_populated() const {
+    void wait_for_tensor_data_populated() const {
         // Stall until all the workers for this tensor
         // have populated the full tensor
         while (this->tensor_attributes->num_workers_completed < this->tensor_attributes->num_shards_to_be_populated) {
@@ -330,7 +330,7 @@ public:
     }
 
     // Main Thread - Wait for the first worker in this tensor to populate the global metadata fields
-    inline void wait_for_tensor_metadata_populated() const {
+    void wait_for_tensor_metadata_populated() const {
         // First worker is responsible for updating all metadata fields
         // Stall until this worker is done
         while (not this->tensor_attributes->metadata_populated) {


### PR DESCRIPTION
### Ticket
#18475

### Problem description
The test has a race condition and fails non-deterministically.

### What's changed
Add a blocking read for the reader / verifier thread:
* For the explanation, see https://github.com/tenstorrent/tt-metal/issues/18475#issuecomment-2690964816

### Checklist
- [X] The test passes for 100K iterations.
