### PR TITLE
#18799: Vendor in tagging workflow and finally get rid of dependence on tenstorrent-metal/tt-metal so we can work on it within the repo. No more switching back and forth

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -163,7 +163,7 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
     steps:
-      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - uses: ./.github/actions/retry-command
         with:
           timeout-seconds: 100

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -83,7 +83,7 @@ jobs:
   create-tag:
     needs: get-params
     if: ${{ fromJSON(needs.get-params.outputs.should-create-release) }}
-    uses: tenstorrent-metal/metal-workflows/.github/workflows/release-verify-or-create-tag.yaml@v2.0.1
+    uses: ./.github/workflows/release-verify-or-create-tag.yaml
     with:
       fetch_depth: 0
       bump_each_commit: false

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -140,7 +140,7 @@ jobs:
           path: RELEASE_NOTES.txt
   # Candidate for breaking up
   create-and-upload-draft-release:
-    needs: [create-tag, create-release-notes, build-artifact, test-wheels, single-card-demos]
+    needs: [create-tag, create-release-notes, build-artifact, test-wheels]
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -31,6 +31,32 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
+  test-wheels:
+    needs: build-artifact
+    uses: ./.github/workflows/_test-wheels-impl.yaml
+    with:
+      from-precompiled: true
+    secrets: inherit
+  single-card-demos:
+    needs: build-artifact
+    uses: ./.github/workflows/single-card-demo-tests-impl.yaml
+    secrets: inherit
+  t3000-demos:
+    needs: build-artifact
+    uses: ./.github/workflows/t3000-demo-tests-impl.yaml
+    secrets: inherit
+  t3000-model-perf:
+    needs: build-artifact
+    uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
+    secrets: inherit
+  tg-demos:
+    needs: build-artifact
+    uses: ./.github/workflows/tg-demo-tests-impl.yaml
+    secrets: inherit
+  tgg-model-perf:
+    needs: build-artifact
+    uses: ./.github/workflows/tgg-model-perf-tests-impl.yaml
+    secrets: inherit
   get-params:
     runs-on: ubuntu-latest
     outputs:
@@ -114,7 +140,7 @@ jobs:
           path: RELEASE_NOTES.txt
   # Candidate for breaking up
   create-and-upload-draft-release:
-    needs: [create-tag, create-release-notes]
+    needs: [create-tag, create-release-notes, build-artifact, test-wheels]
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
@@ -127,6 +153,14 @@ jobs:
         uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a
         with:
           output-files: tt-metalium.tar.gz
+      - name: Download eager 20.04 Python packages
+        uses: actions/download-artifact@v4
+        with:
+          name: eager-dist-ubuntu-20.04-any
+      - name: Download eager 22.04 Python packages
+        uses: actions/download-artifact@v4
+        with:
+          name: eager-dist-ubuntu-22.04-any
       - name: Create VERSION
         run: echo ${{ needs.create-tag.outputs.version }} > VERSION
       - name : Download release notes
@@ -137,6 +171,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog
+      - name: Assert wheels exist
+        run: ls -arhl ttnn-*+*.whl
       - name: Release
         # A major release has not been tagged yet, so we need to do this to avoid
         # Node 16 deprecation warning message
@@ -153,6 +189,7 @@ jobs:
             README.md
             INSTALLING.md
             models/MODEL_UPDATES.md
+            ttnn-*+*.whl
             tt-metalium.tar.gz
           fail_on_unmatched_files: true
   create-docker-release-image:
@@ -167,3 +204,18 @@ jobs:
       base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
