### PR TITLE
[tt-train] Enable all GPT-2 like models

### DIFF
--- a/tt-train/configs/training_shakespear_gpt2l.yaml
+++ b/tt-train/configs/training_shakespear_gpt2l.yaml
@@ -6,7 +6,7 @@ training_config:
   num_epochs: 1
   max_steps: 5000
   learning_rate: 0.0003
-  weight_decay: 0.01
+  weight_decay: 0.1
   use_moreh_adamw: true
   use_kahan_summation: false
   gradient_accumulation_steps: 8

--- a/tt-train/configs/training_shakespear_gpt2l.yaml
+++ b/tt-train/configs/training_shakespear_gpt2l.yaml
@@ -2,7 +2,7 @@ training_config:
   project_name: "tt_train_nano_gpt"
   seed: 5489
   model_save_interval: 500
-  batch_size: 4
+  batch_size: 2
   num_epochs: 1
   max_steps: 5000
   learning_rate: 0.0003
@@ -14,10 +14,10 @@ training_config:
 
   transformer_config:
     runner_type: memory_efficient
-    num_heads: 12
-    embedding_dim: 768
+    num_heads: 20
+    embedding_dim: 1280
     dropout_prob: 0.2
-    num_blocks: 12
+    num_blocks: 36
     vocab_size: 96
     max_sequence_length: 1024
     experimental:

--- a/tt-train/configs/training_shakespear_gpt2m.yaml
+++ b/tt-train/configs/training_shakespear_gpt2m.yaml
@@ -6,7 +6,7 @@ training_config:
   num_epochs: 1
   max_steps: 5000
   learning_rate: 0.0003
-  weight_decay: 0.01
+  weight_decay: 0.1
   use_moreh_adamw: true
   use_kahan_summation: false
   gradient_accumulation_steps: 8

--- a/tt-train/configs/training_shakespear_gpt2m.yaml
+++ b/tt-train/configs/training_shakespear_gpt2m.yaml
@@ -14,10 +14,10 @@ training_config:
 
   transformer_config:
     runner_type: memory_efficient
-    num_heads: 12
-    embedding_dim: 768
+    num_heads: 16
+    embedding_dim: 1024
     dropout_prob: 0.2
-    num_blocks: 12
+    num_blocks: 24
     vocab_size: 96
     max_sequence_length: 1024
     experimental:

--- a/tt-train/configs/training_shakespear_gpt2s.yaml
+++ b/tt-train/configs/training_shakespear_gpt2s.yaml
@@ -6,7 +6,7 @@ training_config:
   num_epochs: 1
   max_steps: 5000
   learning_rate: 0.0003
-  weight_decay: 0.01
+  weight_decay: 0.1
   use_moreh_adamw: true
   use_kahan_summation: false
   gradient_accumulation_steps: 8

--- a/tt-train/configs/training_shakespear_gpt2xl.yaml
+++ b/tt-train/configs/training_shakespear_gpt2xl.yaml
@@ -6,7 +6,7 @@ training_config:
   num_epochs: 1
   max_steps: 5000
   learning_rate: 0.0003
-  weight_decay: 0.01
+  weight_decay: 0.1
   use_moreh_adamw: true
   use_kahan_summation: false
   gradient_accumulation_steps: 32

--- a/tt-train/configs/training_shakespear_gpt2xl.yaml
+++ b/tt-train/configs/training_shakespear_gpt2xl.yaml
@@ -2,22 +2,22 @@ training_config:
   project_name: "tt_train_nano_gpt"
   seed: 5489
   model_save_interval: 500
-  batch_size: 4
+  batch_size: 1
   num_epochs: 1
   max_steps: 5000
   learning_rate: 0.0003
   weight_decay: 0.01
   use_moreh_adamw: true
   use_kahan_summation: false
-  gradient_accumulation_steps: 8
+  gradient_accumulation_steps: 32
   tokenizer_type: bpe
 
   transformer_config:
     runner_type: memory_efficient
-    num_heads: 12
-    embedding_dim: 768
+    num_heads: 32    # original is 25, but tensor parallel requires a multiple of #num_devices
+    embedding_dim: 2048  # original is 1600, but tensor parallel heads creation are broken somewhy (returns padded tensor as result)
     dropout_prob: 0.2
-    num_blocks: 12
+    num_blocks: 48
     vocab_size: 96
     max_sequence_length: 1024
     experimental:

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -56,6 +56,29 @@ ttml::serialization::NamedParameters get_model_parameters(Model &model) {
     return std::visit([](auto &model) { return model->parameters(); }, model);
 }
 
