### PR TITLE
#17878: Enable failure annotations in models + profiler regression tests

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -70,6 +70,7 @@ jobs:
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
             -e ARCH_NAME=${{ inputs.arch }}
+            -e GITHUB_ACTIONS=true
           run_args: |
             source tests/scripts/run_python_model_tests.sh && run_python_model_tests_${{ inputs.arch }}
       - uses: ./.github/actions/slack-report

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -82,6 +82,7 @@ jobs:
         PROFILER_ARTIFACTS_DIR: /work/generated/profiler
         PROFILER_OUTPUT_DIR: /work/generated/profiler/reports
         DONT_USE_VIRTUAL_ENVIRONMENT: 1
+        GITHUB_ACTIONS: true
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION
### Ticket
#17878

### Problem description
Models and profiler regression tests run inside docker container. 
[pytest-github-actions-annotate-failures requires `GITHUB_ACTIONS=true` set inside containers](https://github.com/pytest-dev/pytest-github-actions-annotate-failures?tab=readme-ov-file#usage)

### What's changed
Add `GITHUB_ACTIONS=true` 

### Checklist
- [x] models post commit https://github.com/tenstorrent/tt-metal/actions/runs/13635241628
