### PR TITLE
Add Support for Non-Blocking Reads

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -233,5 +233,79 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
     Finish(mesh_device_->mesh_command_queue(1));
 }
 
+TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
+    // Reads and writes on 2 CQs
+    auto& write_cq = mesh_device_->mesh_command_queue(0);
+    auto& read_cq = mesh_device_->mesh_command_queue(1);
+
+    uint32_t num_tiles = 1024;
+    uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);
+    uint32_t dram_buffer_size = single_tile_size * num_tiles;
+
+    constexpr uint32_t NUM_ITERS = 500;
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = dram_buffer_size,
+        .buffer_type = tt_metal::BufferType::DRAM,
+        .buffer_layout = TensorMemoryLayout::INTERLEAVED,
+        .bottom_up = true};
+    ReplicatedBufferConfig global_buffer_config{.size = dram_buffer_size};
+    MeshCoordinateRange devices_0(
+        MeshCoordinate{0, 0}, MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
+
+    uint32_t num_devices = mesh_device_->num_devices();
+
+    // Read and write different data from the same buffer across iterations
+    auto buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+    // Initialize containers to store input and output data
+    std::vector<std::vector<uint32_t>> input_shard_data = {};
+    std::vector<std::vector<MeshCommandQueue::ShardDataTransfer>> read_shards = {};
+    std::vector<std::vector<uint32_t>> output_shard_data = {};
+
+    for (int i = 0; i < NUM_ITERS; i++) {
+        // Initialize different input data across iterations
+        input_shard_data.push_back(std::vector<uint32_t>(dram_buffer_size / sizeof(uint32_t)));
+        std::iota(input_shard_data.back().begin(), input_shard_data.back().end(), i);
+        // Initialize ShardDataTransfer objects for reads across iterations and allocate
+        // output buffers on host
+        read_shards.push_back({});
+        for (const auto& device_coord : devices_0) {
+            output_shard_data.push_back(std::vector<uint32_t>(input_shard_data.back().size()));
+            read_shards.back().push_back(MeshCommandQueue::ShardDataTransfer{
+                .shard_coord = device_coord,
+                .host_data = output_shard_data.back().data(),
+            });
+        }
+    }
+
+    // Events signalling read and write completion
+    std::vector<MeshEvent> write_events;
+    std::vector<MeshEvent> read_events;
+
+    for (int i = 0; i < NUM_ITERS; i++) {
+        if (i > 0) {
+            // Wait for read to complete before writing, since the same
+            // buffer is used across iterations
+            EnqueueWaitForEvent(write_cq, read_events.back());
+        }
+        EnqueueWriteMeshBuffer(write_cq, buffer, input_shard_data[i], true);
+        write_events.push_back(EnqueueRecordEventToHost(write_cq));
+        // Wait for write to complete before reading
+        EnqueueWaitForEvent(read_cq, write_events.back());
+        read_cq.enqueue_read_shards(read_shards[i], buffer, false);
+        read_events.push_back(EnqueueRecordEventToHost(read_cq));
+    }
+
+    // Stall on read and write CQs before data verification
+    Finish(write_cq);
+    Finish(read_cq);
+
+    uint32_t idx = 0;
+    for (auto& dst_vec : output_shard_data) {
+        EXPECT_EQ(dst_vec, input_shard_data[idx / num_devices]);
+        idx++;
+    }
+}
+
 }  // namespace
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -250,8 +250,7 @@ TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
         .buffer_layout = TensorMemoryLayout::INTERLEAVED,
         .bottom_up = true};
     ReplicatedBufferConfig global_buffer_config{.size = dram_buffer_size};
-    MeshCoordinateRange devices_0(
-        MeshCoordinate{0, 0}, MeshCoordinate{mesh_device_->num_rows() - 1, mesh_device_->num_cols() - 1});
+    MeshCoordinateRange devices_0(mesh_device_->shape());
 
     uint32_t num_devices = mesh_device_->num_devices();
 

