### PR TITLE
Extend MeshTensor read/write APIs to support uneven sharding

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -59,7 +59,7 @@ TEST(MeshShapeTest, Strides) {
     EXPECT_EQ(shape.get_stride(2), 1);   // 1
 }
 
-TEST(MeshShapeTest, Comparison) {
+TEST(MeshShapeTest, Equality) {
     MeshShape shape(2, 3);
 
     EXPECT_EQ(shape, MeshShape(2, 3));
@@ -113,12 +113,29 @@ TEST(MeshCoordinateTest, Construction) {
     EXPECT_EQ(coord_span[4], 5);
 }
 
-TEST(MeshCoordinateTest, Comparison) {
+TEST(MeshCoordinateTest, Equality) {
     MeshCoordinate coord1(1, 2);
 
     EXPECT_EQ(coord1, MeshCoordinate(1, 2));
     EXPECT_NE(coord1, MeshCoordinate(2, 1));
     EXPECT_NE(coord1, MeshCoordinate(1, 2, 1));
+}
+
+TEST(MeshCoordinateTest, ComparisonMismatchedDimensions) {
+    MeshCoordinate coord1(1);
+    EXPECT_ANY_THROW(void(coord1 < MeshCoordinate(1, 2)));
+}
+
+TEST(MeshCoordinateTest, Comparison) {
+    MeshCoordinate coord1(1);
+    MeshCoordinate coord2(2);
+    EXPECT_TRUE(coord1 < coord2);
+    EXPECT_FALSE(coord2 < coord1);
+
+    MeshCoordinate coord3(2, 0, 3);
+    MeshCoordinate coord4(2, 1, 3);
+    EXPECT_TRUE(coord3 < coord4);
+    EXPECT_FALSE(coord4 < coord3);
 }
 
 TEST(MeshCoordinateTest, UnorderedSet) {

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -84,13 +84,17 @@ public:
     static constexpr auto attribute_names = std::forward_as_tuple("value");
     auto attribute_values() const { return std::forward_as_tuple(value_); }
 
-    friend bool operator==(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
-    friend bool operator!=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
-    friend std::ostream& operator<<(std::ostream& os, const MeshCoordinate& shape);
-
 private:
     tt::stl::SmallVector<uint32_t> value_;
 };
+
+bool operator==(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+bool operator!=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+bool operator<(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+bool operator>(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+bool operator<=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+bool operator>=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+std::ostream& operator<<(std::ostream& os, const MeshCoordinate& shape);
 
 // Converts a MeshCoordinate to a linear index.
 // Throws if `coord` is out of bounds of `shape`.

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -118,6 +118,23 @@ bool operator==(const MeshCoordinate& lhs, const MeshCoordinate& rhs) {
 }
 bool operator!=(const MeshCoordinate& lhs, const MeshCoordinate& rhs) { return !(lhs == rhs); }
 
+bool operator<(const MeshCoordinate& lhs, const MeshCoordinate& rhs) {
+    TT_FATAL(
+        lhs.dims() == rhs.dims(),
+        "Cannot compare coordinates with different dimensions: {} != {}",
+        lhs.dims(),
+        rhs.dims());
+    for (size_t i = 0; i < lhs.dims(); ++i) {
+        if (lhs[i] != rhs[i]) {
+            return lhs[i] < rhs[i];
+        }
+    }
+    return false;
+}
+bool operator>(const MeshCoordinate& lhs, const MeshCoordinate& rhs) { return rhs < lhs; }
+bool operator<=(const MeshCoordinate& lhs, const MeshCoordinate& rhs) { return !(lhs > rhs); }
+bool operator>=(const MeshCoordinate& lhs, const MeshCoordinate& rhs) { return !(lhs < rhs); }
+
 std::ostream& operator<<(std::ostream& os, const MeshCoordinate& coord) {
     os << "MeshCoordinate([";
     for (size_t i = 0; i < coord.dims(); ++i) {

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
@@ -187,8 +187,9 @@ std::unique_ptr<MeshToTensor> concat_2d_mesh_to_tensor_composer(MeshDevice& mesh
 Tensor distribute_tensor(
     const Tensor& tensor, const TensorToMesh& mapper, std::optional<std::reference_wrapper<MeshDevice>> mesh_device) {
     TT_FATAL(
-        tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
-        "TensorToMesh does not support multi-device or multi-device host tensors; got storage type: {}",
+        tensor.storage_type() == tt::tt_metal::StorageType::OWNED ||
+            tensor.storage_type() == tt::tt_metal::StorageType::BORROWED,
+        "TensorToMesh only supports host tensors; got storage type: {}",
         tensor.storage_type());
     std::vector<Tensor> tensors = mapper.map(tensor);
     Tensor output = aggregate_as_tensor(tensors, mapper.config());

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include "tt-metalium/mesh_coord.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 
@@ -41,8 +42,13 @@ struct OwnedStorage {
 
 // TODO: #17215 - Replace `DeviceStorage` with "mesh storage".
 struct DeviceStorage {
+    // TODO: come up with a better abstraction for this.
+    DistributedTensorConfig strategy;
+
     std::shared_ptr<Buffer> buffer;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
+    std::map<distributed::MeshCoordinate, TensorSpec> specs;
+
     DeviceStorage() = default;
     DeviceStorage(std::shared_ptr<Buffer> buffer_);
     DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -9,6 +9,7 @@
 #include "tt-metalium/mesh_device.hpp"
 #include "tt-metalium/mesh_command_queue.hpp"
 #include "tt-metalium/overloaded.hpp"
+#include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_impl_wrapper.hpp"
@@ -574,26 +575,22 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
     specs.reserve(num_buffers);
     buffers.reserve(num_buffers);
     shard_data_transfers.reserve(num_buffers);
-    distributed::MeshCoordinateRange coord_range(device->shape());
-    auto shard_coord = coord_range.begin();
-    for (int id = 0; id < device->num_devices(); ++id) {
+    for (const auto& [coord, shard_tensor_spec] : storage.specs) {
         std::vector<T> host_buffer;
-        const auto& shard_tensor_spec = tensor.get_tensor_spec();
         const auto tensor_size_bytes = shard_tensor_spec.compute_packed_buffer_size_bytes();
         host_buffer.resize(tensor_size_bytes / sizeof(T));
         specs.push_back(shard_tensor_spec);
         buffers.push_back(owned_buffer::create<T>(std::move(host_buffer)));
 
         shard_data_transfers.push_back(distributed::MeshCommandQueue::ShardDataTransfer{
-            .shard_coord = *shard_coord,
+            .shard_coord = coord,
             .host_data = std::visit([](auto& b) { return b.data(); }, buffers.back()),
             .region = BufferRegion(0, tensor_size_bytes)});
-        ++shard_coord;
     }
 
     mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, blocking);
 
-    MultiDeviceHostStorage host_storage(AllGatherTensor{}, std::move(buffers), std::move(specs));
+    MultiDeviceHostStorage host_storage(storage.strategy, std::move(buffers), std::move(specs));
     return Tensor(std::move(host_storage), tensor.get_tensor_spec());
 }
 
@@ -741,7 +738,14 @@ DeviceStorage replicate_to_mesh_buffer(
 
     mesh_device->mesh_command_queue(*cq_id).enqueue_write_mesh_buffer(
         mesh_buffer, data_to_write.data(), /*blocking=*/false);
-    return DeviceStorage(mesh_buffer);
+
+    DeviceStorage device_storage(mesh_buffer);
+    std::map<distributed::MeshCoordinate, TensorSpec> specs;
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+        specs.emplace(coord, tensor_spec);
+    }
+    device_storage.specs = specs;
+    return device_storage;
 }
 
 template <typename T>
@@ -761,12 +765,22 @@ DeviceStorage shard_to_mesh_buffer(
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
     shard_data_transfers.reserve(storage.buffers.size());
 
-    distributed::MeshCoordinateRange coord_range(mesh_shape);
+    const auto coord_range = [&storage, &mesh_shape]() {
+        if (auto* shard2d_strategy = std::get_if<ShardTensor2D>(&storage.strategy)) {
+            distributed::MeshShape distribution_shape(shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
+            return distributed::MeshCoordinateRange(distribution_shape);
+        } else {
+            return distributed::MeshCoordinateRange(mesh_shape);
+        }
+    }();
+
+    std::map<distributed::MeshCoordinate, TensorSpec> specs;
     auto shard_coord = coord_range.begin();
     for (int i = 0; i < storage.buffers.size(); ++shard_coord, i++) {
         TensorSpec shard_tensor_spec(
             storage.specs[i].logical_shape(),
             storage.specs[i].tensor_layout().with_memory_config(tensor_spec.memory_config()));
+        specs.emplace(*shard_coord, shard_tensor_spec);
         const auto& shard_host_buffer = storage.buffers[i];
 
         const auto& shard_buffer = mesh_buffer->get_device_buffer(*shard_coord);
@@ -790,7 +804,10 @@ DeviceStorage shard_to_mesh_buffer(
 
     mesh_device->mesh_command_queue(*cq_id).enqueue_write_shards(mesh_buffer, shard_data_transfers, /*blocking=*/false);
 
-    return DeviceStorage(mesh_buffer);
+    DeviceStorage device_storage(mesh_buffer);
+    device_storage.specs = specs;
+    device_storage.strategy = storage.strategy;
+    return device_storage;
 }
 
 template <typename T>
@@ -834,11 +851,15 @@ void copy_to_mesh_tensor(const Tensor& host_tensor, const Tensor& mesh_tensor, t
     TT_FATAL(mesh_tensor.storage_type() == StorageType::DEVICE, "Mesh tensor is not on device.");
     TT_FATAL(tt::tt_metal::detail::InMainThread(), "copy_to_mesh_tensor must be called from the main thread");
     TT_FATAL(mesh_tensor.is_allocated(), "Need data to exist in order to move it to device");
+
     TT_FATAL(host_tensor.get_logical_shape() == mesh_tensor.get_logical_shape(), "Host tensor has different shape");
     TT_FATAL(host_tensor.get_dtype() == mesh_tensor.get_dtype(), "Host tensor has different dtype");
     TT_FATAL(
         host_tensor.get_tensor_spec().page_config() == mesh_tensor.get_tensor_spec().page_config(),
         "Host tensor has different page config");
+
+    // TODO: when copying from multi-device host storage, verify that tensor spec on each piece matches.
+    // Or should we verify that the tensor simply fits into pre-allocated device tensor?
 
     const auto& tensor_spec = mesh_tensor.get_tensor_spec();
     auto mesh_buffer = std::get<DeviceStorage>(mesh_tensor.get_storage()).mesh_buffer;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -213,7 +213,7 @@ Tensor to_device_mesh_tensor(
     QueueId cq_id = ttnn::DefaultQueueId);
 
 template <typename T>
-void copy_to_mesh_tensor(const Tensor& host_tensor, const Tensor& mesh_tensor, QueueId cq_id = ttnn::DefaultQueueId);
+void copy_to_mesh_tensor(const Tensor& host_tensor, Tensor& mesh_tensor, QueueId cq_id = ttnn::DefaultQueueId);
 
 // ======================================================================================
 //                                  .to_layout()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
MeshBuffer-backed Tensors should support uneven shards.

### What's changed
Changes to read/write paths + tests.

### Checklist
- [X] [Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13712167722)
- [X] New/Existing tests provide coverage for changes
