### PR TITLE
Implement a new op called Slice Write

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -62,6 +62,168 @@ def run_slice_rm_sharded(device, n, c, h, w):
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
 
 
+@pytest.mark.parametrize(
+    "dims, begins, ends",
+    [
+        [[16, 256, 256, 64], [0, 0, 0, 0], [1, 1, 256, 64]],
+        [[1, 256, 128, 64], [0, 128, 0, 0], [1, 256, 128, 64]],
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+def test_slice_write_four_dim(dims, begins, ends, layout, device):
+    strides = [1, 1, 1, 1]
+    torch.manual_seed(2005)
+    torch_output = torch.zeros(dims)
+    slices = []
+    for i in range(len(dims)):
+        slices.append(slice(begins[i], ends[i], strides[i]))
+
+    torch_input = torch_output[slices[0], slices[1], slices[2], slices[3]]
+    torch_input = torch.rand(torch_input.shape)
+
+    ttnn_output = ttnn.from_torch(torch_output, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_input = ttnn.to_memory_config(ttnn_input, ttnn.L1_MEMORY_CONFIG)
+    ttnn.slice_write(ttnn_input, ttnn_output, begins, ends, strides)
+    output = ttnn.to_torch(ttnn_output)
+    torch_output[slices[0], slices[1], slices[2], slices[3]] = torch_input
+    written_output = output[slices[0], slices[1], slices[2], slices[3]]
+    # assert False
+    assert_with_pcc(written_output, torch_input, 0.9999)
+    assert_with_pcc(torch_output, output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "dims, slice_dim, slice_size",
+    [
+        [[2, 256, 256, 64], 1, 128],
+        [[2, 256, 128, 32], 2, 16],
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+def test_slice_write_copy(device, dims, slice_dim, slice_size, layout):
+    strides = [1, 1, 1, 1]
+    torch.manual_seed(2005)
+    torch_input = torch.randn(dims)
+    ttnn_output = ttnn.zeros(dims, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)
+    for b in range(dims[0]):
+        for i in range(dims[slice_dim] // slice_size):
+            begins = [b, 0, 0, 0]
+            ends = [b + 1, dims[1], dims[2], dims[3]]
+            begins[slice_dim] = i * slice_size
+            ends[slice_dim] = (i + 1) * slice_size
+            this_ttnn_input = ttnn.from_torch(
+                torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]],
+                device=device,
+                layout=layout,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+
+            this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, ttnn.L1_MEMORY_CONFIG)
+            ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_input, output, 0.9999)
+
+
+def num_to_core_range_set(x):
+    assert x < 8 or x % 8 == 0
+    num_x = min(x, 8)
+    num_y = x // num_x
+    assert num_x * num_y == x
+    return ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(num_x - 1, num_y - 1),
+            ),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "dims, slice_size, cores",
+    [[[2, 256, 256, 64], 128, 16], [[2, 256, 128, 32], 16, 8], [[2, 256, 256, 128], 64, 64]],
+)
+@pytest.mark.parametrize("slice_dim", [1, 2])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_slice_write_height_sharded(device, dims, slice_dim, slice_size, cores, layout, orientation):
+    strides = [1, 1, 1, 1]
+    torch.manual_seed(2005)
+    torch_input = torch.randint(-10, 10, dims)
+    ttnn_output = ttnn.zeros(dims, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)
+    core_range = num_to_core_range_set(cores)
+    num_slices = dims[slice_dim] // slice_size
+    for i in range(num_slices):
+        begins = [0, 0, 0, 0]
+        ends = [dims[0], dims[1], dims[2], dims[3]]
+        begins[slice_dim] = i * slice_size
+        ends[slice_dim] = (i + 1) * slice_size
+        this_ttnn_input = ttnn.from_torch(
+            torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]],
+            device=device,
+            layout=layout,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        memory_config = ttnn.create_sharded_memory_config_(
+            this_ttnn_input.shape, core_range, ttnn.ShardStrategy.HEIGHT, orientation
+        )
+        # x = (i + 1)%num_slices
+        # begins[slice_dim] = (x) * slice_size
+        # ends[slice_dim] = (x + 1) * slice_size
+        this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, memory_config)
+        ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_input, output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "dims, slice_size, core_x, core_y",
+    [[[2, 256, 256, 64], 128, 8, 2], [[2, 256, 128, 32], 16, 4, 4], [[2, 32, 32, 128], 32, 2, 2]],
+)
+@pytest.mark.parametrize("slice_dim", [1, 2])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
+def test_slice_write_block_sharded(device, dims, slice_dim, slice_size, core_x, core_y, layout, orientation):
+    strides = [1, 1, 1, 1]
+    torch.manual_seed(2005)
+    torch_input = torch.randint(-10, 10, dims)
+    ttnn_output = ttnn.zeros(dims, device=device, layout=layout, dtype=ttnn.bfloat16)
+    ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)
+    num_slices = dims[slice_dim] // slice_size
+    for i in range(num_slices):
+        begins = [0, 0, 0, 0]
+        ends = [dims[0], dims[1], dims[2], dims[3]]
+        begins[slice_dim] = i * slice_size
+        ends[slice_dim] = (i + 1) * slice_size
+        this_ttnn_input = ttnn.from_torch(
+            torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]],
+            device=device,
+            layout=layout,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        core_grid = ttnn.CoreGrid(x=core_x, y=core_y)
+        memory_config = ttnn.create_sharded_memory_config_(
+            this_ttnn_input.shape, core_grid, ttnn.ShardStrategy.BLOCK, orientation
+        )
+        # x = (i + 1)%num_slices
+        # begins[slice_dim] = (x) * slice_size
+        # ends[slice_dim] = (x + 1) * slice_size
+        this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, memory_config)
+        ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+
+    output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_input, output, 0.9999)
+
+
 @pytest.mark.parametrize("n", [16])
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -152,6 +152,10 @@ def num_to_core_range_set(x):
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_slice_write_height_sharded(device, dims, slice_dim, slice_size, cores, layout, orientation):
+    core_grid = device.core_grid
+    if core_grid.x * core_grid.y < cores:
+        pytest.skip("Device does not have enough cores")
+
     strides = [1, 1, 1, 1]
     torch.manual_seed(2005)
     torch_input = torch.randint(-10, 10, dims)
