### PR TITLE
Make multi-host tensor printing identical to single device

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -481,7 +481,13 @@ std::string to_string(
                 return ss.str();
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
                 std::stringstream ss;
-                apply(tensor, [&](const Tensor& device_tensor) { ss << to_string<T>(device_tensor) << std::endl; });
+                auto device_tensors = ttnn::distributed::get_tensors_from_multi_device_storage(tensor);
+                for (size_t i = 0; i < device_tensors.size(); i++) {
+                    ss << to_string<T>(device_tensors[i]);
+                    if (i + 1 != device_tensors.size()) {
+                        ss << std::endl;
+                    }
+                }
                 return ss.str();
             } else {
                 raise_unsupported_storage<StorageType>();


### PR DESCRIPTION
### Ticket

### Problem description
Currently printing format for multi-host tensor with a single device has an extra `\n` in the print output.

### What's changed
Remove an extra `\n` in multi-host tensor printing

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13717852596)
- [x] New/Existing tests provide coverage for changes
