### PR TITLE
#0: Move ttnn::Shape and compute_strides to tt_metal

### DIFF
--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "shape_base.hpp"
+
+namespace tt::tt_metal {
+
+class Shape final : protected ShapeBase {
+public:
+    using ShapeBase::ShapeBase;
+    using ShapeBase::operator[];
+    using ShapeBase::cbegin;
+    using ShapeBase::cend;
+    using ShapeBase::empty;
+    using ShapeBase::size;
+    using ShapeBase::view;
+
+    template <std::size_t N>
+    bool operator==(const std::array<uint32_t, N>& other) const {
+        const bool sameSize = value_.size() == N;
+        return sameSize && std::equal(value_.begin(), value_.end(), other.begin());
+    }
+
+    bool operator==(const Shape& other) const;
+    bool operator==(const ShapeBase::Container& other) const;
+
+    [[nodiscard]] size_t rank() const;
+    [[nodiscard]] uint64_t volume() const;
+
+    const uint32_t get_normalized_index(std::int64_t index) const;
+
+    // Needed for reflect / fmt
+    static constexpr auto attribute_names = std::forward_as_tuple("value");
+    auto attribute_values() const { return std::forward_as_tuple(this->value_); }
+
+    std::array<uint32_t, 4> to_array_4D() const;
+    Shape to_rank(size_t new_rank) const;
+
+    friend std::ostream& operator<<(std::ostream& os, const Shape& shape);
+};
+
+std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape& shape);
+
+tt::stl::SmallVector<uint32_t> compute_strides(const tt::tt_metal::Shape& shape);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
         core_coord.cpp
         mesh_coord.cpp
         metal_soc_descriptor.cpp
+        shape.cpp
         shape2d.cpp
         shape_base.cpp
         tt_backend_api_types.cpp

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -67,4 +67,23 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape& shape) {
     return os;
 }
 
+tt::stl::SmallVector<uint32_t> compute_strides(const tt::tt_metal::Shape& shape) {
+    if (shape.rank() == 0) {
+        return {};
+    }
+
+    auto num_elements = shape.volume();
+    // If any dim is 0, volume would be 0
+    if (num_elements == 0) {
+        return tt::stl::SmallVector<uint32_t>(shape.rank(), 0);
+    }
+
+    ttnn::SmallVector<uint32_t> strides;
+    for (std::int32_t index = 0; index < shape.rank(); index++) {
+        num_elements /= shape[index];
+        strides.push_back(num_elements);
+    }
+    return strides;
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -218,7 +218,6 @@ set(TENSOR_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/tensor_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/tensor_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/serialization.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/shape/shape.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/layout/alignment.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/layout/page_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/layout/tensor_layout.cpp

--- a/ttnn/cpp/ttnn/tensor/shape/shape.hpp
+++ b/ttnn/cpp/ttnn/tensor/shape/shape.hpp
@@ -4,47 +4,7 @@
 
 #pragma once
 
-#include <tt-metalium/shape_base.hpp>
-
-namespace tt::tt_metal {
-
-class Shape final : protected ShapeBase {
-public:
-    using ShapeBase::ShapeBase;
-    using ShapeBase::operator[];
-    using ShapeBase::cbegin;
-    using ShapeBase::cend;
-    using ShapeBase::empty;
-    using ShapeBase::size;
-    using ShapeBase::view;
-
-    template <std::size_t N>
-    bool operator==(const std::array<uint32_t, N>& other) const {
-        const bool sameSize = value_.size() == N;
-        return sameSize && std::equal(value_.begin(), value_.end(), other.begin());
-    }
-
-    bool operator==(const Shape& other) const;
-    bool operator==(const ShapeBase::Container& other) const;
-
-    [[nodiscard]] size_t rank() const;
-    [[nodiscard]] uint64_t volume() const;
-
-    const uint32_t get_normalized_index(std::int64_t index) const;
-
-    // Needed for reflect / fmt
-    static constexpr auto attribute_names = std::forward_as_tuple("value");
-    auto attribute_values() const { return std::forward_as_tuple(this->value_); }
-
-    std::array<uint32_t, 4> to_array_4D() const;
-    Shape to_rank(size_t new_rank) const;
-
-    friend std::ostream& operator<<(std::ostream& os, const Shape& shape);
-};
-
-std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Shape& shape);
-
-}  // namespace tt::tt_metal
+#include <tt-metalium/shape.hpp>
 
 namespace ttnn {
 using tt::tt_metal::Shape;

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -14,26 +14,6 @@ namespace tt {
 namespace tt_metal {
 const ttnn::Shape infer_dims_for_reshape(const Tensor& tensor, tt::stl::Span<const int32_t> shape);
 
-static ttnn::SmallVector<uint32_t> compute_strides(const ttnn::Shape& shape) {
-    if (shape.rank() == 0) {
-        return {};
-    }
-
-    auto num_elements = shape.volume();
-    ttnn::SmallVector<uint32_t> strides;
-    for (std::int32_t index = 0; index < shape.rank(); index++) {
-        if (shape[index] == 0) {
-            // Insert 0 to indicate no memory access for this dimension
-            strides.push_back(0);
-            continue;
-        }
-
-        num_elements /= shape[index];
-        strides.push_back(num_elements);
-    }
-    return strides;
-}
-
 static int compute_flat_indices(tt::stl::Span<const int> indices, tt::stl::Span<const uint32_t> strides) {
     int flat_index = 0;
     for (auto i = 0; i < indices.size(); i++) {


### PR DESCRIPTION
### Ticket
None

### Problem description
Introduce ND shape in metal.

### What's changed
Move `ttnn::Shape` and `compute_strides` to tt_metal.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13636477317
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
