### PR TITLE
#18572: Return enqueued events in `ttnn.record_event`, instead of mutating the input argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For information on initial model procedures, please see [Model Bring-Up and Test
 
 ## TT-NN Tech Reports
 
-- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Dec 4th, 2024)
+- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated March 4th, 2025)
 - [Programming Mesh of Devices](./tech_reports/Programming_Mesh_of_Devices/Programming_Mesh_of_Devices_with_TT-NN.md) (updated Sept 9th, 2024)
 - [ViT Implementation in TT-NN on GS](./tech_reports/ViT-TTNN/vit.md)  (updated Sept 22nd, 2024)
 - [LLMs Bring up in TT-NN](./tech_reports/LLMs/llms.md)  (updated Oct 29th, 2024)

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
@@ -52,19 +52,17 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
 
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
     # Initialize the op event so we can write
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     profiler.start("compile")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     spec = test_infra.input_tensor.spec
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
     ttnn.DumpDeviceProfiler(device)
@@ -72,10 +70,10 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     profiler.start("cache")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     # Deallocate the previous output tensor here to make allocation match capture setup
     # This allows us to allocate the input tensor after at the same address
     test_infra.output_tensor.deallocate(force=True)
@@ -86,11 +84,11 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     # Capture
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
 
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.output_tensor.deallocate(force=True)
     trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
