### PR TITLE
Fix all_reduce_async ODR violation in unity builds

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::experimental::ccl {
 namespace detail {
 
 template <typename ccl_operation_t>
-void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
+void bind_all_reduce_async(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
     bind_registered_operation(
         module,
         operation,
@@ -100,7 +100,7 @@ void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation,
 }  // namespace detail
 
 void py_bind_all_reduce_async(pybind11::module& module) {
-    detail::bind_all_reduce(
+    detail::bind_all_reduce_async(
         module,
         ttnn::experimental::all_reduce_async,
         R"doc(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The pybind function name for `all_reduce_async` clashes with the one for `all_reduce` in the same namespace (ODR violation). Unity builds are sensitive to this and could give error like:

```
[1086/1248] Building CXX object ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx.o
FAILED: ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx.o 
/usr/local/bin/ccache /usr/bin/clang++-17 -DFMT_HEADER_ONLY=1 -DTT_ENABLE_LIGHT_METAL_TRACE=1 -I/work/ttnn -I/work/tt_metal -I/work/tt_metal/api -I/work/tt_metal/third_party/umd/device/api -I/work/tt_metal/hostdevcommon/api -I/work/tt_metal/tt_stl -I/work/ttnn/cpp -I/work/build/ttnn/flatbuffers -isystem /work/tt_metal/third_party/tracy/public -isystem /work/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f -isystem /work/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include -isystem /work/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include -isystem /work/.cpmcache/flatbuffers/2c4062bffa52fa4157b1b4deeae73395df475fda/include -isystem /usr/include/python3.10 -stdlib=libc++ -O3 -std=c++20 -fPIC -fvisibility=default -Werror -Wno-deprecated-declarations -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wno-unused-parameter -mavx2 -fPIC -fvisibility-inlines-hidden -fno-lto -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-error=local-type-template-args -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -MP -Wno-int-to-pointer-cast -fno-var-tracking -MD -MT ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx.o -MF ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx.o.d -o ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx.o -c /work/build/ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx
In file included from /work/build/ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx:13:
/work/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp:22:6: error: redefinition of 'bind_all_reduce'
   22 | void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
      |      ^
/work/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp:22:6: note: previous definition is here
   22 | void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
      |      ^
In file included from /work/build/ttnn/CMakeFiles/ttnn.dir/Unity/unity_17_cxx.cxx:13:
/work/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp:103:5: error: no matching function for call to 'bind_all_reduce'
  103 |     detail::bind_all_reduce(
      |     ^~~~~~~~~~~~~~~~~~~~~~~
/work/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp:22:6: note: candidate template ignored: substitution failure [with ccl_operation_t = registered_operation_t<reflect::fixed_string<char, 37UL - 1>{{{116, 116, 110, 110, 58, 58, 101, 120, 112, 101, ...}}}, ExecuteAllReduceAsync, false>]
   22 | void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
      |      ^
2 errors generated.
```

### What's changed
Fix the name for `all_reduce_async`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)