### PR TITLE
#18560: Add workaround for inline writes on BH by writing to L1

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/inline_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/inline_writer.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/dprint.h"
+
+void kernel_main() {
+    uint32_t dst_noc_x = get_arg_val<uint32_t>(0);
+    uint32_t dst_noc_y = get_arg_val<uint32_t>(1);
+    uint32_t dst_addr = get_arg_val<uint32_t>(2);
+    uint32_t value_to_write = get_arg_val<uint32_t>(3);
+    uint32_t num_writes = get_arg_val<uint32_t>(4);
+    uint32_t dst_addr_increment = get_arg_val<uint32_t>(5);
+
+    for (uint32_t i = 0; i < num_writes; i++) {
+        uint32_t noc_to_use;
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            noc_to_use = (i % 2) == 0 ? noc_index : 1 - noc_index;
+        } else {
+            noc_to_use = noc_index;
+        }
+
+        uint64_t dst_noc_addr = get_noc_addr(dst_noc_x, dst_noc_y, dst_addr, noc_to_use);
+        noc_inline_dw_write(dst_noc_addr, value_to_write, 0xF, noc_to_use);
+        dst_addr += dst_addr_increment;
+        value_to_write++;
+    }
+
+    noc_async_write_barrier(noc_index);
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        noc_async_write_barrier(1 - noc_index);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     // Write to stream register at `reg_addr` on core [target_noc_x, target_noc_y]
     uint32_t reg_addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
     uint64_t dest_addr = NOC_XY_ADDR(target_noc_x, target_noc_y, reg_addr);
-    noc_inline_dw_write(dest_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+    noc_inline_dw_write<true>(dest_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
 
     if (target_core_value) {
         while (target_core_value != (NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX) &

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     // Write to stream register at `reg_addr` on core [target_noc_x, target_noc_y]
     uint32_t reg_addr = STREAM_REG_ADDR(stream_id, stream_reg);
     uint64_t dest_addr = NOC_XY_ADDR(target_noc_x, target_noc_y, reg_addr);
-    noc_inline_dw_write(dest_addr, value_to_write);
+    noc_inline_dw_write<true>(dest_addr, value_to_write);
     noc_async_write_barrier();
 
     // Read back value that was written, store in L1 of this core for host to validate

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -236,7 +236,7 @@ inline void fabric_client_router_reserve(
     router_addr += direction * sizeof(uint64_t);
     // stream register to receive router buffer space available updates.
     uint64_t xy_local_addr = get_noc_addr(0);
-    noc_inline_dw_write(
+    noc_inline_dw_write<true>(
         router_addr,
         (STREAM_REG_ADDR(
             STREAM_ID_NOC_RECEIVER_BUFFER_SPACE, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX)));

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -66,7 +66,16 @@
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_NOC_ATOMIC_RET_VAL_ADDR 4
 #define MEM_L1_BARRIER 12
-#define MEM_MAILBOX_BASE 16
+// On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
+// time. If one port on the receipient has no back-pressure then the transaction will hang because there is no mechanism
+// to allow one memory port to move ahead of another. To workaround this hang, we emulate inline writes on Blackhole by
+// writing the value to be written to local L1 first and then issue a noc async write.
+#define MEM_L1_INLINE_BASE 16
+// Each noc has 16B to store value written out by inline writes.
+// Base address for each noc to store the value to be written will be `MEM_L1_INLINE_BASE + (noc_index * 16)`
+#define MEM_L1_INLINE_SIZE_PER_NOC 16
+// Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
+#define MEM_MAILBOX_BASE 48  // (MEM_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_SIZE 12640
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -98,6 +98,8 @@ FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) 
 }
 
 FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_index) {
+    // Workaround for BH inline writes does not apply here because this writes to a stream register.
+    // See comment in `noc_get_interim_inline_value_addr` for more details.
     noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
         noc_index,
         NCRISC_AT_CMD_BUF,

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -106,6 +106,8 @@ FORCE_INLINE
 void dispatch_s_noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t noc_id, uint8_t be = 0xF) {
     WAYPOINT("NWIW");
     DEBUG_SANITIZE_NOC_ADDR(noc_id, addr, 4);
+    // Workaround for BH inline writes does not apply here because this writes to a stream register.
+    // See comment in `noc_get_interim_inline_value_addr` for more details.
     noc_fast_write_dw_inline<noc_mode>(
         noc_id,
         DISPATCH_S_WR_REG_CMD_BUF,

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -382,7 +382,7 @@ public:
             eth_write_remote_reg(reg_addr, val);
         } else {
             const auto dest_addr = get_noc_addr(this->remote_x, this->remote_y, reg_addr);
-            noc_inline_dw_write(dest_addr, val);
+            noc_inline_dw_write<true>(dest_addr, val);
         }
     }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -192,7 +192,8 @@ std::vector<ll_api::memory const*> const& Kernel::binaries(uint32_t build_key) c
 }
 
 std::string DataMovementKernel::config_hash() const {
-    return fmt::format("{}", magic_enum::enum_name(this->config_.noc));
+    return fmt::format(
+        "{}_{}", magic_enum::enum_name(this->config_.noc), magic_enum::enum_name(this->config_.noc_mode));
 }
 
 // Add "eth_" to the hash to differentiate between erisc and brisc.


### PR DESCRIPTION
### Ticket
#18560 

### Problem description
We can potentially run into ND hangs when issuing  transactions that use 4 memory ports (posted atomic and inlines) while there is a lot of noc traffic. Precious PR forced all atomics to be non posted and this PR spoofs inlines by first writing the value into L1 and then issuing a noc async write. Note that this problem doesn’t apply when doing inline writes to stream registers. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13955610326)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13955619804) 
- [x] New/Existing tests provide coverage for changes
