### PR TITLE
Runtime host ID and command type data for dispatch commands

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -8,6 +8,7 @@ import re
 import inspect
 import pytest
 import subprocess
+from loguru import logger
 
 import pandas as pd
 import numpy as np
@@ -24,6 +25,7 @@ from tt_metal.tools.profiler.common import (
 from models.utility_functions import skip_for_grayskull, skip_for_blackhole
 
 PROG_EXMP_DIR = "programming_examples/profiler"
+TRACY_TESTS_DIR = "./tests/ttnn/tracy"
 
 
 def get_device_data(setupStr=""):
@@ -40,27 +42,52 @@ def get_device_data(setupStr=""):
     return devicesData
 
 
-def run_gtest_profiler_test(testbin, testname):
+def set_env_vars(**kwargs):
+    envVarsDict = {
+        "doSync": "TT_METAL_PROFILER_SYNC=1 ",
+        "doDispatchCores": "TT_METAL_DEVICE_PROFILER_DISPATCH=1 ",
+        "slowDispatch": "TT_METAL_SLOW_DISPATCH_MODE=1 ",
+        "dispatchFromEth": "WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ",
+    }
+    envVarsStr = " "
+    for arg, argVal in kwargs.items():
+        if argVal:
+            envVarsStr += envVarsDict[arg]
+    return envVarsStr
+
+
+def run_gtest_profiler_test(testbin, testname, doSync=False):
     clear_profiler_runtime_artifacts()
-    output = subprocess.check_output(
-        f"cd {TT_METAL_HOME} && {testbin} --gtest_filter={testname}", stderr=subprocess.STDOUT, shell=True
-    ).decode("UTF-8")
+    envVars = set_env_vars(doSync=doSync)
+    testCommand = f"cd {TT_METAL_HOME} && {envVars} {testbin} --gtest_filter={testname}"
+    print()
+    logger.info(f"Running: {testCommand}")
+    output = subprocess.check_output(testCommand, stderr=subprocess.STDOUT, shell=True).decode("UTF-8")
     print(output)
     if "SKIPPED" not in output:
         get_device_data()
 
 
-def run_device_profiler_test(testName=None, setupAutoExtract=False, slowDispatch=False):
+def run_device_profiler_test(
+    testName=None,
+    setupAutoExtract=False,
+    slowDispatch=False,
+    doSync=False,
+    doDispatchCores=False,
+    dispatchFromEth=False,
+):
     name = inspect.stack()[1].function
     testCommand = f"build/{PROG_EXMP_DIR}/{name}"
     if testName:
         testCommand = testName
-    print("Running: " + testCommand)
     clear_profiler_runtime_artifacts()
-    slowDispatchEnv = ""
-    if slowDispatch:
-        slowDispatchEnv = "TT_METAL_SLOW_DISPATCH_MODE=1 "
-    profilerRun = os.system(f"cd {TT_METAL_HOME} && {slowDispatchEnv}{testCommand}")
+    envVars = set_env_vars(
+        slowDispatch=slowDispatch, doSync=doSync, doDispatchCores=doDispatchCores, dispatchFromEth=dispatchFromEth
+    )
+    testCommand = f"cd {TT_METAL_HOME} && {envVars} {testCommand}"
+    print()
+    logger.info(f"Running: {testCommand}")
+    profilerRun = os.system(testCommand)
     assert profilerRun == 0
 
     setupStr = ""
@@ -187,85 +214,112 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "grayskull": {
-            "Tensix CQ Dispatch": 16,
-            "Tensix CQ Prefetch": 25,
-        },
-        "wormhole_b0": {
-            "Tensix CQ Dispatch": 16,
-            "Tensix CQ Prefetch": 25,
-        },
-        "blackhole": {
-            "Tensix CQ Dispatch": 16,
-            "Tensix CQ Prefetch": 25,
-        },
+        "Tensix CQ Dispatch": [16, 1501],
+        "Tensix CQ Prefetch": [25, 1990],
     }
 
