### PR TITLE
Move trace buffer management under `TraceBufferPool` class

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -54,7 +54,7 @@ public:
     // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
     virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
 
-    virtual void enqueue_trace(const uint32_t trace_id, bool blocking) = 0;
+    virtual void enqueue_trace(const std::shared_ptr<TraceBuffer>& trace_buffer, bool blocking) = 0;
 
     virtual void enqueue_program(Program& program, bool blocking) = 0;
 

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -135,7 +135,6 @@ public:
         const uint8_t cq_id, const uint32_t tid, const bool block_on_device, const bool block_on_worker_thread) = 0;
     virtual void release_trace(const uint32_t tid) = 0;
 
-    virtual std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) = 0;
     virtual uint32_t get_trace_buffers_size() const = 0;
     virtual void set_trace_buffers_size(uint32_t size) = 0;
 

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -26,6 +26,9 @@
 
 namespace tt::tt_metal {
 
+template <typename TraceId, typename TraceBufferType>
+class TraceBufferPool;
+
 inline namespace v0 {
 
 // A physical PCIexpress Tenstorrent device
@@ -132,7 +135,6 @@ public:
         const bool block_on_device,
         const bool block_on_worker_thread) override;
     void release_trace(const uint32_t tid) override;
-    std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override { return trace_buffers_size_; }
     void set_trace_buffers_size(uint32_t size) override { trace_buffers_size_ = size; }
 
@@ -271,6 +273,8 @@ private:
     std::vector<uint16_t> l1_bank_to_noc_xy_;
 
     program_cache::detail::ProgramCache program_cache_;
+
+    std::unique_ptr<TraceBufferPool<uint32_t, TraceBuffer>> trace_buffer_pool_;
 
     uint32_t trace_buffers_size_ = 0;
     bool uninitialized_error_fired_ =

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -135,6 +135,7 @@ public:
     std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override { return trace_buffers_size_; }
     void set_trace_buffers_size(uint32_t size) override { trace_buffers_size_ = size; }
+
     // Light Metal
     void load_trace(uint8_t cq_id, uint32_t trace_id, const TraceDescriptor& trace_desc) override;
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -171,7 +171,7 @@ public:
         const vector_memcpy_aligned<uint32_t>& go_signal_noc_data);
     void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx);
     void record_end();
-    void enqueue_trace(const MeshTraceId& trace_id, bool blocking);
+    void enqueue_trace(const std::shared_ptr<MeshTraceBuffer>& trace_buffer, bool blocking);
 };
 
 }  // namespace distributed

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -151,7 +151,6 @@ public:
         const bool block_on_device,
         const bool block_on_worker_thread) override;
     void release_trace(const uint32_t tid) override;
