### PR TITLE
Preserve the same default bottom_up for MeshBuffer

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -27,7 +27,7 @@ struct DeviceLocalBufferConfig {
     std::optional<ShardSpecBuffer> shard_parameters;
 
     // The direction in which memory for this buffer is allocated.
-    bool bottom_up = false;
+    std::optional<bool> bottom_up = false;
 };
 
 // Specifies MeshBuffer that is replicated across the virtual mesh.

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -27,7 +27,7 @@ struct DeviceLocalBufferConfig {
     std::optional<ShardSpecBuffer> shard_parameters;
 
     // The direction in which memory for this buffer is allocated.
-    std::optional<bool> bottom_up = false;
+    std::optional<bool> bottom_up;
 };
 
 // Specifies MeshBuffer that is replicated across the virtual mesh.


### PR DESCRIPTION
### Ticket

### Problem description
Currently Buffer is created using `optional<bool> bottom_up` which results in different default default values for DRAM and L1 cases. However, for MeshBuffer `bottom_up` defaults to `false` for all allocated buffers, which causes unnecessary inconsistency.

### What's changed
Changed `bottom_up` to `std::optional<bool>` in `DeviceLocalBufferConfig` to preserve the same behavior.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13648198204)
- [x] New/Existing tests provide coverage for changes