+  release-docs:
+    needs: [
+      build-artifact,
+      get-params,
+      create-tag,
+      create-and-upload-draft-release
+    ]
+    if: ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
+    uses: ./.github/workflows/docs-latest-public.yaml
+    with:
+      version: ${{ needs.create-tag.outputs.version }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+    secrets: inherit

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -31,32 +31,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
-  test-wheels:
-    needs: build-artifact
-    uses: ./.github/workflows/_test-wheels-impl.yaml
-    with:
-      from-precompiled: true
-    secrets: inherit
-  single-card-demos:
-    needs: build-artifact
-    uses: ./.github/workflows/single-card-demo-tests-impl.yaml
-    secrets: inherit
-  t3000-demos:
-    needs: build-artifact
-    uses: ./.github/workflows/t3000-demo-tests-impl.yaml
-    secrets: inherit
-  t3000-model-perf:
-    needs: build-artifact
-    uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
-    secrets: inherit
-  tg-demos:
-    needs: build-artifact
-    uses: ./.github/workflows/tg-demo-tests-impl.yaml
-    secrets: inherit
-  tgg-model-perf:
-    needs: build-artifact
-    uses: ./.github/workflows/tgg-model-perf-tests-impl.yaml
-    secrets: inherit
   get-params:
     runs-on: ubuntu-latest
     outputs:
@@ -140,7 +114,7 @@ jobs:
           path: RELEASE_NOTES.txt
   # Candidate for breaking up
   create-and-upload-draft-release:
-    needs: [create-tag, create-release-notes, build-artifact, test-wheels]
+    needs: [create-tag, create-release-notes]
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
@@ -153,14 +127,6 @@ jobs:
         uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a
         with:
           output-files: tt-metalium.tar.gz
-      - name: Download eager 20.04 Python packages
-        uses: actions/download-artifact@v4
-        with:
-          name: eager-dist-ubuntu-20.04-any
-      - name: Download eager 22.04 Python packages
-        uses: actions/download-artifact@v4
-        with:
-          name: eager-dist-ubuntu-22.04-any
       - name: Create VERSION
         run: echo ${{ needs.create-tag.outputs.version }} > VERSION
       - name : Download release notes
@@ -171,8 +137,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog
-      - name: Assert wheels exist
-        run: ls -arhl ttnn-*+*.whl
       - name: Release
         # A major release has not been tagged yet, so we need to do this to avoid
         # Node 16 deprecation warning message
@@ -189,7 +153,6 @@ jobs:
             README.md
             INSTALLING.md
             models/MODEL_UPDATES.md
-            ttnn-*+*.whl
             tt-metalium.tar.gz
           fail_on_unmatched_files: true
   create-docker-release-image:
@@ -204,18 +167,3 @@ jobs:
       base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
-  release-docs:
-    needs: [
-      build-artifact,
-      get-params,
-      create-tag,
-      create-and-upload-draft-release
-    ]
-    if: ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
-    uses: ./.github/workflows/docs-latest-public.yaml
-    with:
-      version: ${{ needs.create-tag.outputs.version }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-    secrets: inherit

--- a/.github/workflows/release-verify-or-create-tag.yaml
+++ b/.github/workflows/release-verify-or-create-tag.yaml
@@ -1,0 +1,105 @@
+name: Verify/create new release tag
+
+on:
+  workflow_call:
+    inputs:
+      fetch_depth:
+        description: "Commit depth to checkout to scan for previous release tags"
+        default: 0
+        type: number
+      bump_each_commit:
+        description: "Bump each commit as a patch version"
+        default: true
+        type: boolean
+      release_candidate_suffix:
+        description: "Attach -rc# suffix to version number"
+        default: false
+        type: boolean
+    outputs:
+      version:
+        description: "New version"
+        value: ${{ jobs.verify-create-new-tag.outputs.version }}
+
+jobs:
+  verify-create-new-tag:
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version-number.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch_depth }}
+      - uses: paulhatch/semantic-version@v5.4.0
+        id: get-next-semantic-base-version
+        with:
+          tag_prefix: "v"
+          version_format: "v${major}.${minor}.${patch}"
+          bump_each_commit: ${{ inputs.bump_each_commit }}
+      - name: Get release candidate version
+        id: get-release-candidate-version
+        run: |
+          baseVersion=${{ steps.get-next-semantic-base-version.outputs.version }}
+          currentNumberRCs=$(git tag | grep "$baseVersion"-rc | wc -l)
+          newNumber=$(($currentNumberRCs+1))
+          releaseCandidateVersion=$baseVersion-rc$newNumber
+          echo $releaseCandidateVersion
+          echo "release-candidate-version=$releaseCandidateVersion" >> "$GITHUB_OUTPUT"
+      - name: Get full version number
+        id: get-version-number
+        run: |
+          versionNumber=${{ inputs.release_candidate_suffix &&
+          steps.get-release-candidate-version.outputs.release-candidate-version ||
+          steps.get-next-semantic-base-version.outputs.version }}
+          echo "version=$versionNumber" >> "$GITHUB_OUTPUT"
+          echo "$versionNumber"
+      - name: Create tag
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const owner = "${{ github.repository_owner }}";
+            const repo = "${{ github.repository }}".split('/')[1];
+            const version = "${{ steps.get-version-number.outputs.version }}";
+            const sha = "${{ github.sha }}";
+
+            try {
+              const { data: matchingTags } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${version}`,
+              });
+              console.log("Tag already exists");
+            } catch (e) {
+              console.log("Logging github API error");
+              console.log(e);
+              const { response: { status, data: { message } } } = e;
+
+              const isMissingTag = status === 404 && message == "Not Found";
+
+              if (isMissingTag) {
+                const tag = await github.rest.git.createTag({
+                  owner: owner,
+                  repo: repo,
+                  tag: version,
+                  message: `Release for ${version}`,
+                  object: sha,
+                  type: "commit",
+                  tagger: {
+                    name: "Tenstorrent Inc.",
+                    email: "info@tenstorrent.com",
+                  }
+                });
+                github.rest.git.createRef({
+                  owner: owner,
+                  repo: repo,
+                  ref: `refs/tags/${version}`,
+                  sha: tag.data.sha,
+                });
+              } else {
+                console.error(e);
+                console.error("Received an error that's not 404 Not Found for a tag");
+                throw e;
+              }
+            }


### PR DESCRIPTION
### Ticket

#18799

### Problem description

We had external actions that we had maintain separately, with the goal of using them elsewhere.

Obviously didn't happen.

### What's changed

Get rid of it.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
