### PR TITLE
Fix losing tile information in tensor_to_layout for MeshDevice

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -214,7 +214,9 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
                 if (not num_workers_completed) {
                     auto orig_layout = input_tensor.get_tensor_spec().tensor_layout();
                     auto upd_layout = TensorLayout(
-                        orig_layout.get_data_type(), PageConfig(target_layout), orig_layout.get_memory_config());
+                        orig_layout.get_data_type(),
+                        PageConfig(target_layout, orig_layout.get_tile()),
+                        orig_layout.get_memory_config());
                     tensor_modified_layout.set_tensor_spec(TensorSpec(input_tensor.get_logical_shape(), upd_layout));
                 }
             });


### PR DESCRIPTION
### Ticket

### Problem description
We're losing tile information in tensor_to_layout for MeshDevice which causes issues when used with custom tile shapes.
This appears in test failures after replacing single device with MeshDevice

### What's changed
Preserve tile information when constructing new TensorSpec

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13612723267)
- [x] New/Existing tests provide coverage for changes
