### PR TITLE
Clang-formatting buffer files + minor container change for DistributionSpec

### DIFF
--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -53,20 +53,33 @@ struct ShardSpec {
     std::optional<std::array<uint32_t, 2>> physical_shard_shape = std::nullopt;
 
     ShardSpec(
-        const CoreRangeSet &core_sets_,
-        const std::array<uint32_t, 2> &shard_shape_,
-        const ShardOrientation &shard_orientation_ = ShardOrientation::ROW_MAJOR,
-        const ShardMode &shard_mode_ = ShardMode::PHYSICAL) :
-        grid(core_sets_), shape(shard_shape_), orientation(shard_orientation_), mode(shard_mode_), physical_shard_shape(std::nullopt) {
-    }
+        const CoreRangeSet& core_sets_,
+        const std::array<uint32_t, 2>& shard_shape_,
+        const ShardOrientation& shard_orientation_ = ShardOrientation::ROW_MAJOR,
+        const ShardMode& shard_mode_ = ShardMode::PHYSICAL) :
+        grid(core_sets_),
+        shape(shard_shape_),
+        orientation(shard_orientation_),
+        mode(shard_mode_),
+        physical_shard_shape(std::nullopt) {}
 
     ShardSpec(
-        const CoreRangeSet &core_sets_,
-        const std::array<uint32_t, 2> &shard_shape_,
-        const std::array<uint32_t, 2> &physical_shard_shape_,
-        const ShardOrientation &shard_orientation_ = ShardOrientation::ROW_MAJOR) :
-        grid(core_sets_), shape(shard_shape_), orientation(shard_orientation_), mode(ShardMode::LOGICAL), physical_shard_shape(physical_shard_shape_) {
-        TT_FATAL(physical_shard_shape_[0] >= shard_shape_[0] and physical_shard_shape_[1] >= shard_shape_[1], "Physical shard shape ({}, {}) must be greater or equal to logical shard shape ({}, {})!", physical_shard_shape_[0], physical_shard_shape_[1], shard_shape_[0], shard_shape_[1]);
+        const CoreRangeSet& core_sets_,
+        const std::array<uint32_t, 2>& shard_shape_,
+        const std::array<uint32_t, 2>& physical_shard_shape_,
+        const ShardOrientation& shard_orientation_ = ShardOrientation::ROW_MAJOR) :
+        grid(core_sets_),
+        shape(shard_shape_),
+        orientation(shard_orientation_),
+        mode(ShardMode::LOGICAL),
+        physical_shard_shape(physical_shard_shape_) {
+        TT_FATAL(
+            physical_shard_shape_[0] >= shard_shape_[0] and physical_shard_shape_[1] >= shard_shape_[1],
+            "Physical shard shape ({}, {}) must be greater or equal to logical shard shape ({}, {})!",
+            physical_shard_shape_[0],
+            physical_shard_shape_[1],
+            shard_shape_[0],
+            shard_shape_[1]);
     }
 
     const uint32_t num_cores() const { return this->grid.num_cores(); }
@@ -75,9 +88,11 @@ struct ShardSpec {
     bool operator==(const ShardSpec& other) const;
     bool operator!=(const ShardSpec& other) const;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("grid", "shape", "orientation", "mode", "physical_shard_shape");
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("grid", "shape", "orientation", "mode", "physical_shard_shape");
     constexpr auto attribute_values() const {
-        return std::forward_as_tuple(this->grid, this->shape, this->orientation, this->mode, this->physical_shard_shape);
+        return std::forward_as_tuple(
+            this->grid, this->shape, this->orientation, this->mode, this->physical_shard_shape);
     }
 };
 