-    std::shared_ptr<TraceBuffer> get_trace(uint32_t tid) override;
     uint32_t get_trace_buffers_size() const override;
     void set_trace_buffers_size(uint32_t size) override;
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -23,7 +23,7 @@ namespace tt::tt_metal {
 class SubDeviceManagerTracker;
 class ThreadPool;
 
-template <typename TraceKey, typename TraceBufferType>
+template <typename TraceId, typename TraceBufferType>
 class TraceBufferPool;
 
 namespace distributed {

--- a/tt_metal/api/tt-metalium/mesh_trace.hpp
+++ b/tt_metal/api/tt-metalium/mesh_trace.hpp
@@ -47,12 +47,15 @@ class MeshTraceDescriptor {
 public:
     // Mapping of sub_device_id to descriptor
     std::unordered_map<SubDeviceId, TraceWorkerDescriptor> descriptors;
+
     // Store the keys of the map in a vector after descriptor has finished being populated
     // This is an optimization since we sometimes need to only pass the keys in a container
     std::vector<SubDeviceId> sub_device_ids;
+
     // Trace data per logical Device in a Mesh.
     std::vector<MeshTraceData> ordered_trace_data;
     uint32_t total_trace_size = 0;
+
     // Once the trace is captured/staged inside the sysmem_managers on a MeshDevice, assemble all
     // dispatch commands related to the MeshTrace
     void assemble_dispatch_commands(MeshDevice* device, const std::vector<MeshTraceStagingMetadata>& mesh_trace_md);
@@ -62,6 +65,7 @@ public:
 struct MeshTraceBuffer {
     // The trace descriptor associated with a MeshTrace
     std::shared_ptr<MeshTraceDescriptor> desc;
+
     // The MeshBuffer this trace will be serialized to, before being run on a
     // MeshDevice
     std::shared_ptr<MeshBuffer> mesh_buffer;
@@ -72,9 +76,11 @@ class MeshTrace {
 public:
     // Get global (unique) ID for trace
     static MeshTraceId next_id();
+
     // Create an empty MeshTraceBuffer, which needs to be populated
     // with a MeshTraceDescriptor and a MeshBuffer, to get tied to a MeshDevice.
     static std::shared_ptr<MeshTraceBuffer> create_empty_mesh_trace_buffer();
+
     // Once the Trace Data per logical device has been captured in the
     // MeshTraceDescriptor corresponding to this MeshTraceBuffer,
     // it can be binarized to a MeshDevice through a Command Queue.

--- a/tt_metal/api/tt-metalium/sub_device_manager.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager.hpp
@@ -16,11 +16,6 @@
 
 namespace tt::tt_metal {
 
-class TraceBuffer;
-
-template <typename TraceId, typename TraceBufferType>
-class TraceBufferPool;
-
 inline namespace v0 {
 class IDevice;
 }  // namespace v0
@@ -55,8 +50,6 @@ public:
 
     const std::unique_ptr<Allocator>& allocator(SubDeviceId sub_device_id) const;
     std::unique_ptr<Allocator>& sub_device_allocator(SubDeviceId sub_device_id);
-
-    TraceBufferPool<uint32_t, TraceBuffer>* trace_buffer_pool();
 
     uint8_t num_sub_devices() const;
     bool has_allocations() const;
@@ -95,10 +88,6 @@ private:
     std::vector<uint8_t> num_noc_unicast_txns_;
     std::vector<uint8_t> noc_mcast_data_start_index_;
     std::vector<uint8_t> noc_unicast_data_start_index_;
-
-    // Trace buffers are coupled with specific sub device configuration, and become invalidated when sub device manager
-    // changes.
-    std::unique_ptr<TraceBufferPool<uint32_t, TraceBuffer>> trace_buffer_pool_;
 
     // TODO #15944: Temporary until migration to actual fabric is complete
     std::optional<SubDeviceId> fabric_sub_device_id_ = std::nullopt;

--- a/tt_metal/api/tt-metalium/sub_device_manager.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager.hpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 #include "allocator.hpp"
@@ -19,6 +18,9 @@ namespace tt::tt_metal {
 
 class TraceBuffer;
 
+template <typename TraceId, typename TraceBufferType>
+class TraceBufferPool;
+
 inline namespace v0 {
 class IDevice;
 }  // namespace v0
@@ -28,6 +30,7 @@ public:
     // Constructor used for the default/global device
     SubDeviceManager(
         IDevice* device, std::unique_ptr<Allocator>&& global_allocator, tt::stl::Span<const SubDevice> sub_devices);
+
     // Constructor used for regular sub-devices
     SubDeviceManager(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device);
 
@@ -53,9 +56,7 @@ public:
     const std::unique_ptr<Allocator>& allocator(SubDeviceId sub_device_id) const;
     std::unique_ptr<Allocator>& sub_device_allocator(SubDeviceId sub_device_id);
 
-    std::shared_ptr<TraceBuffer>& create_trace(uint32_t tid);
-    void release_trace(uint32_t tid);
-    std::shared_ptr<TraceBuffer> get_trace(uint32_t tid);
+    TraceBufferPool<uint32_t, TraceBuffer>* trace_buffer_pool();
 
     uint8_t num_sub_devices() const;
     bool has_allocations() const;
@@ -95,7 +96,9 @@ private:
     std::vector<uint8_t> noc_mcast_data_start_index_;
     std::vector<uint8_t> noc_unicast_data_start_index_;
 
-    std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
+    // Trace buffers are coupled with specific sub device configuration, and become invalidated when sub device manager
+    // changes.
+    std::unique_ptr<TraceBufferPool<uint32_t, TraceBuffer>> trace_buffer_pool_;
 
     // TODO #15944: Temporary until migration to actual fabric is complete
     std::optional<SubDeviceId> fabric_sub_device_id_ = std::nullopt;

--- a/tt_metal/api/tt-metalium/sub_device_manager_tracker.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager_tracker.hpp
@@ -49,11 +49,11 @@ public:
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
 
     // Used for caching program state by manager and buffers to check that the required manager is still active
-    SubDeviceManager* get_active_sub_device_manager() const;
+    SubDeviceManager& get_active_sub_device_manager() const;
 
     // Currently only used by program's determine_sub_device_ids algorithm to avoid running the search algorithm in the
     // default case to not affect performance
-    SubDeviceManager* get_default_sub_device_manager() const;
+    SubDeviceManager& get_default_sub_device_manager() const;
 
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) const;

--- a/tt_metal/api/tt-metalium/sub_device_manager_tracker.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager_tracker.hpp
@@ -48,16 +48,12 @@ public:
 
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
 
-    SubDeviceManager* get_active_sub_device_manager() const;
-
-    SubDeviceManager* get_default_sub_device_manager() const;
-
     // Used for caching program state by manager and buffers to check that the required manager is still active
-    SubDeviceManagerId get_active_sub_device_manager_id() const;
+    SubDeviceManager* get_active_sub_device_manager() const;
 
     // Currently only used by program's determine_sub_device_ids algorithm to avoid running the search algorithm in the
     // default case to not affect performance
-    SubDeviceManagerId get_default_sub_device_manager_id() const;
+    SubDeviceManager* get_default_sub_device_manager() const;
 
     std::optional<DeviceAddr> lowest_occupied_compute_l1_address(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) const;

--- a/tt_metal/api/tt-metalium/trace_buffer.hpp
+++ b/tt_metal/api/tt-metalium/trace_buffer.hpp
@@ -29,6 +29,7 @@ struct TraceWorkerDescriptor {
 struct TraceDescriptor {
     // Mapping of sub_device_id to descriptor
     std::unordered_map<SubDeviceId, TraceWorkerDescriptor> descriptors;
+
     // Store the keys of the map in a vector after descriptor has finished being populated
     // This is an optimization since we sometimes need to only pass the keys in a container
     std::vector<SubDeviceId> sub_device_ids;

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -691,10 +691,7 @@ void MeshCommandQueue::enqueue_trace(const std::shared_ptr<MeshTraceBuffer>& tra
             mesh_device_, device->sysmem_manager(), dispatch_md, id_, expected_num_workers_completed_, dispatch_core_);
     }
     trace_dispatch::update_worker_state_post_trace_execution(
-        trace_buffer->desc->descriptors,
-        this->reference_sysmem_manager(),
-        config_buffer_mgr_,
-        expected_num_workers_completed_);
+        descriptor->descriptors, this->reference_sysmem_manager(), config_buffer_mgr_, expected_num_workers_completed_);
 
     if (blocking) {
         this->finish();

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -671,10 +671,9 @@ void MeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
     }
 }
 
-void MeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking) {
-    auto trace_inst = mesh_device_->get_mesh_trace(trace_id);
-    auto descriptor = trace_inst->desc;
-    auto buffer = trace_inst->mesh_buffer;
+void MeshCommandQueue::enqueue_trace(const std::shared_ptr<MeshTraceBuffer>& trace_buffer, bool blocking) {
+    auto descriptor = trace_buffer->desc;
+    auto buffer = trace_buffer->mesh_buffer;
     uint32_t num_sub_devices = descriptor->sub_device_ids.size();
 
     auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(num_sub_devices);
@@ -692,7 +691,7 @@ void MeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking)
             mesh_device_, device->sysmem_manager(), dispatch_md, id_, expected_num_workers_completed_, dispatch_core_);
     }
     trace_dispatch::update_worker_state_post_trace_execution(
-        trace_inst->desc->descriptors,
+        trace_buffer->desc->descriptors,
         this->reference_sysmem_manager(),
         config_buffer_mgr_,
         expected_num_workers_completed_);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -594,22 +594,21 @@ void MeshDevice::release_trace(const uint32_t tid) {
     }
 }
 
-void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id) { trace_buffer_pool_->release_trace_buffer(trace_id); }
+void MeshDevice::release_mesh_trace(const MeshTraceId& trace_id) { trace_buffer_pool_->erase(trace_id); }
 
 void MeshDevice::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
-    auto mesh_trace_buffer =
-        trace_buffer_pool_->emplace_trace_buffer(trace_id, MeshTrace::create_empty_mesh_trace_buffer());
+    auto mesh_trace_buffer = trace_buffer_pool_->emplace(trace_id, MeshTrace::create_empty_mesh_trace_buffer());
     mesh_command_queues_[cq_id]->record_begin(trace_id, mesh_trace_buffer->desc);
 }
 
 void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
