### PR TITLE
#18842: Add borrowed storage support for the aggregate_as_tensor function

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -16,75 +16,52 @@ namespace ttnn::distributed::test {
 
 using ::testing::ElementsAre;
 
-using TensorDistributionTest = T3kMultiDeviceFixture;
-
 TensorSpec get_tensor_spec(const ttnn::Shape& shape, DataType dtype) {
     return TensorSpec(shape, TensorLayout(dtype, Layout::ROW_MAJOR, MemoryConfig{}));
 }
 
-TEST_F(TensorDistributionTest, DeviceAggregate) {
+class AggregateTensorTest : public T3kMultiDeviceFixture,
+                            public ::testing::WithParamInterface</*use_borrowed_storage*/ bool> {};
+
+TEST_P(AggregateTensorTest, Roundtrip) {
+    const bool use_borrowed_storage = GetParam();
     const int num_devices = mesh_device_->num_devices();
     std::vector<std::vector<float>> test_data(num_devices);
     for (int i = 0; i < num_devices; i++) {
-        test_data[i].insert(test_data[i].end(), {i * 1.F, i * 2.F, i * 3.F});
+        test_data[i] = std::vector<float>{i * 1.F, i * 2.F, i * 3.F};
     }
 
-    std::vector<Tensor> tensors(num_devices);
+    std::vector<Tensor> tensors;
+    tensors.reserve(num_devices);
 
-    for(int i = 0; i < num_devices; i++) {
-        tensors.push_back(Tensor::from_vector(
-            test_data[i], get_tensor_spec(ttnn::Shape{1, num_devices, 3, 1}, DataType::FLOAT32), mesh_device_.get()));
-    }
-
-    Tensor aggregated_tensor = aggregate_as_tensor(tensors, AllGatherTensor{});
-    EXPECT_TRUE(aggregated_tensor.storage_type() == StorageType::MULTI_DEVICE);
-
-    std::vector<float> test_data_1d;
-
-    for (std::vector<float>& device : test_data) {
-        for (float& datum : device) {
-            test_data_1d.push_back(datum);
+    for (int i = 0; i < num_devices; i++) {
+        if (use_borrowed_storage) {
+            tensors.push_back(Tensor::from_borrowed_data(
+                tt::stl::Span(test_data[i]),
+                ttnn::Shape{1, 1, 3, 1},
+                /*on_creation_callback=*/[]() {},
+                /*on_destruction_callback=*/[]() {}));
+        } else {
+            tensors.push_back(
+                Tensor::from_vector(test_data[i], get_tensor_spec(ttnn::Shape{1, 1, 3, 1}, DataType::FLOAT32)));
         }
     }
 
-    std::vector<float> out_vector = aggregated_tensor.to_vector<float>();
-    EXPECT_EQ(out_vector, test_data_1d);
-}
-
-TEST_F(TensorDistributionTest, BorrowedAggregate) {
-    const int num_devices = mesh_device_->num_devices();
-    std::vector<std::vector<float>> test_data(num_devices);
-    for (int i = 0; i < num_devices; i++) {
-        test_data[i].insert(test_data[i].end(), {i * 1.F, i * 2.F, i * 3.F});
-    }
-
-    std::vector<Tensor> tensors(num_devices);
-    auto on_creation_callback = [] {};
-    auto on_destruction_callback = [] {};
-    for(int i = 0; i < num_devices; i++) {
-        tensors.push_back(Tensor(
-            BorrowedStorage{
-                tt::tt_metal::borrowed_buffer::Buffer(static_cast<float*>(test_data[i].data()), test_data[i].size()),
-                on_creation_callback,
-                on_destruction_callback},
-            ttnn::Shape{1, num_devices, 3, 1},
-            DataType::FLOAT32,
-            Layout::TILE));
-    }
     Tensor aggregated_tensor = aggregate_as_tensor(tensors, AllGatherTensor{});
     EXPECT_TRUE(aggregated_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
 
-    std::vector<float> test_data_1d;
+    const auto tensor_shards = get_device_tensors(aggregated_tensor);
+    ASSERT_EQ(tensor_shards.size(), test_data.size());
 
-    for (std::vector<float>& device : test_data) {
-        for (float& datum : device) {
-            test_data_1d.push_back(datum);
-        }
+    size_t i = 0;
+    for (const auto& tensor_shard : tensor_shards) {
+        EXPECT_EQ(tensor_shard.to_vector<float>(), test_data[i++]);
     }
-
-    std::vector<float> out_vector = aggregated_tensor.to_vector<float>();
-    EXPECT_EQ(out_vector, test_data_1d);
 }
+
+INSTANTIATE_TEST_SUITE_P(AggregateTensorTest, AggregateTensorTest, ::testing::Values(true, false));
+
+using TensorDistributionTest = T3kMultiDeviceFixture;
 
 TEST_F(TensorDistributionTest, DistributeToDevice) {
     Tensor input_tensor = Tensor::from_vector(

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -41,8 +41,8 @@ TEST_F(TensorDistributionTest, DeviceAggregate) {
 
     std::vector<float> test_data_1d;
 
-    for (std::vector<float> device : test_data) {
-        for (float datum : device) {
+    for (std::vector<float>& device : test_data) {
+        for (float& datum : device) {
             test_data_1d.push_back(datum);
         }
     }
@@ -76,8 +76,8 @@ TEST_F(TensorDistributionTest, BorrowedAggregate) {
 
     std::vector<float> test_data_1d;
 
-    for (std::vector<float> device : test_data) {
-        for (float datum : device) {
+    for (std::vector<float>& device : test_data) {
+        for (float& datum : device) {
             test_data_1d.push_back(datum);
         }
     }

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -32,23 +32,15 @@ TEST_F(TensorDistributionTest, DeviceAggregate) {
     std::vector<Tensor> tensors(num_devices);
 
     for(int i = 0; i < num_devices; i++) {
-        tensors.push_back(Tensor::from_vector(
-            test_data[i], get_tensor_spec(ttnn::Shape{1, num_devices, 3, 1}, DataType::FLOAT32), mesh_device_.get()));
+        tensors.push_back(Tensor::from_vector(test_data[i], get_tensor_spec(ttnn::Shape{1, num_devices, 3, 1}, DataType::FLOAT32)), mesh_device_);
     }
 
     Tensor aggregated_tensor = aggregate_as_tensor(tensors, AllGatherTensor{});
+    System.out.println(aggregated_tensor)
     EXPECT_TRUE(aggregated_tensor.storage_type() == StorageType::MULTI_DEVICE);
-
-    std::vector<float> test_data_1d;
-
-    for (std::vector<float> device : test_data) {
-        for (float datum : device) {
-            test_data_1d.push_back(datum);
-        }
-    }
-
+    
     std::vector<float> out_vector = aggregated_tensor.to_vector<float>();
-    EXPECT_EQ(out_vector, test_data_1d);
+    EXPECT_EQ(out_vector, test_data);
 }
 
 TEST_F(TensorDistributionTest, BorrowedAggregate) {
@@ -59,31 +51,17 @@ TEST_F(TensorDistributionTest, BorrowedAggregate) {
     }
 
     std::vector<Tensor> tensors(num_devices);
-    auto on_creation_callback = [] {};
-    auto on_destruction_callback = [] {};
+
     for(int i = 0; i < num_devices; i++) {
-        tensors.push_back(Tensor(
-            BorrowedStorage{
-                tt::tt_metal::borrowed_buffer::Buffer(static_cast<float*>(test_data[i].data()), test_data[i].size()),
-                on_creation_callback,
-                on_destruction_callback},
-            ttnn::Shape{1, num_devices, 3, 1},
-            DataType::FLOAT32,
-            Layout::TILE));
+        tensors.push_back(Tensor()  Tensor::from_vector(test_data[i], get_tensor_spec(ttnn::Shape{1, num_devices, 3, 1}, DataType::FLOAT32)));
     }
+Storage storage, const ttnn::Shape& shape, DataType dtype, Layout layout, const std::optional<Tile>& tile
     Tensor aggregated_tensor = aggregate_as_tensor(tensors, AllGatherTensor{});
+    System.out.println(aggregated_tensor)
     EXPECT_TRUE(aggregated_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
 
-    std::vector<float> test_data_1d;
-
-    for (std::vector<float> device : test_data) {
-        for (float datum : device) {
-            test_data_1d.push_back(datum);
-        }
-    }
-
     std::vector<float> out_vector = aggregated_tensor.to_vector<float>();
-    EXPECT_EQ(out_vector, test_data_1d);
+    EXPECT_EQ(out_vector, test_data);
 }
 
 TEST_F(TensorDistributionTest, DistributeToDevice) {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -104,15 +104,9 @@ Tensor aggregate_as_tensor(
             specs.push_back(shard.get_tensor_spec());
 
             auto visitor = tt::stl::overloaded{[&shard, &host_owned_buffers](const auto& buffer) -> OwnedBuffer {
-                using BufferType = std::decay_t<decltype(buffer)>;
-                using ValueType = typename BufferType::value_type;
+                using BorrowedBufferType = std::vector<typename std::decay_t<decltype(buffer)>::value_type>;
 
-                std::vector<ValueType> physical_data(buffer.begin(), buffer.end());
-
-                std::vector<ValueType> logical_data =
-                    tensor_impl::decode_tensor_data(std::move(physical_data), shard.get_tensor_spec());
-
-                return owned_buffer::create(std::move(logical_data));
+                return owned_buffer::create(BorrowedBufferType(buffer.begin(), buffer.end()));
             }};
 
             host_owned_buffers.push_back(std::visit(visitor, buffer));

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -7,13 +7,16 @@
 #include <memory>
 
 #include <tt-metalium/overloaded.hpp>
+#include "tt-metalium/assert.hpp"
 #include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include "ttnn/distributed/distributed_tensor_config.hpp"
+
 
 using namespace tt::tt_metal;
 
@@ -101,15 +104,9 @@ Tensor aggregate_as_tensor(
             specs.push_back(shard.get_tensor_spec());
 
             auto visitor = tt::stl::overloaded{[&shard, &host_owned_buffers](const auto& buffer) -> OwnedBuffer {
-                using BufferType = std::decay_t<decltype(buffer)>;
-                using ValueType = typename BufferType::value_type;
+                using BorrowedBufferType = std::vector<typename std::decay_t<decltype(buffer)>::value_type>;
 
-                std::vector<ValueType> physical_data(buffer.begin(), buffer.end());
-
-                std::vector<ValueType> logical_data =
-                    tensor_impl::decode_tensor_data(std::move(physical_data), shard.get_tensor_spec());
-
-                return owned_buffer::create(std::move(logical_data));
+                return owned_buffer::create(BorrowedBufferType(buffer.begin(), buffer.end()));
             }};
 
             host_owned_buffers.push_back(std::visit(visitor, buffer));

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -96,7 +96,7 @@ Tensor aggregate_as_tensor(
         }
         auto storage = MultiDeviceHostStorage{config, std::move(host_owned_buffers), specs};
         return Tensor(std::move(storage), reference_shard.get_tensor_spec());
-} else if (storage_type == StorageType::BORROWED) {
+    } else if (storage_type == StorageType::BORROWED) {
         std::vector<ttnn::TensorSpec> specs;
         std::vector<OwnedBuffer> host_owned_buffers;
         for (const auto& shard : tensor_shards) {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -117,6 +117,7 @@ Tensor aggregate_as_tensor(
         auto storage = MultiDeviceHostStorage{config, std::move(host_owned_buffers), specs};
         return Tensor(std::move(storage), reference_shard.get_tensor_spec());
     } else {
+        TT_FATAL(storage_type == StorageType::DEVICE, "Unexpected storage type {}", storage_type);
         std::vector<int> ordered_device_ids;
         std::unordered_map<int, ttnn::TensorSpec> specs;
         std::unordered_map<int, std::shared_ptr<Buffer>> device_buffers;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The aggregate_as_tensor function currently goes straight to assuming anything that isn't an owned tensor is a device tensor and then failing. Borrowed storage is currently the "preferred default" so newly created non-bfp_b types would require a conversion before they could be aggregated otherwise. 

### What's changed
Added support for borrowed storage tensors by turning them into owned tensors and then aggregating them into a multidevicehost storage backed tensor.
Added TT_FATAL checking to prevent any other types from crashing on the storage variant fetch and give some more visibility into failures. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13790103623
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes: tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
