### PR TITLE
Conv2d circular buffers being sequential.

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -274,6 +274,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "conv2d_op_program_factory_common.hpp"
+
+namespace ttnn::operations::conv {
+namespace conv2d {
+
+uint32_t CBIndices::get_next_cb_index() { return next_cb_index++; }
+
+}  // namespace conv2d
+}  // namespace ttnn::operations::conv

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <cstdint>
-#include "tt-metalium/circular_buffer_types.hpp"
+#include "hostdevcommon/kernel_structs.h"
 
 namespace ttnn::operations::conv {
 namespace conv2d {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -5,8 +5,12 @@
 #pragma once
 
 #include <cstdint>
+#include "tt-metalium/circular_buffer_types.hpp"
+
 namespace ttnn::operations::conv {
 namespace conv2d {
+
+using namespace tt;
 
 // In order to make circular buffer indicies sequential, we use variable to keep track of the next available index.
 // Circular buffer indices should be assigned right before their creation.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace ttnn::operations::conv {
+namespace conv2d {
+
+// In order to make circular buffer indicies sequential, we use variable to keep track of the next available index.
+// Circular buffer indices should be assigned right before their creation.
+struct CBIndices {
+    // Invalid value for cb id is 32, number greater than the maximum number of index circular buffer can have.
+    // Not assigning get_next_cb_index() value before creating cb will throw exception in circular_buffer_types.cpp
+    // which can be used as a reminder.
+    uint32_t weight_cb = 32;
+    uint32_t tilize_mode_tilized_act_cb = 32;
+    uint32_t act_cb = 32;
+    uint32_t bias_cb = 32;
+    uint32_t sharded_act_cb = 32;
+    uint32_t cb_for_reader_indices = 32;
+    uint32_t cb_for_l1_array = 32;
+    uint32_t act_cb_row_major_bfloat16 = 32;
+    uint32_t act_cb_second_reader = 32;
+    uint32_t matmul_partials_cb = 32;
+    uint32_t untilize_mode_reblock_cb = 32;
+    uint32_t out0_cb = 32;
+    uint32_t temp_sum_cb = 32;
+
+    uint32_t get_next_cb_index();
+
+private:
+    uint32_t next_cb_index = tt::CBIndex::c_0;
+};
+}  // namespace conv2d
+}  // namespace ttnn::operations::conv

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 namespace ttnn::operations::conv {
 namespace conv2d {
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -961,40 +961,40 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
 
         uint32_t partials_block_num_bytes = out_block_num_tiles * partial_tile_size;
 
-        // CB 0
-        uint32_t act_cb_0_size = tilized_act_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
+        // ACT CB
+        uint32_t act_cb_size = tilized_act_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
 
-        // CB 1
-        uint32_t weights_cb_1_size = weight_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
+        // WEIGHTS CB
+        uint32_t weights_cb_size = weight_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Weights CB Size: {}", weights_cb_size);
 
-        // CB 2
-        uint32_t bias_cb_2_size = bias_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
+        // BIAS CB
+        uint32_t bias_cb_size = bias_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Bias CB Size: {}", bias_cb_size);
 
-        // CB 5
-        uint32_t l1_scratchpad_cb_5_size = conv2d::l1_scratchpad_CB_size;
-        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
+        // L1 CB
+        uint32_t l1_scratchpad_cb_size = conv2d::l1_scratchpad_CB_size;
+        tt::log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
 
-        // CB 6
-        uint32_t row_major_act_cb_6_size = act_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB6 Size: {}", row_major_act_cb_6_size);
+        // ACT ROW MAJOR CB
+        uint32_t row_major_act_cb_size = act_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Act row major CB Size: {}", row_major_act_cb_size);
 
-        // CB 24
-        uint32_t matmul_partial_cb_24_size = partials_block_num_bytes;
+        // MATMUL PARTIALs CB
+        uint32_t matmul_partials_cb_size = partials_block_num_bytes;
         if (interm_dtype == conv_config.dtype) {
-            matmul_partial_cb_24_size = 0;
+            matmul_partials_cb_size = 0;
         } else {
-            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partial_cb_24_size);
+            tt::log_debug(tt::LogOp, "Matmul partial CB Size: {}", matmul_partials_cb_size);
         }
 
-        // CB 25
-        uint32_t tilized_act_cb_25_size = tilized_act_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
+        // TILIZED ACT CB
+        uint32_t tilized_act_cb_size = tilized_act_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Tilized act CB Size: {}", tilized_act_cb_size);
 
-        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
-                                 row_major_act_cb_6_size + matmul_partial_cb_24_size + tilized_act_cb_25_size;
+        uint32_t total_CB_size = act_cb_size + weights_cb_size + bias_cb_size + l1_scratchpad_cb_size +
+                                 row_major_act_cb_size + matmul_partials_cb_size + tilized_act_cb_size;
 
         tt::log_debug(tt::LogOp, "Total CB Size: {}", total_CB_size);
 
@@ -1041,55 +1041,56 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
             act_block_split_last_ntiles *= 2;
             act_block_split_ntiles *= 2;
         }
-        // CB 0
-        uint32_t act_cb_0_size = act_block_split_ntiles * input_tile_size;
-        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
+        // ACT CB
+        uint32_t act_cb_size = act_block_split_ntiles * input_tile_size;
+        tt::log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
 
-        // CB 1
-        uint32_t weights_cb_1_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
+        // WEIGHTS CB
+        uint32_t weights_cb_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
         if (num_blocks_act_h > 1) {
-            weights_cb_1_size *= kernel_size[0];
+            weights_cb_size *= kernel_size[0];
         }
         if (num_blocks_act_h <= 1 && conv_config.enable_weights_double_buffer) {
-            weights_cb_1_size *= 2;
+            weights_cb_size *= 2;
         }
-        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
+        tt::log_debug(tt::LogOp, "Weights CB Size: {}", weights_cb_size);
 
-        // CB 2
-        uint32_t bias_cb_2_size = bias_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
+        // BIAS CB
+        uint32_t bias_cb_size = bias_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Bias CB Size: {}", bias_cb_size);
 
-        uint32_t l1_scratchpad_cb_5_size = conv2d::l1_scratchpad_CB_size;
-        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
+        // L1 CB
+        uint32_t l1_scratchpad_cb_size = conv2d::l1_scratchpad_CB_size;
+        tt::log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
 
-        uint32_t split_second_act_reader_cb_7_size = 0;
+        // SPLIT READER CB
+        uint32_t split_second_act_reader_cb_size = act_block_split_last_ntiles * input_tile_size;
+        tt::log_debug(tt::LogOp, "Split reader CB Size: {}", split_second_act_reader_cb_size);
 
-        split_second_act_reader_cb_7_size = act_block_split_last_ntiles * input_tile_size;
-        tt::log_debug(tt::LogOp, "CB7 Size: {}", split_second_act_reader_cb_7_size);
-
-        // CB 24
-        uint32_t matmul_partials_cb_24_size = output_block_ntiles * partial_tile_size;
+        // MATMUL PARTIALS CB
+        uint32_t matmul_partials_cb_size = output_block_ntiles * partial_tile_size;
         if (untilize_out == false && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_24_size = 0;
+            matmul_partials_cb_size = 0;
         }
         if (is_1d_depthwise_conv) {
-            matmul_partials_cb_24_size = output_tile_size;
+            matmul_partials_cb_size = output_tile_size;
         }
-        if (matmul_partials_cb_24_size != 0) {
-            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partials_cb_24_size);
+        if (matmul_partials_cb_size != 0) {
+            tt::log_debug(tt::LogOp, "Matmul partials CB Size: {}", matmul_partials_cb_size);
         }
-        // CB 25
-        uint32_t tilized_act_cb_25_size = tilzed_act_cb_size;
-        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
+        // TILIZED ACT CB
+        uint32_t tilized_act_cb_size = tilzed_act_cb_size;
+        tt::log_debug(tt::LogOp, "Tilized act CB Size: {}", tilized_act_cb_size);
 
-        uint32_t temp_sum_cb_27_size = 0;
+        // TEMP SUM CB
+        uint32_t temp_sum_cb_size = 0;
         if (is_1d_depthwise_conv) {
-            temp_sum_cb_27_size = output_tile_size;
-            tt::log_debug(tt::LogOp, "CB27 Size: {}", temp_sum_cb_27_size);
+            temp_sum_cb_size = output_tile_size;
+            tt::log_debug(tt::LogOp, "Temp sum CB Size: {}", temp_sum_cb_size);
         }
-        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
-                                 split_second_act_reader_cb_7_size + matmul_partials_cb_24_size +
-                                 tilized_act_cb_25_size + temp_sum_cb_27_size;
+        uint32_t total_CB_size = act_cb_size + weights_cb_size + bias_cb_size + l1_scratchpad_cb_size +
+                                 split_second_act_reader_cb_size + matmul_partials_cb_size + tilized_act_cb_size +
+                                 temp_sum_cb_size;
         return conv2d::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
     } else if (sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
         auto output_shard_shape = output_memory_config.shard_spec.value().shape;
@@ -1133,43 +1134,42 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
 
         uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
 
-        // CB 0
-        uint32_t act_cb_0_size = tilized_act_block_cb_size;
+        // ACT CB
+        uint32_t act_cb_size = tilized_act_block_cb_size;
         if (conv_config.enable_act_double_buffer) {
-            act_cb_0_size *= 2;
+            act_cb_size *= 2;
         }
-        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
+        tt::log_debug(tt::LogOp, "Act CB Size: {}", act_cb_size);
 
-        // CB 1
-        uint32_t weights_cb_1_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
+        // WEIGHTS CB
+        uint32_t weights_cb_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
         if (conv_config.enable_weights_double_buffer) {
-            weights_cb_1_size *= 2;
+            weights_cb_size *= 2;
         }
-        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
+        tt::log_debug(tt::LogOp, "Weights CB Size: {}", weights_cb_size);
 
-        // CB 2
-        uint32_t bias_cb_2_size = bias_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
+        // BIAS CB
+        uint32_t bias_cb_size = bias_block_num_bytes;
+        tt::log_debug(tt::LogOp, "Bias CB Size: {}", bias_cb_size);
 
-        // CB 5
-        uint32_t l1_scratchpad_cb_5_size = conv2d::l1_scratchpad_CB_size;
-        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
+        // L1 CB
+        uint32_t l1_scratchpad_cb_size = conv2d::l1_scratchpad_CB_size;
+        tt::log_debug(tt::LogOp, "L1 CB Size: {}", l1_scratchpad_cb_size);
 
-        // CB 6
-        uint32_t cb6_size = row_major_act_cb_size;
-        tt::log_debug(tt::LogOp, "CB6 Size: {}", cb6_size);
+        // ACT ROW MAJOR CB
+        tt::log_debug(tt::LogOp, "Act row major CB Size: {}", row_major_act_cb_size);
 
-        // CB 24
-        uint32_t matmul_partials_cb_24_size = output_block_ntiles * partial_tile_size;
+        // MATMUL PARTIALS CB
+        uint32_t matmul_partials_cb_size = output_block_ntiles * partial_tile_size;
         if (untilize_out == false && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_24_size = 0;
+            matmul_partials_cb_size = 0;
         } else {
-            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partials_cb_24_size);
+            tt::log_debug(tt::LogOp, "Matmul partials CB Size: {}", matmul_partials_cb_size);
         }
 
-        // CB 25
-        uint32_t tilized_act_cb_25_size = tilized_act_block_cb_size;
-        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
+        // TILIZED ACT CB
+        uint32_t tilized_act_cb_size = tilized_act_block_cb_size;
+        tt::log_debug(tt::LogOp, "Tilized act CB Size: {}", tilized_act_cb_size);
 
         bool need_unpad_after_untilize =
             output_shard_shape[1] * output_shard_shape[0] <
@@ -1177,13 +1177,15 @@ conv_op_l1_usage conv2d::calculate_L1_usage(
 
         tt::log_debug(tt::LogOp, "Need Unpad after untilize: {}", need_unpad_after_untilize);
 
-        uint32_t cb28_size = 0;
+        // UNTILIZED UNPADDED OUT CB
+        uint32_t untilized_unpadded_out_cb_size = 0;
         if (need_unpad_after_untilize && untilize_out) {
-            cb28_size = output_block_ntiles * output_tile_size;
-            tt::log_debug(tt::LogOp, "CB28 Size: {}", cb28_size);
+            untilized_unpadded_out_cb_size = output_block_ntiles * output_tile_size;
+            tt::log_debug(tt::LogOp, "Untilized unapadded out CB Size: {}", untilized_unpadded_out_cb_size);
         }
-        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
-                                 cb6_size + matmul_partials_cb_24_size + tilized_act_cb_25_size + cb28_size;
+        uint32_t total_CB_size = act_cb_size + weights_cb_size + bias_cb_size + l1_scratchpad_cb_size +
+                                 row_major_act_cb_size + matmul_partials_cb_size + tilized_act_cb_size +
+                                 untilized_unpadded_out_cb_size;
         return conv2d::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
     }
     TT_THROW("Invalid shard layout {}", sharding_scheme);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/circular_buffer_types.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
@@ -19,24 +20,6 @@ namespace ttnn::operations::conv {
 namespace conv2d {
 
 using namespace tt;
-
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-const uint32_t act_cb = CBIndex::c_0;
-const uint32_t weight_cb = CBIndex::c_1;
-const uint32_t bias_cb = CBIndex::c_2;
-const uint32_t sharded_act_cb = CBIndex::c_3;
-const uint32_t cb_for_reader_indices = CBIndex::c_4;
-const uint32_t cb_for_l1_array = CBIndex::c_5;
-const uint32_t act_cb_row_major_bfloat16 = CBIndex::c_6;
-const uint32_t act_cb_second_reader = CBIndex::c_7;
-const uint32_t matmul_partials_cb = CBIndex::c_24;
-const uint32_t tilize_mode_tilized_act_cb = CBIndex::c_25;
-const uint32_t untilize_mode_reblock_cb = CBIndex::c_26;
-const uint32_t out0_cb = CBIndex::c_16;
-const uint32_t temp_sum_cb = CBIndex::c_27;
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
 
 tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     tt_metal::Program& program,
@@ -85,8 +68,8 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
     bool with_bias,
     bool split_reader,
     bool fp32_dest_acc_en,
-    bool packer_l1_acc_en) {
-    using namespace CMAKE_UNIQUE_NAMESPACE;
+    bool packer_l1_acc_en,
+    CBIndices& cb_indices) {
     using tt::tt_metal::CBHandle;
     using tt::tt_metal::CircularBuffer;
     using tt::tt_metal::CircularBufferConfig;
@@ -107,9 +90,11 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
         // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
         TT_FATAL(
             shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
+        cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
         CircularBufferConfig cb_sharded_act_config =
-            CircularBufferConfig(shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{sharded_act_cb, act_df}})
-                .set_page_size(sharded_act_cb, shard_shape[1] * num_bytes_for_df);
+            CircularBufferConfig(
+                shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{cb_indices.sharded_act_cb, act_df}})
+                .set_page_size(cb_indices.sharded_act_cb, shard_shape[1] * num_bytes_for_df);
         // incoming data is the input cb instead of raw l1/dram addr
         cb_sharded_act_config.set_globally_allocated_address(*input.buffer());
         cb_sharded_act = tt_metal::CreateCircularBuffer(program, core, cb_sharded_act_config);
@@ -121,22 +106,26 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
             // output df
 
             // num_cb0_tiles is double buffered
+            cb_indices.act_cb = cb_indices.get_next_cb_index();
             CircularBufferConfig cb_act_config =
-                CircularBufferConfig(num_cb0_tiles * tilized_act_tile_size, {{act_cb, tilized_act_df}})
-                    .set_page_size(act_cb, tilized_act_tile_size);
+                CircularBufferConfig(num_cb0_tiles * tilized_act_tile_size, {{cb_indices.act_cb, tilized_act_df}})
+                    .set_page_size(cb_indices.act_cb, tilized_act_tile_size);
             auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
-            log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", act_cb, num_cb0_tiles, tilized_act_tile_size);
+            log_debug(
+                LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, tilized_act_tile_size);
 
             // num_cb0_tilized_tiles is single buffered
+            cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();
             CircularBufferConfig cb_act_row_major_bfloat16_config =
-                CircularBufferConfig(num_cb0_tilized_tiles * act_tile_size, {{act_cb_row_major_bfloat16, act_df}})
-                    .set_page_size(act_cb_row_major_bfloat16, act_tile_size);
+                CircularBufferConfig(
+                    num_cb0_tilized_tiles * act_tile_size, {{cb_indices.act_cb_row_major_bfloat16, act_df}})
+                    .set_page_size(cb_indices.act_cb_row_major_bfloat16, act_tile_size);
             auto cb_act_row_major_bfloat16 =
                 tt_metal::CreateCircularBuffer(program, core, cb_act_row_major_bfloat16_config);
             log_debug(
                 LogOp,
                 "Act CB Row Major BFLOAT16: {}, npages: {}, pagesize: {}",
-                act_cb_row_major_bfloat16,
+                cb_indices.act_cb_row_major_bfloat16,
                 num_cb0_tilized_tiles,
                 act_tile_size);
         } else {
@@ -146,57 +135,62 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
             // Extra cb for second reader if we split act reads across two RISCs
             // In this case, the regular reader only does first half of reads along output block h
             if (split_reader) {
+                cb_indices.act_cb_second_reader = cb_indices.get_next_cb_index();
                 CircularBufferConfig cb_act_config =
-                    CircularBufferConfig(num_cb0_second_reader_tiles * act_tile_size, {{act_cb_second_reader, act_df}})
-                        .set_page_size(act_cb_second_reader, act_tile_size);
+                    CircularBufferConfig(
+                        num_cb0_second_reader_tiles * act_tile_size, {{cb_indices.act_cb_second_reader, act_df}})
+                        .set_page_size(cb_indices.act_cb_second_reader, act_tile_size);
                 auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
                 log_debug(
                     LogOp,
                     "Act CB Second Reader: {}, npages: {}, pagesize: {}",
-                    act_cb_second_reader,
+                    cb_indices.act_cb_second_reader,
                     num_cb0_second_reader_tiles,
                     act_tile_size);
             }
-
-            CircularBufferConfig cb_act_config = CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb, act_df}})
-                                                     .set_page_size(act_cb, act_tile_size);
+            cb_indices.act_cb = cb_indices.get_next_cb_index();
+            CircularBufferConfig cb_act_config =
+                CircularBufferConfig(num_cb0_tiles * act_tile_size, {{cb_indices.act_cb, act_df}})
+                    .set_page_size(cb_indices.act_cb, act_tile_size);
             auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
