### PR TITLE
#18775: Revert "Remove remaining i2s and s2i BH workaround from to/from_device" to see if it fixes T3K and single-card demo test pipelines

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -360,7 +360,8 @@ def test_create_min_width_shard(
             overlap_coregrid=overlap_coregrid,
         )
 
-    expected_entries = 1
+    # BH does s2i and i2s inside of to_device and from_device as device ops
+    expected_entries = 1 if not is_blackhole() else 3 if overlap_coregrid else 4
     assert device.num_program_cache_entries() == expected_entries
 
 
@@ -409,7 +410,7 @@ def test_create_heads_with_slice(
             slice_size=slice_size,
         )
     # BH does s2i and i2s inside of to_device and from_device as device ops
-    expected_entries = 1
+    expected_entries = 1 if not is_blackhole() else 4 if overlap_coregrid else 5
     assert device.num_program_cache_entries() == expected_entries
 
 

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -59,7 +59,13 @@ ttnn::Tensor to_device(
     const std::optional<MemoryConfig>& memory_config,
     QueueId cq_id) {
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
-    return tensor.to_device(mesh_device, mem_config, cq_id);
+    // Currently no direct sharded write support in BLACKHOLE due to alignment issue
+    if (mem_config.is_sharded() and (mesh_device->arch() == tt::ARCH::BLACKHOLE)) {
+        auto interleaved_tensor = tensor.to_device(mesh_device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
+        return ttnn::interleaved_to_sharded(ttnn::DefaultQueueId, interleaved_tensor, mem_config, std::nullopt);
+    } else {
+        return tensor.to_device(mesh_device, mem_config, cq_id);
+    }
 }
 
 ttnn::Tensor allocate_tensor_on_device(
@@ -103,7 +109,13 @@ void copy_host_to_device_tensor(const ttnn::Tensor& host_tensor, ttnn::Tensor de
 }
 
 ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking, QueueId cq_id) {
-    return tensor.cpu(blocking, cq_id);
+    // Currently no direct sharded read support in BLACKHOLE due to alignment issue
+    if (tensor.is_sharded() and (tensor.device()->arch() == tt::ARCH::BLACKHOLE)) {
+        auto interleaved_tensor = ttnn::sharded_to_interleaved(cq_id, tensor, ttnn::DRAM_MEMORY_CONFIG, std::nullopt);
+        return interleaved_tensor.cpu(blocking, cq_id);
+    } else {
+        return tensor.cpu(blocking, cq_id);
+    }
 }
 
 void deallocate(Tensor& tensor, bool force) { tensor.deallocate(force); }


### PR DESCRIPTION
This reverts commit 348b015e40b2cecb5854badce82e59842e9bc821.

### Ticket
#18775

### Problem description

T3K model perf + demo + single-card demo broke recently

### What's changed

this might be the issue

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
