### PR TITLE
#18620: Added minimal sharding support

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -444,6 +444,17 @@ def test_all_gather(
         ),
         (
             2,
+            [1, 1, 32, 2048],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 3))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            2,
             [1, 1, 64, 256],
             2,
             ttnn.TILE_LAYOUT,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -137,9 +137,15 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
 
     // Check for minimal interleaved case
     if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
-        input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
         input_tensor_page_layout == tt::tt_metal::Layout::TILE && this->enable_persistent_fabric_mode) {
-        return AllGatherAsyncVersion::MINIMAL_INTERLEAVED_32;
+        if (input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
+            return AllGatherAsyncVersion::MINIMAL_INTERLEAVED_32;
+        } else if (
+            input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+            input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
+            input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+            return AllGatherAsyncVersion::MINIMAL_SHARDED_32;
+        }
     }
 
     log_trace(tt::LogOp, "[select_version] input_is_sharded: {}", input_is_sharded);
@@ -194,6 +200,24 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program(
                 "Detected all gather specialized shape. all_gather_async_minimal_interleaved_dim3_1_1_32_any is "
                 "called");
             return all_gather_async_minimal_interleaved_dim3_1_1_32_any(
+                input_tensors[0],
+                this->forward_device,
+                this->backward_device,
+                output_tensors[0],
+                this->dim,
+                this->num_links,
+                this->ring_size,
+                this->ring_index,
+                this->topology,
+                this->semaphore,
+                this->sub_device_id,
+                this->enable_persistent_fabric_mode);
+        case AllGatherAsyncVersion::MINIMAL_SHARDED_32:
+            log_trace(
+                tt::LogOp,
+                "Detected all gather specialized shape. all_gather_async_minimal_interleaved_dim3_1_1_32_any is "
+                "called");
+            return all_gather_async_minimal_sharded_dim3_1_1_32_any(
                 input_tensors[0],
                 this->forward_device,
                 this->backward_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -29,6 +29,7 @@ enum class AllGatherAsyncVersion {
     GENERIC = 0,
     MINIMAL_INTERLEAVED_32 = 1,
     LLAMA_POST_BINARY_MATMUL = 2,
+    MINIMAL_SHARDED_32 = 3,
 };
 
 struct AllGatherAsync {
@@ -129,6 +130,19 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_multi_core_with_w
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     bool enable_persistent_fabric_mode);
 tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32_any(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore& semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    bool enable_persistent_fabric_mode);
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_sharded_dim3_1_1_32_any(
     const Tensor& input_tensor,
     std::optional<IDevice*> forward_device,
     std::optional<IDevice*> backward_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -18,7 +18,7 @@
 #include <tt-metalium/host_api.hpp>
 #include "cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
-
+#include "cpp/ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp"
 
 #include "cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
@@ -51,6 +51,231 @@ void append_fabric_connection_rt_args(
             sender_worker_buffer_index_semaphore_id,
             writer_rt_args);
     }
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_sharded_dim3_1_1_32_any(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore& semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    bool enable_persistent_fabric_mode) {
+    tt::tt_metal::Program program{};
+    const bool enable_async_output_tensor = false;
+    TT_FATAL(
+        enable_persistent_fabric_mode,
+        "only persistent fabric mode is supported for all_gather_async_minimal_interleaved_dim3_1_1_32_any");
+
+    IDevice* device = input_tensor.device();
+    bool is_first_chip = ring_index == 0;
+    bool is_last_chip = ring_index == ring_size - 1;
+    log_trace(
+        tt::LogOp,
+        "DEBUG: device: {}, is_first_chip: {}, is_last_chip: {}",
+        input_tensor.device()->id(),
+        is_first_chip,
+        is_last_chip);
+
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
+        ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+            device,
+            forward_device.value_or(nullptr),
+            backward_device.value_or(nullptr),
+            &program,
+            enable_persistent_fabric_mode,
+            num_links);
+
+    // Get OP Config, topology config
+    std::vector<Tensor> input_tensors = {input_tensor};
+    std::vector<Tensor> output_tensors = {output_tensor};
+    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
+    LineTopology line_topology(ring_size, ring_index);
+    const size_t num_targets_forward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+    const size_t num_targets_backward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+
+    // Get worker cores, assuming 1 worker per link
+    uint32_t num_workers_per_link = 1;
+    const auto [sender_worker_core_range, sender_worker_cores] =
+        choose_worker_cores(num_links, num_workers_per_link, enable_persistent_fabric_mode, device, sub_device_id);
+
+    // L1 Scratch CB Creation
+    const size_t packet_size_bytes = local_fabric_handle->get_edm_buffer_size_bytes();
+    uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
+    uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
+    uint32_t cb_num_pages = 3 * num_pages_per_packet;  // tripple buffering
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
+            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
+    tt::tt_metal::CBHandle cb_src0_workers = CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
+    const auto reserved_packet_header_CB_index = tt::CB::c_in1;
+    static constexpr auto num_packet_headers_storable = 8;
+    static constexpr auto packet_header_size_bytes = sizeof(tt::fabric::PacketHeader);
+    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_packet_headers_storable * packet_header_size_bytes * 2,
+            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
+            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
+    auto reserved_packet_header_CB_handle =
+        CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+
+    // Tensor Info
+    const auto input_tensor_layout = input_tensor.buffer()->buffer_layout();
+    const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
+    const auto input_tensor_page_layout = input_tensor.layout();
+    const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const auto output_tensor_layout = output_tensor.buffer()->buffer_layout();
+    const auto output_tensor_buffer_type = output_tensor.buffer()->buffer_type();
+    const auto output_tensor_page_layout = output_tensor.layout();
+
+    // KERNEL CREATION
+    // Reader
+    auto reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
+    reader_kernel_config.compile_args = {
+        ring_index,                 // my_chip_id
+        src0_cb_index,              // cb0_id
+        num_pages_per_packet,       // packet_size_in_pages
+        op_config.get_page_size(),  // tensor0_page_size
+    };
+    shard_builder::extend_sharding_compile_time_args(input_tensor, reader_kernel_config.compile_args);
+    log_trace(tt::LogOp, "Reader Compile Args:");
+    for (const auto& arg : reader_kernel_config.compile_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
+        "sharded_dim3_1_1_32_any_reader.cpp",
+        sender_worker_core_range,
+        reader_kernel_config);
+
+    // Writer
+    auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
+    writer_kernel_config.compile_args = {
+        ring_index,                       // my_chip_id
+        reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+        num_packet_headers_storable,      // num_packet_headers_storable
+        src0_cb_index,                    // cb0_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_targets_forward_direction
+        num_targets_backward,             // num_targets_backward_direction
+    };
+    shard_builder::extend_sharding_compile_time_args(output_tensor, writer_kernel_config.compile_args);
+    log_trace(tt::LogOp, "Writer Compile Args:");
+    for (const auto& arg : writer_kernel_config.compile_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/"
+        "sharded_dim3_1_1_32_any_writer.cpp",
+        sender_worker_core_range,
+        writer_kernel_config);
+
+    // Kernel Runtime Args
+    CoreCoord drain_sync_core;  // the first worker of each chip is the drain sync core, which contains the output ready
+                                // semaphore
+    for (uint32_t link = 0; link < num_links; link++) {
+        CoreCoord core = sender_worker_cores[link];
+        if (link == 0) {
+            // drain sync core is the first worker core
+            drain_sync_core = device->worker_core_from_logical_core(core);
+        }
+        std::optional<ttnn::ccl::SenderWorkerAdapterSpec> forward_fabric_connection =
+            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+                ? std::nullopt
+                : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
+        std::optional<ttnn::ccl::SenderWorkerAdapterSpec> backward_fabric_connection =
+            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+                ? std::nullopt
+                : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
+
+        // Set reader runtime args
+        uint32_t base_pages_per_worker = input_tensor_num_pages / num_links;
+        uint32_t remainder = input_tensor_num_pages % num_links;
+        uint32_t input_tile_id_start = link * base_pages_per_worker + std::min(link, remainder);
+        uint32_t input_tile_id_end = (link + 1) * base_pages_per_worker + std::min(link + 1, remainder);
+        std::vector<uint32_t> reader_rt_args = {
+            input_tensor.buffer()->address(),  // tensor_address0
+            input_tile_id_start,               // tile_id_start
+            input_tile_id_end,                 // tile_id_end
+        };
+        shard_builder::extend_sharding_run_time_args(input_tensor, reader_rt_args);
+        log_trace(tt::LogOp, "Reader Runtime Args:");
+        for (const auto& arg : reader_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+
+        // Set writer runtime args
+        bool wait_output_semaphore = (link == 0) && !enable_async_output_tensor;
+        bool reset_global_semaphore = (link == 0) && !enable_async_output_tensor;
+        uint32_t out_ready_sem_wait_value = ring_size * num_links;
+        uint32_t output_tile_id_start = ring_index * input_tensor_num_pages + input_tile_id_start;
+        uint32_t output_tile_id_end = ring_index * input_tensor_num_pages + input_tile_id_end;
+        std::vector<uint32_t> writer_rt_args = {
+            output_tensor.buffer()->address(),  // tensor_address0
+            semaphore.address(),                // out_ready_sem_bank_addr (absolute address)
+            output_tile_id_start,               // tile_id_start
+            output_tile_id_end,                 // tile_id_end
+            wait_output_semaphore,              // wait_output_semaphore
+            reset_global_semaphore,             // reset_global_semaphore
+            drain_sync_core.x,                  // out_ready_sem_noc0_x
+            drain_sync_core.y,                  // out_ready_sem_noc0_y
+            out_ready_sem_wait_value,           // out_ready_sem_wait_value
+        };
+        shard_builder::extend_sharding_run_time_args(output_tensor, writer_rt_args);
+        log_trace(tt::LogOp, "Writer Runtime Args:");
+        for (const auto& arg : writer_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        append_fabric_connection_rt_args(forward_fabric_connection, core, program, writer_rt_args);
+        append_fabric_connection_rt_args(backward_fabric_connection, core, program, writer_rt_args);
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+    }
+
+    auto override_runtime_arguments_callback =
+        [worker_sender_reader_kernel_id, worker_sender_writer_kernel_id, semaphore, sender_worker_cores](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& input = input_tensors[0];
+            const auto& output = output_tensors[0];
+
+            auto semaphore = static_cast<const ttnn::AllGatherAsync*>(operation)->semaphore;
+
+            log_trace(tt::LogOp, "DEBUG: semaphore: {}", semaphore.address());
+
+            // update senders
+            auto& worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
+            auto& worker_writer_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_writer_kernel_id);
+            for (const auto& core : sender_worker_cores) {
+                // reader
+                auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
+                worker_reader_sender_runtime_args[0] = input.buffer()->address();
+                // writer
+                auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
+                worker_writer_sender_runtime_args[0] = output.buffer()->address();
+                worker_writer_sender_runtime_args[1] = semaphore.address();
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
 tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleaved_dim3_1_1_32_any(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_reader.cpp
@@ -35,30 +35,13 @@ void kernel_main() {
     uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
 
-    // print every compile and runtime arg in uint32_t
-    DPRINT << "ct args: \n";
-    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
-    DPRINT << "buffer0_type: " << (uint32_t)buffer0_type << "\n";
-    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
-    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
-    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
-
-    DPRINT << "rt args: \n";
-    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
-    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << "\n";
-    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << "\n";
-
     // interleaved addrgen
     constexpr bool is_dram = buffer0_type == tt::tt_metal::BufferType::DRAM;
     auto tensor0_addrgen = InterleavedAddrGenFast<is_dram>{
         .bank_base_address = tensor_address0, .page_size = tensor0_page_size, .data_format = get_dataformat(cb0_id)};
 
-    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
-    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
-
     uint32_t tile_id = tile_id_start;
     while (tile_id < tile_id_end) {
-        DPRINT << "tile_id: " << tile_id << "\n";
         cb_reserve_back(cb0_id, packet_size_in_pages);
         const uint32_t l1_write_addr_base = get_write_ptr(cb0_id);
         uint32_t l1_write_addr = l1_write_addr_base;
@@ -73,6 +56,4 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb0_id, packet_size_in_pages);
     }
-
-    DPRINT << "DONE \n";
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -47,37 +47,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
-    size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
-
-    DPRINT << "ct args: \n";
-    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
-    DPRINT << "reserved_packet_header_cb_id: " << (uint32_t)reserved_packet_header_cb_id << "\n";
-    DPRINT << "num_packet_headers_storable: " << (uint32_t)num_packet_headers_storable << "\n";
-    DPRINT << "buffer0_type: " << (uint32_t)buffer0_type << "\n";
-    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
-    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
-    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
-    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << "\n";
-    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << "\n";
-
-    DPRINT << "rt args: \n";
-    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
-    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << "\n";
-    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << "\n";
-    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << "\n";
-    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << "\n";
-    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << "\n";
-    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << "\n";
-    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << "\n";
-    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << "\n";
-
-    DPRINT << "arg_for_fab: " << (uint32_t)arg_for_fab << "\n";
-    DPRINT << "fabric_connection arg 0" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
-    DPRINT << "fabric_connection arg 1" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
-    DPRINT << "fabric_connection arg 2" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
-    DPRINT << "fabric_connection arg 3" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
-    DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
 
     // packet header cb
     cb_reserve_back(reserved_packet_header_cb_id, 1);
@@ -89,9 +59,6 @@ void kernel_main() {
     cb_reserve_back(reserved_packet_header_cb_id, 1);
     auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
     cb_push_back(reserved_packet_header_cb_id, 1);
-    DPRINT << "packet_header_buffer_addr_forward: " << (uint32_t)packet_header_buffer_addr_forward << "\n";
-    DPRINT << "packet_header_buffer_addr_backward: " << (uint32_t)packet_header_buffer_addr_backward << "\n";
-    DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -113,15 +80,8 @@ void kernel_main() {
     }
 
     // 1. mcast via fabric to remote tensor addresses
-    DPRINT << "num_targets_forward_direction: " << num_targets_forward_direction << "\n";
-    DPRINT << "num_targets_backward_direction: " << num_targets_backward_direction << "\n";
-    DPRINT << "my_chip_id: " << my_chip_id << "\n";
-
-    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
-    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
     uint32_t tile_id = tile_id_start;
     while (tile_id < tile_id_end) {
-        DPRINT << "tile_id: " << tile_id << "\n";
         cb_wait_front(cb0_id, packet_size_in_pages);
         size_t l1_read_addr = get_read_ptr(cb0_id);
         uint32_t num_pages_to_read = std::min(tile_id_end - tile_id, packet_size_in_pages);
@@ -129,10 +89,6 @@ void kernel_main() {
         uint32_t contig_pages_advanced = 1;  // always 1 for interleaved
         for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
             uint64_t noc0_dest_noc_addr = get_noc_addr(tile_id, tensor0_addrgen, 0 /*offset*/, 0 /*noc_id*/);
-
-            DPRINT << "j: " << j << "\n";
-            DPRINT << "noc0_dest_noc_addr: " << noc0_dest_noc_addr << "\n";
-            DPRINT << "tile_id: " << tile_id << "\n";
 
             write_and_advance_local_read_address_for_fabric_write(
                 noc0_dest_noc_addr,
@@ -177,19 +133,16 @@ void kernel_main() {
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
-    DPRINT << "inc done\n";
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
         while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
-        DPRINT << "waitval done\n";
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
-        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
+        const uint64_t dest_noc_addr = get_noc_addr(out_ready_sem_bank_addr);
         noc_inline_dw_write(dest_noc_addr, 0);
-        DPRINT << "reset done\n";
     }
 
     if (fabric_connection.is_logically_connected()) {
@@ -197,5 +150,4 @@ void kernel_main() {
     }
 
     noc_async_write_barrier();
-    DPRINT << "DONE \n";
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/sharded_dim3_1_1_32_any_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/sharded_dim3_1_1_32_any_reader.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include <cstdint>
+#include <utility>
+
+using address_t = uint32_t;
+using tt::tt_metal::BufferType;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(2);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(3);
+
+typedef ShardedInfo<
+    get_compile_time_arg_val(4),
+    get_compile_time_arg_val(5),
+    get_compile_time_arg_val(6),
+    get_compile_time_arg_val(7),
+    get_compile_time_arg_val(8),
+    get_compile_time_arg_val(9),
+    get_compile_time_arg_val(10)>
+    tensor_shard_info;
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 0;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
+    const auto [mapping_table, rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(arg_idx));
+    arg_idx += rt_increment;
+    // print every compile and runtime arg in uint32_t
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << "\n";
+    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << "\n";
+
+    // interleaved addrgen
+    experimental::ShardedAddrGen<tensor_shard_info> tensor0_addrgen = {
+        .bank_base_address = tensor_address0, .shard_array = mapping_table};
+
+    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
+
+    uint32_t tile_id = tile_id_start;
+    while (tile_id < tile_id_end) {
+        DPRINT << "tile_id: " << tile_id << "\n";
+        cb_reserve_back(cb0_id, packet_size_in_pages);
+        const uint32_t l1_write_addr_base = get_write_ptr(cb0_id);
+        uint32_t l1_write_addr = l1_write_addr_base;
+
+        uint32_t num_pages_to_read = std::min(tile_id_end - tile_id, packet_size_in_pages);
+        for (uint32_t j = 0; j < num_pages_to_read; j++) {
+            auto tile_address = get_noc_addr(tile_id, tensor0_addrgen);
+            noc_async_read(tile_address, l1_write_addr, tensor0_page_size);
+            l1_write_addr += tensor0_page_size;
+            tile_id++;
+        }
+
+        noc_async_read_barrier();
+        cb_push_back(cb0_id, packet_size_in_pages);
+    }
+
+    DPRINT << "DONE \n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/sharded_dim3_1_1_32_any_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/sharded_dim3_1_1_32_any_reader.cpp
@@ -47,28 +47,13 @@ void kernel_main() {
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(arg_idx));
     arg_idx += rt_increment;
-    // print every compile and runtime arg in uint32_t
-    DPRINT << "ct args: \n";
-    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
-    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
-    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
-    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
 
-    DPRINT << "rt args: \n";
-    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
-    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << "\n";
-    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << "\n";
-
-    // interleaved addrgen
+    // sharded addrgen
     experimental::ShardedAddrGen<tensor_shard_info> tensor0_addrgen = {
         .bank_base_address = tensor_address0, .shard_array = mapping_table};
 
-    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
-    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
-
     uint32_t tile_id = tile_id_start;
     while (tile_id < tile_id_end) {
-        DPRINT << "tile_id: " << tile_id << "\n";
         cb_reserve_back(cb0_id, packet_size_in_pages);
         const uint32_t l1_write_addr_base = get_write_ptr(cb0_id);
         uint32_t l1_write_addr = l1_write_addr_base;
@@ -84,6 +69,4 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb0_id, packet_size_in_pages);
     }
-
-    DPRINT << "DONE \n";
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/sharded_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/sharded_dim3_1_1_32_any_writer.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "minimal_ccl_common.hpp"
+#include <cstdint>
+#include <utility>
+
+using address_t = uint32_t;
+using tt::tt_metal::BufferType;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
+constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+
+typedef ShardedInfo<
+    get_compile_time_arg_val(8),
+    get_compile_time_arg_val(9),
+    get_compile_time_arg_val(10),
+    get_compile_time_arg_val(11),
+    get_compile_time_arg_val(12),
+    get_compile_time_arg_val(13),
+    get_compile_time_arg_val(14)>
+    tensor_shard_info;
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 0;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
+    bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    const auto [mapping_table, rt_increment] =
+        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(arg_idx));
+    arg_idx += rt_increment;
+    size_t arg_for_fab = arg_idx;
+    auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
+
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "reserved_packet_header_cb_id: " << (uint32_t)reserved_packet_header_cb_id << "\n";
+    DPRINT << "num_packet_headers_storable: " << (uint32_t)num_packet_headers_storable << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << "\n";
+    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << "\n";
+    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << "\n";
+    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << "\n";
+    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << "\n";
+    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << "\n";
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << "\n";
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << "\n";
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << "\n";
+
+    DPRINT << "arg_for_fab: " << (uint32_t)arg_for_fab << "\n";
+    DPRINT << "fabric_connection arg 0" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 1" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 2" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 3" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+
+    // packet header cb
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    DPRINT << "packet_header_buffer_addr_forward: " << (uint32_t)packet_header_buffer_addr_forward << "\n";
+    DPRINT << "packet_header_buffer_addr_backward: " << (uint32_t)packet_header_buffer_addr_backward << "\n";
+    DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
+
+    // pre-populate packet headers
+    volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
+    pkt_hdr_forward->to_chip_multicast(
+        tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+    pkt_hdr_backward->to_chip_multicast(
+        tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+
+    // sharded addrgen
+    experimental::ShardedAddrGen<tensor_shard_info> tensor0_addrgen = {
+        .bank_base_address = tensor_address0, .shard_array = mapping_table};
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.open();
+    }
+
+    // 1. mcast via fabric to remote tensor addresses
+    DPRINT << "num_targets_forward_direction: " << num_targets_forward_direction << "\n";
+    DPRINT << "num_targets_backward_direction: " << num_targets_backward_direction << "\n";
+    DPRINT << "my_chip_id: " << my_chip_id << "\n";
+
+    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet size in pages: " << (uint32_t)packet_size_in_pages << "\n";
+    uint32_t tile_id = tile_id_start;
+    while (tile_id < tile_id_end) {
+        DPRINT << "tile_id: " << tile_id << "\n";
+        cb_wait_front(cb0_id, packet_size_in_pages);
+        size_t l1_read_addr = get_read_ptr(cb0_id);
+        uint32_t num_pages_to_read = std::min(tile_id_end - tile_id, packet_size_in_pages);
+
+        uint32_t contig_pages_advanced = 1;  // always 1 for interleaved
+        for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
+            uint64_t noc0_dest_noc_addr = get_noc_addr(tile_id, tensor0_addrgen);
+
+            DPRINT << "j: " << j << "\n";
+            DPRINT << "noc0_dest_noc_addr: " << noc0_dest_noc_addr << "\n";
+            DPRINT << "tile_id: " << tile_id << "\n";
+
+            write_and_advance_local_read_address_for_fabric_write(
+                noc0_dest_noc_addr,
+                pkt_hdr_forward,
+                pkt_hdr_backward,
+                fabric_connection,
+                l1_read_addr,
+                contig_pages_advanced * tensor0_page_size);
+
+            tile_id++;
+        }
+        noc_async_writes_flushed();
+
+        cb_pop_front(cb0_id, packet_size_in_pages);
+    }
+
+    // 2. mcast output ready semaphore
+    uint64_t out_ready_sem_noc_addr_in_pkt =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
+    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
+    pkt_hdr->to_noc_unicast_atomic_inc(tt::fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_noc_addr_in_pkt,
+        static_cast<uint16_t>(1),  // increment 1
+        32});
+    // Write the mcast packet (forward)
+    if (fabric_connection.has_forward_connection()) {
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+    }
+    // Write the mcast packet (backward)
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+    }
+    // increment locally
+    uint64_t out_ready_sem_noc_addr =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+    DPRINT << "inc done\n";
+
+    // 3. wait for mcast output ready semaphore
+    if (wait_output_semaphore) {
+        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
+        DPRINT << "waitval done\n";
+    }
+
+    // 4. global semaphore reset
+    if (reset_global_semaphore) {
+        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
+        noc_inline_dw_write(dest_noc_addr, 0);
+        DPRINT << "reset done\n";
+    }
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.close();
+    }
+
+    noc_async_write_barrier();
+    DPRINT << "DONE \n";
+}


### PR DESCRIPTION
### Ticket
#18620 

### Problem description
We are adding a sharded version of the minimal all gather using the sharded address generator. This is blocking the P0 merged OPs for CCL needed for 80tk/s Llama so please LGTM

NOTE: This is mostly copy-paste from the interleaved minimal but we want sharding only in the fused ops making it easier if this kernel is sharding only

### What's changed
Due to the importance of keeping the performance high, a new minimal all gather was added that is compatible with sharding

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13663305260
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