+uint64_t get_number_of_parameters(Model &model, bool enable_tp) {
+    auto *device = &ttml::autograd::ctx().get_device();
+    auto num_devices = static_cast<uint32_t>(device->num_devices());
+
+    auto contains = [](const std::string &str, const std::string &substr) {
+        return str.find(substr) != std::string::npos;
+    };
+
+    auto parameters = get_model_parameters(model);
+    uint64_t num_params = 0;
+    for (const auto &[name, tensor_ptr] : parameters) {
+        auto tensor = tensor_ptr->get_value();
+        auto params_in_tensor = tensor.get_logical_volume();
+        if (enable_tp && (contains(name, "fc") || contains(name, "linear"))) {
+            num_params += params_in_tensor * num_devices;
+        } else {
+            num_params += params_in_tensor;
+        }
+    }
+
+    return num_params;
+}
+
 using ttml::autograd::TensorPtr;
 
 using DatasetSample = std::pair<std::span<const uint32_t>, std::span<const uint32_t>>;
@@ -600,6 +623,9 @@ int main(int argc, char **argv) {
     fmt::print("    Learning rate: {}\n", adamw_params.lr);
     fmt::print("    Weight decay: {}\n", adamw_params.weight_decay);
     fmt::print("    Use Kahan summation: {}\n", adamw_params.use_kahan_summation);
+
+    fmt::print("Number of parameters: {}\n", get_number_of_parameters(model, enable_tp));
+
     auto select_optimizer = [&model,
                              &adamw_params](bool use_moreh_adamw) -> std::unique_ptr<ttml::optimizers::OptimizerBase> {
         if (use_moreh_adamw) {

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -411,6 +411,12 @@ int main(int argc, char **argv) {
     app.add_option("-n,--name", run_name, "Run name")->default_val(run_name);
     CLI11_PARSE(app, argc, argv);
 
+    // DEBUG
+    // ddp = true;
+    enable_tp = true;
+    // config_name = std::string(CONFIGS_FOLDER) + "/training_shakespear_gpt2l.yaml";
+    config_name = std::string(CONFIGS_FOLDER) + "/training_shakespear_gpt2xl.yaml";
+
     if (ddp && enable_tp) {
         throw std::logic_error("DDP and TP cannot be enabled at the same time. Disable DDP or TP.");
     }

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -411,12 +411,6 @@ int main(int argc, char **argv) {
     app.add_option("-n,--name", run_name, "Run name")->default_val(run_name);
     CLI11_PARSE(app, argc, argv);
 
-    // DEBUG
-    // ddp = true;
-    enable_tp = true;
-    // config_name = std::string(CONFIGS_FOLDER) + "/training_shakespear_gpt2l.yaml";
-    config_name = std::string(CONFIGS_FOLDER) + "/training_shakespear_gpt2xl.yaml";
-
     if (ddp && enable_tp) {
         throw std::logic_error("DDP and TP cannot be enabled at the same time. Disable DDP or TP.");
     }

--- a/tt-train/sources/ttml/autograd/graph.cpp
+++ b/tt-train/sources/ttml/autograd/graph.cpp
@@ -27,6 +27,7 @@ NodeId Graph::add_node(GradFunction&& grad_function, std::span<NodeId> links) {
             const std::type_info& typeInfo = grad_function.target_type();
             auto demangled_name = core::demangle(typeInfo.name());
             auto time = std::chrono::high_resolution_clock::now();
+            fmt::print("Node {} Demangled name {} start running...\n", curr_id, demangled_name);
             grad_function();
             auto duration =
                 std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - time);

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -6,6 +6,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 namespace ttml::core::distributed {
 
@@ -19,8 +20,7 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor) {
     }
 
     // all_reduce Mean is not supported, use sum and divide by #devices
-    auto result = ttnn::experimental::all_reduce(
-        tensor, ttnn::operations::reduction::ReduceType::Sum, 1, std::nullopt, ttnn::ccl::Topology::Ring);
+    auto result = ttnn_fixed::distributed::all_reduce(tensor);
     result = ttnn::multiply(result, 1.0F / static_cast<float>(devices_count));
     return result;
 }

--- a/tt-train/sources/ttml/models/distributed/gpt2.cpp
+++ b/tt-train/sources/ttml/models/distributed/gpt2.cpp
@@ -176,6 +176,7 @@ ttml::autograd::TensorPtr DistributedTransformer::operator()(
     const ttml::autograd::TensorPtr& x, const ttml::autograd::TensorPtr& mask) {
     auto tok_emb_out = (*tok_emb)(x);
     auto out = (*pos_emb)(tok_emb_out);
+
     for (auto& block : blocks) {
         if (runner_type == RunnerType::MemoryEfficient) {
             out = memory_efficient_runner(*block, out, mask);
@@ -185,6 +186,7 @@ ttml::autograd::TensorPtr DistributedTransformer::operator()(
             throw std::runtime_error("Unknown runner type. Supported runner types ['default', 'memory_efficient']");
         }
     }
+
     out = (*ln_fc)(out);
     auto logits = (*fc)(out);
     auto log_softmax = ttml::ops::log_softmax_moreh(logits, 3);

--- a/tt-train/sources/ttml/models/distributed/gpt2.hpp
+++ b/tt-train/sources/ttml/models/distributed/gpt2.hpp
@@ -33,7 +33,8 @@ private:
 public:
     explicit DistributedTransformer(const TransformerConfig& config);
 
-    ttml::autograd::TensorPtr operator()(const ttml::autograd::TensorPtr& x, const ttml::autograd::TensorPtr& mask);
+    ttml::autograd::TensorPtr operator()(
+        const ttml::autograd::TensorPtr& x, const ttml::autograd::TensorPtr& mask) override;
 };
 
 [[nodiscard]] std::shared_ptr<DistributedTransformer> create(const TransformerConfig& config);

--- a/tt-train/sources/ttml/modules/distributed/gpt_block.hpp
+++ b/tt-train/sources/ttml/modules/distributed/gpt_block.hpp
@@ -19,7 +19,7 @@ class DistributedGPTMLP : public autograd::ModuleBase {
 public:
     DistributedGPTMLP(uint32_t embedding_size, float dropout_prob);
 
-    autograd::TensorPtr operator()(const autograd::TensorPtr& input);
+    autograd::TensorPtr operator()(const autograd::TensorPtr& input) override;
 
 private:
     std::shared_ptr<distributed::ColumnParallelLinear> m_fc1;
@@ -32,7 +32,7 @@ public:
     explicit DistributedGPTBlock(
         uint32_t embedding_size, uint32_t num_heads, float dropout_prob, bool use_composite_layernorm = false);
 
-    autograd::TensorPtr operator()(const autograd::TensorPtr& input, const autograd::TensorPtr& mask);
+    autograd::TensorPtr operator()(const autograd::TensorPtr& input, const autograd::TensorPtr& mask) override;
 
 private:
     std::shared_ptr<DistributedGPTMLP> m_mlp;

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -27,17 +27,18 @@ RowParallelLinear::RowParallelLinear(
     }
 }
 
-autograd::TensorPtr RowParallelLinear::operator()(autograd::TensorPtr tensor) {
+autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& tensor) {
+    auto x = tensor;
     if (!m_input_is_parallel) {
-        tensor = ops::distributed::scatter(tensor, tensor->get_rank() - 1U);
+        x = ops::distributed::scatter(x, tensor->get_rank() - 1U);
     }
     // do not pass bias
-    tensor = ops::linear_op(tensor, m_weight, /* bias */ nullptr);
-    tensor = ops::distributed::all_reduce(tensor);
+    x = ops::linear_op(x, m_weight, /* bias */ nullptr);
+    x = ops::distributed::all_reduce(x);
     if (m_bias != nullptr) {
-        tensor = ops::add(tensor, m_bias);
+        x = ops::add(x, m_bias);
     }
-    return tensor;
+    return x;
 }
 
 void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias) {
@@ -81,13 +82,14 @@ ColumnParallelLinear::ColumnParallelLinear(
     }
 }
 
-autograd::TensorPtr ColumnParallelLinear::operator()(autograd::TensorPtr tensor) {
-    tensor = ops::distributed::broadcast(tensor);
-    tensor = ops::linear_op(tensor, m_weight, m_bias);
+autograd::TensorPtr ColumnParallelLinear::operator()(const autograd::TensorPtr& tensor) {
+    auto x = tensor;
+    x = ops::distributed::broadcast(x);
+    x = ops::linear_op(x, m_weight, m_bias);
     if (m_gather_output) {
-        tensor = ops::distributed::all_gather(tensor, tensor->get_rank() - 1U);
+        x = ops::distributed::all_gather(x, tensor->get_rank() - 1U);
     }
-    return tensor;
+    return x;
 }
 
 void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias) {

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -31,7 +31,6 @@ autograd::TensorPtr RowParallelLinear::operator()(autograd::TensorPtr tensor) {
     if (!m_input_is_parallel) {
         tensor = ops::distributed::scatter(tensor, tensor->get_rank() - 1U);
     }
-
     // do not pass bias
     tensor = ops::linear_op(tensor, m_weight, /* bias */ nullptr);
     tensor = ops::distributed::all_reduce(tensor);

--- a/tt-train/sources/ttml/modules/distributed/linear.hpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.hpp
@@ -13,7 +13,7 @@ class RowParallelLinear : public autograd::ModuleBase {
 public:
     RowParallelLinear(
         uint32_t in_features, uint32_t out_features, bool has_bias = true, bool input_is_parallel = false);
-    autograd::TensorPtr operator()(autograd::TensorPtr tensor);
+    autograd::TensorPtr operator()(const autograd::TensorPtr& tensor) override;
 
 private:
     void initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias = true);
@@ -26,7 +26,7 @@ private:
 class ColumnParallelLinear : public autograd::ModuleBase {
 public:
     ColumnParallelLinear(uint32_t in_features, uint32_t out_features, bool has_bias = true, bool gather_output = false);
-    autograd::TensorPtr operator()(autograd::TensorPtr tensor);
+    autograd::TensorPtr operator()(const autograd::TensorPtr& tensor) override;
 
 private:
     void initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias = true);

--- a/tt-train/sources/ttml/modules/distributed/multi_head_attention.hpp
+++ b/tt-train/sources/ttml/modules/distributed/multi_head_attention.hpp
@@ -23,7 +23,7 @@ private:
 public:
     explicit DistributedMultiHeadAttention(uint32_t embedding_dim, uint32_t num_heads, float dropout_prob);
 
-    autograd::TensorPtr operator()(const autograd::TensorPtr& x, const autograd::TensorPtr& mask);
+    autograd::TensorPtr operator()(const autograd::TensorPtr& x, const autograd::TensorPtr& mask) override;
 };
 
 }  // namespace ttml::modules::distributed

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -32,8 +32,7 @@ autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim) {
 }
 
 autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor) {
-    auto out = autograd::create_tensor(ttnn::experimental::all_reduce(
-        tensor->get_value(), ttnn::operations::reduction::ReduceType::Sum, 1, std::nullopt, ttnn::ccl::Topology::Ring));
+    auto out = autograd::create_tensor(ttnn_fixed::distributed::all_reduce(tensor->get_value()));
     autograd::GradFunction grad = [tensor, out]() { tensor->add_grad(out->get_grad()); };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
@@ -43,8 +42,7 @@ autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor) {
 autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor) {
     auto out = autograd::create_tensor(tensor->get_value());
     autograd::GradFunction grad = [tensor, out]() {
-        tensor->add_grad(ttnn::experimental::all_reduce(
-            out->get_grad(), ttnn::operations::reduction::ReduceType::Sum, 1, std::nullopt, ttnn::ccl::Topology::Ring));
+        tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad()));
     };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.hpp
@@ -7,6 +7,7 @@
 
 namespace ttml::ttnn_fixed::distributed {
 
+tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor);
 tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim);
 
 }  // namespace ttml::ttnn_fixed::distributed

