### PR TITLE
Avoid Buffers outliving the MeshBuffer containing them

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -27,7 +27,7 @@ struct DeviceLocalBufferConfig {
     std::optional<ShardSpecBuffer> shard_parameters;
 
     // The direction in which memory for this buffer is allocated.
-    bool bottom_up = false;
+    std::optional<bool> bottom_up;
 };
 
 // Specifies MeshBuffer that is replicated across the virtual mesh.
@@ -98,7 +98,7 @@ public:
     const ShardedBufferConfig& global_shard_spec() const;
     const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
 
-    const std::shared_ptr<Buffer>& get_device_buffer(const MeshCoordinate& device_coord) const;
+    Buffer* get_device_buffer(const MeshCoordinate& device_coord = MeshCoordinate(0, 0)) const;
     uint32_t datum_size_bytes() const;
     Shape2D physical_shard_shape() const;
     std::pair<bool, bool> replicated_dims() const;

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -27,7 +27,7 @@ struct DeviceLocalBufferConfig {
     std::optional<ShardSpecBuffer> shard_parameters;
 
     // The direction in which memory for this buffer is allocated.
-    std::optional<bool> bottom_up;
+    bool bottom_up = false;
 };
 
 // Specifies MeshBuffer that is replicated across the virtual mesh.

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -37,12 +37,12 @@ private:
 
     // Helper functions for reading and writing individual shards
     void write_shard_to_device(
-        std::shared_ptr<Buffer>& shard_view,
+        Buffer* shard_view,
         const void* src,
         const BufferRegion& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void read_shard_from_device(
-        std::shared_ptr<Buffer>& shard_view,
+        Buffer* shard_view,
         void* dst,
         const BufferRegion& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -163,8 +163,8 @@ MeshDevice* MeshBuffer::device() const {
     return device.get();
 }
 
-const std::shared_ptr<Buffer>& MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const {
-    return buffers_.at(device_coord);
+Buffer* MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const {
+    return buffers_.at(device_coord).get();
 }
 
 DeviceAddr MeshBuffer::size() const {

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -199,10 +199,7 @@ void MeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
 }
 
 void MeshCommandQueue::write_shard_to_device(
-    std::shared_ptr<Buffer>& shard_view,
-    const void* src,
-    const BufferRegion& region,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    Buffer* shard_view, const void* src, const BufferRegion& region, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     buffer_dispatch::write_to_device_buffer(
@@ -210,10 +207,7 @@ void MeshCommandQueue::write_shard_to_device(
 }
 
 void MeshCommandQueue::read_shard_from_device(
-    std::shared_ptr<Buffer>& shard_view,
-    void* dst,
-    const BufferRegion& region,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    Buffer* shard_view, void* dst, const BufferRegion& region, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     this->drain_events_from_completion_queue();
     auto device = shard_view->device();
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -157,27 +157,6 @@ DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& 
     TT_THROW("Tensor is not a multi-device tensor");
 }
 
-Tensor get_device_tensor(const Tensor& multi_device_tensor, const int device_id) {
-    if (std::holds_alternative<tt::tt_metal::DeviceStorage>(multi_device_tensor.get_storage())) {
-        const auto& device_storage = std::get<tt::tt_metal::DeviceStorage>(multi_device_tensor.get_storage());
-
-        auto* mesh_device = multi_device_tensor.mesh_device();
-        TT_FATAL(mesh_device != nullptr, "Tensor is not a mesh tensor");
-        auto* mesh_buffer = device_storage.get_mesh_buffer();
-        auto mesh_coordinate = mesh_device->get_view().find_device(device_id);
-
-        auto device_buffer = mesh_buffer->get_device_buffer(mesh_coordinate);
-        auto tensor_spec = multi_device_tensor.get_tensor_spec();
-        return Tensor{DeviceStorage{device_buffer}, tensor_spec};
-    }
-
-    TT_THROW("User is trying to access a device tensor that is not on device.");
-}
-
-Tensor get_device_tensor(const Tensor& multi_device_tensor, const IDevice* device) {
-    return get_device_tensor(multi_device_tensor, device->id());
-}
-
 bool is_host_mesh_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST; }
 
 bool is_multi_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST; }

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -38,10 +38,6 @@ std::vector<tt::tt_metal::IDevice*> get_mapped_devices(const Tensor& tensor, Mes
 // Get the distributed tensor config from a tensor.
 tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
 
-// Given a multi-device tensor and a device, returns the tensor on the given device.
-Tensor get_device_tensor(const Tensor& multi_device_tensor, const tt::tt_metal::IDevice* device);
-Tensor get_device_tensor(const Tensor& multi_device_tensor, const int device_id);
-
 // Returns true has MultiDeviceHost/MultiDevice Storage
 bool is_host_mesh_tensor(const Tensor& tensor);
 bool is_multi_device_tensor(const Tensor& tensor);

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -373,42 +373,6 @@ void py_module(py::module& module) {
         py::arg("dispatch_core_config"));
 
     module.def("close_mesh_device", &close_mesh_device, py::arg("mesh_device"), py::kw_only());
-    module.def(
-        "get_device_tensor",
-        py::overload_cast<const Tensor&, int>(&ttnn::distributed::get_device_tensor),
-        py::arg("tensor"),
-        py::arg("device_id"),
-        py::kw_only(),
-        R"doc(
-       Get the tensor shard corresponding to the device_id.
-
-
-       Args:
-           tensor (Tensor): The tensor to get the shard from.
-           device_id (int): The device id to get the shard for.
-
-
-       Returns:
-           Tensor: The shard of the tensor corresponding to the device_id.
-   )doc");
-    module.def(
-        "get_device_tensor",
-        py::overload_cast<const Tensor&, const IDevice*>(&ttnn::distributed::get_device_tensor),
-        py::arg("tensor"),
-        py::arg("device"),
-        py::kw_only(),
-        R"doc(
-       Get the tensor shard corresponding to the device.
-
-
-       Args:
-           tensor (Tensor): The tensor to get the shard from.
-           device (Device): The device to get the shard for.
-
-
-       Returns:
-           Tensor: The shard of the tensor corresponding to the device.
-   )doc");
     module.def("get_device_tensors", &get_device_tensors, py::arg("tensor"), py::kw_only());
     module.def(
         "aggregate_as_tensor",

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -423,7 +423,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
-    auto conv_reader_indices_buffer = conv_reader_indices.value().device_buffer();
+    auto conv_reader_indices_buffer = conv_reader_indices.value().mesh_buffer();
 
     // out_subblock_h_ntiles = 8;
 
@@ -1217,7 +1217,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         CircularBufferConfig cb_for_reader_indices_config =
             CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
                 .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
-        cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer);
+        cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer->get_device_buffer());
         auto cb_for_reader_indices_id =
             tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -423,7 +423,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
-    auto conv_reader_indices_buffer = conv_reader_indices.value().mesh_buffer();
+    auto conv_reader_indices_storage = conv_reader_indices.value().device_storage();
 
     // out_subblock_h_ntiles = 8;
 
@@ -1217,7 +1217,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         CircularBufferConfig cb_for_reader_indices_config =
             CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
                 .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
-        cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer->get_device_buffer());
+        cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_storage.get_buffer());
         auto cb_for_reader_indices_id =
             tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
 
@@ -1679,7 +1679,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     auto mcast_sender_cores_vec = grid_to_cores(mcast_sender_cores.start_coord, mcast_sender_cores.end_coord, true);
     auto mcast_receiver_cores_vec = corerange_to_cores(mcast_receiver_cores, std::nullopt, true);
-    // Capture conv_reader_indices_buffer to cache this with the program
+    // Capture conv_reader_indices_storage to cache this with the program
     auto override_runtime_arguments_callback =
         [reader_kernel_id = reader_id,
          mcast_sender_cores = mcast_sender_cores_vec,
@@ -1692,7 +1692,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
          num_cores_x = num_cores_x,
          num_cores_y = num_cores_y,
          has_bias = has_bias,
-         conv_reader_indices_buffer = conv_reader_indices_buffer](
+         conv_reader_indices_storage = conv_reader_indices_storage](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -737,12 +737,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         act_block_num_tiles_split,
         act_tile_size);
 
-    auto conv_reader_indices_buffer = conv_reader_indices.value().device_buffer();
+    auto conv_reader_indices_buffer = conv_reader_indices.value().mesh_buffer();
 
     CircularBufferConfig cb_for_reader_indices_config =
         CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
             .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
-    cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer);
+    cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer->get_device_buffer());
     auto cb_for_reader_indices_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
 
     if (has_bias) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -737,12 +737,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         act_block_num_tiles_split,
         act_tile_size);
 
