### PR TITLE
Add Perf Unit Tests for Llama TG

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -33,9 +33,10 @@ jobs:
           }, # Sean Nijjar
           {
             name: "Llama TG Perf Unit Tests",
+            model-type: "LLM",
             arch: wormhole_b0,
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llama_tg_perf_unit_tests --dispatch-mode ""',
-            timeout: 70,
+            timeout: 900,
             tracy: true,
             runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-perf"],
             owner_id: U071CKL4AFK

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -29,7 +29,17 @@ jobs:
             timeout: 75,
             tracy: true,
             runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-perf"],
-            owner_id: ULMEPM2MA}, # Sean Nijjar
+            owner_id: ULMEPM2MA
+          }, # Sean Nijjar
+          {
+            name: "Llama TG Perf Unit Tests",
+            arch: wormhole_b0,
+            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llama_tg_perf_unit_tests --dispatch-mode ""',
+            timeout: 70,
+            tracy: true,
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-perf"],
+            owner_id: U071CKL4AFK
+          }
         ]
     name: ${{ matrix.test-group.name }}
     env:
@@ -61,6 +71,21 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
+      - name: Save environment data
+        if: ${{ (matrix.test-group.name == 'Llama TG Perf Unit Tests') && !cancelled() }}
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+      - name: Upload benchmark data
+        if: ${{ (matrix.test-group.name == 'Llama TG Perf Unit Tests') && !cancelled() }}
+        uses: ./.github/actions/upload-data-via-sftp
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
       - name: Check perf report exists
         id: check-perf-report
         if: ${{ !cancelled() }}

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -387,6 +387,8 @@ run_pipeline_tests() {
     elif [[ $pipeline_type == "ccl_perf_tg_device" ]]; then
         ./tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh -t tg
         ./tests/ttnn/unit_tests/operations/ccl/perf/run_reduce_scatter_profile.sh -t tg
+    elif [[ $pipeline_type == "llama_tg_perf_unit_tests" ]]; then
+        model_perf_tg_device "$tt_arch" "$pipeline_type" "$dispatch_mode" "$model"
     # TGG pipelines
     elif [[ $pipeline_type == "unit_tgg_device" ]]; then
         unit_tgg_device "$tt_arch" "$pipeline_type" "$dispatch_mode"

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -28,6 +28,25 @@ run_tg_cnn_tests() {
   fi
 }
 
+
+run_llama_tg_perf_unit_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_llama_tg_perf_unit_tests"
+
+  pytest models/demos/llama3/tests/test_ccl_async_perf_TG_llama.py --timeout 900; fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_llama_tg_perf_unit_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 main() {
   # Parse the arguments
   while [[ $# -gt 0 ]]; do
@@ -67,6 +86,8 @@ main() {
     run_tg_llm_tests
   elif [[ "$pipeline_type" == "cnn_model_perf_tg_device" ]]; then
     run_tg_cnn_tests
+  elif [[ "$pipeline_type" == "llama_tg_perf_unit_tests" ]]; then
+    run_llama_tg_perf_unit_tests
   else
     echo "$pipeline_type is invalid (supported: [cnn_model_perf_tg_device, cnn_model_perf_tg_device])" 2>&1
     exit 1


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We need to keep track of perf regressions for llama TG. As such, a superset integration is required.

### What's changed

Add tests and superset integration for kernel device measurements for the following:
- CCL in llama TG
- Ring matmuls in llama TG

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13789539631) CI passes
- [x] [TG Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/13789588637/job/38566206942) passes