### PR TITLE
Add a DeviceBoundThreadPool class conforming to the ThreadPool interface

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -8,6 +8,7 @@ set(UNIT_TESTS_DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_allocator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_trace.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_thread_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
 )
 

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -9,12 +9,13 @@ set(UNIT_TESTS_DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_trace.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_thread_pool.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp # Common utilities
 )
 
-# Define the function to create test executables for each architecture
+set(THREAD_POOL_BENCHMARK_SRC ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_thread_pool.cpp)
+
+# Function to create the main distributed unit test binary
 function(create_unit_test_executable arch_name)
-    # Define the test executable name using the architecture name
     set(exec_name distributed_unit_tests_${arch_name})
     string(REPLACE "wormhole" "wormhole_b0" exec_name "${exec_name}")
 
@@ -43,6 +44,36 @@ function(create_unit_test_executable arch_name)
     )
 endfunction()
 
+# Function to create a separate binary for thread_pool benchmarking
+function(create_thread_pool_benchmark_executable)
+    set(exec_name thread_pool_benchmark)
+    string(REPLACE "wormhole" "wormhole_b0" exec_name "${exec_name}")
+
+    add_executable(${exec_name} ${THREAD_POOL_BENCHMARK_SRC})
+
+    target_link_libraries(
+        ${exec_name}
+        PRIVATE
+            tt_metal
+            test_common_libs
+            benchmark::benchmark
+    )
+
+    target_include_directories(
+        ${exec_name}
+        PRIVATE
+            "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+            ${PROJECT_SOURCE_DIR}/tests
+    )
+
+    set_target_properties(
+        ${exec_name}
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY
+                ${PROJECT_BINARY_DIR}/test/tt_metal/distributed
+    )
+endfunction()
+
 # Define the architectures for which to create test executables
 set(ARCHITECTURES
     "grayskull"
@@ -50,13 +81,10 @@ set(ARCHITECTURES
     "blackhole"
 )
 
-# Create a test executable for each architecture
+# Create distributed test executables for each architecture
 foreach(arch IN LISTS ARCHITECTURES)
     create_unit_test_executable(${arch})
 endforeach()
 
-# Dont do this for now
-# When the test is probed something is constructed that tries to access a device
-# Build machine might not have a device
-# We don't use ctest in this project so we shouldn't need this yet
-#gtest_discover_tests(distributed_unit_tests)
+# Create thread pool benchmark executable
+create_thread_pool_benchmark_executable()

--- a/tests/tt_metal/distributed/benchmark_thread_pool.cpp
+++ b/tests/tt_metal/distributed/benchmark_thread_pool.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+#include <tt-metalium/env_lib.hpp>
+#include "tt_metal/common/thread_pool.hpp"
+#include "tt_metal/llrt/tt_cluster.hpp"
+
+template <typename ThreadPoolCreator>
+static void BM_ThreadPool(benchmark::State& state, ThreadPoolCreator create_thread_pool) {
+    uint32_t num_threads = tt::parse_env("TT_METAL_NUM_BENCHMARK_THREADS", 8);
+
+    auto thread_pool = create_thread_pool(num_threads);
+
+    for (auto _ : state) {
+        uint64_t NUM_ITERS = state.range(0);
+
+        auto work = []() { std::this_thread::sleep_for(std::chrono::microseconds(20)); };
+
+        std::chrono::high_resolution_clock::time_point enqueue_start, enqueue_end;
+        std::chrono::high_resolution_clock::time_point wait_start, wait_end;
+
+        enqueue_start = std::chrono::high_resolution_clock::now();
+        for (std::size_t iter = 0; iter < NUM_ITERS; iter++) {
+            thread_pool->enqueue([&work]() mutable { work(); }, iter % num_threads);
+        }
+        enqueue_end = std::chrono::high_resolution_clock::now();
+
+        wait_start = std::chrono::high_resolution_clock::now();
+        thread_pool->wait();
+        wait_end = std::chrono::high_resolution_clock::now();
+
+        auto enqueue_time = std::chrono::duration_cast<std::chrono::microseconds>(enqueue_end - enqueue_start).count();
+        auto wait_time = std::chrono::duration_cast<std::chrono::microseconds>(wait_end - wait_start).count();
+
+        state.counters["enqueue_time_us"] = enqueue_time;
+        state.counters["wait_time_us"] = wait_time;
+        state.counters["enqueue_time_per_task_us"] = enqueue_time / static_cast<double>(NUM_ITERS);
+        state.counters["wait_time_per_task_us"] = wait_time / static_cast<double>(NUM_ITERS);
+    }
+
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+    state.SetComplexityN(state.range(0));
+}
+
+static void BM_BoostThreadPool(benchmark::State& state) {
+    BM_ThreadPool(state, [](uint32_t num_threads) { return tt::tt_metal::create_boost_thread_pool(num_threads); });
+}
+
+static void BM_DistributedBoostThreadPool(benchmark::State& state) {
+    BM_ThreadPool(
+        state, [](uint32_t num_threads) { return tt::tt_metal::create_distributed_boost_thread_pool(num_threads); });
+}
+
+static void BM_DeviceBoundThreadPool(benchmark::State& state) {
+    BM_ThreadPool(
+        state, [](uint32_t num_threads) { return tt::tt_metal::create_device_bound_thread_pool(num_threads); });
+}
+
+BENCHMARK(BM_BoostThreadPool)->RangeMultiplier(2)->Range(1, 1 << 18)->Complexity(benchmark::oN)->UseRealTime();
+
+BENCHMARK(BM_DistributedBoostThreadPool)
+    ->RangeMultiplier(2)
+    ->Range(1, 1 << 18)
+    ->Complexity(benchmark::oN)
+    ->UseRealTime();
+
+BENCHMARK(BM_DeviceBoundThreadPool)->RangeMultiplier(2)->Range(1, 1 << 18)->Complexity(benchmark::oN)->UseRealTime();
+
+BENCHMARK_MAIN();

--- a/tests/tt_metal/distributed/test_thread_pool.cpp
+++ b/tests/tt_metal/distributed/test_thread_pool.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/common/thread_pool.hpp"
+#include "tt_metal/llrt/tt_cluster.hpp"
+
+namespace tt::tt_metal::distributed::test {
+namespace {
+
+// Stress test for thread pool used by TT-Mesh
+TEST(ThreadPoolTest, StressDeviceBound) {
+    // Enqueue enough tasks to saturate the thread pool.
+    uint64_t NUM_ITERS = 1 << 18;
+    uint32_t num_threads = tt::Cluster::instance().number_of_user_devices();
+    auto thread_pool = create_device_bound_thread_pool(tt::Cluster::instance().number_of_user_devices());
+    // Increment this once for each task in the thread pool.
+    // Use this to verify that tasks actually executed.
+    std::atomic<uint64_t> counter = 0;
+    auto incrementer_fn = [&counter]() {
+        counter++;
+        // Sleep every 10 iterations to slow down the workers - allows
+        // the thread pool to get saturated
+        if (counter.load() % 10 == 0) {
+            std::this_thread::sleep_for(std::chrono::microseconds(1000));
+        }
+    };
+    // Rely on thread-pool to automatically distribute tasks across workers
+    for (std::size_t iter = 0; iter < NUM_ITERS; iter++) {
+        thread_pool->enqueue([&incrementer_fn]() mutable { incrementer_fn(); });
+    }
+
+    // Explicitly specify the thread each task will go to.
+    for (std::size_t iter = 0; iter < NUM_ITERS; iter++) {
+        thread_pool->enqueue([&incrementer_fn]() mutable { incrementer_fn(); }, iter % num_threads);
+    }
+
+    thread_pool->wait();
+    EXPECT_EQ(counter.load(), 2 * NUM_ITERS);
+}
+
+}  // namespace
+
+}  // namespace tt::tt_metal::distributed::test

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -5,13 +5,177 @@
 #include <boost/asio.hpp>
 #include <future>
 #include <iostream>
+#include <numa.h>
+#include <semaphore>
 
 #include "tt_metal/common/thread_pool.hpp"
+#include "tt_metal/llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal {
 
-namespace detail {
+std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node() {
+    std::unordered_map<int, std::vector<uint32_t>> cpu_cores_per_numa_node = {};
+    for (int cpu = 0; cpu < numa_num_configured_cpus(); ++cpu) {
+        int node = numa_node_of_cpu(cpu);
+        cpu_cores_per_numa_node[node].push_back(cpu);
+    }
+    return cpu_cores_per_numa_node;
+}
 
+namespace threading_primitives {
+
+// Data Structure used to queue and submit tasks to custom thread-pool backends.
+// Implemented as a statically allocated ring buffer that holds a task in each slot.
+class TaskQueue {
+public:
+    TaskQueue() {
+        // Initialize ring buffer for traversal. Each node points to the subsequent node, except for the last one,
+        // which points to the head.
+        for (int node_idx = 0; node_idx < ring_buffer_size_; node_idx++) {
+            (node_idx < ring_buffer_size_ - 1) ? ring_buffer_[node_idx].next = (&ring_buffer_[node_idx + 1])
+                                               : ring_buffer_[node_idx].next = &(ring_buffer_[0]);
+        }
+        // Initialize head and tail ptrs to start of ring buffer.
+        head_ = ring_buffer_;
+        tail_ = ring_buffer_;
+    }
+    // Push task to queue (writer).
+    void push(std::function<void()>&& task) {
+        // Stall condition: this push will update the tail (wptr)
+        // to match the location of head (rptr). The current push can
+        // thus overwrite data that's being read. Stall until head
+        // has progressed (data has been read).
+        // A stall is only required when the ring_buffer_ backing the queue
+        // is full. Realistically, this should never happen, given the size
+        while (tail_.load()->next == head_.load());
+        tail_.load()->data = std::move(task);
+        tail_.store(tail_.load()->next);
+    }
+    // Pop task from queue (reader).
+    std::function<void()>&& pop() {
+        TaskQueue::Node* old_head = pop_head();
+        return std::move(old_head->data);
+    }
+
+private:
+    // Node object, representing a slot in the queue.
+    struct Node {
+        std::function<void()> data;
+        Node* next = nullptr;
+    };
+    // Read and write pointers for managing the queue.
+    std::atomic<Node*> head_;
+    std::atomic<Node*> tail_;
+
+    Node* pop_head() {
+        Node* old_head = head_.load();
+        if (old_head == tail_.load()) {
+            TT_THROW("Cannot pop tasks from an empty queue.");
+            return nullptr;  // Queue is empty
+        }
+        head_.store(old_head->next);
+        return old_head;
+    }
+    // Statically allocated ring buffer containing
+    // node objects, which contain handles to data
+    // and another node object to traverse ring buffer.
+    const static uint32_t ring_buffer_size_ = 8192;
+    Node ring_buffer_[ring_buffer_size_];
+};
+// NUMA + CPU Affinity aware executor, used by custom thread-pool implementations.
+// Contains:
+//  1. A TaskQueue where tasks can be submitted by the user, to be asynchronously executed
+//  2. A worker thread to asynchronously execute tasks
+//  3. Primitves to synchronize the application and worker thread
+// Usage:
+// This executor should only be used to asynchronously process tasks for a specific TT-Device
+// (specified through the physical_device_id constructor argument).
+// The executor is NUMA aware, i.e. it will bind its worker thread to a NUMA node that is "closest"
+// to its physical device. The logical_cpu_offset constructor argument can be used to specify the
+// logical base offset within a NUMA node when binding the worker thread.
+// The CPU selection algorithm is:
+// CPUs[numa_node][(physical_device_id + logical_cpu_offset) / num_cores_on_numa_node]
+class NumaAwareExecutor {
+public:
+    NumaAwareExecutor(uint32_t physical_device_id, uint32_t logical_cpu_offset) : tasks_() {
+        static std::unordered_map<int, std::vector<uint32_t>> cpu_cores_per_numa_node = get_cpu_cores_per_numa_node();
+
+        worker = std::thread([this]() {
+            std::function<void()> task;  // Task container for this thread
+            while (true) {
+                {
+                    task_semaphore_.acquire();
+                    if (shutdown_) {
+                        return;
+                    }
+                    task = std::move(tasks_.pop());
+                }
+                task();
+                // Atomically decrement counter used to synchronize with main thread
+                // and notify the main thread if all tasks have completed
+                if (counter_.fetch_sub(1, std::memory_order_release) == 1) {
+                    counter_.notify_all();
+                }
+            }
+        });
+        auto numa_node = tt::Cluster::instance().get_numa_node_for_device(physical_device_id);
+        auto& cpu_cores_on_node = cpu_cores_per_numa_node[numa_node];
+        auto cpu_core_for_worker =
+            cpu_cores_on_node[(physical_device_id + logical_cpu_offset) % cpu_cores_on_node.size()];
+        cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        CPU_SET(cpu_core_for_worker, &cpuset);
+        int rc = pthread_setaffinity_np(worker.native_handle(), sizeof(cpu_set_t), &cpuset);
+        if (rc) {
+            log_warning(
+                tt::LogMetal,
+                "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}",
+                rc);
+        }
+    }
+
+    ~NumaAwareExecutor() {
+        // Destructor called in main thread.
+        // Wait to ensure that the worker thread has completed.
+        this->wait();
+        shutdown_ = true;
+        task_semaphore_.release();
+        worker.join();
+    }
+
+    void enqueue(std::function<void()>&& f) {
+        tasks_.push(std::move(f));  // Move the task directly into queue
+        task_semaphore_.release();  // Notify a worker that a task is available
+        // Light-Weight counter increment to track the number of tasks in flight
+        // Need this because a counting_semaphore does not allow querying state
+        counter_++;
+    }
+
+    void wait() const {
+        // Wait until all tasks have completed (counter_ == 0)
+        // To avoid spinning, sleep until notified by the worker threads
+        // or counter_ changes (this only happens with a spurious wakeup)
+        int current;
+        while ((current = counter_.load(std::memory_order_acquire)) > 0) {
+            counter_.wait(current, std::memory_order_relaxed);
+        }
+    }
+
+private:
+    TaskQueue tasks_;
+    std::thread worker;
+    std::atomic<int> counter_ = 0;
+    std::counting_semaphore<> task_semaphore_{0};
+    bool shutdown_ = false;
+};
+
+}  // namespace threading_primitives
+
+namespace thread_pool_impls {
+// Implementations conforming to the ThreadPool interface.
+using threading_primitives::NumaAwareExecutor;
+
+// Boost backed thread-pool.
 class BoostThreadPool : public ThreadPool {
 public:
     BoostThreadPool(size_t thread_count) : pool_(thread_count) {
@@ -23,7 +187,7 @@ public:
 
     ~BoostThreadPool() noexcept override = default;
 
-    void enqueue(std::function<void()>&& f) override {
+    void enqueue(std::function<void()>&& f, uint32_t thread_idx) override {
         std::packaged_task<void()> task(std::move(f));
         futures_.push_back(task.get_future());
         boost::asio::post(pool_, [executor = std::move(task)]() mutable { executor(); });
@@ -41,10 +205,39 @@ private:
     std::vector<std::future<void>> futures_;
 };
 
-}  // namespace detail
+// Custom Thread-Pool using the threading::Executor class.
+// Allows enqueuing tasks tied to specific devices.
+class DeviceBoundThreadPool : public ThreadPool {
+public:
+    DeviceBoundThreadPool(uint32_t thread_count, uint32_t logical_cpu_offset) {
+        workers_.reserve(thread_count);
+        for (uint32_t i = 0; i < thread_count; i++) {
+            workers_.emplace_back(std::make_unique<NumaAwareExecutor>(i, logical_cpu_offset));
+        }
+    }
+
+    void enqueue(std::function<void()>&& f, uint32_t thread_idx) override {
+        workers_[thread_idx]->enqueue(std::move(f));
+    }
+
+    void wait() override {
+        for (auto& worker : workers_) {
+            worker->wait();
+        }
+    }
+
+private:
+    std::vector<std::unique_ptr<NumaAwareExecutor>> workers_;
+};
+
+}  // namespace thread_pool_impls
 
 std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads) {
-    return std::make_shared<detail::BoostThreadPool>(num_threads);
+    return std::make_shared<thread_pool_impls::BoostThreadPool>(num_threads);
+}
+
+std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads, uint32_t logical_cpu_offset) {
+    return std::make_shared<thread_pool_impls::DeviceBoundThreadPool>(num_threads, logical_cpu_offset);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -12,10 +12,11 @@ namespace tt::tt_metal {
 class ThreadPool {
 public:
     virtual ~ThreadPool() = default;
-    virtual void enqueue(std::function<void()>&& f) = 0;
+    virtual void enqueue(std::function<void()>&& f, uint32_t thread_idx = 0) = 0;
     virtual void wait() = 0;
 };
 
 std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads);
+std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads, uint32_t logical_cpu_offset = 0);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -17,6 +17,7 @@ public:
 };
 
 std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads);
