### PR TITLE
#0: Introduce BufferDistributionSpec for generic single-device ND sharding

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -15,6 +15,7 @@ set(UNIT_TESTS_API_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_intersects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/distribution_spec/test_distribution_spec.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/distribution_spec/test_buffer_distribution_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_banked.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_bit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_region.cpp

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "command_queue_fixture.hpp"
+
+#include <tt-metalium/buffer_distribution_spec.hpp>
+
+namespace distribution_spec_tests {
+using tt::tt_metal::BufferDistributionSpec;
+
+struct BufferDistributionSpecInputs {
+    tt::tt_metal::Shape physical_tensor_shape;
+    tt::tt_metal::Shape physical_shard_shape;
+    tt::tt_metal::Shape2D page_shape;
+    float bytes_per_element;
+    tt::tt_metal::CoreRangeSet grid;
+    tt::tt_metal::ShardOrientation shard_orientation;
+};
+
+struct BufferDistributionSpecExpected {
+    std::vector<CoreCoord> cores;
+    size_t num_cores;
+    size_t num_dev_pages;
+    size_t aligned_size;
+    size_t aligned_size_per_bank;
+};
+
+struct BufferDistributionSpecParams {
+    BufferDistributionSpecInputs inputs;
+    BufferDistributionSpecExpected expected;
+};
+}  // namespace distribution_spec_tests
+// namespace
+
+using namespace distribution_spec_tests;
+using namespace tt::tt_metal;
+
+class BufferDistributionSpecTests : public CommandQueueSingleCardBufferFixture,
+                                    public ::testing::WithParamInterface<BufferDistributionSpecParams> {};
+
+TEST_P(BufferDistributionSpecTests, BufferCreation) {
+    const auto& params = GetParam();
+    auto device = devices_[0];
+
+    auto physical_tensor_shape = params.inputs.physical_tensor_shape;
+    auto physical_shard_shape = params.inputs.physical_shard_shape;
+    auto page_shape = params.inputs.page_shape;
+    auto bytes_per_element = params.inputs.bytes_per_element;
+    auto corerangeset = params.inputs.grid;
+    auto shard_orientation = params.inputs.shard_orientation;
+
+    // Doesn't matter for this test
+    const auto buffer_type = BufferType::L1;
+
+    auto buffer_distribution_spec = tt::tt_metal::BufferDistributionSpec::from_shard_spec(
+        physical_tensor_shape, physical_shard_shape, page_shape, corerangeset, shard_orientation);
+
+    // Check that the stored cores in BufferDistributionSpec is exact cores used
+    EXPECT_EQ(buffer_distribution_spec.get_cores(), params.expected.cores);
+
+    // These values would be passed from tensor correctly based on PageConfig
+    const auto host_size = physical_tensor_shape.volume() * bytes_per_element;
+    const auto page_size = page_shape.height() * page_shape.width() * bytes_per_element;
+    auto buffer = Buffer::create(device, host_size, page_size, buffer_type, buffer_distribution_spec);
+
+    /* These are the params allocator cares about; check all of them */
+    EXPECT_EQ(buffer->num_cores().value(), params.expected.num_cores);
+    // For BufferDistributionSpec, defined as: max number of pages per core * num_cores
+    EXPECT_EQ(buffer->num_dev_pages(), params.expected.num_dev_pages);
+
+    // Alignment is handled internally, not testing that here
+    // In buffer, defined as: num_dev_pages * aligned_page_size
+    EXPECT_EQ(buffer->aligned_size(), params.expected.aligned_size);
+    // In buffer, calculated from: aligned_size, aligned_page_size, num_banks, alignment
+    // TODO: Fix buffer implementation to use aligned_size / num_cores? They should be equal...
+    // - Need to make buffer->num_cores() not optional...
+    EXPECT_EQ(buffer->aligned_size_per_bank(), params.expected.aligned_size_per_bank);
+    EXPECT_EQ(buffer->aligned_size() % buffer->num_cores().value(), 0);
+    EXPECT_EQ(buffer->aligned_size_per_bank(), buffer->aligned_size() / buffer->num_cores().value());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BufferDistributionSpec,
+    BufferDistributionSpecTests,
+    ::testing::Values(
+        // Cut along last two dims; tile layout
+        // page size = 32 x 32 x 2 = 2048 bytes (eg. bfloat16, uint16, etc...)
+        BufferDistributionSpecParams{
+            BufferDistributionSpecInputs{
+                .physical_tensor_shape = tt::tt_metal::Shape{5, 2, 64, 96},
+                .physical_shard_shape = tt::tt_metal::Shape{5, 2, 32, 32},
+                .page_shape = tt::tt_metal::Shape2D{32, 32},
+                .bytes_per_element = 2,
+                .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                .shard_orientation = ShardOrientation::ROW_MAJOR,
+            },
+            BufferDistributionSpecExpected{
+                .cores = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}},
+                .num_cores = 6,
+                .num_dev_pages = 10 * 6,  // Shard shape is 10 pages
+                .aligned_size = 2048 * 60,
+                .aligned_size_per_bank = 2048 * 10,
+            },
+        },
+        // Cut along batch and width; row major layout
+        // page size = 1 x 64 x 4 = 256 bytes (eg. float32, uint32, etc...)
+        BufferDistributionSpecParams{
+            BufferDistributionSpecInputs{
+                .physical_tensor_shape = tt::tt_metal::Shape{5, 2, 64, 128},
+                .physical_shard_shape = tt::tt_metal::Shape{3, 2, 64, 64},
+                .page_shape = tt::tt_metal::Shape2D{1, 64},
+                .bytes_per_element = 4,
+                .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                .shard_orientation = ShardOrientation::COL_MAJOR,
+            },
+            BufferDistributionSpecExpected{
+                .cores = {{0, 0}, {0, 1}, {0, 2}, {0, 3}},
+                .num_cores = 4,
+                .num_dev_pages = 384 * 4,  // Shard shape is 384 pages
+                .aligned_size = 256 * 1536,
+                .aligned_size_per_bank = 256 * 384,
+            },
+        },
+        // Multiple shards per bank; tile layout
+        // page size = 32 x 32 x 1.0625 = 1088 bytes (eg. bfloat8_b)
+        BufferDistributionSpecParams{
+            BufferDistributionSpecInputs{
+                .physical_tensor_shape = tt::tt_metal::Shape{5, 2, 64, 96},
+                .physical_shard_shape = tt::tt_metal::Shape{2, 1, 64, 64},
+                .page_shape = tt::tt_metal::Shape2D{32, 32},
+                .bytes_per_element = 1.0625,  // Headers for block float amortized over elements
+                .grid = CoreRangeSet(std::set<CoreRange>({CoreRange({0, 0}, {2, 0}), CoreRange({0, 1}, {1, 1})})),
+                .shard_orientation = ShardOrientation::ROW_MAJOR,
+            },
+            BufferDistributionSpecExpected{
+                .cores = {{0, 0}, {1, 0}, {2, 0}, {0, 1}, {1, 1}},
+                .num_cores = 5,
+                .num_dev_pages = 3 * 8 * 5,  // Shard shape is 8 pages; 3 shards max per bank (12 shards over 5 banks)
+                .aligned_size = 1088 * 120,
+                .aligned_size_per_bank = 1088 * 24,
+            },
+        },
+        // Generic ND sharding example; row major layout
+        // page size = 1 x 128 x 1 = 128 bytes (eg. uint8, int8, etc...)
+        BufferDistributionSpecParams{
+            BufferDistributionSpecInputs{
+                .physical_tensor_shape = tt::tt_metal::Shape{2, 3, 4, 5, 6, 128},
+                .physical_shard_shape = tt::tt_metal::Shape{3, 1, 5, 4, 2, 128},
+                .page_shape = tt::tt_metal::Shape2D{1, 128},
+                .bytes_per_element = 1,
+                .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                .shard_orientation = ShardOrientation::COL_MAJOR,
+            },
+            BufferDistributionSpecExpected{
+                .cores = {{0, 0}, {0, 1}, {1, 0}, {1, 1}},
+                .num_cores = 4,
+                .num_dev_pages = 5 * 120 *
+                                 4,  // Shard shape is 120 pages; 5 shards max per bank (18 shards over 4 banks)
+                .aligned_size = 128 * 2400,
+                .aligned_size_per_bank = 128 * 600,
+            },
+        })  // Values
+);

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_distribution_spec.cpp
@@ -24,10 +24,11 @@ struct DistributionSpecInputs {
 };
 
 struct DistributionSpecExpected {
-    std::vector<DistributionSpec::TargetData> shard_mapping;
-    std::vector<DistributionSpec::TargetData> coalesced_shard_mapping;
+    std::vector<DistributionSpec::TargetData> noncoalesced_metadata_for_targets;
+    std::vector<DistributionSpec::TargetData> coalesced_metadata_for_targets;
     tt::tt_metal::Shape shard_shape;
     size_t num_targets;
+    size_t max_num_shards_per_target;
 };
 
 struct DistributionSpecParams {
@@ -39,7 +40,7 @@ struct DistributionSpecParams {
 
 using namespace distribution_spec_tests;
 
-TEST(IllegalDistributionSpecCreationTests, RankUnequal) {
+TEST(DistributionSpecTests, IllegalCreationWithUnequalRank) {
     EXPECT_THAT(
         std::function<void()>([]() {
             const auto tensor_shape = tt::tt_metal::Shape{2, 3, 4};
@@ -50,6 +51,43 @@ TEST(IllegalDistributionSpecCreationTests, RankUnequal) {
         }),
         ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr(std::string("Shard shape rank (2) must be same as tensor shape rank (3)!"))));
+}
+
+TEST(DistributionSpecTests, CacheMetadataForTargets) {
+    const auto tensor_shape = tt::tt_metal::Shape{2, 3, 4};
+    const auto shard_shape = tt::tt_metal::Shape{1, 2, 3};
+    const size_t num_targets = 3;
+    auto distribution_spec = tt::tt_metal::DistributionSpec::from_shard_shape(tensor_shape, shard_shape, num_targets);
+
+    auto validate_cached_metadata_for_targets = [](const auto& metadata_for_targets_1,
+                                                   const auto& metadata_for_targets_2) {
+        // Check addresses are the same
+        ASSERT_EQ(&metadata_for_targets_1, &metadata_for_targets_2);
+        // Sanity check values are the same
+        ASSERT_EQ(metadata_for_targets_1, metadata_for_targets_2);
+    };
+
+    // Test caching for MappingMode::COALESCED
+    const auto& coalesced_metadata_for_targets_1 =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::COALESCED);
+    const auto& coalesced_metadata_for_targets_2 =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::COALESCED);
+    validate_cached_metadata_for_targets(coalesced_metadata_for_targets_1, coalesced_metadata_for_targets_2);
+
+    // Test caching for MappingMode::NONCOALESCED
+    const auto& noncoalesced_metadata_for_targets_1 =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::NONCOALESCED);
+    const auto& noncoalesced_metadata_for_targets_2 =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::NONCOALESCED);
+    validate_cached_metadata_for_targets(noncoalesced_metadata_for_targets_1, noncoalesced_metadata_for_targets_2);
+
+    // Test that the caches are still valid switching between modes
+    const auto& coalesced_metadata_for_targets_3 =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::COALESCED);
+    validate_cached_metadata_for_targets(coalesced_metadata_for_targets_1, coalesced_metadata_for_targets_3);
+    const auto& noncoalesced_metadata_for_targets_3 =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::NONCOALESCED);
+    validate_cached_metadata_for_targets(noncoalesced_metadata_for_targets_1, noncoalesced_metadata_for_targets_3);
 }
 
 class DistributionSpecTests : public ::testing::TestWithParam<DistributionSpecParams> {};
