### PR TITLE
#17215: Simplify tensor distribution strategy

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2008,7 +2008,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
         device_input_tensors.push_back(t.to_device(devices[i]));
     }
     // Need to make it a mesh tensor for use with the op
-    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors, AllGatherTensor{});
+    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors);
 
     // FABRIC setup
     const bool enable_persistent_fabric = true;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -837,7 +837,7 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
         device_input_tensors.push_back(t.to_device(devices[i]));
     }
     // Need to make it a mesh tensor for use with the op
-    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors, AllGatherTensor{});
+    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors);
 
     // FABRIC setup
     const bool enable_persistent_fabric = true;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -41,8 +41,8 @@ TEST_P(MultiDeviceTensorCreationTest, Empty) {
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
     EXPECT_EQ(mesh_replicated_tensor.get_workers().size(), mesh_device->num_devices());
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto distribution_shape = get_distribution_shape_from_tensor(mesh_replicated_tensor);
+    EXPECT_FALSE(distribution_shape.has_value());
 }
 
 TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
@@ -71,8 +71,8 @@ TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
     EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(mesh_device->num_devices()));
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto distribution_shape = get_distribution_shape_from_tensor(mesh_replicated_tensor);
+    EXPECT_FALSE(distribution_shape.has_value());
 }
 
 TEST_P(MultiDeviceTensorCreationTest, Full) {
@@ -93,8 +93,8 @@ TEST_P(MultiDeviceTensorCreationTest, Full) {
     EXPECT_EQ(mesh_replicated_tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(mesh_replicated_tensor.layout(), Layout::ROW_MAJOR);
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto distribution_shape = get_distribution_shape_from_tensor(mesh_replicated_tensor);
+    EXPECT_FALSE(distribution_shape.has_value());
 }
 
 TEST_P(MultiDeviceTensorCreationTest, FullLike) {
@@ -127,8 +127,8 @@ TEST_P(MultiDeviceTensorCreationTest, FullLike) {
     EXPECT_EQ(mesh_replicated_tensor.dtype(), tensor.dtype());
     EXPECT_EQ(mesh_replicated_tensor.layout(), tensor.layout());
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto distribution_shape = get_distribution_shape_from_tensor(mesh_replicated_tensor);
+    EXPECT_FALSE(distribution_shape.has_value());
 }
 
 TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
@@ -170,8 +170,8 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
     EXPECT_EQ(mesh_replicated_tensor.dtype(), tensor.dtype());
     EXPECT_EQ(mesh_replicated_tensor.layout(), tensor.layout());
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto distribution_shape = get_distribution_shape_from_tensor(mesh_replicated_tensor);
+    EXPECT_FALSE(distribution_shape.has_value());
 }
 
 TEST_P(MultiDeviceTensorCreationTest, Arange) {
@@ -189,8 +189,8 @@ TEST_P(MultiDeviceTensorCreationTest, Arange) {
     EXPECT_EQ(tensor.get_workers().size(), mesh_device->num_devices());
     EXPECT_EQ(tensor.logical_shape(), ttnn::Shape({1, 1, 1, 1024}));
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto distribution_shape = get_distribution_shape_from_tensor(tensor);
+    EXPECT_FALSE(distribution_shape.has_value());
 }
 
 INSTANTIATE_TEST_SUITE_P(AllTests, MultiDeviceTensorCreationTest, ::testing::Bool());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -86,7 +86,7 @@ TEST_F(MeshTensorDeviceTest, ReplicateHostTensor) {
     for (const auto& [_, shard_spec] : multi_device_storage->specs) {
         EXPECT_EQ(shard_spec.logical_shape(), shape);
     }
-    EXPECT_TRUE(std::holds_alternative<tt::tt_metal::ReplicateTensor>(multi_device_storage->strategy));
+    EXPECT_FALSE(multi_device_storage->distribution_shape.has_value());
 
     // Read the tensor back, and compare it with input data.
     Tensor output_host_tensor = tensor_impl::to_host_mesh_tensor_wrapper(device_tensor);
@@ -118,9 +118,7 @@ TEST_F(MeshTensorDeviceTest, WriteMultiDeviceHostTensor) {
     auto* multi_device_host_storage =
         std::get_if<tt::tt_metal::MultiDeviceHostStorage>(&input_host_tensor_sharded.get_storage());
     ASSERT_NE(multi_device_host_storage, nullptr);
-    const auto* strategy = std::get_if<tt::tt_metal::ShardTensor>(&multi_device_host_storage->strategy);
-    ASSERT_NE(strategy, nullptr);
-    EXPECT_EQ(strategy->shard_dimension, 1);
+    EXPECT_FALSE(multi_device_host_storage->distribution_shape.has_value());
 
     // Write host tensor to device.
     Tensor device_tensor =
@@ -129,9 +127,7 @@ TEST_F(MeshTensorDeviceTest, WriteMultiDeviceHostTensor) {
 
     auto* multi_device_storage = std::get_if<tt::tt_metal::MultiDeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(multi_device_storage, nullptr);
-    const auto* device_tensor_strategy = std::get_if<tt::tt_metal::ShardTensor>(&multi_device_storage->strategy);
-    ASSERT_NE(device_tensor_strategy, nullptr);
-    EXPECT_EQ(device_tensor_strategy->shard_dimension, 1);
+    EXPECT_FALSE(multi_device_storage->distribution_shape.has_value());
 
     // Read the tensor back, and compare it with input data.
     Tensor output_host_tensor = aggregate_tensor(

--- a/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn_test_fixtures.hpp"
 #include "ttnn/cpp/ttnn/tensor/types.hpp"
 #include "ttnn/cpp/ttnn/operations/creation.hpp"
@@ -11,34 +12,38 @@ namespace ttnn::distributed::test {
 
 using namespace tt::tt_metal;
 
-Tensor create_host_multi_device_tensor(const Tensor& tensor, const ReplicateTensor& strategy) {
+Tensor create_host_multi_device_tensor(
+    const Tensor& tensor, int replication_factor, const std::optional<MeshShape>& distribution_shape) {
     std::vector<OwnedBuffer> owned_buffers;
     std::vector<ttnn::TensorSpec> specs;
 
-    for (int i = 0; i < strategy.replication_factor; i++) {
+    for (int i = 0; i < replication_factor; i++) {
         owned_buffers.push_back(std::get<OwnedStorage>(tensor.get_storage()).buffer);
         specs.push_back(tensor.get_tensor_spec());
     }
 
-    return Tensor{MultiDeviceHostStorage(strategy, owned_buffers, specs), tensor.get_tensor_spec()};
+    return Tensor{MultiDeviceHostStorage(distribution_shape, owned_buffers, specs), tensor.get_tensor_spec()};
 }
 
 TEST_F(T3kMultiDeviceFixture, TestGetTensorsFromMultiDeviceStorage) {
     MeshDevice* mesh_device = this->mesh_device_.get();
     const auto input_tensor = ttnn::ones(ttnn::Shape({32, 32}), DataType::BFLOAT16);
-    const auto replicated_tensor = create_host_multi_device_tensor(input_tensor, ReplicateTensor(8));
+    const auto replicated_tensor =
+        create_host_multi_device_tensor(input_tensor, /*replication_factor=*/8, std::nullopt);
     const auto device_tensors = get_tensors_from_multi_device_storage(replicated_tensor);
 
     EXPECT_EQ(device_tensors.size(), 8);
 }
 
-TEST_F(T3kMultiDeviceFixture, TestGetDistributedTensorConfigFromMultiDeviceStorage) {
+TEST_F(T3kMultiDeviceFixture, TestGetDistributionShapeFromMultiDeviceStorage) {
     MeshDevice* mesh_device = this->mesh_device_.get();
     const auto input_tensor = ttnn::ones(ttnn::Shape({32, 32}), DataType::BFLOAT16);
-    const auto replicated_tensor = create_host_multi_device_tensor(input_tensor, ReplicateTensor(8));
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(replicated_tensor);
+    const auto replicated_tensor =
+        create_host_multi_device_tensor(input_tensor, /*replication_factor=*/8, MeshShape(1, 8));
 
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    const auto shape = get_distribution_shape_from_tensor(replicated_tensor);
+    ASSERT_TRUE(shape.has_value());
+    EXPECT_EQ(*shape, MeshShape(1, 8));
 }
 
 }  // namespace ttnn::distributed::test

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -153,9 +153,9 @@ template <class T, ttnn::DataType TensorType>
         host_owned_specs.push_back(ttnn::TensorSpec(
             shape, ttnn::TensorLayout(TensorType, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), ttnn::MemoryConfig{})));
     }
-    auto distributed_tensor_config = tt::tt_metal::get_distributed_tensor_config(config);
-    auto storage = tt::tt_metal::MultiDeviceHostStorage(
-        distributed_tensor_config, std::move(host_owned_buffers), host_owned_specs);
+    auto distribution_shape = tt::tt_metal::get_distribution_shape(config);
+    auto storage =
+        tt::tt_metal::MultiDeviceHostStorage(distribution_shape, std::move(host_owned_buffers), host_owned_specs);
 
     // remove possible paddings from the shape (it conflicts with ROW MAJOR)
     auto output = ttnn::Tensor(std::move(storage), host_owned_specs[0]);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -96,7 +96,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
         scattered_tensors.push_back(sliced_tensor);
     }
     auto distributed_tensor = ttnn::distributed::create_multi_device_tensor(
-        scattered_tensors, ttnn::StorageType::MULTI_DEVICE, storage.strategy);
+        scattered_tensors, ttnn::StorageType::MULTI_DEVICE, storage.distribution_shape);
     return distributed_tensor;
 }
 

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -354,8 +354,8 @@ Tensor convert_python_tensors_to_tt_tensors(
         host_owned_buffers.push_back(std::get<OwnedStorage>(shard.get_storage()).buffer);
         host_owned_specs.push_back(shard.get_tensor_spec());
     }
-    auto distributed_tensor_config = get_distributed_tensor_config(strategy);
-    auto storage = MultiDeviceHostStorage{distributed_tensor_config, std::move(host_owned_buffers), host_owned_specs};
+    auto storage =
+        MultiDeviceHostStorage{get_distribution_shape(strategy), std::move(host_owned_buffers), host_owned_specs};
 
     auto output = Tensor(std::move(storage), tt_shards.at(0).get_tensor_spec());
     output = tt::tt_metal::set_tensor_id(output);

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -368,7 +368,7 @@ typename device_operation_t::tensor_args_t get_shard_tensor_args(std::size_t ind
 }
 
 static Tensor make_tensor_return_value_from_shards(auto& old_storage, std::vector<Tensor>& output_shards) {
-    return distributed::create_multi_device_tensor(output_shards, StorageType::MULTI_DEVICE, old_storage.strategy);
+    return distributed::create_multi_device_tensor(output_shards, StorageType::MULTI_DEVICE, old_storage.distribution_shape);
 }
 
 static std::vector<Tensor> make_tensor_return_value_from_shards(auto& old_storage,  std::vector<std::vector<Tensor>>& output_shards) {

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -28,7 +28,8 @@ std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);
 
 // Given a list of per-device shards, returns multi-device tensor.
 Tensor aggregate_as_tensor(
-    const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config);
+    const std::vector<Tensor>& tensor_shards,
+    const std::optional<distributed::MeshShape>& distribution_shape = std::nullopt);
 
 std::vector<int> get_t3k_physical_device_ids_ring();
 
@@ -36,7 +37,7 @@ std::vector<int> get_t3k_physical_device_ids_ring();
 std::vector<tt::tt_metal::IDevice*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_device);
 
 // Get the distributed tensor config from a tensor.
-tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
+std::optional<distributed::MeshShape> get_distribution_shape_from_tensor(const Tensor& tensor);
 
 // Given a multi-device tensor and a device, returns the tensor on the given device.
 Tensor get_device_tensor(const Tensor& multi_device_tensor, const tt::tt_metal::IDevice* device);
@@ -56,6 +57,6 @@ std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_de
 Tensor create_multi_device_tensor(
     const std::vector<Tensor>& tensors,
     tt::tt_metal::StorageType storage_type,
-    const tt::tt_metal::DistributedTensorConfig& strategy);
+    const std::optional<distributed::MeshShape>& distribution_shape);
 
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -412,7 +412,7 @@ void py_module(py::module& module) {
     module.def("get_device_tensors", &get_device_tensors, py::arg("tensor"), py::kw_only());
     module.def(
         "aggregate_as_tensor",
-        [](const std::vector<Tensor>& tensors) -> Tensor { return aggregate_as_tensor(tensors, AllGatherTensor{}); },
+        [](const std::vector<Tensor>& tensors) -> Tensor { return aggregate_as_tensor(tensors); },
         py::arg("tensors"),
         py::kw_only());
     module.def("get_t3k_physical_device_ids_ring", &get_t3k_physical_device_ids_ring);

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "tt-metalium/mesh_coord.hpp"
+
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/types.hpp"
 
@@ -14,7 +16,7 @@ class TensorToMesh {
 public:
     virtual ~TensorToMesh() = default;
     virtual std::vector<Tensor> map(const Tensor& tensor) const = 0;
-    virtual tt::tt_metal::DistributedTensorConfig config() const = 0;
+    virtual std::optional<MeshShape> distribution_shape() const = 0;
 };
 
 // Composer interface that aggregates a multi-device tensor into a host tensor.

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.cpp
@@ -55,4 +55,14 @@ bool operator==(const ShardTensor2D& lhs, const ShardTensor2D& rhs) {
            lhs.shard_mesh.y == rhs.shard_mesh.y;
 }
 
+std::optional<distributed::MeshShape> get_distribution_shape(
+    const std::unordered_map<std::string, std::string>& metadata) {
+    auto config = get_distributed_tensor_config(metadata);
+    if (std::holds_alternative<ShardTensor2D>(config)) {
+        auto shard_mesh = std::get<ShardTensor2D>(config);
+        return distributed::MeshShape(shard_mesh.shard_mesh.y, shard_mesh.shard_mesh.x);
+    }
+    return std::nullopt;
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
@@ -6,6 +6,9 @@
 
 #include <unordered_map>
 #include <variant>
+#include <optional>
+
+#include "tt-metalium/mesh_coord.hpp"
 
 namespace tt::tt_metal {
 
@@ -37,5 +40,8 @@ bool operator==(const AllGatherTensor&, const AllGatherTensor&);
 // DistributedTensorConfig is a variant of different ways in which a tensor can be distributed across devices.
 using DistributedTensorConfig = std::variant<ReplicateTensor, ShardTensor, ShardTensor2D, AllGatherTensor>;
 DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata);
+
+std::optional<distributed::MeshShape> get_distribution_shape(
+    const std::unordered_map<std::string, std::string>& metadata);
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -242,7 +242,12 @@ MultiDeviceHostStorage load_multi_device_host_storage(
         }
     }
 
-    return {strategy, buffers, specs};
+    std::optional<distributed::MeshShape> distribution_shape = std::nullopt;
+    if (auto* shard2d = std::get_if<ShardTensor2D>(&strategy)) {
+        distribution_shape = distributed::MeshShape(shard2d->shard_mesh.y, shard2d->shard_mesh.x);
+    }
+
+    return {distribution_shape, buffers, specs};
 }
 
 OwnedStorage load_owned_storage(FILE* input_file, DataType data_type) {

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -19,7 +19,6 @@ std::vector<std::shared_ptr<Buffer>> MultiDeviceStorage::get_buffers() const {
 
 MultiDeviceStorage::MultiDeviceStorage(
     const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_, const TensorSpec& tensor_spec) :
-    strategy(ReplicateTensor{}),
     mesh_buffer(mesh_buffer_)  //
 {
     // TODO: #17215 - In the long term, this code won't exist: no interactions will be made with individual Buffers, and

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -217,7 +217,7 @@ Tensor::Tensor(const std::vector<IDevice*>& workers) :
     }
 }
 
-Tensor::Tensor(uint32_t num_buffers, std::optional<DistributedTensorConfig> distributed_tensor_config) :
+Tensor::Tensor(uint32_t num_buffers, std::optional<distributed::MeshShape> distribution_shape) :
     tensor_attributes(std::make_shared<TensorAttributes>()) {
     if (num_buffers == 0) {
         return;
@@ -228,9 +228,7 @@ Tensor::Tensor(uint32_t num_buffers, std::optional<DistributedTensorConfig> dist
             return Storage(OwnedStorage());
         }
         MultiDeviceHostStorage storage;
-        if (distributed_tensor_config.has_value()) {
-            storage.strategy = distributed_tensor_config.value();
-        }
+        storage.distribution_shape = distribution_shape;
         storage.buffers = std::vector<OwnedBuffer>(num_buffers, OwnedBuffer());
         storage.specs = std::vector<ttnn::TensorSpec>(
             num_buffers,

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -105,8 +105,7 @@ public:
 
     // Constructors to initialize unpopulated tensor with workers and storage specified. Use this when creating tensor
     // handles in async mode.
-    explicit Tensor(
-        uint32_t num_buffers, std::optional<DistributedTensorConfig> distributed_tensor_config = std::nullopt);
+    explicit Tensor(uint32_t num_buffers, std::optional<distributed::MeshShape> distribution_shape = std::nullopt);
     explicit Tensor(const std::vector<IDevice*>& workers);
 
     Tensor(const Tensor& other);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -610,7 +610,7 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking) {
 
     mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, /*blocking=*/true);
 
-    MultiDeviceHostStorage host_storage(storage.strategy, std::move(buffers), std::move(specs));
+    MultiDeviceHostStorage host_storage(storage.distribution_shape, std::move(buffers), std::move(specs));
     return Tensor(std::move(host_storage), tensor.get_tensor_spec());
 }
 
@@ -812,7 +812,7 @@ MultiDeviceStorage shard_to_mesh_buffer(
     mesh_device->mesh_command_queue().enqueue_write_shards(mesh_buffer, shard_data_transfers, /*blocking=*/false);
 
     return MultiDeviceStorage(
-        storage.strategy, std::move(ordered_device_ids), std::move(buffers), std::move(specs), mesh_buffer);
+        storage.distribution_shape, std::move(ordered_device_ids), std::move(buffers), std::move(specs), mesh_buffer);
 }
 
 template <typename T>
@@ -1135,7 +1135,7 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
                             prev_spec.logical_shape(),
                             prev_spec.padded_shape())));
                 }