--- a/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/trivial_ttnn_ops.cpp
@@ -13,7 +13,7 @@
 namespace ttml::ttnn_fixed {
 
 tt::tt_metal::Tensor sum_over_dim(const tt::tt_metal::Tensor& t, uint32_t dim) {
-    return sum_ttnn(t, dim, /* keepdim */ true);
+    return sum_moreh(t, dim, /* keepdim */ true);
 }
 
 tt::tt_metal::Tensor sum_over_batch(const tt::tt_metal::Tensor& t) {
@@ -64,14 +64,13 @@ tt::tt_metal::Tensor mean_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep
 }
 
 tt::tt_metal::Tensor sum_moreh(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
-    auto res = ttnn::moreh_sum(
+    return ttnn::moreh_sum(
         t,
         dim,
         keep_dim,
         std::nullopt,
         std::nullopt,
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
-    return res;
 }
 tt::tt_metal::Tensor sum_ttnn(const tt::tt_metal::Tensor& t, int dim, bool keep_dim) {
     return ttnn::sum(t, dim, keep_dim, std::nullopt, core::ComputeKernelConfig::precise());


### PR DESCRIPTION
### Problem description
Unlock all GPT2 models in tt-train. 

### What's changed
* Add custom all_reduce (with moreh_sum)
* Substitute all ttnn::sum with ttnn::moreh_sum before it is fixed
* Add configs for GPT2-(S, M, L, XL)
* Add function to roughly calculate number of parameters 

GPT2-S - 163M
GPT2-M - 406M
GPT2-L - 838M
GPT2-XL - 2.5B (increased number of heads 25->32, embedding dimension 1600 -> 2048; it is done to make TP work)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13640609836
- [x] New/Existing tests provide coverage for changes
