### PR TITLE
ccl_send_reader_two_input too large with O2

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -8,6 +8,7 @@
 #include "hostdevcommon/kernel_structs.h"
 #include "cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include "cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp"
+#include "tt-metalium/kernel_types.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/erisc_datamover_builder.hpp"
 
@@ -890,6 +891,8 @@ tt::tt_metal::KernelHandle generate_multi_command_stream_kernel_ct_args(
             log_trace(tt::LogOp, "\t\t{}: {}", i, arg);
         }
     }
+    // Kernel overflowed with O2
+    datamovement_kernel_config.opt_level = tt::tt_metal::KernelBuildOptLevel::Os;
     auto sender_worker_reader_kernel = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18760

### Problem description
This kernel doesn't compile because it's too large. I wasn't caught in CI as the changes were merged immediately after my JITBuild changes.

### What's changed
Make this kernel compile at Os (same as before JITBuild changes)

TTNN tests on T3K no longer have a build error
https://github.com/tenstorrent/tt-metal/actions/runs/13728013470/job/38401707453

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