@@ -103,10 +101,10 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     for iter in range(0, num_warmup_iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         reshard_out = ttnn.reshard(tt_image_res, input_mem_config, reshard_out)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
         ttnn.DumpDeviceProfiler(device)
 
@@ -118,11 +116,11 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
     for iter in range(0, num_measurement_iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         # TODO: Add in place support to ttnn to_memory_config
         reshard_out = ttnn.reshard(tt_image_res, input_mem_config, reshard_out)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         outputs.append(tt_output_res.cpu(blocking=False))
     ttnn.synchronize_device(device)

--- a/models/demos/qwen/demo/demo.py
+++ b/models/demos/qwen/demo/demo.py
@@ -416,8 +416,6 @@ def run_qwen_demo(
 
         # Create events
         profiler.start(f"compile_trace_{batch_idx}")
-        op_event = ttnn.create_event(mesh_device)
-        write_event = ttnn.create_event(mesh_device)
 
         current_pos = ttnn.from_torch(
             torch.tensor(decoding_pos, dtype=torch.int32),
@@ -492,7 +490,7 @@ def run_qwen_demo(
         logger.info(f"Starting decode loop...")
         profiler.start(f"inference_decode", iteration=batch_idx)
 
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(mesh_device, 1)
         while users_decoding:
             if iteration == 0:  # First iteration also accounts for compile time
                 profiler.start(f"compile_decode", iteration=batch_idx)
@@ -501,14 +499,14 @@ def run_qwen_demo(
             # Execute trace
             ttnn.wait_for_event(0, write_event)
             ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
-            ttnn.record_event(0, op_event)
+            op_event = ttnn.record_event(mesh_device, 0)
 
             # Write to host
             ttnn.wait_for_event(1, op_event)
             tt_output_torch = ttnn.to_torch(
                 tt_out_tok.cpu(blocking=True, cq_id=1), mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1)
             )[0, 0, 0, :batch_size]
-            ttnn.record_event(1, write_event)
+            write_event = ttnn.record_event(mesh_device, 1)
 
             # Save output token to print out later
             for user in range(batch_size):

--- a/models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_e2e_resnet50.py
@@ -91,18 +91,17 @@ def run_model(device, tt_inputs, test_infra, num_warmup_iterations, num_measurem
 def run_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
+
     # Initialize the op event so we can write
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     profiler.start("compile")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
     ttnn.dump_device_profiler(device)
@@ -110,10 +109,10 @@ def run_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, num_meas
     profiler.start("cache")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("cache")
     ttnn.dump_device_profiler(device)
@@ -121,10 +120,10 @@ def run_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, num_meas
     for iter in range(0, num_warmup_iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         _ = ttnn.from_device(test_infra.run(), blocking=True)
         ttnn.dump_device_profiler(device)
 
@@ -136,10 +135,10 @@ def run_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, num_meas
     for iter in range(0, num_measurement_iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         outputs.append(ttnn.from_device(test_infra.run(), blocking=False))
     ttnn.synchronize_devices(device)
     profiler.end(f"run")
@@ -204,19 +203,17 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
 
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
     # Initialize the op event so we can write
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     profiler.start("compile")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     spec = test_infra.input_tensor.spec
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
     ttnn.dump_device_profiler(device)
@@ -224,10 +221,10 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
     profiler.start("cache")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     # Deallocate the previous output tensor here to make allocation match capture setup
     # This allows us to allocate the input tensor after at the same address
     test_infra.output_tensor.deallocate(force=True)
@@ -238,10 +235,10 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
     # Capture
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.output_tensor.deallocate(force=True)
     trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
 
@@ -255,10 +252,10 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
     for iter in range(0, num_warmup_iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         input_tensor = ttnn.reshard(tt_image_res, input_mem_config, input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
         ttnn.dump_device_profiler(device)
 
@@ -270,11 +267,11 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
     for iter in range(0, num_measurement_iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         # TODO: Add in place support to ttnn to_memory_config
         input_tensor = ttnn.reshard(tt_image_res, input_mem_config, input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         outputs.append(tt_output_res.cpu(blocking=False))
     ttnn.synchronize_devices(device)

--- a/models/demos/ttnn_resnet/tests/resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/resnet50_performant.py
@@ -144,28 +144,27 @@ def run_resnet50_2cqs_inference(
     )
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
+
     # Initialize the op event so we can write
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     # First run configures convs JIT
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
 
     # Optimized run
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
 
@@ -176,10 +175,10 @@ def run_resnet50_2cqs_inference(
     for iter in range(0, 2):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         outputs.append(ttnn.from_device(test_infra.run(), blocking=False))
 
     ttnn.synchronize_devices(device)
@@ -210,19 +209,18 @@ def run_resnet50_trace_2cqs_inference(
     )
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
+
     # Initialize the op event so we can write
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     # First run configures convs JIT
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     spec = test_infra.input_tensor.spec
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
     test_infra.output_tensor.deallocate(force=True)
@@ -230,20 +228,20 @@ def run_resnet50_trace_2cqs_inference(
     # Optimized run
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
 
     # Capture
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.output_tensor.deallocate(force=True)
     trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
     tid = ttnn.begin_trace_capture(device, cq_id=0)
@@ -259,11 +257,11 @@ def run_resnet50_trace_2cqs_inference(
     for iter in range(0, 2):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         # TODO: Add in place support to ttnn to_memory_config
         input_tensor = ttnn.reshard(tt_image_res, input_mem_config, input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         outputs.append(ttnn.from_device(test_infra.output_tensor, blocking=False))
     ttnn.synchronize_devices(device)

--- a/models/demos/yolov4/tests/yolov4_perfomant.py
+++ b/models/demos/yolov4/tests/yolov4_perfomant.py
@@ -136,19 +136,18 @@ def run_yolov4_trace_2cqs_inference(
     )
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
+
     # Initialize the op event so we can write
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     # First run configures convs JIT
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     spec = test_infra.input_tensor.spec
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
     test_infra.dealloc_output()
@@ -156,20 +155,20 @@ def run_yolov4_trace_2cqs_inference(
     # Optimized run
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.run()
     test_infra.validate()
 
     # Capture
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     test_infra.dealloc_output()
     trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
     tid = ttnn.begin_trace_capture(device, cq_id=0)
@@ -184,11 +183,11 @@ def run_yolov4_trace_2cqs_inference(
     for iter in range(0, 2):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
         # TODO: Add in place support to ttnn to_memory_config
         input_tensor = ttnn.reshard(tt_image_res, input_mem_config, input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
     ttnn.synchronize_devices(device)
 

--- a/models/demos/yolov4/tests/yolov4_perfomant_webdemo.py
+++ b/models/demos/yolov4/tests/yolov4_perfomant_webdemo.py
@@ -52,19 +52,18 @@ class Yolov4Trace2CQ:
             device
         )
         self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
-        self.op_event = ttnn.create_event(device)
-        self.write_event = ttnn.create_event(device)
+
         # Initialize the op event so we can write
-        ttnn.record_event(0, self.op_event)
+        self.op_event = ttnn.record_event(device, 0)
 
         # First run configures convs JIT
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
-        ttnn.record_event(1, self.write_event)
+        self.write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, self.write_event)
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         spec = self.test_infra.input_tensor.spec
-        ttnn.record_event(0, self.op_event)
+        self.op_event = ttnn.record_event(device, 0)
         self.test_infra.run()
         self.test_infra.validate()
         self.test_infra.dealloc_output()
@@ -72,20 +71,20 @@ class Yolov4Trace2CQ:
         # Optimized run
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
-        ttnn.record_event(1, self.write_event)
+        self.write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, self.write_event)
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
-        ttnn.record_event(0, self.op_event)
+        self.op_event = ttnn.record_event(device, 0)
         self.test_infra.run()
         self.test_infra.validate()
 
         # Capture
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
-        ttnn.record_event(1, self.write_event)
+        self.write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, self.write_event)
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
-        ttnn.record_event(0, self.op_event)
+        self.op_event = ttnn.record_event(device, 0)
         self.test_infra.dealloc_output()
         trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
@@ -113,11 +112,11 @@ class Yolov4Trace2CQ:
         tt_inputs_host = self.tt_inputs_host if tt_inputs_host is None else tt_inputs_host
         ttnn.wait_for_event(1, self.op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
-        ttnn.record_event(1, self.write_event)
+        self.write_event = ttnn.record_event(self.device, 1)
         ttnn.wait_for_event(0, self.write_event)
         # TODO: Add in place support to ttnn to_memory_config
         self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
-        ttnn.record_event(0, self.op_event)
+        self.op_event = ttnn.record_event(self.device, 0)
         ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
         ttnn.synchronize_devices(self.device)
 

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -130,9 +130,6 @@ def test_unet_trace_2cq(
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
-
     dram_grid_size = device.dram_grid_size()
     dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
@@ -151,26 +148,26 @@ def test_unet_trace_2cq(
     input_tensor = ttnn.allocate_tensor_on_device(
         ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, dram_memory_config
     )
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     logger.info(f"Compiling model with warmup run")
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
 
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
 
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
     logger.info(f"Done compile run")
 
     logger.info(f"Capturing trace")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     input_trace_addr = l1_input_tensor.buffer_address()
     spec = l1_input_tensor.spec
@@ -191,11 +188,11 @@ def test_unet_trace_2cq(
     for _ in range(iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(0, write_event)
 
         l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
 
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         outputs.append(output_tensor.cpu(blocking=False))
@@ -259,9 +256,6 @@ def test_unet_trace_2cq_multi_device(
 
     torch_output_tensor = model(torch_input)
 
-    op_event = ttnn.create_event(mesh_device)
-    write_event = ttnn.create_event(mesh_device)
-
     dram_grid_size = mesh_device.dram_grid_size()
     dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
@@ -280,26 +274,26 @@ def test_unet_trace_2cq_multi_device(
     input_tensor = ttnn.allocate_tensor_on_device(
         ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, mesh_device, dram_memory_config
     )
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(mesh_device, 0)
 
     logger.info(f"Compiling model with warmup run")
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
 
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
 
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(mesh_device, 0)
     output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
     logger.info(f"Done compile run")
 
     logger.info(f"Capturing trace")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(mesh_device, 0)
 
     input_trace_addr = buffer_address(l1_input_tensor)
     spec = l1_input_tensor.spec
@@ -320,11 +314,11 @@ def test_unet_trace_2cq_multi_device(
     for _ in range(iterations):
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(mesh_device, 1)
         ttnn.wait_for_event(0, write_event)
 
         l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(mesh_device, 0)
 
         ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
         outputs.append(output_tensor.cpu(blocking=False))
@@ -365,11 +359,6 @@ def test_unet_trace_2cq_same_io(
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    op_event = ttnn.create_event(device)
-    write_event = ttnn.create_event(device)
-    model_event = ttnn.create_event(device)
-    read_event = ttnn.create_event(device)
-
     dram_grid_size = device.dram_grid_size()
     dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
@@ -388,18 +377,18 @@ def test_unet_trace_2cq_same_io(
     input_tensor = ttnn.allocate_tensor_on_device(
         ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, input_dram_memory_config
     )
-    ttnn.record_event(0, op_event)
-    ttnn.record_event(1, read_event)
+    op_event = ttnn.record_event(device, 0)
+    read_event = ttnn.record_event(device, 1)
 
     logger.info(f"Compiling model with warmup run")
     start = time.time()
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
 
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
 
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
     output_dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
@@ -418,10 +407,10 @@ def test_unet_trace_2cq_same_io(
     logger.info(f"Capturing trace")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
 
     input_trace_addr = l1_input_tensor.buffer_address()
     spec = l1_input_tensor.spec
@@ -441,28 +430,28 @@ def test_unet_trace_2cq_same_io(
     start = time.time()
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     for _ in range(iterations - 1):
         ttnn.wait_for_event(0, write_event)
         l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(device, 0)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         ttnn.wait_for_event(0, read_event)
         dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
-        ttnn.record_event(0, model_event)
+        model_event = ttnn.record_event(device, 0)
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(device, 1)
         ttnn.wait_for_event(1, model_event)
         outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
-        ttnn.record_event(1, read_event)
+        read_event = ttnn.record_event(device, 1)
     ttnn.wait_for_event(0, write_event)
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
     ttnn.wait_for_event(0, read_event)
     dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
-    ttnn.record_event(0, model_event)
+    model_event = ttnn.record_event(device, 0)
     ttnn.wait_for_event(1, model_event)
     outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
     ttnn.synchronize_device(device)
@@ -525,11 +514,6 @@ def test_unet_trace_2cq_same_io_multi_device(
 
     torch_output_tensor = model(torch_input)
 
-    op_event = ttnn.create_event(mesh_device)
-    write_event = ttnn.create_event(mesh_device)
-    model_event = ttnn.create_event(mesh_device)
-    read_event = ttnn.create_event(mesh_device)
-
     dram_grid_size = mesh_device.dram_grid_size()
     dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
@@ -548,18 +532,18 @@ def test_unet_trace_2cq_same_io_multi_device(
     input_tensor = ttnn.allocate_tensor_on_device(
         ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, mesh_device, input_dram_memory_config
     )
-    ttnn.record_event(0, op_event)
-    ttnn.record_event(1, read_event)
+    op_event = ttnn.record_event(mesh_device, 0)
+    read_event = ttnn.record_event(mesh_device, 1)
 
     logger.info(f"Compiling model with warmup run")
     start = time.time()
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
 
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
 
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(mesh_device, 0)
     output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
     output_dram_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet(
@@ -578,10 +562,10 @@ def test_unet_trace_2cq_same_io_multi_device(
     logger.info(f"Capturing trace")
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(mesh_device, 0)
 
     input_trace_addr = buffer_address(l1_input_tensor)
     shape = l1_input_tensor.shape
@@ -605,28 +589,28 @@ def test_unet_trace_2cq_same_io_multi_device(
     start = time.time()
     ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(mesh_device, 1)
     for _ in range(iterations - 1):
         ttnn.wait_for_event(0, write_event)
         l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-        ttnn.record_event(0, op_event)
+        op_event = ttnn.record_event(mesh_device, 0)
         ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
         ttnn.wait_for_event(0, read_event)
         dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
-        ttnn.record_event(0, model_event)
+        model_event = ttnn.record_event(mesh_device, 0)
         ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
-        ttnn.record_event(1, write_event)
+        write_event = ttnn.record_event(mesh_device, 1)
         ttnn.wait_for_event(1, model_event)
         outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
-        ttnn.record_event(1, read_event)
+        read_event = ttnn.record_event(mesh_device, 1)
     ttnn.wait_for_event(0, write_event)
     l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(mesh_device, 0)
     ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
     ttnn.wait_for_event(0, read_event)
     dram_output_tensor = ttnn.reshard(output_tensor, output_dram_memory_config, dram_output_tensor)
-    ttnn.record_event(0, model_event)
+    model_event = ttnn.record_event(mesh_device, 0)
     ttnn.wait_for_event(1, model_event)
     outputs.append(dram_output_tensor.cpu(blocking=False, cq_id=1))
     ttnn.synchronize_devices(mesh_device)

--- a/tech_reports/AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md
+++ b/tech_reports/AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md
@@ -170,7 +170,7 @@ In order to use multiple command queues, we need to be familiar with the followi
   This is a parameter to the device creation api, and sets how many command queues to create the device with. The default is one, and the max is two. In pytest, we can pass this using the `device_params` fixture:
 
   `@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 800768, "num_command_queues": 2}], indirect=True)`
-* `ttnn.record_event(device, cq_id = 0)`
+* `event = ttnn.record_event(device, cq_id = 0)`
 
   This will record the event on the device after all current commands on the specified command queue are finished. This event will be visible to all command queue
 * `ttnn.wait_for_event(cq_id = 0, event = event)`
@@ -255,6 +255,8 @@ This way CQ1 will always have started/finished writing the next input and allows
 # `write_event` signals when input write is completed. This is used to signal that the input tensor can be read/consumed
 
 # `last_op_event` signals when the last operation is completed. This is the producer of the otuput tensor so once this is completed, we can issue the next read
+
+# `read_event` signals when output read is completed. This is used to signal that the output tensor can be overwritten
 
 # Allocate our persistent input tensor
 input_dram_tensor = ttnn.allocate_tensor_on_device(input_shape, input_dtype, input_layout, device, input_sharded_dram_mem_config)

--- a/tech_reports/AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md
+++ b/tech_reports/AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md
@@ -170,10 +170,7 @@ In order to use multiple command queues, we need to be familiar with the followi
   This is a parameter to the device creation api, and sets how many command queues to create the device with. The default is one, and the max is two. In pytest, we can pass this using the `device_params` fixture:
 
   `@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 800768, "num_command_queues": 2}], indirect=True)`
-* `event = ttnn.create_event(device)`
-
-  This will create an event object for the specified device
-* `ttnn.record_event(cq_id = 0, event = event)`
+* `ttnn.record_event(device, cq_id = 0)`
 
   This will record the event on the device after all current commands on the specified command queue are finished. This event will be visible to all command queue
 * `ttnn.wait_for_event(cq_id = 0, event = event)`
@@ -204,16 +201,15 @@ The first event we use is an event to signal that the write has completed on com
 ```py
 # This example uses 1 CQ for only writing inputs (CQ 1), and one CQ for executing programs/reading back the output (CQ 0)
 
-# Create the event for signalling when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
-op_event = ttnn.create_event(device)
-# Create the event for when input write is completed. This is used to signal that the input tensor can be read/consumed
-write_event = ttnn.create_event(device)
+# `op_event` signals when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
+
+# `write_event` signals when input write is completed. This is used to signal that the input tensor can be read/consumed
 
 # Allocate our persistent input tensor
 input_dram_tensor = ttnn.allocate_tensor_on_device(shape, dtype, layout, device, sharded_dram_mem_config)
 
 # Dummy record an op event on CQ 0 since we wait on this first in the loop
-ttnn.record_event(0, op_event)
+op_event =ttnn.record_event(device, 0)
 
 outputs = []
 
@@ -223,13 +219,13 @@ for iter in range(0, 2):
     # Write the next input tensor on CQ 1
     ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
     # Signal that the write has finished on CQ 1
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     # Make CQ 0 stall until CQ 1 has signalled that the write has finished
     ttnn.wait_for_event(0, write_event)
     # Run the first operation of the model on CQ 0
     input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, sharded_l1_mem_config)
     # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     # Run the rest of the model and issue output readback on the default CQ (0)
     output_tensor = run_model(input_l1_tensor)
     outputs.append(output_tensor.cpu(blocking=False))
@@ -254,14 +250,11 @@ This way CQ1 will always have started/finished writing the next input and allows
 ```py
 # This example uses 1 CQ for writing inputs and reading outputs (CQ 1), and one CQ for executing programs (CQ 0)
 
-# Create the event for signalling when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
-first_op_event = ttnn.create_event(device)
-# Create the event for when input write is completed. This is used to signal that the input tensor can be read/consumed
-write_event = ttnn.create_event(device)
-# Create the event for signalling when the last operation is completed. This is the producer of the otuput tensor so once this is completed, we can issue the next read
-last_op_event = ttnn.create_event(device)
-# Create the event for when output read is completed. This is used to signal that the output tensor can be overwritten
-read_event = ttnn.create_event(device)
+# `first_op_event` signals when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
+
+# `write_event` signals when input write is completed. This is used to signal that the input tensor can be read/consumed
+
+# `last_op_event` signals when the last operation is completed. This is the producer of the otuput tensor so once this is completed, we can issue the next read
 
 # Allocate our persistent input tensor
 input_dram_tensor = ttnn.allocate_tensor_on_device(input_shape, input_dtype, input_layout, device, input_sharded_dram_mem_config)
@@ -269,9 +262,9 @@ input_dram_tensor = ttnn.allocate_tensor_on_device(input_shape, input_dtype, inp
 output_dram_tensor = ttnn.allocate_tensor_on_device(output_shape, output_dtype, output_layout, device, output_sharded_dram_mem_config)
 
 # Dummy record an op event on CQ 0 since we wait on this first in the loop
-ttnn.record_event(0, first_op_event)
+first_op_event = ttnn.record_event(device, 0)
 # Dummy record a read event on CQ 1 since we wait on this first in the loop
-ttnn.record_event(1, read_event)
+read_event = ttnn.record_event(device, 1)
 
 outputs = []
 
@@ -280,7 +273,7 @@ ttnn.wait_for_event(1, first_op_event)
 # Write the next input tensor on CQ 1
 ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
 # Signal that the write has finished on CQ 1
-ttnn.record_event(1, write_event)
+write_event = ttnn.record_event(device, 1)
 
 for iter in range(0, 2):
     # Make CQ 0 stall until CQ 1 has signalled that the write has finished
@@ -288,7 +281,7 @@ for iter in range(0, 2):
     # Run the first operation of the model on CQ 0
     input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, sharded_l1_mem_config)
     # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-    ttnn.record_event(0, first_op_event)
+    first_op_event = ttnn.record_event(device, 0)
     # Run the rest of the model and issue output readback on the default CQ (0)
     output_tensor = run_model(input_l1_tensor)
     # Make CQ 0 stall until CQ 1 has signalled that the read has finished
@@ -296,27 +289,27 @@ for iter in range(0, 2):
     # Run the last operation of the model on CQ 0
     output_dram_tensor = ttnn.reshard(output_tensor, output_sharded_dram_mem_config, output_dram_tensor)
     # Signal that the model has finished on CQ 0
-    ttnn.record_event(0, last_op_event)
+    last_op_event = ttnn.record_event(device, 0)
 
     # Stall CQ 1 for the input tensor consumer (CQ 0) to signal it has finished so we can start overwriting the previous input tensor with the new one
     ttnn.wait_for_event(1, first_op_event)
     # Write the next input tensor on CQ 1
     ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
     # Signal that the write has finished on CQ 1
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
 
     # Make CQ 1 stall until CQ 0 has signalled that the model has finished
     ttnn.wait_for_event(1, last_op_event)
     outputs.append(output_dram_tensor.cpu(blocking=False, cq_id=1))
     # Signal that the read has finished on CQ 1
-    ttnn.record_event(1, read_event)
+    read_event = ttnn.record_event(device, 1)
 
 # Make CQ 0 stall until CQ 1 has signalled that the write has finished
 ttnn.wait_for_event(0, write_event)
 # Run the first operation of the model on CQ 0
 input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, sharded_l1_mem_config)
 # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-ttnn.record_event(0, first_op_event)
+first_op_event = ttnn.record_event(device, 0)
 # Run the rest of the model and issue output readback on the default CQ (0)
 output_tensor = run_model(input_l1_tensor)
 # Make CQ 0 stall until CQ 1 has signalled that the read has finished
@@ -324,13 +317,13 @@ ttnn.wait_for_event(0, read_event)
 # Run the last operation of the model on CQ 0
 output_dram_tensor = ttnn.reshard(output_tensor, output_sharded_dram_mem_config, output_dram_tensor)
 # Signal that the model has finished on CQ 0
-ttnn.record_event(0, last_op_event)
+last_op_event = ttnn.record_event(device, 0)
 
 # Make CQ 1 stall until CQ 0 has signalled that the model has finished
 ttnn.wait_for_event(1, last_op_event)
 outputs.append(output_dram_tensor.cpu(blocking=False, cq_id=1))
 # Signal that the read has finished on CQ 1
-ttnn.record_event(1, read_event)
+read_event = ttnn.record_event(device, 1)
 
 # Final synchronize to wait for all outputs to be read to host since we used non-blocking reads
 ttnn.synchronize_device(device)
@@ -365,16 +358,15 @@ We use a persistent DRAM tensor to write our input, and we make the input to our
 ```py
 # This example uses 1 CQ for only writing inputs (CQ 1), and one CQ for executing programs/reading back the output (CQ 0)
 
-# Create the event for signalling when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
-op_event = ttnn.create_event(device)
-# Create the event for when input write is completed. This is used to signal that the input tensor can be read/consumed
-write_event = ttnn.create_event(device)
+# `op_event` signals when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
+
+# `write_event` signals when input write is completed. This is used to signal that the input tensor can be read/consumed
 
 # Allocate our persistent input tensor
 input_dram_tensor = ttnn.allocate_tensor_on_device(shape, dtype, layout, device, sharded_dram_mem_config)
 
 # Dummy record an op event on CQ 0 since we wait on this first in the loop
-ttnn.record_event(0, op_event)
+op_event = ttnn.record_event(device, 0)
 
 # First run to compile the model
 # Stall CQ 1 for the input tensor consumer (CQ 0) to signal it has finished so we can start overwriting the previous input tensor with the new one
@@ -382,23 +374,23 @@ ttnn.wait_for_event(1, op_event)
 # Write the next input tensor on CQ 1
 ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
 # Signal that the write has finished on CQ 1
-ttnn.record_event(1, write_event)
+write_event = ttnn.record_event(device, 1)
 # Make CQ 0 stall until CQ 1 has signalled that the write has finished
 ttnn.wait_for_event(0, write_event)
 # Run the first operation of the model on CQ 0
 input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, sharded_l1_mem_config)
 # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-ttnn.record_event(0, op_event)
+op_event = ttnn.record_event(device, 0)
 # Run the rest of the model and issue output readback on the default CQ (0)
 output_tensor = run_model(input_l1_tensor)
 
 # Capture the trace of the model
 ttnn.wait_for_event(1, op_event)
 ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
-ttnn.record_event(1, write_event)
+write_event = ttnn.record_event(device, 1)
 ttnn.wait_for_event(0, write_event)
 input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, sharded_l1_mem_config)
-ttnn.record_event(0, op_event)
+op_event = ttnn.record_event(device, 0)
 # Record the address of the input tensor to trace so that we can validate we allocated our input tensor at the right address
 input_trace_addr = input_l1_tensor.buffer_address()
 spec = input_l1_tensor.spec
@@ -422,14 +414,14 @@ for iter in range(0, 2):
     # Write the next input tensor on CQ 1
     ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
     # Signal that the write has finished on CQ 1
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
     # Make CQ 0 stall until CQ 1 has signalled that the write has finished
     ttnn.wait_for_event(0, write_event)
     # Run the first operation of the model on CQ 0
     # Note here that we are writing to our persisent input tensor in place to reuse the address
     input_l1_tensor = ttnn.reshard(input_dram_tensor, sharded_l1_mem_config, input_l1_tensor)
     # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-    ttnn.record_event(0, op_event)
+    op_event = ttnn.record_event(device, 0)
     # Run the rest of the model and issue output readback on the default CQ (0)
     ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
     outputs.append(output_tensor.cpu(blocking=False))
@@ -447,22 +439,21 @@ We also use a persistent DRAM tensor to write/read our output.
 ```py
 # This example uses 1 CQ for writing inputs and reading outputs (CQ 1), and one CQ for executing programs (CQ 0)
 
-# Create the event for signalling when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
-first_op_event = ttnn.create_event(device)
-# Create the event for when input write is completed. This is used to signal that the input tensor can be read/consumed
-write_event = ttnn.create_event(device)
-# Create the event for signalling when the last operation is completed. This is the producer of the otuput tensor so once this is completed, we can issue the next read
-last_op_event = ttnn.create_event(device)
-# Create the event for when output read is completed. This is used to signal that the output tensor can be overwritten
-read_event = ttnn.create_event(device)
+# `first_op_event` signals when the first operation is completed. This is the consumer of the input tensor so once this is completed, we can issue the next write
+
+# `write_event` signals when input write is completed. This is used to signal that the input tensor can be read/consumed
+
+# `last_op_event` signals when the last operation is completed. This is the producer of the otuput tensor so once this is completed, we can issue the next read
+
+# `read_event` signals when output read is completed. This is used to signal that the output tensor can be overwritten
 
 # Allocate our persistent input tensor
 input_dram_tensor = ttnn.allocate_tensor_on_device(shape, dtype, layout, device, sharded_dram_mem_config)
 
 # Dummy record an op event on CQ 0 since we wait on this first in the loop
-ttnn.record_event(0, first_op_event)
+first_op_event = ttnn.record_event(device, 0)
 # Dummy record a read event on CQ 1 since we wait on this first in the loop
-ttnn.record_event(1, read_event)
+read_event = ttnn.record_event(device, 1)
 
 # First run to compile the model
 # Stall CQ 1 for the input tensor consumer (CQ 0) to signal it has finished so we can start overwriting the previous input tensor with the new one
@@ -470,13 +461,13 @@ ttnn.wait_for_event(1, first_op_event)
 # Write the next input tensor on CQ 1
 ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
 # Signal that the write has finished on CQ 1
-ttnn.record_event(1, write_event)
+write_event = ttnn.record_event(device, 1)
 # Make CQ 0 stall until CQ 1 has signalled that the write has finished
 ttnn.wait_for_event(0, write_event)
 # Run the first operation of the model on CQ 0
 input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, input_sharded_l1_mem_config)
 # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-ttnn.record_event(0, first_op_event)
+first_op_event = ttnn.record_event(device, 0)
 # Run the rest of the model on the default CQ (0)
 output_tensor = run_model(input_l1_tensor)
 # Make CQ 0 stall until CQ 1 has signalled that the read has finished
@@ -484,15 +475,15 @@ ttnn.wait_for_event(0, read_event)
 # Run the last operation of the model on CQ 0
 output_dram_tensor = ttnn.reshard(output_tensor, output_sharded_dram_mem_config)
 # Signal that the model has finished on CQ 0
-ttnn.record_event(0, last_op_event)
+last_op_event = ttnn.record_event(device, 0)
 
 # Capture the trace of the model
 ttnn.wait_for_event(1, op_event)
 ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
-ttnn.record_event(1, write_event)
+write_event = ttnn.record_event(device, 1)
 ttnn.wait_for_event(0, write_event)
 input_l1_tensor = ttnn.to_memory_config(input_dram_tensor, sharded_l1_mem_config)
-ttnn.record_event(0, op_event)
+op_event = ttnn.record_event(device, 0)
 # Record the address of the input tensor to trace so that we can validate we allocated our input tensor at the right address
 input_trace_addr = input_l1_tensor.buffer_address()
 spec = input_l1_tensor.spec
@@ -515,7 +506,7 @@ ttnn.wait_for_event(1, first_op_event)
 # Write the next input tensor on CQ 1
 ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
 # Signal that the write has finished on CQ 1
-ttnn.record_event(1, write_event)
+write_event = ttnn.record_event(device, 1)
 
 for iter in range(0, 2):
     # Make CQ 0 stall until CQ 1 has signalled that the write has finished
@@ -524,7 +515,7 @@ for iter in range(0, 2):
     # Note here that we are writing to our persisent input tensor in place to reuse the address
     input_l1_tensor = ttnn.reshard(input_dram_tensor, sharded_l1_mem_config, input_l1_tensor)
     # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-    ttnn.record_event(0, first_op_event)
+    first_op_event = ttnn.record_event(device, 0)
     # Run the rest of the model on the default CQ (0)
     ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
     # Make CQ 0 stall until CQ 1 has signalled that the read has finished
@@ -532,20 +523,20 @@ for iter in range(0, 2):
     # Run the last operation of the model on CQ 0
     output_dram_tensor = ttnn.reshard(output_tensor, output_sharded_dram_mem_config, output_dram_tensor)
     # Signal that the model has finished on CQ 0
-    ttnn.record_event(0, last_op_event)
+    last_op_event = ttnn.record_event(device, 0)
 
     # Stall CQ 1 for the input tensor consumer (CQ 0) to signal it has finished so we can start overwriting the previous input tensor with the new one
     ttnn.wait_for_event(1, first_op_event)
     # Write the next input tensor on CQ 1
     ttnn.copy_host_to_device_tensor(host_tensor, input_dram_tensor, cq_id=1)
     # Signal that the write has finished on CQ 1
-    ttnn.record_event(1, write_event)
+    write_event = ttnn.record_event(device, 1)
 
     # Make CQ 1 stall until CQ 0 has signalled that the model has finished
     ttnn.wait_for_event(1, last_op_event)
     outputs.append(output_dram_tensor.cpu(blocking=False, cq_id=1))
     # Signal that the read has finished on CQ 1
-    ttnn.record_event(1, read_event)
+    read_event = ttnn.record_event(device, 1)
 
 # Make CQ 0 stall until CQ 1 has signalled that the write has finished
 ttnn.wait_for_event(0, write_event)
@@ -553,7 +544,7 @@ ttnn.wait_for_event(0, write_event)
 # Note here that we are writing to our persisent input tensor in place to reuse the address
 input_l1_tensor = ttnn.reshard(input_dram_tensor, sharded_l1_mem_config, input_l1_tensor)
 # Signal to the producer (CQ 1) that CQ 0 is finished with the input and it can be overwritten
-ttnn.record_event(0, first_op_event)
+first_op_event = ttnn.record_event(device, 0)
 # Run the rest of the model on the default CQ (0)
 ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
 # Make CQ 0 stall until CQ 1 has signalled that the read has finished
@@ -561,13 +552,13 @@ ttnn.wait_for_event(0, read_event)
 # Run the last operation of the model on CQ 0
 output_dram_tensor = ttnn.reshard(output_tensor, output_sharded_dram_mem_config, output_dram_tensor)
 # Signal that the model has finished on CQ 0
-ttnn.record_event(0, last_op_event)
+last_op_event = ttnn.record_event(device, 0)
 
 # Make CQ 1 stall until CQ 0 has signalled that the model has finished
 ttnn.wait_for_event(1, last_op_event)
 outputs.append(output_dram_tensor.cpu(blocking=False, cq_id=1))
 # Signal that the read has finished on CQ 1
-ttnn.record_event(1, read_event)
+read_event = ttnn.record_event(device, 1)
 
 # Final synchronize to wait for all outputs to be read to host since we used non-blocking reads
 ttnn.synchronize_device(device)

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -36,9 +36,6 @@ def test_multi_device_events(t3k_mesh_device, shape):
         return ttnn.neg(ttnn.add(ttnn.mul(input_1, ttnn.neg(ttnn.gelu(input_0))), ttnn.relu(input_1)))
 
     for i in range(10):
-        # Create events to synchronize data movement with workload execution.
-        write_event = ttnn.create_event(t3k_mesh_device)
-        workload_event = ttnn.create_event(t3k_mesh_device)
         # Create torch inputs, for validation
         torch_input_tensor_0 = torch.rand(
             (t3k_mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -66,13 +63,13 @@ def test_multi_device_events(t3k_mesh_device, shape):
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
         # Wait for write to be completed before issuing workload
-        ttnn.record_event(data_movement_cq, write_event)
+        write_event = ttnn.record_event(t3k_mesh_device, data_movement_cq)
         ttnn.wait_for_event(workload_cq, write_event)
         logger.info("Execute Workload")
         # Execute workload
         ttnn_output = run_op_chain(input_0_dev, input_1_dev, workload_cq)
         # Wait for workload to be completed before issuing read
-        ttnn.record_event(workload_cq, workload_event)
+        workload_event = ttnn.record_event(t3k_mesh_device, workload_cq)
         ttnn.wait_for_event(data_movement_cq, workload_event)
         logger.info("Read Back Workload Outputs")
         # Read device outputs and validate

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -45,15 +45,15 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
         trace_cq = 0
         data_movement_cq = 1
 
-        def event_sync(event, record_cq, wait_cq):
-            ttnn.record_event(record_cq, event)
+        def event_sync(device, record_cq, wait_cq):
+            event = ttnn.record_event(device, record_cq)
             ttnn.wait_for_event(wait_cq, event)
 
     else:
         trace_cq = 0
         data_movement_cq = 0
 
-        def event_sync(event, record_cq, wait_cq):
+        def event_sync(device, record_cq, wait_cq):
             pass
 
     # Compile program binaries
@@ -68,8 +68,6 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
     logger.info("Done Trace Capture")
 
     for i in range(NUM_TRACE_LOOPS):
-        write_event = ttnn.create_event(t3k_mesh_device)
-        trace_event = ttnn.create_event(t3k_mesh_device)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (t3k_mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -96,11 +94,11 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
         logger.info("Send Inputs to Device")
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
-        event_sync(write_event, data_movement_cq, trace_cq)
+        event_sync(t3k_mesh_device, data_movement_cq, trace_cq)
         logger.info("Execute Trace")
         # Execute trace
         ttnn.execute_trace(t3k_mesh_device, tid, cq_id=trace_cq, blocking=False)
-        event_sync(trace_event, trace_cq, data_movement_cq)
+        event_sync(t3k_mesh_device, trace_cq, data_movement_cq)
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
             logger.info("Read Back Trace Outputs with All Gather")
@@ -173,15 +171,15 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
         trace_cq = 0
         data_movement_cq = 1
 
-        def event_sync(event, record_cq, wait_cq):
-            ttnn.record_event(record_cq, event)
+        def event_sync(device, record_cq, wait_cq):
+            event = ttnn.record_event(device, record_cq)
             ttnn.wait_for_event(wait_cq, event)
 
     else:
         trace_cq = 0
         data_movement_cq = 0
 
-        def event_sync(event, record_cq, wait_cq):
+        def event_sync(device, record_cq, wait_cq):
             pass
 
     # Compile program binaries
@@ -216,8 +214,6 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
         num_trace_loops = 5
 
     for i in range(num_trace_loops):
-        write_event = ttnn.create_event(t3k_mesh_device)
-        trace_event = ttnn.create_event(t3k_mesh_device)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (t3k_mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -258,7 +254,7 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_weight, weight_dev, cq_id=data_movement_cq)
-        event_sync(write_event, data_movement_cq, trace_cq)
+        event_sync(t3k_mesh_device, data_movement_cq, trace_cq)
         # Execute trace
         logger.info("Execute Trace 0")
         ttnn.execute_trace(t3k_mesh_device, tid, cq_id=trace_cq, blocking=False)
@@ -266,7 +262,7 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
         ttnn.execute_trace(t3k_mesh_device, tid_1, cq_id=trace_cq, blocking=False)
         logger.info("Execute Trace 2")
         ttnn.execute_trace(t3k_mesh_device, tid_2, cq_id=trace_cq, blocking=False)
-        event_sync(trace_event, trace_cq, data_movement_cq)
+        event_sync(t3k_mesh_device, trace_cq, data_movement_cq)
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
             logger.info("Read Back Trace 0 Outputs")

--- a/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
@@ -41,15 +41,15 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
         trace_cq = 0
         data_movement_cq = 1
 
-        def event_sync(event, record_cq, wait_cq):
-            ttnn.record_event(record_cq, event)
+        def event_sync(device, record_cq, wait_cq):
+            event = ttnn.record_event(device, record_cq)
             ttnn.wait_for_event(wait_cq, event)
 
     else:
         trace_cq = 0
         data_movement_cq = 0
 
-        def event_sync(event, record_cq, wait_cq):
+        def event_sync(device, record_cq, wait_cq):
             pass
 
     # Compile program binaries
@@ -64,8 +64,6 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     logger.info("Done Trace Capture")
 
     for i in range(NUM_TRACE_LOOPS):
-        write_event = ttnn.create_event(mesh_device)
-        trace_event = ttnn.create_event(mesh_device)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -92,11 +90,11 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
         logger.info("Send Inputs to Device")
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
-        event_sync(write_event, data_movement_cq, trace_cq)
+        event_sync(mesh_device, data_movement_cq, trace_cq)
         logger.info("Execute Trace")
         # Execute trace
         ttnn.execute_trace(mesh_device, tid, cq_id=trace_cq, blocking=False)
-        event_sync(trace_event, trace_cq, data_movement_cq)
+        event_sync(mesh_device, trace_cq, data_movement_cq)
         # Perform host All-Gather
         logger.info("Read Back Trace Outputs")
         ttnn_torch_output_tensor = ttnn.to_torch(
@@ -151,15 +149,15 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         trace_cq = 0
         data_movement_cq = 1
 
-        def event_sync(event, record_cq, wait_cq):
-            ttnn.record_event(record_cq, event)
+        def event_sync(device, record_cq, wait_cq):
+            event = ttnn.record_event(device, record_cq)
             ttnn.wait_for_event(wait_cq, event)
 
     else:
         trace_cq = 0
         data_movement_cq = 0
 
-        def event_sync(event, record_cq, wait_cq):
+        def event_sync(device, record_cq, wait_cq):
             pass
 
     # Compile program binaries
@@ -194,8 +192,6 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         num_trace_loops = 5
 
     for i in range(num_trace_loops):
-        write_event = ttnn.create_event(mesh_device)
-        trace_event = ttnn.create_event(mesh_device)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -236,7 +232,7 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_weight, weight_dev, cq_id=data_movement_cq)
-        event_sync(write_event, data_movement_cq, trace_cq)
+        event_sync(mesh_device, data_movement_cq, trace_cq)
         # Execute trace
         logger.info("Execute Trace 0")
         ttnn.execute_trace(mesh_device, tid, cq_id=trace_cq, blocking=False)
@@ -244,7 +240,7 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         ttnn.execute_trace(mesh_device, tid_1, cq_id=trace_cq, blocking=False)
         logger.info("Execute Trace 2")
         ttnn.execute_trace(mesh_device, tid_2, cq_id=trace_cq, blocking=False)
-        event_sync(trace_event, trace_cq, data_movement_cq)
+        event_sync(mesh_device, trace_cq, data_movement_cq)
 
         # Perform host All-Gather
         logger.info("Read Back Trace 0 Outputs")

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -41,15 +41,15 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
         trace_cq = 0
         data_movement_cq = 1
 
-        def event_sync(event, record_cq, wait_cq):
-            ttnn.record_event(record_cq, event)
+        def event_sync(device, record_cq, wait_cq):
+            event = ttnn.record_event(device, record_cq)
             ttnn.wait_for_event(wait_cq, event)
 
     else:
         trace_cq = 0
         data_movement_cq = 0
 
-        def event_sync(event, record_cq, wait_cq):
+        def event_sync(device, record_cq, wait_cq):
             pass
 
     # Compile program binaries
@@ -64,8 +64,6 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     logger.info("Done Trace Capture")
 
     for i in range(NUM_TRACE_LOOPS):
-        write_event = ttnn.create_event(mesh_device)
-        trace_event = ttnn.create_event(mesh_device)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -92,11 +90,11 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
         logger.info("Send Inputs to Device")
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
-        event_sync(write_event, data_movement_cq, trace_cq)
+        event_sync(mesh_device, data_movement_cq, trace_cq)
         logger.info("Execute Trace")
         # Execute trace
         ttnn.execute_trace(mesh_device, tid, cq_id=trace_cq, blocking=False)
-        event_sync(trace_event, trace_cq, data_movement_cq)
+        event_sync(mesh_device, trace_cq, data_movement_cq)
         # Perform host All-Gather
         logger.info("Read Back Trace Outputs")
         ttnn_torch_output_tensor = ttnn.to_torch(
@@ -150,15 +148,15 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         trace_cq = 0
         data_movement_cq = 1
 
-        def event_sync(event, record_cq, wait_cq):
-            ttnn.record_event(record_cq, event)
+        def event_sync(device, record_cq, wait_cq):
+            event = ttnn.record_event(device, record_cq)
             ttnn.wait_for_event(wait_cq, event)
 
     else:
         trace_cq = 0
         data_movement_cq = 0
 
-        def event_sync(event, record_cq, wait_cq):
+        def event_sync(device, record_cq, wait_cq):
             pass
 
     # Compile program binaries
@@ -193,8 +191,6 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         num_trace_loops = 5
 
     for i in range(num_trace_loops):
-        write_event = ttnn.create_event(mesh_device)
-        trace_event = ttnn.create_event(mesh_device)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (mesh_device.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -235,7 +231,7 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
         ttnn.copy_host_to_device_tensor(ttnn_weight, weight_dev, cq_id=data_movement_cq)
-        event_sync(write_event, data_movement_cq, trace_cq)
+        event_sync(mesh_device, data_movement_cq, trace_cq)
         # Execute trace
         logger.info("Execute Trace 0")
         ttnn.execute_trace(mesh_device, tid, cq_id=trace_cq, blocking=False)
@@ -243,7 +239,7 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         ttnn.execute_trace(mesh_device, tid_1, cq_id=trace_cq, blocking=False)
         logger.info("Execute Trace 2")
         ttnn.execute_trace(mesh_device, tid_2, cq_id=trace_cq, blocking=False)
-        event_sync(trace_event, trace_cq, data_movement_cq)
+        event_sync(mesh_device, trace_cq, data_movement_cq)
 
         # Perform host All-Gather
         logger.info("Read Back Trace 0 Outputs")

--- a/tests/ttnn/unit_tests/test_sub_device.py
+++ b/tests/ttnn/unit_tests/test_sub_device.py
@@ -123,12 +123,10 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     eq = torch.equal(x, y)
     assert eq
 
-    event = ttnn.create_event(device)
-
     yt2 = ttnn.interleaved_to_sharded(
         xt, grid_size, shard_size, shard_scheme, shard_orientation, output_dtype=ttnn.bfloat16
     )
-    ttnn.record_event(0, event, [ttnn.SubDeviceId(1)])
+    event = ttnn.record_event(device, 0, [ttnn.SubDeviceId(1)])
     ttnn.wait_for_event(0, event)
     y2 = ttnn.to_torch(yt2, device=device, mesh_composer=output_mesh_composer)
 

--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -27,30 +27,22 @@ void py_module_types(py::module& module) {
 void py_module(py::module& module) {
     // Single Device APIs
     module.def(
-        "create_event",
-        py::overload_cast<IDevice*>(&create_event),
-        py::arg("device"),
-        R"doc(
-            Create an Event Object on a single device.
-
-            Args:
-                device (Device): The device on which this event will be used for synchronization.
-            )doc");
-
-    module.def(
         "record_event",
-        py::overload_cast<QueueId, const std::shared_ptr<Event>&, const std::vector<SubDeviceId>&>(&record_event),
+        py::overload_cast<IDevice*, QueueId, const std::vector<SubDeviceId>&>(&record_event),
         py::arg("cq_id"),
         py::arg("event"),
         py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
-            Record the completion of commands on this CQ, preceeding this call.
+            Records the completion of commands on this CQ, preceeding this call.
 
             Args:
+                device (ttnn.IDevice*): The device on which the event is being recorded.
                 cq_id (int): The Command Queue on which event completion will be recorded.
-                event (event): The event used to record completion of preceeding commands.
                 sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to sub-devices set by set_sub_device_stall_group.
-            )doc");
+
+            Returns:
+                event: The event used to record completion of preceeding commands.
+        )doc");
 
     module.def(
         "wait_for_event",
@@ -58,7 +50,7 @@ void py_module(py::module& module) {
         py::arg("cq_id"),
         py::arg("event"),
         R"doc(
-            Insert a barrier - Make a CQ wait until an event is recorded.
+            Inserts a barrier - makes a CQ wait until an event is recorded.
 
             Args:
                 cq_id (int): The Command Queue on which the barrier is being issued.
@@ -67,29 +59,22 @@ void py_module(py::module& module) {
 
     // Multi Device APIs
     module.def(
-        "create_event",
-        py::overload_cast<MeshDevice*>(&create_event),
-        py::arg("mesh_device"),
-        R"doc(
-            Create an Event Object on a mesh of devices.
-
-            Args:
-                mesh_device (MeshDevice): The mesh on which this event will be used for synchronization.
-            )doc");
-
-    module.def(
         "record_event",
-        py::overload_cast<QueueId, const MultiDeviceEvent&, const std::vector<SubDeviceId>&>(&record_event),
+        py::overload_cast<MeshDevice*, QueueId, const std::vector<SubDeviceId>&>(&record_event),
         py::arg("cq_id"),
         py::arg("multi_device_event"),
         py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
-            Record the completion of commands on this CQ, preceeding this call.
+            Records the completion of commands on this CQ, preceeding this call.
 
             Args:
+                device (ttnn.MeshDevice*): The device on which the event is being recorded.
                 cq_id (int): The Command Queue on which event completion will be recorded.
-                event (event): The event used to record completion of preceeding commands.
-            )doc");
+                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to sub-devices set by set_sub_device_stall_group.
+
+            Returns:
+                multi_device_event: The event used to record completion of preceeding commands.
+        )doc");
 
     module.def(
         "wait_for_event",
@@ -97,16 +82,15 @@ void py_module(py::module& module) {
         py::arg("cq_id"),
         py::arg("multi_device_event"),
         R"doc(
-            Record the completion of commands on this CQ, preceeding this call.
+            Inserts a barrier - makes a CQ wait until an event is recorded.
 
             Args:
-                cq_id (int): The Command Queue on which event completion will be recorded.
-                event (event): The event used to record completion of preceeding commands.
-                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to sub-devices set by set_sub_device_stall_group.
+                cq_id (int): The Command Queue on which the barrier is being issued.
+                multi_device_event (multi_device_event): The Command Queue will stall until this event is completed.
             )doc");
 
     module.def(
-        "record_event",
+        "record_mesh_event",
         py::overload_cast<
             MeshDevice*,
             QueueId,
@@ -115,13 +99,32 @@ void py_module(py::module& module) {
         py::arg("mesh_device"),
         py::arg("cq_id"),
         py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
-        py::arg("device_range") = std::nullopt);
+        py::arg("device_range") = std::nullopt,
+        R"doc(
+            Records the completion of commands on this CQ, preceeding this call.
+
+            Args:
+                mesh_device (ttnn.MeshDevice*): The device on which the event is being recorded.
+                cq_id (int): The Command Queue on which event completion will be recorded.
+                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to sub-devices set by set_sub_device_stall_group.
+                device_range (ttnn.MeshCoordinateRange, optional): The range of devices to record completion for. Defaults to all devices.
+
+            Returns:
+                MeshEvent: The event used to record completion of preceeding commands.
+        )doc");
 
     module.def(
-        "wait_for_event",
+        "wait_for_mesh_event",
         py::overload_cast<QueueId, const MeshEvent&>(&wait_for_mesh_event),
         py::arg("cq_id"),
-        py::arg("mesh_event"));
+        py::arg("mesh_event"),
+        R"doc(
+            Inserts a barrier - makes a CQ wait until an event is recorded.
+
+            Args:
+                cq_id (int): The Command Queue on which the barrier is being issued.
+                mesh_event (MeshEvent): The Command Queue will stall until this event is completed.
+            )doc");
 }
 
 }  // namespace ttnn::events

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -19,20 +19,14 @@ using ::tt::tt_metal::EnqueueWaitForEvent;
 using ::tt::tt_metal::distributed::EnqueueRecordEventToHost;
 using ::tt::tt_metal::distributed::EnqueueWaitForEvent;
 
-std::shared_ptr<tt::tt_metal::Event> create_event(tt::tt_metal::IDevice* device) {
+std::shared_ptr<tt::tt_metal::Event> record_event(
+    tt::tt_metal::IDevice* device, QueueId cq_id, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids) {
     std::shared_ptr<tt::tt_metal::Event> event = std::make_shared<tt::tt_metal::Event>();
     event->device = device;
-    return event;
-}
-
-void record_event(
-    QueueId cq_id,
-    const std::shared_ptr<tt::tt_metal::Event>& event,
-    const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids) {
-    tt::tt_metal::IDevice* device = event->device;
     device->push_work([device, event, cq_id, sub_device_ids] {
         EnqueueRecordEvent(device->command_queue(*cq_id), event, sub_device_ids);
     });
+    return event;
 }
 
 void wait_for_event(QueueId cq_id, const std::shared_ptr<tt::tt_metal::Event>& event) {
@@ -40,23 +34,14 @@ void wait_for_event(QueueId cq_id, const std::shared_ptr<tt::tt_metal::Event>& e
     device->push_work([device, event, cq_id] { EnqueueWaitForEvent(device->command_queue(*cq_id), event); });
 }
 
-MultiDeviceEvent create_event(MeshDevice* mesh_device) {
+MultiDeviceEvent record_event(
+    MeshDevice* mesh_device, QueueId cq_id, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids) {
     MultiDeviceEvent multi_device_event;
-
     multi_device_event.events.reserve(mesh_device->get_devices().size());
     for (auto* device : mesh_device->get_devices()) {
-        multi_device_event.events.push_back(create_event(device));
+        multi_device_event.events.push_back(record_event(device, cq_id, sub_device_ids));
     }
     return multi_device_event;
-}
-
-void record_event(
-    QueueId cq_id,
-    const MultiDeviceEvent& multi_device_event,
-    const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids) {
-    for (auto& event : multi_device_event.events) {
-        record_event(cq_id, event, sub_device_ids);
-    }
 }
 
 void wait_for_event(QueueId cq_id, const MultiDeviceEvent& multi_device_event) {

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -20,20 +20,16 @@ using MeshEvent = tt::tt_metal::distributed::MeshEvent;
 namespace events {
 
 // Single Device APIs
-std::shared_ptr<tt::tt_metal::Event> create_event(tt::tt_metal::IDevice* device);
-void record_event(
-    QueueId cq_id,
-    const std::shared_ptr<tt::tt_metal::Event>& event,
-    const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids = {});
+std::shared_ptr<tt::tt_metal::Event> record_event(
+    tt::tt_metal::IDevice* device, QueueId cq_id, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids = {});
 void wait_for_event(QueueId cq_id, const std::shared_ptr<tt::tt_metal::Event>& event);
 
 // Multi Device APIs
 struct MultiDeviceEvent {
     std::vector<std::shared_ptr<tt::tt_metal::Event>> events;
 };
-MultiDeviceEvent create_event(MeshDevice* mesh_device);
-void record_event(
-    QueueId cq_id, const MultiDeviceEvent& event, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids = {});
+MultiDeviceEvent record_event(
+    MeshDevice* mesh_device, QueueId cq_id, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids = {});
 void wait_for_event(QueueId cq_id, const MultiDeviceEvent& event);
 
 MeshEvent record_mesh_event(

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -103,9 +103,10 @@ from ttnn._ttnn.multi_device import (
 
 from ttnn._ttnn.events import (
     MeshEvent,
-    create_event,
     record_event,
     wait_for_event,
+    record_mesh_event,
+    wait_for_mesh_event,
 )
 
 from ttnn._ttnn.operations.trace import (


### PR DESCRIPTION
### Ticket
#18572

### Problem description
Creating "empty" events, and relying on populating them in `record_event` is error prone, as this intermediate state of an event is unusable. Moreover, it isn't clear that `record_event` re-populates the event metadata for the entirely new event.

Current API:
```
op_event = ttnn.create_event(device)
...
# Initialize the op event so we can write
ttnn.record_event(0, op_event)
...
ttnn.wait_for_event(1, op_event)
```

This PR changes this to:
```
op_event = ttnn.record_event(device, 0)
...
ttnn.wait_for_event(1, op_event)
```

### What's changed
* Get rid of `ttnn.create_event` and rely on `ttnn.record_event` to return events with the populated metadata.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13643988015)
- [X] [Single card perf](https://github.com/tenstorrent/tt-metal/actions/runs/13645074773)
- [X] [T3K unit, demo, frequent, nightly, model perf](https://github.com/tenstorrent/tt-metal/actions/runs/13645079814) - same failures as on main
- [X] [TG/TGG  unit, frequent, model perf, nightly](https://github.com/tenstorrent/tt-metal/actions/runs/13645198301) - same failures as on main
- [X] New/Existing tests provide coverage for changes