@@ -118,7 +133,7 @@ struct ShardSpecBuffer {
 inline namespace v0 {
 
 struct BufferConfig {
-    IDevice *device;
+    IDevice* device;
     DeviceAddr size;       // Size in bytes
     DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type;
@@ -130,7 +145,7 @@ typedef BufferConfig InterleavedBufferConfig;
 // copied from above instead of using inheritance such that we can use
 // designator constructor
 struct ShardedBufferConfig {
-    IDevice *device;
+    IDevice* device;
     DeviceAddr size;       // Size in bytes
     DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type = BufferType::L1;
@@ -140,7 +155,7 @@ struct ShardedBufferConfig {
 
 }  // namespace v0
 
-bool is_sharded(const TensorMemoryLayout &layout);
+bool is_sharded(const TensorMemoryLayout& layout);
 
 struct BufferPageMapping {
     std::vector<CoreCoord> all_cores_;
@@ -167,11 +182,15 @@ struct BufferRegion {
 };
 
 class Buffer final {
-    struct Private { explicit Private() = default; };
+    // Used in public Buffer constructors so they are only callable within Buffer
+    // Buffer constructors are public so we can call std::make_shared on Buffer
+    struct Private {
+        explicit Private() = default;
+    };
 
-   public:
+public:
     static std::shared_ptr<Buffer> create(
-        IDevice *device,
+        IDevice* device,
         DeviceAddr size,
         DeviceAddr page_size,
         BufferType buffer_type,
@@ -180,7 +199,7 @@ class Buffer final {
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
     static std::shared_ptr<Buffer> create(
-        IDevice *device,
+        IDevice* device,
         DeviceAddr address,
         DeviceAddr size,
         DeviceAddr page_size,
@@ -190,10 +209,10 @@ class Buffer final {
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
 
-    Buffer(const Buffer &other) = delete;
-    Buffer &operator=(const Buffer &other) = delete;
-    Buffer(Buffer &&other) = delete;
-    Buffer &operator=(Buffer &&other) = delete;
+    Buffer(const Buffer& other) = delete;
+    Buffer& operator=(const Buffer& other) = delete;
+    Buffer(Buffer&& other) = delete;
+    Buffer& operator=(Buffer&& other) = delete;
     ~Buffer();
 
     IDevice* device() const { return device_; }
@@ -263,7 +282,7 @@ class Buffer final {
         bool owns_data,
         Private);
 
-   private:
+private:
     enum class AllocationStatus : uint8_t {
         ALLOCATION_REQUESTED,
         ALLOCATION_FAILED,
@@ -277,12 +296,12 @@ class Buffer final {
     void deallocate();
     static void deleter(Buffer* buffer);
     void deallocate_impl();
-    friend void DeallocateBuffer(Buffer &buffer);
+    friend void DeallocateBuffer(Buffer& buffer);
 
     DeviceAddr translate_page_address(uint64_t offset, uint32_t bank_id) const;
 
     IDevice* const device_;
-    const DeviceAddr size_; // Size in bytes
+    const DeviceAddr size_;  // Size in bytes
     const BufferType buffer_type_;
     const TensorMemoryLayout buffer_layout_;
     const bool bottom_up_;
@@ -290,7 +309,7 @@ class Buffer final {
     const bool owns_data_;
 
     std::optional<SubDeviceManagerId> sub_device_manager_id_;
-    Allocator * allocator_;
+    Allocator* allocator_;
 
     std::atomic<AllocationStatus> allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
     DeviceAddr address_ = 0;
@@ -300,7 +319,7 @@ class Buffer final {
     std::atomic<bool> deallocation_requested_ = false;
 
     // These members must be only accessed on the device worker thread
-    DeviceAddr page_size_; // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     std::optional<ShardSpecBuffer> shard_parameters_;
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
 
@@ -311,7 +330,7 @@ class Buffer final {
 
 }  // namespace v0
 
-BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
+BufferPageMapping generate_buffer_page_mapping(const Buffer& buffer);
 
 inline namespace v0 {
 
@@ -322,7 +341,7 @@ using HostDataType = std::variant<
     const std::shared_ptr<std::vector<uint32_t>>,
     const std::shared_ptr<std::vector<float>>,
     const std::shared_ptr<std::vector<bfloat16>>,
-    const void *>;
+    const void*>;
 
 }  // namespace v0
 }  // namespace tt::tt_metal
@@ -330,6 +349,6 @@ using HostDataType = std::variant<
 namespace tt::stl::json {
 template <>
 struct from_json_t<tt_metal::ShardSpec> {
-    tt_metal::ShardSpec operator()(const nlohmann::json &json_object) const;
+    tt_metal::ShardSpec operator()(const nlohmann::json& json_object) const;
 };
 }  // namespace tt::stl::json

--- a/tt_metal/api/tt-metalium/distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/distribution_spec.hpp
@@ -61,13 +61,15 @@ private:
     struct ReplicateCount {
         size_t count = 0;
     };
-    using DistributionType = std::variant<ShardSize, ReplicateCount>;
+    using DistributionType = std::variant<std::monostate, ShardSize, ReplicateCount>;
 
     DistributionSpec(
-        const tt::tt_metal::Shape& tensor_shape, const std::vector<DistributionType>& spec, size_t num_targets);
+        const tt::tt_metal::Shape& tensor_shape,
+        const tt::stl::SmallVector<DistributionType>& spec,
+        size_t num_targets);
 
     tt::tt_metal::Shape tensor_shape_;
-    std::vector<DistributionType> spec_;
+    tt::stl::SmallVector<DistributionType> spec_;
     tt::tt_metal::Shape shard_shape_;  // Determined based on spec_
     size_t num_targets_ = 0;
 };

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -48,8 +48,8 @@ bool is_l1_impl(BufferType buffer_type) { return buffer_type == BufferType::L1 o
 void validate_buffer_size_and_page_size(
     DeviceAddr size,
     DeviceAddr page_size,
-    const BufferType &buffer_type,
-    const TensorMemoryLayout &buffer_layout,
+    const BufferType& buffer_type,
+    const TensorMemoryLayout& buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters) {
     if (size == 0) {
         return;
@@ -84,7 +84,9 @@ std::tuple<std::vector<std::vector<uint32_t>>, std::vector<std::array<uint32_t, 
     const std::array<uint32_t, 2>& page_shape,
     const std::array<uint32_t, 2>& shard_shape,
     const std::array<uint32_t, 2>& tensor2d_size) {
-    std::array<uint32_t, 2> shard_in_pages = {page_shape[0] == 0 ? 0 : shard_shape[0] / page_shape[0], page_shape[1] == 0 ? 0 : shard_shape[1] / page_shape[1]};
+    std::array<uint32_t, 2> shard_in_pages = {
+        page_shape[0] == 0 ? 0 : shard_shape[0] / page_shape[0],
+        page_shape[1] == 0 ? 0 : shard_shape[1] / page_shape[1]};
     std::vector<std::vector<uint32_t>> ret_vec(num_shards);
     std::vector<std::array<uint32_t, 2>> ret_shard_shape(num_shards, shard_in_pages);
 
@@ -199,9 +201,13 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer& buffer) {
     uint32_t num_cores = buffer.num_cores().value();
 
     buffer_page_mapping.all_cores_ = corerange_to_cores(shard_spec.grid(), num_cores, row_major);
-    TT_FATAL(num_cores == buffer_page_mapping.all_cores_.size(), "Buffer has {} cores, but page mapping expects {} cores", num_cores, buffer_page_mapping.all_cores_.size());
+    TT_FATAL(
+        num_cores == buffer_page_mapping.all_cores_.size(),
+        "Buffer has {} cores, but page mapping expects {} cores",
+        num_cores,
+        buffer_page_mapping.all_cores_.size());
     uint32_t core_id = 0;
-    for (const auto &core : buffer_page_mapping.all_cores_) {
+    for (const auto& core : buffer_page_mapping.all_cores_) {
         buffer_page_mapping.core_to_core_id_.insert({core, core_id});
         core_id++;
     }
@@ -332,8 +338,18 @@ std::shared_ptr<Buffer> Buffer::create(
         }
     });
 
-    LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureBufferCreate, buffer, device, std::nullopt, size,
-        page_size, buffer_type, buffer_layout, shard_parameters, bottom_up, sub_device_id);
+    LIGHT_METAL_TRACE_FUNCTION_CALL(
+        CaptureBufferCreate,
+        buffer,
+        device,
+        std::nullopt,
+        size,
+        page_size,
+        buffer_type,
+        buffer_layout,
+        shard_parameters,
+        bottom_up,
+        sub_device_id);
 
     return buffer;
 }
@@ -366,8 +382,18 @@ std::shared_ptr<Buffer> Buffer::create(
     buffer->address_ = address;
     buffer->allocation_status_.store(AllocationStatus::ALLOCATED, std::memory_order::relaxed);
 
-    LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureBufferCreate, buffer, device, address, size,
-        page_size, buffer_type, buffer_layout, shard_parameters, bottom_up, sub_device_id);
+    LIGHT_METAL_TRACE_FUNCTION_CALL(
+        CaptureBufferCreate,
+        buffer,
+        device,
+        address,
+        size,
+        page_size,
+        buffer_type,
+        buffer_layout,
+        shard_parameters,
+        bottom_up,
+        sub_device_id);
 
     return buffer;
 }
@@ -405,9 +431,7 @@ void Buffer::deallocate() {
     if (!owns_data_) {
         return;
     }
-    device_->push_work([self = weak_self.lock()] {
-        self->deallocate_impl();
-    });
+    device_->push_work([self = weak_self.lock()] { self->deallocate_impl(); });
 }
 
 void Buffer::mark_as_deallocated() {
@@ -461,9 +485,12 @@ bool Buffer::is_allocated() const {
     auto allocation_status = allocation_status_.load(std::memory_order::relaxed);
 
     // For calls from different threads we consider buffer to be allocated even if it's just ALLOCATION_REQUESTED,
-    // because once the caller will try to access it, the buffer will already be fully allocated. For the same reason we need to check deallocation_requested_ too.
+    // because once the caller will try to access it, the buffer will already be fully allocated. For the same reason we
+    // need to check deallocation_requested_ too.
     bool deallocation_requested = deallocation_requested_.load(std::memory_order::relaxed);
-    return (allocation_status == AllocationStatus::ALLOCATION_REQUESTED || allocation_status == AllocationStatus::ALLOCATED) && !deallocation_requested;
+    return (allocation_status == AllocationStatus::ALLOCATION_REQUESTED ||
+            allocation_status == AllocationStatus::ALLOCATED) &&
+           !deallocation_requested;
 }
 
 uint32_t Buffer::address() const {
@@ -472,13 +499,13 @@ uint32_t Buffer::address() const {
     }
 
     std::unique_lock lock(allocation_mutex_);
-    allocation_cv_.wait(lock, [this] { return this->allocation_status_.load(std::memory_order::relaxed) != AllocationStatus::ALLOCATION_REQUESTED; });
+    allocation_cv_.wait(lock, [this] {
+        return this->allocation_status_.load(std::memory_order::relaxed) != AllocationStatus::ALLOCATION_REQUESTED;
+    });
     return address_;
 }
 
-DeviceAddr Buffer::page_size() const {
-    return page_size_;
-}
+DeviceAddr Buffer::page_size() const { return page_size_; }
 
 void Buffer::set_page_size(DeviceAddr page_size) {
     TT_FATAL(page_size == 0 ? size_ == 0 : size_ % page_size == 0, "buffer size must be divisible by new page size");
@@ -486,9 +513,7 @@ void Buffer::set_page_size(DeviceAddr page_size) {
     this->buffer_page_mapping_ = nullptr;
 }
 
-uint32_t Buffer::num_pages() const {
-    return page_size() == 0 ? 0 : size() / page_size();
-}
+uint32_t Buffer::num_pages() const { return page_size() == 0 ? 0 : size() / page_size(); }
 
 uint32_t Buffer::num_dev_pages() const {
     if (!is_sharded(this->buffer_layout_)) {
@@ -500,24 +525,16 @@ uint32_t Buffer::num_dev_pages() const {
 
 CoreType Buffer::core_type() const {
     switch (this->buffer_type_) {
-        case BufferType::DRAM:
-            return CoreType::DRAM;
+        case BufferType::DRAM: return CoreType::DRAM;
         case BufferType::L1:
-        case BufferType::L1_SMALL:
-            return CoreType::WORKER;
-        default:
-            TT_THROW("Unknown CoreType {} for buffer", this->buffer_type_);
+        case BufferType::L1_SMALL: return CoreType::WORKER;
+        default: TT_THROW("Unknown CoreType {} for buffer", this->buffer_type_);
     }
 }
 
 bool Buffer::is_l1() const { return is_l1_impl(buffer_type()); }
-bool Buffer::is_dram() const {
-    return buffer_type() == BufferType::DRAM || buffer_type() == BufferType::TRACE;
-}
-bool Buffer::is_trace() const {
-    return buffer_type() == BufferType::TRACE;
-
-}
+bool Buffer::is_dram() const { return buffer_type() == BufferType::DRAM || buffer_type() == BufferType::TRACE; }
+bool Buffer::is_trace() const { return buffer_type() == BufferType::TRACE; }
 
 bool Buffer::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= this->size(); }
 
@@ -550,17 +567,14 @@ DeviceAddr Buffer::bank_local_page_address(uint32_t bank_id, uint32_t page_index
 
 uint32_t Buffer::alignment() const { return allocator_->get_alignment(this->buffer_type()); }
 
-DeviceAddr Buffer::aligned_page_size() const {
-    return align(page_size(), this->alignment());
-}
-DeviceAddr Buffer::aligned_size() const {
-    return this->num_dev_pages() * this->aligned_page_size();
-}
+DeviceAddr Buffer::aligned_page_size() const { return align(page_size(), this->alignment()); }
+DeviceAddr Buffer::aligned_size() const { return this->num_dev_pages() * this->aligned_page_size(); }
 
 DeviceAddr Buffer::aligned_size_per_bank() const {
     uint32_t num_banks =
         is_sharded(this->buffer_layout_) ? this->num_cores().value() : allocator_->get_num_banks(this->buffer_type());
-    return tt::tt_metal::detail::SizeBytesPerBank(this->aligned_size(), this->aligned_page_size(), num_banks, this->alignment());
+    return tt::tt_metal::detail::SizeBytesPerBank(
+        this->aligned_size(), this->aligned_page_size(), num_banks, this->alignment());
 }
 
 DeviceAddr Buffer::sharded_page_address(uint32_t bank_id, uint32_t page_index) const {
@@ -583,8 +597,9 @@ void Buffer::set_shard_spec(const ShardSpecBuffer& shard_spec) {
 }
 
 std::optional<uint32_t> Buffer::num_cores() const {
-    if (!is_sharded(this->buffer_layout_))
+    if (!is_sharded(this->buffer_layout_)) {
         return std::nullopt;
+    }
 
     return this->shard_spec().tensor_shard_spec.grid.num_cores();
 }
@@ -624,25 +639,30 @@ void v1::DeallocateBuffer(const BufferHandle& buffer) { v0::DeallocateBuffer(*bu
 std::size_t v1::GetId(const BufferHandle& buffer) { return buffer->unique_id(); }
 
 void v1::WriteToBuffer(const BufferHandle& buffer, stl::Span<const std::byte> host_buffer) {
-    detail::WriteToBuffer(*buffer, stl::Span<const uint8_t>{reinterpret_cast<const std::uint8_t *>(host_buffer.data()), host_buffer.size()});
+    detail::WriteToBuffer(
+        *buffer,
+        stl::Span<const uint8_t>{reinterpret_cast<const std::uint8_t*>(host_buffer.data()), host_buffer.size()});
 }
 
 void v1::ReadFromBuffer(const BufferHandle& buffer, stl::Span<std::byte> host_buffer, bool shard_order) {
-    detail::ReadFromBuffer(*buffer, reinterpret_cast<std::uint8_t *>(host_buffer.data()), shard_order);
+    detail::ReadFromBuffer(*buffer, reinterpret_cast<std::uint8_t*>(host_buffer.data()), shard_order);
 }
 
 void v1::ReadFromShard(const BufferHandle& buffer, stl::Span<std::byte> host_buffer, std::uint32_t core_id) {
-    detail::ReadShard(*buffer, reinterpret_cast<std::uint8_t *>(host_buffer.data()), core_id);
+    detail::ReadShard(*buffer, reinterpret_cast<std::uint8_t*>(host_buffer.data()), core_id);
 }
 
 }  // namespace tt::tt_metal
 
 namespace tt::stl::json {
-tt_metal::ShardSpec from_json_t<tt_metal::ShardSpec>::operator()(const nlohmann::json &json_object) const {
+tt_metal::ShardSpec from_json_t<tt_metal::ShardSpec>::operator()(const nlohmann::json& json_object) const {
     const auto& shard_mode = from_json<tt_metal::ShardMode>(json_object.at("mode"));
-    const auto& physical_shard_shape = from_json<std::optional<std::array<uint32_t, 2>>>(json_object.at("physical_shard_shape"));
+    const auto& physical_shard_shape =
+        from_json<std::optional<std::array<uint32_t, 2>>>(json_object.at("physical_shard_shape"));
     if (physical_shard_shape.has_value()) {
-        TT_FATAL(shard_mode == tt::tt_metal::ShardMode::LOGICAL, "Physical shard shape can only be provided in logical sharding mode!");
+        TT_FATAL(
+            shard_mode == tt::tt_metal::ShardMode::LOGICAL,
+            "Physical shard shape can only be provided in logical sharding mode!");
         return tt_metal::ShardSpec{
             from_json<CoreRangeSet>(json_object.at("grid")),
             from_json<std::array<uint32_t, 2>>(json_object.at("shape")),
@@ -655,4 +675,4 @@ tt_metal::ShardSpec from_json_t<tt_metal::ShardSpec>::operator()(const nlohmann:
         from_json<tt_metal::ShardOrientation>(json_object.at("orientation")),
         shard_mode};
 }
-}
+}  // namespace tt::stl::json

--- a/tt_metal/impl/buffers/distribution_spec.cpp
+++ b/tt_metal/impl/buffers/distribution_spec.cpp
@@ -63,7 +63,7 @@ std::pair<tt::tt_metal::Shape, tt::tt_metal::Shape> maybe_convert_shapes_for_map
 }  // namespace
 
 DistributionSpec::DistributionSpec(
-    const tt::tt_metal::Shape& tensor_shape, const std::vector<DistributionType>& spec, size_t num_targets) :
+    const tt::tt_metal::Shape& tensor_shape, const tt::stl::SmallVector<DistributionType>& spec, size_t num_targets) :
     tensor_shape_(tensor_shape), spec_(spec) {
     auto rank = tensor_shape.rank();
     TT_FATAL(spec.size() == rank, "Spec rank ({}) must be same as tensor shape rank ({})!", spec.size(), rank);
@@ -101,7 +101,7 @@ DistributionSpec DistributionSpec::from_shard_shape(
         shard_shape.rank(),
         rank);
     // Create spec with ShardSize only
-    std::vector<DistributionType> spec(rank);
+    tt::stl::SmallVector<DistributionType> spec(rank);
     for (size_t i = 0; i < rank; i++) {
         spec[i] = ShardSize{shard_shape[i]};
     }


### PR DESCRIPTION
### Ticket
None

### Problem description
Some minor cleanup in buffer and distribution spec

### What's changed
- Clang-format buffer hpp/cpp files
  - Add comment about struct Private in Buffer
- Switch to tt::stl::SmallVector container for DistributionType in DistributionSpec

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/13726698545
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
