### PR TITLE
Uniformly populate tensor specs per device, when allocating a mesh tensor

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -387,6 +387,7 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
 }
 
 bool MeshDevice::close() {
+    mesh_command_queues_.clear();
     sub_device_manager_tracker_.reset();
     scoped_devices_.reset();
     parent_mesh_.reset();

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -30,8 +30,11 @@ MemoryConfig DeviceStorage::memory_config() const {
         .shard_spec = shard_spec};
 }
 
-DeviceStorage::DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_) :
-    mesh_buffer(std::move(mesh_buffer_)) {}
+DeviceStorage::DeviceStorage(
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
+    std::map<distributed::MeshCoordinate, TensorSpec> specs_,
+    DistributedTensorConfig strategy_) :
+    strategy(std::move(strategy_)), mesh_buffer(std::move(mesh_buffer_)), specs(std::move(specs_)) {}
 
 void DeviceStorage::insert_buffer(const std::shared_ptr<Buffer>& buffer_) { this->buffer = buffer_; }
 

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -51,7 +51,10 @@ struct DeviceStorage {
 
     DeviceStorage() = default;
     DeviceStorage(std::shared_ptr<Buffer> buffer_);
-    DeviceStorage(std::shared_ptr<distributed::MeshBuffer> mesh_buffer_);
+    DeviceStorage(
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
+        std::map<distributed::MeshCoordinate, TensorSpec> specs_,
+        DistributedTensorConfig strategy_);
 
     MemoryConfig memory_config() const;
     void insert_buffer(const std::shared_ptr<Buffer>& buffer_);

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -833,7 +833,11 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
     TT_FATAL(
         tt::tt_metal::detail::InMainThread(), "Allocation of a tensor on mesh must be called from the main thread");
     auto mesh_buffer = tensor_impl::allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
-    DeviceStorage device_storage(std::move(mesh_buffer));
+    std::map<distributed::MeshCoordinate, TensorSpec> specs;
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+        specs.emplace(coord, tensor_spec);
+    }
+    DeviceStorage device_storage(std::move(mesh_buffer), specs, ReplicateTensor());
     return Tensor(std::move(device_storage), tensor_spec);
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Several failing tests that exercise a path that copies tensor into pre-allocated storage.

### What's changed
This aligns the behavior with the existing `MultiDeviceStorage` on main. See this in particular: https://github.com/tenstorrent/tt-metal/blob/bed8ae9a07af6d3b6cb06fbae8dc11a70dc82839/ttnn/cpp/ttnn/tensor/tensor.cpp#L1016-L1041


