### PR TITLE
Fix Reshape for Zero Volume Tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -381,7 +381,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     if (tensor.get_logical_volume() == 0) {
         TT_FATAL(logical_shape.volume() == 0, "Tensor volume is 0, but shape's volume is not");
         TT_FATAL(
-            tensor.storage_type() != StorageType::DEVICE,
+            (tensor.mesh_device() == nullptr && tensor.storage_type() != StorageType::MULTI_DEVICE_HOST),
             "Reshaping a multi-device tensor with 0 volume is not supported");
         return ttnn::experimental::view(tensor, logical_shape, padded_shape);
     }


### PR DESCRIPTION
### Ticket
None

### Problem description
Fixing the last of N150 failures on post-commit

### What's changed
Code-path is valid only for non MeshDevice path.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
