### PR TITLE
Added narrow row support on BH

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -154,6 +154,7 @@ inline void llk_pack_reduce_hw_configure_disaggregated(std::uint32_t pack_output
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
 inline void llk_pack_init(const std::uint32_t pack_output = 16) {
+    // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
@@ -166,13 +167,8 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
 
     set_packer_strides<untilize, tilize>(pack_src_format[output_id], pack_dst_format[output_id], tile_c_dim);
 
-    // TODO: RT is this needed?
-    //  // To untilize narrow tile (32x16) we just pack 2 faces back to back
-    //  // Number of datums to pack per row
-    //  const uint face_dim = face_r_dim * FACE_C_DIM;
-    //  const uint pack_x_dim = (narrow_tile || !untilize) ? face_dim : FACE_R_DIM;
-
-    // TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
+    // Program packer to pack out 16 datums per row
+    TT_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
 }
 
 template <bool out_of_order_output, bool untilize>
@@ -218,14 +214,18 @@ inline void llk_pack_untilize_init(
     static_assert(diagonal == false && "Diagonal packing is not supported for BH!");
     const std::uint32_t output_id = get_output_id(output);
 
-    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal>(
+    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces);
 
+    if constexpr (narrow_row) {
+        TT_SETADCXX(p_setadc::PAC, row_num_datums - 1, 0x0);
+    } else {
+        TT_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
+    }
     // Pack row by row
     // if constexpr (diagonal) {
     //     TT_SETADCXX(p_setadc::PAC, 1-1, 0x0);
     // } else {
-    TT_SETADCXX(p_setadc::PAC, FACE_R_DIM - 1, 0x0);
     // }
 }
 
@@ -261,7 +261,7 @@ inline void llk_pack_untilize(
             16;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
-        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal>(
+        _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
             pack_tile_addr, pack_dst_format[output_id], face_r_dim, num_faces, block_rt * block_ct_dim);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;


### PR DESCRIPTION
### Ticket
#18528

### Problem description
The Blackhole did not have the narrow row feature implementation, causing ResNet-50 fold test to fail. 

### What's changed
The additions include the pack_untilize API change, enabling the narrow_row parameter that was unused up to this point to be passed to the LLK.
The LLK additions modify the untilize algorithm for the packer, in order to disable the reads from Face 1 and Face 3 and only allow the reads from F0 and F2 when the narrow_row is set to true. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [Link to GitHub Workflow](https://github.com/tenstorrent/tt-metal/actions/runs/13768880660)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) [Link to GitHub Workflow](https://github.com/tenstorrent/tt-metal/actions/runs/13815121725)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