-            log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", act_cb, num_cb0_tiles, act_tile_size);
+            log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, act_tile_size);
         }
     } else {
         TT_THROW("Input must be sharded!");
     }
 
     CircularBufferConfig cb_weight_config =
-        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{weight_cb, weight_df}})
-            .set_page_size(weight_cb, weight_tile_size);
+        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{cb_indices.weight_cb, weight_df}})
+            .set_page_size(cb_indices.weight_cb, weight_tile_size);
     auto cb_weight = tt_metal::CreateCircularBuffer(program, core, cb_weight_config);
-    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", weight_cb, num_cb1_tiles, weight_tile_size);
+    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", cb_indices.weight_cb, num_cb1_tiles, weight_tile_size);
 
     // Used for placing tilized activations
     CircularBufferConfig cb_src0_tilized_config =
         CircularBufferConfig(
-            num_cb0_tilized_tiles * tilized_act_tile_size, {{tilize_mode_tilized_act_cb, tilized_act_df}})
-            .set_page_size(tilize_mode_tilized_act_cb, tilized_act_tile_size);
+            num_cb0_tilized_tiles * tilized_act_tile_size, {{cb_indices.tilize_mode_tilized_act_cb, tilized_act_df}})
+            .set_page_size(cb_indices.tilize_mode_tilized_act_cb, tilized_act_tile_size);
     auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, core, cb_src0_tilized_config);
     log_debug(
         LogOp,
         "Tilized Act CB: {}, npages: {}, pagesize: {}",
-        tilize_mode_tilized_act_cb,
+        cb_indices.tilize_mode_tilized_act_cb,
         num_cb0_tilized_tiles,
         tilized_act_tile_size);
 
     CBHandle cb_output = 0;
     if (untilize_out) {
+        cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
         auto output_shard_shape = output.shard_spec().value().shape;
         CircularBufferConfig cb_matmul_partials_config =
-            CircularBufferConfig(num_output_tiles * interm0_single_tile_size, {{matmul_partials_cb, interm0_df}})
-                .set_page_size(matmul_partials_cb, interm0_single_tile_size);
+            CircularBufferConfig(
+                num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
+                .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
         auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
         log_debug(
             LogOp,
             "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-            matmul_partials_cb,
+            cb_indices.matmul_partials_cb,
             num_output_tiles,
             interm0_single_tile_size);
 
@@ -206,48 +200,55 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
         auto shard_shape = output.shard_spec().value().shape;
         uint32_t aligned_output_stick_nbytes = out_tile_size;
         uint32_t aligned_output_num_pages = num_writer_output_tiles;
+        cb_indices.out0_cb = cb_indices.get_next_cb_index();
         CircularBufferConfig cb_output_config =
-            CircularBufferConfig(aligned_output_num_pages * aligned_output_stick_nbytes, {{out0_cb, out_df}})
-                .set_page_size(out0_cb, aligned_output_stick_nbytes);
+            CircularBufferConfig(aligned_output_num_pages * aligned_output_stick_nbytes, {{cb_indices.out0_cb, out_df}})
+                .set_page_size(cb_indices.out0_cb, aligned_output_stick_nbytes);
         cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
         cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
     } else {
         // Share buffer if same data format
         if (interm0_df == out_df) {
             CoreRangeSet cores(std::set<CoreRange>({core}));
+            cb_indices.out0_cb = cb_indices.get_next_cb_index();
+            cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
             std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {
-                {out0_cb, out_df}, {matmul_partials_cb, out_df}};
+                {cb_indices.out0_cb, out_df}, {cb_indices.matmul_partials_cb, out_df}};
+
             CircularBufferConfig cb_matmul_partials_config =
                 CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
-                    .set_page_size(out0_cb, out_tile_size)
-                    .set_page_size(matmul_partials_cb, out_tile_size);
+                    .set_page_size(cb_indices.out0_cb, out_tile_size)
+                    .set_page_size(cb_indices.matmul_partials_cb, out_tile_size);
             if (output.is_sharded()) {
                 cb_matmul_partials_config = cb_matmul_partials_config.set_globally_allocated_address(*output.buffer());
             } else {
                 log_debug(
                     LogOp,
                     "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-                    matmul_partials_cb,
+                    cb_indices.matmul_partials_cb,
                     num_output_tiles,
                     out_tile_size);
             }
             cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_matmul_partials_config);
         } else {
             // Separate buffer if not same data format
+            cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
             CircularBufferConfig cb_matmul_partials_config =
-                CircularBufferConfig(num_output_tiles * interm0_single_tile_size, {{matmul_partials_cb, interm0_df}})
-                    .set_page_size(matmul_partials_cb, interm0_single_tile_size);
+                CircularBufferConfig(
+                    num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
+                    .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
             auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
             log_debug(
                 LogOp,
                 "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-                matmul_partials_cb,
+                cb_indices.matmul_partials_cb,
                 num_output_tiles,
                 interm0_single_tile_size);
 
+            cb_indices.out0_cb = cb_indices.get_next_cb_index();
             CircularBufferConfig cb_output_config =
-                CircularBufferConfig(num_output_tiles * out_tile_size, {{out0_cb, out_df}})
-                    .set_page_size(out0_cb, out_tile_size);
+                CircularBufferConfig(num_output_tiles * out_tile_size, {{cb_indices.out0_cb, out_df}})
+                    .set_page_size(cb_indices.out0_cb, out_tile_size);
             if (output.is_sharded()) {
                 cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
             }
@@ -259,11 +260,13 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_sharde
         uint32_t bias_tile_size = tt_metal::detail::TileSize(bias_df);
         // bias input
         uint32_t bias_pagesize = bias_tile_size;
-        CircularBufferConfig cb_bias_config = CircularBufferConfig(bias_ntiles * bias_pagesize, {{bias_cb, bias_df}})
-                                                  .set_page_size(bias_cb, bias_pagesize);
+        cb_indices.bias_cb = cb_indices.get_next_cb_index();
+        CircularBufferConfig cb_bias_config =
+            CircularBufferConfig(bias_ntiles * bias_pagesize, {{cb_indices.bias_cb, bias_df}})
+                .set_page_size(cb_indices.bias_cb, bias_pagesize);
         auto cb_bias = tt_metal::CreateCircularBuffer(program, core, cb_bias_config);
 
-        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", bias_cb, bias_ntiles, bias_pagesize);
+        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", cb_indices.bias_cb, bias_ntiles, bias_pagesize);
     }
 
     return {cb_sharded_act, cb_output};
@@ -292,8 +295,8 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthw
     bool with_bias,
     bool split_reader,
     bool fp32_dest_acc_en,
-    bool packer_l1_acc_en) {
-    using namespace CMAKE_UNIQUE_NAMESPACE;
+    bool packer_l1_acc_en,
+    CBIndices& cb_indices) {
     using tt::tt_metal::CBHandle;
     using tt::tt_metal::CircularBuffer;
     using tt::tt_metal::CircularBufferConfig;
@@ -314,41 +317,44 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthw
         // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
         TT_FATAL(
             shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
+        cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
         CircularBufferConfig cb_sharded_act_config =
-            CircularBufferConfig(shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{sharded_act_cb, act_df}})
-                .set_page_size(sharded_act_cb, shard_shape[1] * num_bytes_for_df);
+            CircularBufferConfig(
+                shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{cb_indices.sharded_act_cb, act_df}})
+                .set_page_size(cb_indices.sharded_act_cb, shard_shape[1] * num_bytes_for_df);
         // incoming data is the input cb instead of raw l1/dram addr
         cb_sharded_act_config.set_globally_allocated_address(*input.buffer());
         cb_sharded_act = tt_metal::CreateCircularBuffer(program, core, cb_sharded_act_config);
 
         // For 1D convs, locally create act matrix in act_cb, which is always ROW_MAJOR BFLOAT16
         // Then, tilize input in compute
