### PR TITLE
#18695: Enable prepare conv weights tests for blackhole

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/test_prepare_conv_weights.py
@@ -6,24 +6,10 @@ from loguru import logger
 
 import torch
 import pytest
-from models.utility_functions import (
-    is_wormhole_b0,
-    skip_for_grayskull,
-    is_grayskull,
-    is_wormhole_b0,
-    skip_for_wormhole_b0,
-    is_x2_harvested,
-    is_blackhole,
-    skip_for_blackhole,
-    is_blackhole,
-)
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 import ttnn
 
 
-@skip_for_grayskull()
-@skip_for_blackhole()
-# @skip_for_wormhole_b0()
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (
@@ -198,9 +184,6 @@ def test_prepare_conv_weights(
     assert passing
 
 
-@skip_for_grayskull()
-@skip_for_blackhole()
-# @skip_for_wormhole_b0()
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (


### PR DESCRIPTION
### Ticket
#18695 

Removing skips for any arch and removing unused imports from `tests/ttnn/unit_tests/operations/test_prepare_conv_weights.py`. 