### PR TITLE
Dockerized Profiler Regression

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -48,6 +48,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
       tracy: true
     secrets: inherit
   # Slow Dispatch Unit Tests

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -175,6 +175,9 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   build-docs:
     needs: build-artifact
     uses: ./.github/workflows/docs-latest-public.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -63,6 +63,7 @@ jobs:
     with:
       arch: "blackhole"
       runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
   umd-unit-tests:
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -63,6 +63,7 @@ jobs:
     with:
       arch: "blackhole"
       runner-label: ${{ inputs.runner-label || 'BH' }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
   umd-unit-tests:
     secrets: inherit

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -63,8 +63,9 @@ jobs:
     with:
       arch: "blackhole"
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -9,6 +9,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
+      build-wheel: true
     secrets: inherit
   run-profiler-regression:
     needs: build-artifact-profiler

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          #{ arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
+          #{ arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     uses: ./.github/workflows/run-profiler-regression.yaml
@@ -24,3 +24,4 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -25,3 +25,5 @@ jobs:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
       docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -23,6 +23,9 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      docker-image:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       arch:
@@ -50,6 +53,9 @@ on:
         required: true
         type: string
       wheel-artifact-name:
+        required: true
+        type: string
+      docker-image:
         required: true
         type: string
 

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -68,7 +68,7 @@ jobs:
         PROFILER_ARTIFACTS_DIR: /work/generated/profiler
         PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
         TTNN_CONFIG_OVERRIDES: '{"enable_fast_runtime_mode": false}'
-        TT_METAL_DEVICE_PROFILER: 1
+        NO_USE_VENV_PLZ: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -37,6 +37,12 @@ on:
       os:
         required: false
         type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
 
 jobs:
   profiler-regression:
@@ -79,11 +85,19 @@ jobs:
       - name: ⬇️ Download Build
         uses: actions/download-artifact@v4
         with:
-          name: TTMetal_build_any_profiler
+          name: ${{ inputs.build-artifact-name }}
           path: docker-job
       - name: Extract files
         run: tar -xvf ttm_any.tar
-      - uses: ./.github/actions/install-python-deps
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
+          path: docker-job
+      - name: Install Wheel
+        run: |
+          WHEEL_FILENAME=$(ls -1 *.whl)
+          pip3 install $WHEEL_FILENAME
       - name: Run profiler regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 35
+        default: 140
       os:
         required: false
         type: string
@@ -44,7 +44,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 35
+        default: 140
       os:
         required: false
         type: string

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -17,7 +17,15 @@ on:
         required: false
         type: string
         default: "ubuntu-20.04"
-      docker-image:
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      arch:
         required: true
         type: choice
         options:
@@ -37,6 +45,7 @@ on:
       os:
         required: false
         type: string
+        default: "ubuntu-20.04"
       build-artifact-name:
         required: true
         type: string

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -82,7 +82,6 @@ jobs:
         PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
         PROFILER_ARTIFACTS_DIR: /work/generated/profiler
         PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
-        TTNN_CONFIG_OVERRIDES: '{"enable_fast_runtime_mode": false}'
         NO_USE_VENV_PLZ: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -50,10 +50,6 @@ jobs:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
-    env:
-      ARCH_NAME: ${{ inputs.arch }}
-      LOGURU_LEVEL: INFO
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine
@@ -67,6 +63,12 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO
+        PROFILER_SCRIPTS_ROOT: /work/tt_metal/tools/profiler
+        PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
+        PROFILER_ARTIFACTS_DIR: /work/generated/profiler
+        PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
+        TTNN_CONFIG_OVERRIDES: '{"enable_fast_runtime_mode": false}'
+        TT_METAL_DEVICE_PROFILER: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -101,7 +103,14 @@ jobs:
       - name: Run profiler regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          ./tests/scripts/run_profiler_regressions.sh
+          mkdir -p generated/profiler
+          pytest tests/tt_metal/tools/profiler/test_device_profiler.py
+          rm -rf generated/profiler || true
+          mkdir -p generated/profiler
+          tt_metal/tools/profiler/profile_this.py -c 'pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py::test_run_matmul_test[BFLOAT16-input_shapes0]'
+          ls generated/profiler/reports/
+          cat generated/profiler/reports/*/ops_perf_results_*.csv
+          rm -rf generated/profiler || true
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -54,15 +54,36 @@ jobs:
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine
-      - in-service
+      - issue-dockerizing-pipelines
+      #- in-service
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/MLPerf:/mnt/MLPerf
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_any_profiler
+          path: docker-job
       - name: Extract files
         run: tar -xvf ttm_any.tar
       - uses: ./.github/actions/install-python-deps
@@ -75,3 +96,13 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U06CXU895AP # Michael Chiou
+      - name: Cleanup
+        if: always()
+        run: |
+          # We are forced to checkout the repo into a subdir of the host's workdir; this pollutes the host
+          # with root-owned files.  Be sure to clean up after ourselves in case we're on a non-ephemeral runner.
+          echo "pre rm"
+          ls -al /__w/tt-metal/tt-metal
+          rm -rf /__w/tt-metal/tt-metal/docker-job
+          echo "post rm"
+          ls -al /__w/tt-metal/tt-metal

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -17,9 +17,7 @@ on:
         required: false
         type: string
         default: "ubuntu-20.04"
-  workflow_dispatch:
-    inputs:
-      arch:
+      docker-image:
         required: true
         type: choice
         options:
@@ -39,7 +37,6 @@ on:
       os:
         required: false
         type: string
-        default: "ubuntu-20.04"
 
 jobs:
   profiler-regression:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 140
+        default: 35
       os:
         required: false
         type: string
@@ -44,7 +44,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 140
+        default: 35
       os:
         required: false
         type: string
@@ -68,8 +68,7 @@ jobs:
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine
-      - issue-dockerizing-pipelines
-      #- in-service
+      - in-service
     container:
       image: ${{ inputs.docker-image }}
       env:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -87,7 +87,7 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf
-      options: "--device /dev/tenstorrent --network host"
+      options: "--device /dev/tenstorrent"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -88,7 +88,7 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf
-      options: "--device /dev/tenstorrent"
+      options: "--device /dev/tenstorrent --network host"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -103,14 +103,7 @@ jobs:
       - name: Run profiler regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          mkdir -p generated/profiler
-          pytest tests/tt_metal/tools/profiler/test_device_profiler.py
-          rm -rf generated/profiler || true
-          mkdir -p generated/profiler
-          tt_metal/tools/profiler/profile_this.py -c 'pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py::test_run_matmul_test[BFLOAT16-input_shapes0]'
-          ls generated/profiler/reports/
-          cat generated/profiler/reports/*/ops_perf_results_*.csv
-          rm -rf generated/profiler || true
+          ./tests/scripts/run_profiler_regressions.sh
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -81,7 +81,7 @@ jobs:
         PROFILER_TEST_SCRIPTS_ROOT: /work/tests/tt_metal/tools/profiler
         PROFILER_ARTIFACTS_DIR: /work/generated/profiler
         PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
-        NO_USE_VENV_PLZ: 1
+        DONT_USE_VIRTUAL_ENVIRONMENT: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -13,18 +13,18 @@ run_async_mode_T3000_test(){
         remove_default_log_locations
         mkdir -p $PROFILER_ARTIFACTS_DIR
         echo "Skipping first test"
-        #./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
+        ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
-        #if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
-        #then
-        #    echo "No verification as test was skipped"
-        #else
-        #    echo "Verifying test results"
-        #    runDate=$(ls $PROFILER_OUTPUT_DIR/)
-        #    LINE_COUNT=1000 # Smoke test to see at least 1000 ops are reported
-        #    res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
-        #    echo $res
-        #fi
+        if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
+        then
+            echo "No verification as test was skipped"
+        else
+            echo "Verifying test results"
+            runDate=$(ls $PROFILER_OUTPUT_DIR/)
+            LINE_COUNT=1000 # Smoke test to see at least 1000 ops are reported
+            res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
+            echo $res
+        fi
     fi
 }
 

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -12,7 +12,6 @@ run_async_mode_T3000_test(){
     if [ "$ARCH_NAME" == "wormhole_b0" ]; then
         remove_default_log_locations
         mkdir -p $PROFILER_ARTIFACTS_DIR
-        echo "Skipping first test"
         ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
         if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -x
+
 source scripts/tools_setup_common.sh
 
 set -eo pipefail
@@ -86,7 +88,10 @@ run_profiling_test(){
 
     echo "Make sure this test runs in a build with cmake option ENABLE_TRACY=ON"
 
-    source python_env/bin/activate
+    if [[ -z "$NO_USE_VENV_PLZ" ]]; then
+      source python_env/bin/activate
+    fi
+
     export PYTHONPATH=$TT_METAL_HOME
 
     run_additional_T3000_test

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -12,19 +12,19 @@ run_async_mode_T3000_test(){
     if [ "$ARCH_NAME" == "wormhole_b0" ]; then
         remove_default_log_locations
         mkdir -p $PROFILER_ARTIFACTS_DIR
+        echo "Skipping first test"
+        #./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
-        ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
-
-        if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
-        then
-            echo "No verification as test was skipped"
-        else
-            echo "Verifying test results"
-            runDate=$(ls $PROFILER_OUTPUT_DIR/)
-            LINE_COUNT=1000 # Smoke test to see at least 1000 ops are reported
-            res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
-            echo $res
-        fi
+        #if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
+        #then
+        #    echo "No verification as test was skipped"
+        #else
+        #    echo "Verifying test results"
+        #    runDate=$(ls $PROFILER_OUTPUT_DIR/)
+        #    LINE_COUNT=1000 # Smoke test to see at least 1000 ops are reported
+        #    res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
+        #    echo $res
+        #fi
     fi
 }
 

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -87,7 +87,7 @@ run_profiling_test(){
 
     echo "Make sure this test runs in a build with cmake option ENABLE_TRACY=ON"
 
-    if [[ -z "$NO_USE_VENV_PLZ" ]]; then
+    if [[ -z "$DONT_USE_VIRTUAL_ENVIRONMENT" ]]; then
       source python_env/bin/activate
     fi
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to update profiler regression tests to run on ubuntu 22.04 - currently, it is running on 20.04

### What's changed
Containerized the tests to run in a 20.04 environment - where the container can be called to run on a 22.04 environment

### Checklist

https://github.com/tenstorrent/tt-metal/actions/runs/13608009479

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
