### PR TITLE
#0: Reduce max number of sub-devices to 8

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -105,7 +105,7 @@ public:
 
     static constexpr uint32_t MAX_NUM_HW_CQS = 2;
 
-    static constexpr uint32_t DISPATCH_MESSAGE_ENTRIES = 16;
+    static constexpr uint32_t DISPATCH_MESSAGE_ENTRIES = 8;
 
     static constexpr uint32_t DISPATCH_MESSAGES_MAX_OFFSET =
         std::numeric_limits<decltype(go_msg_t::dispatch_message_offset)>::max();

--- a/tt_metal/api/tt-metalium/sub_device_manager.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager.hpp
@@ -25,10 +25,6 @@ class IDevice;
 
 class SubDeviceManager {
 public:
-    static constexpr uint32_t MAX_NUM_SUB_DEVICES = 16;
-    static_assert(
-        MAX_NUM_SUB_DEVICES <= std::numeric_limits<SubDeviceId::value_type>::max(),
-        "MAX_NUM_SUB_DEVICES must be less than or equal to the max value of SubDeviceId::Id");
     // Constructor used for the default/global device
     SubDeviceManager(
         IDevice* device, std::unique_ptr<Allocator>&& global_allocator, tt::stl::Span<const SubDevice> sub_devices);

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -24,10 +24,9 @@
 
 namespace tt::tt_metal {
 
-// assert here to avoid the need to include command_queue_interface.hpp in header
 static_assert(
-    SubDeviceManager::MAX_NUM_SUB_DEVICES <= DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
-    "MAX_NUM_SUB_DEVICES must be less than or equal to DispatchSettings::DISPATCH_MESSAGE_ENTRIES");
+    DispatchSettings::DISPATCH_MESSAGE_ENTRIES <= std::numeric_limits<SubDeviceId::value_type>::max(),
+    "Max number of sub-devices must be less than or equal to the max value of SubDeviceId::Id");
 
 std::atomic<uint64_t> SubDeviceManager::next_sub_device_manager_id_ = 0;
 
@@ -175,7 +174,11 @@ uint8_t SubDeviceManager::get_sub_device_index(SubDeviceId sub_device_id) const 
 }
 
 void SubDeviceManager::validate_sub_devices() const {
-    TT_FATAL(sub_devices_.size() <= SubDeviceManager::MAX_NUM_SUB_DEVICES, "Too many sub devices specified");
+    TT_FATAL(
+        sub_devices_.size() <= DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
+        "Number of sub-devices specified {} is larger than the max number of sub-devices {}",
+        sub_devices_.size(),
+        DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
     // Validate sub device cores fit inside the device grid
     const auto& compute_grid_size = device_->compute_with_storage_grid_size();
     CoreRange device_worker_cores = CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1});


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We originally arbitrarily picked 16 as the max number of sub-devices. Supporting a certain number of sub-devices requires us to allocate resources for them. Previously this was just some L1 space, but we now want to switch to use stream registers which is more resource-constrained, so want to reduce the max number supported.

### What's changed
Reduce max number of sub-devices supported to 8.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13638112291
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
