### PR TITLE
#0: Fix process op logs (compute and ideal were inverted)

### DIFF
--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -706,8 +706,8 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                     add_io_data(opData["output_tensors"], "OUTPUT")
 
                 if "performance_model" in opData.keys():
-                    rowDict["PM IDEAL [ns]"] = opData["performance_model"]["compute_ns"]
-                    rowDict["PM COMPUTE [ns]"] = opData["performance_model"]["ideal_ns"]
+                    rowDict["PM IDEAL [ns]"] = opData["performance_model"]["ideal_ns"]
+                    rowDict["PM COMPUTE [ns]"] = opData["performance_model"]["compute_ns"]
                     rowDict["PM BANDWIDTH [ns]"] = opData["performance_model"]["bandwidth_ns"]
                     rowDict["PM REQ I BW"] = opData["performance_model"]["input_bws"]
                     rowDict["PM REQ O BW"] = opData["performance_model"]["output_bws"]


### PR DESCRIPTION
### Ticket
-
### Problem description
PM Ideal and PM Compute were actually showing inverted values (Ideal was showing compute and vice versa).

### What's changed
Fix processing so now the correct values are displayed.

### Checklist
-