-    auto trace_buffer = trace_buffer_pool_->get_trace_buffer(trace_id);
+    auto trace_buffer = trace_buffer_pool_->get(trace_id);
     mesh_command_queues_[cq_id]->record_end();
     MeshTrace::populate_mesh_buffer(*(mesh_command_queues_[cq_id]), trace_buffer);
 }
 
 void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
-    auto trace_buffer = trace_buffer_pool_->get_trace_buffer(trace_id);
+    auto trace_buffer = trace_buffer_pool_->get(trace_id);
     mesh_command_queues_[cq_id]->enqueue_trace(trace_buffer, blocking);
 }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -609,6 +609,7 @@ void MeshDevice::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
 
 void MeshDevice::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
     auto trace_buffer = trace_buffer_pool_->get(trace_id);
+    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device", trace_id);
     mesh_command_queues_[cq_id]->enqueue_trace(trace_buffer, blocking);
 }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1425,7 +1425,7 @@ void Device::replay_trace(
                 tid,
                 this->id_,
                 active_sub_device_manager->id());
-            EnqueueTrace(this->command_queue(cq_id), tid, block_on_device);
+            command_queue(cq_id).enqueue_trace(trace_buffer, block_on_device);
         },
         block_on_worker_thread);
 }

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -403,12 +403,10 @@ void HWCommandQueue::enqueue_wait_for_event(const std::shared_ptr<Event>& sync_e
     event_dispatch::issue_wait_for_event_commands(id_, sync_event->cq_id, this->manager, sync_event->event_id);
 }
 