@@ -68,22 +106,16 @@ TEST_P(DistributionSpecTests, Sharding) {
     ASSERT_EQ(shard_shape_stored, params.expected.shard_shape);
     auto num_targets_stored = distribution_spec.get_num_targets();
     ASSERT_EQ(num_targets_stored, params.expected.num_targets);
+    auto max_num_shards_per_target_stored = distribution_spec.get_max_num_shards_per_target();
+    ASSERT_EQ(max_num_shards_per_target_stored, params.expected.max_num_shards_per_target);
 
-    auto shard_mapping = distribution_spec.compute_metadata_for_targets(DistributionSpec::MappingMode::NONCOALESCED);
-    auto coalesced_shard_mapping =
-        distribution_spec.compute_metadata_for_targets(DistributionSpec::MappingMode::COALESCED);
+    auto noncoalesced_metadata_for_targets =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::NONCOALESCED);
+    auto coalesced_metadata_for_targets =
+        distribution_spec.get_metadata_for_targets(DistributionSpec::MappingMode::COALESCED);
 
-    auto validate_target_data = [](const auto& target_data, const auto& expected_target_data) {
-        ASSERT_EQ(target_data.size(), expected_target_data.size());
-        for (size_t chunk_id = 0; chunk_id < target_data.size(); chunk_id++) {
-            EXPECT_EQ(target_data[chunk_id], expected_target_data[chunk_id]);
-        }
-    };
-
-    for (size_t target_id = 0; target_id < num_targets_stored; target_id++) {
-        validate_target_data(shard_mapping[target_id], params.expected.shard_mapping[target_id]);
-        validate_target_data(coalesced_shard_mapping[target_id], params.expected.coalesced_shard_mapping[target_id]);
-    }
+    EXPECT_EQ(noncoalesced_metadata_for_targets, params.expected.noncoalesced_metadata_for_targets);
+    EXPECT_EQ(coalesced_metadata_for_targets, params.expected.coalesced_metadata_for_targets);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -98,7 +130,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .num_targets = 20,
             },
             DistributionSpecExpected{
-                .shard_mapping =
+                .noncoalesced_metadata_for_targets =
                     {{{0, 0, 1}, {1, 1, 1}, {2, 2, 1}, {15, 3, 1}, {16, 4, 1}, {17, 5, 1}},
                      {{3, 0, 1}, {4, 1, 1}, {18, 3, 1}, {19, 4, 1}},
                      {{5, 0, 1}, {6, 1, 1}, {7, 2, 1}, {20, 3, 1}, {21, 4, 1}, {22, 5, 1}},
@@ -117,7 +149,7 @@ INSTANTIATE_TEST_SUITE_P(
                      {{68, 0, 1}, {69, 1, 1}},
                      {{70, 0, 1}, {71, 1, 1}, {72, 2, 1}},
                      {{73, 0, 1}, {74, 1, 1}}},
-                .coalesced_shard_mapping =
+                .coalesced_metadata_for_targets =
                     {{{0, 0, 3}, {15, 3, 3}},
                      {{3, 0, 2}, {18, 3, 2}},
                      {{5, 0, 3}, {20, 3, 3}},
@@ -138,6 +170,7 @@ INSTANTIATE_TEST_SUITE_P(
                      {{73, 0, 2}}},
                 .shard_shape = tt::tt_metal::Shape{2, 1, 3},
                 .num_targets = 18,
+                .max_num_shards_per_target = 1,
             },
         },
         // Same 3D spec but with multiple shards per core
@@ -148,7 +181,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .num_targets = 4,
             },
             DistributionSpecExpected{
-                .shard_mapping =
+                .noncoalesced_metadata_for_targets =
                     {{{0, 0, 1},   {1, 1, 1},   {2, 2, 1},   {15, 3, 1},  {16, 4, 1},  {17, 5, 1},
                       {10, 6, 1},  {11, 7, 1},  {12, 8, 1},  {25, 9, 1},  {26, 10, 1}, {27, 11, 1},
                       {35, 12, 1}, {36, 13, 1}, {37, 14, 1}, {50, 15, 1}, {51, 16, 1}, {52, 17, 1},
@@ -186,7 +219,7 @@ INSTANTIATE_TEST_SUITE_P(
                       {59, 16, 1},
                       {68, 18, 1},
                       {69, 19, 1}}},
-                .coalesced_shard_mapping =
+                .coalesced_metadata_for_targets =
                     {{{0, 0, 3},
                       {15, 3, 3},
                       {10, 6, 3},
@@ -207,6 +240,7 @@ INSTANTIATE_TEST_SUITE_P(
                      {{8, 0, 2}, {23, 3, 2}, {33, 6, 2}, {48, 9, 2}, {43, 12, 2}, {58, 15, 2}, {68, 18, 2}}},
                 .shard_shape = tt::tt_metal::Shape{2, 1, 3},
                 .num_targets = 4,
+                .max_num_shards_per_target = 5,
             },
         },
         // 5D spec with no cuts along last two dims (ie. can coalesce last 3 dims)
@@ -217,7 +251,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .num_targets = 5,
             },
             DistributionSpecExpected{
-                .shard_mapping =
+                .noncoalesced_metadata_for_targets =
                     {{{0, 0, 1},    {1, 1, 1},    {2, 2, 1},    {3, 3, 1},    {4, 4, 1},    {5, 5, 1},   {6, 6, 1},
                       {7, 7, 1},    {8, 8, 1},    {9, 9, 1},    {10, 10, 1},  {11, 11, 1},  {12, 12, 1}, {13, 13, 1},
                       {14, 14, 1},  {15, 15, 1},  {16, 16, 1},  {17, 17, 1},  {24, 18, 1},  {25, 19, 1}, {26, 20, 1},
@@ -241,7 +275,7 @@ INSTANTIATE_TEST_SUITE_P(
                       {96, 18, 1},  {97, 19, 1},  {98, 20, 1},  {99, 21, 1},  {100, 22, 1}, {101, 23, 1},
                       {102, 24, 1}, {103, 25, 1}, {104, 26, 1}, {105, 27, 1}, {106, 28, 1}, {107, 29, 1},
                       {108, 30, 1}, {109, 31, 1}, {110, 32, 1}, {111, 33, 1}, {112, 34, 1}, {113, 35, 1}}},
-                .coalesced_shard_mapping =
+                .coalesced_metadata_for_targets =
                     {{{0, 0, 18}, {24, 18, 18}, {90, 36, 6}, {114, 54, 6}},
                      {{18, 0, 6}, {42, 18, 6}, {120, 36, 18}},
                      {{48, 0, 18}, {138, 36, 6}},
@@ -249,6 +283,7 @@ INSTANTIATE_TEST_SUITE_P(
                      {{72, 0, 18}, {96, 18, 18}}},
                 .shard_shape = tt::tt_metal::Shape{1, 2, 3, 2, 3},
                 .num_targets = 5,
+                .max_num_shards_per_target = 2,
             },
         },
         // 4D spec with cut along first dim (ie. can coalesce all dims because last dim is coalesced by default)
@@ -259,7 +294,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .num_targets = 5,
             },
             DistributionSpecExpected{
-                .shard_mapping =
+                .noncoalesced_metadata_for_targets =
                     {{{0, 0, 1},
                       {1, 1, 1},
                       {2, 2, 1},
@@ -273,9 +308,10 @@ INSTANTIATE_TEST_SUITE_P(
                       {10, 10, 1},
                       {11, 11, 1}},
                      {{12, 0, 1}, {13, 1, 1}, {14, 2, 1}, {15, 3, 1}, {16, 4, 1}, {17, 5, 1}}},
-                .coalesced_shard_mapping = {{{0, 0, 12}}, {{12, 0, 6}}},
+                .coalesced_metadata_for_targets = {{{0, 0, 12}}, {{12, 0, 6}}},
                 .shard_shape = tt::tt_metal::Shape{2, 2, 1, 3},
                 .num_targets = 2,
+                .max_num_shards_per_target = 1,
             },
         },
         // 4D spec with no cuts (ie. can coalesce all dims)
@@ -286,7 +322,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .num_targets = 5,
             },
             DistributionSpecExpected{
-                .shard_mapping =
+                .noncoalesced_metadata_for_targets =
                     {{{0, 0, 1},
                       {1, 1, 1},
                       {2, 2, 1},
@@ -298,11 +334,11 @@ INSTANTIATE_TEST_SUITE_P(
                       {8, 8, 1},
                       {9, 9, 1},
                       {10, 10, 1},
-                      {11, 11, 1}},
-                     {{0, 0, 12}}},
-                .coalesced_shard_mapping = {{{0, 0, 12}}},
+                      {11, 11, 1}}},
+                .coalesced_metadata_for_targets = {{{0, 0, 12}}},
                 .shard_shape = tt::tt_metal::Shape{2, 2, 3, 1},
                 .num_targets = 1,