--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -80,4 +80,9 @@ public:
     virtual void finish(tt::stl::Span<const SubDeviceId> sub_device_ids) = 0;
 };
 
+struct ReadBufferDescriptor;
+struct ReadEventDescriptor;
+
+using CompletionReaderVariant = std::variant<std::monostate, ReadBufferDescriptor, ReadEventDescriptor>;
+
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -136,7 +136,7 @@ private:
     MultiProducerSingleConsumerQueue<MeshCompletionReaderVariant> completion_queue_reads_;
     // Main thread pushes to a queue per physical device, specifying the buffer read configuration that
     // must be used by the completion queue reader. Only used for reading buffer data from the Mesh.
-    std::unordered_map<IDevice*, std::unique_ptr<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>>
+    std::unordered_map<uint32_t, std::unique_ptr<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>>
         read_descriptors_;
     // CV used by main thread to notify completion queue reader of work
     std::condition_variable reader_thread_cv_;

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -8,7 +8,10 @@
 #include <queue>
 
 #include "buffer.hpp"
+#include "command_queue.hpp"
 #include "command_queue_interface.hpp"
+#include "multi_producer_single_consumer_queue.hpp"
+
 #include "mesh_buffer.hpp"
 #include "mesh_device.hpp"
 #include "mesh_workload.hpp"
