### PR TITLE
[skip ci] Fix build when not building tests

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -284,7 +284,9 @@ add_subdirectory(detail)
 add_subdirectory(distributed)
 add_subdirectory(tt_stl)
 add_subdirectory(fabric)
-add_subdirectory(test)
+if(TT_METAL_BUILD_TESTS)
+    add_subdirectory(test)
+endif()
 
 install(
     TARGETS


### PR DESCRIPTION
### Ticket
Follow-up to #17987

### Problem description
When we omit processing the test dirs, CMake fails to configure a target that assumes test targets exist.

### What's changed
Added a guard to match the guard around the actual tests.