-
-        CircularBufferConfig cb_act_config = CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb, act_df}})
-                                                 .set_page_size(act_cb, act_tile_size);
+        cb_indices.act_cb = cb_indices.get_next_cb_index();
+        CircularBufferConfig cb_act_config =
+            CircularBufferConfig(num_cb0_tiles * act_tile_size, {{cb_indices.act_cb, act_df}})
+                .set_page_size(cb_indices.act_cb, act_tile_size);
         auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
-        log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", act_cb, num_cb0_tiles, act_tile_size);
+        log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, act_tile_size);
 
     } else {
         TT_THROW("Input must be sharded!");
     }
 
     CircularBufferConfig cb_weight_config =
-        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{weight_cb, weight_df}})
-            .set_page_size(weight_cb, weight_tile_size);
+        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{cb_indices.weight_cb, weight_df}})
+            .set_page_size(cb_indices.weight_cb, weight_tile_size);
     auto cb_weight = tt_metal::CreateCircularBuffer(program, core, cb_weight_config);
-    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", weight_cb, num_cb1_tiles, weight_tile_size);
+    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", cb_indices.weight_cb, num_cb1_tiles, weight_tile_size);
 
     // Used for placing tilized activations
     CircularBufferConfig cb_src0_tilized_config =
         CircularBufferConfig(
-            num_cb0_tilized_tiles * tilized_act_tile_size, {{tilize_mode_tilized_act_cb, tilized_act_df}})
-            .set_page_size(tilize_mode_tilized_act_cb, tilized_act_tile_size);
+            num_cb0_tilized_tiles * tilized_act_tile_size, {{cb_indices.tilize_mode_tilized_act_cb, tilized_act_df}})
+            .set_page_size(cb_indices.tilize_mode_tilized_act_cb, tilized_act_tile_size);
     auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, core, cb_src0_tilized_config);
     log_debug(
         LogOp,
         "Act Tilized CB: {}, npages: {}, pagesize: {}",
-        tilize_mode_tilized_act_cb,
+        cb_indices.tilize_mode_tilized_act_cb,
         num_cb0_tilized_tiles,
         tilized_act_tile_size);
 