+                .max_num_shards_per_target = 1,
             },
         },
         // 1D spec for edge case
@@ -313,10 +349,12 @@ INSTANTIATE_TEST_SUITE_P(
                 .num_targets = 5,
             },
             DistributionSpecExpected{
-                .shard_mapping = {{{0, 0, 1}, {1, 1, 1}, {2, 2, 1}}, {{3, 0, 1}, {4, 1, 1}, {5, 2, 1}}, {{6, 0, 1}}},
-                .coalesced_shard_mapping = {{{0, 0, 3}}, {{3, 0, 3}}, {{6, 0, 1}}},
+                .noncoalesced_metadata_for_targets =
+                    {{{0, 0, 1}, {1, 1, 1}, {2, 2, 1}}, {{3, 0, 1}, {4, 1, 1}, {5, 2, 1}}, {{6, 0, 1}}},
+                .coalesced_metadata_for_targets = {{{0, 0, 3}}, {{3, 0, 3}}, {{6, 0, 1}}},
                 .shard_shape = tt::tt_metal::Shape{3},
                 .num_targets = 3,
+                .max_num_shards_per_target = 1,
             },
         })  // Values
 );

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -41,7 +41,7 @@ protected:
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
             tt::log_info(
-                tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
+                tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
             GTEST_SKIP();
         }

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -25,6 +25,7 @@
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/sub_device_types.hpp>
@@ -211,6 +212,19 @@ public:
         std::optional<bool> bottom_up = std::nullopt,
         std::optional<SubDeviceId> sub_device_id = std::nullopt);
 
