### PR TITLE
#18737: Add blackhole nightly and demo test workflows

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -18,8 +18,6 @@ jobs:
           {
             name: "BH_performance",
             arch: blackhole,
-            # current blackhole baremetals are not tagged with bare-metal
-            # will need to be tagged if running perf tests on BH
             runs-on: ["BH", "bare-metal", "in-service"],
             cmd:
           }

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -10,16 +10,11 @@ jobs:
       matrix:
         test-group: [
           {
-            name: "BH_functionality",
-            arch: blackhole,
-            runs-on: ["cloud-virtual-machine", "BH", "in-service"],
-            cmd: echo addme
-          },
-          {
-            name: "BH_performance",
+            name: "whisper_performance",
             arch: blackhole,
             runs-on: ["BH", "pipeline-perf", "in-service"],
-            cmd: echo addme
+            cmd: pytest -n auto models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation",
+            owner_id: U05RWH3QUPM #Salar Hosseini
           }
         ]
     name: ${{ matrix.test-group.name }}
@@ -31,7 +26,7 @@ jobs:
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - name: Enable Performance mode
-        if: ${{ matrix.test-group.name == 'BH_performance' }}
+        if: ${{ contains(matrix.test-group.name, 'performance') }}
         run: |
           sudo cpupower frequency-set -g performance
       - name: Set up dynamic env vars for build
@@ -45,7 +40,7 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          source ${{ github.workspace }}/tests/scripts/single_card/run_single_card_demo_tests.sh
+          # source ${{ github.workspace }}/tests/scripts/single_card/run_single_card_demo_tests.sh
           ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
@@ -55,11 +50,11 @@ jobs:
             generated/test_reports/
           prefix: "test_reports_"
       - name: Disable Performance mode
-        if: ${{ matrix.test-group.name == 'BH_performance' }}
+        if: ${{ contains(matrix.test-group.name, 'performance') }}
         run: |
           sudo cpupower frequency-set -g ondemand
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U0883RN6CRE  #William Ly
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -47,21 +47,6 @@ jobs:
           export PYTHONPATH=$TT_METAL_HOME
           source ${{ github.workspace }}/tests/scripts/single_card/run_single_card_demo_tests.sh
           ${{ matrix.test-group.cmd }}
-      - name: Save environment data
-        if: ${{ matrix.test-group.name == 'BH_performance' && !cancelled() }}
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          source ${{ github.workspace }}/python_env/bin/activate
-          python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
-      - name: Upload benchmark data
-        if: ${{ matrix.test-group.name == 'BH_performance' && !cancelled() }}
-        uses: ./.github/actions/upload-data-via-sftp
-        with:
-          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
-          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
       - uses: ./.github/actions/upload-artifact-with-job-uuid
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -13,13 +13,13 @@ jobs:
             name: "BH_functionality",
             arch: blackhole,
             runs-on: ["cloud-virtual-machine", "BH", "in-service"],
-            cmd:
+            cmd: echo addme
           },
           {
             name: "BH_performance",
             arch: blackhole,
-            runs-on: ["BH", "bare-metal", "in-service"],
-            cmd:
+            runs-on: ["BH", "pipeline-perf", "in-service"],
+            cmd: echo addme
           }
         ]
     name: ${{ matrix.test-group.name }}