@@ -357,26 +363,32 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthw
     CoreRangeSet cores(std::set<CoreRange>({core}));
 
     // breakdown above as separate CBs
+    cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
     CircularBufferConfig cb_matmul_partials_config =
-        CircularBufferConfig(1 * out_tile_size, {{matmul_partials_cb, out_df}})
-            .set_page_size(matmul_partials_cb, out_tile_size);
+        CircularBufferConfig(1 * out_tile_size, {{cb_indices.matmul_partials_cb, out_df}})
+            .set_page_size(cb_indices.matmul_partials_cb, out_tile_size);
     auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
-    log_debug(LogOp, "Matmul Partials CB: {}, npages: {}, pagesize: {}", matmul_partials_cb, 1, out_tile_size);
+    log_debug(
+        LogOp, "Matmul Partials CB: {}, npages: {}, pagesize: {}", cb_indices.matmul_partials_cb, 1, out_tile_size);
 
+    cb_indices.temp_sum_cb = cb_indices.get_next_cb_index();
     CircularBufferConfig cb_temp_sum_config =
-        CircularBufferConfig(1 * out_tile_size, {{temp_sum_cb, out_df}}).set_page_size(temp_sum_cb, out_tile_size);
+        CircularBufferConfig(1 * out_tile_size, {{cb_indices.temp_sum_cb, out_df}})
+            .set_page_size(cb_indices.temp_sum_cb, out_tile_size);
     auto cb_temp_sum = tt_metal::CreateCircularBuffer(program, core, cb_temp_sum_config);
-    log_debug(LogOp, "Temp Sum CB: {}, npages: {}, pagesize: {}", temp_sum_cb, 1, out_tile_size);
+    log_debug(LogOp, "Temp Sum CB: {}, npages: {}, pagesize: {}", cb_indices.temp_sum_cb, 1, out_tile_size);
 
-    std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {{out0_cb, out_df}};
+    cb_indices.out0_cb = cb_indices.get_next_cb_index();
+    std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {{cb_indices.out0_cb, out_df}};
     CircularBufferConfig cb_output_config =
         CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
-            .set_page_size(out0_cb, out_tile_size);
+            .set_page_size(cb_indices.out0_cb, out_tile_size);
 
     if (output.is_sharded()) {
         cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
     } else {
-        log_debug(LogOp, "Output CB: {}, npages: {}, pagesize: {}", out0_cb, num_output_tiles, out_tile_size);
+        log_debug(
+            LogOp, "Output CB: {}, npages: {}, pagesize: {}", cb_indices.out0_cb, num_output_tiles, out_tile_size);
     }
     cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
 
@@ -406,10 +418,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     bool enable_weights_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding) {
-    using namespace CMAKE_UNIQUE_NAMESPACE;
     using tt::tt_metal::CBHandle;
     using tt::tt_metal::CircularBuffer;
     using tt::tt_metal::CircularBufferConfig;
+    CBIndices cb_indices = CBIndices();
+    // Non-optional circular buffer indicies
+    cb_indices.weight_cb = cb_indices.get_next_cb_index();
+    cb_indices.tilize_mode_tilized_act_cb = cb_indices.get_next_cb_index();
 
     bool pass = true;
     tt_metal::IDevice* device = a.device();
@@ -1104,7 +1119,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             has_bias,
             split_reader,
             fp32_dest_acc_en,
-            packer_l1_acc_en);
+            packer_l1_acc_en,
+            cb_indices);
     } else {
         // TODO: Moving this function call to after kernel logic causes pcc fails
         // There are additional CBs and semaphores created in 2D conv in kernel logic,
@@ -1132,7 +1148,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
             has_bias,
             split_reader,
             fp32_dest_acc_en,
-            packer_l1_acc_en);
+            packer_l1_acc_en,
+            cb_indices);
     }
     CBHandle cb_sharded_act = std::get<0>(input_output_cbs);
     CBHandle cb_output = std::get<1>(input_output_cbs);
@@ -1211,20 +1228,22 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
                     "writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
             }
         }
-
         // Local L1 to store array for reader indices
         // All convs use packed uint16 indices, so each entry can be 2B (not 4)
+        cb_indices.cb_for_reader_indices = cb_indices.get_next_cb_index();
         CircularBufferConfig cb_for_reader_indices_config =