-void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
+void HWCommandQueue::enqueue_trace(const std::shared_ptr<TraceBuffer>& trace_buffer, bool blocking) {
     ZoneScopedN("HWCommandQueue_enqueue_trace");
-
-    auto trace_inst = this->device_->get_trace(trace_id);
-    auto descriptor = trace_inst->desc;
-    auto buffer = trace_inst->buffer;
+    auto descriptor = trace_buffer->desc;
+    auto buffer = trace_buffer->buffer;
     uint32_t num_sub_devices = descriptor->sub_device_ids.size();
 
     auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(num_sub_devices);
@@ -430,10 +428,10 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
         virtual_enqueue_program_dispatch_core_);
 
     trace_dispatch::update_worker_state_post_trace_execution(
-        trace_inst->desc->descriptors, this->manager, this->config_buffer_mgr, this->expected_num_workers_completed);
+        descriptor->descriptors, this->manager, this->config_buffer_mgr, this->expected_num_workers_completed);
 
     if (blocking) {
-        this->finish(trace_inst->desc->sub_device_ids);
+        this->finish(descriptor->sub_device_ids);
     }
 }
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -53,7 +53,7 @@ public:
     // This function is temporarily needed since MeshCommandQueue relies on the CommandQueue object
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override;
 
-    void enqueue_trace(const uint32_t trace_id, bool blocking) override;
+    void enqueue_trace(const std::shared_ptr<TraceBuffer>& trace_buffer, bool blocking) override;
     void enqueue_program(Program& program, bool blocking) override;
     void enqueue_read_buffer(
         const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -363,9 +363,8 @@ void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureEnqueueTrace, cq, trace_id, blocking);
     detail::DispatchStateCheck(true);
