### PR TITLE
#0: Add test group per op for L2 nightly

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -48,8 +48,12 @@ jobs:
       matrix:
         os: ["ubuntu-20.04"]
         test-group:
-          - name: ttnn nightly tests
-            cmd: pytest tests/ttnn/nightly/unit_tests -xv -m "not disable_fast_runtime_mode"
+          - name: ttnn nightly conv tests
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
+          - name: ttnn nightly matmul tests
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
+          - name: ttnn nightly pool tests
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
     name: ${{ matrix.test-group.name }}
     env:
       LOGURU_LEVEL: INFO

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -50,10 +50,13 @@ jobs:
         test-group:
           - name: ttnn nightly conv tests
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
+            owner: U052J2QDDKQ # Pavle Josipovic
           - name: ttnn nightly matmul tests
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
+            owner: U06Q7ESTFEV # Borys Bradel
           - name: ttnn nightly pool tests
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
+            owner: U052J2QDDKQ # Pavle Josipovic
     name: ${{ matrix.test-group.name }}
     env:
       LOGURU_LEVEL: INFO
@@ -87,7 +90,8 @@ jobs:
             generated/test_reports/
           prefix: "test_reports_"
       - uses: ./.github/actions/slack-report
-        if: ${{ failure() }}
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U06Q7ESTFEV # Borys Bradel
+          owner: ${{ matrix.test-group.owner }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18868

### Problem description
L2 job is running all ops in one combined test group.

### What's changed
Split L2 test groups per op owner, each with slack notify

### Checklist
- [x] L2 tests: https://github.com/tenstorrent/tt-metal/actions/runs/13754128386