### PR TITLE
#7525: Re-enable single-card WH BERT perf tests

### DIFF
--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -156,7 +156,7 @@ def run_perf_bert11(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, model_config_str, expected_inference_time, expected_compile_time, inference_iterations",
-    ([8, "BFLOAT8_B-SHARDED", 0.0324, 6, 10],),
+    ([8, "BFLOAT8_B-SHARDED", 0.0324, 12, 10],),
 )
 def test_perf_bare_metal_wh(
     device,

--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -151,7 +151,7 @@ def run_perf_bert11(
     logger.info(f"bert11 compile time: {compile_time}")
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="May hang, need to check functional tests")
+@pytest.mark.skipif(is_blackhole(), reason="Not functional on BH")
 @run_for_wormhole_b0(reason_str="WH specific batch size")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(

--- a/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
@@ -44,7 +44,6 @@ def test_perf_device_bare_metal(batch_size, test, expected_perf):
     run_bert_perf(batch_size, test, expected_perf)
 
 
-@pytest.mark.skip("#7525: Hangs non-deterministically on device perf, likely same issue as demo model")
 @skip_for_grayskull("Incorrect device metrics for grayskull")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(

--- a/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
@@ -50,7 +50,7 @@ def test_perf_device_bare_metal(batch_size, test, expected_perf):
     "batch_size, test, expected_perf",
     [
         [7, "BERT_LARGE-batch_8-BFLOAT8_B-SHARDED", 280],
-        [8, "BERT_LARGE-batch_8-BFLOAT8_B-SHARDED", 340],
+        [8, "BERT_LARGE-batch_8-BFLOAT8_B-SHARDED", 360],
     ],
 )
 def test_perf_device_bare_metal_wh(batch_size, test, expected_perf):


### PR DESCRIPTION
### Ticket

#7525

### Problem description

These perf tests were hanging and we disabled

### What's changed

Let's try re-enable

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13702895427
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13702897710/job/38323986464
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