-    auto trace_buffer = cq.device()->get_trace(trace_id);
-    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device", trace_id);
-    cq.enqueue_trace(trace_buffer, blocking);
+    // Device performs additional checks that replaying a trace is safe and valid.
+    cq.device()->replay_trace(cq.id(), trace_id, /*block_on_device=*/blocking, /*block_on_worker_thread=*/blocking);
 }
 
 }  // namespace v0

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -363,8 +363,9 @@ void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureEnqueueTrace, cq, trace_id, blocking);
     detail::DispatchStateCheck(true);
-    TT_FATAL(cq.device()->get_trace(trace_id) != nullptr, "Trace instance {} must exist on device", trace_id);
-    cq.enqueue_trace(trace_id, blocking);
+    auto trace_buffer = cq.device()->get_trace(trace_id);
+    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device", trace_id);
+    cq.enqueue_trace(trace_buffer, blocking);
 }
 
 }  // namespace v0

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -16,11 +16,8 @@
 #include <data_types.hpp>
 #include <sub_device.hpp>
 #include <sub_device_types.hpp>
-#include <trace.hpp>
-#include <trace_buffer.hpp>
 #include <span.hpp>
 #include <tt_align.hpp>
-#include "trace/trace_buffer_pool.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
 #include "tt_cluster.hpp"
