### PR TITLE
Making CB indices contiguous for conv halo op

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -11,19 +11,21 @@ namespace NAMESPACE {
 void MAIN {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
 
-    pack_untilize_init<per_core_block_tile_cnt>(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    pack_untilize_init<per_core_block_tile_cnt>(src_cb_id, out_cb_id);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
-        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+        cb_wait_front(src_cb_id, per_core_block_tile_cnt);
+        cb_reserve_back(out_cb_id, per_core_block_tile_cnt);
 
-        pack_untilize_block<per_core_block_tile_cnt>(tt::CBIndex::c_0, 1, tt::CBIndex::c_16);
+        pack_untilize_block<per_core_block_tile_cnt>(src_cb_id, 1, out_cb_id);
 
-        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
-        cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
+        cb_push_back(out_cb_id, per_core_block_tile_cnt);
+        cb_pop_front(src_cb_id, per_core_block_tile_cnt);
     }
 
-    pack_untilize_uninit(tt::CBIndex::c_16);
+    pack_untilize_uninit(out_cb_id);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
@@ -11,19 +11,21 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
-    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    uint32_t src_cb_id = get_compile_time_arg_val(2);
+    uint32_t out_cb_id = get_compile_time_arg_val(3);
+    untilize_init(src_cb_id, out_cb_id);
 
     // UNPACK(( DPRINT << "Block count=" << uint32_t(per_core_block_cnt) << " tile count=" << per_core_block_tile_cnt <<
     // ENDL() ));
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
-        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+        cb_wait_front(src_cb_id, per_core_block_tile_cnt);
+        cb_reserve_back(out_cb_id, per_core_block_tile_cnt);
 
-        untilize_block(tt::CBIndex::c_0, per_core_block_tile_cnt, tt::CBIndex::c_16);
+        untilize_block(src_cb_id, per_core_block_tile_cnt, out_cb_id);
 
-        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
-        cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
+        cb_push_back(out_cb_id, per_core_block_tile_cnt);
+        cb_pop_front(src_cb_id, per_core_block_tile_cnt);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -132,7 +132,8 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column_subgrid(
     std::vector<uint32_t> compute_args = {
         (uint32_t)nblocks_per_core,  // per_core_block_cnt
         (uint32_t)ntiles_per_block,  // per_block_ntiles
-    };
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index};
 
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
@@ -317,11 +318,13 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
     std::vector<uint32_t> compute_args = {
         (uint32_t)nblocks_per_core,  // per_core_block_cnt
         (uint32_t)ntiles_per_block,  // per_block_ntiles
-    };
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index};
     std::vector<uint32_t> compute_args_cliff = {
         (uint32_t)nblocks_per_core_cliff,
         (uint32_t)ntiles_per_block,  // per_block_ntiles
-    };
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index};
 
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
@@ -943,11 +946,13 @@ operation::ProgramWithCallbacks untilize_multi_core(
     std::vector<uint32_t> compute_args = {
         (uint32_t)nblocks_per_core,  // per_core_block_cnt
         (uint32_t)ntiles_per_block,  // per_block_ntiles
-    };
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index};
     std::vector<uint32_t> compute_args_cliff = {
         (uint32_t)nblocks_per_core_cliff,
         (uint32_t)ntiles_per_block,  // per_block_ntiles
-    };
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index};
 
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
@@ -1300,8 +1305,9 @@ operation::ProgramWithCallbacks untilize_single_core(
 
     std::vector<uint32_t> compute_args = {
         uint32_t(num_tiles / num_tiles_per_block),  // per_core_block_cnt
-        uint32_t(num_tiles_per_block)               // per_core_block_tile_cnt
-    };
+        uint32_t(num_tiles_per_block),              // per_core_block_tile_cnt
+        uint32_t(src0_cb_index),
+        uint32_t(output_cb_index)};
 
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
@@ -19,6 +19,27 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement::detail {
 
+// In order to make circular buffer indicies sequential, we use variable to keep track of the next available index.
+// Circular buffer indices should be assigned right before their creation.
+struct CBIndices {
+    // Invalid value for cb id is 32, number greater than the maximum number of index circular buffer can have.
+    // Not assigning get_next_cb_index() value before creating cb will throw exception in circular_buffer_types.cpp
+    // which can be used as a reminder.
+    uint32_t src_cb_id = 32;
+    uint32_t pad_cb_id = 32;
+    uint32_t out_cb_id = 32;
+
+    // Additional CBs for sharded data kernel configs
+    uint32_t padding_config_cb_id = 32;
+    uint32_t local_config_cb_id = 32;
+    uint32_t remote_config_cb_id = 32;
+    uint32_t untilize_out_cb_id = 32;
+    uint32_t get_next_cb_id() { return next_cb_id++; }
+
+private:
+    uint32_t next_cb_id = tt::CBIndex::c_0;
+};
+
 operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     Program& program,
     const Tensor& input_tensor,
@@ -66,56 +87,53 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
         in_page_size = input_shard_shape[1] * in_nbytes;
         input_npages = remapped_input_shard_shape_for_output_grid;
     }