@@ -58,3 +58,8 @@ jobs:
         if: ${{ matrix.test-group.name == 'BH_performance' }}
         run: |
           sudo cpupower frequency-set -g ondemand
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U0883RN6CRE  #William Ly

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -17,7 +17,7 @@ jobs:
           },
           {
             name: "BH_performance",
-            arch: wormhole_b0,
+            arch: blackhole,
             # current blackhole baremetals are not tagged with bare-metal
             # will need to be tagged if running perf tests on BH
             runs-on: ["BH", "bare-metal", "in-service"],
@@ -36,7 +36,6 @@ jobs:
         if: ${{ matrix.test-group.name == 'BH_performance' }}
         run: |
           sudo cpupower frequency-set -g performance
-      - uses: ./.github/actions/ensure-active-weka-mount
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -13,7 +13,7 @@ jobs:
             name: "whisper_performance",
             arch: blackhole,
             runs-on: ["BH", "pipeline-perf", "in-service"],
-            cmd: pytest -n auto models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation",
+            cmd: pytest models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation",
             owner_id: U05RWH3QUPM #Salar Hosseini
           }
         ]

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -1,0 +1,78 @@
+name: "[internal] Blackhole Demo tests impl"
+
+on:
+  workflow_call:
+
+jobs:
+  single-card-demo-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {
+            name: "BH_functionality",
+            arch: blackhole,
+            runs-on: ["cloud-virtual-machine", "BH", "in-service"],
+            cmd:
+          },
+          {
+            name: "BH_performance",
+            arch: wormhole_b0,
+            # current blackhole baremetals are not tagged with bare-metal
+            # will need to be tagged if running perf tests on BH
+            runs-on: ["BH", "bare-metal", "in-service"],
+            cmd:
+          }
+        ]
+    name: ${{ matrix.test-group.name }}
+    env:
+      ARCH_NAME: ${{ matrix.test-group.arch }}
+      LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    runs-on: ${{ matrix.test-group.runs-on }}
+    steps:
+      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
+      - name: Enable Performance mode
+        if: ${{ matrix.test-group.name == 'BH_performance' }}
+        run: |
+          sudo cpupower frequency-set -g performance
+      - uses: ./.github/actions/ensure-active-weka-mount
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: ./.github/actions/prepare-metal-run
+      - uses: ./.github/actions/install-python-deps
+      - name: Run demo regression tests
+        timeout-minutes: 70
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          source ${{ github.workspace }}/tests/scripts/single_card/run_single_card_demo_tests.sh
+          ${{ matrix.test-group.cmd }}
+      - name: Save environment data
+        if: ${{ matrix.test-group.name == 'BH_performance' && !cancelled() }}
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+      - name: Upload benchmark data
+        if: ${{ matrix.test-group.name == 'BH_performance' && !cancelled() }}
+        uses: ./.github/actions/upload-data-via-sftp
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"
+      - name: Disable Performance mode
+        if: ${{ matrix.test-group.name == 'BH_performance' }}
+        run: |
+          sudo cpupower frequency-set -g ondemand

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -47,7 +47,7 @@ jobs:
           export PYTHONPATH=$TT_METAL_HOME
           source ${{ github.workspace }}/tests/scripts/single_card/run_single_card_demo_tests.sh
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/upload-artifact-with-job-uuid
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -1,0 +1,17 @@
+name: "(Blackhole) Demo tests"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: "0 */6 * * 1,2,3,4,5"
+    - cron: "0 */4 * * 0,6"
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+  single-card-demo-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-demo-tests-impl.yaml

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -2,10 +2,10 @@ name: "(Blackhole) Demo tests"
 
 on:
   workflow_dispatch:
