### PR TITLE
#18332: Fix BN hang for SFPU Kernel

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -17,9 +17,11 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3], [1, 2, 3, 4])),
+        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
+        *(torch.Size([n, c, 1024, 1024]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
+        torch.Size([2, 2, 4096, 4096]),
     ],
 )
 @pytest.mark.parametrize(
@@ -32,11 +34,12 @@ from models.utility_functions import skip_for_grayskull
     ],
 )
 @pytest.mark.parametrize("weight", [True, False])
+@pytest.mark.parametrize("training", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
 @pytest.mark.parametrize("momentum", [0.0, 0.1, 0.5])
 def test_batch_norm_training_fp32(
-    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training=True, testing_dtype="float32"
+    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype="float32"
 ):
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -17,11 +17,9 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
-        *(torch.Size([n, c, 1024, 1024]) for n, c in product([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8])),
-        torch.Size([2, 2, 4096, 4096]),
+        *(torch.Size([n, c, 32, 32]) for n, c in product([4, 5], [7, 8])),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([4, 5], [7, 8])),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([2, 3], [1, 2])),
     ],
 )
 @pytest.mark.parametrize(
@@ -36,9 +34,9 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("training", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
-@pytest.mark.parametrize("momentum", [0.0, 0.1, 0.5])
-def test_batch_norm_training_fp32(
+@pytest.mark.parametrize("eps", [1.0, 0.0, 1e-05])
+@pytest.mark.parametrize("momentum", [0.0, 0.1])
+def test_batch_norm_tests_fp32(
     input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype="float32"
 ):
     in_data, input_tensor = data_gen_with_range_batch_norm(
@@ -123,8 +121,8 @@ def test_batch_norm_training_fp32(
 
 
 @skip_for_grayskull("Unsupported dtype for Grayskull")
-@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
-@pytest.mark.parametrize("channel_size", [1, 2, 3, 4])
+@pytest.mark.parametrize("eps", [1.0, 1e-05])
+@pytest.mark.parametrize("channel_size", [1, 4])
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
 def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
@@ -170,9 +168,9 @@ def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3], [1, 2, 3, 4])),
+        *(torch.Size([n, c, 32, 32]) for n, c in product([3, 4], [3, 4])),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([3, 4], [3, 4])),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([2, 3], [3, 4])),
     ],
 )
 @pytest.mark.parametrize(
@@ -186,7 +184,7 @@ def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
 )
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
+@pytest.mark.parametrize("eps", [1.0, 0.0, 1e-05])
 def test_batch_norm_fp32(
     input_shapes, check_mean, check_var, weight, bias, eps, device, training=False, testing_dtype="float32"
 ):
@@ -245,9 +243,9 @@ def test_batch_norm_fp32(
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2, 3], [1, 2, 3, 4])),
+        *(torch.Size([n, c, 32, 32]) for n, c in product([3, 4], [3, 4])),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([3, 4], [3, 4])),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([2, 3], [3, 4])),
     ],
 )
 @pytest.mark.parametrize(
@@ -265,8 +263,8 @@ def test_batch_norm_fp32(
 )
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
-@pytest.mark.parametrize("momentum", [0.0, 0.1, 0.5])
+@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34])
+@pytest.mark.parametrize("momentum", [0.0, 0.5])
 def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device):
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = (

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -42,13 +42,15 @@ ALWI void batchnorm_bcast_tiles(
     for (uint32_t i = 0; i < onetile; ++i) {
         copy_tile(cb_batch_var, i, i * 2);
     }
+    add_binary_tile_init();
     copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_eps);
     for (uint32_t i = 0; i < onetile; ++i) {
         copy_tile(cb_eps, i, i * 2 + 1);
 
-        add_binary_tile_init();
         add_binary_tile(i * 2, i * 2 + 1);
-        rsqrt_tile_init();
+    }
+    rsqrt_tile_init();
+    for (uint32_t i = 0; i < onetile; ++i) {
         rsqrt_tile(i * 2);
 
         pack_tile(i * 2, cb_den);
@@ -75,20 +77,20 @@ ALWI void batchnorm_bcast_tiles(
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_other, i, i * 2);
         }
+        sub_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(cb_other, cb_bcast);
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_bcast, i, i * 2 + 1);
-            sub_binary_tile_init();
             sub_binary_tile(i * 2, i * 2 + 1);
         }
         cb_pop_front(cb_other, onetile);
 
         //(input - batch_mean)/(sqrt(batch_var + eps))
         cb_reserve_back(cb_affine_or_out, onetile);
