### PR TITLE
#18843: Update BN sweep test

### DIFF
--- a/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
+++ b/tests/sweep_framework/sweeps/normalization/batch_norm/batch_norm.py
@@ -24,7 +24,7 @@ random.seed(0)
 
 parameters = {
     "BN_Testing": {
-        "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 16),
+        "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [2, 4, 64, 64], 4),
         "input_dtype": [ttnn.bfloat16, ttnn.float32],
         "input_layout": [ttnn.TILE_LAYOUT],
         "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],


### PR DESCRIPTION
### Ticket
#18843

### Problem description
Sweep test has 24k test. Hence, needs to be reduced

### What's changed
Reduced the test cases to 6144

### Results : 
<img width="1290" alt="Screenshot 2025-03-09 at 11 42 34 PM" src="https://github.com/user-attachments/assets/95a5983e-b1b9-489d-b588-3b3526e10259" />


### Checklist

- [x] [ttnn - Run sweeps](https://github.com/tenstorrent/tt-metal/actions/runs/13751265850)