-    ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
-    assert ENV_VAR_ARCH_NAME in REF_COUNT_DICT.keys()
+    def verify_stats(devicesData):
+        verifiedStat = []
+        for device, deviceData in devicesData["data"]["devices"].items():
+            for ref, counts in REF_COUNT_DICT.items():
+                if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
+                    verifiedStat.append(ref)
+                    res = False
+                    readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
+                    allowedRange = 20
+                    for count in counts:
+                        if count - allowedRange < readCount < count + allowedRange:
+                            res = True
+                            break
+                    assert (
+                        res
+                    ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
-    os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
+        statTypes = ["Dispatch", "Prefetch"]
+        statTypesSet = set(statTypes)
+        for statType in statTypes:
+            for stat in verifiedStat:
+                if statType in stat and statType in statTypesSet:
+                    statTypesSet.remove(statType)
+        assert len(statTypesSet) == 0
 
-    devicesData = run_device_profiler_test(setupAutoExtract=True)
+    verify_stats(run_device_profiler_test(setupAutoExtract=True, doDispatchCores=True))
 
-    stats = devicesData["data"]["devices"]["0"]["cores"]["DEVICE"]["analysis"]
+    verify_stats(
+        run_device_profiler_test(
+            testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
+            setupAutoExtract=True,
+            doDispatchCores=True,
+        )
+    )
 
-    verifiedStat = []
-    for stat in REF_COUNT_DICT[ENV_VAR_ARCH_NAME].keys():
-        if stat in stats.keys():
-            verifiedStat.append(stat)
-            assert stats[stat]["stats"]["Count"] == REF_COUNT_DICT[ENV_VAR_ARCH_NAME][stat], "Wrong Dispatch zone count"
-
-    statTypes = ["Dispatch", "Prefetch"]
-    statTypesSet = set(statTypes)
-    for statType in statTypes:
-        for stat in verifiedStat:
-            if statType in stat:
-                statTypesSet.remove(statType)
-    assert len(statTypesSet) == 0
-    os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+    verify_stats(
+        run_device_profiler_test(
+            testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_all_devices",
+            setupAutoExtract=True,
+            doDispatchCores=True,
+        )
+    )
 
 
+# Eth dispatch will be deprecated
 @skip_for_blackhole()
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [17, 12, 3896],
-        "Ethernet CQ Prefetch": [18, 1948],
+        "Ethernet CQ Dispatch": [17, 1567],
+        "Ethernet CQ Prefetch": [18, 1951],
     }
-    os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
     devicesData = run_device_profiler_test(
-        testName="WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest ./tests/ttnn/tracy/test_dispatch_profiler.py::test_with_ops",
+        testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
         setupAutoExtract=True,
+        doDispatchCores=True,
+        dispatchFromEth=True,
     )
     for device, deviceData in devicesData["data"]["devices"].items():
         for ref, counts in REF_COUNT_DICT.items():
             if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
+                res = False
+                readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
+                allowedRange = 20
+                for count in counts:
+                    if count - allowedRange < readCount < count + allowedRange:
+                        res = True
+                        break
                 assert (
-                    deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"] in counts
-                ), "Wrong ethernet dispatch zone count"
+                    res
+                ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
     devicesData = run_device_profiler_test(
-        testName="WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest ./tests/ttnn/tracy/test_dispatch_profiler.py::test_all_devices",
+        testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_all_devices",
         setupAutoExtract=True,
+        doDispatchCores=True,
+        dispatchFromEth=True,
     )
     for device, deviceData in devicesData["data"]["devices"].items():
         for ref, counts in REF_COUNT_DICT.items():
             if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
+                res = False
+                readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
+                allowedRange = 20
+                for count in counts:
+                    if count - allowedRange < readCount < count + allowedRange:
+                        res = True
+                        break
                 assert (
-                    deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"] in counts
-                ), "Wrong ethernet dispatch zone count"
-    os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+                    res
+                ), f"Wrong ethernet dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
 
 @skip_for_grayskull()
 def test_profiler_host_device_sync():
     TOLERANCE = 0.1
 
