### PR TITLE
#17536: add matmul output mem config validation

### DIFF
--- a/models/demos/t3000/falcon40b/tt/model_utils.py
+++ b/models/demos/t3000/falcon40b/tt/model_utils.py
@@ -282,6 +282,7 @@ def falcon_prefill_matmul(
 
     is_fp32_accumulate = compute_kernel_config.fp32_dest_acc_en
 
+    output_mem_config.shard_spec = None
     if use_2d_mm:
         # print("Selecting MM 2d")
         matmul_pgmcfg = matmul_2d_config(

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -211,11 +211,13 @@ class TtMixtralAttention(LightweightModule):
         if self.k_mem_config is None:
             self.k_mem_config = k_heads_1B1D.memory_config()
 
+        out_mem_config = self.q_mem_config
+        out_mem_config.shard_spec = None
         q_heads_1B4D = ttnn.matmul(
             q_heads_1B4D,
             rot_mat,
             program_config=self.model_config["ROT_MAT_MM_PROGCFG"],
-            memory_config=self.q_mem_config,
+            memory_config=out_mem_config,
             compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
             # [seqlen, bsz, padd_heads, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, bsz, padd_heads, head_dim]
         )

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -70,6 +70,7 @@ class DistributedNorm(LightweightModule):
 
         # Distributed norm already performs a gather
         if self.args.is_multichip and not self.args.is_distributed_norm(mode):
+            input_mem_cfg.shard_spec = None
             x = ttnn.all_gather(x, dim=3, num_links=1, topology=self.args.ccl_topology(), memory_config=input_mem_cfg)
         else:
             x = ttnn.to_memory_config(x, input_mem_cfg)

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -169,6 +169,11 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
     shard_shape = (32, 1024)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     sharded_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+    out_shard_shape = (32, 128)
+    out_shard_spec = ttnn.ShardSpec(shard_grid, out_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    out_sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec
+    )
     input_tensor_in0 = ttnn.to_memory_config(input_tensor_in0, sharded_mem_config)
 
     # in1 shard config
@@ -203,7 +208,7 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
         input_tensor_in0,
         input_tensor_in1,
         program_config=program_config,
-        memory_config=sharded_mem_config,
+        memory_config=out_sharded_mem_config,
         dtype=ttnn.bfloat16,
         compute_kernel_config=compute_kernel_config,
     )

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -2089,7 +2089,7 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     out_mem_config = ttnn.create_sharded_memory_config(
         shape=(32, 256),
-        core_grid=ttnn.CoreGrid(x=1, y=8),
+        core_grid=ttnn.CoreGrid(x=8, y=1),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
     )
@@ -2100,8 +2100,8 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     # Block sharded
     out_mem_config = ttnn.create_sharded_memory_config(
-        shape=(32, 256),
-        core_grid=ttnn.CoreGrid(x=1, y=8),
+        shape=(256, 256),
+        core_grid=ttnn.CoreGrid(x=1, y=1),
         strategy=ttnn.ShardStrategy.BLOCK,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
     )

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1454,12 +1454,13 @@ void Matmul::validate(
             output_tensor_spec.memory_config(),
             this->output_mem_config);
     } else {
-        TT_FATAL(
+        // TODO: try to change these to fatals and fix test_llama_model.py in APC
+        TT_ASSERT(
             output_tensor_spec.memory_config().memory_layout == this->output_mem_config.memory_layout,
             "Mismatch between computed {} and provided {} mem config memory layout",
             output_tensor_spec.memory_config().memory_layout,
             this->output_mem_config.memory_layout);
-        TT_FATAL(
+        TT_ASSERT(
             output_tensor_spec.memory_config().buffer_type == this->output_mem_config.buffer_type,
             "Mismatch between computed {} and provided {} mem config buffer type",
             output_tensor_spec.memory_config().buffer_type,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1447,24 +1447,23 @@ void Matmul::validate(
             "tensor {}",
             optional_output_tensor_c->memory_config(),
             this->output_mem_config);
-    } else if (this->output_mem_config.shard_spec.has_value()) {
-        TT_FATAL(
-            output_tensor_spec.memory_config() == this->output_mem_config,
-            "Mismatch between computed {} and provided {} mem config",
-            output_tensor_spec.memory_config(),
-            this->output_mem_config);
     } else {
-        // TODO: try to change these to fatals and fix test_llama_model.py in APC
-        TT_ASSERT(
+        TT_FATAL(
             output_tensor_spec.memory_config().memory_layout == this->output_mem_config.memory_layout,
             "Mismatch between computed {} and provided {} mem config memory layout",
             output_tensor_spec.memory_config().memory_layout,
             this->output_mem_config.memory_layout);
-        TT_ASSERT(
+        TT_FATAL(
             output_tensor_spec.memory_config().buffer_type == this->output_mem_config.buffer_type,
             "Mismatch between computed {} and provided {} mem config buffer type",
             output_tensor_spec.memory_config().buffer_type,
             this->output_mem_config.buffer_type);
+        // Needs to be an assert, there are too many existing models not specifying shard spec correctly.
+        TT_ASSERT(
+            output_tensor_spec.memory_config() == this->output_mem_config,
+            "Mismatch between computed {} and provided {} mem config",
+            output_tensor_spec.memory_config(),
+            this->output_mem_config);
     }
 
     TT_FATAL(this->bcast_batch.has_value(), "Error: bcast_batch field should have been automatically populated");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1458,9 +1458,9 @@ void Matmul::validate(
             "Mismatch between computed {} and provided {} mem config buffer type",
             output_tensor_spec.memory_config().buffer_type,
             this->output_mem_config.buffer_type);
-        // Needs to be an assert, there are too many existing models not specifying shard spec correctly.
-        TT_ASSERT(
-            output_tensor_spec.memory_config() == this->output_mem_config,
+        TT_FATAL(
+            !this->output_mem_config.shard_spec.has_value() ||
+                output_tensor_spec.memory_config() == this->output_mem_config,
             "Mismatch between computed {} and provided {} mem config",
             output_tensor_spec.memory_config(),
             this->output_mem_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1447,6 +1447,13 @@ void Matmul::validate(
             "tensor {}",
             optional_output_tensor_c->memory_config(),
             this->output_mem_config);
+    } else if (this->output_mem_config.shard_spec.has_value()) {
+        const auto output_tensor_spec = this->compute_output_specs(input_tensors, {}, optional_input_tensors).at(0);
+        TT_FATAL(
+            output_tensor_spec.memory_config() == this->output_mem_config,
+            "Mismatch between computed {} and provided {} mem config",
+            output_tensor_spec.memory_config(),
+            this->output_mem_config);
     }
 
     TT_FATAL(this->bcast_batch.has_value(), "Error: bcast_batch field should have been automatically populated");

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -270,6 +270,7 @@ void py_module(py::module& module) {
         - Note: there are various additional constraints related to specific program
           configs chosen. Please look at the error messages carefully and fix
           problems appropriately.
+        - Note: if memory_config is provided, it will be compared to what matmul wants to use. The shard spec can be set to None to not compare it.
         - Note: If optional output tensor is specified, then dtype and memory config need to be checked as follows:
           - if they are default then they should be set based on optional output tensor
           - if the are not default then they should be compared and if there is a difference an error is reported


### PR DESCRIPTION
### Ticket
Link to Github Issue #17536

### Problem description
- upstream users need to know whether output memory configs are valid or not

### What's changed
- add checks for output memory config
- add a note about it
- fix tests/models to pass in output memory config with no shard spec instead of shard spec of input tensor to avoid incorrect comparison
- could not fix all models, make full check that includes the shard spec an assert

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13709782250
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13704407729
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13704405318/job/38329076330 fails the same way as main https://github.com/tenstorrent/tt-metal/actions/runs/13702886135/job/38323809298
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes


TG demo test fails for unrelated reasons: https://github.com/tenstorrent/tt-metal/actions/runs/13885105963
