### PR TITLE
#0: [skip ci] Raise L2 timeout to 2h

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 120
   workflow_dispatch:
     inputs:
       arch:
@@ -31,7 +31,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 120
   schedule:
     - cron: "0 22 * * *"
 
@@ -63,7 +63,7 @@ jobs:
         with:
           name: eager-dist-${{ matrix.os }}-any
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ fromJSON(inputs.timeout) || '45' }}
+        timeout-minutes: ${{ fromJSON(inputs.timeout) || '120' }}
         uses: ./.github/actions/docker-run
         with:
           docker_username: ${{ github.actor }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
More tests were added to metal L2 nightly, raise L2 timeout to 2h.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