-  workflow_call:
-  schedule:
-    - cron: "0 */6 * * 1,2,3,4,5"
-    - cron: "0 */4 * * 0,6"
+  # workflow_call:
+  # schedule:
+  #   - cron: "0 */6 * * 1,2,3,4,5"
+  #   - cron: "0 */4 * * 0,6"
 
 jobs:
   build-artifact:

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -10,14 +10,15 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        card: [BH]
-        model: [whisper]
-    name: Nightly ${{ matrix.card }} ${{ matrix.model }}
+        test-group: [
+            { model: whisper, card: BH, owner_id: U05RWH3QUPM},  #Salar Hosseini
+          ]
+    name: Nightly ${{ matrix.test-group.card }} ${{ matrix.test-group.model }}
     env:
       ARCH_NAME: blackhole
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
+    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.test-group.card }}"]
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - name: Set up dyanmic env vars for build
@@ -33,7 +34,7 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          pytest -n auto tests/nightly/single_card/${{ matrix.model }}
+          pytest -n auto tests/nightly/single_card/${{ matrix.test-group.model }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -41,3 +42,8 @@ jobs:
           path: |
             generated/test_reports/
           prefix: "test_reports_"
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          pytest -n auto tests/nightly/single_card/${{ matrix.test-group.model }}
+          pytest tests/nightly/single_card/${{ matrix.test-group.model }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -34,7 +34,7 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           pytest -n auto tests/nightly/single_card/${{ matrix.model }}
-      - uses: ./.github/actions/upload-artifact-with-job-uuid
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -1,0 +1,54 @@
+name: "[internal] Blackhole nightly tests impl"
+
+on:
+  workflow_call:
+
+jobs:
+  nightly-bh-models:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        card: [BH]
+        model: [whisper]
+    name: Nightly ${{ matrix.card }} ${{ matrix.model }}
+    env:
+      ARCH_NAME: blackhole
+      LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
+    steps:
+      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
+      - uses: ./.github/actions/retry-command
+        with:
+          timeout-seconds: 100
+          max-retries: 10
+          backoff-seconds: 60
+          command: ./.github/scripts/cloud_utils/mount_weka.sh
+      - name: Set up dyanmic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: ./.github/actions/prepare-metal-run
+      - uses: ./.github/actions/install-python-deps
+      - name: Run frequent reg tests scripts
+        timeout-minutes: 30
+        # Llama3 has a single pytest for multiple llama models, hence it requires calling it multiple times.
+        # Due to host OOM issues in CI vm, we currently only run llama-1B in the model matrix.
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          if [[ "${{ matrix.model }}" == *"llama3"* ]]; then
+            pytest -n auto tests/nightly/single_card/llama3 -k ${{ matrix.model }}
+          fi
+            if [[ "${{ matrix.model }}" != *"llama3"* ]]; then
+            pytest -n auto tests/nightly/single_card/${{ matrix.model }}
+          fi
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -28,8 +28,6 @@ jobs:
       - uses: ./.github/actions/install-python-deps
       - name: Run frequent reg tests scripts
         timeout-minutes: 30
-        # Llama3 has a single pytest for multiple llama models, hence it requires calling it multiple times.
-        # Due to host OOM issues in CI vm, we currently only run llama-1B in the model matrix.
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -20,12 +20,6 @@ jobs:
     runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - uses: ./.github/actions/retry-command
-        with:
-          timeout-seconds: 100
-          max-retries: 10
-          backoff-seconds: 60
-          command: ./.github/scripts/cloud_utils/mount_weka.sh
       - name: Set up dyanmic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -33,12 +33,7 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          if [[ "${{ matrix.model }}" == *"llama3"* ]]; then
-            pytest -n auto tests/nightly/single_card/llama3 -k ${{ matrix.model }}
-          fi
-            if [[ "${{ matrix.model }}" != *"llama3"* ]]; then
-            pytest -n auto tests/nightly/single_card/${{ matrix.model }}
-          fi
+          pytest -n auto tests/nightly/single_card/${{ matrix.model }}
       - uses: ./.github/actions/upload-artifact-with-job-uuid
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -1,0 +1,16 @@
+name: "(Blackhole) Blackhole nightly tests"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: "0 */6 * * *"
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+  fd-nightly:
+    needs: build-artifact
+    uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
+    secrets: inherit

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -2,9 +2,9 @@ name: "(Blackhole) Blackhole nightly tests"
 
 on:
   workflow_dispatch:
-  workflow_call:
-  schedule:
-    - cron: "0 */6 * * *"
+  # workflow_call:
+  # schedule:
+  #   - cron: "0 */6 * * *"
 
 jobs:
   build-artifact:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18737

### Problem description
Provide context for the problem.

### What's changed
Add blackhole nightly and demo test workflows.
The workflows are separate from single-card workflows due to lack of available BH runners. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
