### PR TITLE
[skip ci] Run Smoke tests in PR Gate

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -55,10 +55,18 @@ jobs:
 
   smoke-tests:
     needs: build-artifact
-    uses: ./.github/workflows/zzz_smoke.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "N150",
+          "N300",
+        ]
+    uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
 
   # Slow Dispatch Unit Tests
   sd-unit-tests:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -40,10 +40,16 @@ jobs:
     with:
       version: "22.04"
 
-  # TODO: Earmark some runners for low-latency jobs and activate Smoke tests here in PR Gate
-  #smoke-tests:
-  #  needs: pr-gate-build
-  #  uses: ./.github/workflows/zzz_smoke.yaml
-  #  with:
-  #    docker-image: ${{ needs.pr-gate-build.outputs.ci-build-docker-image }}
-  #    package-artifact-name: ${{ needs.pr-gate-build.outputs.packages-artifact-name }}
+  smoke-tests:
+    needs: pr-gate-build
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "tt-beta-ubuntu-2204-n300-large-stable",
+        ]
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.pr-gate-build.outputs.ci-build-docker-image }}
+      package-artifact-name: ${{ needs.pr-gate-build.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,4 +1,4 @@
-name: "Smoke tests"
+name: "zzz Smoke tests"
 
 on:
   workflow_call:
@@ -9,21 +9,18 @@ on:
       package-artifact-name:
         required: true
         type: string
+      runner:
+        required: true
+        type: string
 
 jobs:
   metalium-smoke:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [
-          "N150",
-          "N300",
-          # "P150" # Machines aren't ready yet
-        ]
-    runs-on:
-      - in-service
-      - cloud-virtual-machine
-      - ${{ matrix.platform }}
+    runs-on: >-
+      ${{
+        startsWith(inputs.runner, 'tt-beta-ubuntu')
+        && fromJSON(format('["{0}"]', inputs.runner))
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner))
+      }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       volumes:
@@ -35,11 +32,6 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - name: workaround
-        run: |
-          # The test-reporting action needs this set, and we can't seem to opt out of it.
-          git config --global --add safe.directory /__w/tt-metal/tt-metal
-
       - uses: actions/download-artifact@v4
         timeout-minutes: 10
         with:
@@ -60,6 +52,11 @@ jobs:
         run: |
           /usr/libexec/tt-metalium/validation/tt-metalium-validation-smoke
 
+      - name: workaround
+        run: |
+          # The test-reporting action runs git ls-files with no way to opt-out.
+          # Give it a dummy repo so it doesn't fail.
+          git init
       - name: Test Report
         uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
         if: ${{ !cancelled() }}
@@ -67,13 +64,16 @@ jobs:
           name: Metalium ${{ matrix.platform }} smoke tests
           path: /work/test-reports/*.xml
           reporter: jest-junit
-      - uses: ./.github/actions/upload-artifact-with-job-uuid
-        timeout-minutes: 10
+          working-directory: /work
+
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         if: ${{ !cancelled() }}
+        timeout-minutes: 10
         with:
           path: |
             /work/test-reports/
           prefix: "test_reports_"
+
       # Arbitrary limit that's higher than we would like, but the JIT build seems inconsistent.
       # Keep it here as a guardrail to keep Smoke tests fast.  We can adjust as needed.
       - name: Check for slow tests


### PR DESCRIPTION
### Ticket
#17851

### Problem description
No tests are run automatically in PRs
We have the beginning of a 'smoke' test, but are infra constrained

### What's changed
Light up the Smoke tests in the PR Gate, but only where we can target the new runners which are not (yet) saturated.
We'll monitor to see if any adjustments are needed for workflow latencies.

### Checklist
- [x] Made sure All Post Commit can [still run Smoke as before](https://github.com/tenstorrent/tt-metal/actions/runs/13710916570/job/38347445388).

