### PR TITLE
Added mesh support to global circular buffer

### DIFF
--- a/tt_metal/api/tt-metalium/global_circular_buffer_impl.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer_impl.hpp
@@ -6,10 +6,12 @@
 
 #include <cstdint>
 #include <memory>
+#include <variant>
 
 #include "core_coord.hpp"
 #include "buffer_constants.hpp"
 #include "hal.hpp"
+#include "distributed.hpp"
 
 namespace tt::tt_metal {
 
@@ -57,8 +59,8 @@ private:
 
     // GlobalCircularBuffer is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
-    std::shared_ptr<Buffer> cb_buffer_;
-    std::shared_ptr<Buffer> cb_config_buffer_;
+    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> cb_buffer_;
+    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> cb_config_buffer_;
     IDevice* device_;
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping_;
     CoreRangeSet sender_cores_;

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -170,10 +170,10 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
                 cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
             }
         }
-        if (auto mesh_device = dynamic_cast<distributed::MeshDevice*>(device)) {
+        if (std::holds_alternative<std::shared_ptr<distributed::MeshBuffer>>(cb_config_buffer)) {
             auto mesh_buffer = std::get<std::shared_ptr<distributed::MeshBuffer>>(cb_config_buffer);
             distributed::EnqueueWriteMeshBuffer(
-                mesh_device->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+                mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
         } else {
             if (device->using_slow_dispatch()) {
                 detail::WriteToBuffer(*extract_buffer(cb_config_buffer), cb_config_host_buffer);

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -19,12 +19,44 @@
 #include <tt_align.hpp>
 
 #include "tt_cluster.hpp"
+#include "overloaded.hpp"
 
 namespace tt::tt_metal {
 
 namespace v1 {
 
 namespace experimental {
+
+namespace {
+Buffer* extract_buffer(
+    const std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>>& buffer_variant) {
+    return std::visit(
+        tt::stl::overloaded{
+            [](const std::shared_ptr<Buffer>& buffer) { return buffer.get(); },
+            [](const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer) {
+                auto shape = mesh_buffer->device()->shape();
+                return mesh_buffer->get_device_buffer(*distributed::MeshCoordinateRange(shape).begin()).get();
+            }},
+        buffer_variant);
+}
+std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> create_cb_buffer(
+    const ShardedBufferConfig& config) {
+    auto mesh_device = dynamic_cast<distributed::MeshDevice*>(config.device);
+    if (!mesh_device) {
+        return CreateBuffer(config);
+    }
+    distributed::MeshBufferConfig mesh_config = distributed::ReplicatedBufferConfig{
+        .size = config.size,
+    };
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = config.page_size,
+        .buffer_type = config.buffer_type,
+        .buffer_layout = config.buffer_layout,
+        .shard_parameters = config.shard_parameters,
+    };
+    return distributed::MeshBuffer::create(mesh_config, local_config, mesh_device);
+}
+}  // namespace
 
 GlobalCircularBuffer::GlobalCircularBuffer(
     IDevice* device,
@@ -69,7 +101,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = shard_parameters,
     };
-    cb_buffer_ = CreateBuffer(cb_buffer_shard_config);
+    cb_buffer_ = create_cb_buffer(cb_buffer_shard_config);
 
     auto l1_alignment = hal.get_alignment(HalMemType::L1);
     // is_sender, receiver_val, fifo_start_addr, fifo_size, fifo_ptr, noc_xy coords, and pages_sent
@@ -86,7 +118,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    cb_config_buffer_ = CreateBuffer(cb_config_buffer_shard_config);
+    cb_config_buffer_ = create_cb_buffer(cb_config_buffer_shard_config);
 
     // Write the config buffer to the device
     // Only block for the slow dispatch case
@@ -96,12 +128,12 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
                        cb_config_page_size,
                        num_noc_xy_words,
                        l1_alignment,
-                       buffer_address = cb_buffer_->address(),
+                       buffer_address = cb_buffer().address(),
                        cb_config_buffer = cb_config_buffer_,
                        size = size_,
                        sender_receiver_core_mapping = sender_receiver_core_mapping_] {
-        auto config_buffer_address = cb_config_buffer->address();
-        const auto& core_to_core_id = cb_config_buffer->get_buffer_page_mapping()->core_to_core_id_;
+        auto config_buffer_address = extract_buffer(cb_config_buffer)->address();
+        const auto& core_to_core_id = extract_buffer(cb_config_buffer)->get_buffer_page_mapping()->core_to_core_id_;
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
         uint32_t noc_xy_address = config_buffer_address + num_config_elements * sizeof(uint32_t);
         uint32_t pages_sent_address = tt::align(noc_xy_address + num_noc_xy_words * sizeof(uint32_t), l1_alignment);
@@ -138,16 +170,23 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
                 cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
             }
         }
-        if (device->using_slow_dispatch()) {
-            detail::WriteToBuffer(*cb_config_buffer, cb_config_host_buffer);
-            tt::Cluster::instance().l1_barrier(device->id());
+        if (auto mesh_device = dynamic_cast<distributed::MeshDevice*>(device)) {
+            auto mesh_buffer = std::get<std::shared_ptr<distributed::MeshBuffer>>(cb_config_buffer);
+            distributed::EnqueueWriteMeshBuffer(
+                mesh_device->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
         } else {
-            EnqueueWriteBuffer(device->command_queue(), cb_config_buffer, cb_config_host_buffer.data(), false);
+            if (device->using_slow_dispatch()) {
+                detail::WriteToBuffer(*extract_buffer(cb_config_buffer), cb_config_host_buffer);
+                tt::Cluster::instance().l1_barrier(device->id());
+            } else {
+                EnqueueWriteBuffer(
+                    device->command_queue(), *extract_buffer(cb_config_buffer), cb_config_host_buffer.data(), false);
+            }
         }
     });
 }
 
-const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_; }
+const Buffer& GlobalCircularBuffer::cb_buffer() const { return *extract_buffer(cb_buffer_); }
 
 const CoreRangeSet& GlobalCircularBuffer::sender_cores() const { return sender_cores_; }
 
@@ -155,9 +194,9 @@ const CoreRangeSet& GlobalCircularBuffer::receiver_cores() const { return receiv
 
 const CoreRangeSet& GlobalCircularBuffer::all_cores() const { return all_cores_; }
 
-DeviceAddr GlobalCircularBuffer::buffer_address() const { return cb_buffer_->address(); }
+DeviceAddr GlobalCircularBuffer::buffer_address() const { return cb_buffer().address(); }
 
-DeviceAddr GlobalCircularBuffer::config_address() const { return cb_config_buffer_->address(); }
+DeviceAddr GlobalCircularBuffer::config_address() const { return extract_buffer(cb_config_buffer_)->address(); }
 
 uint32_t GlobalCircularBuffer::size() const { return size_; }
 


### PR DESCRIPTION
### Ticket

### Problem description
I'm working on using MeshDevice everywhere in TT-NN, and it runs into an issue of GlobalCircularBuffer not supporting MeshDevice/MeshBuffer, this manifests in failing `prefetcher.py` test.

### What's changed
Added support for MeshDevice/MeshBuffer in GlobalCircularBuffer. This, together with removing TT-NN's `DeviceGlobalCircularBuffer` and `MultiDeviceGlobalCircularBuffer` resolves the failure. The full change is shown in this [commit](https://github.com/tenstorrent/tt-metal/pull/18470/commits/041d3638c6afe6dcfa700f620b6dd85491466fb0)

### Checklist
- [ ] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13718502710)
- [x] New/Existing tests provide coverage for changes
