### PR TITLE
Better tracking of per-device tensor spec

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -98,7 +98,11 @@ public:
     const ShardedBufferConfig& global_shard_spec() const;
     const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
 
-    Buffer* get_device_buffer(const MeshCoordinate& device_coord = MeshCoordinate(0, 0)) const;
+    Buffer* get_device_buffer(const MeshCoordinate& device_coord) const;
+
+    // TODO: Remove this method, once there is no need to interop MeshBuffer with Buffer.
+    Buffer* get_reference_buffer() const;
+
     uint32_t datum_size_bytes() const;
     Shape2D physical_shard_shape() const;
     std::pair<bool, bool> replicated_dims() const;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -167,6 +167,8 @@ Buffer* MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const 
     return buffers_.at(device_coord).get();
 }
 
+Buffer* MeshBuffer::get_reference_buffer() const { return buffers_.values().front().get(); }
+
 DeviceAddr MeshBuffer::size() const {
     return std::visit(
         tt::stl::overloaded{

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -255,7 +255,11 @@ void py_module(py::module& module) {
 
     module.def(
         "copy_host_to_device_tensor",
-        &ttnn::operations::core::copy_host_to_device_tensor,
+        [](const ttnn::Tensor& host_tensor, ttnn::Tensor device_tensor, QueueId cq_id = ttnn::DefaultQueueId) {
+            // Copies `device_tensor`, to be able to asynchronously populate metadata in tensor attributes, stored as a
+            // shared pointer.
+            tt::tt_metal::write_tensor(host_tensor, std::move(device_tensor), cq_id);
+        },
         py::arg("host_tensor"),
         py::arg("device_tensor"),
         py::arg("cq_id") = ttnn::DefaultQueueId);

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1523,9 +1523,10 @@ void pytensor_module(py::module& m_tensor) {
                     tt::stl::overloaded{
                         [](const DeviceStorage& s) -> uint32_t {
                             if (s.mesh_buffer) {
-                                return s.get_mesh_buffer()->address();
+                                return s.mesh_buffer->address();
                             } else {
-                                return s.get_buffer()->address();
+                                TT_FATAL(s.buffer != nullptr, "Tensor is not allocated.");
+                                return s.buffer->address();
                             }
                         },
                         [&](auto&&) -> uint32_t {

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -98,10 +98,6 @@ ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, MeshDevice*
     return tt::tt_metal::allocate_tensor_on_mesh(spec, mesh_device);
 }
 
-void copy_host_to_device_tensor(const ttnn::Tensor& host_tensor, ttnn::Tensor device_tensor, QueueId cq_id) {
-    tt::tt_metal::write_tensor(std::move(host_tensor), std::move(device_tensor), cq_id);
-}
-
 ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking, QueueId cq_id) {
     return tensor.cpu(blocking, cq_id);
 }

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -53,9 +53,6 @@ ttnn::Tensor allocate_tensor_on_device(
 ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, IDevice* device);
 ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, MeshDevice* device);
 
-void copy_host_to_device_tensor(
-    const ttnn::Tensor& host_tensor, ttnn::Tensor device_tensor, ttnn::QueueId cq_id = ttnn::DefaultQueueId);
-
 ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true, ttnn::QueueId cq_id = ttnn::DefaultQueueId);
 
 void deallocate(Tensor& tensor, bool force = true);

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -10,47 +10,49 @@ namespace tt::tt_metal {
 DeviceStorage::DeviceStorage(std::shared_ptr<Buffer> buffer_) { buffer = std::move(buffer_); }
 
 MemoryConfig DeviceStorage::memory_config() const {
-    if (this->mesh_buffer.get() != nullptr) {
-        auto buffer = this->mesh_buffer->get_device_buffer();
-        std::optional<ShardSpec> shard_spec = std::nullopt;
+    auto* buffer_to_use = get_buffer();
 
-        if (is_sharded(buffer->buffer_layout())) {
-            shard_spec = buffer->shard_spec().tensor_shard_spec;
-        }
-        return MemoryConfig{
-            .memory_layout = buffer->buffer_layout(), .buffer_type = buffer->buffer_type(), .shard_spec = shard_spec};
-    }
     std::optional<ShardSpec> shard_spec = std::nullopt;
-    if (is_sharded(this->buffer->buffer_layout())) {
-        shard_spec = this->buffer->shard_spec().tensor_shard_spec;
+
+    if (is_sharded(buffer_to_use->buffer_layout())) {
+        shard_spec = buffer_to_use->shard_spec().tensor_shard_spec;
     }
     return MemoryConfig{
-        .memory_layout = this->buffer->buffer_layout(),
-        .buffer_type = this->buffer->buffer_type(),
-        .shard_spec = shard_spec};
+        .memory_layout = buffer_to_use->buffer_layout(),
+        .buffer_type = buffer_to_use->buffer_type(),
+        .shard_spec = shard_spec,
+    };
 }
 
 DeviceStorage::DeviceStorage(
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-    std::map<distributed::MeshCoordinate, TensorSpec> specs_,
-    DistributedTensorConfig strategy_) :
-    strategy(std::move(strategy_)), mesh_buffer(std::move(mesh_buffer_)), specs(std::move(specs_)) {}
+    DistributedTensorConfig strategy_,
+    std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs_) :
+    strategy(std::move(strategy_)), specs(std::move(specs_)), mesh_buffer(std::move(mesh_buffer_)) {}
 
 void DeviceStorage::insert_buffer(const std::shared_ptr<Buffer>& buffer_) { this->buffer = buffer_; }
 
 Buffer* DeviceStorage::get_buffer() const {
-    if (this->mesh_buffer.get() == nullptr) {
-        TT_FATAL(this->buffer != nullptr, "Buffer is not allocated");
-        return this->buffer.get();
+    if (this->mesh_buffer.get() != nullptr) {
+        return this->mesh_buffer->get_reference_buffer();
     }
-    return this->mesh_buffer->get_device_buffer();
+    TT_FATAL(this->buffer != nullptr, "Buffer is not allocated");
+    return this->buffer.get();
 }
 
 bool DeviceStorage::is_allocated() const {
-    if (this->mesh_buffer.get() == nullptr) {
-        return this->buffer != nullptr && this->buffer->is_allocated();
+    if (this->mesh_buffer.get() != nullptr) {
+        return this->mesh_buffer->is_allocated();
     }
-    return this->mesh_buffer->is_allocated();
+    return this->buffer != nullptr && this->buffer->is_allocated();
+}
+
+IDevice* DeviceStorage::get_device() const {
+    if (this->mesh_buffer.get() != nullptr) {
+        return this->mesh_buffer->device();
+    }
+    TT_FATAL(this->buffer != nullptr, "Buffer is not allocated");
+    return this->buffer->device();
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -44,17 +44,17 @@ struct OwnedStorage {
 struct DeviceStorage {
     // TODO: come up with a better abstraction for this.
     DistributedTensorConfig strategy;
+    std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
 
     std::shared_ptr<Buffer> buffer;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
-    std::map<distributed::MeshCoordinate, TensorSpec> specs;
 
     DeviceStorage() = default;
     DeviceStorage(std::shared_ptr<Buffer> buffer_);
     DeviceStorage(
         std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
-        std::map<distributed::MeshCoordinate, TensorSpec> specs_,
-        DistributedTensorConfig strategy_);
+        DistributedTensorConfig strategy_,
+        std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs_);
 
     MemoryConfig memory_config() const;
     void insert_buffer(const std::shared_ptr<Buffer>& buffer_);
@@ -64,17 +64,8 @@ struct DeviceStorage {
     const auto attribute_values() const { return std::make_tuple(this->memory_config()); }
 
     bool is_allocated() const;
-    distributed::MeshBuffer* get_mesh_buffer() const {
-        TT_FATAL(mesh_buffer != nullptr, "Mesh buffer is not allocated");
-        return mesh_buffer.get();
-    }
-    IDevice* get_device() const {
-        if (mesh_buffer != nullptr) {
-            return mesh_buffer->device();
-        }
-        TT_FATAL(buffer != nullptr, "Buffer is not allocated");
-        return buffer->device();
-    }
+
+    IDevice* get_device() const;
 };
 
 using BorrowedBuffer = std::variant<

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -667,10 +667,6 @@ bool Tensor::is_scalar() const {
 }
 
 Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
-    if (distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device)) {
-        return allocate_tensor_on_mesh(tensor_spec, mesh_device);
-    }
-
     ZoneScoped;
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::create_device_tensor",
@@ -680,8 +676,13 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
         device,
         tensor_spec.tensor_layout().get_memory_config());
 
-    auto device_buffer = tensor_impl::allocate_buffer_on_device(device, tensor_spec);
-    auto output = Tensor(DeviceStorage{device_buffer}, tensor_spec);
+    Tensor output;
+    if (distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device)) {
+        output = allocate_tensor_on_mesh(tensor_spec, mesh_device);
+    } else {
+        auto device_buffer = tensor_impl::allocate_buffer_on_device(device, tensor_spec);
+        output = Tensor(DeviceStorage{device_buffer}, tensor_spec);
+    }
     output = tt::tt_metal::set_tensor_id(output);
 
     GraphTracker::instance().track_function_end(output);
@@ -833,11 +834,12 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
     TT_FATAL(
         tt::tt_metal::detail::InMainThread(), "Allocation of a tensor on mesh must be called from the main thread");
     auto mesh_buffer = tensor_impl::allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
-    std::map<distributed::MeshCoordinate, TensorSpec> specs;
+    std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
+    specs.reserve(mesh_device->shape().mesh_size());
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-        specs.emplace(coord, tensor_spec);
+        specs.emplace_back(coord, tensor_spec);
     }
-    DeviceStorage device_storage(std::move(mesh_buffer), specs, ReplicateTensor());
+    DeviceStorage device_storage(std::move(mesh_buffer), ReplicateTensor(), std::move(specs));
     return Tensor(std::move(device_storage), tensor_spec);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -837,7 +837,7 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
     std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
     specs.reserve(mesh_device->shape().mesh_size());
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-        specs.emplace_back(coord, tensor_spec);
+        specs.push_back(std::make_pair(coord, tensor_spec));
     }
     DeviceStorage device_storage(std::move(mesh_buffer), ReplicateTensor(), std::move(specs));
     return Tensor(std::move(device_storage), tensor_spec);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`std::map` doesn't need to be used in `DeviceStorage`.

### What's changed
Replace `std::map` with `std::vector` in the implementation of per-device tracking of tensor specs.

Also minor clean ups: 
* Explicit `MeshBuffer::get_reference_buffer`
* Remove `DeviceStorage::get_mesh_buffer` - it was used in one place and `struct` method is not necessary.
*  Move implementations of `DeviceStorage` methods from the header file into .cpp.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13754979078)
- [X] New/Existing tests provide coverage for changes