### PR TITLE
#0: Add asserts that all txns are completed by end of user kernel on brisc for dedicated noc mode

### DIFF
--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -44,6 +44,17 @@ void kernel_launch(uint32_t kernel_base_addr) {
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
         kernel_main();
+        if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
+            WAYPOINT("NKFW");
+            // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the
+            // NOC interface is in a known idle state for the next kernel.
+            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+            WAYPOINT("NKFD");
+        }
     }
 #endif
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We added these asserts for ncrisc and eth, but not for brisc. Brisc should also have these asserts to avoid cases where user txns haven't finished.

### What's changed
Add watcher asserts in brisk.cc

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
