### PR TITLE
#18746: Use autoincrement stream register to signal work done

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -155,7 +155,7 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on.
     string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
-    int line_num = 57;
+    int line_num = 66;
 
     string expected = fmt::format(
         "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. Current kernel: {}.",

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -15,7 +15,7 @@ TEST(DeviceCommandTest, AddDispatchWait) {
     calculator.add_dispatch_wait();
 
     HostMemDeviceCommand command(calculator.write_offset_bytes());
-    command.add_dispatch_wait(0, 0, 0);
+    command.add_dispatch_wait(0, 0, 0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
@@ -24,7 +24,7 @@ TEST(DeviceCommandTest, AddDispatchWaitWithPrefetchStall) {
     calculator.add_dispatch_wait_with_prefetch_stall();
 
     HostMemDeviceCommand command(calculator.write_offset_bytes());
-    command.add_dispatch_wait_with_prefetch_stall(0, 0, 0);
+    command.add_dispatch_wait_with_prefetch_stall(0, 0, 0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -615,9 +615,8 @@ void gen_wait_and_stall_cmd(IDevice* device, vector<uint32_t>& prefetch_cmds, ve
 
     CQDispatchCmd wait;
     wait.base.cmd_id = CQ_DISPATCH_CMD_WAIT;
-    wait.wait.barrier = true;
-    wait.wait.notify_prefetch = true;
-    wait.wait.wait = true;
+    wait.wait.flags = CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER | CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH |
+                      CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
     wait.wait.addr = dispatch_wait_addr_g;
     wait.wait.count = 0;
     add_bare_dispatcher_cmd(dispatch_cmds, wait);
@@ -2163,6 +2162,7 @@ void configure_for_single_chip(
         0,
         0,
         0,
+        DispatchMemMap::get(DISPATCH_CORE_TYPE).get_dispatch_stream_index(0),
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -33,8 +33,17 @@ void kernel_main() {
     uint64_t dispatch_addr = NOC_XY_ADDR(
         NOC_X(mailboxes->go_message.master_x),
         NOC_Y(mailboxes->go_message.master_y),
-        DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
-    noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31, false);
+        DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_message.dispatch_message_offset);
+    noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
+        dispatch_addr,
+        0xF,  // byte-enable
+        NOC_UNICAST_WRITE_VC,
+        false,  // mcast
+        true    // posted
+    );
 #endif
 
     // DRAM NOC src address

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord.cpp
@@ -35,8 +35,17 @@ void kernel_main() {
     uint64_t dispatch_addr = NOC_XY_ADDR(
         NOC_X(mailboxes->go_message.master_x),
         NOC_Y(mailboxes->go_message.master_y),
-        DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
-    noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31, false);
+        DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_message.dispatch_message_offset);
+    noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
+        dispatch_addr,
+        0xF,  // byte-enable
+        NOC_UNICAST_WRITE_VC,
+        false,  // mcast
+        true    // posted
+    );
 #endif
 
     // DRAM NOC src address

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t target_noc_x = get_arg_val<uint32_t>(0);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(1);
+    uint32_t stream_id = get_arg_val<uint32_t>(2);
+    uint32_t target_core_value = get_arg_val<uint32_t>(3);
+    uint32_t semaphore_addr = get_semaphore(get_arg_val<uint32_t>(4));
+    uint32_t multicast_start_x = get_arg_val<uint32_t>(5);
+    uint32_t multicast_end_x = get_arg_val<uint32_t>(6);
+    uint32_t multicast_start_y = get_arg_val<uint32_t>(7);
+    uint32_t multicast_end_y = get_arg_val<uint32_t>(8);
+    uint32_t num_dests = get_arg_val<uint32_t>(9);
+
+    volatile tt_l1_ptr uint32_t* semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    if (target_core_value) {
+        // Clear the stream register and signal the other cores it's safe to send.
+        NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, 0);
+        *semaphore_ptr = 1;
+        uint64_t multicast_data_addr = get_noc_multicast_addr(
+            multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, semaphore_addr);
+        noc_semaphore_set_multicast(semaphore_addr, multicast_data_addr, num_dests);
+    }
+
+    noc_semaphore_wait(semaphore_ptr, 1);
+
+    // Write to stream register at `reg_addr` on core [target_noc_x, target_noc_y]
+    uint32_t reg_addr = STREAM_REG_ADDR(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
+    uint64_t dest_addr = NOC_XY_ADDR(target_noc_x, target_noc_y, reg_addr);
+    noc_inline_dw_write(dest_addr, 1 << REMOTE_DEST_BUF_WORDS_FREE_INC);
+
+    if (target_core_value) {
+        while (target_core_value != (NOC_STREAM_READ_REG(stream_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX) &
+                                     ((1 << REMOTE_DEST_WORDS_FREE_WIDTH) - 1))) {
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -42,8 +42,17 @@ void MAIN {
         uint64_t dispatch_addr = NOC_XY_ADDR(
             NOC_X(mailboxes->go_message.master_x),
             NOC_Y(mailboxes->go_message.master_y),
-            DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
-        noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
+            DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_message.dispatch_message_offset);
+        noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
+                        noc_index,
+                        NCRISC_AT_CMD_BUF,
+                        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
+                        dispatch_addr,
+                        0xF,  // byte-enable
+                        NOC_UNICAST_WRITE_VC,
+                        false,  // mcast
+                        true    // posted
+                    );
     }
 #else
 #if defined(TRISC0) or defined(TRISC1) or defined(TRISC2)

--- a/tt_metal/api/tt-metalium/command_queue_common.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_common.hpp
@@ -19,9 +19,8 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     COMPLETION_Q0_LAST_EVENT = 4,
     COMPLETION_Q1_LAST_EVENT = 5,
     DISPATCH_S_SYNC_SEM = 6,
-    DISPATCH_MESSAGE = 7,
-    FABRIC_INTERFACE = 8,
-    UNRESERVED = 9
+    FABRIC_INTERFACE = 7,
+    UNRESERVED = 8
 };
 
 // likely only used in impl

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -133,10 +133,15 @@ struct kernel_config_msg_t {
 } __attribute__((packed));
 
 struct go_msg_t {
-    volatile uint8_t dispatch_message_offset;
-    volatile uint8_t master_x;
-    volatile uint8_t master_y;
-    volatile uint8_t signal;  // INIT, GO, DONE, RESET_RD_PTR
+    union {
+        uint32_t all;
+        struct {
+            uint8_t dispatch_message_offset;
+            uint8_t master_x;
+            uint8_t master_y;
+            uint8_t signal;  // INIT, GO, DONE, RESET_RD_PTR
+        };
+    };
 } __attribute__((packed));
 
 struct launch_msg_t {  // must be cacheline aligned
@@ -338,7 +343,7 @@ struct mailboxes_t {
     struct slave_sync_msg_t slave_sync;
     uint32_t launch_msg_rd_ptr;
     struct launch_msg_t launch[launch_msg_buffer_num_entries];
-    struct go_msg_t go_message;
+    volatile struct go_msg_t go_message;
     struct watcher_msg_t watcher;
     struct dprint_buf_msg_t dprint_buf;
     uint32_t pads_2[PROFILER_NOC_ALIGNMENT_PAD_COUNT];

--- a/tt_metal/api/tt-metalium/dispatch_mem_map.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_mem_map.hpp
@@ -68,7 +68,14 @@ public:
 
     uint32_t get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const;
 
-    uint32_t get_dispatch_message_offset(uint32_t index) const;
+    uint32_t get_sync_offset(uint32_t index) const;
+
+    uint32_t get_dispatch_message_addr_start() const;
+
+    uint32_t get_dispatch_stream_index(uint32_t index) const;
+
+    // Offset to be passed in the go message.
+    uint8_t get_dispatch_message_update_offset(uint32_t index) const;
 
 private:
     DispatchMemMap() = default;

--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -149,7 +149,6 @@ public:
     uint32_t prefetch_q_rd_ptr_size_{0};    // configured with alignment
     uint32_t prefetch_q_pcie_rd_ptr_size_;  // configured with alignment
     uint32_t dispatch_s_sync_sem_;          // configured with alignment
-    uint32_t dispatch_message_;             // configured with alignment
     uint32_t other_ptrs_size;               // configured with alignment
 
     // cq_prefetch

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -158,6 +158,8 @@ private:
     uint32_t noc_stream_reg_space_size_;
     uint32_t noc_stream_remote_dest_buf_size_reg_index_;
     uint32_t noc_stream_remote_dest_buf_start_reg_index_;
+    uint32_t noc_stream_remote_dest_buf_space_available_reg_index_;
+    uint32_t noc_stream_remote_dest_buf_space_available_update_reg_index_;
     bool coordinate_virtualization_enabled_;
     uint32_t virtual_worker_start_x_;
     uint32_t virtual_worker_start_y_;
@@ -201,6 +203,12 @@ public:
     }
     uint32_t get_noc_stream_remote_dest_buf_start_reg_index() const {
         return noc_stream_remote_dest_buf_start_reg_index_;
+    }
+    uint32_t get_noc_stream_remote_dest_buf_space_available_reg_index() const {
+        return noc_stream_remote_dest_buf_space_available_reg_index_;
+    }
+    uint32_t get_noc_stream_remote_dest_buf_space_available_update_reg_index() const {
+        return noc_stream_remote_dest_buf_space_available_update_reg_index_;
     }
 
     float get_eps() const { return eps_; }

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -41,12 +41,7 @@ void write_go_signal(
     run_program_go_signal.master_x = dispatch_core.x;
     run_program_go_signal.master_y = dispatch_core.y;
     run_program_go_signal.dispatch_message_offset =
-        (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(sub_device_index);
-
-    uint32_t dispatch_message_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE) +
-        DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(sub_device_index);
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_message_update_offset(sub_device_index);
 
     // When running with dispatch_s enabled:
     //   - dispatch_d must notify dispatch_s that a go signal can be sent
@@ -66,7 +61,7 @@ void write_go_signal(
     go_signal_cmd_sequence.add_dispatch_go_signal_mcast(
         expected_num_workers_completed,
         *reinterpret_cast<uint32_t*>(&run_program_go_signal),
-        dispatch_message_addr,
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(sub_device_index),
         send_mcast ? device->num_noc_mcast_txns(sub_device_id) : 0,
         send_unicasts ? ((num_unicast_txns > 0) ? num_unicast_txns : device->num_noc_unicast_txns(sub_device_id)) : 0,
         device->noc_data_start_index(sub_device_id, send_mcast, send_unicasts), /* noc_data_start_idx */

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -85,7 +85,6 @@ int main() {
 
     while (1) {
         // Wait...
-        go_msg_t* go_msg_address = &(mailboxes->go_message);
         WAYPOINT("GW");
 
         uint8_t go_message_signal = RUN_MSG_DONE;
@@ -96,10 +95,7 @@ int main() {
             if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
                 // Set the rd_ptr on workers to specified value
                 mailboxes->launch_msg_rd_ptr = 0;
-                uint64_t dispatch_addr = NOC_XY_ADDR(
-                    NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y),
-                    DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
                 mailboxes->go_message.signal = RUN_MSG_DONE;
                 // Notify dispatcher that this has been done
                 internal_::notify_dispatch_core_done(dispatch_addr);
@@ -145,10 +141,7 @@ int main() {
             // Notify dispatcher core that it has completed
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
                 launch_msg_address->kernel_config.enables = 0;
-                uint64_t dispatch_addr = NOC_XY_ADDR(
-                    NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y),
-                    DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 internal_::notify_dispatch_core_done(dispatch_addr);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -25,6 +25,7 @@
 #include "circular_buffer_init.h"
 #include "dataflow_api.h"
 #include "dev_mem_map.h"
+#include "noc_overlay_parameters.h"
 
 #include "debug/watcher_common.h"
 #include "debug/waypoint.h"
@@ -436,22 +437,11 @@ int main() {
                 // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently guaranteed
                 // to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid value.
                 // For future proofing, the noc_index value is initialized to 0, to ensure an invalid NOC txn is not issued.
-                uint64_t dispatch_addr = NOC_XY_ADDR(
-                    NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y),
-                    DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
                 mailboxes->go_message.signal = RUN_MSG_DONE;
                 // Notify dispatcher that this has been done
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
-                noc_fast_atomic_increment(
-                    noc_index,
-                    NCRISC_AT_CMD_BUF,
-                    dispatch_addr,
-                    NOC_UNICAST_WRITE_VC,
-                    1,
-                    31 /*wrap*/,
-                    false /*linked*/,
-                    post_atomic_increments /*posted*/);
+                notify_dispatch_core_done(dispatch_addr, noc_index);
             }
         }
 
@@ -584,24 +574,13 @@ int main() {
                 // Set launch message to invalid, so that the next time this slot is encountered, kernels are only run if a valid launch message is sent.
                 launch_msg_address->kernel_config.enables = 0;
                 launch_msg_address->kernel_config.preload = 0;
-                uint64_t dispatch_addr = NOC_XY_ADDR(
-                    NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y),
-                    DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 // Only executed if watcher is enabled. Ensures that we don't report stale data due to invalid launch
                 // messages in the ring buffer. Must be executed before the atomic increment, as after that the launch
                 // message is no longer owned by us.
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
-                noc_fast_atomic_increment(
-                    noc_index,
-                    NCRISC_AT_CMD_BUF,
-                    dispatch_addr,
-                    NOC_UNICAST_WRITE_VC,
-                    1,
-                    31 /*wrap*/,
-                    false /*linked*/,
-                    post_atomic_increments /*posted*/);
+                notify_dispatch_core_done(dispatch_addr, noc_index);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
         }

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -123,10 +123,7 @@ void __attribute__((noinline)) Application(void) {
 
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
                 launch_msg_address->kernel_config.enables = 0;
-                uint64_t dispatch_addr = NOC_XY_ADDR(
-                    NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y),
-                    DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 internal_::notify_dispatch_core_done(dispatch_addr);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
@@ -137,10 +134,7 @@ void __attribute__((noinline)) Application(void) {
         } else if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
             // Reset the launch message buffer read ptr
             mailboxes->launch_msg_rd_ptr = 0;
-            uint64_t dispatch_addr = NOC_XY_ADDR(
-                NOC_X(mailboxes->go_message.master_x),
-                NOC_Y(mailboxes->go_message.master_y),
-                DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+            uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
             mailboxes->go_message.signal = RUN_MSG_DONE;
             internal_::notify_dispatch_core_done(dispatch_addr);
         } else {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -172,21 +172,10 @@ int main() {
             // Notify dispatcher core that it has completed
             if (launch_msg_address->kernel_config.mode == DISPATCH_MODE_DEV) {
                 launch_msg_address->kernel_config.enables = 0;
-                uint64_t dispatch_addr = NOC_XY_ADDR(
-                    NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y),
-                    DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
+                uint64_t dispatch_addr = calculate_dispatch_addr(&mailboxes->go_message);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
-                noc_fast_atomic_increment(
-                    noc_index,
-                    NCRISC_AT_CMD_BUF,
-                    dispatch_addr,
-                    NOC_UNICAST_WRITE_VC,
-                    1,
-                    31 /*wrap*/,
-                    false /*linked*/,
-                    true /*posted*/);
+                notify_dispatch_core_done(dispatch_addr, noc_index);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
         }

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -21,7 +21,7 @@ void assert_and_hang(uint32_t line_num) {
 #if defined(COMPILE_FOR_ERISC)
     // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
     // still running and try to make it exit.
-    tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
+    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
     go_message_ptr->signal = RUN_MSG_DONE;
 
     // This exits to base FW

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -242,7 +242,7 @@ inline void debug_sanitize_post_noc_addr_and_hang(
 #if defined(COMPILE_FOR_ERISC)
     // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
     // still running and try to make it exit.
-    tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
+    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
     go_message_ptr->signal = RUN_MSG_DONE;
 
     // For erisc, we can't hang the kernel/fw, because the core doesn't get restarted when a new

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -146,15 +146,16 @@ void notify_dispatch_core_done(uint64_t dispatch_addr) {
         while (!noc_cmd_buf_ready(n, NCRISC_AT_CMD_BUF));
     }
     DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
-    noc_fast_atomic_increment(
+    noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
         noc_index,
         NCRISC_AT_CMD_BUF,
+        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
         dispatch_addr,
+        0xF,  // byte-enable
         NOC_UNICAST_WRITE_VC,
-        1,
-        31 /*wrap*/,
-        false /*linked*/,
-        true /*posted*/);
+        false,  // mcast
+        true    // posted
+    );
 }
 
 }  // namespace internal_

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -16,6 +16,9 @@
 #include "noc/noc_parameters.h"
 #include "debug/dprint.h"
 #include "risc_common.h"
+#if !defined(COMPILE_FOR_TRISC)
+#include "dataflow_api.h"
+#endif
 
 extern uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
 extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];
@@ -82,3 +85,28 @@ void wait_for_go_message() {
         invalidate_l1_cache();
     }
 }
+
+#if !defined(COMPILE_FOR_TRISC)
+FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) {
+    go_msg_t go_message;
+    go_message.all = go_message_in->all;
+    uint64_t addr = NOC_XY_ADDR(
+        NOC_X(go_message.master_x),
+        NOC_Y(go_message.master_y),
+        DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * go_message.dispatch_message_offset);
+    return addr;
+}
+
+FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_index) {
+    noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
+        dispatch_addr,
+        0xF,  // byte-enable
+        NOC_UNICAST_WRITE_VC,
+        false,  // mcast
+        true    // posted
+    );
+}
+#endif

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -468,16 +468,13 @@ void issue_buffer_dispatch_command_sequence(
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     if (dispatch_params.issue_wait) {
-        uint32_t dispatch_message_base_addr =
-            DispatchMemMap::get(dispatch_core_type)
-                .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
         for (const auto& sub_device_id : sub_device_ids) {
             auto offset_index = *sub_device_id;
-            uint32_t dispatch_message_addr =
-                dispatch_message_base_addr +
-                DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
             command_sequence.add_dispatch_wait(
-                false, dispatch_message_addr, dispatch_params.expected_num_workers_completed[offset_index]);
+                CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
+                0,
+                DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(offset_index),
+                dispatch_params.expected_num_workers_completed[offset_index]);
         }
     }
     if constexpr (std::is_same_v<T, ShardedBufferWriteDispatchParams>) {
@@ -838,24 +835,22 @@ void issue_read_buffer_dispatch_command_sequence(
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
-    uint32_t dispatch_message_base_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
     uint32_t last_index = num_worker_counters - 1;
     // We only need the write barrier + prefetch stall for the last wait cmd
     for (uint32_t i = 0; i < last_index; ++i) {
         auto offset_index = *sub_device_ids[i];
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr +
-            DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
         command_sequence.add_dispatch_wait(
-            false, dispatch_message_addr, dispatch_params.expected_num_workers_completed[offset_index]);
+            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
+            0,
+            DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(offset_index),
+            dispatch_params.expected_num_workers_completed[offset_index]);
     }
     auto offset_index = *sub_device_ids[last_index];
-    uint32_t dispatch_message_addr =
-        dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
     command_sequence.add_dispatch_wait_with_prefetch_stall(
-        true, dispatch_message_addr, dispatch_params.expected_num_workers_completed[offset_index]);
+        CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER,
+        0,
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(offset_index),
+        dispatch_params.expected_num_workers_completed[offset_index]);
 
     bool flush_prefetch = false;
     command_sequence.add_dispatch_write_host(

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -162,14 +162,11 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
                 break;
             case CQ_DISPATCH_CMD_WAIT:
                 cq_file << fmt::format(
-                    " (barrier={}, notify_prefetch={}, clear_count=(), wait={}, addr={:#010x}, "
-                    "count = {})",
-                    val(cmd->wait.barrier),
-                    val(cmd->wait.notify_prefetch),
-                    val(cmd->wait.clear_count),
-                    val(cmd->wait.wait),
+                    " (flags={}, count={}, addr={:#010x}, stream={})",
+                    val(cmd->wait.flags),
+                    val(cmd->wait.count),
                     val(cmd->wait.addr),
-                    val(cmd->wait.count));
+                    val(cmd->wait.stream));
                 break;
             case CQ_DISPATCH_CMD_DEBUG:
                 cq_file << fmt::format(

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -45,16 +45,9 @@ public:
     vector_memcpy_aligned<uint32_t> cmd_vector() const;
 
     void add_dispatch_wait(
-        uint8_t barrier,
-        uint32_t address,
-        uint32_t count,
-        uint8_t clear_count = 0,
-        bool notify_prefetch = false,
-        bool do_wait = true,
-        uint8_t dispatcher_type = 0);
+        uint32_t flags, uint32_t address, uint32_t stream, uint32_t count, uint8_t dispatcher_type = 0);
 
-    void add_dispatch_wait_with_prefetch_stall(
-        uint8_t barrier, uint32_t address, uint32_t count, uint8_t clear_count = 0, bool do_wait = true);
+    void add_dispatch_wait_with_prefetch_stall(uint32_t flags, uint32_t address, uint32_t stream, uint32_t count);
 
     void add_prefetch_relay_linear(uint32_t noc_xy_addr, uint32_t lengthB, uint32_t addr);
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -73,10 +73,35 @@ uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrT
            tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
 }
 
-uint32_t DispatchMemMap::get_dispatch_message_offset(uint32_t index) const {
+uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
     TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
     uint32_t offset = index * hal.get_alignment(HalMemType::L1);
     return offset;
+}
+
+uint32_t DispatchMemMap::get_dispatch_message_addr_start() const {
+    // Address of the first dispatch message entry. Remaining entries are each offset by
+    // get_noc_stream_reg_space_size() bytes.
+    return tt::tt_metal::hal.get_noc_overlay_start_addr() +
+           tt::tt_metal::hal.get_noc_stream_reg_space_size() * get_dispatch_stream_index(0) +
+           tt::tt_metal::hal.get_noc_stream_remote_dest_buf_space_available_update_reg_index() * sizeof(uint32_t);
+}
+
+uint32_t DispatchMemMap::get_dispatch_stream_index(uint32_t index) const {
+    if (last_core_type == CoreType::WORKER) {
+        // There are 64 streams. CBs use entries 8-39.
+        return 48u + index;
+    } else if (last_core_type == CoreType::ETH) {
+        // There are 32 streams.
+        return 16u + index;
+    } else {
+        TT_THROW("get_dispatch_starting_stream_index not implemented for core type");
+    }
+}
+
+uint8_t DispatchMemMap::get_dispatch_message_update_offset(uint32_t index) const {
+    TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGES_MAX_OFFSET);
+    return index;
 }
 
 DispatchMemMap& DispatchMemMap::get_instance() {
@@ -114,8 +139,6 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
             device_cq_addr_sizes_[dev_addr_idx] = settings.prefetch_q_pcie_rd_ptr_size_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM) {
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
-        } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_MESSAGE) {
-            device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_message_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
             if (llrt::RunTimeOptions::get_instance().get_fd_fabric()) {
                 device_cq_addr_sizes_[dev_addr_idx] = tt_fabric::PACKET_HEADER_SIZE_BYTES;

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -116,10 +116,6 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     this->device = device;
     this->dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
     this->packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
-    this->dispatch_message_addr =
-        DispatchMemMap::get(this->dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE) +
-        DispatchMemMap::get(this->dispatch_core_type).get_dispatch_message_offset(*this->sub_device_id);
 }
 
 void EnqueueProgramCommand::process() {

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -66,7 +66,6 @@ private:
     CoreType dispatch_core_type;
     uint32_t expected_num_workers_completed;
     uint32_t packed_write_max_unicast_sub_cmds;
-    uint32_t dispatch_message_addr;
     uint32_t multicast_cores_launch_message_wptr = 0;
     uint32_t unicast_cores_launch_message_wptr = 0;
     // TODO: There will be multiple ids once programs support spanning multiple sub_devices

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -62,6 +62,7 @@ void DispatchKernel::GenerateStaticConfigs() {
                 ? hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
         static_config_.distributed_dispatcher = DispatchQueryManager::instance().distributed_dispatcher();
+        static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
             my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
@@ -109,6 +110,7 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.mcast_go_signal_addr = 0;                // Unused
         static_config_.unicast_go_signal_addr = 0;              // Unused
         static_config_.distributed_dispatcher = 0;              // Unused
+        static_config_.first_stream_used = 0;                   // Unused
 
         static_config_.host_completion_q_wr_ptr =
             my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
@@ -158,6 +160,7 @@ void DispatchKernel::GenerateStaticConfigs() {
                 ? hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
         static_config_.distributed_dispatcher = DispatchQueryManager::instance().distributed_dispatcher();
+        static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
             my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
@@ -363,10 +366,12 @@ void DispatchKernel::CreateKernel() {
         dependent_config_.fabric_router_noc_xy.value_or(0xdeadbeef),
         static_config_.client_interface_addr.value_or(0),
 
+        static_config_.first_stream_used.value(),
+
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 37);
+    TT_ASSERT(compile_args.size() == 38);
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
     auto upstream_virtual_core =
         device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());
@@ -403,15 +408,9 @@ void DispatchKernel::ConfigureCore() {
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
     uint32_t dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
-    uint32_t dispatch_message_base_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
     for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {
-        uint32_t dispatch_s_sync_sem_addr =
-            dispatch_s_sync_sem_base_addr + my_dispatch_constants.get_dispatch_message_offset(i);
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr + my_dispatch_constants.get_dispatch_message_offset(i);
+        uint32_t dispatch_s_sync_sem_addr = dispatch_s_sync_sem_base_addr + my_dispatch_constants.get_sync_offset(i);
         detail::WriteToDeviceL1(device_, logical_core_, dispatch_s_sync_sem_addr, zero, GetCoreType());
-        detail::WriteToDeviceL1(device_, logical_core_, dispatch_message_addr, zero, GetCoreType());
     }
 
     // For DISPATCH_D, need to clear completion q events

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -32,6 +32,7 @@ typedef struct dispatch_static_config {
     std::optional<uint32_t> mcast_go_signal_addr;
     std::optional<uint32_t> unicast_go_signal_addr;
     std::optional<uint32_t> distributed_dispatcher;
+    std::optional<uint32_t> first_stream_used;
 
     std::optional<uint32_t> host_completion_q_wr_ptr;  // 26
     std::optional<uint32_t> dev_completion_q_wr_ptr;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -14,7 +14,7 @@ typedef struct dispatch_s_static_config {
     std::optional<uint32_t> mcast_go_signal_addr;
     std::optional<uint32_t> unicast_go_signal_addr;
     std::optional<uint32_t> distributed_dispatcher;
-    std::optional<uint32_t> worker_sem_base_addr;
+    std::optional<uint32_t> first_stream_used;
     std::optional<uint32_t> max_num_worker_sems;
     std::optional<uint32_t> max_num_go_signal_noc_data_entries;
 } dispatch_s_static_config_t;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -433,8 +433,6 @@ void PrefetchKernel::ConfigureCore() {
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
         uint32_t completion_q_rd_ptr =
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-        uint32_t dispatch_message_addr =
-            my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
         uint32_t completion_q0_last_event_ptr =
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q0_LAST_EVENT);
         uint32_t completion_q1_last_event_ptr =

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -235,13 +235,21 @@ struct CQDispatchWritePackedLargeCmd {
     uint16_t write_offset_index;
 } __attribute__((packed));
 
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_NONE = 0x00;
+// Issue a write barrier
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER = 0x01;
+// Increment prefetch semaphore
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH = 0x02;
+// Wait for a count value on memory.
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY = 0x04;
+// Wait for a count value on a stream
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM = 0x08;
+// Clear a count value on a stream.
+constexpr uint32_t CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM = 0x10;
+
 struct CQDispatchWaitCmd {
-    uint8_t barrier;          // if true, issue write barrier
-    uint8_t notify_prefetch;  // if true, inc prefetch sem
-    uint8_t clear_count;      // if true, reset count to 0
-    uint8_t wait;             // if true, wait on count value below
-    uint8_t pad1;
-    uint16_t pad2;
+    uint8_t flags;    // see above
+    uint16_t stream;  // stream to read/write
     uint32_t addr;   // address to read
     uint32_t count;  // wait while address is < count
 } __attribute__((packed));
@@ -272,7 +280,7 @@ struct CQDispatchGoSignalMcastCmd {
     uint8_t num_unicast_txns;
     uint8_t noc_data_start_index;
     uint32_t wait_count;
-    uint32_t wait_addr;
+    uint32_t wait_stream;  // Index of the stream to wait on
 } __attribute__((packed));
 
 struct CQDispatchNotifySlaveGoSignalCmd {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -62,8 +62,10 @@ constexpr uint32_t upstream_chip_id = get_compile_time_arg_val(32);
 constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(33);
 constexpr uint32_t client_interface_addr = get_compile_time_arg_val(34);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(35);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(36);
+constexpr uint32_t first_stream_used = get_compile_time_arg_val(35);
+
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(36);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(37);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
@@ -868,15 +870,27 @@ static uint32_t process_debug_cmd(uint32_t cmd_ptr) {
     return cmd_ptr + cmd->debug.stride;
 }
 
+FORCE_INLINE
+uint32_t stream_wrap_ge(uint32_t a, uint32_t b) {
+    constexpr uint32_t shift = 32 - MEM_WORD_ADDR_WIDTH;
+    // Careful below: have to take the signed diff for 2s complement to handle the wrap
+    // Below relies on taking the diff first then the compare to move the wrap
+    // to 2^31 away
+    int32_t diff = a - b;
+    return (diff << shift) >= 0;
+}
+
 static void process_wait() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    auto flags = cmd->wait.flags;
 
-    uint32_t barrier = cmd->wait.barrier;
-    uint32_t notify_prefetch = cmd->wait.notify_prefetch;
-    uint32_t clear_count = cmd->wait.clear_count;
-    uint32_t wait = cmd->wait.wait;
-    uint32_t addr = cmd->wait.addr;
+    uint32_t barrier = flags & CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER;
+    uint32_t notify_prefetch = flags & CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH;
+    uint32_t clear_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM;
+    uint32_t wait_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
+    uint32_t wait_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM;
     uint32_t count = cmd->wait.count;
+    uint32_t stream = cmd->wait.stream;
 
     if (barrier) {
         // DPRINT << " DISPATCH BARRIER\n";
@@ -884,21 +898,34 @@ static void process_wait() {
     }
 
     WAYPOINT("PWW");
-    volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
     uint32_t heartbeat = 0;
-    if (wait) {
+    if (wait_memory) {
+        uint32_t addr = cmd->wait.addr;
+        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
         // DPRINT << " DISPATCH WAIT " << HEX() << addr << DEC() << " count " << count << ENDL();
         do {
             invalidate_l1_cache();
             IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
         } while (!wrap_ge(*sem_addr, count));
     }
+    if (wait_stream) {
+        volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
+        DPRINT << " DISPATCH WAIT STREAM " << HEX() << stream << DEC() << " count " << count << ENDL();
+        do {
+            IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+        } while (!stream_wrap_ge(*sem_addr, count));
+    }
     WAYPOINT("PWD");
 
-    if (clear_count) {
+    if (clear_stream) {
+        volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
         uint32_t neg_sem_val = -(*sem_addr);
-        noc_semaphore_inc(get_noc_addr_helper(my_noc_xy, addr), neg_sem_val, noc_index);
-        noc_async_atomic_barrier(noc_index);
+        NOC_STREAM_WRITE_REG(
+            stream,
+            STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
+            neg_sem_val << REMOTE_DEST_BUF_WORDS_FREE_INC);
     }
     if (notify_prefetch) {
         noc_semaphore_inc(
@@ -920,7 +947,7 @@ static void process_delay_cmd() {
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-    volatile tt_l1_ptr uint32_t* worker_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd->mcast.wait_addr);
+    uint32_t stream = cmd->mcast.wait_stream;
     // The location of the go signal embedded in the command does not meet NOC alignment requirements.
     // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
     // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
@@ -929,8 +956,8 @@ void process_go_signal_mcast_cmd() {
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
     *aligned_go_signal_storage = cmd->mcast.go_signal;
 
-    while (*worker_sem_addr < cmd->mcast.wait_count) {
-        invalidate_l1_cache();
+    while (!stream_wrap_ge(
+        NOC_STREAM_READ_REG(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX), cmd->mcast.wait_count)) {
     }
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     // send go signal update here
@@ -1180,6 +1207,16 @@ void kernel_main() {
     static_assert(my_noc_index != upstream_noc_index);
     if constexpr (my_noc_index != upstream_noc_index) {
         noc_local_state_init(upstream_noc_index);
+    }
+
+    for (size_t i = 0; i < max_num_worker_sems; i++) {
+        uint32_t index = i + first_stream_used;
+
+        NOC_STREAM_WRITE_REG(
+            index,
+            STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
+            -NOC_STREAM_READ_REG(index, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)
+                << REMOTE_DEST_BUF_WORDS_FREE_INC);
     }
 
     static_assert(is_d_variant || split_dispatch_page_preamble_size == 0);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -34,8 +34,8 @@ constexpr uint32_t mcast_go_signal_addr = get_compile_time_arg_val(6);
 constexpr uint32_t unicast_go_signal_addr = get_compile_time_arg_val(7);
 constexpr uint32_t distributed_dispatcher =
     get_compile_time_arg_val(8);  // dispatch_s and dispatch_d running on different cores
-constexpr uint32_t worker_sem_base_addr =
-    get_compile_time_arg_val(9);  // workers update the semaphore at this location to signal completion
+constexpr uint32_t first_stream_used = get_compile_time_arg_val(9);
+
 constexpr uint32_t max_num_worker_sems = get_compile_time_arg_val(10);  // maximum number of worker semaphores
 constexpr uint32_t max_num_go_signal_noc_data_entries =
     get_compile_time_arg_val(11);  // maximum number of go signal data words
@@ -120,12 +120,20 @@ void dispatch_s_noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t noc_id,
 }
 
 FORCE_INLINE
+uint32_t stream_wrap_gt(uint32_t a, uint32_t b) {
+    constexpr uint32_t shift = 32 - MEM_WORD_ADDR_WIDTH;
+    // Careful below: have to take the signed diff for 2s complement to handle the wrap
+    // Below relies on taking the diff first then the compare to move the wrap
+    // to 2^31 away
+    int32_t diff = a - b;
+    return (diff << shift) > 0;
+}
+
+FORCE_INLINE
 void wait_for_workers(volatile CQDispatchCmd tt_l1_ptr* cmd) {
-    uint8_t dispatch_message_offset = *((uint8_t*)&cmd->mcast.go_signal + offsetof(go_msg_t, dispatch_message_offset));
-    volatile tt_l1_ptr uint32_t* worker_sem =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_base_addr + dispatch_message_offset);
-    while (wrap_gt(cmd->mcast.wait_count, *worker_sem)) {
-        invalidate_l1_cache();
+    volatile uint32_t* worker_sem =
+        (volatile uint32_t*)STREAM_REG_ADDR(cmd->mcast.wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+    while (stream_wrap_gt(cmd->mcast.wait_count, *worker_sem)) {
     }
 }
 
@@ -133,13 +141,15 @@ template <bool flush_write = false>
 FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
     if constexpr (distributed_dispatcher) {
         bool write = false;
-        for (uint32_t i = 0, worker_sem_addr = worker_sem_base_addr; i < num_worker_sems;
-             ++i, worker_sem_addr += L1_ALIGNMENT) {
+        for (uint32_t i = 0; i < num_worker_sems; i++) {
             uint32_t num_workers_signalling_completion =
-                *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr);
+                NOC_STREAM_READ_REG(i + first_stream_used, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
             if (num_workers_signalling_completion != worker_count_update_for_dispatch_d[i]) {
                 worker_count_update_for_dispatch_d[i] = num_workers_signalling_completion;
-                uint64_t dispatch_d_dst = get_noc_addr_helper(dispatch_d_noc_xy, worker_sem_addr);
+                // Writing to STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX sets
+                // STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX (rather than incrementing it).
+                uint64_t dispatch_d_dst = get_noc_addr_helper(
+                    dispatch_d_noc_xy, STREAM_REG_ADDR(i + first_stream_used, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
                 dispatch_s_noc_inline_dw_write(dispatch_d_dst, num_workers_signalling_completion, my_noc_index);
                 write = true;
             }
@@ -178,12 +188,14 @@ FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t sync_index = cmd->mcast.wait_stream - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
-    volatile tt_l1_ptr uint32_t* sync_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        dispatch_s_sync_sem_base_addr + (cmd->mcast.wait_addr - worker_sem_base_addr));
+
+    volatile tt_l1_ptr uint32_t* sync_sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
 
     // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
-    uint32_t& mcasts_sent = num_mcasts_sent[(cmd->mcast.wait_addr - worker_sem_base_addr) / L1_ALIGNMENT];
+    uint32_t& mcasts_sent = num_mcasts_sent[sync_index];
     while (wrap_ge(mcasts_sent, *sync_sem_addr)) {
         invalidate_l1_cache();
         // Update dispatch_d with the latest num_workers
@@ -219,24 +231,25 @@ void process_go_signal_mcast_cmd() {
 
 FORCE_INLINE
 void process_dispatch_s_wait_cmd() {
-    static constexpr uint32_t worker_sem_max_addr = worker_sem_base_addr + (max_num_worker_sems - 1) * L1_ALIGNMENT;
-
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
     // Limited Usage of Wait CMD: dispatch_s should get a wait command only if it's not on the
     // same core as dispatch_d and is used to clear the worker count
-    ASSERT(cmd->wait.clear_count && distributed_dispatcher);
-    uint32_t worker_sem_addr = cmd->wait.addr;
-    ASSERT(worker_sem_addr >= worker_sem_base_addr && worker_sem_addr <= worker_sem_max_addr);
-    uint32_t index = (worker_sem_addr - worker_sem_base_addr) / L1_ALIGNMENT;
-    volatile tt_l1_ptr uint32_t* worker_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr);
+    ASSERT(
+        (cmd->wait.flags == (CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM)) &&
+        distributed_dispatcher);
+    uint32_t stream = cmd->wait.stream;
+    uint32_t index = stream - first_stream_used;
+    volatile uint32_t* worker_sem =
+        (volatile uint32_t*)STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+
     // Wait for workers to complete
-    while (wrap_gt(cmd->wait.count, *worker_sem)) {
-        invalidate_l1_cache();
+    while (stream_wrap_gt(cmd->wait.count, *worker_sem)) {
     }
     // Send updated worker count to dispatch_d and wait for updated count to get picked up by NOC before clearing the
     // counter. dispatch_d will clear it's own counter
     update_worker_completion_count_on_dispatch_d<true>();
-    *worker_sem = 0;
+    // Reset SPACE_AVAILABLE to 0.
+    NOC_STREAM_WRITE_REG(stream, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, 0);
     worker_count_update_for_dispatch_d[index] =
         0;  // Local worker count update for dispatch_d should reflect state of worker semaphore on dispatch_s
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -268,6 +281,18 @@ void kernel_main() {
     // Initialize customized command buffers.
     dispatch_s_wr_reg_cmd_buf_init();
     dispatch_s_atomic_cmd_buf_init();
+    if constexpr (distributed_dispatcher) {
+        for (size_t i = 0; i < max_num_worker_sems; i++) {
+            uint32_t index = i + first_stream_used;
+
+            NOC_STREAM_WRITE_REG(
+                index,
+                STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
+                -NOC_STREAM_READ_REG(index, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)
+                    << REMOTE_DEST_BUF_WORDS_FREE_INC);
+        }
+    }
+
     cmd_ptr = cb_base;
     bool done = false;
     uint32_t total_pages_acquired = 0;

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -117,8 +117,7 @@ DispatchSettings DispatchSettings::defaults(
 std::vector<std::string> DispatchSettings::get_errors() const {
     std::vector<std::string> msgs;
 
-    if (!prefetch_q_rd_ptr_size_ || !prefetch_q_pcie_rd_ptr_size_ || !dispatch_s_sync_sem_ || !dispatch_message_ ||
-        !other_ptrs_size) {
+    if (!prefetch_q_rd_ptr_size_ || !prefetch_q_pcie_rd_ptr_size_ || !dispatch_s_sync_sem_ || !other_ptrs_size) {
         msgs.push_back(fmt::format("configuration with_alignment() is a required\n"));
     }
 
@@ -190,9 +189,9 @@ void DispatchSettings::initialize(const DispatchSettings& other) {
 bool DispatchSettings::operator==(const DispatchSettings& other) const {
     return num_hw_cqs_ == other.num_hw_cqs_ && prefetch_q_rd_ptr_size_ == other.prefetch_q_rd_ptr_size_ &&
            prefetch_q_pcie_rd_ptr_size_ == other.prefetch_q_pcie_rd_ptr_size_ &&
-           dispatch_s_sync_sem_ == other.dispatch_s_sync_sem_ && dispatch_message_ == other.dispatch_message_ &&
-           other_ptrs_size == other.other_ptrs_size && prefetch_q_entries_ == other.prefetch_q_entries_ &&
-           prefetch_q_size_ == other.prefetch_q_size_ && prefetch_max_cmd_size_ == other.prefetch_max_cmd_size_ &&
+           dispatch_s_sync_sem_ == other.dispatch_s_sync_sem_ && other_ptrs_size == other.other_ptrs_size &&
+           prefetch_q_entries_ == other.prefetch_q_entries_ && prefetch_q_size_ == other.prefetch_q_size_ &&
+           prefetch_max_cmd_size_ == other.prefetch_max_cmd_size_ &&
            prefetch_cmddat_q_size_ == other.prefetch_cmddat_q_size_ &&
            prefetch_scratch_db_size_ == other.prefetch_scratch_db_size_ &&
            prefetch_d_buffer_size_ == other.prefetch_d_buffer_size_ && prefetch_d_pages_ == other.prefetch_d_pages_ &&
@@ -276,7 +275,6 @@ DispatchSettings& DispatchSettings::with_alignment(uint32_t l1_alignment) {
     this->prefetch_q_rd_ptr_size_ = sizeof(prefetch_q_ptr_type);
     this->prefetch_q_pcie_rd_ptr_size_ = l1_alignment - sizeof(prefetch_q_ptr_type);
     this->dispatch_s_sync_sem_ = DISPATCH_MESSAGE_ENTRIES * l1_alignment;
-    this->dispatch_message_ = DISPATCH_MESSAGE_ENTRIES * l1_alignment;
     this->other_ptrs_size = l1_alignment;
 
     return *this;

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -60,26 +60,21 @@ void issue_record_event_commands(
     auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
-    uint32_t dispatch_message_base_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-
     uint32_t last_index = num_worker_counters - 1;
     for (uint32_t i = 0; i < num_worker_counters; ++i) {
         auto offset_index = *sub_device_ids[i];
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr +
-            DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
         // recording an event does not have any side-effects on the dispatch completion count
         // hence clear_count is set to false, i.e. the number of workers on the dispatcher is
         // not reset
         // We only need the write barrier for the last wait cmd.
+        /* write_barrier ensures that all writes initiated by the dispatcher are
+                                        flushed before the event is recorded */
         command_sequence.add_dispatch_wait(
-            (i == num_worker_counters - 1), /* write_barrier ensures that all writes initiated by the dispatcher are
-                                               flushed before the event is recorded */
-            dispatch_message_addr,
-            expected_num_workers_completed[offset_index],
-            false /* recording an event does not have any side-effects on the dispatch completion count */);
+            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM |
+                ((i == num_worker_counters - 1) ? CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER : 0),
+            0,
+            DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(offset_index),
+            expected_num_workers_completed[offset_index]);
     }
 
     std::vector<CQDispatchWritePackedUnicastSubCmd> unicast_sub_cmds(num_command_queues);
@@ -143,7 +138,8 @@ void issue_wait_for_event_commands(
     uint32_t last_completed_event_address =
         event_cq_id == 0 ? completion_q0_last_event_addr : completion_q1_last_event_addr;
 
-    command_sequence.add_dispatch_wait(false, last_completed_event_address, event_id, false);
+    command_sequence.add_dispatch_wait(
+        CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY, last_completed_event_address, 0, event_id);
 
     sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -416,10 +416,6 @@ void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDevi
     // Initialize stall command sequences for this program.
     auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
-    uint32_t dispatch_message_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE) +
-        DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(*sub_device_id);
     uint32_t uncached_stall_cmd_sizeB = hal.get_alignment(HalMemType::HOST) + hal.get_alignment(HalMemType::HOST);
     uint32_t cached_stall_cmd_seqB = hal.get_alignment(HalMemType::HOST);
 
@@ -427,12 +423,18 @@ void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDevi
         HostMemDeviceCommand(uncached_stall_cmd_sizeB);
     // Empty wait command initialized here. Will get updated when program is enqueued.
     program_command_sequence.stall_command_sequences[UncachedStallSequenceIdx].add_dispatch_wait_with_prefetch_stall(
-        true, dispatch_message_addr, 0);
+        CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER | CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
+        0,
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(*sub_device_id),
+        0);
     // Empty wait command initialized here. Will get updated when program is enqueued.
     program_command_sequence.stall_command_sequences[CachedStallSequenceIdx] =
         HostMemDeviceCommand(cached_stall_cmd_seqB);
     program_command_sequence.stall_command_sequences[CachedStallSequenceIdx].add_dispatch_wait(
-        false, dispatch_message_addr, 0);
+        CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
+        0,
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(*sub_device_id),
+        0);
 }
 
 template <typename PackedSubCmd>
@@ -1395,10 +1397,6 @@ void assemble_device_commands(
 
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     auto sub_device_index = *sub_device_id;
-    uint32_t dispatch_message_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE) +
-        DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(sub_device_index);
     if (tt_metal::DispatchQueryManager::instance().dispatch_s_enabled()) {
         // dispatch_d signals dispatch_s to send the go signal, use a barrier if there are cores active
         uint16_t index_bitmask = 0;
@@ -1409,7 +1407,7 @@ void assemble_device_commands(
     } else {
         // Wait Noc Write Barrier, wait for binaries/configs and launch_msg to be written to worker cores
         if (program_transfer_info.num_active_cores > 0) {
-            device_command_sequence.add_dispatch_wait(true, dispatch_message_addr, 0, 0, false, false);
+            device_command_sequence.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0);
         }
     }
     go_msg_t run_program_go_signal;
@@ -1418,13 +1416,13 @@ void assemble_device_commands(
     run_program_go_signal.master_x = 0;
     run_program_go_signal.master_y = 0;
     run_program_go_signal.dispatch_message_offset =
-        (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(sub_device_index);
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_message_update_offset(sub_device_index);
     uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
     // Num Workers Resolved when the program is enqueued
     device_command_sequence.add_dispatch_go_signal_mcast(
         0,
         *reinterpret_cast<uint32_t*>(&run_program_go_signal),
-        dispatch_message_addr,
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(sub_device_index),
         num_noc_mcast_txns,
         num_noc_unicast_txns,
         noc_data_start_idx,
@@ -1619,7 +1617,7 @@ void update_program_dispatch_commands(
     run_program_go_signal.master_x = (uint8_t)dispatch_core.x;
     run_program_go_signal.master_y = (uint8_t)dispatch_core.y;
     run_program_go_signal.dispatch_message_offset =
-        (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(*sub_device_id);
+        DispatchMemMap::get(dispatch_core_type).get_dispatch_message_update_offset(*sub_device_id);
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->go_signal =
         *reinterpret_cast<uint32_t*>(&run_program_go_signal);
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
@@ -1852,13 +1850,9 @@ void reset_worker_dispatch_state_on_device(
             num_sub_devices;
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
-    bool clear_count = true;
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    uint32_t dispatch_message_base_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
     if (reset_launch_msg_state) {
         if (DispatchQueryManager::instance().dispatch_s_enabled()) {
             uint16_t index_bitmask = 0;
@@ -1874,15 +1868,13 @@ void reset_worker_dispatch_state_on_device(
         reset_launch_message_read_ptr_go_signal.master_y = (uint8_t)dispatch_core.y;
         for (uint32_t i = 0; i < num_sub_devices; ++i) {
             reset_launch_message_read_ptr_go_signal.dispatch_message_offset =
-                (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
-            uint32_t dispatch_message_addr =
-                dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
+                DispatchMemMap::get(dispatch_core_type).get_dispatch_message_update_offset(i);
             // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
             SubDeviceId sub_device_id(static_cast<uint8_t>(i));
             command_sequence.add_dispatch_go_signal_mcast(
                 expected_num_workers_completed[i],
                 *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal),
-                dispatch_message_addr,
+                DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(i),
                 device->num_noc_mcast_txns(sub_device_id),
                 device->num_noc_unicast_txns(sub_device_id),
                 device->noc_data_start_index(sub_device_id),
@@ -1893,17 +1885,23 @@ void reset_worker_dispatch_state_on_device(
     // this step, before sending kernel config data to workers or notifying dispatch_s that its safe to send the
     // go_signal. Clear the dispatch <--> worker semaphore, since trace starts at 0.
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
         SubDeviceId sub_device_id(static_cast<uint8_t>(i));
         uint32_t expected_num_workers = expected_num_workers_completed[i] +
                                         device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) +
                                         device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
         if (DispatchQueryManager::instance().distributed_dispatcher()) {
             command_sequence.add_dispatch_wait(
-                false, dispatch_message_addr, expected_num_workers, clear_count, false, true, 1);
+                CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
+                0,
+                DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(i),
+                expected_num_workers,
+                1);
         }
-        command_sequence.add_dispatch_wait(false, dispatch_message_addr, expected_num_workers, clear_count);
+        command_sequence.add_dispatch_wait(
+            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
+            0,
+            DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(i),
+            expected_num_workers);
     }
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
     manager.fetch_queue_reserve_back(cq_id);

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -86,10 +86,6 @@ void issue_trace_commands(
     auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
 
-    uint32_t dispatch_message_base_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-
     go_msg_t reset_launch_message_read_ptr_go_signal;
     reset_launch_message_read_ptr_go_signal.signal = RUN_MSG_RESET_READ_PTR;
     reset_launch_message_read_ptr_go_signal.master_x = (uint8_t)dispatch_core.x;
@@ -105,17 +101,15 @@ void issue_trace_commands(
             desc.num_traced_programs_needing_go_signal_multicast ? device->num_noc_mcast_txns(id) : 0;
         const auto& num_noc_unicast_txns =
             desc.num_traced_programs_needing_go_signal_unicast ? device->num_noc_unicast_txns(id) : 0;
-        reset_launch_message_read_ptr_go_signal.dispatch_message_offset =
-            (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(*id);
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(*id);
         auto index = *id;
+        reset_launch_message_read_ptr_go_signal.dispatch_message_offset =
+            DispatchMemMap::get(dispatch_core_type).get_dispatch_message_update_offset(index);
 
         // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
         command_sequence.add_dispatch_go_signal_mcast(
             expected_num_workers_completed[index],
             *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal),
-            dispatch_message_addr,
+            DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(index),
             num_noc_mcast_txns,
             num_noc_unicast_txns,
             noc_data_start_idx,
@@ -125,7 +119,6 @@ void issue_trace_commands(
     // Wait to ensure that all workers have reset their read_ptr. dispatch_d will stall until all workers have completed
     // this step, before sending kernel config data to workers or notifying dispatch_s that its safe to send the
     // go_signal. Clear the dispatch <--> worker semaphore, since trace starts at 0.
-    constexpr bool clear_count = true;
     for (const auto& [id, desc] : dispatch_md.trace_worker_descriptors) {
         auto index = *id;
         uint32_t expected_num_workers = expected_num_workers_completed[index];
@@ -135,14 +128,20 @@ void issue_trace_commands(
         if (desc.num_traced_programs_needing_go_signal_unicast) {
             expected_num_workers += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, id);
         }
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(index);
 
         if (DispatchQueryManager::instance().distributed_dispatcher()) {
             command_sequence.add_dispatch_wait(
-                false, dispatch_message_addr, expected_num_workers, clear_count, false, true, 1);
+                CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
+                0,
+                DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(index),
+                expected_num_workers,
+                1);
         }
-        command_sequence.add_dispatch_wait(false, dispatch_message_addr, expected_num_workers, clear_count);
+        command_sequence.add_dispatch_wait(
+            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
+            0,
+            DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(index),
+            expected_num_workers);
     }
 
     uint32_t page_size_log2 = __builtin_ctz(dispatch_md.trace_buffer_page_size);

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -116,8 +116,8 @@ uint32_t compute_build_key(chip_id_t device_id, uint8_t num_hw_cqs) {
 JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t device_id, uint8_t num_hw_cqs, bool is_fw) {
     // Get the dispatch message address for this device
     CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
-    uint32_t dispatch_message_addr = DispatchMemMap::get(dispatch_core_type, num_hw_cqs)
-                                         .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
+    uint32_t dispatch_message_addr =
+        DispatchMemMap::get(dispatch_core_type, num_hw_cqs).get_dispatch_message_addr_start();
 
     // Prepare the container for build states
     uint32_t num_build_states = hal.get_num_risc_processors();

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -121,6 +121,9 @@ void Hal::initialize_bh() {
     this->noc_stream_reg_space_size_ = NOC_STREAM_REG_SPACE_SIZE;
     this->noc_stream_remote_dest_buf_size_reg_index_ = STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX;
     this->noc_stream_remote_dest_buf_start_reg_index_ = STREAM_REMOTE_DEST_BUF_START_REG_INDEX;
+    this->noc_stream_remote_dest_buf_space_available_reg_index_ = STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX;
+    this->noc_stream_remote_dest_buf_space_available_update_reg_index_ =
+        STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX;
     this->coordinate_virtualization_enabled_ = COORDINATE_VIRTUALIZATION_ENABLED;
     this->virtual_worker_start_x_ = VIRTUAL_TENSIX_START_X;
     this->virtual_worker_start_y_ = VIRTUAL_TENSIX_START_Y;

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -129,6 +129,9 @@ void Hal::initialize_wh() {
     this->noc_stream_reg_space_size_ = NOC_STREAM_REG_SPACE_SIZE;
     this->noc_stream_remote_dest_buf_size_reg_index_ = STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX;
     this->noc_stream_remote_dest_buf_start_reg_index_ = STREAM_REMOTE_DEST_BUF_START_REG_INDEX;
+    this->noc_stream_remote_dest_buf_space_available_reg_index_ = STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX;
+    this->noc_stream_remote_dest_buf_space_available_update_reg_index_ =
+        STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX;
     this->coordinate_virtualization_enabled_ = COORDINATE_VIRTUALIZATION_ENABLED;
     this->virtual_worker_start_x_ = VIRTUAL_TENSIX_START_X;
     this->virtual_worker_start_y_ = VIRTUAL_TENSIX_START_Y;


### PR DESCRIPTION

### Ticket
#18746

### Problem description
Currently we can't use posted atomic increments on Blackhole, which causes a regression in performance since all the write acks seem to cause NOC congestion when sending DONE messages.

### What's changed
If we use auto-incrementing stream registers, we can continue to use posted transactions (in this case inline writes) on Blackhole to do the updates, since they're not affected by the same bug as posted (or inline) transactions to L1.

Since many cores are writing to the same destination, a stream register has better latency and can better handle the traffic than L1 could, reducing the done->GO latency by around 70 cycles.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
