### PR TITLE
Adjust mesh event TTNN APIs 

### DIFF
--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -106,7 +106,7 @@ void py_module(py::module& module) {
             )doc");
 
     module.def(
-        "record_mesh_event",
+        "record_event",
         py::overload_cast<
             MeshDevice*,
             QueueId,
@@ -118,9 +118,8 @@ void py_module(py::module& module) {
         py::arg("device_range") = std::nullopt);
 
     module.def(
-        "wait_for_mesh_event",
-        py::overload_cast<MeshDevice*, QueueId, const MeshEvent&>(&wait_for_mesh_event),
-        py::arg("mesh_device"),
+        "wait_for_event",
+        py::overload_cast<QueueId, const MeshEvent&>(&wait_for_mesh_event),
         py::arg("cq_id"),
         py::arg("mesh_event"));
 }

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -68,8 +68,8 @@ MeshEvent record_mesh_event(
     return EnqueueRecordEventToHost(mesh_device->mesh_command_queue(*cq_id), sub_device_ids, device_range);
 }
 
-void wait_for_mesh_event(MeshDevice* mesh_device, QueueId cq_id, const MeshEvent& event) {
-    EnqueueWaitForEvent(mesh_device->mesh_command_queue(*cq_id), event);
+void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event) {
+    EnqueueWaitForEvent(event.device()->mesh_command_queue(*cq_id), event);
 }
 
 }  // namespace ttnn::events

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -41,7 +41,7 @@ MeshEvent record_mesh_event(
     QueueId cq_id,
     const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids = {},
     const std::optional<ttnn::MeshCoordinateRange>& device_range = std::nullopt);
-void wait_for_mesh_event(MeshDevice* mesh_device, QueueId cq_id, const MeshEvent& event);
+void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event);
 
 }  // namespace events
 }  // namespace ttnn

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -106,10 +106,6 @@ from ttnn._ttnn.events import (
     create_event,
     record_event,
     wait_for_event,
-    record_mesh_event,
-    wait_for_mesh_event,
-    record_mesh_event,
-    wait_for_mesh_event,
 )
 
 from ttnn._ttnn.operations.trace import (


### PR DESCRIPTION
### Ticket
N/A

### Problem description
No need for "mesh_event" suffix, and `wait_for_event` can look exactly like its single device version.

### Checklist
- [X] New/Existing tests provide coverage for changes