@@ -23,6 +26,9 @@ namespace distributed {
 
 class MeshEvent;
 struct MeshReadEventDescriptor;
+struct MeshBufferReadDescriptor;
+
+using MeshCompletionReaderVariant = std::variant<MeshBufferReadDescriptor, MeshReadEventDescriptor>;
 
 class MeshCommandQueue {
     // Main interface to dispatch data and workloads to a MeshDevice
@@ -30,6 +36,7 @@ class MeshCommandQueue {
     // tt::tt_metal::CommandQueue.
     // Additional support for Reads and Writes to be added
 private:
+    void populate_read_descriptor_queue();
     void populate_virtual_program_dispatch_core();
     void populate_dispatch_core_type();
     CoreCoord virtual_program_dispatch_core() const;
@@ -45,8 +52,10 @@ private:
         std::shared_ptr<Buffer>& shard_view,
         void* dst,
         const BufferRegion& region,
+        std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
-
+    void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking);
+    void increment_num_entries_in_completion_queue();
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
     void read_sharded_buffer(MeshBuffer& buffer, void* dst);
@@ -94,6 +103,7 @@ private:
     // TODO: All Mesh level host state managed by this class should be moved out, since its not
     // tied to system memory anyway.
     SystemMemoryManager& reference_sysmem_manager();
+    MultiProducerSingleConsumerQueue<CompletionReaderVariant>& get_read_descriptor_queue(IDevice* device);
 
     std::array<tt::tt_metal::WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> config_buffer_mgr_;
     std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed_;
@@ -113,15 +123,47 @@ private:
     uint32_t id_ = 0;
     CoreCoord dispatch_core_;
     CoreType dispatch_core_type_ = CoreType::WORKER;
-    std::queue<std::shared_ptr<MeshReadEventDescriptor>> event_descriptors_;
-    // MeshCommandQueues and the MeshDevice share the thread-pool
-    std::shared_ptr<ThreadPool> thread_pool_;
+    // MeshCommandQueues and the MeshDevice share thread-pools for dispatching to and reading from the Mesh
+    std::shared_ptr<ThreadPool>
+        dispatch_thread_pool_;  // Thread pool used to dispatch to the Mesh (used by main thread)
+    std::shared_ptr<ThreadPool>
+        reader_thread_pool_;  // Thread pool used to read from the Mesh (used by the Completion Queue Reader thread)
+
+    // Member Vars used to control the execution of the Completion Queue Reader thread
+
+    // TODO: Explore other thread-safe data-structures for these queues.
+    // Main thread submits request to the completion queue reader through this queue
+    MultiProducerSingleConsumerQueue<MeshCompletionReaderVariant> completion_queue_reads_;
+    // Main thread pushes to a queue per physical device, specifying the buffer read configuration that
+    // must be used by the completion queue reader. Only used for reading buffer data from the Mesh.
+    std::unordered_map<IDevice*, std::unique_ptr<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>>
+        read_descriptors_;
+    // CV used by main thread to notify completion queue reader of work
+    std::condition_variable reader_thread_cv_;
+    std::mutex reader_thread_cv_mutex_;
+    // CV used by the completion queue reader to notify the main thread that all work is completed
+    std::condition_variable reads_processed_cv_;
+    std::mutex reads_processed_cv_mutex_;
+    // Number of outstanding reads to be completed by the completion queue reader
+    std::atomic<uint32_t> num_outstanding_reads_ = 0;
+    // Exit signal for the completion queue reader
+    bool exit_condition_ = false;
+    // Completion Queue Reader thread
+    std::thread completion_queue_reader_thread_;
+    // Global Mutex (used by both CQs) to safely use the reader_thread_pool_
+    inline static std::mutex reader_thread_pool_mutex_;
 
 public:
-    MeshCommandQueue(MeshDevice* mesh_device, uint32_t id, std::shared_ptr<ThreadPool>& thread_pool);
+    MeshCommandQueue(
+        MeshDevice* mesh_device,
+        uint32_t id,
+        std::shared_ptr<ThreadPool>& dispatch_thread_pool,
+        std::shared_ptr<ThreadPool>& reader_thread_pool);
 
     MeshCommandQueue(const MeshCommandQueue& other) = delete;
     MeshCommandQueue& operator=(const MeshCommandQueue& other) = delete;
+
+    ~MeshCommandQueue();
 
     MeshDevice* device() const { return mesh_device_; }
     uint32_t id() const { return id_; }
@@ -172,6 +214,12 @@ public:
     void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx);
     void record_end();
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking);
+    // Main function (event loop) for the Completion Queue Reader
+    void read_completion_queue();
+    // Helper function - read events from Completion Queue
+    void read_completion_queue_event(MeshReadEventDescriptor& read_event_descriptor);
+    // Helper function - read buffer data from Completion Queue
+    void copy_buffer_data_to_user_space(MeshBufferReadDescriptor& read_buffer_descriptor);
 };
 
 }  // namespace distributed

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -66,7 +66,10 @@ private:
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     std::unordered_map<MeshTraceId, std::shared_ptr<MeshTraceBuffer>> trace_buffer_pool_;
     uint32_t trace_buffers_size_ = 0;
-    std::shared_ptr<ThreadPool> thread_pool_;
+
+    std::shared_ptr<ThreadPool> dispatch_thread_pool_;
+    std::shared_ptr<ThreadPool> reader_thread_pool_;
+
     std::recursive_mutex push_work_mutex_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -25,14 +25,50 @@ struct MeshReadEventDescriptor {
     MeshCoordinateRange device_range;
 };
 