+std::shared_ptr<ThreadPool> create_distributed_boost_thread_pool(int num_threads);
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads, uint32_t logical_cpu_offset = 0);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -12,7 +12,7 @@ namespace tt::tt_metal {
 class ThreadPool {
 public:
     virtual ~ThreadPool() = default;
-    virtual void enqueue(std::function<void()>&& f, uint32_t thread_idx = 0) = 0;
+    virtual void enqueue(std::function<void()>&& f, std::optional<uint32_t> device_idx = std::nullopt) = 0;
     virtual void wait() = 0;
 };
 

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -425,12 +425,11 @@ void MeshCommandQueue::enqueue_write_shard_to_sub_grid(
         // Multi-Threaded writes supported for Replicated buffers.
         // Currently not supported when doing TT-Mesh Native sharding, since we
         // rely on TTNN to perform sharding and call enqueue_write_shards
-        auto dispatch_lambda =
-            std::function<void(MeshCoordinate)>([this, &buffer, host_data, &region](MeshCoordinate&& coord) {
-                auto device_shard_view = buffer.get_device_buffer(coord);
-                const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
-                this->write_shard_to_device(device_shard_view, host_data, buffer_region);
-            });
+        auto dispatch_lambda = [this, &buffer, host_data, &region](MeshCoordinate coord) {
+            auto device_shard_view = buffer.get_device_buffer(coord);
+            const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
+            this->write_shard_to_device(device_shard_view, host_data, buffer_region);
+        };
         for (const auto& coord : device_range) {
             dispatch_thread_pool_->enqueue(
                 [&dispatch_lambda, coord]() { dispatch_lambda(std::move(coord)); },
@@ -467,16 +466,14 @@ void MeshCommandQueue::enqueue_write_shards(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-
-    auto dispatch_lambda =
-        std::function<void(uint32_t)>([&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
-            auto& shard_data_transfer = shard_data_transfers[shard_idx];
-            auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
-            this->write_shard_to_device(
-                device_shard_view,
-                shard_data_transfer.host_data,
-                shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
-        });
+    auto dispatch_lambda = [&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
+        auto& shard_data_transfer = shard_data_transfers[shard_idx];
+        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
+        this->write_shard_to_device(
+            device_shard_view,
+            shard_data_transfer.host_data,
+            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+    };
 
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
         dispatch_thread_pool_->enqueue(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -131,8 +131,8 @@ MeshDevice::MeshDevice(
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
     parent_mesh_(std::move(parent_mesh)),
-    dispatch_thread_pool_(create_boost_thread_pool(view_->shape().mesh_size())),
-    reader_thread_pool_(create_boost_thread_pool(view_->shape().mesh_size())) {}
+    dispatch_thread_pool_(create_device_bound_thread_pool(view_->shape().mesh_size())),
+    reader_thread_pool_(create_device_bound_thread_pool(view_->shape().mesh_size(), view_->shape().mesh_size())) {}
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Existing Boost backed thread pool implementation does not guarantee an optimal distribution of work across devices
- Performance analysis also shows that a custom implementation with threads pinned to physical devices provides lower host overhead

### What's changed
 - Add a `DeviceBoundThreadPool` class conforming to the `ThreadPool` interface
- This class is built on top of the `NumaAwareExecutor` class
 - Can be created using the `create_device_bound_thread_pool` API
 - Allows submitting tasks to specific threads (each thread is tied to a physical device, and can thus process tasks only for that device)
 - Is NUMA Aware: Threads spawned for a physical device will be pinned to NUMA nodes "closest" to the device


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
