### PR TITLE
Temporarily disable more post-commit tests using CCL operations

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_N300_post_commit.py
@@ -61,6 +61,7 @@ def test_ring_reduce_scatter_n300_post_commit(
     enable_async,
     num_iters=5,
 ):
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     run_reduce_scatter_test(
         n300_mesh_device,
         num_devices,
@@ -138,6 +139,7 @@ def test_width_sharded_reduce_scatter_N300_post_commit(
     enable_async,
     num_iters=5,
 ):
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     run_reduce_scatter_sharded_test(
         t3k_mesh_device,
         num_devices,


### PR DESCRIPTION
### Ticket
None

### Problem description
CCL operations do not work on branch. Work pending on CCL op port to fabric apis.

### What's changed
Skipping more post-commit tests using CCL operations temporarily


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