-            CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
-                .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
+            CircularBufferConfig(
+                out_block_h_datums * 2, {{cb_indices.cb_for_reader_indices, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_indices.cb_for_reader_indices, out_block_h_datums * 2);
         cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer);
         auto cb_for_reader_indices_id =
             tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
 
         // Local L1 to store temp vars
+        cb_indices.cb_for_l1_array = cb_indices.get_next_cb_index();
         CircularBufferConfig cb_for_l1_array_config =
-            CircularBufferConfig(l1_scratchpad_CB_size, {{cb_for_l1_array, tt::DataFormat::Float16_b}})
-                .set_page_size(cb_for_l1_array, l1_scratchpad_CB_size);
+            CircularBufferConfig(l1_scratchpad_CB_size, {{cb_indices.cb_for_l1_array, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_indices.cb_for_l1_array, l1_scratchpad_CB_size);
         auto cb_for_l1_array_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
     } else {
         TT_THROW("Sharded input not supported for this conv yet!");
@@ -1274,7 +1293,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         (uint32_t)in0_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
         (uint32_t)(transpose_mcast ? 1 : 0),
         (uint32_t)act_block_h_datums_last_block,
-        (uint32_t)act_block_h_datums_split_last};
+        (uint32_t)act_block_h_datums_split_last,
+        (uint32_t)cb_indices.act_cb,
+        (uint32_t)cb_indices.sharded_act_cb,
+        (uint32_t)cb_indices.cb_for_reader_indices,
+        (uint32_t)cb_indices.tilize_mode_tilized_act_cb,
+        (uint32_t)cb_indices.act_cb_row_major_bfloat16,
+        (uint32_t)cb_indices.cb_for_l1_array};
 
     // define for bias
     std::map<string, string> writer_defines;
@@ -1312,10 +1337,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
 
     writer_compile_time_args = {
         (uint32_t)(dst_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0),
-        out0_cb,
-        weight_cb,
-        bias_cb,
+        cb_indices.out0_cb,
+        cb_indices.weight_cb,
+        cb_indices.bias_cb,
         (uint32_t)(bias_buffer == nullptr ? 0 : (bias_buffer->buffer_type() == BufferType::DRAM ? 1 : 0)),
+        cb_indices.act_cb_second_reader,
+        cb_indices.sharded_act_cb,
+        cb_indices.cb_for_reader_indices,
         num_blocks_act_w,  // = number of blocks of weight in height dim
         in1_block_num_tiles,
         conv_act_c_blocks,
@@ -1389,7 +1417,17 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         untilize_out,
 
         bias_ntiles_per_core,
-        out0_cb};
+
+        cb_indices.bias_cb,
+        cb_indices.act_cb,
+        cb_indices.weight_cb,
+        cb_indices.act_cb_row_major_bfloat16,
+        cb_indices.act_cb_second_reader,
+        cb_indices.matmul_partials_cb,
+        cb_indices.tilize_mode_tilized_act_cb,
+
+        cb_indices.out0_cb,
+        cb_indices.temp_sum_cb};
 
     auto writer_mcast_noc = tt::tt_metal::NOC::NOC_0;
     auto reader_noc =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/circular_buffer_types.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include <tt-metalium/work_split.hpp>
@@ -47,19 +48,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     using tt::tt_metal::CircularBuffer;
     using tt::tt_metal::CircularBufferConfig;
 
-    const uint32_t act_cb = CBIndex::c_0;
-    const uint32_t weight_cb = CBIndex::c_1;
-    const uint32_t bias_cb = CBIndex::c_2;
-    const uint32_t sharded_act_cb = CBIndex::c_3;
-    const uint32_t cb_for_reader_indices = CBIndex::c_4;
-    const uint32_t cb_for_l1_array = CBIndex::c_5;
-    const uint32_t act_cb_row_major_bfloat16 = CBIndex::c_6;
-    const uint32_t act_cb_second_reader = CBIndex::c_7;
-    const uint32_t matmul_partials_cb = CBIndex::c_24;
-    const uint32_t tilize_mode_tilized_act_cb = CBIndex::c_25;
-    const uint32_t untilize_mode_reblock_cb = CBIndex::c_26;
-    const uint32_t out0_cb = CBIndex::c_16;
-
+    CBIndices cb_indices = CBIndices();
     bool pass = true;
     enable_split_reader = false;
     tt_metal::IDevice* device = a.device();
@@ -563,11 +552,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     std::string weights_kernel_path =
         "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp";
 
-    std::vector<uint32_t> reader_rt_args;
     std::vector<uint32_t> activation_kernel_compile_args;
     std::vector<uint32_t> weights_kernel_compile_args;
-    std::vector<uint32_t> writer_rt_args;
-    std::vector<uint32_t> writer_compile_time_args;
     std::vector<uint32_t> compute_kernel_args;
     bool tilize_in0 = false;
 
@@ -579,46 +565,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     auto act_mcast_start = device->worker_core_from_logical_core(act_mcast_start_core_logical);
     auto act_mcast_end = device->worker_core_from_logical_core(act_mcast_end_core_logical);
     TT_FATAL(act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
-
-    activation_kernel_compile_args = {
-        (uint32_t)0,  // Never in DRAM
-        (uint32_t)stride_h,
-        (uint32_t)stride_w,
-        (uint32_t)dilation_h,
-        (uint32_t)dilation_w,
-        (uint32_t)input_size_w,
-        (uint32_t)conv_act_c_read_bytes,
-        (uint32_t)filter_h,  // Input filter window height
-        (uint32_t)filter_w,  // Input filter window width
-        (uint32_t)act_block_h_datums,
-        (uint32_t)act_block_num_tiles,
-        (uint32_t)input_num_cores,
-        (uint32_t)num_blocks_act_h_per_core,
-        (uint32_t)per_core_num_blocks_act_w,
-        (uint32_t)act_mcast_sender_semaphore,
-        (uint32_t)act_mcast_receiver_semaphore,
-        (uint32_t)act_mcast_start.x,
-        (uint32_t)act_mcast_start.y,
-        (uint32_t)act_mcast_end.x,
-        (uint32_t)act_mcast_end.y,
-        (uint32_t)act_block_num_tiles * tt_metal::detail::TileSize(tilized_act_df),
-        (uint32_t)output_num_cores};
-    weights_kernel_compile_args = {
-        weight_cb,                                                      // cb_id_weight
-        act_block_w_ntiles / (filter_h * filter_w),                     // core_in_channels_ntiles
-        filter_h * filter_w,                                            // window_size_hw
-        weight_block_w_ntiles,                                          // weight_block_width_ntiles
-        weight_block_num_tiles,                                         // weight_block_num_tiles
-        weight_matrix_width_ntiles,                                     // weight_matrix_width_ntiles
-        (weight_matrix_width_ntiles * input_channels_padded) / 32,      // weight_next_channel_stride_h
-        weight_matrix_width_ntiles * weight_block_in_channels_ntiles,   // weight_next_block_this_core_stride_h
-        weight_matrix_width_ntiles * weight_block_in_channels_ntiles *  // weight_next_block_other_core_stride_h
-            per_core_num_blocks_act_w,
-        input_num_cores,            // other_core_weight_height_blocks
-        per_core_num_blocks_act_w,  // this_core_weight_height_blocks
-        num_blocks_act_h_per_core,
-        bias_cb,
-        bias_in_dram};
 
     std::map<string, string> writer_defines;
     std::map<string, string> writer_mcast_sender_defines;
@@ -652,6 +598,151 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         compute_defines["PACKER_L1_ACC"] = "1";
     }
     uint32_t num_output_tiles = per_core_out_matrix_height_ntiles * p_config.per_core_out_matrix_width_ntile;