+        mul_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_den);
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_den, i, i * 2 + 1);
-            mul_binary_tile_init();
             mul_binary_tile(i * 2, i * 2 + 1);
 
             pack_tile(i * 2, cb_affine_or_out);
@@ -106,10 +108,10 @@ ALWI void batchnorm_bcast_tiles(
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_affine_or_out, i, i * 2);
             }
+            mul_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_affine_or_out, cb_weight);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_weight, i, i * 2 + 1);
-                mul_binary_tile_init();
                 mul_binary_tile(i * 2, i * 2 + 1);
 
                 pack_tile(i * 2, cb_scaled_output);
@@ -129,10 +131,10 @@ ALWI void batchnorm_bcast_tiles(
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_tmp_1, i, i * 2);
             }
+            add_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_tmp_1, cb_bias);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_bias, i, i * 2 + 1);
-                add_binary_tile_init();
                 add_binary_tile(i * 2, i * 2 + 1);
 
                 pack_tile(i * 2, cb_output_0);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -19,7 +19,6 @@ ALWI void batchnorm_bcast_tiles(
     uint32_t cb_batch_var,
     uint32_t cb_eps,
     uint32_t cb_den,
-    uint32_t cb_num,
     uint32_t cb_weight,
     uint32_t cb_bias,
     uint32_t cb_tmp_1,
@@ -33,14 +32,43 @@ ALWI void batchnorm_bcast_tiles(
     auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
     auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
 
-    // input - batch_mean
-    cb_wait_front(cb_bcast, onetile);
+    // 1/(sqrt(batch_var + eps)) = cb_den
+    cb_reserve_back(cb_den, onetile);
+    cb_wait_front(cb_batch_var, onetile);
+
+    tile_regs_acquire();
+    tile_regs_wait();
+    copy_tile_to_dst_init_short_with_dt(cb_eps, cb_batch_var);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile(cb_batch_var, i, i * 2);
+    }
+    copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_eps);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile(cb_eps, i, i * 2 + 1);
+
+        add_binary_tile_init();
+        add_binary_tile(i * 2, i * 2 + 1);
+        rsqrt_tile_init();
+        rsqrt_tile(i * 2);
+
+        pack_tile(i * 2, cb_den);
+    }
+    tile_regs_commit();
+    tile_regs_release();
+    cb_push_back(cb_den, onetile);
+    cb_pop_front(cb_batch_var, onetile);
+
+    cb_wait_front(cb_bcast, onetile);  // input - batch_mean
+    cb_wait_front(cb_den, onetile);    // (input - batch_mean)/(sqrt(batch_var + eps)) = result
+    if (weight_has_value) {            // result = result * weight
+        cb_wait_front(cb_weight, onetile);
+    }
+    if (bias_has_value) {  // result = result + bias
+        cb_wait_front(cb_bias, onetile);
+    }
     for (uint32_t j = tile_start; j < freq; ++j) {
+        // input - batch_mean
         cb_wait_front(cb_other, onetile);
-
-        cb_reserve_back(cb_num, onetile);
-
-        sub_binary_tile_init();
         tile_regs_acquire();
         tile_regs_wait();
         copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_other);
