### PR TITLE
[skip CI] #14393: Update github hosted runners to use ubuntu-latest

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -102,7 +102,7 @@ jobs:
           pip install pyyaml
           python tests/sweep_framework/framework/sweeps_workflow_verification.py
   cmake-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-metal/issues/14393

### Problem description
Github hosted runners on Ubuntu 20.04 are being deprecated https://github.com/actions/runner-images/issues/11101

### What's changed
Change all-static-checks workflow to use ubuntu-latest runners

### Checklist
Tested affected workflow passes on branch https://github.com/tenstorrent/tt-metal/actions/runs/13728958041/job/38401814000