+    uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
+    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
+    uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
+
+    // Local L1 to store temp vars
+    // Used for act_mcast_sender_semaphore_valid_addr_ptr
+    cb_indices.cb_for_l1_array = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_for_l1_array_config =
+        CircularBufferConfig(l1_scratchpad_CB_size, {{cb_indices.cb_for_l1_array, tt::DataFormat::Float16_b}})
+            .set_page_size(cb_indices.cb_for_l1_array, l1_scratchpad_CB_size);
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    log_debug(LogOp, "CB for L1 Array CB: {}, npages: {}, pagesize: {}", cb_indices.cb_for_l1_array, 1, 32 * 2);
+
+    cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_sharded_act_config =
+        CircularBufferConfig(
+            shard_shape[0] * shard_shape[1] * datum_size(act_df), {{cb_indices.sharded_act_cb, act_df}})
+            .set_page_size(cb_indices.sharded_act_cb, shard_shape[1] * datum_size(act_df));
+    cb_sharded_act_config.set_globally_allocated_address(*a.buffer());
+
+    tt_metal::CreateCircularBuffer(program, all_cores, cb_sharded_act_config);
+
+    cb_indices.act_cb = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_act_config =
+        CircularBufferConfig(act_block_num_tiles_split * tilized_act_tile_size, {{cb_indices.act_cb, tilized_act_df}})
+            .set_page_size(cb_indices.act_cb, tilized_act_tile_size);
+    auto cb_act = tt_metal::CreateCircularBuffer(program, all_cores, cb_act_config);
+    log_debug(
+        LogOp,
+        "Act CB: {}, npages: {}, pagesize: {}",
+        cb_indices.act_cb,
+        act_block_num_tiles_split,
+        tilized_act_tile_size);
+
+    // Used for placing tilized activations
+    cb_indices.tilize_mode_tilized_act_cb = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_src0_tilized_config =
+        CircularBufferConfig(
+            act_block_num_tiles * tilized_act_tile_size, {{cb_indices.tilize_mode_tilized_act_cb, tilized_act_df}})
+            .set_page_size(cb_indices.tilize_mode_tilized_act_cb, tilized_act_tile_size);
+    auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_tilized_config);
+    log_debug(
+        LogOp,
+        "Tilized Act CB: {}, npages: {}, pagesize: {}",
+        cb_indices.tilize_mode_tilized_act_cb,
+        act_block_num_tiles,
+        tilized_act_tile_size);
+
+    cb_indices.weight_cb = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_weight_config =
+        CircularBufferConfig(weight_block_num_tiles * weight_tile_size, {{cb_indices.weight_cb, weight_df}})
+            .set_page_size(cb_indices.weight_cb, weight_tile_size);
+    auto cb_weight = tt_metal::CreateCircularBuffer(program, all_cores, cb_weight_config);
+    log_debug(
+        LogOp,
+        "Weight CB: {}, npages: {}, pagesize: {}, ",
+        cb_indices.weight_cb,
+        weight_block_num_tiles,
+        weight_tile_size);
+
+    cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_act_row_major_bfloat16_config =
+        CircularBufferConfig(
+            act_block_num_tiles_split * act_tile_size, {{cb_indices.act_cb_row_major_bfloat16, act_df}})
+            .set_page_size(cb_indices.act_cb_row_major_bfloat16, act_tile_size);
+    auto cb_act_row_major_bfloat16 =
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_act_row_major_bfloat16_config);
+    log_debug(
+        LogOp,
+        "Act Row Major CB: {}, npages: {}, pagesize: {}",
+        cb_indices.act_cb_row_major_bfloat16,
+        act_block_num_tiles_split,
+        act_tile_size);
+
+    auto conv_reader_indices_buffer = conv_reader_indices.value().device_buffer();
+
+    cb_indices.cb_for_reader_indices = cb_indices.get_next_cb_index();
+    CircularBufferConfig cb_for_reader_indices_config =
+        CircularBufferConfig(out_block_h_datums * 2, {{cb_indices.cb_for_reader_indices, tt::DataFormat::Float16_b}})
+            .set_page_size(cb_indices.cb_for_reader_indices, out_block_h_datums * 2);
+    cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer);
+    auto cb_for_reader_indices_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
+
+    if (has_bias) {
+        uint32_t bias_tile_size = tt_metal::detail::TileSize(bias_df);
+        // bias input
+        uint32_t bias_pagesize = bias_tile_size;
+        cb_indices.bias_cb = cb_indices.get_next_cb_index();
+        CircularBufferConfig cb_bias_config =
+            CircularBufferConfig(bias_ntiles * bias_pagesize, {{cb_indices.bias_cb, bias_df}})
+                .set_page_size(cb_indices.bias_cb, bias_pagesize);
+        auto cb_bias = tt_metal::CreateCircularBuffer(program, all_cores, cb_bias_config);
+
+        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", cb_indices.bias_cb, bias_ntiles, bias_pagesize);
+    }
+
+    uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
+    uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
+
+    cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
+    // Share buffer if same data format
+    CBHandle cb_output = 0;
+    if (interm0_df == out_df) {
+        cb_indices.out0_cb = cb_indices.get_next_cb_index();
+        // CoreRangeSet cores(std::set<CoreRange>({core}));
+        std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {
+            {cb_indices.out0_cb, out_df}, {cb_indices.matmul_partials_cb, out_df}};
+        CircularBufferConfig cb_matmul_partials_config =
+            CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
+                .set_page_size(cb_indices.out0_cb, out_tile_size)
+                .set_page_size(cb_indices.matmul_partials_cb, out_tile_size);
+        if (output.is_sharded()) {
+            cb_matmul_partials_config = cb_matmul_partials_config.set_globally_allocated_address(*output.buffer());
+        } else {
+            log_debug(
+                LogOp,
+                "Matmul Partials CB: {}, npages: {}, pagesize: {}",
+                cb_indices.matmul_partials_cb,
+                num_output_tiles,
+                out_tile_size);
+        }
+        cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_matmul_partials_config);
+    } else {
+        // Separate buffer if not same data format
+        CircularBufferConfig cb_matmul_partials_config =
+            CircularBufferConfig(
+                num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
+                .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
+        auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, all_cores, cb_matmul_partials_config);
+        log_debug(
+            LogOp,
+            "Matmul Partials CB: {}, npages: {}, pagesize: {}",
+            cb_indices.matmul_partials_cb,
+            num_output_tiles,
+            interm0_single_tile_size);
+        cb_indices.out0_cb = cb_indices.get_next_cb_index();
+        CircularBufferConfig cb_output_config =
+            CircularBufferConfig(num_output_tiles * out_tile_size, {{cb_indices.out0_cb, out_df}})
+                .set_page_size(cb_indices.out0_cb, out_tile_size);
+        if (output.is_sharded()) {
+            cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
+        }
+        cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    }
+
     compute_kernel_args = {
         act_block_w_ntiles,      // in0_block_w
         act_num_subblocks,       // in0_num_sublocks
@@ -675,132 +766,67 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         untilize_out,  // untilize_out
 
         bias_ntiles,
+        cb_indices.bias_cb,
 
-        out0_cb,
-
+        cb_indices.act_cb,
+        cb_indices.weight_cb,
+        cb_indices.act_cb_row_major_bfloat16,
+        cb_indices.act_cb_second_reader,
+        cb_indices.matmul_partials_cb,
+        cb_indices.tilize_mode_tilized_act_cb,
+        cb_indices.out0_cb,
+        0,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
+
     };
 
-    uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
-    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
-    uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
+    activation_kernel_compile_args = {
+        (uint32_t)0,  // Never in DRAM
+        (uint32_t)stride_h,
+        (uint32_t)stride_w,
+        (uint32_t)dilation_h,
+        (uint32_t)dilation_w,
+        (uint32_t)input_size_w,
+        (uint32_t)conv_act_c_read_bytes,
+        (uint32_t)filter_h,  // Input filter window height
+        (uint32_t)filter_w,  // Input filter window width
+        (uint32_t)act_block_h_datums,
+        (uint32_t)act_block_num_tiles,
+        (uint32_t)input_num_cores,
+        (uint32_t)num_blocks_act_h_per_core,
+        (uint32_t)per_core_num_blocks_act_w,
+        (uint32_t)act_mcast_sender_semaphore,
+        (uint32_t)act_mcast_receiver_semaphore,
+        (uint32_t)act_mcast_start.x,
+        (uint32_t)act_mcast_start.y,
+        (uint32_t)act_mcast_end.x,
+        (uint32_t)act_mcast_end.y,
+        (uint32_t)act_block_num_tiles * tt_metal::detail::TileSize(tilized_act_df),
+        (uint32_t)output_num_cores,
+        (uint32_t)cb_indices.act_cb,
+        (uint32_t)cb_indices.weight_cb,
+        (uint32_t)cb_indices.sharded_act_cb,
+        (uint32_t)cb_indices.cb_for_reader_indices,
+        (uint32_t)cb_indices.cb_for_l1_array,
+        (uint32_t)cb_indices.act_cb_row_major_bfloat16,
+        (uint32_t)cb_indices.tilize_mode_tilized_act_cb};
 