+    // Forked APIs for BufferDistributionSpec
+    // - Only usable for tensor allocation in OPs
+    // TODO: Need to support proper read/write for buffers with BufferDistributionSpec
+    static std::shared_ptr<Buffer> create(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferDistributionSpec& buffer_distribution_spec,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+    // TODO: Add create with address or just port over existing one?
+
     Buffer(const Buffer& other) = delete;
     Buffer& operator=(const Buffer& other) = delete;
     Buffer(Buffer&& other) = delete;
@@ -262,6 +276,7 @@ public:
     ShardSpecBuffer shard_spec() const;
     void set_shard_spec(const ShardSpecBuffer& shard_spec);
 
+    // TODO: Consolidate with interleaved and delete this (maybe get from BufferDistributionSpec)
     std::optional<uint32_t> num_cores() const;
 
     const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
@@ -280,6 +295,7 @@ public:
         BufferType buffer_type,
         TensorMemoryLayout buffer_layout,
         const std::optional<ShardSpecBuffer>& shard_parameter,
+        const std::optional<BufferDistributionSpec>& buffer_distribution_spec,
         std::optional<bool> bottom_up,
         std::optional<SubDeviceId> sub_device_id,
         bool owns_data,
@@ -321,10 +337,26 @@ private:
     // Used exclusively for is_allocated() method
     std::atomic<bool> deallocation_requested_ = false;
 
+    // Private helper function to commonize code path for buffer creation with either ShardSpecBuffer or
+    // BufferDistributionSpec
+    // TODO: Delete if/when we remove ShardSpecBuffer
+    static std::shared_ptr<Buffer> create_buffer(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        const BufferType buffer_type,
+        const TensorMemoryLayout buffer_layout,
+        const std::optional<ShardSpecBuffer>& shard_parameters,
+        const std::optional<BufferDistributionSpec>& buffer_distribution_spec,
+        const std::optional<bool> bottom_up,
+        const std::optional<SubDeviceId> sub_device_id);
+
     // These members must be only accessed on the device worker thread
     DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     std::optional<ShardSpecBuffer> shard_parameters_;
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
+
+    std::optional<BufferDistributionSpec> buffer_distribution_spec_;
 
     std::weak_ptr<Buffer> weak_self;
     size_t unique_id_ = 0;

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distribution_spec.hpp>
+#include <tt-metalium/shape2d.hpp>
+
+namespace tt::tt_metal {
+
+class BufferDistributionSpec {
+public:
+    static BufferDistributionSpec from_shard_spec(
+        const tt::tt_metal::Shape& tensor_shape,
+        const tt::tt_metal::Shape& physical_shard_shape,
+        const Shape2D& page_shape,
+        const CoreRangeSet& corerangeset,
+        const ShardOrientation shard_orientation);
+
+    size_t num_dev_pages_per_core() const {
+        return page_distribution_spec_.get_shard_shape().volume() *
+               page_distribution_spec_.get_max_num_shards_per_target();
+    }
+    size_t num_cores() const { return cores_.size(); }
+    std::vector<CoreCoord> get_cores() const { return cores_; }
+
+private:
+    BufferDistributionSpec(const DistributionSpec& page_distribution_spec, const std::vector<CoreCoord>& cores);
+
+    DistributionSpec page_distribution_spec_;
+    std::vector<CoreCoord> cores_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/distribution_spec.hpp
@@ -18,6 +18,7 @@ public:
 
     tt::tt_metal::Shape get_shard_shape() const { return shard_shape_; }
     size_t get_num_targets() const { return num_targets_; }
+    size_t get_max_num_shards_per_target() const { return max_num_shards_per_target_; }
 
     // ChunkMapping defined as:
     // - src: Element offset from tensor shape
@@ -51,7 +52,7 @@ public:
     // Metadata for all targets stores one TargetData per num_targets
     // The mapping to target is implied in the position of the TargetData
     // When consuming the metadata, it is user's responsibility to map TargetData to the correct device/core
-    std::vector<TargetData> compute_metadata_for_targets(const MappingMode mapping_mode) const;
+    const std::vector<TargetData>& get_metadata_for_targets(const MappingMode mapping_mode);
 
 private:
     struct ShardSize {
@@ -68,10 +69,19 @@ private:
         const tt::stl::SmallVector<DistributionType>& spec,
         size_t num_targets);
 
+    // Helper function for generating cached metadata_for_targets
+    std::vector<TargetData> compute_metadata_for_targets(const MappingMode mapping_mode) const;
+
     tt::tt_metal::Shape tensor_shape_;
     tt::stl::SmallVector<DistributionType> spec_;
     tt::tt_metal::Shape shard_shape_;  // Determined based on spec_
     size_t num_targets_ = 0;
+    size_t max_num_shards_per_target_ = 0;
+
+    // Cached metadata_for_targets after first time it is computed
+    // Store two versions, one for each MappingMode
+    std::optional<std::vector<TargetData>> noncoalesced_metadata_for_targets_ = std::nullopt;
+    std::optional<std::vector<TargetData>> coalesced_metadata_for_targets_ = std::nullopt;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -8,6 +8,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/distribution_spec.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_distribution_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer_types.cpp

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -107,26 +107,26 @@ DeviceAddr Allocator::allocate_buffer(Buffer* buffer) {
     auto page_size = buffer->aligned_page_size();
     auto buffer_type = buffer->buffer_type();
     auto bottom_up = buffer->bottom_up();
-    auto num_shards = buffer->num_cores();
+    auto num_cores = buffer->num_cores();
     this->verify_safe_allocation();
     if (config_.disable_interleaved) {
-        TT_FATAL(num_shards.has_value(), "Interleaved allocation is disabled, see validate_num_banks");
+        TT_FATAL(num_cores.has_value(), "Interleaved allocation is disabled, see validate_num_banks");
     }
     switch (buffer_type) {
         case BufferType::DRAM:
-            address = dram_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_shards);
+            address = dram_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_cores);
             break;
         case BufferType::L1:
-            address = l1_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_shards);
+            address = l1_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_cores);
             break;
         case BufferType::L1_SMALL: {
-            TT_FATAL(num_shards.has_value(), "L1_SMALL only supports sharded allocations, see validate_num_banks");
-            address = l1_small_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_shards);
+            TT_FATAL(num_cores.has_value(), "L1_SMALL only supports sharded allocations, see validate_num_banks");
+            address = l1_small_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_cores);
             break;
         }
         case BufferType::TRACE:
             address =
