### PR TITLE
#18495: Update blackhole tests

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_round.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_round.py
@@ -23,7 +23,6 @@ mem_configs = [
 ]
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "decimals",
     [0],

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -706,7 +706,8 @@ Tensor is_odd(const Tensor& input, const std::optional<MemoryConfig>& output_mem
 
 Tensor _round(const Tensor& input, int32_t decimals, const std::optional<MemoryConfig>& output_mem_config) {
     auto arch = input.device()->arch();
-    TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+    TT_FATAL(
+        arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE, "Op is only supported on Wormhole & Blackhole");
     Tensor floor_res = ttnn::floor(input, output_mem_config);
     if (decimals != 0) {  // TODO: For decimal value!=0
         Tensor power_10 = ttnn::power(ttnn::full_like(input, 10.0f), decimals, output_mem_config);


### PR DESCRIPTION
### Ticket
#18495 

### Problem description
Round op was failed with TT_FATAL message which was checking only for Wormhole arch

### What's changed
Updated the TT_FATAL condition with arch and tested the same. Test was passing

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/50c272f9-a72c-46ce-b156-dc527851d904" />


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)