@@ -50,77 +78,28 @@ ALWI void batchnorm_bcast_tiles(
         copy_tile_to_dst_init_short_with_dt(cb_other, cb_bcast);
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_bcast, i, i * 2 + 1);
+            sub_binary_tile_init();
             sub_binary_tile(i * 2, i * 2 + 1);
-            tile_regs_commit();
-            pack_tile(i * 2, cb_num);
         }
-        tile_regs_release();
-        cb_push_back(cb_num, onetile);
         cb_pop_front(cb_other, onetile);
-    }
-    cb_pop_front(cb_bcast, onetile);
 
-    // 1/(sqrt(batch_var + eps))
-    cb_reserve_back(cb_den, onetile);
-    cb_wait_front(cb_batch_var, onetile);
-
-    add_binary_tile_init();
-    rsqrt_tile_init();
-    copy_tile_to_dst_init_short_with_dt(cb_eps, cb_batch_var);
-    for (uint32_t i = 0; i < onetile; ++i) {
-        copy_tile(cb_batch_var, i, i * 2);
-    }
-    copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_eps);
-    for (uint32_t i = 0; i < onetile; ++i) {
-        copy_tile(cb_eps, i, i * 2 + 1);
-
-        add_binary_tile(i * 2, i * 2 + 1);
-        rsqrt_tile(i * 2);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile(i * 2, cb_den);
-    }
-    tile_regs_release();
-
-    cb_push_back(cb_den, onetile);
-    cb_pop_front(cb_batch_var, onetile);
-
-    // (input - batch_mean)/(sqrt(batch_var + eps)) = result
-    cb_wait_front(cb_den, onetile);
-    for (uint32_t j = tile_start; j < freq; ++j) {
-        cb_wait_front(cb_num, onetile);
-
+        //(input - batch_mean)/(sqrt(batch_var + eps))
         cb_reserve_back(cb_affine_or_out, onetile);
-
-        mul_binary_tile_init();
-        tile_regs_acquire();
-        tile_regs_wait();
-        copy_tile_to_dst_init_short_with_dt(cb_den, cb_num);
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_num, i, i * 2);
-        }
-        copy_tile_to_dst_init_short_with_dt(cb_num, cb_den);
+        copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_den);
         for (uint32_t i = 0; i < onetile; ++i) {
             copy_tile(cb_den, i, i * 2 + 1);
+            mul_binary_tile_init();
             mul_binary_tile(i * 2, i * 2 + 1);
-            tile_regs_commit();
+
             pack_tile(i * 2, cb_affine_or_out);
         }
+        tile_regs_commit();
         tile_regs_release();
         cb_push_back(cb_affine_or_out, onetile);
-        cb_pop_front(cb_num, onetile);
-    }
-    cb_pop_front(cb_den, onetile);
 
-    if (weight_has_value) {  // result = result * weight
-        cb_wait_front(cb_weight, onetile);
-        for (uint32_t j = tile_start; j < freq; ++j) {
+        if (weight_has_value) {  // result = result * weight
             cb_wait_front(cb_affine_or_out, onetile);
-
             cb_reserve_back(cb_scaled_output, onetile);
-
-            mul_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
             copy_tile_to_dst_init_short_with_dt(cb_weight, cb_affine_or_out);
@@ -130,25 +109,20 @@ ALWI void batchnorm_bcast_tiles(
             copy_tile_to_dst_init_short_with_dt(cb_affine_or_out, cb_weight);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_weight, i, i * 2 + 1);
+                mul_binary_tile_init();
                 mul_binary_tile(i * 2, i * 2 + 1);
-                tile_regs_commit();
+
                 pack_tile(i * 2, cb_scaled_output);
             }
+            tile_regs_commit();
             tile_regs_release();
             cb_push_back(cb_scaled_output, onetile);
             cb_pop_front(cb_affine_or_out, onetile);
         }
-        cb_pop_front(cb_weight, onetile);
-    }
 