-
     // Construct CBs
     // //
-
-    uint32_t src_cb_id = tt::CBIndex::c_0;
-    uint32_t pad_cb_id = tt::CBIndex::c_1;
-    uint32_t untilize_out_cb_id = tt::CBIndex::c_16;
-    uint32_t out_cb_id = tt::CBIndex::c_17;
-
+    CBIndices cb_indices = CBIndices();
+    cb_indices.src_cb_id = cb_indices.get_next_cb_id();
     // input CB (sharded)
-    auto src_cb_config = CircularBufferConfig(input_npages * in_page_size, {{src_cb_id, in_df}})
-                             .set_page_size(src_cb_id, in_page_size)
+    auto src_cb_config = CircularBufferConfig(input_npages * in_page_size, {{cb_indices.src_cb_id, in_df}})
+                             .set_page_size(cb_indices.src_cb_id, in_page_size)
                              .set_globally_allocated_address(*src_buffer);
     auto src_cb = CreateCircularBuffer(program, all_cores, src_cb_config);
-    log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", src_cb_id, input_npages, in_page_size);
+    log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", cb_indices.src_cb_id, input_npages, in_page_size);
 
-    uint32_t input_to_writer_cb_id = src_cb_id;
+    uint32_t input_to_writer_cb_id = cb_indices.src_cb_id;
     if (!skip_untilize) {
-        input_to_writer_cb_id = untilize_out_cb_id;
-
+        cb_indices.untilize_out_cb_id = cb_indices.get_next_cb_id();
+        input_to_writer_cb_id = cb_indices.untilize_out_cb_id;
         // output of untilize from compute kernel goes into this CB
         uint32_t output_ntiles = ntiles_per_block * input_nblocks_per_core;
         auto untilize_out_cb_config =
-            CircularBufferConfig(output_ntiles * out_tile_size, {{untilize_out_cb_id, out_df}})
-                .set_page_size(untilize_out_cb_id, out_tile_size);
+            CircularBufferConfig(output_ntiles * out_tile_size, {{cb_indices.untilize_out_cb_id, out_df}})
+                .set_page_size(cb_indices.untilize_out_cb_id, out_tile_size);
         auto untilize_out_cb = CreateCircularBuffer(program, all_cores, untilize_out_cb_config);
-        log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", untilize_out_cb_id, output_ntiles, out_tile_size);
+        log_debug(
+            tt::LogOp,
+            "CB {} :: npages = {}, pagesize = {}",
+            cb_indices.untilize_out_cb_id,
+            output_ntiles,
+            out_tile_size);
     }
 
+    cb_indices.out_cb_id = cb_indices.get_next_cb_id();
     // output shard, after inserting halo and padding, goes into this CB as input to next op.
     uint32_t out_cb_pagesize = out_stick_nbytes;
     uint32_t out_cb_npages = max_out_nsticks_per_core;
-    auto out_cb_config = CircularBufferConfig(out_cb_npages * out_cb_pagesize, {{out_cb_id, out_df}})
-                             .set_page_size(out_cb_id, out_cb_pagesize)
+    auto out_cb_config = CircularBufferConfig(out_cb_npages * out_cb_pagesize, {{cb_indices.out_cb_id, out_df}})
+                             .set_page_size(cb_indices.out_cb_id, out_cb_pagesize)
                              .set_globally_allocated_address(*dst_buffer);
     auto out_cb = CreateCircularBuffer(program, all_cores, out_cb_config);
