### PR TITLE
#0: Add regression test for demonstrating heterogeneous op dispatch

### DIFF
--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -167,7 +167,7 @@ void py_module(py::module& module) {
             "create_submesh",
             &MeshDevice::create_submesh,
             py::arg("submesh_shape"),
-            py::arg("offset"),
+            py::arg("offset") = std::nullopt,
             py::keep_alive<1, 0>())  // Keep MeshDevice alive as long as SubmeshDevice is alive
         .def(
             "create_submeshes",


### PR DESCRIPTION
### Ticket
None

### Problem description
Lacking examples demonstrating heterogeneous op dispatch using submesh APIs

### What's changed
- Added small regression test
- Make specifying offsets for submesh optional

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13696057601) 
- [x] [T3000 Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/13844927577)
