### PR TITLE
#0: Temporarily enable APC on push for integration branch

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -23,7 +23,7 @@ on:
         type: boolean
         description: "Re-run failed jobs (max 3)"
   push:
-    branches: ["main"]
+    branches: ["main", "jchu/ttnn-integration-with-mesh"]
 
 permissions:
   actions: read


### PR DESCRIPTION
### Ticket
None

### Problem description
Automated APC regression needed to track regressions on branch. 

### What's changed
Temporarily enable automated APC trigger when changes are pushed onto

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
