### PR TITLE
Bump UMD to fix unit tests on P150

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -479,6 +479,11 @@ const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(chip
 }
 
 int Cluster::get_device_aiclk(const chip_id_t& chip_id) const {
+    if (this->arch_ == tt::ARCH::BLACKHOLE) {
+        // For Blackhole bring up remove AICLK query due to lack of ARC message support
+        log_info(tt::LogDevice, "For Blackhole hardcode AICLK to 1350 MHz due to lack of ARC message support");
+        return 1350;
+    }
     if (this->device_to_mmio_device_.find(chip_id) != this->device_to_mmio_device_.end()) {
         // get_clocks returns MMIO device ID -> clock frequency
         // There is one driver per MMIO device, so we use that to index returned map

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -478,12 +478,7 @@ const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(chip
     return worker_logical_to_virtual_y;
 }
 
-int Cluster::get_device_aiclk(const chip_id_t &chip_id) const {
-    if (this->arch_ == tt::ARCH::BLACKHOLE) {
-        // For Blackhole bring up remove AICLK query due to lack of ARC message support
-        log_info(tt::LogDevice, "For Blackhole hardcode AICLK to 800 MHz due to lack of ARC message support");
-        return 800;
-    }
+int Cluster::get_device_aiclk(const chip_id_t& chip_id) const {
     if (this->device_to_mmio_device_.find(chip_id) != this->device_to_mmio_device_.end()) {
         // get_clocks returns MMIO device ID -> clock frequency
         // There is one driver per MMIO device, so we use that to index returned map


### PR DESCRIPTION
### Ticket

Bump UMD to fix failing unit test on 80.15 firmware for Blackhole.
Related to https://github.com/tenstorrent/tt-metal/issues/17178

### Problem description

Test on 80.15 fw was failing because of not reading the harvesting mask for ETH and DRAM properly.

### What's changed

Harvesting masks are read properly from cluster descriptor now.

### Checklist
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649803834
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13656511777
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649806811
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/13649808945
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649811215
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649813952
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649816216
- [ ] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649817803
- [x] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649819292
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13649820697