-                return MultiDeviceHostStorage{storage.strategy, output_buffers, output_specs};
+                return MultiDeviceHostStorage{storage.distribution_shape, output_buffers, output_specs};
             },
             [](const auto& s) -> RetType { TT_THROW("Unsupported storage type {}", tt::stl::get_type_name(s)); }},
         tensor.get_storage());

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -189,13 +189,13 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
             validate_worker_modes(workers),
             "All device threads/workers must be running in the same mode (ASYNC or SYNC)");
 
-        std::optional<DistributedTensorConfig> distributed_config = std::nullopt;
+        std::optional<distributed::MeshShape> distribution_shape = std::nullopt;
         if (auto* host_storage = std::get_if<MultiDeviceHostStorage>(&input_tensor.get_storage());
             host_storage != nullptr) {
-            distributed_config = host_storage->strategy;
+            distribution_shape = host_storage->distribution_shape;
         }
 
-        Tensor tensor_modified_layout = Tensor(workers.size(), distributed_config);
+        Tensor tensor_modified_layout = Tensor(workers.size(), distribution_shape);
         for (int worker_index = 0; worker_index < workers.size(); ++worker_index) {
             auto& worker = workers[worker_index];
             worker->push_work([input_tensor, tensor_modified_layout, target_layout, worker, worker_index]() mutable {

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -72,8 +72,9 @@ Tensor transform(const Tensor& tensor, std::function<Tensor(const Tensor&)> tran
     std::transform(input_tensors.begin(), input_tensors.end(), output_tensors.begin(), [&](const auto& device_tensor) {
         return transform_func(device_tensor);
     });
+
     return ttnn::distributed::create_multi_device_tensor(
-        output_tensors, tensor.storage_type(), ttnn::distributed::get_distributed_tensor_config_from_tensor(tensor));
+        output_tensors, tensor.storage_type(), ttnn::distributed::get_distribution_shape_from_tensor(tensor));
 }
 
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable) {


### PR DESCRIPTION
### Ticket
#17215

### Problem description
The purpose of `DistributedTensorConfig` is not clear. In practice, its sole use is to get the correct devices that the tensor is going to be uploaded to:
https://github.com/tenstorrent/tt-metal/blob/e03382a7480125628571795e021417fc95efe93a/ttnn/cpp/ttnn/distributed/api.cpp#L153-L156

This can be accommodated by a much simpler bit of information:
```
// If specified, the tensor is distributed across the specific mesh shape.
// Otherwise, the tensor is distributed in row-major order across mesh.
std::optional<distributed::MeshShape> distribution_shape;
```

We may simplify and generalize tensor storage even further to something like:
```
// Shape of `multi_device_specs` always matches the shape of device.
// Empty optional spec indicates no data is written to the corresponding coordinate.
distributed::MeshContainer<std::optional<TensorSpec>> multi_device_specs;
```

One blocker that might prevent us from going for it is a legitimate use case where a tensor that lived on 1x8 mesh is re-uploaded to 2x4 mesh. Another blocker is that we need to plumb `MeshDevice` to more places in tensor infra. We can explore this as part of TT-distributed migration.

### What's changed
* Remove `DistributedTensorConfig` in multi-device/host storage types. Replace it with `std::optional<distributed::MeshShape>`.
* Serialization will still rely on `DistributedTensorConfig`. Anything other than `ShardTensor2D` will be ignored, and `ShardTensor2D` will be converted to 2D `MeshShape`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13663025499)
- [X] New/Existing tests provide coverage for changes
