### PR TITLE
#0: Saved timestamped data in dispatcher

### DIFF
--- a/tt_metal/api/tt-metalium/cq_commands.hpp
+++ b/tt_metal/api/tt-metalium/cq_commands.hpp
@@ -252,7 +252,7 @@ struct CQDispatchDelayCmd {
 
 struct CQDispatchSetWriteOffsetCmd {
     uint8_t pad1;
-    uint16_t pad2;
+    uint16_t program_host_id;  // Program Host ID for upcoming commands. Used for profiling.
     uint32_t offset0;
     uint32_t offset1;
     uint32_t offset2;

--- a/tt_metal/api/tt-metalium/device_command.hpp
+++ b/tt_metal/api/tt-metalium/device_command.hpp
@@ -485,6 +485,7 @@ public:
         auto initialize_write_offset_cmd = [&](CQDispatchCmd* write_offset_cmd) {
             *write_offset_cmd = {};
             write_offset_cmd->base.cmd_id = CQ_DISPATCH_CMD_SET_WRITE_OFFSET;
+            write_offset_cmd->set_write_offset.program_host_id = 0;
             write_offset_cmd->set_write_offset.offset0 = write_offset0;
             write_offset_cmd->set_write_offset.offset1 = write_offset1;
             write_offset_cmd->set_write_offset.offset2 = write_offset2;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1535,6 +1535,8 @@ void update_program_dispatch_commands(
         (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset1));
     static constexpr uint32_t eth_l1_write_offset_offset =
         (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset2));
+    static constexpr uint32_t program_host_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
     // Update Stall Command Sequence
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Program binary is in flight. Issue a Prefetch Stall
@@ -1554,6 +1556,10 @@ void update_program_dispatch_commands(
         tensix_l1_write_offset_offset,
         &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
         sizeof(uint32_t));
+    // May truncate to fit the space.
+    decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id) runtime_id = program.get_runtime_id();
+    cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
+        program_host_id_offset, &runtime_id, sizeof(runtime_id));
     if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
             eth_l1_write_offset_offset,


### PR DESCRIPTION
### Problem description
Currently, it's difficult to attribute dispatch thread time to particular programs of data those programs are sending.

### What's changed
Store the type of the current command and the runtime ID of the program that's currently being dispatched as timestamped data, to make it easier to analyze the time cq_dispatch.cpp is taking.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
