### PR TITLE
Fix simulator

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -142,9 +142,9 @@ void Cluster::generate_cluster_descriptor() {
     // Cluster descriptor yaml not available for Blackhole bring up
     if (this->target_type_ == TargetDevice::Simulator) {
         // Passing simulator reported physical devices as logical devices.
-        this->cluster_desc_ =
-            tt_ClusterDescriptor::create_mock_cluster(tt_SimulationDevice::detect_available_device_ids(), this->arch_)
-                .get();
+        this->mock_cluster_desc_ptr_ =
+            tt_ClusterDescriptor::create_mock_cluster(tt_SimulationDevice::detect_available_device_ids(), this->arch_);
+        this->cluster_desc_ = this->mock_cluster_desc_ptr_.get();
     } else {
         this->cluster_desc_ = this->driver_->get_cluster_description();
         for (const auto &chip_id : this->cluster_desc_->get_all_chips()) {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -318,6 +318,9 @@ private:
     // UMD static APIs `detect_available_device_ids` and `detect_number_of_chips` only returns number of MMIO mapped
     // devices
     tt_ClusterDescriptor* cluster_desc_ = nullptr;
+    // In case of mock cluster descriptor, the tt_cluster holds the ownership of the created object;
+    // This is obviously a design issue. This should go away once the design is fixed.
+    std::unique_ptr<tt_ClusterDescriptor> mock_cluster_desc_ptr_;
     // There is an entry for every device that can be targeted (MMIO and remote)
     std::unordered_map<chip_id_t, metal_SocDescriptor> sdesc_per_chip_;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-umd/issues/564

### Problem description
A couple of fixes for tt-umd-simulators repo. We don't have a regular CI, so this can easily diverge and get broken.

### What's changed
- Bump UMD with the simulator changes
- When obtaining mock cluster descriptor, get ownership of the unique_ptr so it doesn't go out of scope.

### Checklist
All runs on brosko/fix_simulator :
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718526336
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718528020
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718529703
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/13718531761
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718534323
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718536175
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718538169
- [ ] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718539882
- [x] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718541482
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/13718543282