-MeshCommandQueue::MeshCommandQueue(MeshDevice* mesh_device, uint32_t id, std::shared_ptr<ThreadPool>& thread_pool) :
-    thread_pool_(thread_pool) {
-    this->mesh_device_ = mesh_device;
-    this->id_ = id;
+struct MeshBufferReadDescriptor {
+    std::unordered_map<IDevice*, uint32_t> num_reads_per_dev;
+};
+
+MeshCommandQueue::MeshCommandQueue(
+    MeshDevice* mesh_device,
+    uint32_t id,
+    std::shared_ptr<ThreadPool>& dispatch_thread_pool,
+    std::shared_ptr<ThreadPool>& reader_thread_pool) :
+    dispatch_thread_pool_(dispatch_thread_pool), reader_thread_pool_(reader_thread_pool) {
+    mesh_device_ = mesh_device;
+    id_ = id;
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
         config_buffer_mgr_, expected_num_workers_completed_, DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
     this->populate_virtual_program_dispatch_core();
     this->populate_dispatch_core_type();
+    this->populate_read_descriptor_queue();
+    completion_queue_reader_thread_ = std::thread(&MeshCommandQueue::read_completion_queue, this);
+}
+
+MeshCommandQueue::~MeshCommandQueue() {
+    TT_FATAL(completion_queue_reads_.empty(), "The completion reader queue must be empty when closing devices.");
+
+    for (auto& queue : read_descriptors_) {
+        TT_FATAL(queue.second->empty(), "No buffer read requests should be outstanding when closing devices.");
+    }
+
+    TT_FATAL(
+        num_outstanding_reads_ == 0,
+        "Mismatch between num_outstanding reads and number of entries in completion reader queue.");
+
+    {
+        std::lock_guard lock(reader_thread_cv_mutex_);
+        reader_thread_cv_.notify_one();
+        exit_condition_ = true;
+    }
+    completion_queue_reader_thread_.join();
+}
+
+void MeshCommandQueue::populate_read_descriptor_queue() {
+    for (auto& device : mesh_device_->get_devices()) {
+        read_descriptors_.emplace(
+            device, std::make_unique<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>());
+    }
 }
 
 void MeshCommandQueue::populate_virtual_program_dispatch_core() {
@@ -189,8 +225,9 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
 
 void MeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto event = this->enqueue_record_event_to_host(sub_device_ids);
-    this->drain_events_from_completion_queue();
-    this->verify_reported_events_after_draining(event);
+
+    std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
+    reads_processed_cv_.wait(lock, [this] { return num_outstanding_reads_.load() == 0; });
 }
 
 void MeshCommandQueue::write_shard_to_device(
@@ -208,14 +245,10 @@ void MeshCommandQueue::read_shard_from_device(
     std::shared_ptr<Buffer>& shard_view,
     void* dst,
     const BufferRegion& region,
+    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    this->drain_events_from_completion_queue();
     auto device = shard_view->device();
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
-
-    bool exit_condition = false;
 
     if (is_sharded(shard_view->buffer_layout())) {
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
@@ -226,10 +259,10 @@ void MeshCommandQueue::read_shard_from_device(
             buffer_dispatch::copy_sharded_buffer_from_core_to_completion_queue(
                 core_id, *shard_view, dispatch_params, sub_device_ids, cores[core_id], this->dispatch_core_type());
             if (dispatch_params.pages_per_txn > 0) {
-                auto read_descriptor = std::get<tt::tt_metal::ReadBufferDescriptor>(
-                    *buffer_dispatch::generate_sharded_buffer_read_descriptor(dst, dispatch_params, *shard_view));
-                buffer_dispatch::copy_completion_queue_data_into_user_space(
-                    read_descriptor, mmio_device_id, channel, id_, device->sysmem_manager(), exit_condition);
+                num_txns_per_device[device]++;
+                auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
+                read_descriptor_queue.push(
+                    buffer_dispatch::generate_sharded_buffer_read_descriptor(dst, dispatch_params, *shard_view));
             }
         }
     } else {
@@ -238,10 +271,10 @@ void MeshCommandQueue::read_shard_from_device(
         buffer_dispatch::copy_interleaved_buffer_to_completion_queue(
             dispatch_params, *shard_view, sub_device_ids, this->dispatch_core_type());
         if (dispatch_params.pages_per_txn > 0) {
-            auto read_descriptor = std::get<tt::tt_metal::ReadBufferDescriptor>(
-                *buffer_dispatch::generate_interleaved_buffer_read_descriptor(dst, dispatch_params, *shard_view));
-            buffer_dispatch::copy_completion_queue_data_into_user_space(
-                read_descriptor, mmio_device_id, channel, id_, device->sysmem_manager(), exit_condition);
+            num_txns_per_device[device]++;
+            auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
+            read_descriptor_queue.push(
+                buffer_dispatch::generate_interleaved_buffer_read_descriptor(dst, dispatch_params, *shard_view));
         }
     }
 }
@@ -353,8 +386,9 @@ void MeshCommandQueue::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
         for (std::size_t shard_x = 0; shard_x < num_shards_x; shard_x++) {
             auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(device_y, device_x));
             const BufferRegion region(0, device_shard_view->size());
-            this->read_shard_from_device(device_shard_view, shard_data.data(), region);
-
+            std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
+            this->read_shard_from_device(device_shard_view, shard_data.data(), region, num_txns_per_device);
+            this->submit_memcpy_request(num_txns_per_device, true);
             uint32_t write_offset = shard_x * single_write_size + shard_y * stride_size_bytes * shard_shape.height();
             uint32_t size_to_write = total_write_size_per_shard;
             uint32_t local_offset = 0;
@@ -399,9 +433,9 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
             });
 
         for (const auto& coord : device_range) {
-            thread_pool_->enqueue([&dispatch_lambda, coord]() { dispatch_lambda(std::move(coord)); });
+            dispatch_thread_pool_->enqueue([&dispatch_lambda, coord]() { dispatch_lambda(std::move(coord)); });
         }
-        thread_pool_->wait();
+        dispatch_thread_pool_->wait();
     } else {
         this->write_sharded_buffer(buffer, host_data);
     }