-    // Local L1 to store temp vars
-    // Used for act_mcast_sender_semaphore_valid_addr_ptr
-    CircularBufferConfig cb_for_l1_array_config =
-        CircularBufferConfig(l1_scratchpad_CB_size, {{cb_for_l1_array, tt::DataFormat::Float16_b}})
-            .set_page_size(cb_for_l1_array, l1_scratchpad_CB_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
-    log_debug(LogOp, "CB for L1 Array CB: {}, npages: {}, pagesize: {}", cb_for_l1_array, 1, 32 * 2);
-
-    CircularBufferConfig cb_sharded_act_config =
-        CircularBufferConfig(shard_shape[0] * shard_shape[1] * datum_size(act_df), {{sharded_act_cb, act_df}})
-            .set_page_size(sharded_act_cb, shard_shape[1] * datum_size(act_df));
-    cb_sharded_act_config.set_globally_allocated_address(*a.buffer());
-
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_sharded_act_config);
-
-    CircularBufferConfig cb_act_config =
-        CircularBufferConfig(act_block_num_tiles_split * tilized_act_tile_size, {{act_cb, tilized_act_df}})
-            .set_page_size(act_cb, tilized_act_tile_size);
-    auto cb_act = tt_metal::CreateCircularBuffer(program, all_cores, cb_act_config);
-    log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", act_cb, act_block_num_tiles_split, tilized_act_tile_size);
-
-    // Used for placing tilized activations
-    CircularBufferConfig cb_src0_tilized_config =
-        CircularBufferConfig(
-            act_block_num_tiles * tilized_act_tile_size, {{tilize_mode_tilized_act_cb, tilized_act_df}})
-            .set_page_size(tilize_mode_tilized_act_cb, tilized_act_tile_size);
-    auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_tilized_config);
-    log_debug(
-        LogOp,
-        "Tilized Act CB: {}, npages: {}, pagesize: {}",
-        tilize_mode_tilized_act_cb,
-        act_block_num_tiles,
-        tilized_act_tile_size);
-
-    CircularBufferConfig cb_weight_config =
-        CircularBufferConfig(weight_block_num_tiles * weight_tile_size, {{weight_cb, weight_df}})
-            .set_page_size(weight_cb, weight_tile_size);
-    auto cb_weight = tt_metal::CreateCircularBuffer(program, all_cores, cb_weight_config);
-    log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}, ", weight_cb, weight_block_num_tiles, weight_tile_size);
-
-    CircularBufferConfig cb_act_row_major_bfloat16_config =
-        CircularBufferConfig(act_block_num_tiles_split * act_tile_size, {{act_cb_row_major_bfloat16, act_df}})
-            .set_page_size(act_cb_row_major_bfloat16, act_tile_size);
-    auto cb_act_row_major_bfloat16 =
-        tt_metal::CreateCircularBuffer(program, all_cores, cb_act_row_major_bfloat16_config);
-    log_debug(
-        LogOp,
-        "Act Row Major CB: {}, npages: {}, pagesize: {}",
-        act_cb_row_major_bfloat16,
-        act_block_num_tiles_split,
-        act_tile_size);
-
-    auto conv_reader_indices_buffer = conv_reader_indices.value().device_buffer();
-
-    CircularBufferConfig cb_for_reader_indices_config =
-        CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
-            .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
-    cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer);
-    auto cb_for_reader_indices_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
-
-    if (has_bias) {
-        uint32_t bias_tile_size = tt_metal::detail::TileSize(bias_df);
-        // bias input
-        uint32_t bias_pagesize = bias_tile_size;
-        CircularBufferConfig cb_bias_config = CircularBufferConfig(bias_ntiles * bias_pagesize, {{bias_cb, bias_df}})
-                                                  .set_page_size(bias_cb, bias_pagesize);
-        auto cb_bias = tt_metal::CreateCircularBuffer(program, all_cores, cb_bias_config);
-
-        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", bias_cb, bias_ntiles, bias_pagesize);
-    }
-
-    uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
-    uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
-
-    // Share buffer if same data format
-    CBHandle cb_output = 0;
-    if (interm0_df == out_df) {
-        // CoreRangeSet cores(std::set<CoreRange>({core}));
-        std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {
-            {out0_cb, out_df}, {matmul_partials_cb, out_df}};
-        CircularBufferConfig cb_matmul_partials_config =
-            CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
-                .set_page_size(out0_cb, out_tile_size)
-                .set_page_size(matmul_partials_cb, out_tile_size);
-        if (output.is_sharded()) {
-            cb_matmul_partials_config = cb_matmul_partials_config.set_globally_allocated_address(*output.buffer());
-        } else {
-            log_debug(
-                LogOp,
-                "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-                matmul_partials_cb,
-                num_output_tiles,
-                out_tile_size);
-        }
-        cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_matmul_partials_config);
-    } else {
-        // Separate buffer if not same data format
-        CircularBufferConfig cb_matmul_partials_config =
-            CircularBufferConfig(num_output_tiles * interm0_single_tile_size, {{matmul_partials_cb, interm0_df}})
-                .set_page_size(matmul_partials_cb, interm0_single_tile_size);
-        auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, all_cores, cb_matmul_partials_config);
-        log_debug(
-            LogOp,
-            "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-            matmul_partials_cb,
-            num_output_tiles,
-            interm0_single_tile_size);
-
-        CircularBufferConfig cb_output_config =
-            CircularBufferConfig(num_output_tiles * out_tile_size, {{out0_cb, out_df}})
-                .set_page_size(out0_cb, out_tile_size);
-        if (output.is_sharded()) {
-            cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-        }
-        cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-    }
+    weights_kernel_compile_args = {
+        cb_indices.weight_cb,                                           // cb_id_weight
+        act_block_w_ntiles / (filter_h * filter_w),                     // core_in_channels_ntiles
+        filter_h * filter_w,                                            // window_size_hw
+        weight_block_w_ntiles,                                          // weight_block_width_ntiles
+        weight_block_num_tiles,                                         // weight_block_num_tiles
+        weight_matrix_width_ntiles,                                     // weight_matrix_width_ntiles
+        (weight_matrix_width_ntiles * input_channels_padded) / 32,      // weight_next_channel_stride_h
+        weight_matrix_width_ntiles * weight_block_in_channels_ntiles,   // weight_next_block_this_core_stride_h
+        weight_matrix_width_ntiles * weight_block_in_channels_ntiles *  // weight_next_block_other_core_stride_h
+            per_core_num_blocks_act_w,
+        input_num_cores,            // other_core_weight_height_blocks
+        per_core_num_blocks_act_w,  // this_core_weight_height_blocks
+        num_blocks_act_h_per_core,
+        cb_indices.bias_cb,
+        bias_in_dram};
 
     auto act_kernel_id = CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -65,6 +65,13 @@ void kernel_main() {
     constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(19);
     constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(20);
     constexpr uint32_t num_output_cores = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
+    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(26);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(27);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(28);
 
     constexpr uint32_t num_mcast_cores = MAX(num_input_cores, num_output_cores);
     uint32_t i = 0;  // Runtime arg index
@@ -88,19 +95,10 @@ void kernel_main() {
     // Equivalent to Core Index.
     uint32_t this_core_id = this_core_x + (num_cores_x * this_core_y);
 
-    constexpr uint32_t cb_id_act = tt::CBIndex::c_0;
-    constexpr uint32_t cb_id_weight = tt::CBIndex::c_1;
-
-    constexpr uint32_t tilized_in0_cb_id = tt::CBIndex::c_25;
-    constexpr uint32_t cb_id_sharded_act = tt::CBIndex::c_3;
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = tt::CBIndex::c_6;
-
-    constexpr uint32_t cb_reader_indices = tt::CBIndex::c_4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
     // L1 array
-    constexpr uint32_t cb_l1_array = tt::CBIndex::c_5;
     volatile tt_l1_ptr uint32_t* act_mcast_sender_semaphore_valid_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_l1_array));
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -122,15 +122,14 @@ void MAIN {
     constexpr uint32_t out_block_w = in1_block_w;
 
     // CB indices
-    constexpr uint32_t in0_cb_id = tt::CBIndex::c_0;
-    constexpr uint32_t in1_cb_id = tt::CBIndex::c_1;
-    constexpr uint32_t in0_pretilize_cb_id = tt::CBIndex::c_6;
-    constexpr uint32_t in0_cb_second_reader_id = tt::CBIndex::c_7;
-    constexpr uint32_t eltwise_mul_partials_cb = tt::CBIndex::c_24;
-    constexpr uint32_t tilized_in0_cb_id = tt::CBIndex::c_25;
-    constexpr uint32_t temp_sum_cb = tt::CBIndex::c_27;
-    constexpr uint32_t prev_eltwise_cb = tt::CBIndex::c_29;
-    constexpr uint32_t out_cb_id = tt::CBIndex::c_16;
+    constexpr uint32_t in0_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in1_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t in0_pretilize_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t in0_cb_second_reader_id = get_compile_time_arg_val(21);
+    constexpr uint32_t eltwise_mul_partials_cb = get_compile_time_arg_val(22);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
+    constexpr uint32_t temp_sum_cb = get_compile_time_arg_val(25);
 
     constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -93,29 +93,27 @@ void MAIN {
     constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(13);  // out_subblock_h * out_subblock_w;
     constexpr bool tilize_in0 = get_compile_time_arg_val(14);
     constexpr bool untilize_out = get_compile_time_arg_val(15);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t in0_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in1_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t in0_pretilize_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t in0_cb_second_reader_id = get_compile_time_arg_val(21);
+    constexpr uint32_t matmul_partials_cb = get_compile_time_arg_val(22);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
 
 #ifdef WIDTH_SHARDED
-    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(18);
+    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(26);
 #endif
 
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     constexpr uint32_t out_block_w = in1_block_w;
     constexpr bool spill = in0_num_blocks_w > 1;
 
-    // CB indices
-    constexpr uint32_t in0_cb_id = tt::CBIndex::c_0;
-    constexpr uint32_t in1_cb_id = tt::CBIndex::c_1;
-    constexpr uint32_t in0_pretilize_cb_id = tt::CBIndex::c_6;
-    constexpr uint32_t in0_cb_second_reader_id = tt::CBIndex::c_7;
-    constexpr uint32_t matmul_partials_cb = tt::CBIndex::c_24;
-    constexpr uint32_t tilized_in0_cb_id = tt::CBIndex::c_25;
-
     constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? matmul_partials_cb : out_cb_id;
 
 #ifdef FUSE_BIAS
     constexpr uint32_t bias_ntiles_w = get_compile_time_arg_val(16);
-    constexpr uint32_t bias_cb_id = tt::CBIndex::c_2;
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(17);
     uint32_t bias_block_offset = 0;
     constexpr uint32_t mm_out_cb_id = matmul_partials_cb;
 #else

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -81,6 +81,12 @@ void kernel_main() {
     const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(22));
     constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(23);
     constexpr bool transpose_mcast = get_compile_time_arg_val(24) == 1;
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(27);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(28);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(29);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(30);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(31);
+    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(32);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);
@@ -105,17 +111,10 @@ void kernel_main() {
 
     tt_l1_ptr uint32_t* act_mcast_sender_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(i));
 
-    constexpr uint32_t cb_id_act = tt::CBIndex::c_0;
-    constexpr uint32_t tilized_in0_cb_id = tt::CBIndex::c_25;
-    constexpr uint32_t cb_id_sharded_act = tt::CBIndex::c_3;
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = tt::CBIndex::c_6;
-
-    constexpr uint32_t cb_reader_indices = tt::CBIndex::c_4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
     // L1 array
-    constexpr uint32_t cb_l1_array = tt::CBIndex::c_5;
     volatile tt_l1_ptr uint32_t* l1_array = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_l1_array));
     // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
     volatile tt_l1_ptr uint32_t* act_mcast_sender_semaphore_valid_addr_ptr = &l1_array[0];

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -34,6 +34,10 @@ void kernel_main() {
     constexpr uint32_t act_block_h_datums_second_reader = get_compile_time_arg_val(26);
     constexpr uint32_t act_block_h_datums_second_reader_read = act_block_h_datums_second_reader / 2;
 
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(27);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(28);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(29);
+
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);
     i += 1;