-                trace_buffer_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_shards);
+                trace_buffer_manager_->allocate_buffer(size, page_size, bottom_up, config_.compute_grid, num_cores);
             break;
         default: {
             TT_THROW("Unsupported buffer type!");

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "buffer_distribution_spec.hpp"
+#include "assert.hpp"
+
+namespace tt::tt_metal {
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+tt::tt_metal::Shape convert_shape_to_shape_in_pages(const tt::tt_metal::Shape& shape, const Shape2D& page_shape) {
+    auto shape_in_pages = shape;
+    TT_FATAL(
+        shape[-2] % page_shape.height() == 0,
+        "Shape height ({}) must be divisible by page height ({})!",
+        shape[-2],
+        page_shape.height());
+    TT_FATAL(
+        shape[-1] % page_shape.width() == 0,
+        "Shape width ({}) must be divisible by page width ({})!",
+        shape[-1],
+        page_shape.width());
+    shape_in_pages[-2] /= page_shape.height();
+    shape_in_pages[-1] /= page_shape.width();
+    return shape_in_pages;
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+BufferDistributionSpec::BufferDistributionSpec(
+    const DistributionSpec& page_distribution_spec, const std::vector<CoreCoord>& cores) :
+    page_distribution_spec_(page_distribution_spec), cores_(cores) {};
+
+BufferDistributionSpec BufferDistributionSpec::from_shard_spec(
+    const tt::tt_metal::Shape& tensor_shape,
+    const tt::tt_metal::Shape& physical_shard_shape,
+    const Shape2D& page_shape,
+    const CoreRangeSet& corerangeset,
+    const ShardOrientation shard_orientation) {
+    TT_FATAL(
+        physical_shard_shape.rank() == tensor_shape.rank(),
+        "Physical shard shape rank ({}) must be same as tensor shape rank ({})!",
+        physical_shard_shape.rank(),
+        tensor_shape.rank());
+    auto tensor_shape_in_pages = CMAKE_UNIQUE_NAMESPACE::convert_shape_to_shape_in_pages(tensor_shape, page_shape);
+    auto shard_shape_in_pages =
+        CMAKE_UNIQUE_NAMESPACE::convert_shape_to_shape_in_pages(physical_shard_shape, page_shape);
+    auto page_distribution_spec =
+        DistributionSpec::from_shard_shape(tensor_shape_in_pages, shard_shape_in_pages, corerangeset.num_cores());
+
+    const bool row_major = shard_orientation == ShardOrientation::ROW_MAJOR;
+    auto cores = corerange_to_cores(corerangeset, page_distribution_spec.get_num_targets(), row_major);
+
+    return BufferDistributionSpec(page_distribution_spec, cores);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/distribution_spec.cpp
+++ b/tt_metal/impl/buffers/distribution_spec.cpp
@@ -105,6 +105,9 @@ DistributionSpec::DistributionSpec(
 
     // Always set num_targets to num_targets used if num_targets provided > num_shards
     num_targets_ = std::min(num_targets, num_shards);
+
+    // Maximum number of shards per target if we have multiple shards per target
+    max_num_shards_per_target_ = tt::div_up(num_shards, num_targets_);
 }
 
 DistributionSpec DistributionSpec::from_shard_shape(
@@ -255,6 +258,25 @@ std::vector<DistributionSpec::TargetData> DistributionSpec::compute_metadata_for
     iterate_over_shards(metadata_for_targets, actual_shard_shape, shard_id, 0, 0);
 
     return metadata_for_targets;
+}
+
+const std::vector<DistributionSpec::TargetData>& DistributionSpec::get_metadata_for_targets(
+    const MappingMode mapping_mode) {
+    switch (mapping_mode) {
+        case DistributionSpec::MappingMode::COALESCED: {
+            if (!coalesced_metadata_for_targets_.has_value()) {
+                coalesced_metadata_for_targets_ = compute_metadata_for_targets(mapping_mode);
+            }
+            return coalesced_metadata_for_targets_.value();
+        }
+        case DistributionSpec::MappingMode::NONCOALESCED: {
+            if (!noncoalesced_metadata_for_targets_.has_value()) {
+                noncoalesced_metadata_for_targets_ = compute_metadata_for_targets(mapping_mode);
+            }
+            return noncoalesced_metadata_for_targets_.value();
+        }
+    }
+    TT_THROW("MappingMode {} is unsupported in get_metadata_for_targets!", mapping_mode);
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
None

### Problem description
Current buffer does not handle ND sharding, so introducing `BufferDistributionSpec` which is a new sharding scheme to describe generic ND sharding.  It builds upon concepts introduced with `DistributionSpec`, but specific for single device. Eventually, it can replace `ShardSpecBuffer`.

### What's changed
- Builds on top of DistributionSpec with single-device buffer concepts
  * Intended to replace ShardSpecBuffer for single-device sharding
- Updates to DistributionSpec:
  * Add max_num_shards_per_target to DistributionSpec
  * Add caching for computed metadata + tests to test caching
  * Fix extra target in expected test case for DistributionSpec
    * Not caught because test code did not check the size of the vector<TargetData>
    * Switch to just comparing vector<TargetData> directly instead of iterating over
- Updates to Buffer:
  * Add support for creating buffer with BufferDistributionSpec
  * Only allocation is supported in this PR
    * Need to look at read/write APIs next
  * Add minor comment about use of Private struct in Buffer constructor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14717701257
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