@@ -421,6 +455,8 @@ void MeshCommandQueue::enqueue_read_mesh_buffer(
     void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
     TT_FATAL(
         buffer->global_layout() == MeshBufferLayout::SHARDED, "Can only read a Sharded MeshBuffer from a MeshDevice.");
+    TT_FATAL(
+        blocking, "Non-Blocking reads are not supported through {}. Use enqueue_read_shards_instead.", __FUNCTION__);
     this->read_sharded_buffer(*buffer, host_data);
 }
 
@@ -442,9 +478,29 @@ void MeshCommandQueue::enqueue_write_shards(
         });
 
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
-        thread_pool_->enqueue([&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); });
+        dispatch_thread_pool_->enqueue([&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); });
     }
-    thread_pool_->wait();
+    dispatch_thread_pool_->wait();
+
+    if (blocking) {
+        this->finish();
+    }
+}
+
+void MeshCommandQueue::increment_num_entries_in_completion_queue() {
+    {
+        std::lock_guard lock(reader_thread_cv_mutex_);
+        num_outstanding_reads_++;
+        reader_thread_cv_.notify_one();
+    }
+}
+
+void MeshCommandQueue::submit_memcpy_request(
+    std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) {
+    completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
+        std::in_place_type<MeshBufferReadDescriptor>, std::move(num_txns_per_device)));
+
+    this->increment_num_entries_in_completion_queue();
 
     if (blocking) {
         this->finish();
@@ -457,24 +513,16 @@ void MeshCommandQueue::enqueue_read_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    auto dispatch_lambda =
-        std::function<void(uint32_t)>([&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
-            auto& shard_data_transfer = shard_data_transfers[shard_idx];
-            auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
-            read_shard_from_device(
-                device_shard_view,
-                shard_data_transfer.host_data,
-                shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
-        });
-
-    for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
-        thread_pool_->enqueue([&dispatch_lambda, shard_idx]() { dispatch_lambda(shard_idx); });
+    std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
+    for (const auto& shard_data_transfer : shard_data_transfers) {
+        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
+        this->read_shard_from_device(
+            device_shard_view,
+            shard_data_transfer.host_data,
+            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())),
+            num_txns_per_device);
     }