@@ -38,8 +35,7 @@ SubDeviceManager::SubDeviceManager(
     id_(next_sub_device_manager_id_++),
     sub_devices_(sub_devices.begin(), sub_devices.end()),
     local_l1_size_(tt::align(local_l1_size, hal.get_alignment(HalMemType::L1))),
-    device_(device),
-    trace_buffer_pool_(std::make_unique<TraceBufferPool<uint32_t, TraceBuffer>>()) {
+    device_(device) {
     TT_ASSERT(device != nullptr, "Device must not be null");
     this->validate_sub_devices();
     this->populate_sub_device_ids();
@@ -53,8 +49,7 @@ SubDeviceManager::SubDeviceManager(
     id_(next_sub_device_manager_id_++),
     device_(device),
     sub_devices_(sub_devices.begin(), sub_devices.end()),
-    local_l1_size_(0),
-    trace_buffer_pool_(std::make_unique<TraceBufferPool<uint32_t, TraceBuffer>>()) {
+    local_l1_size_(0) {
     TT_ASSERT(device != nullptr, "Device must not be null");
 
     this->populate_sub_device_ids();
@@ -124,8 +119,6 @@ std::unique_ptr<Allocator>& SubDeviceManager::sub_device_allocator(SubDeviceId s
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
     return sub_device_allocators_[sub_device_index];
 }
-
-TraceBufferPool<uint32_t, TraceBuffer>* SubDeviceManager::trace_buffer_pool() { return trace_buffer_pool_.get(); }
 
 bool SubDeviceManager::has_allocations() const {
     for (const auto& allocator : sub_device_allocators_) {

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -126,14 +126,6 @@ SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() cons
     return default_sub_device_manager_;
 }
 
-SubDeviceManagerId SubDeviceManagerTracker::get_active_sub_device_manager_id() const {
-    return active_sub_device_manager_->id();
-}
-
-SubDeviceManagerId SubDeviceManagerTracker::get_default_sub_device_manager_id() const {
-    return default_sub_device_manager_->id();
-}
-
 std::optional<DeviceAddr> SubDeviceManagerTracker::lowest_occupied_compute_l1_address(
     tt::stl::Span<const SubDeviceId> sub_device_ids) const {
     constexpr uint32_t global_bank_id = 0;

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -137,7 +137,7 @@ std::optional<DeviceAddr> SubDeviceManagerTracker::lowest_occupied_compute_l1_ad
     } else {
         DeviceAddr lowest_addr = std::numeric_limits<DeviceAddr>::max();
         for (const auto& sub_device_id : sub_device_ids) {
-            const auto& allocator = this->get_active_sub_device_manager()->sub_device_allocator(sub_device_id);
+            const auto& allocator = this->get_active_sub_device_manager().sub_device_allocator(sub_device_id);
             if (allocator) {
                 auto found_addr = allocator->get_lowest_occupied_l1_address(global_bank_id);
                 if (found_addr.has_value()) {

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -120,10 +120,10 @@ void SubDeviceManagerTracker::remove_sub_device_manager(SubDeviceManagerId sub_d
     sub_device_managers_.erase(sub_device_manager);
 }
 
-SubDeviceManager* SubDeviceManagerTracker::get_active_sub_device_manager() const { return active_sub_device_manager_; }
+SubDeviceManager& SubDeviceManagerTracker::get_active_sub_device_manager() const { return *active_sub_device_manager_; }
 
-SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() const {
-    return default_sub_device_manager_;
+SubDeviceManager& SubDeviceManagerTracker::get_default_sub_device_manager() const {
+    return *default_sub_device_manager_;
 }
 
 std::optional<DeviceAddr> SubDeviceManagerTracker::lowest_occupied_compute_l1_address(

--- a/tt_metal/impl/trace/trace_buffer_pool.hpp
+++ b/tt_metal/impl/trace/trace_buffer_pool.hpp
@@ -11,26 +11,44 @@
 
 namespace tt::tt_metal {
 
+// Provides an interface for keeping a collection of TraceBuffers keyed by TraceId.
 template <typename TraceId, typename TraceBufferType>
 class TraceBufferPool {
 public:
-    std::shared_ptr<TraceBufferType> emplace_trace_buffer(
-        TraceId trace_id, std::shared_ptr<TraceBufferType> trace_buffer) {
-        auto [it, emplaced] = trace_buffer_pool_.emplace(trace_id, std::move(trace_buffer));
-        TT_FATAL(emplaced, "Trace buffer with trace_id {} already exists", trace_id);
-        return it->second;
-    }
+    // Emplaces `trace_buffer` by `trace_id`.
+    // Throws if there is already an entry for `trace_id`.
+    std::shared_ptr<TraceBufferType> emplace(TraceId trace_id, std::shared_ptr<TraceBufferType> trace_buffer);
 
-    void release_trace_buffer(TraceId trace_id) { trace_buffer_pool_.erase(trace_id); }
+    // Erases trace buffer for `trace_id`.
+    // Throws if no trace buffer exists for `trace_id`.
+    void erase(TraceId trace_id);
 
-    std::shared_ptr<TraceBufferType> get_trace_buffer(TraceId trace_id) {
-        auto it = trace_buffer_pool_.find(trace_id);
-        TT_FATAL(it != trace_buffer_pool_.end(), "Trace buffer with trace_id {} not found", trace_id);
-        return it->second;
-    }
+    // Returns a trace buffer, or nullptr if it doesn't exist.
+    std::shared_ptr<TraceBufferType> get(TraceId trace_id);
 
 private:
-    std::unordered_map<TraceId, std::shared_ptr<TraceBufferType>> trace_buffer_pool_;
+    std::unordered_map<TraceId, std::shared_ptr<TraceBufferType>> trace_buffers_;
 };
+
+template <typename TraceId, typename TraceBufferType>
+std::shared_ptr<TraceBufferType> TraceBufferPool<TraceId, TraceBufferType>::emplace(
+    TraceId trace_id, std::shared_ptr<TraceBufferType> trace_buffer) {
+    auto [it, emplaced] = trace_buffers_.emplace(trace_id, std::move(trace_buffer));
+    TT_FATAL(emplaced, "Trace buffer with trace_id {} already exists", trace_id);
+    return it->second;
+}
+
+template <typename TraceId, typename TraceBufferType>
+void TraceBufferPool<TraceId, TraceBufferType>::erase(TraceId trace_id) {
+    auto it = trace_buffers_.find(trace_id);
+    TT_FATAL(it != trace_buffers_.end(), "Trace buffer with trace_id {} does not exist", trace_id);
+    trace_buffers_.erase(trace_id);
+}
+
+template <typename TraceId, typename TraceBufferType>
+std::shared_ptr<TraceBufferType> TraceBufferPool<TraceId, TraceBufferType>::get(TraceId trace_id) {
+    auto it = trace_buffers_.find(trace_id);
+    return it != trace_buffers_.end() ? it->second : nullptr;
+}
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/trace/trace_buffer_pool.hpp
+++ b/tt_metal/impl/trace/trace_buffer_pool.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <unordered_map>
+#include <memory>
+
+#include <assert.hpp>
+
+namespace tt::tt_metal {
+
+template <typename TraceId, typename TraceBufferType>
+class TraceBufferPool {
+public:
+    std::shared_ptr<TraceBufferType> emplace_trace_buffer(
+        TraceId trace_id, std::shared_ptr<TraceBufferType> trace_buffer) {
+        auto [it, emplaced] = trace_buffer_pool_.emplace(trace_id, std::move(trace_buffer));
+        TT_FATAL(emplaced, "Trace buffer with trace_id {} already exists", trace_id);
+        return it->second;
+    }
+
+    void release_trace_buffer(TraceId trace_id) { trace_buffer_pool_.erase(trace_id); }
+
+    std::shared_ptr<TraceBufferType> get_trace_buffer(TraceId trace_id) {
+        auto it = trace_buffer_pool_.find(trace_id);
+        TT_FATAL(it != trace_buffer_pool_.end(), "Trace buffer with trace_id {} not found", trace_id);
+        return it->second;
+    }
+
+private:
+    std::unordered_map<TraceId, std::shared_ptr<TraceBufferType>> trace_buffer_pool_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/trace/trace_buffer_pool.hpp
+++ b/tt_metal/impl/trace/trace_buffer_pool.hpp
@@ -9,46 +9,57 @@
 
 #include <assert.hpp>
 
+#include "sub_device_types.hpp"
+
 namespace tt::tt_metal {
 
-// Provides an interface for keeping a collection of TraceBuffers keyed by TraceId.
+// TraceBuffers are valid and can be enqueued for replay as long as the SubDeviceManagerId is active on device.
+// This class provides a convenient abstraction for keeping a collection of TraceBuffers along with the
+// SubDeviceManagerId they were captured on, keyed by TraceId.
 template <typename TraceId, typename TraceBufferType>
 class TraceBufferPool {
 public:
-    // Emplaces `trace_buffer` by `trace_id`.
+    // Emplaces `trace_buffer` and `sub_device_manager_id` by `trace_id`.
     // Throws if there is already an entry for `trace_id`.
-    std::shared_ptr<TraceBufferType> emplace(TraceId trace_id, std::shared_ptr<TraceBufferType> trace_buffer);
+    std::shared_ptr<TraceBufferType> emplace(
+        TraceId trace_id, SubDeviceManagerId sub_device_manager_id, std::shared_ptr<TraceBufferType> trace_buffer);
 
-    // Erases trace buffer for `trace_id`.
-    // Throws if no trace buffer exists for `trace_id`.
+    // Erases entry for `trace_id`.
+    // Throws if no trace exists for `trace_id`.
     void erase(TraceId trace_id);
 
-    // Returns a trace buffer, or nullptr if it doesn't exist.
-    std::shared_ptr<TraceBufferType> get(TraceId trace_id);
+    struct TraceEntry {
+        SubDeviceManagerId sub_device_manager_id;
+        std::shared_ptr<TraceBufferType> trace_buffer;
+    };
+
+    // Returns an entry for `trace_id`, or nullopt if it doesn't exist.
+    std::optional<TraceEntry> get_trace(TraceId trace_id);
 
 private:
-    std::unordered_map<TraceId, std::shared_ptr<TraceBufferType>> trace_buffers_;
+    std::unordered_map<TraceId, TraceEntry> traces_;
 };
 
 template <typename TraceId, typename TraceBufferType>
 std::shared_ptr<TraceBufferType> TraceBufferPool<TraceId, TraceBufferType>::emplace(
-    TraceId trace_id, std::shared_ptr<TraceBufferType> trace_buffer) {
-    auto [it, emplaced] = trace_buffers_.emplace(trace_id, std::move(trace_buffer));
-    TT_FATAL(emplaced, "Trace buffer with trace_id {} already exists", trace_id);
-    return it->second;
+    TraceId trace_id, SubDeviceManagerId sub_device_manager_id, std::shared_ptr<TraceBufferType> trace_buffer) {
+    auto [it, emplaced] = traces_.emplace(trace_id, TraceEntry{sub_device_manager_id, std::move(trace_buffer)});
+    TT_FATAL(emplaced, "Entry with trace_id {} already exists", trace_id);
+    return it->second.trace_buffer;
 }
 
 template <typename TraceId, typename TraceBufferType>
 void TraceBufferPool<TraceId, TraceBufferType>::erase(TraceId trace_id) {
-    auto it = trace_buffers_.find(trace_id);
-    TT_FATAL(it != trace_buffers_.end(), "Trace buffer with trace_id {} does not exist", trace_id);
-    trace_buffers_.erase(trace_id);
+    auto it = traces_.find(trace_id);
+    TT_FATAL(it != traces_.end(), "Entry with trace_id {} does not exist", trace_id);
+    traces_.erase(trace_id);
 }
 
 template <typename TraceId, typename TraceBufferType>
-std::shared_ptr<TraceBufferType> TraceBufferPool<TraceId, TraceBufferType>::get(TraceId trace_id) {
-    auto it = trace_buffers_.find(trace_id);
-    return it != trace_buffers_.end() ? it->second : nullptr;
+std::optional<typename TraceBufferPool<TraceId, TraceBufferType>::TraceEntry>
+TraceBufferPool<TraceId, TraceBufferType>::get_trace(TraceId trace_id) {
+    auto it = traces_.find(trace_id);
+    return it != traces_.end() ? std::optional<TraceEntry>{it->second} : std::nullopt;
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Several small issues:
1. Code for single device and mesh device duplicates trace buffer management.
2. Too many methods related to trace buffer management exposed publicly.
3. Not clear why `TraceBufferPool` is on `SubDeviceManager` (see comment below).
4. Not clear why CQ interface takes trace ID and performs a lookup instead of just taking trace buffer.

### What's changed
* Add a layer of abstraction `TraceBufferPool` that encapsulates functionality to look up / emplace / erase trace buffers from a map.
* This allows to rely on the internal `TraceBufferPool` interface, and remove `MeshDevice::create_mesh_trace`, `MeshDevice::get_mesh_trace`, `SubDeviceManager ::create_trace`, `SubDeviceManager ::release_trace`, `SubDeviceManager::get_trace`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13665959938) - pending
- [X] Manually ran mesh trace tests on T3K.
- [X] New/Existing tests provide coverage for changes