-    os.environ["TT_METAL_PROFILER_SYNC"] = "1"
     syncInfoFile = PROFILER_LOGS_DIR / PROFILER_HOST_DEVICE_SYNC_INFO
 
-    deviceData = run_device_profiler_test(testName="pytest ./tests/ttnn/tracy/test_profiler_sync.py::test_all_devices")
+    deviceData = run_device_profiler_test(
+        testName=f"pytest {TRACY_TESTS_DIR}/test_profiler_sync.py::test_all_devices", doSync=True
+    )
     reportedFreq = deviceData["data"]["deviceInfo"]["freq"] * 1e6
     assert os.path.isfile(syncInfoFile)
 
@@ -287,7 +341,9 @@ def test_profiler_host_device_sync():
                 1 - TOLERANCE
             ), f"Frequency ratio {deviceFreqRatio} is too small on device {device}"
 
-    deviceData = run_device_profiler_test(testName="pytest ./tests/ttnn/tracy/test_profiler_sync.py::test_with_ops")
+    deviceData = run_device_profiler_test(
+        testName=f"pytest {TRACY_TESTS_DIR}/test_profiler_sync.py::test_with_ops", doSync=1
+    )
     reportedFreq = deviceData["data"]["deviceInfo"]["freq"] * 1e6
     assert os.path.isfile(syncInfoFile)
 
@@ -300,8 +356,6 @@ def test_profiler_host_device_sync():
 
             assert freq < (reportedFreq * (1 + TOLERANCE)), f"Frequency {freq} is too large on device {device}"
             assert freq > (reportedFreq * (1 - TOLERANCE)), f"Frequency {freq} is too small on device {device}"
-
-    os.environ["TT_METAL_PROFILER_SYNC"] = "0"
 
 
 def test_timestamped_events():
@@ -375,12 +429,11 @@ def test_sub_device_profiler():
         "./build/test/tt_metal/unit_tests_dispatch",
         "CommandQueueSingleCardFixture.TensixTestSubDeviceBasicPrograms",
     )
-    os.environ["TT_METAL_PROFILER_SYNC"] = "1"
     run_gtest_profiler_test(
         "./build/test/tt_metal/unit_tests_dispatch",
         "CommandQueueSingleCardFixture.TensixActiveEthTestSubDeviceBasicEthPrograms",
+        doSync=True,
     )