-    thread_pool_->wait();
-
-    if (blocking) {
-        this->finish();
-    }
+    this->submit_memcpy_request(num_txns_per_device, blocking);
 }
 
 MeshEvent MeshCommandQueue::enqueue_record_event_helper(
@@ -512,8 +560,9 @@ MeshEvent MeshCommandQueue::enqueue_record_event(
 MeshEvent MeshCommandQueue::enqueue_record_event_to_host(
     tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
     auto event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/true, device_range);
-    event_descriptors_.push(std::make_shared<MeshReadEventDescriptor>(MeshReadEventDescriptor{
-        .single_device_descriptor = ReadEventDescriptor(event.id()), .device_range = event.device_range()}));
+    completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
+        std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
+    this->increment_num_entries_in_completion_queue();
     return event;
 }
 
@@ -524,34 +573,88 @@ void MeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
     }
 }
 
-void MeshCommandQueue::drain_events_from_completion_queue() {
-    constexpr bool exit_condition = false;
-    auto num_events = event_descriptors_.size();
-    for (std::size_t event_idx = 0; event_idx < num_events; event_idx++) {
-        auto& mesh_read_descriptor = event_descriptors_.front();
-        auto& device_range = mesh_read_descriptor->device_range;
-        for (const auto& coord : device_range) {
-            auto device = mesh_device_->get_device(coord);
-            chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
-            uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
-            bool exit_condition = false;
-            device->sysmem_manager().completion_queue_wait_front(id_, exit_condition);
-
-            event_dispatch::read_events_from_completion_queue(
-                mesh_read_descriptor->single_device_descriptor, mmio_device_id, channel, id_, device->sysmem_manager());
+void MeshCommandQueue::read_completion_queue() {
+    while (true) {
+        {
+            std::unique_lock<std::mutex> lock(reader_thread_cv_mutex_);
+            reader_thread_cv_.wait(lock, [this] { return num_outstanding_reads_ or exit_condition_; });
         }
-        event_descriptors_.pop();
+        if (exit_condition_) {
+            return;
+        } else {
+            uint32_t num_reads = num_outstanding_reads_.load();
+            for (uint32_t i = 0; i < num_reads; i++) {
+                auto mesh_read_descriptor = *(completion_queue_reads_.pop());
+                std::visit(
+                    [&](auto&& mesh_read_descriptor) {
+                        using T = std::decay_t<decltype(mesh_read_descriptor)>;
+                        if constexpr (std::is_same_v<T, MeshBufferReadDescriptor>) {
+                            this->copy_buffer_data_to_user_space(mesh_read_descriptor);
+                        } else {
+                            this->read_completion_queue_event(mesh_read_descriptor);
+                        }
+                    },
+                    mesh_read_descriptor);
+            }
+            std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
+            num_outstanding_reads_.fetch_sub(num_reads);
+            if (num_outstanding_reads_ == 0) {
+                reads_processed_cv_.notify_one();
+            }
+        }
     }
 }
 
-void MeshCommandQueue::verify_reported_events_after_draining(const MeshEvent& event) {
-    auto& device_range = event.device_range();
+MultiProducerSingleConsumerQueue<CompletionReaderVariant>& MeshCommandQueue::get_read_descriptor_queue(
+    IDevice* device) {
+    return *(read_descriptors_[device]);
+}
+
+void MeshCommandQueue::copy_buffer_data_to_user_space(MeshBufferReadDescriptor& read_buffer_descriptor) {
+    auto reader_lambda = [this](IDevice* device, uint32_t num_reads) {
+        auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+
+        for (int i = 0; i < num_reads; i++) {
+            buffer_dispatch::copy_completion_queue_data_into_user_space(
+                std::get<ReadBufferDescriptor>(*(read_descriptor_queue.pop())),
+                mmio_device_id,
+                channel,
+                id_,
+                device->sysmem_manager(),
+                exit_condition_);
+        }
+    };
+
+    {
+        // The reader_thread_pool is a shared resource between command queues.
+        // It must be used inside a critical section. Performance-wise, this is
+        // okay, since workloads don't require issuing simultaneous reads on different
+        // MeshCQs. If such an access pattern is used, the reads will be serialized
+        // on host across MeshCQs. This is still better than independent reader threads
+        // per MeshCQ (since we run out of host resources with 2 reader threads per
+        // physical device).
+        std::lock_guard<std::mutex> lock(reader_thread_pool_mutex_);
+        for (auto& metadata : read_buffer_descriptor.num_reads_per_dev) {
+            reader_thread_pool_->enqueue([&reader_lambda, device = metadata.first, num_reads = metadata.second]() {
+                reader_lambda(device, num_reads);
+            });
+        }
+        reader_thread_pool_->wait();
+    }
+}
+
+void MeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& read_event_descriptor) {
+    auto& device_range = read_event_descriptor.device_range;
     for (const auto& coord : device_range) {
-        TT_FATAL(
-            mesh_device_->get_device(coord)->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) >=
-                event.id(),
-            "Expected to see event id {} in completion queue",
-            event.id());
+        auto device = mesh_device_->get_device(coord);
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+        device->sysmem_manager().completion_queue_wait_front(id_, exit_condition_);
+
+        event_dispatch::read_events_from_completion_queue(
+            read_event_descriptor.single_device_descriptor, mmio_device_id, channel, id_, device->sysmem_manager());
     }
 }
 

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -67,7 +67,7 @@ MeshCommandQueue::~MeshCommandQueue() {
 void MeshCommandQueue::populate_read_descriptor_queue() {
     for (auto& device : mesh_device_->get_devices()) {
         read_descriptors_.emplace(
-            device, std::make_unique<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>());
+            device->id(), std::make_unique<MultiProducerSingleConsumerQueue<CompletionReaderVariant>>());
     }
 }
 
@@ -607,7 +607,7 @@ void MeshCommandQueue::read_completion_queue() {
 
 MultiProducerSingleConsumerQueue<CompletionReaderVariant>& MeshCommandQueue::get_read_descriptor_queue(
     IDevice* device) {
-    return *(read_descriptors_[device]);
+    return *(read_descriptors_[device->id()]);
 }
 
 void MeshCommandQueue::copy_buffer_data_to_user_space(MeshBufferReadDescriptor& read_buffer_descriptor) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -119,7 +119,8 @@ MeshDevice::MeshDevice(
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
     parent_mesh_(std::move(parent_mesh)),
-    thread_pool_(create_boost_thread_pool(view_->shape().mesh_size())) {}
+    dispatch_thread_pool_(create_boost_thread_pool(view_->shape().mesh_size())),
+    reader_thread_pool_(create_boost_thread_pool(view_->shape().mesh_size())) {}
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,
@@ -653,7 +654,8 @@ bool MeshDevice::initialize(
     mesh_command_queues_.reserve(this->num_hw_cqs());
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(std::make_unique<MeshCommandQueue>(this, cq_id, thread_pool_));
+            mesh_command_queues_.push_back(
+                std::make_unique<MeshCommandQueue>(this, cq_id, dispatch_thread_pool_, reader_thread_pool_));
         }
     }
     return true;

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -45,8 +45,6 @@ struct ReadBufferDescriptor {
         starting_host_page_id(starting_host_page_id) {}
 };
 
-using CompletionReaderVariant = std::variant<std::monostate, ReadBufferDescriptor, ReadEventDescriptor>;
-
 // Contains helper functions to interface with buffers on device
 namespace buffer_dispatch {
 


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
Non-Blocking reads are currently not supported by the TT-Mesh infra. This is feature is used by multiple models relying on 2 CQs, and is thus necessary for functional parity.

### What's changed
- Introduce a Completion Queue Reader Thread in the MeshCommandQueue
- Add a reader_thread_pool, that is different from the dispatch_thread_pool
- The former is used by the CQ Reader. The latter is used by the main thread
- For single CQ execution, this gives the same threading model as the existing implementation. For Multi-CQ execution, this spawns less threads
- This should not affect performance, since we don't use both CQs to perform simulatenous reads
- Make EventSynchronize rely on event_ids instead of calling finish() on the MeshCommandQueue

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
