### PR TITLE
Revert "Set a timeout for TG Demo (#18054)"

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   tg-demo-tests:
-    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
None

### Problem description
Encountered a timeout; so my earlier setting of the timeout may not have been correct.

### What's changed
This reverts commit 18433246b99fea337b5abcee1d09eb574159c1fd.