-    os.environ["TT_METAL_PROFILER_SYNC"] = "0"
     run_gtest_profiler_test(
         "./build/test/tt_metal/unit_tests_dispatch",
         "CommandQueueSingleCardTraceFixture.TensixTestSubDeviceTraceBasicPrograms",

--- a/tests/ttnn/tracy/test_trace_runs.py
+++ b/tests/ttnn/tracy/test_trace_runs.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 1996800}], indirect=True)
+def test_with_ops(device):
+    device.enable_async(True)
+    ttnn.enable_program_cache(device)
+
+    torch.manual_seed(0)
+    m = 1024
+    k = 1024
+    n = 1024
+    torch_a = torch.randn((m, k), dtype=torch.bfloat16)
+    torch_b = torch.randn((k, n), dtype=torch.bfloat16)
+
+    a = ttnn.from_torch(torch_a)
+    b = ttnn.from_torch(torch_b)
+
+    a = ttnn.to_device(a, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    b = ttnn.to_device(b, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    a = ttnn.to_layout(a, ttnn.TILE_LAYOUT)
+    b = ttnn.to_layout(b, ttnn.TILE_LAYOUT)
+
+    ttnn.matmul(a, b, core_grid=ttnn.CoreGrid(y=8, x=8))
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    for i in range(100):
+        ttnn.matmul(a, b, core_grid=ttnn.CoreGrid(y=8, x=8))
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    for i in range(5):
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    ttnn.release_trace(device, tid)

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -261,7 +261,7 @@ struct CQDispatchDelayCmd {
 
 struct CQDispatchSetWriteOffsetCmd {
     uint8_t pad1;
-    uint16_t pad2;
+    uint16_t program_host_id;  // Program Host ID for upcoming commands. Used for profiling.
     uint32_t offset0;
     uint32_t offset1;
     uint32_t offset2;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1050,10 +1050,9 @@ void set_go_signal_noc_data() {
 static inline bool process_cmd_d(
     uint32_t& cmd_ptr, uint32_t* l1_cache, uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
     bool done = false;
-
 re_run_command:
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-
+    DeviceTimestampedData("process_cmd_d_dispatch", (uint32_t)cmd->base.cmd_id);
     switch (cmd->base.cmd_id) {
         case CQ_DISPATCH_CMD_WRITE_LINEAR:
             WAYPOINT("DWB");
@@ -1092,6 +1091,7 @@ re_run_command:
         case CQ_DISPATCH_CMD_WRITE_PACKED: {
             // DPRINT << "cmd_write_packed" << ENDL();
             uint32_t flags = cmd->write_packed.flags;
+            DeviceTimestampedData("subtype_data_dispatch", flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST);
             if (flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST) {
                 process_write_packed<true, CQDispatchWritePackedMulticastSubCmd>(
                     flags, l1_cache, block_noc_writes_to_clear, block_next_start_addr);
@@ -1155,7 +1155,8 @@ re_run_command:
         case CQ_DISPATCH_CMD_SET_WRITE_OFFSET:
             // DPRINT << "write offset: " << cmd->set_write_offset.offset0 << " " << cmd->set_write_offset.offset1 << "
             // "
-            //        << cmd->set_write_offset.offset2 << ENDL();
+            //        << cmd->set_write_offset.offset2 << " host id " << cmd->set_write_offset.program_host_id << ENDL();
+            DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.program_host_id);
             write_offset[0] = cmd->set_write_offset.offset0;
             write_offset[1] = cmd->set_write_offset.offset1;
             write_offset[2] = cmd->set_write_offset.offset2;
@@ -1193,6 +1194,7 @@ static inline bool process_cmd_h(
 
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
 
+    DeviceTimestampedData("process_cmd_h_dispatch", (uint32_t)cmd->base.cmd_id);
     switch (cmd->base.cmd_id) {
         case CQ_DISPATCH_CMD_WRITE_LINEAR_H:
             // DPRINT << "dispatch_h write_linear_h\n";

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -15,9 +15,12 @@
 #include "hostdevcommon/profiler_common.h"
 #include <rtoptions.hpp>
 #include <dev_msgs.h>
-#include "tracy/Tracy.hpp"
 #include <device.hpp>
 #include "tools/profiler/event_metadata.hpp"
+
+#include "hostdevcommon/profiler_common.h"
+#include "tracy/Tracy.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 
 #include "llrt.hpp"
 
@@ -280,24 +283,33 @@ void DeviceProfiler::logPacketData(
     std::string source_file = "";
     uint64_t source_line = 0;
 
+    nlohmann::json metaData;
+
+    if (hash_to_zone_src_locations.find((uint16_t)timer_id) != hash_to_zone_src_locations.end()) {
+        std::stringstream source_info(hash_to_zone_src_locations[timer_id]);
+        getline(source_info, zone_name, ',');
+        getline(source_info, source_file, ',');
+
+        std::string source_line_str;
+        getline(source_info, source_line_str, ',');
+        source_line = stoi(source_line_str);
+    }
+
     if ((packet_type == kernel_profiler::ZONE_START) || (packet_type == kernel_profiler::ZONE_END)) {
         tracy::TTDeviceEventPhase zone_phase = tracy::TTDeviceEventPhase::begin;
         if (packet_type == kernel_profiler::ZONE_END) {
             zone_phase = tracy::TTDeviceEventPhase::end;
         }
 
-        if (hash_to_zone_src_locations.find((uint16_t)timer_id) != hash_to_zone_src_locations.end()) {
-            std::stringstream source_info(hash_to_zone_src_locations[timer_id]);
-            getline(source_info, zone_name, ',');
-            getline(source_info, source_file, ',');
-
-            std::string source_line_str;
-            getline(source_info, source_line_str, ',');
-            source_line = stoi(source_line_str);
+        // TODO(MO) Until #14847 avoid attaching opID as the zone function name except for B and E FW
+        // This is to avoid generating 5 to 10 times more source locations which is capped at 32K
+        uint32_t tracy_run_host_id = run_host_id;
+        if (zone_name.find("BRISC-FW") == std::string::npos && zone_name.find("ERISC-FW") == std::string::npos) {
+            tracy_run_host_id = 0;
         }
 
         tracy::TTDeviceEvent event = tracy::TTDeviceEvent(
-            run_host_id,
+            tracy_run_host_id,
             device_id,
             core.x,
             core.y,
@@ -310,9 +322,48 @@ void DeviceProfiler::logPacketData(
             zone_phase);
 
         auto ret = device_events.insert(event);
+        this->current_zone_it = ret.first;
+        event.run_num = 1;
 
         if (!ret.second) {
             return;
+        }
+    }
+
+    if (packet_type == kernel_profiler::TS_DATA) {
+        if (this->current_zone_it != device_events.end()) {
+            // Check if we are in NCRISC Dispatch zone. If so, we could have gotten dispatch meta data packets
+            // These packets can amend parent zone's info
+            if (tracy::riscName[risc_num] == "NCRISC" &&
+                this->current_zone_it->zone_phase == tracy::TTDeviceEventPhase::begin &&
+                this->current_zone_it->zone_name.find("DISPATCH") != std::string::npos) {
+                if (zone_name.find("process_cmd") != std::string::npos) {
+                    this->current_dispatch_meta_data.cmd_type =
+                        fmt::format("{}", magic_enum::enum_name((CQDispatchCmdId)data));
+                    metaData["dispatch_command_type"] = this->current_dispatch_meta_data.cmd_type;
+                } else if (zone_name.find("runtime_host_id_dispatch") != std::string::npos) {
+                    this->current_dispatch_meta_data.worker_runtime_id = (uint32_t)data;
+                    metaData["workers_runtime_id"] = this->current_dispatch_meta_data.worker_runtime_id;
+                }
+                tracy::TTDeviceEvent event = tracy::TTDeviceEvent(
+                    this->current_dispatch_meta_data.worker_runtime_id,
+                    this->current_zone_it->chip_id,
+                    this->current_zone_it->core_x,
+                    this->current_zone_it->core_y,
+                    this->current_zone_it->risc,
+                    this->current_zone_it->marker,
+                    this->current_zone_it->timestamp,
+                    this->current_zone_it->line,
+                    this->current_zone_it->file,
+                    fmt::format(
+                        "{}:{}",
+                        this->current_dispatch_meta_data.worker_runtime_id,
+                        this->current_dispatch_meta_data.cmd_type),
+                    this->current_zone_it->zone_phase);
+                device_events.erase(this->current_zone_it);
+                auto ret = device_events.insert(event);
+                this->current_zone_it = ret.first;
+            }
         }
     }
 
@@ -333,7 +384,8 @@ void DeviceProfiler::logPacketData(
         zone_name,
         packet_type,
         source_line,
-        source_file);
+        source_file,
+        metaData);
 
     logNocTracePacketDataToJson(
         noc_trace_json_log,
@@ -368,9 +420,16 @@ void DeviceProfiler::logPacketDataToCSV(
     const std::string_view zone_name,
     kernel_profiler::PacketTypes packet_type,
     uint64_t source_line,
-    const std::string_view source_file) {
+    const std::string_view source_file,
+    const nlohmann::json& metaData) {
+    std::string metaDataStr = "";
+    if (!metaData.is_null()) {
+        metaDataStr = metaData.dump();
+        std::replace(metaDataStr.begin(), metaDataStr.end(), ',', ';');
+    }
+
     log_file_ofs << fmt::format(
-                        "{},{},{},{},{},{},{},{},{},{},{},{},{}",
+                        "{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
                         device_id,
                         core_x,
                         core_y,
@@ -383,7 +442,8 @@ void DeviceProfiler::logPacketDataToCSV(
                         zone_name,
                         magic_enum::enum_name(packet_type),
                         source_line,
-                        source_file)
+                        source_file,
+                        metaDataStr)
                  << std::endl;
 }
 
@@ -468,7 +528,7 @@ void DeviceProfiler::emitCSVHeader(
     log_file_ofs << "ARCH: " << get_string_lowercase(device_architecture)
                  << ", CHIP_FREQ[MHz]: " << device_core_frequency << std::endl;
     log_file_ofs << "PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], data, run ID, "
-                    "run host ID,  zone name, type, source line, source file"
+                    "run host ID,  zone name, type, source line, source file, meta data"
                  << std::endl;
 }
 
@@ -568,6 +628,8 @@ DeviceProfiler::DeviceProfiler(const bool new_logs) {
     if (new_logs) {
         std::filesystem::remove(log_path);
     }
+
+    this->current_zone_it = device_events.begin();
 #endif
 }
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -30,6 +30,14 @@ namespace tt {
 
 namespace tt_metal {
 
+struct DisptachMetaData {
+    // Dispatch command queue command type
+    std::string cmd_type = "";
+
+    // Worker's runtime id
+    uint32_t worker_runtime_id = 0;
+};
+
 class DeviceProfiler {
 private:
     // Device architecture
@@ -52,6 +60,12 @@ private:
 
     // Zone sourece locations
     std::unordered_set<std::string> zone_src_locations;
+
+    // Iterator on the current zone being processed
+    std::set<tracy::TTDeviceEvent>::iterator current_zone_it;
+
+    // Holding current data collected for dispatch command queue zones
+    DisptachMetaData current_dispatch_meta_data;
 
     // 32bit FNV-1a hashing
     uint32_t hash32CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261));
@@ -103,7 +117,8 @@ private:
         const std::string_view zone_name,
         kernel_profiler::PacketTypes packet_type,
         uint64_t source_line,
-        const std::string_view source_file);
+        const std::string_view source_file,
+        const nlohmann::json& metaData);
 
     // dump noc trace related profile data to json file
     void logNocTracePacketDataToJson(

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1669,6 +1669,8 @@ void update_program_dispatch_commands(
         (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset1));
     static constexpr uint32_t eth_l1_write_offset_offset =
         (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset2));
+    static constexpr uint32_t program_host_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
     // Update Stall Command Sequence
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Program binary is in flight. Issue a Prefetch Stall
@@ -1688,6 +1690,13 @@ void update_program_dispatch_commands(
         tensix_l1_write_offset_offset,
         &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
         sizeof(uint32_t));
+    // May truncate to fit the space.
+    static_assert(
+        std::is_same_v<uint16_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id)>,
+        "program_host_id type should be uint16_t");
+    uint16_t runtime_id = program.get_runtime_id();
+    cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
+        program_host_id_offset, &runtime_id, sizeof(runtime_id));
     if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
             eth_l1_write_offset_offset,

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events.cpp
@@ -4,11 +4,10 @@
 
 #include <cstdint>
 
-constexpr uint16_t THE_ID = 12345;
 void kernel_main() {
     for (int i = 0; i < LOOP_COUNT; i++) {
         DeviceZoneScopedN("TEST-FULL");
-        DeviceTimestampedData(THE_ID, i + ((uint64_t)1 << 32));
+        DeviceTimestampedData("TEST", i + ((uint64_t)1 << 32));
         DeviceRecordEvent(i);
 // Max unroll size
 #pragma GCC unroll 65534

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events_compute.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events_compute.cpp
@@ -6,12 +6,11 @@
 #include "compute_kernel_api.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
-constexpr uint16_t THE_ID = 12345;
 namespace NAMESPACE {
 void MAIN {
     for (int i = 0; i < LOOP_COUNT; i++) {
         DeviceZoneScopedN("TEST-FULL");
-        DeviceTimestampedData(THE_ID, i + ((uint64_t)1 << 32));
+        DeviceTimestampedData("TEST", i + ((uint64_t)1 << 32));
         DeviceRecordEvent(i);
 // Max unroll size
 #pragma GCC unroll 65534

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -32,10 +32,8 @@
     DO_PRAGMA(message(PROFILER_MSG_NAME(name))); \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
 
-#if defined(PROFILE_KERNEL) &&                                                                     \
-    (!defined(DISPATCH_KERNEL) ||                                                                  \
-     (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)) &&           \
-     (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)))
+#if defined(PROFILE_KERNEL) && \
+    (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)))
 namespace kernel_profiler {
 
 extern uint32_t wIndex;
@@ -412,24 +410,24 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 #include "noc_event_profiler.hpp"
 
 // Not dispatch
-#if (                            \
-    !defined(DISPATCH_KERNEL) || \
-    !(defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)))
+#if (!defined(DISPATCH_KERNEL))
 
 #define DeviceZoneScopedN(name)                                                \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
 
-#define DeviceTimestampedData(data_id, data) kernel_profiler::timeStampedData<data_id>(data);
+#define DeviceTimestampedData(name, data)                                          \
+    {                                                                              \
+        DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+        kernel_profiler::timeStampedData<hash>(data);                              \
+    }
 
 #define DeviceRecordEvent(event_id) kernel_profiler::recordEvent(event_id);
 
 // Dispatch and enabled
-#elif (                                                                                                 \
-    defined(DISPATCH_KERNEL) &&                                                                       \
-    (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)) && \
-    (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
+#elif (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
 
 #define DeviceZoneScopedN(name)                                                         \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                         \
@@ -437,9 +435,14 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
     kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
         kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH>();
 
-#define DeviceTimestampedData(data_id, data) kernel_profiler::timeStampedData<data_id, true>(data);
+#define DeviceTimestampedData(name, data)                                                       \
+    {                                                                                           \
+        DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                            \
+        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));              \
+        kernel_profiler::timeStampedData<hash, kernel_profiler::DoingDispatch::DISPATCH>(data); \
+    }
 
-#define DeviceRecordEvent(event_id) kernel_profiler::recordEvent<true>(event_id);
+#define DeviceRecordEvent(event_id) kernel_profiler::recordEvent<kernel_profiler::DoingDispatch::DISPATCH>(event_id);
 
 // Dispatch but disabled
 #else

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -210,7 +210,7 @@ def import_device_profile_log(logPath):
                 timerID = {"id": int(row[4].strip()), "zone_name": "", "type": "", "src_line": "", "src_file": ""}
                 timeData = int(row[5].strip())
                 statData = 0
-                if len(row) == 13:
+                if len(row) == 14:
                     statData = int(row[6].strip())
                     timerID["run_id"] = int(row[7].strip())
                     timerID["run_host_id"] = int(row[8].strip())
@@ -218,13 +218,7 @@ def import_device_profile_log(logPath):
                     timerID["type"] = row[10].strip()
                     timerID["src_line"] = int(row[11].strip())
                     timerID["src_file"] = row[12].strip()
-                elif len(row) == 12:
-                    statData = int(row[6].strip())
-                    timerID["run_id"] = int(row[7].strip())
-                    timerID["zone_name"] = row[8].strip()
-                    timerID["type"] = row[9].strip()
-                    timerID["src_line"] = int(row[10].strip())
-                    timerID["src_file"] = row[11].strip()
+                    timerID["meta_data"] = row[13].strip()
 
                 if chipID in devicesData["devices"].keys():
                     if core in devicesData["devices"][chipID]["cores"].keys():


### PR DESCRIPTION
### Ticket
#18811 

### Problem description
Dispatch zone scope do not have enough data to present what exactly the dispatch cores is doing

### What's changed
Use `DeviceTimestampedData` to attach command type and host runtime ID to be parsed by host and attached to CQ-Dispatch activity. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14084181858)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14070589220)
- [x] [Device Perf](https://github.com/tenstorrent/tt-metal/actions/runs/14084192346)
 
Sample tracy run: 



https://github.com/user-attachments/assets/d61d1bb8-7399-4aaf-9bd8-71b350188c9f




[Uploading TG_LLMA_nopcie.tracy.zip…]()

