### PR TITLE
#17026: Update rsub backward

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -545,8 +545,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardRsub::invoke(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<ttnn::Tensor>> result = {std::nullopt, std::nullopt};
 
-    preallocated_tensors_check(
-        input_grad, other_grad, input, other, {are_required_outputs[0], are_required_outputs[1]});
+    preallocated_tensors_check(input_grad, other_grad, grad, grad, {are_required_outputs[0], are_required_outputs[1]});
     if (are_required_outputs.at(0)) {
         ttnn::neg(queue_id, grad, output_mem_config, input_grad);
         result[0] = input_grad;


### PR DESCRIPTION
### Ticket
Link to Github Issue #17026

### Problem description
ttnn.rsub backward binary sharded throws exception when input dtype is bfloat16

### What's changed
Updated the dtype of optional output tensor to match the input dtype.

### Checklist
- [ ] All post commit CI
