### PR TITLE
Get device directly from tensor in attn_matmul instead of going through buffer

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -205,11 +205,11 @@ const operation::Hash GroupAttnMatmulDeviceOperation::compute_program_hash(
         std::get<DeviceStorage>(input_tensor_a.storage()).memory_config().memory_layout,
         std::get<DeviceStorage>(input_tensor_a.storage()).memory_config().buffer_type,
         input_tensor_a.dtype(),
-        std::get<DeviceStorage>(input_tensor_b.storage()).buffer->device()->id(),
+        input_tensor_a.device()->id(),
         std::get<DeviceStorage>(input_tensor_b.storage()).memory_config().memory_layout,
         std::get<DeviceStorage>(input_tensor_b.storage()).memory_config().buffer_type,
         input_tensor_b.dtype(),
-        std::get<DeviceStorage>(input_tensor_b.storage()).buffer->device()->id());
+        input_tensor_b.device()->id());
 }
 
 }  // namespace ttnn::operations::experimental::matmul


### PR DESCRIPTION
### Ticket

### Problem description
Call to `storage.buffer->device()` will create problems in the future, when we use MeshDevice to represent single devices.

### What's changed
Replace `std::get<DeviceStorage>(input_tensor.storage()).buffer->device()->id()` with simpler `input_tensor.device()`

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13613106692)
- [x] New/Existing tests provide coverage for changes