-    if (bias_has_value) {  // result = result + bias
-        cb_wait_front(cb_bias, onetile);
-        for (uint32_t j = tile_start; j < freq; ++j) {
+        if (bias_has_value) {  // result = result + bias
             cb_wait_front(cb_tmp_1, onetile);
-
             cb_reserve_back(cb_output_0, onetile);
-
-            add_binary_tile_init();
             tile_regs_acquire();
             tile_regs_wait();
             copy_tile_to_dst_init_short_with_dt(cb_bias, cb_tmp_1);
@@ -158,14 +132,23 @@ ALWI void batchnorm_bcast_tiles(
             copy_tile_to_dst_init_short_with_dt(cb_tmp_1, cb_bias);
             for (uint32_t i = 0; i < onetile; ++i) {
                 copy_tile(cb_bias, i, i * 2 + 1);
+                add_binary_tile_init();
                 add_binary_tile(i * 2, i * 2 + 1);
-                tile_regs_commit();
+
                 pack_tile(i * 2, cb_output_0);
             }
+            tile_regs_commit();
             tile_regs_release();
             cb_push_back(cb_output_0, onetile);
             cb_pop_front(cb_tmp_1, onetile);
         }
+    }
+    cb_pop_front(cb_bcast, onetile);
+    cb_pop_front(cb_den, onetile);
+    if (weight_has_value) {
+        cb_pop_front(cb_weight, onetile);
+    }
+    if (bias_has_value) {
         cb_pop_front(cb_bias, onetile);
     }
 }
@@ -188,7 +171,6 @@ void MAIN {
     constexpr auto cb_batch_var = get_compile_time_arg_val(5);  // batch_var
     constexpr auto cb_eps = get_compile_time_arg_val(6);        // eps
     constexpr auto cb_den = get_compile_time_arg_val(7);        // 1/(sqrt(batch_var + eps))
-    constexpr auto cb_num = get_compile_time_arg_val(8);        // input - batch_mean
     constexpr auto cb_weight = get_compile_time_arg_val(9);     // weight tensor
     constexpr auto cb_tmp_1 = get_compile_time_arg_val(10);     // (input - batch_mean)/(sqrt(batch_var + eps))
     constexpr auto cb_bias = get_compile_time_arg_val(11);      // bias tensor
@@ -213,7 +195,6 @@ void MAIN {
             cb_batch_var,
             cb_eps,
             cb_den,
-            cb_num,
             cb_weight,
             cb_bias,
             cb_tmp_1,
@@ -230,7 +211,6 @@ void MAIN {
             cb_batch_var,
             cb_eps,
             cb_den,
-            cb_num,
             cb_weight,
             cb_bias,
             cb_tmp_1,


### PR DESCRIPTION
### Ticket
#18332

### Problem description
Batch norm kernel hangs for larger shapes. This was because the buffer size is set to 2. The kernel reserves `freq` number of tiles. So when this gets more than 2, there is an hang as it tries to reserve more than the size. Hence unpack and math threads got hung at the `copy_tile` call while the pack thread was stuck at `cb_reserve_back`.

### What's changed

- Reduced the number of `freq` loops in the kernel to ensure that as each tile gets reserved, they also get popped before the next tile gets reserved
- Removed `cb_num` buffer as I have rearranged the computation. As the denominator value is now computed first, the numerator result that is packed in dst tile `i*2` shall be used as such for the next computation
- Moved `tile_reg_*` APIs out of the loop to ensure they work when its more than onetile
- Updated test file as mentioned [here](https://github.com/tenstorrent/tt-metal/pull/18596#issuecomment-2699539017) 

### Checklist
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/13669874130)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13669875670) - Same as in main
- [ ] Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) -  [Link to test](https://github.com/tenstorrent/tt-metal/actions/runs/13669876707)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/13669881768)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/13669882737) 
- [x] [Single-card Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/13669883588)