@@ -192,6 +196,10 @@ def test_slice_write_height_sharded(device, dims, slice_dim, slice_size, cores, 
 @pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT])
 def test_slice_write_block_sharded(device, dims, slice_dim, slice_size, core_x, core_y, layout, orientation):
+    core_grid = device.core_grid
+    if core_grid.x < core_x or core_grid.y < core_y:
+        pytest.skip("Device does not have enough cores")
+
     strides = [1, 1, 1, 1]
     torch.manual_seed(2005)
     torch_input = torch.randint(-10, 10, dims)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -460,6 +460,9 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.cpp
@@ -881,6 +884,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reshape/view_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_pybind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/experimental/conv3d/conv3d_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/argmax/argmax_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.hpp"
+#include "ttnn/operations/experimental/slice_write/slice_write_pybind.hpp"
 #include "ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.hpp"
 #include "ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_pybind.hpp"
 #include "ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_pybind.hpp"
@@ -43,6 +44,8 @@
 namespace ttnn::operations::experimental {
 
 void py_module(py::module& module) {
+    slice_write::bind_slice_write(module);
+
     transformer::detail::bind_concatenate_heads(module);
     transformer::detail::bind_split_qkv(module);
     transformer::detail::bind_nlp_create_qkv_heads(module);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t stick_size = get_arg_val<uint32_t>(1);
+    uint32_t stick_size_offset = get_arg_val<uint32_t>(2);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(3);
+    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(4);
+    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(5);
+    uint32_t start_id = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+
+    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
+
+    uint32_t i_stick = start_id;
+    uint32_t sticks_read = 0;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+        cb_reserve_back(cb_id_in0, num_read_per_barrier);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            uint64_t src_noc_addr = get_noc_addr(i_stick, s0);
+            noc_async_read(src_noc_addr, l1_write_addr, stick_size);
+            l1_write_addr += stick_size_offset;
+            i_stick += 1;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_writer_interleaved.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t padded_stick_size = get_arg_val<uint32_t>(1);
+    const uint32_t unpadded_stick_size = get_arg_val<uint32_t>(2);
+    const uint32_t stick_size_offset = get_arg_val<uint32_t>(3);
+    const uint32_t num_dims = get_arg_val<uint32_t>(4);
+    const uint32_t start_id = get_arg_val<uint32_t>(5);
+    const uint32_t num_sticks_per_core = get_arg_val<uint32_t>(6);
+    const uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(7);
+    const uint32_t num_read_per_barrier = get_arg_val<uint32_t>(8);
+
+#ifdef DEBUG
+    DPRINT << "dst_addr: " << dst_addr << ENDL();
+    DPRINT << "padded_stick_size: " << padded_stick_size << ENDL();
+    DPRINT << "unpadded_stick_size: " << unpadded_stick_size << ENDL();
+    DPRINT << "stick_size_offset: " << stick_size_offset << ENDL();
+    DPRINT << "num_dims: " << num_dims << ENDL();
+    DPRINT << "start_id: " << start_id << ENDL();
+    DPRINT << "num_sticks_per_core: " << num_sticks_per_core << ENDL();
+    DPRINT << "num_sticks_per_core_read: " << num_sticks_per_core_read << ENDL();
+    DPRINT << "num_read_per_barrier: " << num_read_per_barrier << ENDL();
+#endif
+    tt_l1_ptr uint32_t* num_unpadded_sticks = (tt_l1_ptr uint32_t*)(get_arg_addr(9));
+    volatile tt_l1_ptr uint32_t* num_padded_sticks = num_unpadded_sticks + num_dims;
+    volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+#ifdef DEBUG
+    DPRINT << "num_unpadded_sticks: " << num_unpadded_sticks[0] << " " << num_unpadded_sticks[1] << " "
+           << num_unpadded_sticks[2] << " " << num_unpadded_sticks[3] << " " << ENDL();
+    DPRINT << "num_padded_sticks: " << num_padded_sticks[0] << " " << num_padded_sticks[1] << " "
+           << num_padded_sticks[2] << " " << num_padded_sticks[3] << " " << ENDL();
+    DPRINT << "Out CB Page size: " << get_local_cb_interface(cb_id_out0).fifo_page_size << ENDL();
+#endif
+    constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;
+
+    const InterleavedAddrGen<dst0_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = padded_stick_size};
+
+    uint32_t dst_stick_id = start_id;
+    uint32_t sticks_read = 0;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+        cb_wait_front(cb_id_out0, num_read_per_barrier);
+        uint32_t src_buffer_l1_addr = get_read_ptr(cb_id_out0);
+
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s0);
+            noc_async_write(src_buffer_l1_addr, dst_noc_addr, unpadded_stick_size);
+            src_buffer_l1_addr += stick_size_offset;
+            dst_stick_id++;
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    dst_stick_id += num_padded_sticks[j];
+                } else {
+                    break;
+                }
+            }
+        }
+        noc_async_read_barrier();
+        cb_pop_front(cb_id_out0, num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/constants.hpp>
+#include "slice_write_op.hpp"
+#include "slice_write_program_factory.hpp"
+#include "tt-metalium/assert.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental {
+
+void SliceWriteDeviceOperation::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    using namespace tt::constants;
+    const bool has_step = std::any_of(this->step.cbegin(), this->step.cend(), [](uint32_t s) { return s != 1; });
+    const auto& input_tensor_a = input_tensors.at(0);
+    const auto& output_tensor = output_tensors.at(0).value();
+    const auto output_padded_shape = output_tensor.get_padded_shape();
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(
+        input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() &&
+            output_padded_shape.rank() == this->slice_start.rank() &&
+            this->slice_start.rank() == this->slice_end.rank(),
+        "Ranks of input tensor, output_tensor, slice start and slice end should be equal. Got {} {} {} {}",
+        input_tensor_a.get_padded_shape().rank(),
+        output_padded_shape.rank(),
+        this->slice_start.rank(),
+        this->slice_end.rank());
+    for (uint32_t i = 0; i < output_padded_shape.rank(); i++) {
+        TT_FATAL(
+            this->slice_start[i] < output_padded_shape[i],
+            "Start is outside the bounds of the output tensor for index {}. Got {}. Size {}",
+            i,
+            this->slice_start[i],
+            output_padded_shape[i]);
+        TT_FATAL(
+            this->slice_end[i] <= output_padded_shape[i],
+            "Ends {} must be less than or equal to the shape of the tensor {}",
+            this->slice_end[i],
+            output_padded_shape[i]);
+        // Check if start shape is <= end shape
+        TT_FATAL(
+            this->slice_start[i] <= this->slice_end[i],
+            "Slice start {} should be less than slice end {}",
+            this->slice_start[i],
+            this->slice_end[i]);
+    }
+    TT_FATAL(
+        this->slice_start[-1] == 0,
+        "Slice write doesn't support slicing along the last dimension. Slice start [-1] should be 0");
+    TT_FATAL(
+        this->slice_end[-1] == output_padded_shape[-1],
+        "Slice write doesn't support slicing along the last dimension. Slice end [-1] should be equal to output shape "
+        "[-1]");
+}
+
+std::vector<ttnn::Tensor> SliceWriteDeviceOperation::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<ttnn::Tensor>& output_tensors) const {
+    TT_FATAL(output_tensors.size() == 1, "A Single Output tensor should be provided to Slice Write.");
+    return output_tensors;
+}
+
+std::vector<ttnn::TensorSpec> SliceWriteDeviceOperation::compute_output_specs(
+    const std::vector<Tensor>& input_tensors) const {
+    return {input_tensors[0].get_tensor_spec()};
+}
+
+operation::ProgramWithCallbacks SliceWriteDeviceOperation::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+
+    return detail::slice_write_multi_core(
+        input_tensor_a, output_tensor, this->slice_start, this->slice_end, this->step);
+}
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_op.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn::operations::experimental {
+
+struct SliceWriteDeviceOperation {
+    const ttnn::Shape slice_start;
+    const ttnn::Shape slice_end;
+    const ttnn::Shape step;
+
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+
+    std::vector<ttnn::Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<ttnn::Tensor>& output_tensors) const;
+
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -1,0 +1,640 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "optional"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/logger.hpp"
+#include "ttnn/operations/math.hpp"
+#include <cstdint>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/hal_exp.hpp>
+
+#include "slice_write_op.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_op.hpp"
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::detail {
+
+using SliceWriteRuntimeArgs = std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>>;
+SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    const CoreRangeSet& core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_sticks_per_core_group_1,
+    uint32_t num_sticks_per_core_group_2,
+    uint32_t max_read_size) {
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.get_logical_shape();
+    auto output_shape = output_tensor.get_logical_shape();
+
+    TT_FATAL(
+        input_tensor.element_size() == output_tensor.element_size(),
+        "Input & output should have the same element size");
+    TT_FATAL(input_tensor.dtype() == output_tensor.dtype(), "Input & output should have the same dtype");
+
+    uint32_t output_row_size_bytes = output_shape[-1] * input_tensor.element_size();
+    uint32_t input_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    // This currently just matches tile version where we iterate over the row as well
+    num_input_sticks_per_dim[0] = 1;
+    num_output_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = input_shape[-(i + 1)];
+        uint32_t num_total_dim = output_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_input_sticks_per_dim[i] = num_unpadded_dim;
+        num_output_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    std::string unpadded_sticks_str = "";
+    for (auto& i : num_input_sticks_per_dim) {
+        unpadded_sticks_str += std::to_string(i) + ", ";
+    }
+    std::string padded_sticks_str = "";
+    for (auto& i : num_output_sticks_per_dim) {
+        padded_sticks_str += std::to_string(i) + ", ";
+    }
+    std::string accumulated_str = "";
+    for (auto& i : accumulated_total_per_dim) {
+        accumulated_str += std::to_string(i) + ", ";
+    }
+
+    using namespace tt::tt_metal::experimental;
+    auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    uint32_t input_row_size_bytes_offset = tt::round_up(input_row_size_bytes, src_buffer_alignment);
+    TT_FATAL(
+        output_tensor_start[-1] == 0,
+        "slice_write expects output start for the last dimension to be 0. Got {}",
+        output_tensor_start[-1]);
+
+    std::vector<uint32_t> common_writer_kernel_args = {
+        output_buffer->address() + output_tensor_start[-1] * output_tensor.element_size(),
+        output_row_size_bytes,
+        input_row_size_bytes,
+        input_row_size_bytes_offset,
+        num_dims,
+        0,
+        0,
+        0,
+        0};
+
+    common_writer_kernel_args.insert(
+        common_writer_kernel_args.end(), num_input_sticks_per_dim.begin(), num_input_sticks_per_dim.end());
+    common_writer_kernel_args.insert(
+        common_writer_kernel_args.end(), num_output_sticks_per_dim.begin(), num_output_sticks_per_dim.end());
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(output_tensor, output_tensor_start);
+
+    for (uint32_t i = 0, num_sticks_read = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_sticks_per_core;
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_2;
+        } else {
+            // no-op
+            num_sticks_per_core = 0;
+        }
+
+        // issue more reads before calling barrier
+        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+        if (num_sticks_per_core != 0) {
+            num_sticks_per_core_read =
+                tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core, input_row_size_bytes_offset, max_read_size);
+            num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
+        }
+
+        id_per_dim[0] = num_sticks_read % num_input_sticks_per_dim[0];
+        uint32_t unpadded_written = num_sticks_read / num_input_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = unpadded_written % num_input_sticks_per_dim[j];
+            unpadded_written = unpadded_written / num_input_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+        std::vector<uint32_t> writer_kernel_args = common_writer_kernel_args;
+
+        uint32_t addr_offset = 5;  // output buffer addr, output_row_size_bytes, input_row_size_bytes, num_dims
+        writer_kernel_args[addr_offset++] = start_id;
+        writer_kernel_args[addr_offset++] = num_sticks_per_core;
+        writer_kernel_args[addr_offset++] = num_sticks_per_core_read;
+        writer_kernel_args[addr_offset] = num_read_per_barrier;
+        writer_kernel_args.insert(writer_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+
+        std::vector<uint32_t> reader_kernel_args = {
+            input_buffer->address(),
+            input_row_size_bytes,
+            input_row_size_bytes_offset,
+            num_sticks_per_core,
+            num_sticks_per_core_read,
+            num_read_per_barrier,
+            num_sticks_read,
+            0};
+        num_sticks_read += num_sticks_per_core;
+        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+    }
+
+    return ret_val;
+}
+
+SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    const std::vector<CoreCoord>& cores,
+    uint32_t max_read_size) {
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.get_logical_shape();
+    auto output_shape = output_tensor.get_logical_shape();
+
+    TT_FATAL(
+        input_tensor.element_size() == output_tensor.element_size(),
+        "Input & output should have the same element size");
+    TT_FATAL(input_tensor.dtype() == output_tensor.dtype(), "Input & output should have the same dtype");
+
+    TT_FATAL(input_tensor.shard_spec().has_value(), "Input tensor should be sharded");
+    auto shard_spec = input_tensor.shard_spec().value();
+    auto input_cores = shard_spec.grid;
+    auto input_shard_shape = shard_spec.shape;
+    uint32_t output_row_size_bytes = output_shape[-1] * input_tensor.element_size();
+    uint32_t input_row_size_bytes = input_shard_shape[1] * input_tensor.element_size();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    // This currently just matches tile version where we iterate over the row as well
+    num_input_sticks_per_dim[0] = 1;
+    num_output_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = input_shape[-(i + 1)];
+        uint32_t num_total_dim = output_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_input_sticks_per_dim[i] = num_unpadded_dim;
+        num_output_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    std::string unpadded_sticks_str = "";
+    for (auto& i : num_input_sticks_per_dim) {
+        unpadded_sticks_str += std::to_string(i) + ", ";
+    }
+    std::string padded_sticks_str = "";
+    for (auto& i : num_output_sticks_per_dim) {
+        padded_sticks_str += std::to_string(i) + ", ";
+    }
+    std::string accumulated_str = "";
+    for (auto& i : accumulated_total_per_dim) {
+        accumulated_str += std::to_string(i) + ", ";
+    }
+
+    using namespace tt::tt_metal::experimental;
+    auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    uint32_t input_row_size_bytes_offset = tt::round_up(input_row_size_bytes, src_buffer_alignment);
+    TT_FATAL(
+        output_tensor_start[-1] == 0,
+        "slice_write expects output start for the last dimension to be 0. Got {}",
+        output_tensor_start[-1]);
+
+    tt::log_debug("Output Buffer adddress: {}", output_buffer->address());
+    std::vector<uint32_t> common_writer_kernel_args = {
+        output_buffer->address() + output_tensor_start[-1] * output_tensor.element_size(),
+        output_row_size_bytes,
+        input_row_size_bytes,
+        input_row_size_bytes_offset,
+        num_dims,
+        0,
+        0,
+        0,
+        0};
+
+    common_writer_kernel_args.insert(
+        common_writer_kernel_args.end(), num_input_sticks_per_dim.begin(), num_input_sticks_per_dim.end());
+    common_writer_kernel_args.insert(
+        common_writer_kernel_args.end(), num_output_sticks_per_dim.begin(), num_output_sticks_per_dim.end());
+
+    auto num_cores_total = cores.size();
+
+    bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    bool is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+
+    auto total_num_input_sticks = input_tensor.volume() / input_shape[-1];
+    const auto num_sticks_per_core = shard_spec.shape[0];
+    // issue more reads before calling barrier
+    const uint32_t num_sticks_per_core_read =
+        tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core, input_row_size_bytes_offset, max_read_size);
+    const uint32_t num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
+
+    tt::log_debug(
+        "num_sticks_per_core = {}, num_sticks_per_core_read = {}, num_read_per_barrier = {}",
+        num_sticks_per_core,
+        num_sticks_per_core_read,
+        num_read_per_barrier);
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(output_tensor, output_tensor_start);
+    uint32_t core_index = 0;
+    for (const auto& core : cores) {
+        uint32_t core_w_index = 0;
+        uint32_t core_h_index = core_index;
+        if (is_block_sharded) {
+            core_w_index = rm_orientation ? core.x : core.y;
+            core_h_index = rm_orientation ? core.y : core.x;
+        }
+        tt::log_debug(" Core : {}", core);
+        const uint32_t num_sticks_read = core_h_index * num_sticks_per_core;
+        const uint32_t width_offset = core_w_index * input_row_size_bytes;
+
+        id_per_dim[0] = num_sticks_read % num_input_sticks_per_dim[0];
+        uint32_t unpadded_written = num_sticks_read / num_input_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = unpadded_written % num_input_sticks_per_dim[j];
+            unpadded_written = unpadded_written / num_input_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+        std::vector<uint32_t> writer_kernel_args = common_writer_kernel_args;
+        writer_kernel_args[0] += width_offset;
+        tt::log_debug("Output address: {}", writer_kernel_args[0]);
+        tt::log_debug("Output Start ID: {}\n", start_id);
+
+        uint32_t addr_offset = 5;  // output buffer addr, output_row_size_bytes, input_row_size_bytes, num_dims
+        writer_kernel_args[addr_offset++] = start_id;
+        writer_kernel_args[addr_offset++] = num_sticks_per_core;
+        writer_kernel_args[addr_offset++] = num_sticks_per_core;
+        writer_kernel_args[addr_offset] = num_read_per_barrier;
+        writer_kernel_args.insert(writer_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+
+        std::vector<uint32_t> reader_kernel_args = {num_sticks_per_core};
+        ret_val[core_index] = {reader_kernel_args, writer_kernel_args};
+        core_index++;
+    }
+
+    return ret_val;
+}
+
+operation::ProgramWithCallbacks slice_write_rm_sharded_input_multi_core(
+    const Tensor& input,
+    const Tensor& output,
+    const ttnn::Shape& output_tensor_start,
+    const ttnn::Shape& output_tensor_end) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    // This should allocate a DRAM buffer on the device
+    tt::tt_metal::IDevice* device = input.device();
+    const auto output_padded_shape = output.get_padded_shape();
+    const auto input_padded_shape = input.get_padded_shape();
+
+    auto input_shape = input.get_logical_shape();
+    auto output_shape = output.get_logical_shape();
+
+    uint32_t num_unpadded_sticks = input.volume() / input_shape[-1];
+
+    TT_FATAL(input.shard_spec().has_value(), "Input tensor should be sharded");
+    TT_FATAL(
+        input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+            input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED,
+        "Input tensor should be height or block sharded");
+    bool is_height_sharded = input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    bool is_block_sharded = input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    auto shard_spec = input.shard_spec().value();
+    auto input_cores = shard_spec.grid;
+    bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+
+    tt::log_debug("Input cores = {}", input_cores);
+    tt::log_debug("Input shard spec = {}", shard_spec);
+
+    auto total_num_input_sticks = input.volume() / input_shape[-1];
+    auto num_input_sticks_per_core = shard_spec.shape[0];
+
+    uint32_t output_row_size_bytes = output_shape[-1] * output.element_size();
+    uint32_t input_row_size_bytes = shard_spec.shape[1] * input.element_size();
+
+    uint32_t max_read_size = 4096;
+    if (is_height_sharded) {
+        TT_FATAL(output_row_size_bytes == input_row_size_bytes, "Input & output should have the same row size");
+    }
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    const uint32_t src0_cb_index = tt::CBIndex::c_0;
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    num_input_sticks_per_dim[0] = 1;
+    num_output_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = input_shape[-(i + 1)];
+        uint32_t num_total_dim = output_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_input_sticks_per_dim[i] = num_unpadded_dim;
+        num_output_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    TT_FATAL(
+        input_cb_data_format == output_cb_data_format,
+        "Input & output should have the same data format, {} , {}",
+        input_cb_data_format,
+        output_cb_data_format);
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_input_sticks_per_core * input_row_size_bytes, {{src0_cb_index, input_cb_data_format}})
+            .set_page_size(src0_cb_index, input_row_size_bytes)
+            .set_globally_allocated_address(*input.buffer());
+
+    auto input_cb_handle = tt::tt_metal::CreateCircularBuffer(program, input_cores, cb_src0_config);
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
+    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
+        input_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/"
+        "slice_write_writer_interleaved.cpp",
+        input_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
+
+    const auto iter_cores = corerange_to_cores(input_cores, std::nullopt, rm_orientation);
+
+    auto all_runtime_args =
+        get_slice_write_runtime_args_rm_sharded_input(input, output, output_tensor_start, iter_cores, max_read_size);
+
+    uint32_t i = 0;
+    for (const auto& core : iter_cores) {
+        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+        i++;
+    }
+
+    auto override_runtime_args_callback = [iter_cores,
+                                           unary_reader_kernel_id,
+                                           unary_writer_kernel_id,
+                                           output_tensor_start,
+                                           max_read_size,
+                                           input_cb_handle](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>&,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto src_tensor = input_tensors.at(0);
+        auto dst_tensor = output_tensors.at(0);
+
+        UpdateDynamicCircularBufferAddress(program, input_cb_handle, *src_tensor.buffer());
+
+        auto all_runtime_args = get_slice_write_runtime_args_rm_sharded_input(
+            src_tensor, dst_tensor, output_tensor_start, iter_cores, max_read_size);
+
+        uint32_t i = 0;
+        for (const auto& core : iter_cores) {
+            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+            i++;
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
+    const Tensor& input,
+    const Tensor& output,
+    const ttnn::Shape& output_tensor_start,
+    const ttnn::Shape& output_tensor_end) {
+    const ttnn::Shape output_shape = output.get_padded_shape();
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+    // This should allocate a DRAM buffer on the device
+    tt::tt_metal::IDevice* device = input.device();
+    const auto output_padded_shape = output.get_padded_shape();
+    const auto input_padded_shape = input.get_padded_shape();
+
+    uint32_t num_unpadded_sticks = input.volume() / input.get_padded_shape()[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+
+    uint32_t output_row_size_bytes = output_padded_shape[-1] * output.element_size();
+    uint32_t input_row_size_bytes = input_padded_shape[-1] * input.element_size();
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    uint32_t src_stick_size = input_row_size_bytes;
+    uint32_t dst_stick_size = output_row_size_bytes;
+
+    uint32_t src0_cb_index = 0;
+    uint32_t max_read_size = 4096;
+
+    auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::experimental::hal::get_dram_alignment()
+                                    : ::experimental::hal::get_l1_alignment();
+    auto dst_buffer_alignment = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::experimental::hal::get_dram_alignment()
+                                    : ::experimental::hal::get_l1_alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+
+    // if begins is not aligned then we need to pad the cb size, so that we can read from the nearest aligned address
+    uint32_t begins_bytes = output_tensor_start[-1] * input.element_size();
+    uint32_t misalignment = begins_bytes % src_buffer_alignment;
+
+    if (misalignment != 0) {
+        alignment *= 2;
+    }
+
+    uint32_t cb_page_size = tt::round_up(input_row_size_bytes, alignment);
+
+    uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
+                                                                                         : num_sticks_per_core_group_2;
+    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+    if (num_input_pages != 0) {
+        num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(num_input_pages, cb_page_size, max_read_size);
+        num_read_per_barrier = num_input_pages / num_sticks_per_core_read;
+    }
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_read_per_barrier * 2 * cb_page_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, cb_page_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
+
+    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_cb_index, src0_is_dram};
+    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/"
+        "slice_write_reader_interleaved.cpp",
+        total_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args_vec));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/"
+        "slice_write_writer_interleaved.cpp",
+        total_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
+
+    auto all_runtime_args = get_slice_write_runtime_args_rm(
+        input,
+        output,
+        output_tensor_start,
+        num_cores_total,
+        num_cores,
+        num_cores_y,
+        core_group_1,
+        core_group_2,
+        num_sticks_per_core_group_1,
+        num_sticks_per_core_group_2,
+        max_read_size);
+
+    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+    }
+
+    auto override_runtime_args_callback =
+        [unary_reader_kernel_id, unary_writer_kernel_id, compute_with_storage_grid_size, max_read_size](
+            const void* operation,
+            const Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            auto src_tensor = input_tensors.at(0);
+            auto dst_tensor = output_tensors.at(0);
+            uint32_t num_cores_x = compute_with_storage_grid_size.x;
+            uint32_t num_cores_y = compute_with_storage_grid_size.y;
+            uint32_t num_cores_total = num_cores_x * num_cores_y;
+            uint32_t num_unpadded_sticks = src_tensor.volume() / src_tensor.get_padded_shape()[-1];
+            auto
+                [num_cores,
+                 all_cores,
+                 core_group_1,
+                 core_group_2,
+                 num_sticks_per_core_group_1,
+                 num_sticks_per_core_group_2] =
+                    tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+
+            const auto tensor_start =
+                static_cast<const ttnn::operations::experimental::SliceWriteDeviceOperation*>(operation)->slice_start;
+            auto all_runtime_args = get_slice_write_runtime_args_rm(
+                src_tensor,
+                dst_tensor,
+                tensor_start,
+                num_cores_total,
+                num_cores,
+                num_cores_y,
+                core_group_1,
+                core_group_2,
+                num_sticks_per_core_group_1,
+                num_sticks_per_core_group_2,
+                max_read_size);
+
+            for (uint32_t i = 0, num_tiles_written = 0; i < num_cores_total; i++) {
+                CoreCoord core = {i / num_cores_y, i % num_cores_y};
+                SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+                SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks slice_write_multi_core(
+    const Tensor& a,
+    const Tensor& output,
+    const ttnn::Shape& output_tensor_start,
+    const ttnn::Shape& output_tensor_end,
+    const ttnn::Shape& step) {
+    bool has_step = false;
+    for (int i = 0; i < step.size(); i++) {
+        if (step[i] != 1) {
+            has_step = true;
+            break;
+        }
+    }
+    TT_FATAL(!output.is_sharded(), "Sharded output is not supported for slice_write operation");
+    TT_FATAL(!has_step, "Step is not supported for slice_write operation");
+    TT_FATAL(a.get_layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for slice_write operation");
+    if (a.is_sharded()) {  // Supports Height & Block Sharding
+        return slice_write_rm_sharded_input_multi_core(a, output, output_tensor_start, output_tensor_end);
+    } else if (!a.is_sharded()) {
+        return slice_write_rm_interleaved_multi_core(a, output, output_tensor_start, output_tensor_end);
+    }
+    TT_THROW("Unsupport input memory layout for slice_write operation");
+}
+
+}  // namespace ttnn::operations::experimental::detail

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -2,18 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "optional"
-#include "tt-metalium/assert.hpp"
-#include "tt-metalium/buffer_constants.hpp"
-#include "tt-metalium/core_coord.hpp"
-#include "tt-metalium/logger.hpp"
-#include "ttnn/operations/math.hpp"
-#include <cstdint>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal_exp.hpp>
 
 #include "slice_write_op.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_op.hpp"
@@ -501,11 +494,11 @@ operation::ProgramWithCallbacks slice_write_rm_interleaved_multi_core(
     uint32_t max_read_size = 4096;
 
     auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                    ? ::experimental::hal::get_dram_alignment()
-                                    : ::experimental::hal::get_l1_alignment();
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
     auto dst_buffer_alignment = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                    ? ::experimental::hal::get_dram_alignment()
-                                    : ::experimental::hal::get_l1_alignment();
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
     auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
 
     // if begins is not aligned then we need to pad the cb size, so that we can read from the nearest aligned address

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::experimental::detail {
+
+tt::tt_metal::operation::ProgramWithCallbacks slice_write_multi_core(
+    const Tensor& a,
+    const Tensor& output,
+    const ttnn::Shape& output_tensor_start,
+    const ttnn::Shape& output_tensor_end,
+    const ttnn::Shape& step);
+
+}  // namespace ttnn::operations::experimental::detail

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -116,7 +116,7 @@ ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
         }
         tt::log_debug("Invoking SliceWriteDeviceOperation");
 
-        tt::tt_metal::operation::run(
+        (void)tt::tt_metal::operation::run(
             SliceWriteDeviceOperation{ttnn::Shape(begins), ttnn::Shape(padded_ends), ttnn::Shape(step)},
             {input},
             {},

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "slice_write.hpp"
+#include "device/slice_write_op.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/logger.hpp"
+#include "ttnn/common/queue_id.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "cpp/ttnn/operations/creation.hpp"
+#include "cpp/ttnn/operations/data_movement/copy/copy.hpp"
+#include "cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
+#include "cpp/ttnn/operations/data_movement/common/common.hpp"
+
+namespace ttnn::operations::experimental {
+
+// Specialization for uint32_t and N=4
+template <>
+ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor,
+    const std::array<uint32_t, 4>& begins,
+    const std::array<uint32_t, 4>& ends,
+    const std::array<uint32_t, 4>& step) {
+    const auto& padded_input_shape = input_tensor.get_padded_shape();
+    const auto& padded_output_shape = output_tensor.get_padded_shape();
+
+    TT_FATAL(padded_input_shape.rank() == 4, "Input tensor must have rank 4");
+    TT_FATAL(padded_output_shape.rank() == 4, "Output tensor must have rank 4");
+
+    bool no_step = step[0] == 1 && step[1] == 1 && step[2] == 1 && step[3] == 1;
+    bool starts_zero = begins[0] == 0 && begins[1] == 0 && begins[2] == 0 && begins[3] == 0;
+    bool ends_max = ends[0] == padded_output_shape[0] && ends[1] == padded_output_shape[1] &&
+                    ends[2] == padded_output_shape[2] && ends[3] == padded_output_shape[3];
+
+    TT_FATAL(no_step, "Slice Write does not support strides");
+
+    bool rm_only = !no_step && input_tensor.get_layout() == Layout::TILE;
+    ttnn::Tensor input = input_tensor;
+    if (rm_only) {
+        input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
+    }
+    TT_FATAL(
+        (!input_tensor.is_sharded()) ||
+            (input_tensor.is_sharded() &&
+             input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) ||
+            (input_tensor.is_sharded() &&
+             input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED),
+        "Slice Write currently supports Interleaved or Height & Block Sharding for input tensors.");
+
+    TT_FATAL(!output_tensor.is_sharded(), "Slice Write currently doesn't support sharded output tensors.");
+    const bool tiled = input.get_layout() == Layout::TILE;
+    bool on_device = input.storage_type() == StorageType::DEVICE;
+
+    std::array<uint32_t, 4> actual_shape_vec;
+    std::array<uint32_t, 4> padded_shape_vec;
+    const std::array<uint32_t, 4> padded_ends =
+        tiled ? std::array<uint32_t, 4>(
+                    {ends[0],
+                     ends[1],
+                     std::max(tt::round_up(ends[2], tt::constants::TILE_HEIGHT), tt::constants::TILE_HEIGHT),
+                     std::max(tt::round_up(ends[3], tt::constants::TILE_WIDTH), tt::constants::TILE_WIDTH)})
+              : ends;
+    bool empty = false;
+    for (int i = 0; i < 4; ++i) {
+        TT_FATAL(ends[i] >= begins[i], "End {} must be greater than or equal to start {}", ends[i], begins[i]);
+        uint32_t offset = step[i] - begins[i] - 1;
+        uint32_t dim_size = (ends[i] + offset) / step[i];
+        empty |= dim_size == 0;
+        actual_shape_vec[i] = dim_size;
+        padded_shape_vec[i] = std::max((padded_ends[i] + offset) / step[i], 1u);
+    }
+    ttnn::Shape actual_shape(actual_shape_vec);
+    ttnn::Shape padded_shape(padded_shape_vec);
+
+    if (empty) {
+        tt::log_debug("Empty tensor slice, returning unchanged output tensor");
+        return output_tensor;
+    }
+
+    for (int i = 0; i < 4; i++) {
+        TT_FATAL(
+            actual_shape[i] == input.get_logical_shape()[i],
+            "Size of the slice being written {} should match the size of the input tensor {} at dim {}. Got {}, "
+            "expected {} , {}",
+            actual_shape[i],
+            input.get_logical_shape()[i],
+            i,
+            actual_shape,
+            input.get_logical_shape(),
+            padded_shape);
+    }
+
+    if (on_device) {
+        auto memory_config = output_tensor.memory_config();
+
+        // Check for in-place unpad optimization
+        if (input.is_sharded() && input.memory_config() == memory_config && padded_input_shape.rank() > 1) {
+            TT_FATAL(no_step, "Sharded tensor slice implementation does not support striding");
+            bool in_place_unpad = true;
+            for (int i = 0; i < 2; ++i) {
+                in_place_unpad &= begins[i] == 0 && ends[i] == 1 && padded_output_shape[i] == 1;
+            }
+            in_place_unpad &=
+                begins[2] == 0 && tt::div_up(ends[2], input.shard_spec().value().shape[0]) ==
+                                      tt::div_up(padded_output_shape[2], input.shard_spec().value().shape[0]);
+            in_place_unpad &= begins[3] == 0 && ends[3] == padded_output_shape[3];
+            if (in_place_unpad) {
+                tt::log_info("In-place unpad optimization via copy");
+                ttnn::copy(DefaultQueueId, input_tensor, output_tensor);
+                return output_tensor;
+            }
+        }
+        tt::log_debug("Invoking SliceWriteDeviceOperation");
+
+        tt::tt_metal::operation::run(
+            SliceWriteDeviceOperation{ttnn::Shape(begins), ttnn::Shape(padded_ends), ttnn::Shape(step)},
+            {input},
+            {},
+            {output_tensor},
+            queue_id)[0];
+        return output_tensor;
+    }
+
+    TT_THROW("Expects Input on Device");
+    return output_tensor;
+}
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations {
+namespace experimental {
+
+struct SliceWriteOperation {
+    template <typename T, std::size_t N>
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& output_tensor,
+        const std::array<T, N>& output_tensor_start,
+        const std::array<T, N>& output_tensor_end,
+        const std::array<T, N>& step);
+};
+
+}  // namespace experimental
+}  // namespace operations
+}  // namespace ttnn
+
+namespace ttnn::experimental {
+constexpr auto slice_write = ttnn::
+    register_operation_with_auto_launch_op<"ttnn::slice_write", ttnn::operations::experimental::SliceWriteOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "cpp/pybind11/decorators.hpp"
+
+#include "slice_write.hpp"
+#include "slice_write_pybind.hpp"
+
+namespace ttnn::operations::experimental::slice_write {
+namespace py = pybind11;
+
+void bind_slice_write(py::module& module) {
+    auto doc =
+        R"doc(
+            Writes the input tensor to a slice of the output tensor.
+
+            Constraints:
+                Input & Output must have rank == 4.
+                DType must be bfloat16.
+                Supports only Row Major Tensors.
+                Output Tensor must be interleaved.
+                Input Tensor can be interleaved, height sharded or block sharded.
+                Steps must be all ones.
+                Slicing along the last dimension is not supported.
+
+            Args:
+                input_tensor: Input Tensor.
+                output_tensor: Output Tensor.
+                slice_start: Start indices of input tensor. Values along each dim must be < input_tensor_shape[i].
+                slice_end: End indices of input tensor. Values along each dim must be < input_tensor_shape[i].
+                slice_step: (Optional[List[int[tensor rank]]) Step size for each dim. Default is None, which works out be 1 for each dimension.
+
+            Keyword Args:
+                memory_config Memory Config of the output tensor
+                queue_id (uint8, optional) command queue id
+
+            Returns:
+                ttnn.Tensor: the output tensor after writing the input tensor to it.
+
+            Example:
+                >>> ttnn.slice_write(ttnn_input_tensor, ttnn_output_tensor, output_start_indices, output_end_indices, strides)
+                )doc";
+
+    // TODO: implementing the array version and overloading the pybind with all the possible array sizes is better than
+    // a vector with a fixed size default value
+    using OperationType = decltype(ttnn::experimental::slice_write);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::experimental::slice_write,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               const ttnn::Tensor& output_tensor,
+               const std::array<uint32_t, 4>& start,
+               const std::array<uint32_t, 4>& end,
+               const std::array<uint32_t, 4>& step,
+               QueueId queue_id) { return self(queue_id, input_tensor, output_tensor, start, end, step); },
+            py::arg("input_tensor"),
+            py::arg("output_tensor"),
+            py::arg("start"),
+            py::arg("end"),
+            py::arg("step"),
+            py::kw_only(),
+            py::arg("queue_id") = DefaultQueueId,
+        });
+}
+}  // namespace ttnn::operations::experimental::slice_write

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write_pybind.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::slice_write {
+namespace py = pybind11;
+
+void bind_slice_write(py::module& module);
+
+}  // namespace ttnn::operations::experimental::slice_write


### PR DESCRIPTION
### What's changed
Implemented a new op called "slice_write", which takes an input tensor and writes it to a slice of an output tensor. This op always expects an output tensor to be passed. 

This op is necessary for implementing a performant version of Conv2D that uses DRAM for storing its inputs & outputs. 

###Limitations
This implementation is focused only on the use case of Conv2D in DRAM, and thus only supports features that are necessary for that op. 

- Doesn't support slicing along the smallest dimension.
- Input & Output must be row major. Both L1 and DRAM are supported for both. 
- Output must be interleaved. Input may be either interleaved, height sharded or block sharded. 
- Input & Output must be of rank 4. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14089533061)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14077683910)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14099916646) (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes