### PR TITLE
#18703: Binary_ng - the num of tiles value passed to the LLK CB API's to be a compile-time argument

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -588,6 +588,8 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
 
+    const uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
+
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(compute_kernel, is_sfpu_op),
@@ -595,6 +597,7 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
         tt_metal::ComputeConfig{
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .compile_args = {num_tiles_per_cycle},
             .defines = std::move(compute_kernel_defines)});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -18,9 +18,9 @@ ALWI void process_tile(
     tt::CBIndex cb_post_rhs,
     tt::CBIndex cb_out,
     uint32_t freq,
-    uint32_t tile_start) {
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
-    constexpr uint32_t onetile = 1;
 
 #if BCAST_INPUT
 #define CB_PRE_BCAST cb_pre_rhs
@@ -34,14 +34,14 @@ ALWI void process_tile(
 #define CB_POST_OTHER cb_post_rhs
 #endif
 
-    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, onetile);
-    cb_wait_front(CB_POST_BCAST, onetile);
+    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
+    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, onetile);
-        cb_wait_front(CB_POST_OTHER, onetile);
+        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
+        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
         binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
@@ -55,16 +55,18 @@ ALWI void process_tile(
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_push_back(cb_out, onetile);
-        cb_pop_front(CB_POST_OTHER, onetile);
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
     }
-    cb_pop_front(CB_POST_BCAST, onetile);
+    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
 }
 
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
 
     if (num_tiles == 0) {
         return;
@@ -90,11 +92,20 @@ void MAIN {
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
 
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
-        process_tile(cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start);
+        process_tile(
+            cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start, num_tiles_per_cycle);
     }
 
     if (remaining_iterations > 0) {
-        process_tile(cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, remaining_iterations, tile_start);
+        process_tile(
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -14,6 +14,8 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
     constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
     constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
@@ -30,16 +32,14 @@ void MAIN {
     binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
-    constexpr uint32_t onetile = 1;
-
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
-        cb_wait_front(cb_post_lhs, onetile);
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
 
-        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
-        cb_wait_front(cb_post_rhs, onetile);
+        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
         binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
@@ -53,9 +53,9 @@ void MAIN {
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_push_back(cb_out, onetile);
-        cb_pop_front(cb_post_lhs, onetile);
-        cb_pop_front(cb_post_rhs, onetile);
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
+        cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -13,6 +13,8 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
     constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
     constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
@@ -29,16 +31,14 @@ void MAIN {
     binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
-    constexpr uint32_t onetile = 1;
-
-    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
-    cb_wait_front(cb_post_rhs, onetile);
+    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+    cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
-        cb_wait_front(cb_post_lhs, onetile);
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
         binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
@@ -52,8 +52,8 @@ void MAIN {
         pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_pop_front(cb_post_lhs, onetile);
-        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
+        cb_push_back(cb_out, num_tiles_per_cycle);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -25,9 +25,9 @@ ALWI void process_tile(
     tt::CBIndex cb_post_rhs,
     tt::CBIndex cb_out,
     uint32_t freq,
-    uint32_t tile_start) {
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
     using namespace ckernel;
-    constexpr uint32_t onetile = 1;
 
 #if BCAST_INPUT
 #define CB_PRE_BCAST cb_pre_rhs
@@ -41,46 +41,50 @@ ALWI void process_tile(
 #define CB_POST_OTHER cb_post_rhs
 #endif
 
-    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, onetile);
-    cb_wait_front(CB_POST_BCAST, onetile);
+    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
+    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
 
     for (uint32_t j = tile_start; j < freq; ++j) {
-        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, onetile);
-        cb_wait_front(CB_POST_OTHER, onetile);
+        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
+        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
         BINARY_SFPU_INIT
 #endif
         tile_regs_acquire();
         copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
-        for (uint32_t i = 0; i < onetile; ++i) {
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_lhs, i, i * 2);
         }
         copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
-        for (uint32_t i = 0; i < onetile; ++i) {
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_rhs, i, i * 2 + 1);
 
             BINARY_SFPU_OP(i * 2, i * 2 + 1);
             PROCESS_POST_ACTIVATIONS(i * 2);
-            tile_regs_commit();
+        }
+        tile_regs_commit();
 
-            tile_regs_wait();
+        tile_regs_wait();
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             pack_tile(i * 2, cb_out);
         }
         tile_regs_release();
 
-        cb_push_back(cb_out, onetile);
-        cb_pop_front(CB_POST_OTHER, onetile);
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
     }
-    cb_pop_front(CB_POST_BCAST, onetile);
+    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
 }
 
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
 
     if (num_tiles == 0) {
         return;
@@ -106,11 +110,20 @@ void MAIN {
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
 
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
-        process_tile(cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start);
+        process_tile(
+            cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start, num_tiles_per_cycle);
     }
 
     if (remaining_iterations > 0) {
-        process_tile(cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, remaining_iterations, tile_start);
+        process_tile(
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -20,6 +20,8 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
     constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
     constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
@@ -36,41 +38,42 @@ void MAIN {
     BINARY_SFPU_INIT
 #endif
 
-    constexpr uint32_t onetile = 1;
-
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
-        cb_wait_front(cb_post_lhs, onetile);
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
 
-        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
-        cb_wait_front(cb_post_rhs, onetile);
+        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
         BINARY_SFPU_INIT
 #endif
         tile_regs_acquire();
         copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
-        for (uint32_t i = 0; i < onetile; ++i) {
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_lhs, i, i * 2);
         }
         copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
-        for (uint32_t i = 0; i < onetile; ++i) {
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_rhs, i, i * 2 + 1);
 
             BINARY_SFPU_OP(i * 2, i * 2 + 1);
             PROCESS_POST_ACTIVATIONS(i * 2);
-            tile_regs_commit();
+        }
+        tile_regs_commit();
 
-            tile_regs_wait();
+        tile_regs_wait();
+
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             pack_tile(i * 2, cb_out);
         }
         tile_regs_release();
 
-        cb_push_back(cb_out, onetile);
-        cb_pop_front(cb_post_lhs, onetile);
-        cb_pop_front(cb_post_rhs, onetile);
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
+        cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -20,6 +20,8 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
     constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
     constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
     constexpr auto cb_out = tt::CBIndex::c_2;
@@ -36,39 +38,40 @@ void MAIN {
     BINARY_SFPU_INIT
 #endif
 
-    constexpr uint32_t onetile = 1;
-
-    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
-    cb_wait_front(cb_post_rhs, onetile);
+    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+    cb_wait_front(cb_post_rhs, num_tiles_per_cycle);
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
-        cb_wait_front(cb_post_lhs, onetile);
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        cb_wait_front(cb_post_lhs, num_tiles_per_cycle);
 
-        cb_reserve_back(cb_out, onetile);
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
         BINARY_SFPU_INIT
 #endif
         tile_regs_acquire();
         copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
-        for (uint32_t i = 0; i < onetile; ++i) {
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_lhs, i, i * 2);
         }
         copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
-        for (uint32_t i = 0; i < onetile; ++i) {
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             copy_tile(cb_post_rhs, i, i * 2 + 1);
             BINARY_SFPU_OP(i * 2, i * 2 + 1);
             PROCESS_POST_ACTIVATIONS(i * 2);
-            tile_regs_commit();
+        }
+        tile_regs_commit();
 
-            tile_regs_wait();
+        tile_regs_wait();
+
+        for (uint32_t i = 0; i < num_tiles_per_cycle; ++i) {
             pack_tile(i * 2, cb_out);
         }
         tile_regs_release();
 
-        cb_pop_front(cb_post_lhs, onetile);
-        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_post_lhs, num_tiles_per_cycle);
+        cb_push_back(cb_out, num_tiles_per_cycle);
     }
 }
 }  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
Link to Github Issue #18703

### Problem description
In binary_ng, we are processing `onetile` per CB for (rd/wr/math). This value can be passed as compile-time arg to the kernels instead of being defined in each kernel. Later if this changes to be a dynamic value, decided by split_work API, we can pass this arg as a runtime-arg to the kernels

### What's changed
- passed num tiles processed by CBs and DST as a compile-time argument
- move `tile_reg` api's out of loop to maintain sync between the `tile_reg` api's

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13784301332
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13678025477
https://github.com/tenstorrent/tt-metal/actions/runs/13750103607
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
