### PR TITLE
Pass in Physical Device IDs to DeviceBoundThreadPool ctor

### DIFF
--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -8,8 +8,14 @@
 #include <memory>
 #include <optional>
 #include <thread>
-
+#include <vector>
 namespace tt::tt_metal {
+
+inline namespace v0 {
+
+class IDevice;
+
+}  // namespace v0
 
 class ThreadPool {
 public:
@@ -20,6 +26,12 @@ public:
 
 std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads);
 std::shared_ptr<ThreadPool> create_distributed_boost_thread_pool(int num_threads);
+// API accespting the number of threads to spawn in the pool. Will bind each thread to a CPU core, but the
+// binding strategy will not be NUMA aware. Used for testing and benchmarking host-code.
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads, uint32_t logical_cpu_offset = 0);
+// API accepting the physical devices the pool will be bound to. The threads will be bound to CPU cores in a
+// NUMA aware manner (will be "closest" to the device it serves). Used for production data-paths.
+std::shared_ptr<ThreadPool> create_device_bound_thread_pool(
+    const std::vector<tt::tt_metal::IDevice*>& physical_devices, uint32_t logical_cpu_offset = 0);
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
- `MeshCommandQueue` passes in the physical device ID to `DeviceBoundThreadPool::enqueue` 
- `DeviceBoundThreadPool::enqueue`  currently uses the physical device ID as the thread ID
- When a sub-mesh is spawned on a larger Physical Cluster, the thread-ids are not guaranteed to match the physical device IDs, which can lead to UB
- Add a `phys_device_to_thread_id_` translation to the `DeviceBoundThreadPool` class and use it to convert physical device IDs to thread IDs