-    log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", out_cb_id, out_cb_npages, out_cb_pagesize);
+    log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", cb_indices.out_cb_id, out_cb_npages, out_cb_pagesize);
 
     // CB for pad val buffer (stick sized)
     uint32_t pad_cb_pagesize = out_stick_nbytes;
     uint32_t pad_cb_npages = 1;
-    auto pad_cb_config = CircularBufferConfig(pad_cb_pagesize * pad_cb_npages, {{pad_cb_id, out_df}})
-                             .set_page_size(pad_cb_id, pad_cb_pagesize);
+    cb_indices.pad_cb_id = cb_indices.get_next_cb_id();
+    auto pad_cb_config = CircularBufferConfig(pad_cb_pagesize * pad_cb_npages, {{cb_indices.pad_cb_id, out_df}})
+                             .set_page_size(cb_indices.pad_cb_id, pad_cb_pagesize);
     auto pad_cb = CreateCircularBuffer(program, all_cores, pad_cb_config);
-    log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", pad_cb_id, pad_cb_npages, pad_cb_pagesize);
-
-    // Additional CBs for sharded data kernel configs
-    uint32_t padding_config_cb_id = tt::CBIndex::c_2;
-    uint32_t local_config_cb_id = tt::CBIndex::c_3;
-    uint32_t remote_config_cb_id = tt::CBIndex::c_4;
+    log_debug(tt::LogOp, "CB {} :: npages = {}, pagesize = {}", cb_indices.pad_cb_id, pad_cb_npages, pad_cb_pagesize);
 
     tt::DataFormat kernel_config_df = tt::DataFormat::RawUInt16;  // NOTE: UInt16 is not supported for CB types
     uint32_t config_nbytes =
@@ -125,7 +143,8 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     // Gather data
     if (!skip_untilize) {
         // compute kernel
-        std::vector<uint32_t> compute_ct_args = {input_nblocks_per_core, ntiles_per_block};
+        std::vector<uint32_t> compute_ct_args = {
+            input_nblocks_per_core, ntiles_per_block, cb_indices.src_cb_id, input_to_writer_cb_id};
         std::string compute_kernel(
             "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
         if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH) {
@@ -146,28 +165,34 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
 
     auto padding_config_buffer = padding_config.device_buffer();
     const uint32_t num_cores = all_cores.num_cores();
+    cb_indices.padding_config_cb_id = cb_indices.get_next_cb_id();
     auto padding_config_cb_config =
-        CircularBufferConfig(padding_config_buffer->size() / num_cores, {{padding_config_cb_id, kernel_config_df}})
-            .set_page_size(padding_config_cb_id, padding_config_buffer->page_size())
+        CircularBufferConfig(
+            padding_config_buffer->size() / num_cores, {{cb_indices.padding_config_cb_id, kernel_config_df}})
+            .set_page_size(cb_indices.padding_config_cb_id, padding_config_buffer->page_size())
             .set_globally_allocated_address(*padding_config_buffer);
     CBHandle padding_config_cb = CreateCircularBuffer(program, all_cores, padding_config_cb_config);
 
     auto local_config_buffer = local_config.device_buffer();
+    cb_indices.local_config_cb_id = cb_indices.get_next_cb_id();
     auto local_config_cb_config =
-        CircularBufferConfig(local_config_buffer->size() / num_cores, {{local_config_cb_id, kernel_config_df}})
-            .set_page_size(local_config_cb_id, local_config_buffer->page_size())
+        CircularBufferConfig(
+            local_config_buffer->size() / num_cores, {{cb_indices.local_config_cb_id, kernel_config_df}})
+            .set_page_size(cb_indices.local_config_cb_id, local_config_buffer->page_size())
             .set_globally_allocated_address(*local_config_buffer);
     CBHandle local_config_cb = CreateCircularBuffer(program, all_cores, local_config_cb_config);
 
     auto remote_config_buffer = remote_config.device_buffer();
+    cb_indices.remote_config_cb_id = cb_indices.get_next_cb_id();
     auto remote_config_cb_config =
-        CircularBufferConfig(remote_config_buffer->size() / num_cores, {{remote_config_cb_id, kernel_config_df}})
-            .set_page_size(remote_config_cb_id, remote_config_buffer->page_size())
+        CircularBufferConfig(
+            remote_config_buffer->size() / num_cores, {{cb_indices.remote_config_cb_id, kernel_config_df}})
+            .set_page_size(cb_indices.remote_config_cb_id, remote_config_buffer->page_size())
             .set_globally_allocated_address(*remote_config_buffer);
     CBHandle remote_config_cb = CreateCircularBuffer(program, all_cores, remote_config_cb_config);
 
-    bool const is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
-    bool const is_width_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool is_width_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED;
 
     auto aligned_input_nstick_nbytes = out_stick_nbytes;
     log_debug(tt::LogOp, "out_stick_nbytes = {}", out_stick_nbytes);
@@ -181,10 +206,10 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
         0,  // padding_config_cb_id
         0,  // local_config_cb_id
         0,  // remote_config_cb_id
-        src_cb_id,
+        cb_indices.src_cb_id,
         input_to_writer_cb_id,
-        out_cb_id,
-        pad_cb_id,
+        cb_indices.out_cb_id,
+        cb_indices.pad_cb_id,
         pad_val,
         input_npages,
         out_stick_nbytes,
@@ -195,7 +220,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
         aligned_input_nstick_nbytes};
 
     reader_ct_args[0] = 0;
-    reader_ct_args[1] = local_config_cb_id;
+    reader_ct_args[1] = cb_indices.local_config_cb_id;
     reader_ct_args[2] = 0;
 
     KernelHandle reader_kernel_id0 = CreateKernel(
@@ -205,9 +230,9 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_ct_args});
 