-    auto conv_reader_indices_buffer = conv_reader_indices.value().mesh_buffer();
+    auto conv_reader_indices_storage = conv_reader_indices.value().device_storage();
 
     CircularBufferConfig cb_for_reader_indices_config =
         CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
             .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
-    cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer->get_device_buffer());
+    cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_storage.get_buffer());
     auto cb_for_reader_indices_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
 
     if (has_bias) {
@@ -874,8 +874,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
              (uint32_t)(core_index < output_num_cores)});
     }
 
-    // Capture conv_reader_indices_buffer to cache this with the program
-    auto empty_callback = [conv_reader_indices_buffer](
+    // Capture conv_reader_indices_storage to cache this with the program
+    auto empty_callback = [conv_reader_indices_storage](
                               const void* operation,
                               tt::tt_metal::Program& program,
                               const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -22,7 +22,7 @@ bool can_deallocate(const Tensor& input_tensor) {
                 if (storage.mesh_buffer) {
                     return storage.mesh_buffer.use_count() == 1;
                 }
-                return storage.get_buffer().use_count() == 1;
+                return storage.buffer.use_count() == 1;
             } else {
                 return false;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
@@ -144,26 +144,26 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     TT_ASSERT(local_config.get_dtype() == DataType::UINT16);
     TT_ASSERT(remote_config.get_dtype() == DataType::UINT16);
 
-    auto padding_config_buffer = padding_config.device_buffer();
+    auto padding_config_buffer = padding_config.mesh_buffer();
     const uint32_t num_cores = all_cores.num_cores();
     auto padding_config_cb_config =
         CircularBufferConfig(padding_config_buffer->size() / num_cores, {{padding_config_cb_id, kernel_config_df}})
             .set_page_size(padding_config_cb_id, padding_config_buffer->page_size())
-            .set_globally_allocated_address(*padding_config_buffer);
+            .set_globally_allocated_address(*padding_config_buffer->get_device_buffer());
     CBHandle padding_config_cb = CreateCircularBuffer(program, all_cores, padding_config_cb_config);
 
-    auto local_config_buffer = local_config.device_buffer();
+    auto local_config_buffer = local_config.mesh_buffer();
     auto local_config_cb_config =
         CircularBufferConfig(local_config_buffer->size() / num_cores, {{local_config_cb_id, kernel_config_df}})
             .set_page_size(local_config_cb_id, local_config_buffer->page_size())
-            .set_globally_allocated_address(*local_config_buffer);
+            .set_globally_allocated_address(*local_config_buffer->get_device_buffer());
     CBHandle local_config_cb = CreateCircularBuffer(program, all_cores, local_config_cb_config);
 
-    auto remote_config_buffer = remote_config.device_buffer();
+    auto remote_config_buffer = remote_config.mesh_buffer();
     auto remote_config_cb_config =
         CircularBufferConfig(remote_config_buffer->size() / num_cores, {{remote_config_cb_id, kernel_config_df}})
             .set_page_size(remote_config_cb_id, remote_config_buffer->page_size())
-            .set_globally_allocated_address(*remote_config_buffer);
+            .set_globally_allocated_address(*remote_config_buffer->get_device_buffer());
     CBHandle remote_config_cb = CreateCircularBuffer(program, all_cores, remote_config_cb_config);
 
     bool const is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -88,7 +88,6 @@ Tensor tensor_reshape(
                         const auto& tensor_spec = tensor.tensor_spec();
                         auto page_size_bytes = tensor_spec.compute_page_size_bytes();
                         device_buffer->set_page_size(page_size_bytes);
-                        device_storage.insert_buffer(device_buffer);
                         return Tensor(device_storage, new_spec);
                     } else {
                         tt::tt_metal::DeviceStorage device_storage = std::get<T>(tensor.get_storage());
@@ -115,7 +114,6 @@ Tensor tensor_reshape(
                         shard_spec_buffer.set_shard_spec(shard_spec);
 
                         device_buffer->set_shard_spec(shard_spec_buffer);
-                        device_storage.insert_buffer(device_buffer);
 
                         MemoryConfig mem_config = input_tensor.memory_config();
                         mem_config.shard_spec = shard_spec;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -42,7 +42,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     // This should allocate a DRAM buffer on the device
     IDevice* device = input.device();
     tt::tt_metal::Buffer* src_dram_buffer = input.buffer();
-    auto reader_indices_buffer = reader_indices.device_buffer();
+    auto reader_indices_buffer = reader_indices.mesh_buffer();
     tt::tt_metal::Buffer* dst_dram_buffer = output.buffer();
 
     const auto input_shape = input.get_padded_shape();
@@ -152,7 +152,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         CircularBufferConfig(
             in_reader_indices_cb_npages * in_reader_indices_cb_pagesize, {{in_reader_indices_cb_id, indices_df}})
             .set_page_size(in_reader_indices_cb_id, in_reader_indices_cb_pagesize)
-            .set_globally_allocated_address(*reader_indices_buffer);
+            .set_globally_allocated_address(*reader_indices_buffer->get_device_buffer());
     auto in_reader_indices_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_reader_indices_cb_config);
 
     uint32_t in_cb_sz = 0;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -42,7 +42,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     // This should allocate a DRAM buffer on the device
     IDevice* device = input.device();
     tt::tt_metal::Buffer* src_dram_buffer = input.buffer();
-    auto reader_indices_buffer = reader_indices.mesh_buffer();
+    auto reader_indices_storage = reader_indices.device_storage();
     tt::tt_metal::Buffer* dst_dram_buffer = output.buffer();
 
     const auto input_shape = input.get_padded_shape();
@@ -152,7 +152,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         CircularBufferConfig(
             in_reader_indices_cb_npages * in_reader_indices_cb_pagesize, {{in_reader_indices_cb_id, indices_df}})
             .set_page_size(in_reader_indices_cb_id, in_reader_indices_cb_pagesize)
-            .set_globally_allocated_address(*reader_indices_buffer->get_device_buffer());
+            .set_globally_allocated_address(*reader_indices_storage.get_buffer());
     auto in_reader_indices_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_reader_indices_cb_config);
 
     uint32_t in_cb_sz = 0;
@@ -240,7 +240,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         log_debug(tt::LogOp, "in_tiled_cb :: PS = {}, NP = {}", in_tiled_cb_pagesize, in_tiled_cb_npages);
         log_debug(tt::LogOp, "out_cb :: PS = {}, NP = {}", out_cb_pagesize, out_cb_npages);
         log_debug(tt::LogOp, "in_addr: {}", src_dram_buffer->address());
-        log_debug(tt::LogOp, "in_reader_indices_addr: {}", reader_indices_buffer->address());
+        log_debug(tt::LogOp, "in_reader_indices_addr: {}", reader_indices_storage.get_buffer()->address());
         log_debug(tt::LogOp, "out_addr: {}", dst_dram_buffer->address());
         log_debug(tt::LogOp, "kernel_size_h: {}", kernel_size_h);
         log_debug(tt::LogOp, "kernel_size_w: {}", kernel_size_w);
@@ -385,7 +385,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     auto compute_kernel = CreateKernel(program, compute_kernel_fname, core_range, compute_config);
 
-    // Capture reader_indices_buffer to cache this with the program
+    // Capture reader_indices_storage to cache this with the program
     return {
         std::move(program),
         {.reader0_kernel = reader0_kernel,
@@ -394,7 +394,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
          .cb_out = cb_out,
          .ncores = ncores,
          .ncores_w = ncores_w,
-         .reader_indices_buffer = reader_indices_buffer}};
+         .reader_indices_storage = reader_indices_storage}};
 }
 
 Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -46,7 +46,7 @@ struct Pool2D {
             tt::tt_metal::CBHandle cb_out;
             uint32_t ncores;
             uint32_t ncores_w;
-            std::shared_ptr<Buffer> reader_indices_buffer;
+            std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> reader_indices_buffer;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -46,7 +46,7 @@ struct Pool2D {
             tt::tt_metal::CBHandle cb_out;
             uint32_t ncores;
             uint32_t ncores_w;
-            std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> reader_indices_buffer;
+            tt::tt_metal::DeviceStorage reader_indices_storage;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -244,12 +244,12 @@ operation::ProgramWithCallbacks upsample_multi_core(
     auto config_tensor_device = config_tensor.to_device(device, memory_config);
 
     tt::DataFormat config_df = tt::DataFormat::RawUInt16;
-    auto config_buffer = config_tensor_device.device_buffer();
+    auto config_buffer = config_tensor_device.mesh_buffer();
     auto config_buffer_page_size = config_buffer->page_size();
     uint32_t config_cb_id = CBIndex::c_6;
     auto config_cb_config = CircularBufferConfig(config_buffer_page_size, {{config_cb_id, config_df}})
                                 .set_page_size(config_cb_id, config_buffer->page_size())
-                                .set_globally_allocated_address(*config_buffer);
+                                .set_globally_allocated_address(*config_buffer->get_device_buffer());
     CBHandle config_cb = CreateCircularBuffer(program, all_cores, config_cb_config);
 
     // Kernels

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -244,12 +244,13 @@ operation::ProgramWithCallbacks upsample_multi_core(
     auto config_tensor_device = config_tensor.to_device(device, memory_config);
 
     tt::DataFormat config_df = tt::DataFormat::RawUInt16;
-    auto config_buffer = config_tensor_device.mesh_buffer();
+    auto config_storage = config_tensor_device.device_storage();
+    auto config_buffer = config_storage.get_buffer();
     auto config_buffer_page_size = config_buffer->page_size();
     uint32_t config_cb_id = CBIndex::c_6;
     auto config_cb_config = CircularBufferConfig(config_buffer_page_size, {{config_cb_id, config_df}})
                                 .set_page_size(config_cb_id, config_buffer->page_size())
-                                .set_globally_allocated_address(*config_buffer->get_device_buffer());
+                                .set_globally_allocated_address(*config_buffer);
     CBHandle config_cb = CreateCircularBuffer(program, all_cores, config_cb_config);
 
     // Kernels
@@ -310,8 +311,8 @@ operation::ProgramWithCallbacks upsample_multi_core(
         TT_THROW("Unsupported memory layout");
     }
 
-    // Capture config_buffer to cache this with the program
-    auto override_runtime_args_callback = [writer_kernel, cb_src0, out_cb, config_cb, config_buffer](
+    // Capture config_storage to cache this with the program
+    auto override_runtime_args_callback = [writer_kernel, cb_src0, out_cb, config_cb, config_storage](
                                               const void* operation,
                                               Program& program,
                                               const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -11,7 +11,7 @@ DeviceStorage::DeviceStorage(std::shared_ptr<Buffer> buffer_) { buffer = std::mo
 
 MemoryConfig DeviceStorage::memory_config() const {
     if (this->mesh_buffer.get() != nullptr) {
-        const auto& buffer = this->mesh_buffer->get_device_buffer(tt::tt_metal::distributed::MeshCoordinate(0, 0));
+        auto buffer = this->mesh_buffer->get_device_buffer(tt::tt_metal::distributed::MeshCoordinate(0, 0));
         std::optional<ShardSpec> shard_spec = std::nullopt;
 
         if (is_sharded(buffer->buffer_layout())) {
@@ -35,10 +35,10 @@ DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffe
 
 void DeviceStorage::insert_buffer(const std::shared_ptr<Buffer>& buffer_) { this->buffer = buffer_; }
 
-const std::shared_ptr<Buffer>& DeviceStorage::get_buffer() const {
+Buffer* DeviceStorage::get_buffer() const {
     if (this->mesh_buffer.get() == nullptr) {
         TT_FATAL(this->buffer != nullptr, "Buffer is not allocated");
-        return this->buffer;
+        return this->buffer.get();
     }
     return this->mesh_buffer->get_device_buffer(tt::tt_metal::distributed::MeshCoordinate(0, 0));
 }

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -11,7 +11,7 @@ DeviceStorage::DeviceStorage(std::shared_ptr<Buffer> buffer_) { buffer = std::mo
 
 MemoryConfig DeviceStorage::memory_config() const {
     if (this->mesh_buffer.get() != nullptr) {
-        auto buffer = this->mesh_buffer->get_device_buffer(tt::tt_metal::distributed::MeshCoordinate(0, 0));
+        auto buffer = this->mesh_buffer->get_device_buffer();
         std::optional<ShardSpec> shard_spec = std::nullopt;
 
         if (is_sharded(buffer->buffer_layout())) {
@@ -40,7 +40,7 @@ Buffer* DeviceStorage::get_buffer() const {
         TT_FATAL(this->buffer != nullptr, "Buffer is not allocated");
         return this->buffer.get();
     }
-    return this->mesh_buffer->get_device_buffer(tt::tt_metal::distributed::MeshCoordinate(0, 0));
+    return this->mesh_buffer->get_device_buffer();
 }
 
 bool DeviceStorage::is_allocated() const {

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -49,7 +49,7 @@ struct DeviceStorage {
 
     MemoryConfig memory_config() const;
     void insert_buffer(const std::shared_ptr<Buffer>& buffer_);
-    const std::shared_ptr<Buffer>& get_buffer() const;
+    Buffer* get_buffer() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("memory_config");
     const auto attribute_values() const { return std::make_tuple(this->memory_config()); }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -279,7 +279,7 @@ void Tensor::populate_buffers_and_metadata(const Tensor& other) {
                 if (storage.mesh_buffer != nullptr) {
                     std::get<DeviceStorage>(this->tensor_attributes->storage).mesh_buffer = storage.mesh_buffer;
                 } else {
-                    std::get<DeviceStorage>(this->tensor_attributes->storage).insert_buffer(storage.get_buffer());
+                    std::get<DeviceStorage>(this->tensor_attributes->storage).insert_buffer(storage.buffer);
                 }
             } else if constexpr (std::is_same_v<
                                      StorageType,
@@ -750,9 +750,9 @@ void memcpy(
     }
 
     if (!region.has_value()) {
-        EnqueueReadBuffer(queue, src.device_buffer(), dst, blocking);
+        EnqueueReadBuffer(queue, *src.buffer(), dst, blocking);
     } else {
-        EnqueueReadSubBuffer(queue, src.device_buffer(), dst, region.value(), blocking);
+        EnqueueReadSubBuffer(queue, *src.buffer(), dst, region.value(), blocking);
     }
 }
 
@@ -769,9 +769,9 @@ void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::option
     }
 
     if (!region.has_value()) {
-        EnqueueWriteBuffer(queue, dst.device_buffer(), src, false);
+        EnqueueWriteBuffer(queue, *dst.buffer(), src, false);
     } else {
-        EnqueueWriteSubBuffer(queue, dst.device_buffer(), src, region.value(), false);
+        EnqueueWriteSubBuffer(queue, *dst.buffer(), src, region.value(), false);
     }
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -889,7 +889,7 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id
                             async_safe_tensor.get_storage());
                         EnqueueWriteBuffer(
                             worker->command_queue(*cq_id),
-                            device_storage.get_buffer(),
+                            *device_storage.get_buffer(),
                             host_data,
                             /*blocking=*/false);
                     },

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -252,7 +252,7 @@ public:
         auto storage_type = this->storage_type();
         if (storage_type == tt::tt_metal::StorageType::DEVICE) {
             auto storage = std::get<DeviceStorage>(this->get_storage());
-            return std::vector<Buffer*>{storage.get_buffer().get()};
+            return std::vector<Buffer*>{storage.get_buffer()};
         } else {
             TT_THROW("Cannot get buffers from a tensor with non-device storage.");
         }
@@ -263,9 +263,8 @@ public:
             storage_type == tt::tt_metal::StorageType::DEVICE,
             "ttnn::Tensor::buffer(): Expected Tensor with DeviceStorage, got {}",
             storage_type);
-        return std::get<DeviceStorage>(this->get_storage()).get_buffer().get();
+        return std::get<DeviceStorage>(this->get_storage()).get_buffer();
     }
-    std::shared_ptr<Buffer> device_buffer() const { return std::get<DeviceStorage>(this->get_storage()).get_buffer(); }
 
     distributed::MeshDevice* mesh_device() const {
         if (this->mesh_device_.has_value()) {

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -265,6 +265,7 @@ public:
             storage_type);
         return std::get<DeviceStorage>(this->get_storage()).get_buffer();
     }
+    const DeviceStorage& device_storage() const { return std::get<DeviceStorage>(this->get_storage()); }
 
     distributed::MeshDevice* mesh_device() const {
         if (this->mesh_device_.has_value()) {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -177,13 +177,12 @@ std::shared_ptr<distributed::MeshBuffer> allocate_mesh_buffer_on_device(
     distributed::MeshDevice* mesh_device, const TensorSpec& tensor_spec);
 
 template <typename T>
-void read_data_from_device_buffer(
-    CommandQueue& cq, std::shared_ptr<Buffer> device_buffer, void* host_buffer_data, bool blocking) {
+void read_data_from_device_buffer(CommandQueue& cq, Buffer& device_buffer, void* host_buffer_data, bool blocking) {
     EnqueueReadBuffer(cq, device_buffer, host_buffer_data, blocking);
 }
 
 template <typename T>
-void read_data_from_device_buffer(std::shared_ptr<Buffer> device_buffer, std::vector<T>& host_buffer) {
+void read_data_from_device_buffer(Buffer& device_buffer, std::vector<T>& host_buffer) {
     ::tt::tt_metal::detail::ReadFromBuffer(device_buffer, host_buffer);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -160,7 +160,12 @@ void insert_buffer_and_shape_for_device(
                 s.insert_buffer(std::get<OwnedStorage>(shard.tensor_attributes->storage).get_buffer());
             } else if constexpr (std::is_same_v<T, DeviceStorage>) {
                 TT_FATAL(shard.storage_type() == StorageType::DEVICE, "Shard must be a device tensor");
-                s.insert_buffer(std::get<DeviceStorage>(shard.tensor_attributes->storage).get_buffer());
+                auto& shard_storage = std::get<DeviceStorage>(shard.tensor_attributes->storage);
+                if (shard_storage.mesh_buffer) {
+                    s.mesh_buffer = shard_storage.mesh_buffer;
+                } else {
+                    s.insert_buffer(shard_storage.buffer);
+                }
             } else {
                 TT_THROW("Unsupported storage in insert_buffer_and_shape_for_device");
             }

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -95,7 +95,6 @@ def manage_config(name, value):
 
 
 from ttnn._ttnn.multi_device import (
-    get_device_tensor,
     get_device_tensors,
     aggregate_as_tensor,
     get_t3k_physical_device_ids_ring,


### PR DESCRIPTION
### Ticket

### Problem description
Currently a user can get `std::shared_ptr<Buffer>` from `MeshBuffer`, which can outlive the `MeshBuffer` itself, for example if an op decides to cache it. This issue causes a hang in `test_new_conv2d.py::test_sd_conv_wh` on my branch.

### What's changed
Forbid extending Buffer lifetime by allowing to get only raw pointers to Buffer from MeshBuffer.
Remove `get_device_tensor` APIs, because they allow to create Tensors referring to a single Buffer from MeshBuffer.
Change OPs using this caching pattern to cache `DeviceStorage` instead of `shared_ptr<Buffer>`, which contains the MeshBuffer itself.
Variety of minor fixes throughout the code, adapting it to the change

### Checklist
- [ ] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13648692255)
- [x] New/Existing tests provide coverage for changes
