### PR TITLE
Added padding for non-tile multiple channels

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -53,7 +53,14 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t in_nbytes = datum_size(in_df);
     uint32_t out_nbytes = datum_size(out_df);
 
-    uint32_t in_nbytes_c = input_shape[3] / num_shards_c * in_nbytes;     // row of input (channels)
+    uint32_t in_nbytes_c;
+    // non-tile multiple is possible just if C = 16, otherwise we pad shards to 32
+    if ((input_shape[3] / num_shards_c) % tt::constants::TILE_WIDTH != 0 &&
+        (input_shape[3] / num_shards_c) > tt::constants::TILE_WIDTH) {
+        in_nbytes_c = tt::round_up(input_shape[3], num_shards_c * tt::constants::TILE_WIDTH) / num_shards_c * in_nbytes;
+    } else {
+        in_nbytes_c = input_shape[3] / num_shards_c * in_nbytes;
+    }
     uint32_t out_nbytes_c = output_shape[3] / num_shards_c * out_nbytes;  // row of output (channels)
 
     tt::DataFormat indices_df =


### PR DESCRIPTION
### Ticket
#18198
 
### Problem description
Some maxpool width sharded tests fail on blackhole because they had non-tile multiple width per shard. 

### What's changed
Shard is padded to tile multiple in those cases. Also that is applied in cases where shard width is greater than 32, because case when shard is 16 is still valid. Values less than 32 and not equal to 16 are invalid and assert will be triggered.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/13650400447
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/13652246635 https://github.com/tenstorrent/tt-metal/actions/runs/13652242921
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