-    reader_ct_args[0] = padding_config_cb_id;
+    reader_ct_args[0] = cb_indices.padding_config_cb_id;
     reader_ct_args[1] = 0;
-    reader_ct_args[2] = remote_config_cb_id;
+    reader_ct_args[2] = cb_indices.remote_config_cb_id;
 
     KernelHandle reader_kernel_id1 = CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -160,7 +160,11 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
         core,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-    std::vector<uint32_t> compute_args = {uint32_t(num_tiles / num_tiles_per_block), uint32_t(num_tiles_per_block)};
+    std::vector<uint32_t> compute_args = {
+        uint32_t(num_tiles / num_tiles_per_block),
+        uint32_t(num_tiles_per_block),
+        uint32_t(src0_cb_index),
+        uint32_t(output_cb_index)};
 
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
@@ -767,7 +771,9 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
             program,
             compute_kernel,
             core_range,
-            ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {nblocks_per_core, num_tiles_per_row}});
+            ComputeConfig{
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = {nblocks_per_core, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16}});
     }
     if (has_cliff) {
         auto tilize_cliff_kernel_id = CreateKernel(
@@ -775,7 +781,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
             compute_kernel,
             core_range_cliff,
             ComputeConfig{
-                .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {nblocks_per_core_cliff, num_tiles_per_row}});
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = {nblocks_per_core_cliff, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16}});
     }
 
     uint32_t tile_height = output.get_tensor_spec().tile().get_height();
@@ -997,6 +1004,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     std::vector<uint32_t> compute_args = {
         (uint32_t)nblocks_per_core,  // per_core_block_cnt
         (uint32_t)ntiles_per_block,  // per_block_ntiles
+        (uint32_t)src0_cb_index,
+        (uint32_t)output_cb_index,
     };
 
     std::string compute_kernel(


### PR DESCRIPTION
### Ticket
[#18281](https://github.com/tenstorrent/tt-metal/issues/18281)

### Problem description
Due to circular buffer not being contiguous fast dispatch performance is hurt and warnings are generated when conv2d op is called. Part of the conv2d is micro op halo generating warnings. Once we pass sequential cb indices to halo_gather kernel other kernels synchronizing with halo_gather need to be updated as well to avoid the hang, hence the change in untilize and pack_untilize kernels.

### What's changed
1. Circular buffer indices are made sequential by assigning them values incrementally and dynamically right before CB creation.
2. CB indices are being passed to kernels as compile time arguments.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13721241942)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/13698660209)
- [x] [(Single-card) Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/13698676822)
