### PR TITLE
Use slow matmuls for SD WH pipeline and increase timeout

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -139,7 +139,7 @@ jobs:
       matrix:
         test-config:
           - model: "stable_diffusion"
-            cmd: pytest --timeout 900 -n auto tests/nightly/single_card/stable_diffusion
+            cmd: SLOW_MATMULS=1 pytest --timeout 900 -n auto tests/nightly/single_card/stable_diffusion
               # Skipping due to issue #15932
               # - model: "mamba 1"
               # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1

--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -139,7 +139,7 @@ jobs:
       matrix:
         test-config:
           - model: "stable_diffusion"
-            cmd: SLOW_MATMULS=1 pytest --timeout 900 -n auto tests/nightly/single_card/stable_diffusion
+            cmd: SLOW_MATMULS=1 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
               # Skipping due to issue #15932
               # - model: "mamba 1"
               # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1


### PR DESCRIPTION
The tests would occasionally fail on the CI; so I enabled `SLOW_MATMULS` env var for all unit tests to reduce the probability of di/dt occuring.

I also increased the timeout since the tests last a bit longer now.

https://github.com/tenstorrent/tt-metal/actions/runs/13629389522