### PR TITLE
Ensure we have Boost::asio target

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -27,10 +27,11 @@ CPMAddPackage(
         "BOOST_ENABLE_CMAKE ON"
         "BOOST_SKIP_INSTALL_RULES ON"
         "BUILD_SHARED_LIBS OFF"
-        "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess"
+        "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess\\\;asio"
     FIND_PACKAGE_ARGUMENTS "CONFIG REQUIRED"
 )
 
+ensureboosttarget(asio)
 ensureboosttarget(core)
 ensureboosttarget(container)
 ensureboosttarget(smart_ptr)

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(
         Tracy::TracyClient
         TT::Metalium::HostDevCommon
         yaml-cpp::yaml-cpp
+        Boost::asio
 )


### PR DESCRIPTION
### Ticket
None

### Problem description
A dependency on ASIO was introduced in #18395, but we only "accidentally" have it available because it (sometimes) comes along with other Boost headers.  CI was fine because it happened to be there.  But in some envs it isn't there (or too old).

### What's changed
Declared our dependency on it.
