### PR TITLE
#18469: use fast_reduce_nc for ttnn.sum front dims

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -8,11 +8,27 @@
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
+#include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/operations/core/core.hpp"
 
 namespace ttnn {
 namespace operations::reduction {
+
+std::pair<ttnn::SmallVector<int>, ttnn::SmallVector<int>> split_height_width_dims(
+    const ttnn::SmallVector<int>& dim, const Tensor& input_tensor_arg) {
+    ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
+    auto input_shape = input_tensor_arg.get_logical_shape();
+    auto rank = input_shape.size();
+    for (int i = 0; i < dim.size(); i++) {
+        if (dim[i] < rank - 2) {
+            non_height_width_dims.push_back(dim[i]);
+        } else {
+            height_width_dims.push_back(dim[i]);
+        }
+    }
+    return {non_height_width_dims, height_width_dims};
+}
 
 ttnn::SmallVector<int> generate_reduce_dim(
     const Tensor& input_tensor_arg, const std::optional<std::variant<int, ttnn::SmallVector<int>>>& dim_arg) {
@@ -57,22 +73,19 @@ float get_pad_value(ReduceType reduce_type) {
                : (reduce_type == ReduceType::Min ? std::numeric_limits<float>::infinity() : 0);
 }
 
-template <ReduceType reduce_type>
-static Tensor reduce_impl(
-    const Tensor& input_tensor_arg,
-    const ttnn::SmallVector<int>& dim,
-    const bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar) {
-    using ttnn::operations::experimental::auto_format::AutoFormat;
-    auto input_shape = input_tensor_arg.get_logical_shape();
-    auto rank = input_shape.size();
-    auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
-
+Tensor adjust_shape(
+    const Tensor& tensor,
+    const Shape& input_shape,
+    bool keepdim,
+    const ttnn::SmallVector<int>& height_width_dims,
+    const ttnn::SmallVector<int>& non_height_width_dims) {
     ttnn::SmallVector<uint32_t> output_shape;
     for (int axis = 0; axis < input_shape.size(); axis++) {
-        if (std::find(dim.begin(), dim.end(), axis) != dim.end()) {
+        bool in_height_width_dims =
+            std::find(height_width_dims.begin(), height_width_dims.end(), axis) != height_width_dims.end();
+        bool in_non_height_width_dims =
+            std::find(non_height_width_dims.begin(), non_height_width_dims.end(), axis) != non_height_width_dims.end();
+        if (in_height_width_dims || in_non_height_width_dims) {
             if (keepdim) {
                 output_shape.push_back(1);
             }
@@ -81,6 +94,23 @@ static Tensor reduce_impl(
             output_shape.push_back(input_shape[axis]);
         }
     }
+    auto output_tensor = ttnn::reshape(tensor, ttnn::Shape{output_shape});
+    return output_tensor;
+}
+
+template <ReduceType reduce_type>
+static Tensor reduce_impl(
+    const Tensor& input_tensor_arg,
+    const ttnn::SmallVector<int>& dim,
+    const bool keepdim,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    float scalar,
+    const ttnn::SmallVector<int>& non_height_width_dims) {
+    using ttnn::operations::experimental::auto_format::AutoFormat;
+    auto input_shape = input_tensor_arg.get_logical_shape();
+    auto rank = input_shape.size();
+    auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
 
     Tensor output_tensor;
     float pad_value = get_pad_value(reduce_type);
@@ -105,7 +135,8 @@ static Tensor reduce_impl(
                             /*keepdim=*/true,
                             memory_config,
                             compute_kernel_config,
-                            scalar);
+                            scalar,
+                            non_height_width_dims);
                     } else {
                         output_tensor = reduce_impl<ReduceType::Sum>(
                             output_tensor,
@@ -113,7 +144,8 @@ static Tensor reduce_impl(
                             /*keepdim=*/true,
                             memory_config,
                             compute_kernel_config,
-                            scalar);
+                            scalar,
+                            non_height_width_dims);
                     }
                     if (transpose) {
                         output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
@@ -195,8 +227,7 @@ static Tensor reduce_impl(
             TT_THROW("Unsupported reduction operation");
         }
     }
-    output_tensor = ttnn::reshape(output_tensor, ttnn::Shape{output_shape});
-    return output_tensor;
+    return adjust_shape(output_tensor, input_shape, keepdim, dim, non_height_width_dims);
 }
 
 template <ReduceType reduce_type>
@@ -205,7 +236,8 @@ static Tensor std_var_impl(
     const ttnn::SmallVector<int>& dim,
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    const ttnn::SmallVector<int>& non_height_width_dims) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     auto input_shape = input_tensor_arg.get_logical_shape();
     auto rank = input_shape.size();
@@ -217,20 +249,35 @@ static Tensor std_var_impl(
     }
 
     auto mean_tensor = reduce_impl<ReduceType::Sum>(
-        input_tensor_arg, dim, keepdim, memory_config_arg, compute_kernel_config, 1.0 / reduced_volume);
+        input_tensor_arg,
+        dim,
+        keepdim,
+        memory_config_arg,
+        compute_kernel_config,
+        1.0 / reduced_volume,
+        non_height_width_dims);
     auto mean_square_tensor = reduce_impl<ReduceType::Sum>(
         ttnn::pow(input_tensor_arg, 2.0f, memory_config),
         dim,
         keepdim,
         memory_config_arg,
         compute_kernel_config,
-        1.0 / reduced_volume);
+        1.0 / reduced_volume,
+        non_height_width_dims);
     Tensor output_tensor =
         ttnn::subtract(mean_square_tensor, ttnn::pow(mean_tensor, 2.0f, memory_config), std::nullopt, memory_config);
     if constexpr (reduce_type == ReduceType::Std) {
         output_tensor = ttnn::sqrt(output_tensor, memory_config);
     }
     return output_tensor;
+}
+
+template <ReduceType reduce_type>
+bool call_fast_nc(DataType dtype) {
+    if constexpr (reduce_type != ReduceType::Sum) {
+        return false;
+    }
+    return dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B;
 }
 
 template <ReduceType reduce_type>
@@ -245,10 +292,30 @@ Tensor Reduce<reduce_type>::invoke(
     float pad_value = get_pad_value(reduce_type);
     bool is_tiled = input_tensor_arg.get_layout() == TILE_LAYOUT;
     auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
-    if constexpr (reduce_type == ReduceType::Std || reduce_type == ReduceType::Var) {
-        return std_var_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config);
+    // TODO: generalize to support all types, parameters, and formats. Issue #18566
+    ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
+    if (call_fast_nc<reduce_type>(input_tensor.get_dtype())) {
+        auto dims = split_height_width_dims(dim, input_tensor);
+        non_height_width_dims = dims.first;
+        height_width_dims = dims.second;
+
+        if (non_height_width_dims.size() > 0) {
+            auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
+            input_tensor = ttnn::experimental::reduction::fast_reduce_nc(
+                input_tensor, non_height_width_dims, std::nullopt, memory_config, compute_kernel_config);
+            if (height_width_dims.size() == 0) {
+                return adjust_shape(
+                    input_tensor, input_tensor.get_logical_shape(), keepdim, height_width_dims, non_height_width_dims);
+            }
+            dim = height_width_dims;
+        }
     }
-    return reduce_impl<reduce_type>(input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar);
+    if constexpr (reduce_type == ReduceType::Std || reduce_type == ReduceType::Var) {
+        return std_var_impl<reduce_type>(
+            input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, non_height_width_dims);
+    }
+    return reduce_impl<reduce_type>(
+        input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, non_height_width_dims);
 }
 
 Tensor pool_sum(
@@ -263,7 +330,8 @@ Tensor pool_sum(
         /*keepdim=*/true,
         memory_config_arg,
         compute_kernel_config,
-        scalar);
+        scalar,
+        /*non_height_width_dims=*/{});
 }
 
 template class Reduce<ReduceType::Sum>;


### PR DESCRIPTION
### Ticket
Link to Github Issue #18469

### Problem description
For front dimensions, sum transposes first. For some tensors, that step fails due to size expansion.

### What's changed
- call fast_reduce_nc for sum for front dimensions to avoid the transpose
- float32 and other generic reduces will be dealt with in a subsequent PR

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13663704316
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13663702918
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13657772938
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13657770545
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
