### PR TITLE
#0: [skip ci] Fix L2 timeout message

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           name: eager-dist-${{ matrix.os }}-any
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ inputs.timeout || '45' }}
+        timeout-minutes: ${{ fromJSON(inputs.timeout) || '45' }}
         uses: ./.github/actions/docker-run
         with:
           docker_username: ${{ github.actor }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
https://github.com/tenstorrent/tt-metal/actions/runs/13709114613/job/38343396981
```
Error: An error occurred when attempting to determine the step timeout.
Error: The template is not valid. .github/workflows/tt-metal-l2-nightly.yaml (Line: 66, Col: 26): Unexpected value '45'
```

### What's changed
Convert input.timeout to expected type (number) using `fromJSON`

### Checklist
- [x] metal l2: https://github.com/tenstorrent/tt-metal/actions/runs/13712686130
