### PR TITLE
[skip ci] Report PR Gate status

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -18,8 +18,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    branches:
-      - "main"
 
 concurrency:
   # Use github.run_id on main branch (or any protected branch)
@@ -33,15 +31,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-gate-build:
-    name: Build
+  build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     uses: ./.github/workflows/build-artifact.yaml
     with:
       version: "22.04"
 
   smoke-tests:
-    needs: pr-gate-build
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +47,22 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.pr-gate-build.outputs.ci-build-docker-image }}
-      package-artifact-name: ${{ needs.pr-gate-build.outputs.packages-artifact-name }}
+      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
+      package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
+
+  # GitHub has so many design limitations it's not even funny.
+  # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
+  workflow-status:
+    name: PR Gate Status
+    if: always() # Force this job to run so GH can 'see' it
+    needs: [build, smoke-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if all jobs passed
+        uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
+        with:
+          required-jobs: "build"
+          optional-jobs: "smoke-tests"
+        env:
+          NEEDS_CONTEXT: '${{ toJSON(needs) }}'


### PR DESCRIPTION
### Ticket
None

### Problem description
GH is being GH and we need to do extra legwork if we want to be able to make a 'workflow' mandatory rather than individual jobs.  Even more legwork if some jobs may be skipped because they would be redundant.

### What's changed
* Wired up a job to report the overall status of the workflow
* Tidied up job ID's/names since now we're not trying to make them useful to GH.
* De-restricted the trigger from PRs-to-main to any PR.  Not sure why I did that originally.
