### PR TITLE
Temporarily Skip TT-Train Tests Until CCL Ops ported to Fabric

### DIFF
--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -118,7 +118,9 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2) {
     EXPECT_TRUE(xt::allclose(chunk1, xtensors_back[1]));
 }
 
-TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
+TEST_F(N300UtilsTest, DISABLED_TestXTensorReplicateAllReduce) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric ";
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -142,6 +144,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicateAllReduceBadTiles) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::experimental::all_reduce)";
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -182,6 +186,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2AddScalar) {
 }
 
 TEST_F(N300UtilsTest, TestXTensorShardAxis3Matmul) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
+
     xt::random::seed(42);
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -48,6 +48,7 @@ protected:
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = true;
@@ -91,6 +92,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = false;
@@ -128,6 +130,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = true;
@@ -167,6 +170,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = false;
@@ -201,6 +205,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = true;
@@ -242,6 +247,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = false;
@@ -277,6 +283,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNoAllGather) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = true;
@@ -326,6 +333,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNoAllGather) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = false;
@@ -370,6 +378,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t batch_size = 64;
     uint32_t sequence_length = 256;
     uint32_t in_features = 384U;
@@ -437,6 +446,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t batch_size = 64;
     uint32_t sequence_length = 256;
     uint32_t in_features = 384U;
@@ -504,6 +514,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNanoGPT) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     uint32_t batch_size = 64;
     uint32_t sequence_length = 256;
     uint32_t in_features = 384U;

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -39,6 +39,7 @@ protected:
 };
 
 TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_reduce)";
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -87,6 +88,7 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
 }
 
 TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_reduce)";
     auto* device = &ttml::autograd::ctx().get_device();
     device->enable_program_cache();
     auto mesh_shape = device->shape();
@@ -142,6 +144,7 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
 }
 
 TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_reduce)";
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -191,6 +194,7 @@ TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
 }
 
 TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -234,6 +238,7 @@ TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
 }
 
 TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Reducing noise in CI by temporarily skipping TT-Train tests that invoke CCL operations

### What's changed
Tagged relevant tests to skip

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
