### PR TITLE
Expose more creation functions for MeshDevice, change SubMesh ownership

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -81,14 +81,11 @@ TEST_F(MeshDeviceTest, CreateSubmesh) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
     EXPECT_THAT(mesh_device_->get_devices(), SizeIs(8));
     EXPECT_TRUE(mesh_device_->is_parent_mesh());
-    EXPECT_THAT(mesh_device_->get_submeshes(), IsEmpty());
 
     auto submesh = mesh_device_->create_submesh(MeshShape{1, 2}, MeshCoordinate{1, 1});
-    EXPECT_THAT(mesh_device_->get_submeshes(), SizeIs(1));
     EXPECT_EQ(submesh->shape(), MeshShape(1, 2));
     EXPECT_THAT(submesh->get_devices(), SizeIs(2));
     EXPECT_FALSE(submesh->is_parent_mesh());
-    EXPECT_THAT(submesh->get_submeshes(), IsEmpty());
 
     // Verify coordinates are correct.
     EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 1})->id(), submesh->get_device(MeshCoordinate{0, 0})->id());
@@ -110,8 +107,6 @@ TEST_F(MeshDeviceTest, CreateSubmeshes) {
         EXPECT_EQ(submesh->shape(), MeshShape(1, 2));
         EXPECT_THAT(submesh->get_devices(), SizeIs(2));
     }
-
-    EXPECT_EQ(mesh_device_->get_submeshes(), submeshes);
 }
 
 }  // namespace

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -94,8 +94,6 @@ TEST_F(MeshDeviceTest, CreateSubmesh) {
     EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 1})->id(), submesh->get_device(MeshCoordinate{0, 0})->id());
     EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 2})->id(), submesh->get_device(MeshCoordinate{0, 1})->id());
     EXPECT_EQ(submesh->get_device(MeshCoordinate{1, 1}), nullptr);
-
-    EXPECT_EQ(mesh_device_->get_submeshes(), submeshes);
 }
 
 TEST_F(MeshDeviceTest, CreateSubmeshesNonDivisibleSubshape) {
@@ -112,6 +110,8 @@ TEST_F(MeshDeviceTest, CreateSubmeshes) {
         EXPECT_EQ(submesh->shape(), MeshShape(1, 2));
         EXPECT_THAT(submesh->get_devices(), SizeIs(2));
     }
+
+    EXPECT_EQ(mesh_device_->get_submeshes(), submeshes);
 }
 
 }  // namespace

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -81,16 +81,21 @@ TEST_F(MeshDeviceTest, CreateSubmesh) {
     EXPECT_EQ(mesh_device_->shape(), MeshShape(2, 4));
     EXPECT_THAT(mesh_device_->get_devices(), SizeIs(8));
     EXPECT_TRUE(mesh_device_->is_parent_mesh());
+    EXPECT_THAT(mesh_device_->get_submeshes(), IsEmpty());
 
     auto submesh = mesh_device_->create_submesh(MeshShape{1, 2}, MeshCoordinate{1, 1});
+    EXPECT_THAT(mesh_device_->get_submeshes(), SizeIs(1));
     EXPECT_EQ(submesh->shape(), MeshShape(1, 2));
     EXPECT_THAT(submesh->get_devices(), SizeIs(2));
     EXPECT_FALSE(submesh->is_parent_mesh());
+    EXPECT_THAT(submesh->get_submeshes(), IsEmpty());
 
     // Verify coordinates are correct.
     EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 1})->id(), submesh->get_device(MeshCoordinate{0, 0})->id());
     EXPECT_EQ(mesh_device_->get_device(MeshCoordinate{1, 2})->id(), submesh->get_device(MeshCoordinate{0, 1})->id());
     EXPECT_EQ(submesh->get_device(MeshCoordinate{1, 1}), nullptr);
