### PR TITLE
Use the new name for the new runners

### DIFF
--- a/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests-wrapper.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: tt-ubuntu-2204-n300-large-stable },
+          { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-large-stable },
         ]
     uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
     with:

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           {name: fabric unit tests, cmd: ./tests/scripts/run_cpp_fabric_tests.sh },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
-    runs-on: ${{ startsWith(inputs.runner-label, 'tt-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)) || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)) }}
+    runs-on: ${{ startsWith(inputs.runner-label, 'tt-beta-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)) || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)) }}
     env:
       ARCH_NAME: ${{ inputs.arch }}
       LOGURU_LEVEL: INFO


### PR DESCRIPTION
### Ticket
None

### Problem description
The new runners are being renamed to tt-beta-ubuntu-foo, accommodate this change.

### What's changed
Reference the new name for the new runners

