### PR TITLE
Afuller/try new ci runners

### DIFF
--- a/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
@@ -2,6 +2,8 @@ name: "[post-commit] Fabric unit tests"
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *" # Run every hour
 
 jobs:
   build-artifact:

--- a/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N300 },
+          { arch: wormhole_b0, runner-label: tt-ubuntu-2204-n300-large-stable },
         ]
     uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
     with:

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -49,10 +49,7 @@ jobs:
           {name: fabric unit tests, cmd: ./tests/scripts/run_cpp_fabric_tests.sh },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
-    runs-on:
-      - ${{ inputs.runner-label }}
-      - cloud-virtual-machine
-      - in-service
+    runs-on: ${{ startsWith(inputs.runner-label, 'tt-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)) || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)) }}
     env:
       ARCH_NAME: ${{ inputs.arch }}
       LOGURU_LEVEL: INFO


### PR DESCRIPTION
### Ticket
#18664

### Problem description
We want to start using the new CI runners.  But first we want to test them out a bit.

### What's changed
Scheduled a job outside of APC to run on a new CI runner.
The same task when run inside APC will continue to run on the existing runners to minimize potential disruption.
Checked the syntax by having a run that targeted each type: https://github.com/tenstorrent/tt-metal/actions/runs/13666458620