@@ -41,9 +45,6 @@ void kernel_main() {
     if (noop) {
         return;
     }
-
-    constexpr uint32_t cb_id_act = 0;
-    constexpr uint32_t cb_id_sharded_act = 3;
 
     // LOOP TO FILL READER OFFSETS
     /* We can add another loop to read chunks of a stick as well.
@@ -69,7 +70,6 @@ void kernel_main() {
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 
     // LOOP TO FILL READER INDICES
-    constexpr uint32_t cb_reader_indices = tt::CBIndex::c_4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -31,6 +31,10 @@ void kernel_main() {
     constexpr uint32_t weight_size_h = get_compile_time_arg_val(15);
     constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(16);
 
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(27);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(28);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(29);
+
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);
     i += 1;
@@ -38,9 +42,6 @@ void kernel_main() {
     if (noop) {
         return;
     }
-
-    constexpr uint32_t cb_id_act = 0;
-    constexpr uint32_t cb_id_sharded_act = 3;
 
     // LOOP TO FILL READER OFFSETS
     /* We can add another loop to read chunks of a stick as well.
@@ -70,7 +71,6 @@ void kernel_main() {
 #endif
 
     // LOOP TO FILL READER INDICES
-    constexpr uint32_t cb_reader_indices = tt::CBIndex::c_4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -12,48 +12,50 @@ void kernel_main() {
     constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
-
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(32);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
+    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(35);
 
     // MCAST args
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(33);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(34);
-    constexpr uint32_t conv_act_size_c_bytes = get_compile_time_arg_val(35);
-    constexpr uint32_t coalesced_read_bytes = get_compile_time_arg_val(36);
-    constexpr uint32_t window_outer_offset = get_compile_time_arg_val(37);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(38);
-    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(39);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(40);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(36);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(37);
+    constexpr uint32_t conv_act_size_c_bytes = get_compile_time_arg_val(38);
+    constexpr uint32_t coalesced_read_bytes = get_compile_time_arg_val(39);
+    constexpr uint32_t window_outer_offset = get_compile_time_arg_val(40);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(41);
+    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(42);
+    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(43);
 
     constexpr uint32_t act_block_h_datums_read_last_block =
         act_block_h_datums_last_block > act_block_h_datums
@@ -98,12 +100,9 @@ void kernel_main() {
     constexpr uint32_t tile_nbytes = get_tile_size(cb_id_out0);
     constexpr DataFormat out_df = get_dataformat(cb_id_out0);
 
-    constexpr uint32_t cb_id_act_second_reader = 7;
-    constexpr uint32_t cb_id_sharded_act = 3;
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;  // Extra /2 because of packed uint16 reads
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 
-    constexpr uint32_t cb_reader_indices = tt::CBIndex::c_4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
     uint32_t reader_idx = 0;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -11,48 +11,50 @@ void kernel_main() {
     constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
-
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_id_act_second_reader = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(32);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
+    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(35);
 
     // MCAST args
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(33);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(34);
-    constexpr uint32_t conv_act_size_c_bytes = get_compile_time_arg_val(35);
-    constexpr uint32_t coalesced_read_bytes = get_compile_time_arg_val(36);
-    constexpr uint32_t window_outer_offset = get_compile_time_arg_val(37);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(38);
-    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(39);
-    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(40);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(36);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(37);
+    constexpr uint32_t conv_act_size_c_bytes = get_compile_time_arg_val(38);
+    constexpr uint32_t coalesced_read_bytes = get_compile_time_arg_val(39);
+    constexpr uint32_t window_outer_offset = get_compile_time_arg_val(40);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(41);
+    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(42);
+    constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(43);
 
     constexpr uint32_t act_block_h_datums_read_last_block =
         act_block_h_datums_last_block > act_block_h_datums
@@ -104,14 +106,11 @@ void kernel_main() {
     uint32_t weights_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(i));
     i += 1;
 
-    constexpr uint32_t cb_id_act_second_reader = 7;
-    constexpr uint32_t cb_id_sharded_act = 3;
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;  // Extra /2 because of packed uint16 reads
     constexpr uint32_t act_block_h_datums_first_reader_read =
         act_block_h_datums_first_reader / 2;  // Extra /2 because of packed uint16 reads
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 
-    constexpr uint32_t cb_reader_indices = tt::CBIndex::c_4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
     uint32_t reader_idx = 0;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_mcast_receiver_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_mcast_receiver_depthwise_conv1d.cpp
@@ -12,36 +12,36 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
 
     constexpr uint32_t total_weight_num_tiles =
         weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_mcast_sender_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_mcast_sender_depthwise_conv1d.cpp
@@ -12,36 +12,36 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
 
     constexpr uint32_t total_weight_num_tiles =
         weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -12,37 +12,37 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(32);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
+    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(35);
 
     constexpr uint32_t total_weight_num_tiles =
         weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -12,37 +12,37 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
-    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(32);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
+    constexpr uint32_t output_rows_tiles = get_compile_time_arg_val(35);
     constexpr uint32_t total_weight_num_tiles =
         weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -17,36 +17,36 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
 
     uint32_t i = 0;
     i += 19;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -18,36 +18,36 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
 
-    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
-    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
-    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(13);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(15);
 
     // Bias arg. Unused if bias fusion is not enabled.
-    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(16);
 
-    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
-    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
-    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
-    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
-    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12);  // == weight_next_block_stride_w
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
-    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
-    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
-    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
-    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(21);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(15);  // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(25);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(26);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(28);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(29);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(30);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(31);
 
-    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
+    constexpr uint32_t out_addr = get_compile_time_arg_val(32);
 
     uint32_t i = 0;
     i += 1;


### PR DESCRIPTION
### Ticket
[#18281](https://github.com/tenstorrent/tt-metal/issues/18281)

### Problem description
Redo of the following [PR](https://github.com/tenstorrent/tt-metal/pull/18476). 
Circular buffers created in Conv2d program factories are not sequential, this is causing numerous warnings which are creating noise.

### What's changed
This is a second iteration of the already approved pr. Things added are couple of using namespaces and includes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13720274728)
