### PR TITLE
Delegate to allocate_tensor_on_mesh for MeshDevice targets

### DIFF
--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -45,20 +45,18 @@ std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor) {
         return tensors;
     } else if (std::holds_alternative<tt::tt_metal::DeviceStorage>(tensor.get_storage())) {
         auto& device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
-        if (device_storage.mesh_buffer) {
-            if (device_storage.mesh_buffer->device()->num_devices() == 1) {
-                return {tensor};
+        if (auto mesh_buffer = device_storage.mesh_buffer;
+            mesh_buffer != nullptr and mesh_buffer->device()->num_devices() > 1) {
+            std::vector<ttnn::Tensor> tensors;
+            auto devices = mesh_buffer->device()->get_devices();
+            for (auto device : devices) {
+                auto shard = tt::tt_metal::get_shard_for_device(tensor, device);
+                tensors.push_back(shard);
             }
+            return tensors;
+        } else {
+            return {tensor};
         }
-        TT_THROW("Not implemented");
-
-        std::vector<ttnn::Tensor> tensors;
-        auto devices = tt::tt_metal::get_devices(tensor);
-        for (auto device : devices) {
-            auto shard = tt::tt_metal::get_shard_for_device(tensor, device);
-            tensors.push_back(shard);
-        }
-        return tensors;
     } else {
         return {tensor};
     }

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -88,7 +88,7 @@ ttnn::Tensor allocate_tensor_on_device(
     Layout layout,
     MeshDevice* mesh_device,
     const std::optional<MemoryConfig>& memory_config) {
-    return allocate_tensor_on_device(
+    return allocate_tensor_on_mesh(
         TensorSpec(
             shape,
             tt::tt_metal::TensorLayout(
@@ -101,7 +101,7 @@ ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, IDevice* de
 }
 
 ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, MeshDevice* mesh_device) {
-    return tt::tt_metal::allocate_tensor_on_devices(spec, mesh_device->get_devices());
+    return tt::tt_metal::allocate_tensor_on_mesh(spec, mesh_device);
 }
 
 void copy_host_to_device_tensor(const ttnn::Tensor& host_tensor, ttnn::Tensor device_tensor, QueueId cq_id) {

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -83,11 +83,6 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
     }
 }
 
-std::vector<IDevice*> get_devices(const Tensor& tensor) {
-    std::vector<IDevice*> devices;
-    TT_THROW("Not implemented");
-}
-
 uint32_t num_buffers_in_tensor(const Tensor& tensor) {
     if (std::holds_alternative<MultiDeviceHostStorage>(tensor.get_storage())) {
         auto host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -63,9 +63,6 @@ Tensor transform(const Tensor& tensor, std::function<Tensor(const Tensor&)> tran
 // Given a multi-device tensor, and a callable, applies the function to all per-device tensors.
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);
 
-// Given a multi-device tensor, returns all the devices it is mapped to.
-std::vector<IDevice*> get_devices(const Tensor& multi_device_tensor);
-
 uint32_t num_buffers_in_tensor(const Tensor& tensor);
 
 Tensor get_shard_for_device(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- fixes tests/ttnn/unit_tests/operations/test_prefetcher.py
- fixes up tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py::test_tensor_preallocation_and_write_apis

### What's changed
- Delegate to allocate_tensor_on_mesh for MeshDevice targets
- Fix `ttnn.get_device_tensors()` for single-device flow

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
