### PR TITLE
Fix missing integer cast for environment variable

### DIFF
--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -219,6 +219,8 @@ class TtModelArgs:
             assert (
                 max_prefill_chunk_size_div1024 is not None
             ), f"Unsupported model {self.model_name} on device {self.device_name}"
+        else:
+            max_prefill_chunk_size_div1024 = int(max_prefill_chunk_size_div1024)
         self.max_prefill_chunk_size = max_prefill_chunk_size_div1024 * 1024
 
         if callable(optimizations):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This PR fixes a type error in the Llama3 demo implementation caused by loading `MAX_PREFILL_CHUNK_SIZE` as a string instead of an integer.

### What's changed
Cast an integer

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