+
+    EXPECT_EQ(mesh_device_->get_submeshes(), submeshes);
 }
 
 TEST_F(MeshDeviceTest, CreateSubmeshesNonDivisibleSubshape) {

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -65,7 +65,9 @@ private:
     std::shared_ptr<ScopedDevices> scoped_devices_;
     MeshDeviceID mesh_id_;
     std::unique_ptr<MeshDeviceView> view_;
-    std::shared_ptr<MeshDevice> parent_mesh_;  // Submesh keeps the parent mesh alive
+    // Submesh keeps the parent mesh alive. Parent_mesh_ is null if the current mesh is the parent mesh.
+    std::shared_ptr<MeshDevice> parent_mesh_;
+    std::vector<std::weak_ptr<MeshDevice>> submeshes_;
     std::vector<std::unique_ptr<MeshCommandQueue>> mesh_command_queues_;
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     std::unordered_map<MeshTraceId, std::shared_ptr<MeshTraceBuffer>> trace_buffer_pool_;
@@ -257,6 +259,8 @@ public:
     std::string to_string() const;
     bool is_parent_mesh() const;
 
+    std::vector<std::shared_ptr<MeshDevice>> get_submeshes() const;
+
     std::shared_ptr<MeshDevice> create_submesh(
         const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset = std::nullopt);
 
@@ -286,14 +290,14 @@ public:
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
-    static std::shared_ptr<MeshDevice> create_single_device(
+    static std::shared_ptr<MeshDevice> create_unit_mesh(
         int device_id,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
-    static std::map<int, std::shared_ptr<MeshDevice>> create_single_devices(
+    static std::map<int, std::shared_ptr<MeshDevice>> create_unit_meshes(
         const std::vector<int>& device_ids,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -46,6 +46,12 @@ private:
             size_t num_command_queues,
             const DispatchCoreConfig& dispatch_core_config,
             const MeshDeviceConfig& config);
+        ScopedDevices(
+            const std::vector<int>& device_ids,
+            size_t l1_small_size,
+            size_t trace_region_size,
+            size_t num_command_queues,
+            const DispatchCoreConfig& dispatch_core_config);
 
         // Destructor releases physical resources
         ~ScopedDevices();
@@ -59,9 +65,7 @@ private:
     std::shared_ptr<ScopedDevices> scoped_devices_;
     MeshDeviceID mesh_id_;
     std::unique_ptr<MeshDeviceView> view_;
-    std::vector<std::shared_ptr<MeshDevice>>
-        submeshes_;                          // Parent owns submeshes and is responsible for their destruction
-    std::weak_ptr<MeshDevice> parent_mesh_;  // Submesh created with reference to parent mesh
+    std::shared_ptr<MeshDevice> parent_mesh_;  // Submesh keeps the parent mesh alive
     std::vector<std::unique_ptr<MeshCommandQueue>> mesh_command_queues_;
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     std::unordered_map<MeshTraceId, std::shared_ptr<MeshTraceBuffer>> trace_buffer_pool_;
@@ -80,7 +84,7 @@ public:
     MeshDevice(
         std::shared_ptr<ScopedDevices> scoped_devices,
         std::unique_ptr<MeshDeviceView> mesh_device_view,
-        std::weak_ptr<MeshDevice> parent_mesh = {});
+        std::shared_ptr<MeshDevice> parent_mesh = {});
     ~MeshDevice() override;
 
     MeshDevice(const MeshDevice&) = delete;
@@ -253,8 +257,6 @@ public:
     std::string to_string() const;
     bool is_parent_mesh() const;
 
-    std::vector<std::shared_ptr<MeshDevice>> get_submeshes() const;
-
     std::shared_ptr<MeshDevice> create_submesh(
         const MeshShape& submesh_shape, const std::optional<MeshCoordinate>& offset = std::nullopt);
 
@@ -279,6 +281,20 @@ public:
 
     static std::shared_ptr<MeshDevice> create(
         const MeshDeviceConfig& config,
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+        size_t num_command_queues = 1,
+        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
+    static std::shared_ptr<MeshDevice> create_single_device(
+        int device_id,
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+        size_t num_command_queues = 1,
+        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
+    static std::map<int, std::shared_ptr<MeshDevice>> create_single_devices(
+        const std::vector<int>& device_ids,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -166,7 +166,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     auto submeshes = mesh_device->create_submeshes(MeshShape(1, 1));
     TT_FATAL(
         device_ids.size() == submeshes.size(),
-        "Create unexpected number of submeshes {} instead of {}",
+        "Created an unexpected number of submeshes: {} instead of {}",
         submeshes.size(),
         device_ids.size());
     std::map<int, std::shared_ptr<MeshDevice>> result;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -71,13 +71,25 @@ MeshDevice::ScopedDevices::ScopedDevices(
     size_t trace_region_size,
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
-    const MeshDeviceConfig& config) {
-    auto physical_device_ids = SystemMesh::instance().request_available_devices(config);
-    opened_devices_ = tt::tt_metal::detail::CreateDevices(
-        physical_device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
+    const MeshDeviceConfig& config) :
+    ScopedDevices(
+        SystemMesh::instance().request_available_devices(config),
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config) {}
 
-    for (auto physical_device_id : physical_device_ids) {
-        devices_.push_back(opened_devices_.at(physical_device_id));
+MeshDevice::ScopedDevices::ScopedDevices(
+    const std::vector<int>& device_ids,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config) {
+    opened_devices_ = tt::tt_metal::detail::CreateDevices(
+        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
+
+    for (auto device_id : device_ids) {
+        devices_.push_back(opened_devices_.at(device_id));
     }
 }
 
@@ -114,7 +126,7 @@ IDevice* MeshDevice::reference_device() const { return this->get_devices().at(0)
 MeshDevice::MeshDevice(
     std::shared_ptr<ScopedDevices> mesh_handle,
     std::unique_ptr<MeshDeviceView> mesh_device_view,
-    std::weak_ptr<MeshDevice> parent_mesh) :
+    std::shared_ptr<MeshDevice> parent_mesh) :
     scoped_devices_(std::move(mesh_handle)),
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
@@ -132,10 +144,50 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
         l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, config);
     MeshContainer<IDevice*> devices(config.mesh_shape, scoped_devices->root_devices());
     auto mesh_device = std::make_shared<MeshDevice>(
-        std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::weak_ptr<MeshDevice>());
+        std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::shared_ptr<MeshDevice>());
 
     mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
     return mesh_device;
+}
+
+std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_single_devices(
+    const std::vector<int>& device_ids,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+    auto scoped_devices = std::make_shared<ScopedDevices>(
+        device_ids, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
+    MeshContainer<IDevice*> devices(MeshShape(1, device_ids.size()), scoped_devices->root_devices());
+    auto mesh_device = std::make_shared<MeshDevice>(
+        std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::shared_ptr<MeshDevice>());
+
+    auto submeshes = mesh_device->create_submeshes(MeshShape(1, 1));
+    TT_FATAL(
+        device_ids.size() == submeshes.size(),
+        "Create unexpected number of submeshes {} instead of {}",
+        submeshes.size(),
+        device_ids.size());
+    std::map<int, std::shared_ptr<MeshDevice>> result;
+    for (size_t i = 0; i < device_ids.size(); i++) {
+        submeshes[i]->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
+        result[device_ids[i]] = submeshes[i];
+    }
+
+    return result;
+}
+
+std::shared_ptr<MeshDevice> MeshDevice::create_single_device(
+    int device_id,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t num_command_queues,
+    const DispatchCoreConfig& dispatch_core_config,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+    return create_single_devices(
+               {device_id}, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, l1_bank_remap)
+        .at(device_id);
 }
 
 std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
@@ -181,7 +233,6 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
     auto submesh = std::make_shared<MeshDevice>(
         scoped_devices_, std::make_unique<MeshDeviceView>(submesh_devices_container), shared_from_this());
 
-    submeshes_.push_back(submesh);
     log_trace(LogMetal, "Instantiating submesh {}: {} with offset: {}", submesh->id(), submesh_shape, offset);
     log_trace(LogMetal, "Submesh {} instantiated with {} devices", submesh->id(), submesh->get_devices().size());
     return submesh;
@@ -326,10 +377,6 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
 }
 
 bool MeshDevice::close() {
-    for (const auto& submesh : submeshes_) {
-        submesh->close();
-    }
-    submeshes_.clear();
     sub_device_manager_tracker_.reset();
     if (scoped_devices_) {
         scoped_devices_.reset();
@@ -352,9 +399,7 @@ MeshDeviceID MeshDevice::id() const { return mesh_id_; }
 // For a mesh, build id is the same as the device id for the reference device
 chip_id_t MeshDevice::build_id() const { return reference_device()->id(); }
 
-bool MeshDevice::is_parent_mesh() const { return parent_mesh_.expired(); }
-
-std::vector<std::shared_ptr<MeshDevice>> MeshDevice::get_submeshes() const { return submeshes_; }
+bool MeshDevice::is_parent_mesh() const { return parent_mesh_ == nullptr; }
 
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device) { return os << mesh_device.to_string(); }
 


### PR DESCRIPTION
### Ticket

### Problem description
I'm integrating MeshDevice into TT-NN, trying to make all python code to always use MeshDevice 1x1 instead of single device APIs. To make MeshDevice APIs compatible, we need a way to create a single MeshDevice with specifying device id.
Moreover, we need an ability to create MeshDevice 1x1 for each of multiple device ids to fully mimic CreateDevices API exposed to python. Creating MeshDevices 1 by 1 for each device id is not equivalent to creating/closing them at the same time (causes fails in inividual calls to metal's CreateDevice CloseDevice). So I added a helper function to create a common mesh device and then create submeshes out of it. This presents a new ownership issue, because the parent mesh device must be kept alive longer than the children devices, however the current python code wasn't designed to handle that. So this PR inverts ownership relationship - each submesh keeps a shared_ptr to the parent mesh, ensuring that its being kept alive until the submesh is destroyed.

### What's changed
Added new creation functions for MeshDevice
Changed the ownership model, parent MeshDevice doesn't keep submeshes meshes alive, but the submeshes keep the parent one alive. I think it makes some sense and simplifies `MeshDevice::close()`, but I'm open to discussion on possibly better ways to achieve the goal.
Removed the usages of `get_submeshes` method.

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13688057501)
- [x] New/Existing tests provide coverage for changes
