### PR TITLE
#18345: increase default layernorm precision

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
@@ -22,7 +22,7 @@ ttnn::Tensor ExecuteLayerNorm::invoke(
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, false, true, false);
     return operation::run(
                LayerNorm{
                    .norm_type = LayerNormType::LAYERNORM,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
@@ -21,8 +21,12 @@ ttnn::Tensor ExecuteLayerNorm::invoke(
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, false, true, false);
+    bool is_float_32 = input_tensor.get_dtype() == DataType::FLOAT32;
+    bool approx_mode = !is_float_32;
+    bool fp32_acc = is_float_32;
+    bool dst_full_sync_en = false;
+    auto kernel_config_val = init_device_compute_kernel_config(
+        arch, compute_kernel_config, MathFidelity::HiFi4, approx_mode, fp32_acc, dst_full_sync_en);
     return operation::run(
                LayerNorm{
                    .norm_type = LayerNormType::LAYERNORM,


### PR DESCRIPTION
### Ticket
Link to Github Issue #18345

### Problem description
- layernorm is not precise enough in some scenarios

### What's changed
- if use float32, increase accuracy

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13594629609
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13594634424
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13594632129
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
