### PR TITLE
Add ring support for 1D EDM Fabric

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "TG CCL tests", arch: wormhole_b0, cmd: run_tg_nightly_ccl_tests, timeout: 40, owner_id: ULMEPM2MA}, # Sean Nijjar
+          { name: "TG CCL tests", arch: wormhole_b0, cmd: run_tg_nightly_ccl_tests, timeout: 45, owner_id: ULMEPM2MA}, # Sean Nijjar
         ]
     name: ${{ matrix.test-group.name }}
     runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "pipeline-functional"]

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -57,7 +57,16 @@ def profile_results(is_unicast, num_mcasts, num_unicasts, line_size, packet_size
 
 
 def run_fabric_edm(
-    is_unicast, num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw
+    is_unicast,
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    ring_topology,
+    expected_bw,
 ):
     logger.warning("removing file profile_log_device.csv")
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
@@ -70,7 +79,8 @@ def run_fabric_edm(
                 {num_op_invocations} \
                 {int(line_sync)} \
                 {line_size} \
-                {packet_size} "
+                {packet_size} \
+                {int(ring_topology)}"
     rc = os.system(cmd)
     if rc != 0:
         if os.WEXITSTATUS(rc) == 1:
@@ -91,12 +101,21 @@ def run_fabric_edm(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("ring_topology", [False])
 @pytest.mark.parametrize(
     "expected_bw",
     [6.7],
 )
 def test_fabric_edm_mcast_bw(
-    num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    ring_topology,
+    expected_bw,
 ):
     run_fabric_edm(
         False,
@@ -107,6 +126,7 @@ def test_fabric_edm_mcast_bw(
         line_sync,
         line_size,
         packet_size,
+        ring_topology,
         expected_bw,
     )
 
@@ -118,12 +138,21 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("ring_topology", [False])
 @pytest.mark.parametrize(
     "expected_bw",
     [8.4],
 )
 def test_fabric_edm_unicast_bw(
-    num_mcasts, num_unicasts, num_links, num_op_invocations, line_sync, line_size, packet_size, expected_bw
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    ring_topology,
+    expected_bw,
 ):
     run_fabric_edm(
         True,
@@ -134,5 +163,6 @@ def test_fabric_edm_unicast_bw(
         line_sync,
         line_size,
         packet_size,
+        ring_topology,
         expected_bw,
     )

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -131,7 +131,7 @@ def test_fabric_edm_mcast_ring_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.4), (2, 6.0)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.7), (2, 6.0)])
 def test_fabric_edm_mcast_bw(
     num_mcasts,
     num_unicasts,

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -96,17 +96,12 @@ def run_fabric_edm(
 
 @pytest.mark.parametrize("num_mcasts", [200000])
 @pytest.mark.parametrize("num_unicasts", [0])
-@pytest.mark.parametrize("num_links", [1, 2])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("ring_topology", [False])
-@pytest.mark.parametrize(
-    "expected_bw",
-    [6.7],
-)
-def test_fabric_edm_mcast_bw(
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 7.6), (2, 7.3)])
+def test_fabric_edm_mcast_ring_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -114,7 +109,6 @@ def test_fabric_edm_mcast_bw(
     line_sync,
     line_size,
     packet_size,
-    ring_topology,
     expected_bw,
 ):
     run_fabric_edm(
@@ -126,23 +120,49 @@ def test_fabric_edm_mcast_bw(
         line_sync,
         line_size,
         packet_size,
-        ring_topology,
+        True,
+        expected_bw,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [200000])
+@pytest.mark.parametrize("num_unicasts", [0])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.4), (2, 6.0)])
+def test_fabric_edm_mcast_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+):
+    run_fabric_edm(
+        False,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        False,
         expected_bw,
     )
 
 
 @pytest.mark.parametrize("num_mcasts", [0])
 @pytest.mark.parametrize("num_unicasts", [200000])
-@pytest.mark.parametrize("num_links", [1, 2])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("ring_topology", [False])
-@pytest.mark.parametrize(
-    "expected_bw",
-    [8.4],
-)
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 8.4), (2, 8.0)])
 def test_fabric_edm_unicast_bw(
     num_mcasts,
     num_unicasts,
@@ -151,7 +171,6 @@ def test_fabric_edm_unicast_bw(
     line_sync,
     line_size,
     packet_size,
-    ring_topology,
     expected_bw,
 ):
     run_fabric_edm(
@@ -163,6 +182,6 @@ def test_fabric_edm_unicast_bw(
         line_sync,
         line_size,
         packet_size,
-        ring_topology,
+        False,
         expected_bw,
     )

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -108,13 +108,13 @@ TEST_F(Fabric1DFixture, TestUnicast) {
     tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
         .edm_noc_x = edm_eth_core.x,
         .edm_noc_y = edm_eth_core.y,
-        .edm_buffer_base_addr = edm_config.sender_channel_base_addresses[0],
-        .num_buffers_per_channel = edm_config.sender_0_num_buffers,
-        .edm_l1_sem_addr = edm_config.sender_channel_0_local_flow_control_semaphore_address,
-        .edm_connection_handshake_addr = edm_config.sender_channel_0_connection_semaphore_address,
-        .edm_worker_location_info_addr = edm_config.sender_channel_0_worker_conn_info_base_address,
+        .edm_buffer_base_addr = edm_config.sender_channels_base_address[0],
+        .num_buffers_per_channel = edm_config.sender_channels_num_buffers[0],
+        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[0],
+        .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[0],
+        .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[0],
         .buffer_size_bytes = edm_config.channel_buffer_size_bytes,
-        .buffer_index_semaphore_id = edm_config.sender_channel_0_buffer_index_semaphore_address,
+        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[0],
         .persistent_fabric = true};
 
     auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -108,7 +108,7 @@ TEST_F(Fabric1DFixture, TestUnicast) {
     tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
         .edm_noc_x = edm_eth_core.x,
         .edm_noc_y = edm_eth_core.y,
-        .edm_buffer_base_addr = edm_config.sender_0_channel_base_address,
+        .edm_buffer_base_addr = edm_config.sender_channel_base_addresses[0],
         .num_buffers_per_channel = edm_config.sender_0_num_buffers,
         .edm_l1_sem_addr = edm_config.sender_channel_0_local_flow_control_semaphore_address,
         .edm_connection_handshake_addr = edm_config.sender_channel_0_connection_semaphore_address,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     params.line_size = line_size;
-    params.ring_topology = ring_topology;
+    params.topology = ring_topology ? ttnn::ccl::Topology::Ring : ttnn::ccl::Topology::Linear;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params, packet_payload_size_bytes);
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -13,6 +13,7 @@ int main(int argc, char** argv) {
     bool line_sync = std::stoi(argv[arg_idx++]);
     std::size_t line_size = std::stoi(argv[arg_idx++]);
     std::size_t packet_payload_size_bytes = std::stoi(argv[arg_idx++]);
+    bool ring_topology = std::stoi(argv[arg_idx++]);
 
     uint32_t min_test_num_devices = 8;
     if (tt::tt_metal::GetNumAvailableDevices() < min_test_num_devices) {
@@ -23,6 +24,7 @@ int main(int argc, char** argv) {
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     params.line_size = line_size;
+    params.ring_topology = ring_topology;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params, packet_payload_size_bytes);
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2240,6 +2240,9 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
             unicast_forward = true;
             mcast_fwd_hops = tt::div_up(line_size - 1, 2);
             mcast_bwd_hops = line_size - 1 - mcast_fwd_hops;
+            if (i % 2 == 0) {
+                std::swap(mcast_fwd_hops, mcast_bwd_hops);
+            }
             unicast_hops = mcast_fwd_hops;
         } else {
             backward_device = i == 0 ? nullptr : devices[i - 1];

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
@@ -14,6 +14,7 @@ def create_and_load_sub_device_manager_with_fabric_interface(
     enable_persistent_fabric=True,
     wrap_fabric_around_mesh=False,
     context_switch_interval_override=None,
+    topology=ttnn.Topology.Linear,
 ):
     assert ccl_worker_sub_device_id < len(worker_sub_devices)
     mesh_sub_device_manager_id, fabric_subdevice_id = mesh_device.create_sub_device_manager_with_fabric(
@@ -26,13 +27,14 @@ def create_and_load_sub_device_manager_with_fabric_interface(
             mesh_device,
             wrap_fabric_around_mesh=wrap_fabric_around_mesh,
             context_switch_interval_override=context_switch_interval_override,
+            topology=topology,
         )
     return mesh_sub_device_manager_id
 
 
-def teardown_fabric_interface(mesh_device):
+def teardown_fabric_interface(mesh_device, wrap_fabric_around_mesh=False, topology=ttnn.Topology.Linear):
     logger.debug(f"Tearing down fabric (this may take a while if context switch interval is large)")
-    ttnn.teardown_edm_fabric(mesh_device)
+    ttnn.teardown_edm_fabric(mesh_device, wrap_fabric_around_mesh=wrap_fabric_around_mesh, topology=topology)
     ttnn.synchronize_device(mesh_device)
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -173,6 +173,7 @@ def run_all_gather_impl(
             0,
             enable_persistent_fabric,
             wrap_fabric_around_mesh=wrap_fabric_around_mesh,
+            topology=all_gather_topology,
         )
         mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
@@ -334,7 +335,9 @@ def run_all_gather_impl(
 
     if enable_persistent_fabric and teardown_persistent_fabric:
         mesh_device.reset_sub_device_stall_group()
-        teardown_fabric_interface(mesh_device)
+        teardown_fabric_interface(
+            mesh_device, wrap_fabric_around_mesh=wrap_fabric_around_mesh, topology=all_gather_topology
+        )
 
     if not passed:
         assert eq, f"{i} FAILED: {output}"
@@ -516,6 +519,80 @@ def test_all_gather_sharded(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        rand_tensor=True,
+        input_shard_shape=input_shard_shape,
+        input_shard_grid=input_shard_grid,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+        wrap_fabric_around_mesh=True,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        (
+            4,
+            [1, 4, 32, 1280],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 320),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [False])
+def test_all_gather_sharded_ring(
+    pcie_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    if num_links > 1:
+        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the pcie_mesh_device (and hence only has 1 link available for use)"
+
+    run_all_gather_impl(
+        pcie_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
         enable_async=enable_async,
         rand_tensor=True,

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -91,7 +91,7 @@ struct FabricEriscDatamoverConfig {
         std::size_t channel_buffer_size_bytes,
         std::size_t sender_ratio_size,
         std::size_t receiver_ratio_size,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     std::size_t channel_buffer_size_bytes = 0;
     std::size_t channel_buffer_size_bytes_with_channel_sync = 0;
@@ -107,7 +107,7 @@ struct FabricEriscDatamoverConfig {
     std::size_t num_used_sender_channels = 0;
     std::size_t num_used_receiver_channels = 0;
 
-    bool enable_ring_topology = false;
+    Topology topology = Topology::Linear;
 
 private:
     FabricEriscDatamoverConfig();

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -22,8 +22,8 @@
 namespace tt::tt_fabric {
 
 struct FabricEriscDatamoverConfig {
-    static constexpr uint32_t num_sender_channels = 3;
-    static constexpr uint32_t num_receiver_channels = 2;
+    static constexpr std::size_t num_sender_channels = 3;
+    static constexpr std::size_t num_receiver_channels = 2;
     static constexpr bool constrain_to_power_of_2_buffer_slot_counts = true;
 
     static constexpr std::size_t field_size = 16;
@@ -88,7 +88,10 @@ struct FabricEriscDatamoverConfig {
     std::size_t available_channel_buffering_space;
 
     FabricEriscDatamoverConfig(
-        std::size_t channel_buffer_size_bytes, std::size_t sender_ratio_size, std::size_t receiver_ratio_size);
+        std::size_t channel_buffer_size_bytes,
+        std::size_t sender_ratio_size,
+        std::size_t receiver_ratio_size,
+        bool ring_topology = false);
 
     std::size_t channel_buffer_size_bytes = 0;
     std::size_t channel_buffer_size_bytes_with_channel_sync = 0;
@@ -100,6 +103,11 @@ struct FabricEriscDatamoverConfig {
 
     std::array<std::size_t, num_sender_channels> sender_channels_base_address;
     std::array<std::size_t, num_receiver_channels> receiver_channels_base_address;
+
+    std::size_t num_used_sender_channels = 0;
+    std::size_t num_used_receiver_channels = 0;
+
+    bool enable_ring_topology = false;
 
 private:
     FabricEriscDatamoverConfig();
@@ -241,6 +249,8 @@ public:
     bool enable_persistent_mode = false;
     bool build_in_worker_connection_mode = false;
     size_t firmware_context_switch_interval = default_firmware_context_switch_interval;
+    bool enable_first_level_ack = false;
+    bool fuse_receiver_flush_and_completion_ptr = true;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -35,12 +35,10 @@ struct FabricEriscDatamoverConfig {
 
     // Global
     static constexpr std::size_t eth_channel_sync_size = 16;
-    std::size_t handshake_addr = tt::tt_metal::experimental::hal::get_erisc_l1_unreserved_base() /* + 1024*/;
-    std::size_t edm_channel_ack_addr = handshake_addr + eth_channel_sync_size;
-    std::size_t termination_signal_address =
-        edm_channel_ack_addr +
-        (4 * eth_channel_sync_size);  // pad extra bytes to match old EDM so handshake logic will still work
-    std::size_t edm_status_address = termination_signal_address + field_size;
+    std::size_t handshake_addr;
+    std::size_t edm_channel_ack_addr;
+    std::size_t termination_signal_address;  // pad extra bytes to match old EDM so handshake logic will still work
+    std::size_t edm_status_address;
 
     // Debug and Counters
     static constexpr std::size_t receiver_channel_counters_size_bytes =
@@ -48,15 +46,8 @@ struct FabricEriscDatamoverConfig {
     static constexpr std::size_t sender_channel_counters_size_bytes =
         (((tt::tt_fabric::sender_channel_counters_l1_size - 1) / field_size) + 1) * field_size;
 
-    std::size_t receiver_channel_0_counters_address = edm_status_address + field_size;
-    std::size_t receiver_channel_1_counters_address =
-        receiver_channel_0_counters_address + receiver_channel_counters_size_bytes;
-    std::size_t sender_channel_0_counters_address =
-        receiver_channel_1_counters_address + receiver_channel_counters_size_bytes;
-    std::size_t sender_channel_1_counters_address =
-        sender_channel_0_counters_address + sender_channel_counters_size_bytes;
-    std::size_t sender_channel_2_counters_address =
-        sender_channel_1_counters_address + sender_channel_counters_size_bytes;
+    std::array<std::size_t, num_receiver_channels> receiver_channels_counters_address;
+    std::array<std::size_t, num_sender_channels> sender_channels_counters_address;
 
     // Packet header history buffer(s)
     static constexpr std::size_t receiver_completed_packet_header_cb_size_headers = 32;
@@ -65,122 +56,53 @@ struct FabricEriscDatamoverConfig {
     static constexpr std::size_t sender_completed_packet_header_cb_size_headers = 32;
     static constexpr std::size_t sender_completed_packet_header_cb_size_bytes =
         sizeof(tt::tt_fabric::PacketHeader) * sender_completed_packet_header_cb_size_headers;
-    std::size_t receiver_0_completed_packet_header_cb_address =
-        sender_channel_2_counters_address + sender_channel_counters_size_bytes;
-    std::size_t receiver_1_completed_packet_header_cb_address =
-        receiver_0_completed_packet_header_cb_address + receiver_completed_packet_header_cb_size_bytes;
-    std::size_t sender_0_completed_packet_header_cb_address =
-        receiver_1_completed_packet_header_cb_address + receiver_completed_packet_header_cb_size_bytes;
-    std::size_t sender_1_completed_packet_header_cb_address =
-        sender_0_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
-    std::size_t sender_2_completed_packet_header_cb_address =
-        sender_1_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
+    std::array<std::size_t, num_receiver_channels> receivers_completed_packet_header_cb_address;
+    std::array<std::size_t, num_sender_channels> senders_completed_packet_header_cb_address;
 
-    // ----------- Sender Channel 0
-    std::size_t sender_channel_0_buffer_index_address =
-        sender_2_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
+    // ----------- Sender Channels
+    std::array<std::size_t, num_sender_channels> sender_channels_buffer_index_address;
     // Connection info layout:
     // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
     // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
     // 2: WorkerXY (as uint32_t)
     // 3: Hold's EDM's rdptr for the buffer index in the channel
-    std::size_t sender_channel_0_worker_conn_info_base_address = sender_channel_0_buffer_index_address + field_size;
-    std::size_t sender_channel_0_local_flow_control_semaphore_address =
-        sender_channel_0_worker_conn_info_base_address + sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo);
-    // sender_channel_0_conn_info_edm_rdptr_address_address + field_size;
-    std::size_t sender_channel_0_producer_terminate_connection_address =
-        sender_channel_0_local_flow_control_semaphore_address + field_size;
+    std::array<std::size_t, num_sender_channels> sender_channels_worker_conn_info_base_address;
+    std::array<std::size_t, num_sender_channels> sender_channels_local_flow_control_semaphore_address;
+    std::array<std::size_t, num_sender_channels> sender_channels_producer_terminate_connection_address;
     // persistent mode field
-    std::size_t sender_channel_0_connection_semaphore_address =
-        sender_channel_0_producer_terminate_connection_address + field_size;
+    std::array<std::size_t, num_sender_channels> sender_channels_connection_semaphore_address;
     // persistent mode field
-    std::size_t sender_channel_0_buffer_index_semaphore_address =
-        sender_channel_0_connection_semaphore_address + field_size;
+    std::array<std::size_t, num_sender_channels> sender_channels_buffer_index_semaphore_address;
 
     static_assert(sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo) % field_size == 0);
 
-    // ----------- Sender Channel 1
-    std::size_t sender_channel_1_buffer_index_address = sender_channel_0_buffer_index_semaphore_address + field_size;
-    // Connection info layout:
-    // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
-    // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
-    // 2: WorkerXY (as uint32_t)
-    // 3: Hold's EDM's rdptr for the buffer index in the channel
-    std::size_t sender_channel_1_worker_conn_info_base_address = sender_channel_1_buffer_index_address + field_size;
-    std::size_t sender_channel_1_local_flow_control_semaphore_address =
-        sender_channel_1_worker_conn_info_base_address + sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo);
-    // sender_channel_1_conn_info_edm_rdptr_address_address + field_size;
-    std::size_t sender_channel_1_producer_terminate_connection_address =
-        sender_channel_1_local_flow_control_semaphore_address + field_size;
-
+    // ----------- Receiver Channels
+    std::array<std::size_t, num_receiver_channels> receiver_channels_local_buffer_index_address;
     // persistent mode field
-    std::size_t sender_channel_1_connection_semaphore_address =
-        sender_channel_1_producer_terminate_connection_address + field_size;
-    // persistent mode field
-    std::size_t sender_channel_1_buffer_index_semaphore_address =
-        sender_channel_1_connection_semaphore_address + field_size;
-
-    // ----------- Sender Channel 2
-    std::size_t sender_channel_2_buffer_index_address = sender_channel_1_buffer_index_semaphore_address + field_size;
-    // Connection info layout:
-    // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
-    // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
-    // 2: WorkerXY (as uint32_t)
-    // 3: Hold's EDM's rdptr for the buffer index in the channel
-    std::size_t sender_channel_2_worker_conn_info_base_address = sender_channel_2_buffer_index_address + field_size;
-    std::size_t sender_channel_2_local_flow_control_semaphore_address =
-        sender_channel_2_worker_conn_info_base_address + sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo);
-    // sender_channel_2_conn_info_edm_rdptr_address_address + field_size;
-    std::size_t sender_channel_2_producer_terminate_connection_address =
-        sender_channel_2_local_flow_control_semaphore_address + field_size;
-
-    // persistent mode field
-    std::size_t sender_channel_2_connection_semaphore_address =
-        sender_channel_2_producer_terminate_connection_address + field_size;
-    // persistent mode field
-    std::size_t sender_channel_2_buffer_index_semaphore_address =
-        sender_channel_2_connection_semaphore_address + field_size;
-
-    // ----------- Receiver 0 Channel
-    std::size_t receiver_channel_0_local_buffer_index_address =
-        sender_channel_2_buffer_index_semaphore_address + field_size;
-    // persistent mode field
-    std::size_t receiver_channel_0_downstream_flow_control_semaphore_address =
-        receiver_channel_0_local_buffer_index_address + field_size;
-
-    // ----------- Receiver 1 Channel
-    std::size_t receiver_channel_1_local_buffer_index_address =
-        receiver_channel_0_downstream_flow_control_semaphore_address + field_size;
-    // persistent mode field
-    std::size_t receiver_channel_1_downstream_flow_control_semaphore_address =
-        receiver_channel_1_local_buffer_index_address + field_size;
+    std::array<std::size_t, num_receiver_channels> receiver_channels_downstream_flow_control_semaphore_address;
 
     // Channel Allocations
-    std::size_t max_l1_loading_size = tt::tt_metal::experimental::hal::get_erisc_l1_unreserved_size() +
-                                      tt::tt_metal::experimental::hal::get_erisc_l1_unreserved_base();
-    std::size_t buffer_region_start =
-        (receiver_channel_1_downstream_flow_control_semaphore_address + field_size + buffer_alignment) &
-        ~(buffer_alignment - 1);  // Align
-    std::size_t available_channel_buffering_space = max_l1_loading_size - buffer_region_start;
+    std::size_t max_l1_loading_size;
+    ;
+    std::size_t buffer_region_start;
+    std::size_t available_channel_buffering_space;
 
     FabricEriscDatamoverConfig(
         std::size_t channel_buffer_size_bytes, std::size_t sender_ratio_size, std::size_t receiver_ratio_size);
 
     std::size_t channel_buffer_size_bytes = 0;
     std::size_t channel_buffer_size_bytes_with_channel_sync = 0;
-    std::size_t sender_0_channel_size_bytes = 0;
-    std::size_t sender_0_num_buffers = 0;
-    std::size_t sender_1_channel_size_bytes = 0;
-    std::size_t sender_1_num_buffers = 0;
-    std::size_t sender_2_channel_size_bytes = 0;
-    std::size_t sender_2_num_buffers = 0;
-    std::size_t receiver_0_channel_size_bytes = 0;
-    std::size_t receiver_0_num_buffers = 0;
-    std::size_t receiver_1_channel_size_bytes = 0;
-    std::size_t receiver_1_num_buffers = 0;
 
-    std::array<std::size_t, num_sender_channels> sender_channel_base_addresses = {0, 0, 0};
-    std::array<std::size_t, num_receiver_channels> receiver_channel_base_addresses = {0, 0};
+    std::array<std::size_t, num_sender_channels> sender_channels_size_bytes;
+    std::array<std::size_t, num_receiver_channels> receiver_channels_size_bytes;
+    std::array<std::size_t, num_sender_channels> sender_channels_num_buffers;
+    std::array<std::size_t, num_receiver_channels> receiver_channels_num_buffers;
+
+    std::array<std::size_t, num_sender_channels> sender_channels_base_address;
+    std::array<std::size_t, num_receiver_channels> receiver_channels_base_address;
+
+private:
+    FabricEriscDatamoverConfig();
 };
 
 struct SenderWorkerAdapterSpec {
@@ -219,6 +141,8 @@ public:
     // payload only, no header
     static constexpr size_t default_packet_payload_size_bytes = tt::tile_size(tt::DataFormat::Bfp8_b) * 4;
 
+    static constexpr uint32_t num_virtual_channels = 2;
+
     FabricEriscDatamoverBuilder(
         const CoreCoord& my_eth_core_logical,
         size_t my_noc_x,
@@ -226,19 +150,16 @@ public:
         size_t my_chip_id,
         size_t peer_chip_id,
 
-        std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_id,
-        std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_id,
-        std::optional<size_t> receiver_channel_0_downstream_teardown_semaphore_id,
-        std::optional<size_t> receiver_channel_1_downstream_teardown_semaphore_id,
-        size_t sender_channel_0_flow_control_semaphore_id,
-        size_t sender_channel_1_flow_control_semaphore_id,
-        size_t sender_channel_2_flow_control_semaphore_id,
-        size_t sender_channel_0_connection_semaphore_id,
-        size_t sender_channel_1_connection_semaphore_id,
-        size_t sender_channel_2_connection_semaphore_id,
-        size_t sender_channel_0_buffer_index_semaphore_id,
-        size_t sender_channel_1_buffer_index_semaphore_id,
-        size_t sender_channel_2_buffer_index_semaphore_id,
+        const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>&
+            receiver_channels_downstream_flow_control_semaphore_id,
+        const std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>&
+            receiver_channels_downstream_teardown_semaphore_id,
+        const std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels>&
+            sender_channels_flow_control_semaphore_id,
+        const std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels>&
+            sender_channels_connection_semaphore_id,
+        const std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels>&
+            sender_channels_buffer_index_semaphore_id,
 
         const FabricEriscDatamoverConfig& config,
         bool enable_persistent_mode,
@@ -269,7 +190,8 @@ public:
 
     void teardown_from_host(
         tt::tt_metal::IDevice* d,
-        tt::tt_fabric::TerminationSignal termination_signal = tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE) const;
+        tt::tt_fabric::TerminationSignal termination_signal =
+            tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE) const;
 
     void set_firmware_context_switch_interval(size_t interval);
 
@@ -286,54 +208,36 @@ public:
     size_t handshake_address = 0;
     size_t channel_buffer_size = 0;
 
-    size_t sender_0_num_buffers = 0;
-    size_t sender_1_num_buffers = 0;
-    size_t sender_2_num_buffers = 0;
-    size_t receiver_0_num_buffers = 0;
-    size_t receiver_1_num_buffers = 0;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_num_buffers;
+    std::array<size_t, FabricEriscDatamoverConfig::num_receiver_channels> receiver_channels_num_buffers;
 
-    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> local_sender_channel_buffer_addresses;
-    std::array<size_t, FabricEriscDatamoverConfig::num_receiver_channels> local_receiver_channel_buffer_addresses;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> local_sender_channels_buffer_address;
+    std::array<size_t, FabricEriscDatamoverConfig::num_receiver_channels> local_receiver_channels_buffer_address;
 
-    size_t local_sender_channel_0_connection_info_addr;
-    size_t local_sender_channel_1_connection_info_addr;
-    size_t local_sender_channel_2_connection_info_addr;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> local_sender_channels_connection_info_addr;
 
     size_t termination_signal_ptr = 0;
     size_t edm_status_ptr = 0;
 
     // Semaphore IDs
     // this is the receiver channel's local sem for flow controlling with downstream fabric sender
-    std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_id;
-    std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_id;
-    std::optional<size_t> receiver_channel_0_downstream_teardown_semaphore_id;
-    std::optional<size_t> receiver_channel_1_downstream_teardown_semaphore_id;
-    size_t sender_channel_0_flow_control_semaphore_id = 0;
-    size_t sender_channel_1_flow_control_semaphore_id = 0;
-    size_t sender_channel_2_flow_control_semaphore_id = 0;
-    size_t sender_channel_0_connection_semaphore_id = 0;
-    size_t sender_channel_1_connection_semaphore_id = 0;
-    size_t sender_channel_2_connection_semaphore_id = 0;
-    size_t sender_channel_0_buffer_index_semaphore_id = 0;
-    size_t sender_channel_1_buffer_index_semaphore_id = 0;
-    size_t sender_channel_2_buffer_index_semaphore_id = 0;
-    size_t receiver_channel_0_local_buffer_index_address = 0;
-    size_t receiver_channel_1_local_buffer_index_address = 0;
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>
+        receiver_channels_downstream_flow_control_semaphore_id;
+    std::array<std::optional<size_t>, FabricEriscDatamoverConfig::num_receiver_channels>
+        receiver_channels_downstream_teardown_semaphore_id;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_flow_control_semaphore_id;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_connection_semaphore_id;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_buffer_index_semaphore_id;
+    std::array<size_t, FabricEriscDatamoverConfig::num_receiver_channels> receiver_channels_local_buffer_index_address;
 
-    std::optional<size_t> downstream_edm_vc0_noc_x;
-    std::optional<size_t> downstream_edm_vc1_noc_x;
-    std::optional<size_t> downstream_edm_vc0_noc_y;
-    std::optional<size_t> downstream_edm_vc1_noc_y;
-    std::optional<size_t> downstream_edm_vc0_buffer_base_address;
-    std::optional<size_t> downstream_edm_vc1_buffer_base_address;
-    std::optional<size_t> downstream_edm_vc0_semaphore_address;
-    std::optional<size_t> downstream_edm_vc1_semaphore_address;
-    std::optional<size_t> downstream_edm_vc0_worker_registration_address;
-    std::optional<size_t> downstream_edm_vc1_worker_registration_address;
-    std::optional<size_t> downstream_edm_vc0_worker_location_info_address;
-    std::optional<size_t> downstream_edm_vc1_worker_location_info_address;
-    std::optional<size_t> downstream_vc0_sender_channel_buffer_index_semaphore_id;
-    std::optional<size_t> downstream_vc1_sender_channel_buffer_index_semaphore_id;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_edm_vcs_noc_x;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_edm_vcs_noc_y;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_edm_vcs_buffer_base_address;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_edm_vcs_semaphore_address;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_edm_vcs_worker_registration_address;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_edm_vcs_worker_location_info_address;
+    std::array<std::optional<size_t>, num_virtual_channels> downstream_vcs_sender_channel_buffer_index_semaphore_id;
+
     bool enable_persistent_mode = false;
     bool build_in_worker_connection_mode = false;
     size_t firmware_context_switch_interval = default_firmware_context_switch_interval;

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -22,6 +22,8 @@
 namespace tt::tt_fabric {
 
 struct FabricEriscDatamoverConfig {
+    static constexpr uint32_t num_sender_channels = 3;
+    static constexpr uint32_t num_receiver_channels = 2;
     static constexpr bool constrain_to_power_of_2_buffer_slot_counts = true;
 
     static constexpr std::size_t field_size = 16;
@@ -46,11 +48,15 @@ struct FabricEriscDatamoverConfig {
     static constexpr std::size_t sender_channel_counters_size_bytes =
         (((tt::tt_fabric::sender_channel_counters_l1_size - 1) / field_size) + 1) * field_size;
 
-    std::size_t receiver_channel_counters_address = edm_status_address + field_size;
+    std::size_t receiver_channel_0_counters_address = edm_status_address + field_size;
+    std::size_t receiver_channel_1_counters_address =
+        receiver_channel_0_counters_address + receiver_channel_counters_size_bytes;
     std::size_t sender_channel_0_counters_address =
-        receiver_channel_counters_address + receiver_channel_counters_size_bytes;
+        receiver_channel_1_counters_address + receiver_channel_counters_size_bytes;
     std::size_t sender_channel_1_counters_address =
         sender_channel_0_counters_address + sender_channel_counters_size_bytes;
+    std::size_t sender_channel_2_counters_address =
+        sender_channel_1_counters_address + sender_channel_counters_size_bytes;
 
     // Packet header history buffer(s)
     static constexpr std::size_t receiver_completed_packet_header_cb_size_headers = 32;
@@ -59,16 +65,20 @@ struct FabricEriscDatamoverConfig {
     static constexpr std::size_t sender_completed_packet_header_cb_size_headers = 32;
     static constexpr std::size_t sender_completed_packet_header_cb_size_bytes =
         sizeof(tt::tt_fabric::PacketHeader) * sender_completed_packet_header_cb_size_headers;
-    std::size_t receiver_completed_packet_header_cb_address =
-        sender_channel_1_counters_address + sender_channel_counters_size_bytes;
+    std::size_t receiver_0_completed_packet_header_cb_address =
+        sender_channel_2_counters_address + sender_channel_counters_size_bytes;
+    std::size_t receiver_1_completed_packet_header_cb_address =
+        receiver_0_completed_packet_header_cb_address + receiver_completed_packet_header_cb_size_bytes;
     std::size_t sender_0_completed_packet_header_cb_address =
-        receiver_completed_packet_header_cb_address + receiver_completed_packet_header_cb_size_bytes;
+        receiver_1_completed_packet_header_cb_address + receiver_completed_packet_header_cb_size_bytes;
     std::size_t sender_1_completed_packet_header_cb_address =
         sender_0_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
+    std::size_t sender_2_completed_packet_header_cb_address =
+        sender_1_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
 
     // ----------- Sender Channel 0
     std::size_t sender_channel_0_buffer_index_address =
-        sender_1_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
+        sender_2_completed_packet_header_cb_address + sender_completed_packet_header_cb_size_bytes;
     // Connection info layout:
     // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
     // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
@@ -110,18 +120,46 @@ struct FabricEriscDatamoverConfig {
     std::size_t sender_channel_1_buffer_index_semaphore_address =
         sender_channel_1_connection_semaphore_address + field_size;
 
-    // ----------- Receiver Channel
-    std::size_t receiver_channel_local_buffer_index_address =
-        sender_channel_1_buffer_index_semaphore_address + field_size;
+    // ----------- Sender Channel 2
+    std::size_t sender_channel_2_buffer_index_address = sender_channel_1_buffer_index_semaphore_address + field_size;
+    // Connection info layout:
+    // 0: buffer_index_rdptr -> Tells EDM the address in worker L1 to update EDM's copy of channel rdptr
+    // 1: worker_teardown_semaphore_address -> Tells EDM where to signal connection teardown completion in worker's L1
+    // 2: WorkerXY (as uint32_t)
+    // 3: Hold's EDM's rdptr for the buffer index in the channel
+    std::size_t sender_channel_2_worker_conn_info_base_address = sender_channel_2_buffer_index_address + field_size;
+    std::size_t sender_channel_2_local_flow_control_semaphore_address =
+        sender_channel_2_worker_conn_info_base_address + sizeof(tt::tt_fabric::EDMChannelWorkerLocationInfo);
+    // sender_channel_2_conn_info_edm_rdptr_address_address + field_size;
+    std::size_t sender_channel_2_producer_terminate_connection_address =
+        sender_channel_2_local_flow_control_semaphore_address + field_size;
+
     // persistent mode field
-    std::size_t receiver_channel_downstream_flow_control_semaphore_address =
-        receiver_channel_local_buffer_index_address + field_size;
+    std::size_t sender_channel_2_connection_semaphore_address =
+        sender_channel_2_producer_terminate_connection_address + field_size;
+    // persistent mode field
+    std::size_t sender_channel_2_buffer_index_semaphore_address =
+        sender_channel_2_connection_semaphore_address + field_size;
+
+    // ----------- Receiver 0 Channel
+    std::size_t receiver_channel_0_local_buffer_index_address =
+        sender_channel_2_buffer_index_semaphore_address + field_size;
+    // persistent mode field
+    std::size_t receiver_channel_0_downstream_flow_control_semaphore_address =
+        receiver_channel_0_local_buffer_index_address + field_size;
+
+    // ----------- Receiver 1 Channel
+    std::size_t receiver_channel_1_local_buffer_index_address =
+        receiver_channel_0_downstream_flow_control_semaphore_address + field_size;
+    // persistent mode field
+    std::size_t receiver_channel_1_downstream_flow_control_semaphore_address =
+        receiver_channel_1_local_buffer_index_address + field_size;
 
     // Channel Allocations
     std::size_t max_l1_loading_size = tt::tt_metal::experimental::hal::get_erisc_l1_unreserved_size() +
                                       tt::tt_metal::experimental::hal::get_erisc_l1_unreserved_base();
     std::size_t buffer_region_start =
-        (receiver_channel_downstream_flow_control_semaphore_address + field_size + buffer_alignment) &
+        (receiver_channel_1_downstream_flow_control_semaphore_address + field_size + buffer_alignment) &
         ~(buffer_alignment - 1);  // Align
     std::size_t available_channel_buffering_space = max_l1_loading_size - buffer_region_start;
 
@@ -134,12 +172,15 @@ struct FabricEriscDatamoverConfig {
     std::size_t sender_0_num_buffers = 0;
     std::size_t sender_1_channel_size_bytes = 0;
     std::size_t sender_1_num_buffers = 0;
-    std::size_t receiver_channel_size_bytes = 0;
-    std::size_t receiver_num_buffers = 0;
+    std::size_t sender_2_channel_size_bytes = 0;
+    std::size_t sender_2_num_buffers = 0;
+    std::size_t receiver_0_channel_size_bytes = 0;
+    std::size_t receiver_0_num_buffers = 0;
+    std::size_t receiver_1_channel_size_bytes = 0;
+    std::size_t receiver_1_num_buffers = 0;
 
-    std::size_t sender_0_channel_base_address = 0;
-    std::size_t sender_1_channel_base_address = 0;
-    std::size_t receiver_channel_base_address = 0;
+    std::array<std::size_t, num_sender_channels> sender_channel_base_addresses = {0, 0, 0};
+    std::array<std::size_t, num_receiver_channels> receiver_channel_base_addresses = {0, 0};
 };
 
 struct SenderWorkerAdapterSpec {
@@ -185,14 +226,19 @@ public:
         size_t my_chip_id,
         size_t peer_chip_id,
 
-        std::optional<size_t> receiver_channel_downstream_flow_control_semaphore_id,
-        std::optional<size_t> receiver_channel_downstream_teardown_semaphore_id,
+        std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_id,
+        std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_id,
+        std::optional<size_t> receiver_channel_0_downstream_teardown_semaphore_id,
+        std::optional<size_t> receiver_channel_1_downstream_teardown_semaphore_id,
         size_t sender_channel_0_flow_control_semaphore_id,
         size_t sender_channel_1_flow_control_semaphore_id,
+        size_t sender_channel_2_flow_control_semaphore_id,
         size_t sender_channel_0_connection_semaphore_id,
         size_t sender_channel_1_connection_semaphore_id,
+        size_t sender_channel_2_connection_semaphore_id,
         size_t sender_channel_0_buffer_index_semaphore_id,
         size_t sender_channel_1_buffer_index_semaphore_id,
+        size_t sender_channel_2_buffer_index_semaphore_id,
 
         const FabricEriscDatamoverConfig& config,
         bool enable_persistent_mode,
@@ -209,7 +255,7 @@ public:
         bool build_in_worker_connection_mode = false);
 
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_worker_channel() const;
-    [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel() const;
+    [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc) const;
 
     [[nodiscard]] std::vector<uint32_t> get_compile_time_args() const;
 
@@ -223,8 +269,7 @@ public:
 
     void teardown_from_host(
         tt::tt_metal::IDevice* d,
-        tt::tt_fabric::TerminationSignal termination_signal =
-            tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE) const;
+        tt::tt_fabric::TerminationSignal termination_signal = tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE) const;
 
     void set_firmware_context_switch_interval(size_t interval);
 
@@ -243,36 +288,52 @@ public:
 
     size_t sender_0_num_buffers = 0;
     size_t sender_1_num_buffers = 0;
-    size_t receiver_num_buffers = 0;
+    size_t sender_2_num_buffers = 0;
+    size_t receiver_0_num_buffers = 0;
+    size_t receiver_1_num_buffers = 0;
 
-    size_t local_sender_channel_0_buffer_address = 0;
-    size_t local_sender_channel_0_connection_info_addr = 0;
-    size_t local_sender_channel_1_buffer_address = 0;
-    size_t local_sender_channel_1_connection_info_addr = 0;
-    size_t local_receiver_channel_buffer_address = 0;
+    std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> local_sender_channel_buffer_addresses;
+    std::array<size_t, FabricEriscDatamoverConfig::num_receiver_channels> local_receiver_channel_buffer_addresses;
+
+    size_t local_sender_channel_0_connection_info_addr;
+    size_t local_sender_channel_1_connection_info_addr;
+    size_t local_sender_channel_2_connection_info_addr;
 
     size_t termination_signal_ptr = 0;
     size_t edm_status_ptr = 0;
 
     // Semaphore IDs
     // this is the receiver channel's local sem for flow controlling with downstream fabric sender
-    std::optional<size_t> receiver_channel_downstream_flow_control_semaphore_id;
-    std::optional<size_t> receiver_channel_downstream_teardown_semaphore_id;
+    std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_id;
+    std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_id;
+    std::optional<size_t> receiver_channel_0_downstream_teardown_semaphore_id;
+    std::optional<size_t> receiver_channel_1_downstream_teardown_semaphore_id;
     size_t sender_channel_0_flow_control_semaphore_id = 0;
     size_t sender_channel_1_flow_control_semaphore_id = 0;
+    size_t sender_channel_2_flow_control_semaphore_id = 0;
     size_t sender_channel_0_connection_semaphore_id = 0;
     size_t sender_channel_1_connection_semaphore_id = 0;
+    size_t sender_channel_2_connection_semaphore_id = 0;
     size_t sender_channel_0_buffer_index_semaphore_id = 0;
     size_t sender_channel_1_buffer_index_semaphore_id = 0;
-    size_t receiver_channel_local_buffer_index_address = 0;
+    size_t sender_channel_2_buffer_index_semaphore_id = 0;
+    size_t receiver_channel_0_local_buffer_index_address = 0;
+    size_t receiver_channel_1_local_buffer_index_address = 0;
 
-    std::optional<size_t> downstream_edm_noc_x;
-    std::optional<size_t> downstream_edm_noc_y;
-    std::optional<size_t> downstream_edm_buffer_base_address;
-    std::optional<size_t> downstream_edm_semaphore_address;
-    std::optional<size_t> downstream_edm_worker_registration_address;
-    std::optional<size_t> downstream_edm_worker_location_info_address;
-    std::optional<size_t> downstream_sender_channel_buffer_index_semaphore_id;
+    std::optional<size_t> downstream_edm_vc0_noc_x;
+    std::optional<size_t> downstream_edm_vc1_noc_x;
+    std::optional<size_t> downstream_edm_vc0_noc_y;
+    std::optional<size_t> downstream_edm_vc1_noc_y;
+    std::optional<size_t> downstream_edm_vc0_buffer_base_address;
+    std::optional<size_t> downstream_edm_vc1_buffer_base_address;
+    std::optional<size_t> downstream_edm_vc0_semaphore_address;
+    std::optional<size_t> downstream_edm_vc1_semaphore_address;
+    std::optional<size_t> downstream_edm_vc0_worker_registration_address;
+    std::optional<size_t> downstream_edm_vc1_worker_registration_address;
+    std::optional<size_t> downstream_edm_vc0_worker_location_info_address;
+    std::optional<size_t> downstream_edm_vc1_worker_location_info_address;
+    std::optional<size_t> downstream_vc0_sender_channel_buffer_index_semaphore_id;
+    std::optional<size_t> downstream_vc1_sender_channel_buffer_index_semaphore_id;
     bool enable_persistent_mode = false;
     bool build_in_worker_connection_mode = false;
     size_t firmware_context_switch_interval = default_firmware_context_switch_interval;

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -312,14 +312,18 @@ public:
 };
 
 struct LowLatencyRoutingFields {
-    static constexpr uint32_t FIELD_WIDTH = 2;
-    static constexpr uint32_t FIELD_MASK = 0b11;
-    static constexpr uint32_t NOOP = 0b00;
-    static constexpr uint32_t WRITE_ONLY = 0b01;
-    static constexpr uint32_t FORWARD_ONLY = 0b10;
-    static constexpr uint32_t WRITE_AND_FORWARD = 0b11;
-    static constexpr uint32_t FWD_ONLY_FIELD = 0xAAAAAAAA;
-    static constexpr uint32_t WR_ONLY_FIELD = 0x55555555;
+    static constexpr uint32_t FIELD_WIDTH = 3;
+    static constexpr uint32_t FIELD_MASK = 0b111;
+    static constexpr uint32_t PATH_ROUTING_FIELD_MASK = 0b011;
+    static constexpr uint32_t VC_FIELD_MASK = 0b100;
+    static constexpr uint32_t NOOP = 0b000;
+    static constexpr uint32_t WRITE_ONLY = 0b001;
+    static constexpr uint32_t FORWARD_ONLY = 0b010;
+    static constexpr uint32_t WRITE_AND_FORWARD = 0b011;
+    static constexpr uint32_t MAX_NUM_ENCODINGS = sizeof(uint32_t) * CHAR_BIT / FIELD_WIDTH;
+    static constexpr uint32_t FWD_ONLY_FIELD = 0x92492492;
+    static constexpr uint32_t WR_ONLY_FIELD = 0x49249249;
+    static constexpr uint32_t HIGH_VC_FIELD = 0x24924924;
     uint32_t value;
 };
 
@@ -328,17 +332,21 @@ struct LowLatencyPacketHeader : public PacketHeaderBase<LowLatencyPacketHeader> 
     uint8_t padding0[8];
 
 private:
-    inline static uint32_t calculate_chip_unicast_routing_fields_value(uint8_t distance_in_hops) {
+    inline static uint32_t calculate_chip_unicast_routing_fields_value(
+        uint8_t distance_in_hops, uint8_t distance_to_high_vc = LowLatencyRoutingFields::MAX_NUM_ENCODINGS) {
         // Example of unicast 3 hops away
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice
         // (forward to neighbor is not encoded in the field) Last line will do 0b01 << 4 = 0b010000. This means that on
         // the 3rd chip, we will write only Together this means the final encoding is 0b011010
         return (LowLatencyRoutingFields::FWD_ONLY_FIELD &
                 ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
-               (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
+               (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) |
+               (LowLatencyRoutingFields::HIGH_VC_FIELD
+                << (distance_to_high_vc - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
     }
     inline static uint32_t calculate_chip_multicast_routing_fields_value(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
+        const MulticastRoutingCommandHeader& chip_multicast_command_header,
+        uint8_t distance_to_high_vc = LowLatencyRoutingFields::MAX_NUM_ENCODINGS) {
         // Example of starting 3 hops away mcasting to 2 chips
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice
         // (forward to neighbor is not encoded in the field) Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 =
@@ -353,7 +361,10 @@ private:
                // of readability of the packet header
                ((LowLatencyRoutingFields::WR_ONLY_FIELD &
                  ((1 << (chip_multicast_command_header.range_hops) * LowLatencyRoutingFields::FIELD_WIDTH) - 1))
-                << ((chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH));
+                << ((chip_multicast_command_header.start_distance_in_hops - 1) *
+                    LowLatencyRoutingFields::FIELD_WIDTH)) |
+               (LowLatencyRoutingFields::HIGH_VC_FIELD
+                << (distance_to_high_vc - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
     }
 
 public:

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -143,13 +143,16 @@ struct PacketHeaderBase {
     inline void set_noc_send_type(NocSendType& type) { this->noc_send_type = type; }
     inline void set_command_fields(NocCommandFields& fields) { this->command_fields = fields; }
 
-    inline Derived& to_chip_unicast(uint8_t distance_in_hops) {
-        static_cast<Derived*>(this)->to_chip_unicast_impl(distance_in_hops);
+    inline Derived& to_chip_unicast(
+        uint8_t distance_in_hops, uint8_t distance_to_high_vc = Derived::default_high_vc_distance) {
+        static_cast<Derived*>(this)->to_chip_unicast_impl(distance_in_hops, distance_to_high_vc);
         return *static_cast<Derived*>(this);
     }
 
-    inline Derived& to_chip_multicast(const MulticastRoutingCommandHeader& mcast_routing_command_header) {
-        static_cast<Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
+    inline Derived& to_chip_multicast(
+        const MulticastRoutingCommandHeader& mcast_routing_command_header,
+        uint8_t distance_to_high_vc = Derived::default_high_vc_distance) {
+        static_cast<Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header, distance_to_high_vc);
         return *static_cast<Derived*>(this);
     }
 
@@ -192,14 +195,16 @@ struct PacketHeaderBase {
         return *static_cast<Derived*>(this);
     }
 
-    inline volatile Derived* to_chip_unicast(uint8_t distance_in_hops) volatile {
-        static_cast<volatile Derived*>(this)->to_chip_unicast_impl(distance_in_hops);
+    inline volatile Derived* to_chip_unicast(
+        uint8_t distance_in_hops, uint8_t distance_to_high_vc = Derived::default_high_vc_distance) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_unicast_impl(distance_in_hops, distance_to_high_vc);
         return static_cast<volatile Derived*>(this);
     }
 
     inline volatile Derived* to_chip_multicast(
-        const MulticastRoutingCommandHeader& mcast_routing_command_header) volatile {
-        static_cast<volatile Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
+        const MulticastRoutingCommandHeader& mcast_routing_command_header,
+        uint8_t distance_to_high_vc = Derived::default_high_vc_distance) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header, distance_to_high_vc);
         return static_cast<volatile Derived*>(this);
     }
 
@@ -261,6 +266,7 @@ struct PacketHeaderBase {
 };
 
 struct PacketHeader : public PacketHeaderBase<PacketHeader> {
+    static constexpr uint8_t default_high_vc_distance = 0;
     ChipSendType chip_send_type;
     RoutingFields routing_fields;
     // Sort of hack to work-around DRAM read alignment issues that must be 32B aligned
@@ -273,12 +279,12 @@ struct PacketHeader : public PacketHeaderBase<PacketHeader> {
     // manage this complexity.
     uint8_t padding0[10];
 
-private:
-    inline static uint32_t calculate_chip_unicast_routing_fields_value(uint8_t distance_in_hops) {
+    inline static uint32_t calculate_chip_unicast_routing_fields_value(
+        uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
         return RoutingFields::LAST_CHIP_IN_MCAST_VAL | distance_in_hops;
     }
     inline static uint32_t calculate_chip_multicast_routing_fields_value(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
+        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
         return ((static_cast<uint8_t>(chip_multicast_command_header.range_hops)
                  << RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH)) |
                static_cast<uint8_t>(chip_multicast_command_header.start_distance_in_hops);
@@ -290,24 +296,28 @@ public:
 
     inline void set_routing_fields(RoutingFields& fields) { this->routing_fields = fields; }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops) {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
         this->chip_send_type = CHIP_UNICAST;
-        this->routing_fields.value = PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
-    }
-    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) {
-        this->chip_send_type = CHIP_MULTICAST;
         this->routing_fields.value =
-            PacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
+            PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
+    }
+    inline void to_chip_multicast_impl(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
+        this->chip_send_type = CHIP_MULTICAST;
+        this->routing_fields.value = PacketHeader::calculate_chip_multicast_routing_fields_value(
+            chip_multicast_command_header, distance_to_high_vc);
     }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) volatile {
         this->chip_send_type = CHIP_UNICAST;
-        this->routing_fields.value = PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
-    }
-    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) volatile {
-        this->chip_send_type = CHIP_MULTICAST;
         this->routing_fields.value =
-            PacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
+            PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
+    }
+    inline void to_chip_multicast_impl(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) volatile {
+        this->chip_send_type = CHIP_MULTICAST;
+        this->routing_fields.value = PacketHeader::calculate_chip_multicast_routing_fields_value(
+            chip_multicast_command_header, distance_to_high_vc);
     }
 };
 
@@ -328,12 +338,13 @@ struct LowLatencyRoutingFields {
 };
 
 struct LowLatencyPacketHeader : public PacketHeaderBase<LowLatencyPacketHeader> {
+    static constexpr uint8_t default_high_vc_distance = LowLatencyRoutingFields::MAX_NUM_ENCODINGS;
     LowLatencyRoutingFields routing_fields;
     uint8_t padding0[8];
 
 private:
     inline static uint32_t calculate_chip_unicast_routing_fields_value(
-        uint8_t distance_in_hops, uint8_t distance_to_high_vc = LowLatencyRoutingFields::MAX_NUM_ENCODINGS) {
+        uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
         // Example of unicast 3 hops away
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice
         // (forward to neighbor is not encoded in the field) Last line will do 0b01 << 4 = 0b010000. This means that on
@@ -345,8 +356,7 @@ private:
                 << (distance_to_high_vc - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
     }
     inline static uint32_t calculate_chip_multicast_routing_fields_value(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header,
-        uint8_t distance_to_high_vc = LowLatencyRoutingFields::MAX_NUM_ENCODINGS) {
+        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
         // Example of starting 3 hops away mcasting to 2 chips
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice
         // (forward to neighbor is not encoded in the field) Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 =
@@ -371,22 +381,24 @@ public:
     // Specialized implementations for LowLatencyPacketHeader
     inline void set_routing_fields(LowLatencyRoutingFields& fields) { this->routing_fields = fields; }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops) {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
         this->routing_fields.value =
-            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
+            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
     }
-    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) {
-        this->routing_fields.value =
-            LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
+    inline void to_chip_multicast_impl(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
+        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(
+            chip_multicast_command_header, distance_to_high_vc);
     }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) volatile {
         this->routing_fields.value =
-            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
+            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
     }
-    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) volatile {
-        this->routing_fields.value =
-            LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
+    inline void to_chip_multicast_impl(
+        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) volatile {
+        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(
+            chip_multicast_command_header, distance_to_high_vc);
     }
 };
 
@@ -398,6 +410,7 @@ static_assert(
 
 static constexpr size_t header_size_bytes = sizeof(PacketHeader);
 
+// TODO: Should be piped from host to determine which packet header to use
 #define FABRIC_LOW_LATENCY_MODE 1
 
 #if defined FABRIC_LOW_LATENCY_MODE and FABRIC_LOW_LATENCY_MODE == 1

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -319,7 +319,7 @@ struct LowLatencyRoutingFields {
     static constexpr uint32_t FORWARD_ONLY = 0b10;
     static constexpr uint32_t WRITE_AND_FORWARD = 0b11;
     static constexpr uint32_t FWD_ONLY_FIELD = 0xAAAAAAAA;
-    static constexpr uint32_t WR_AND_FWD_FIELD = 0xFFFFFFFF;
+    static constexpr uint32_t WR_ONLY_FIELD = 0x55555555;
     uint32_t value;
 };
 
@@ -345,17 +345,15 @@ private:
         // 0b110000. This means starting from the 3rd chip, we will write and forward once Last line will do 0b01 << 6 =
         // 0b01000000. This means that on the 5th chip, we will write only Together this means the final encoding is
         // 0b01111010
-        return (LowLatencyRoutingFields::FWD_ONLY_FIELD &
-                ((1 << (chip_multicast_command_header.start_distance_in_hops - 1) *
-                           LowLatencyRoutingFields::FIELD_WIDTH) -
-                 1)) |
-               (LowLatencyRoutingFields::WR_AND_FWD_FIELD &
-                ((1 << (chip_multicast_command_header.range_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)
-                    << ((chip_multicast_command_header.start_distance_in_hops - 1) *
-                        LowLatencyRoutingFields::FIELD_WIDTH)) |
-               (LowLatencyRoutingFields::WRITE_ONLY << (chip_multicast_command_header.start_distance_in_hops +
-                                                        chip_multicast_command_header.range_hops - 2) *
-                                                           LowLatencyRoutingFields::FIELD_WIDTH);
+        return (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (chip_multicast_command_header.start_distance_in_hops +
+                                                                  chip_multicast_command_header.range_hops - 2) *
+                                                                     LowLatencyRoutingFields::FIELD_WIDTH) -
+                                                           1)) |
+               // TODO: We can skip the masking of the upper bits for improved performance on the workers, at the cost
+               // of readability of the packet header
+               ((LowLatencyRoutingFields::WR_ONLY_FIELD &
+                 ((1 << (chip_multicast_command_header.range_hops) * LowLatencyRoutingFields::FIELD_WIDTH) - 1))
+                << ((chip_multicast_command_header.start_distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH));
     }
 
 public:

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <climits>
 #include <limits>
 
 namespace tt::tt_fabric {
@@ -143,16 +144,13 @@ struct PacketHeaderBase {
     inline void set_noc_send_type(NocSendType& type) { this->noc_send_type = type; }
     inline void set_command_fields(NocCommandFields& fields) { this->command_fields = fields; }
 
-    inline Derived& to_chip_unicast(
-        uint8_t distance_in_hops, uint8_t distance_to_high_vc = Derived::default_high_vc_distance) {
-        static_cast<Derived*>(this)->to_chip_unicast_impl(distance_in_hops, distance_to_high_vc);
+    inline Derived& to_chip_unicast(uint8_t distance_in_hops) {
+        static_cast<Derived*>(this)->to_chip_unicast_impl(distance_in_hops);
         return *static_cast<Derived*>(this);
     }
 
-    inline Derived& to_chip_multicast(
-        const MulticastRoutingCommandHeader& mcast_routing_command_header,
-        uint8_t distance_to_high_vc = Derived::default_high_vc_distance) {
-        static_cast<Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header, distance_to_high_vc);
+    inline Derived& to_chip_multicast(const MulticastRoutingCommandHeader& mcast_routing_command_header) {
+        static_cast<Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
         return *static_cast<Derived*>(this);
     }
 
@@ -195,16 +193,14 @@ struct PacketHeaderBase {
         return *static_cast<Derived*>(this);
     }
 
-    inline volatile Derived* to_chip_unicast(
-        uint8_t distance_in_hops, uint8_t distance_to_high_vc = Derived::default_high_vc_distance) volatile {
-        static_cast<volatile Derived*>(this)->to_chip_unicast_impl(distance_in_hops, distance_to_high_vc);
+    inline volatile Derived* to_chip_unicast(uint8_t distance_in_hops) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_unicast_impl(distance_in_hops);
         return static_cast<volatile Derived*>(this);
     }
 
     inline volatile Derived* to_chip_multicast(
-        const MulticastRoutingCommandHeader& mcast_routing_command_header,
-        uint8_t distance_to_high_vc = Derived::default_high_vc_distance) volatile {
-        static_cast<volatile Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header, distance_to_high_vc);
+        const MulticastRoutingCommandHeader& mcast_routing_command_header) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
         return static_cast<volatile Derived*>(this);
     }
 
@@ -279,12 +275,11 @@ struct PacketHeader : public PacketHeaderBase<PacketHeader> {
     // manage this complexity.
     uint8_t padding0[10];
 
-    inline static uint32_t calculate_chip_unicast_routing_fields_value(
-        uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
+    inline static uint32_t calculate_chip_unicast_routing_fields_value(uint8_t distance_in_hops) {
         return RoutingFields::LAST_CHIP_IN_MCAST_VAL | distance_in_hops;
     }
     inline static uint32_t calculate_chip_multicast_routing_fields_value(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
+        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
         return ((static_cast<uint8_t>(chip_multicast_command_header.range_hops)
                  << RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH)) |
                static_cast<uint8_t>(chip_multicast_command_header.start_distance_in_hops);
@@ -296,28 +291,24 @@ public:
 
     inline void set_routing_fields(RoutingFields& fields) { this->routing_fields = fields; }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) {
         this->chip_send_type = CHIP_UNICAST;
-        this->routing_fields.value =
-            PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
+        this->routing_fields.value = PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline void to_chip_multicast_impl(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
+    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) {
         this->chip_send_type = CHIP_MULTICAST;
-        this->routing_fields.value = PacketHeader::calculate_chip_multicast_routing_fields_value(
-            chip_multicast_command_header, distance_to_high_vc);
+        this->routing_fields.value =
+            PacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) volatile {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
         this->chip_send_type = CHIP_UNICAST;
-        this->routing_fields.value =
-            PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
+        this->routing_fields.value = PacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline void to_chip_multicast_impl(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) volatile {
+    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) volatile {
         this->chip_send_type = CHIP_MULTICAST;
-        this->routing_fields.value = PacketHeader::calculate_chip_multicast_routing_fields_value(
-            chip_multicast_command_header, distance_to_high_vc);
+        this->routing_fields.value =
+            PacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
 };
 
@@ -343,8 +334,7 @@ struct LowLatencyPacketHeader : public PacketHeaderBase<LowLatencyPacketHeader> 
     uint8_t padding0[8];
 
 private:
-    inline static uint32_t calculate_chip_unicast_routing_fields_value(
-        uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
+    inline static uint32_t calculate_chip_unicast_routing_fields_value(uint8_t distance_in_hops) {
         // Example of unicast 3 hops away
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice
         // (forward to neighbor is not encoded in the field) Last line will do 0b01 << 4 = 0b010000. This means that on
@@ -353,20 +343,21 @@ private:
                 ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
                (LowLatencyRoutingFields::WRITE_ONLY << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) |
                (LowLatencyRoutingFields::HIGH_VC_FIELD
-                << (distance_to_high_vc - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
+                << ((distance_in_hops - 1) >> 1) *
+                       LowLatencyRoutingFields::FIELD_WIDTH);  // Flip to high VC at the middle of the path
     }
     inline static uint32_t calculate_chip_multicast_routing_fields_value(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
+        const MulticastRoutingCommandHeader& chip_multicast_command_header) {
         // Example of starting 3 hops away mcasting to 2 chips
         // First line will do 0xAAAAAAAA & 0b1111 = 0b1010. This means starting from our neighbor, we will forward twice
         // (forward to neighbor is not encoded in the field) Second line will do 0xFFFFFFFF & 0b11 = 0b11. 0b11 << 4 =
         // 0b110000. This means starting from the 3rd chip, we will write and forward once Last line will do 0b01 << 6 =
         // 0b01000000. This means that on the 5th chip, we will write only Together this means the final encoding is
         // 0b01111010
-        return (LowLatencyRoutingFields::FWD_ONLY_FIELD & ((1 << (chip_multicast_command_header.start_distance_in_hops +
-                                                                  chip_multicast_command_header.range_hops - 2) *
-                                                                     LowLatencyRoutingFields::FIELD_WIDTH) -
-                                                           1)) |
+        uint32_t distance_in_hops =
+            chip_multicast_command_header.start_distance_in_hops + chip_multicast_command_header.range_hops - 1;
+        return (LowLatencyRoutingFields::FWD_ONLY_FIELD &
+                ((1 << (distance_in_hops - 1) * LowLatencyRoutingFields::FIELD_WIDTH) - 1)) |
                // TODO: We can skip the masking of the upper bits for improved performance on the workers, at the cost
                // of readability of the packet header
                ((LowLatencyRoutingFields::WR_ONLY_FIELD &
@@ -374,31 +365,30 @@ private:
                 << ((chip_multicast_command_header.start_distance_in_hops - 1) *
                     LowLatencyRoutingFields::FIELD_WIDTH)) |
                (LowLatencyRoutingFields::HIGH_VC_FIELD
-                << (distance_to_high_vc - 1) * LowLatencyRoutingFields::FIELD_WIDTH);
+                << ((distance_in_hops - 1) >> 1) *
+                       LowLatencyRoutingFields::FIELD_WIDTH);  // Flip to high VC at the middle of the path
     }
 
 public:
     // Specialized implementations for LowLatencyPacketHeader
     inline void set_routing_fields(LowLatencyRoutingFields& fields) { this->routing_fields = fields; }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) {
         this->routing_fields.value =
-            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
+            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline void to_chip_multicast_impl(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) {
-        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(
-            chip_multicast_command_header, distance_to_high_vc);
+    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) {
+        this->routing_fields.value =
+            LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
 
-    inline void to_chip_unicast_impl(uint8_t distance_in_hops, uint8_t distance_to_high_vc) volatile {
+    inline void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
         this->routing_fields.value =
-            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops, distance_to_high_vc);
+            LowLatencyPacketHeader::calculate_chip_unicast_routing_fields_value(distance_in_hops);
     }
-    inline void to_chip_multicast_impl(
-        const MulticastRoutingCommandHeader& chip_multicast_command_header, uint8_t distance_to_high_vc) volatile {
-        this->routing_fields.value = LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(
-            chip_multicast_command_header, distance_to_high_vc);
+    inline void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) volatile {
+        this->routing_fields.value =
+            LowLatencyPacketHeader::calculate_chip_multicast_routing_fields_value(chip_multicast_command_header);
     }
 };
 

--- a/tt_metal/api/tt-metalium/fabric_edm_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_types.hpp
@@ -8,6 +8,8 @@
 
 namespace tt::tt_fabric {
 
+enum class Topology { Ring = 0, Linear = 1, Mesh = 2 };
+
 struct WorkerXY {
     uint16_t x;
     uint16_t y;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -37,35 +37,79 @@ namespace tt::tt_fabric {
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     std::size_t channel_buffer_size_bytes, std::size_t sender_ratio_size, std::size_t receiver_ratio_size) {
     TT_FATAL(
-        (receiver_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        (receiver_0_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
+        "receiver_0_completed_packet_header_cb_address {} must be aligned to {} bytes",
+        receiver_0_completed_packet_header_cb_address,
+        eth_word_l1_alignment);
+    TT_FATAL(
+        (receiver_1_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
+        "receiver_1_completed_packet_header_cb_address {} must be aligned to {} bytes",
+        receiver_1_completed_packet_header_cb_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_0_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_0_completed_packet_header_cb_address {} must be aligned to {} bytes",
+        sender_0_completed_packet_header_cb_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_1_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_1_completed_packet_header_cb_address {} must be aligned to {} bytes",
+        sender_1_completed_packet_header_cb_address,
+        eth_word_l1_alignment);
+    TT_FATAL(
+        (sender_2_completed_packet_header_cb_address % eth_word_l1_alignment == 0),
+        "sender_2_completed_packet_header_cb_address {} must be aligned to {} bytes",
+        sender_2_completed_packet_header_cb_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_channel_0_buffer_index_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_channel_0_buffer_index_address {} must be aligned to {} bytes",
+        sender_channel_0_buffer_index_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_channel_0_worker_conn_info_base_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_channel_0_worker_conn_info_base_address {} must be aligned to {} bytes",
+        sender_channel_0_worker_conn_info_base_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_channel_0_local_flow_control_semaphore_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_channel_0_local_flow_control_semaphore_address {} must be aligned to {} bytes",
+        sender_channel_0_local_flow_control_semaphore_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_channel_0_producer_terminate_connection_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_channel_0_producer_terminate_connection_address {} must be aligned to {} bytes",
+        sender_channel_0_producer_terminate_connection_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_channel_1_local_flow_control_semaphore_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_channel_1_local_flow_control_semaphore_address {} must be aligned to {} bytes",
+        sender_channel_1_local_flow_control_semaphore_address,
+        eth_word_l1_alignment);
     TT_FATAL(
         (sender_channel_1_producer_terminate_connection_address % eth_word_l1_alignment == 0),
-        "receiver_completed_packet_header_cb_address must be aligned to 16 bytes");
+        "sender_channel_1_producer_terminate_connection_address {} must be aligned to {} bytes",
+        sender_channel_1_producer_terminate_connection_address,
+        eth_word_l1_alignment);
+    TT_FATAL(
+        (sender_channel_2_local_flow_control_semaphore_address % eth_word_l1_alignment == 0),
+        "sender_channel_2_local_flow_control_semaphore_address {} must be aligned to {} bytes",
+        sender_channel_2_local_flow_control_semaphore_address,
+        eth_word_l1_alignment);
+    TT_FATAL(
+        (sender_channel_2_producer_terminate_connection_address % eth_word_l1_alignment == 0),
+        "sender_channel_2_producer_terminate_connection_address {} must be aligned to {} bytes",
+        sender_channel_2_producer_terminate_connection_address,
+        eth_word_l1_alignment);
 
     TT_FATAL(
         sender_channel_1_buffer_index_address != sender_channel_0_buffer_index_address,
+        "FabricEriscDatamoverConfig was constructed with illegal buffer index address");
+    TT_FATAL(
+        sender_channel_2_buffer_index_address != sender_channel_0_buffer_index_address,
+        "FabricEriscDatamoverConfig was constructed with illegal buffer index address");
+    TT_FATAL(
+        sender_channel_1_buffer_index_address != sender_channel_2_buffer_index_address,
         "FabricEriscDatamoverConfig was constructed with illegal buffer index address");
     const size_t min_buffer_size =
         sizeof(tt::tt_fabric::PacketHeader) + 2 * FabricEriscDatamoverConfig::eth_channel_sync_size;
@@ -75,53 +119,92 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         "size of {}",
         min_buffer_size);
 
-    constexpr size_t default_pow2_num_sender_buffer_slots = 8;
-    constexpr size_t default_pow2_num_receiver_buffer_slots = 16;
+    // TODO: Review
+    constexpr size_t default_pow2_num_sender_buffer_slots = 4;
+    constexpr size_t default_pow2_num_receiver_buffer_slots = 8;
 
     const std::size_t channel_buffer_size_with_channel_sync =
-        channel_buffer_size_bytes +
-        sizeof(tt::tt_fabric::PacketHeader);  // + 16 // sizeof(tt::tt_fabric::PacketHeader);
+        channel_buffer_size_bytes + sizeof(tt::tt_fabric::PacketHeader);  // + 16 // sizeof(tt::tt_fabric::PacketHeader);
 
-    const size_t next_lowest_power_of_2_buffer_slot_count =
-
-        this->channel_buffer_size_bytes = channel_buffer_size_bytes;
+    const size_t next_lowest_power_of_2_buffer_slot_count = this->channel_buffer_size_bytes = channel_buffer_size_bytes;
     this->channel_buffer_size_bytes_with_channel_sync = channel_buffer_size_with_channel_sync;
-    const std::size_t total_ratio_count = 2 * sender_ratio_size + receiver_ratio_size;
+    const std::size_t total_ratio_count = 3 * sender_ratio_size + 2 * receiver_ratio_size;
 
-    this->sender_0_channel_size_bytes = tt::round_down(
-        (available_channel_buffering_space / total_ratio_count) * sender_ratio_size,
-        channel_buffer_size_with_channel_sync);
-    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
-        this->sender_0_num_buffers = default_pow2_num_sender_buffer_slots;
-    } else {
-        this->sender_0_num_buffers = this->sender_0_channel_size_bytes / channel_buffer_size_with_channel_sync;
-    }
-    this->sender_1_channel_size_bytes = tt::round_down(
-        (available_channel_buffering_space / total_ratio_count) * sender_ratio_size,
-        channel_buffer_size_with_channel_sync);
-    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
-        this->sender_1_num_buffers = default_pow2_num_sender_buffer_slots;
-    } else {
-        this->sender_1_num_buffers = this->sender_1_channel_size_bytes / channel_buffer_size_with_channel_sync;
-    }
-    this->receiver_channel_size_bytes = tt::round_down(
-        (available_channel_buffering_space / total_ratio_count) * receiver_ratio_size,
-        channel_buffer_size_with_channel_sync);
-    if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
-        this->receiver_num_buffers = default_pow2_num_receiver_buffer_slots;
-    } else {
-        this->receiver_num_buffers = this->receiver_channel_size_bytes / channel_buffer_size_with_channel_sync;
-    }
+    auto buffer_initializer = [available_channel_buffering_space = this->available_channel_buffering_space,
+                               total_ratio_count,
+                               default_pow2_num_sender_buffer_slots,
+                               channel_buffer_size_with_channel_sync](
+                                  auto& channel_size_bytes,
+                                  auto& num_buffers,
+                                  const auto ratio_size,
+                                  const auto default_pow2_num_buffer_slots) {
+        channel_size_bytes = tt::round_down(
+            (available_channel_buffering_space / total_ratio_count) * ratio_size,
+            channel_buffer_size_with_channel_sync);
+        if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
+            num_buffers = default_pow2_num_buffer_slots;
+        } else {
+            num_buffers = channel_size_bytes / channel_buffer_size_with_channel_sync;
+        }
+    };
 
-    this->sender_0_channel_base_address = buffer_region_start;
-    this->sender_1_channel_base_address = this->sender_0_channel_base_address + this->sender_0_channel_size_bytes;
-    this->receiver_channel_base_address = this->sender_1_channel_base_address + this->sender_1_channel_size_bytes;
+    buffer_initializer(
+        this->sender_0_channel_size_bytes,
+        this->sender_0_num_buffers,
+        sender_ratio_size,
+        default_pow2_num_sender_buffer_slots);
+    TT_FATAL(
+        channel_buffer_size_with_channel_sync <= this->sender_0_channel_size_bytes / this->sender_0_num_buffers,
+        "Specified channel buffer size and number of buffer slots does not fit");
+    buffer_initializer(
+        this->sender_1_channel_size_bytes,
+        this->sender_1_num_buffers,
+        sender_ratio_size,
+        default_pow2_num_sender_buffer_slots);
+    TT_FATAL(
+        channel_buffer_size_with_channel_sync <= this->sender_1_channel_size_bytes / this->sender_1_num_buffers,
+        "Specified channel buffer size and number of buffer slots does not fit");
+    buffer_initializer(
+        this->sender_2_channel_size_bytes,
+        this->sender_2_num_buffers,
+        sender_ratio_size,
+        default_pow2_num_sender_buffer_slots);
+    TT_FATAL(
+        channel_buffer_size_with_channel_sync <= this->sender_2_channel_size_bytes / this->sender_2_num_buffers,
+        "Specified channel buffer size and number of buffer slots does not fit");
+    buffer_initializer(
+        this->receiver_0_channel_size_bytes,
+        this->receiver_0_num_buffers,
+        receiver_ratio_size,
+        default_pow2_num_receiver_buffer_slots);
+    TT_FATAL(
+        channel_buffer_size_with_channel_sync <= this->receiver_0_channel_size_bytes / this->receiver_0_num_buffers,
+        "Specified channel buffer size and number of buffer slots does not fit");
+    buffer_initializer(
+        this->receiver_1_channel_size_bytes,
+        this->receiver_1_num_buffers,
+        receiver_ratio_size,
+        default_pow2_num_receiver_buffer_slots);
+    TT_FATAL(
+        channel_buffer_size_with_channel_sync <= this->receiver_1_channel_size_bytes / this->receiver_1_num_buffers,
+        "Specified channel buffer size and number of buffer slots does not fit");
 
-    log_trace(tt::LogOp, "Sender 0 channel_start: {}", this->sender_0_channel_base_address);
-    log_trace(tt::LogOp, "Sender 1 channel_start: {}", this->sender_1_channel_base_address);
-    log_trace(tt::LogOp, "Receiver channel_start: {}", this->receiver_channel_base_address);
+    this->sender_channel_base_addresses[0] = buffer_region_start;
+    this->sender_channel_base_addresses[1] = this->sender_channel_base_addresses[0] + this->sender_0_channel_size_bytes;
+    this->sender_channel_base_addresses[2] = this->sender_channel_base_addresses[1] + this->sender_1_channel_size_bytes;
+    this->receiver_channel_base_addresses[0] =
+        this->sender_channel_base_addresses[2] + this->sender_2_channel_size_bytes;
+    this->receiver_channel_base_addresses[1] =
+        this->receiver_channel_base_addresses[0] + this->receiver_0_channel_size_bytes;
 
-    static constexpr size_t total_num_channels = 3;  // sender0, sender1, receiver
+    log_trace(tt::LogOp, "Sender 0 channel_start: {}", this->sender_channel_base_addresses[0]);
+    log_trace(tt::LogOp, "Sender 1 channel_start: {}", this->sender_channel_base_addresses[1]);
+    log_trace(tt::LogOp, "Sender 2 channel_start: {}", this->sender_channel_base_addresses[2]);
+    log_trace(tt::LogOp, "Receiver 0 channel_start: {}", this->receiver_channel_base_addresses[0]);
+    log_trace(tt::LogOp, "Receiver 1 channel_start: {}", this->receiver_channel_base_addresses[1]);
+    log_trace(tt::LogOp, "Available channel buffering space: {}", this->available_channel_buffering_space);
+
+    static constexpr size_t total_num_channels = 5;  // sender0, sender1, sender2, receiver0, receiver1
     const size_t max_channel_buffer_size = (available_channel_buffering_space / total_num_channels) -
                                            FabricEriscDatamoverConfig::eth_channel_sync_size -
                                            sizeof(tt::tt_fabric::PacketHeader);
@@ -136,14 +219,21 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         this->sender_1_channel_size_bytes > 0,
         "Internal error when computing `sender_1_channel_size_bytes` which was computed to be size 0");
     TT_FATAL(
-        this->receiver_channel_size_bytes > 0,
-        "Internal error when computing `receiver_channel_size_bytes` which was computed to be size 0");
+        this->sender_2_channel_size_bytes > 0,
+        "Internal error when computing `sender_2_channel_size_bytes` which was computed to be size 0");
     TT_FATAL(
-        this->sender_0_channel_size_bytes + this->sender_1_channel_size_bytes + this->receiver_channel_size_bytes <=
+        this->receiver_0_channel_size_bytes > 0,
+        "Internal error when computing `receiver_0_channel_size_bytes` which was computed to be size 0");
+    TT_FATAL(
+        this->receiver_1_channel_size_bytes > 0,
+        "Internal error when computing `receiver_1_channel_size_bytes` which was computed to be size 0");
+    TT_FATAL(
+        this->sender_0_channel_size_bytes + this->sender_1_channel_size_bytes + this->sender_2_channel_size_bytes +
+                this->receiver_0_channel_size_bytes + this->receiver_1_channel_size_bytes <=
             this->available_channel_buffering_space,
         "Internal error when computing channel sizes. Total channel size exceeds available space");
     TT_FATAL(
-        this->receiver_channel_base_address + this->receiver_channel_size_bytes < this->max_l1_loading_size,
+        this->receiver_channel_base_addresses.back() + this->receiver_1_channel_size_bytes < this->max_l1_loading_size,
         "Internal error - channel buffers spilled past the end of usable L1 region.");
 }
 
@@ -214,14 +304,19 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     size_t my_chip_id,
     size_t peer_chip_id,
 
-    std::optional<size_t> receiver_channel_downstream_flow_control_semaphore_id,
-    std::optional<size_t> receiver_channel_downstream_teardown_semaphore_id,
+    std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_id,
+    std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_id,
+    std::optional<size_t> receiver_channel_0_downstream_teardown_semaphore_id,
+    std::optional<size_t> receiver_channel_1_downstream_teardown_semaphore_id,
     size_t sender_channel_0_flow_control_semaphore_id,
     size_t sender_channel_1_flow_control_semaphore_id,
+    size_t sender_channel_2_flow_control_semaphore_id,
     size_t sender_channel_0_connection_semaphore_id,
     size_t sender_channel_1_connection_semaphore_id,
+    size_t sender_channel_2_connection_semaphore_id,
     size_t sender_channel_0_buffer_index_semaphore_id,
     size_t sender_channel_1_buffer_index_semaphore_id,
+    size_t sender_channel_2_buffer_index_semaphore_id,
 
     const FabricEriscDatamoverConfig& config,
     bool enable_persistent_mode,
@@ -237,25 +332,32 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     channel_buffer_size(config.channel_buffer_size_bytes),
     sender_0_num_buffers(config.sender_0_num_buffers),
     sender_1_num_buffers(config.sender_1_num_buffers),
-    receiver_num_buffers(config.receiver_num_buffers),
+    sender_2_num_buffers(config.sender_2_num_buffers),
+    receiver_0_num_buffers(config.receiver_0_num_buffers),
+    receiver_1_num_buffers(config.receiver_1_num_buffers),
 
     // this is the receiver channel's local sem for flow controlling with downstream fabric sender
-    receiver_channel_downstream_flow_control_semaphore_id(receiver_channel_downstream_flow_control_semaphore_id),
-    receiver_channel_downstream_teardown_semaphore_id(receiver_channel_downstream_teardown_semaphore_id),
+    receiver_channel_0_downstream_flow_control_semaphore_id(receiver_channel_0_downstream_flow_control_semaphore_id),
+    receiver_channel_0_downstream_teardown_semaphore_id(receiver_channel_0_downstream_teardown_semaphore_id),
+    receiver_channel_1_downstream_flow_control_semaphore_id(receiver_channel_1_downstream_flow_control_semaphore_id),
+    receiver_channel_1_downstream_teardown_semaphore_id(receiver_channel_1_downstream_teardown_semaphore_id),
     sender_channel_0_flow_control_semaphore_id(sender_channel_0_flow_control_semaphore_id),
     sender_channel_1_flow_control_semaphore_id(sender_channel_1_flow_control_semaphore_id),
+    sender_channel_2_flow_control_semaphore_id(sender_channel_2_flow_control_semaphore_id),
     sender_channel_0_connection_semaphore_id(sender_channel_0_connection_semaphore_id),
     sender_channel_1_connection_semaphore_id(sender_channel_1_connection_semaphore_id),
+    sender_channel_2_connection_semaphore_id(sender_channel_2_connection_semaphore_id),
     sender_channel_0_buffer_index_semaphore_id(sender_channel_0_buffer_index_semaphore_id),
     sender_channel_1_buffer_index_semaphore_id(sender_channel_1_buffer_index_semaphore_id),
+    sender_channel_2_buffer_index_semaphore_id(sender_channel_2_buffer_index_semaphore_id),
 
-    receiver_channel_local_buffer_index_address(config.receiver_channel_local_buffer_index_address),
-
-    local_sender_channel_0_buffer_address(config.sender_0_channel_base_address),
+    receiver_channel_0_local_buffer_index_address(config.receiver_channel_0_local_buffer_index_address),
+    receiver_channel_1_local_buffer_index_address(config.receiver_channel_1_local_buffer_index_address),
+    local_sender_channel_buffer_addresses(config.sender_channel_base_addresses),
     local_sender_channel_0_connection_info_addr(config.sender_channel_0_worker_conn_info_base_address),
-    local_sender_channel_1_buffer_address(config.sender_1_channel_base_address),
     local_sender_channel_1_connection_info_addr(config.sender_channel_1_worker_conn_info_base_address),
-    local_receiver_channel_buffer_address(config.receiver_channel_base_address),
+    local_sender_channel_2_connection_info_addr(config.sender_channel_2_worker_conn_info_base_address),
+    local_receiver_channel_buffer_addresses(config.receiver_channel_base_addresses),
 
     termination_signal_ptr(config.termination_signal_address),
     edm_status_ptr(config.edm_status_address),
@@ -269,11 +371,15 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         this->sender_0_num_buffers == this->sender_1_num_buffers);  //, "Implementation expects sender_0_num_buffers and
                                                                     // sender_1_num_buffers to be the same for now");
     log_trace(tt::LogTest, "Sender 0 num buffers: {}", this->sender_0_num_buffers);
-    log_trace(tt::LogTest, "Sender 0 channel address: {}", this->local_sender_channel_0_buffer_address);
+    log_trace(tt::LogTest, "Sender 0 channel address: {}", this->local_sender_channel_buffer_addresses[0]);
     log_trace(tt::LogTest, "Sender 1 num buffers: {}", this->sender_1_num_buffers);
-    log_trace(tt::LogTest, "Sender 1 channel address: {}", this->local_sender_channel_1_buffer_address);
-    log_trace(tt::LogTest, "Receiver num buffers: {}", this->receiver_num_buffers);
-    log_trace(tt::LogTest, "Receiver channel address: {}", this->local_receiver_channel_buffer_address);
+    log_trace(tt::LogTest, "Sender 1 channel address: {}", this->local_sender_channel_buffer_addresses[1]);
+    log_trace(tt::LogTest, "Sender 2 num buffers: {}", this->sender_2_num_buffers);
+    log_trace(tt::LogTest, "Sender 2 channel address: {}", this->local_sender_channel_buffer_addresses[2]);
+    log_trace(tt::LogTest, "Receiver 0 num buffers: {}", this->receiver_0_num_buffers);
+    log_trace(tt::LogTest, "Receiver 0 channel address: {}", this->local_receiver_channel_buffer_addresses[0]);
+    log_trace(tt::LogTest, "Receiver 1 num buffers: {}", this->receiver_1_num_buffers);
+    log_trace(tt::LogTest, "Receiver 1 channel address: {}", this->local_receiver_channel_buffer_addresses[1]);
 
     return std::vector<uint32_t>{
         this->firmware_context_switch_interval,
@@ -282,17 +388,22 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         this->channel_buffer_size,
 
         this->sender_0_num_buffers,
-        this->receiver_num_buffers,
+        this->receiver_0_num_buffers,
 
-        config.sender_0_channel_base_address,
+        config.sender_channel_base_addresses[0],
         config.sender_channel_0_worker_conn_info_base_address,
-        config.sender_1_channel_base_address,
+        config.sender_channel_base_addresses[1],
         config.sender_channel_1_worker_conn_info_base_address,
-        config.receiver_channel_base_address,
-        config.receiver_channel_base_address,
+        config.sender_channel_base_addresses[2],
+        config.sender_channel_2_worker_conn_info_base_address,
+        config.receiver_channel_base_addresses[0],
+        config.receiver_channel_base_addresses[0],
+        config.receiver_channel_base_addresses[1],
+        config.receiver_channel_base_addresses[1],
 
-        config.sender_0_channel_base_address,
-        config.sender_1_channel_base_address,
+        config.sender_channel_base_addresses[0],
+        config.sender_channel_base_addresses[1],
+        config.sender_channel_base_addresses[2],
 
         this->termination_signal_ptr,
         this->edm_status_ptr,
@@ -300,18 +411,24 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
 
         // fabric counters
         FabricEriscDatamoverConfig::enable_fabric_counters,
-        config.receiver_channel_counters_address,
+        config.receiver_channel_0_counters_address,
+        config.receiver_channel_1_counters_address,
         config.sender_channel_0_counters_address,
         config.sender_channel_1_counters_address,
+        config.sender_channel_2_counters_address,
 
         // fabric pkt header recording
         FabricEriscDatamoverConfig::enable_fabric_pkt_header_recording,
 
-        config.receiver_completed_packet_header_cb_address,
+        config.receiver_0_completed_packet_header_cb_address,
+        FabricEriscDatamoverConfig::receiver_completed_packet_header_cb_size_headers,
+        config.receiver_1_completed_packet_header_cb_address,
         FabricEriscDatamoverConfig::receiver_completed_packet_header_cb_size_headers,
         config.sender_0_completed_packet_header_cb_address,
         FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers,
         config.sender_1_completed_packet_header_cb_address,
+        FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers,
+        config.sender_2_completed_packet_header_cb_address,
         FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers};
 }
 
@@ -319,21 +436,39 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
     return std::vector<uint32_t>{
         this->sender_channel_0_connection_semaphore_id,
         this->sender_channel_1_connection_semaphore_id,
+        this->sender_channel_2_connection_semaphore_id,
         this->sender_channel_0_buffer_index_semaphore_id,
-        this->downstream_sender_channel_buffer_index_semaphore_id.value_or(-1),
-        this->downstream_edm_buffer_base_address != std::nullopt,
-        this->downstream_edm_buffer_base_address.value_or(0),
-        this->downstream_edm_noc_x.value_or(0),
-        this->downstream_edm_noc_y.value_or(0),
-        this->downstream_edm_semaphore_address.value_or(-1),
-        this->downstream_edm_worker_registration_address.value_or(0),
-        this->downstream_edm_worker_location_info_address.value_or(0),
-        this->receiver_channel_local_buffer_index_address,
+
+        this->downstream_vc0_sender_channel_buffer_index_semaphore_id.value_or(-1),
+        this->downstream_vc1_sender_channel_buffer_index_semaphore_id.value_or(-1),
+
+        this->downstream_edm_vc0_buffer_base_address != std::nullopt,
+        this->downstream_edm_vc0_buffer_base_address.value_or(0),
+        this->downstream_edm_vc0_noc_x.value_or(0),
+        this->downstream_edm_vc0_noc_y.value_or(0),
+        this->downstream_edm_vc0_semaphore_address.value_or(-1),
+        this->downstream_edm_vc0_worker_registration_address.value_or(0),
+        this->downstream_edm_vc0_worker_location_info_address.value_or(0),
+        this->receiver_channel_0_local_buffer_index_address,
         // this is the receiver channel's local sem for flow controlling with downstream fabric sender
-        this->receiver_channel_downstream_flow_control_semaphore_id.value_or(-1),
-        this->receiver_channel_downstream_teardown_semaphore_id.value_or(-1),
+        this->receiver_channel_0_downstream_flow_control_semaphore_id.value_or(-1),
+        this->receiver_channel_0_downstream_teardown_semaphore_id.value_or(-1),
+
+        this->downstream_edm_vc1_buffer_base_address != std::nullopt,
+        this->downstream_edm_vc1_buffer_base_address.value_or(0),
+        this->downstream_edm_vc1_noc_x.value_or(0),
+        this->downstream_edm_vc1_noc_y.value_or(0),
+        this->downstream_edm_vc1_semaphore_address.value_or(-1),
+        this->downstream_edm_vc1_worker_registration_address.value_or(0),
+        this->downstream_edm_vc1_worker_location_info_address.value_or(0),
+        this->receiver_channel_1_local_buffer_index_address,
+        // this is the receiver channel's local sem for flow controlling with downstream fabric sender
+        this->receiver_channel_1_downstream_flow_control_semaphore_id.value_or(-1),
+        this->receiver_channel_1_downstream_teardown_semaphore_id.value_or(-1),
+
         this->sender_channel_0_flow_control_semaphore_id,
-        this->sender_channel_1_flow_control_semaphore_id};
+        this->sender_channel_1_flow_control_semaphore_id,
+        this->sender_channel_2_flow_control_semaphore_id};
 }
 
 FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
@@ -351,10 +486,16 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
             config.sender_channel_0_local_flow_control_semaphore_address;
         auto sender_channel_0_connection_semaphore_address = config.sender_channel_0_connection_semaphore_address;
 
-        std::optional<size_t> receiver_channel_downstream_flow_control_semaphore_address =
+        std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_address =
             build_in_worker_connection_mode ? 0
                                             : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
-        std::optional<size_t> receiver_channel_downstream_terminate_semaphore_address =
+        std::optional<size_t> receiver_channel_0_downstream_terminate_semaphore_address =
+            build_in_worker_connection_mode ? 0
+                                            : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_address =
+            build_in_worker_connection_mode ? 0
+                                            : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        std::optional<size_t> receiver_channel_1_downstream_terminate_semaphore_address =
             build_in_worker_connection_mode ? 0
                                             : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_1_flow_control_semaphore_id =
@@ -366,6 +507,15 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
         auto sender_channel_1_buffer_index_semaphore_id =
             build_in_worker_connection_mode ? 0
                                             : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        auto sender_channel_2_flow_control_semaphore_id =
+            build_in_worker_connection_mode ? 0
+                                            : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        auto sender_channel_2_connection_semaphore_id =
+            build_in_worker_connection_mode ? 0
+                                            : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        auto sender_channel_2_buffer_index_semaphore_id =
+            build_in_worker_connection_mode ? 0
+                                            : tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
 
         return FabricEriscDatamoverBuilder(
             ethernet_core,
@@ -374,35 +524,50 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
             local_chip_id,
             peer_chip_id,
 
-            receiver_channel_downstream_flow_control_semaphore_address,
-            receiver_channel_downstream_terminate_semaphore_address,
+            receiver_channel_0_downstream_flow_control_semaphore_address,
+            receiver_channel_0_downstream_terminate_semaphore_address,
+            receiver_channel_1_downstream_flow_control_semaphore_address,
+            receiver_channel_1_downstream_terminate_semaphore_address,
             sender_channel_0_flow_control_semaphore_address,
             sender_channel_1_flow_control_semaphore_id,
+            sender_channel_2_flow_control_semaphore_id,
             sender_channel_0_connection_semaphore_address,
             sender_channel_1_connection_semaphore_id,
+            sender_channel_2_connection_semaphore_id,
             sender_channel_0_buffer_index_semaphore_address,
             sender_channel_1_buffer_index_semaphore_id,
+            sender_channel_2_buffer_index_semaphore_id,
 
             config,
             enable_persistent_mode,
             build_in_worker_connection_mode);
 
     } else {
-        std::optional<size_t> receiver_channel_downstream_flow_control_semaphore_id =
+        std::optional<size_t> receiver_channel_0_downstream_flow_control_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
-        std::optional<size_t> receiver_channel_downstream_teardown_semaphore_id =
+        std::optional<size_t> receiver_channel_0_downstream_teardown_semaphore_id =
+            tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        std::optional<size_t> receiver_channel_1_downstream_flow_control_semaphore_id =
+            tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        std::optional<size_t> receiver_channel_1_downstream_teardown_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_0_flow_control_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_1_flow_control_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        auto sender_channel_2_flow_control_semaphore_id =
+            tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_0_connection_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_1_connection_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        auto sender_channel_2_connection_semaphore_id =
+            tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_0_buffer_index_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
         auto sender_channel_1_buffer_index_semaphore_id =
+            tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
+        auto sender_channel_2_buffer_index_semaphore_id =
             tt::tt_metal::CreateSemaphore(program, ethernet_core, 0, CoreType::ETH);
 
         return FabricEriscDatamoverBuilder(
@@ -412,14 +577,19 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
             local_chip_id,
             peer_chip_id,
 
-            receiver_channel_downstream_flow_control_semaphore_id,
-            receiver_channel_downstream_teardown_semaphore_id,
+            receiver_channel_0_downstream_flow_control_semaphore_id,
+            receiver_channel_0_downstream_teardown_semaphore_id,
+            receiver_channel_1_downstream_flow_control_semaphore_id,
+            receiver_channel_1_downstream_teardown_semaphore_id,
             sender_channel_0_flow_control_semaphore_id,
             sender_channel_1_flow_control_semaphore_id,
+            sender_channel_2_flow_control_semaphore_id,
             sender_channel_0_connection_semaphore_id,
             sender_channel_1_connection_semaphore_id,
+            sender_channel_2_connection_semaphore_id,
             sender_channel_0_buffer_index_semaphore_id,
             sender_channel_1_buffer_index_semaphore_id,
+            sender_channel_2_buffer_index_semaphore_id,
 
             config,
             enable_persistent_mode);
@@ -439,7 +609,7 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_worker_
     return SenderWorkerAdapterSpec{
         this->my_noc_x,
         this->my_noc_y,
-        this->local_sender_channel_0_buffer_address,
+        this->local_sender_channel_buffer_addresses[0],
         this->sender_0_num_buffers,
         this->sender_channel_0_flow_control_semaphore_id,
         this->sender_channel_0_connection_semaphore_id,
@@ -449,35 +619,63 @@ SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_worker_
         this->enable_persistent_mode};
 }
 
-SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_channel() const {
-    return SenderWorkerAdapterSpec{
-        this->my_noc_x,
-        this->my_noc_y,
-        this->local_sender_channel_1_buffer_address,
-        this->sender_1_num_buffers,
-        this->sender_channel_1_flow_control_semaphore_id,
-        this->sender_channel_1_connection_semaphore_id,
-        this->config.sender_channel_1_worker_conn_info_base_address,
-        this->config.channel_buffer_size_bytes,
-        this->sender_channel_1_buffer_index_semaphore_id,
-        false};
+SenderWorkerAdapterSpec FabricEriscDatamoverBuilder::build_connection_to_fabric_channel(uint32_t vc) const {
+    if (vc == 0) {
+        return SenderWorkerAdapterSpec{
+            this->my_noc_x,
+            this->my_noc_y,
+            this->local_sender_channel_buffer_addresses[1],
+            this->sender_1_num_buffers,
+            this->sender_channel_1_flow_control_semaphore_id,
+            this->sender_channel_1_connection_semaphore_id,
+            this->config.sender_channel_1_worker_conn_info_base_address,
+            this->config.channel_buffer_size_bytes,
+            this->sender_channel_1_buffer_index_semaphore_id,
+            false};
+    } else if (vc == 1) {
+        return SenderWorkerAdapterSpec{
+            this->my_noc_x,
+            this->my_noc_y,
+            this->local_sender_channel_buffer_addresses[2],
+            this->sender_2_num_buffers,
+            this->sender_channel_2_flow_control_semaphore_id,
+            this->sender_channel_2_connection_semaphore_id,
+            this->config.sender_channel_2_worker_conn_info_base_address,
+            this->config.channel_buffer_size_bytes,
+            this->sender_channel_2_buffer_index_semaphore_id,
+            false};
+    } else {
+        TT_THROW("Invalid VC");
+    }
 }
 
 void FabricEriscDatamoverBuilder::connect_to_downstream_edm(const FabricEriscDatamoverBuilder& downstream_edm) {
     TT_FATAL(
         !this->build_in_worker_connection_mode, "Tried to connect two EDMs to each other in worker connection mode");
-    const auto adapter_spec = downstream_edm.build_connection_to_fabric_channel();
+    const auto adapter_spec_vc0 = downstream_edm.build_connection_to_fabric_channel(0);
+    const auto adapter_spec_vc1 = downstream_edm.build_connection_to_fabric_channel(1);
 
     log_trace(
-        tt::LogTest, "Connecting to downstream EDM at x={}, y={}", adapter_spec.edm_noc_x, adapter_spec.edm_noc_y);
+        tt::LogTest,
+        "Connecting to downstream EDM at x={}, y={}",
+        adapter_spec_vc0.edm_noc_x,
+        adapter_spec_vc0.edm_noc_y);
 
-    this->downstream_edm_noc_x = adapter_spec.edm_noc_x;
-    this->downstream_edm_noc_y = adapter_spec.edm_noc_y;
-    this->downstream_edm_buffer_base_address = adapter_spec.edm_buffer_base_addr;
-    this->downstream_edm_semaphore_address = adapter_spec.edm_l1_sem_addr;
-    this->downstream_edm_worker_registration_address = adapter_spec.edm_connection_handshake_addr;
-    this->downstream_edm_worker_location_info_address = adapter_spec.edm_worker_location_info_addr;
-    this->downstream_sender_channel_buffer_index_semaphore_id = adapter_spec.buffer_index_semaphore_id;
+    this->downstream_edm_vc0_noc_x = adapter_spec_vc0.edm_noc_x;
+    this->downstream_edm_vc0_noc_y = adapter_spec_vc0.edm_noc_y;
+    this->downstream_edm_vc0_buffer_base_address = adapter_spec_vc0.edm_buffer_base_addr;
+    this->downstream_edm_vc0_semaphore_address = adapter_spec_vc0.edm_l1_sem_addr;
+    this->downstream_edm_vc0_worker_registration_address = adapter_spec_vc0.edm_connection_handshake_addr;
+    this->downstream_edm_vc0_worker_location_info_address = adapter_spec_vc0.edm_worker_location_info_addr;
+    this->downstream_vc0_sender_channel_buffer_index_semaphore_id = adapter_spec_vc0.buffer_index_semaphore_id;
+
+    this->downstream_edm_vc1_noc_x = adapter_spec_vc1.edm_noc_x;
+    this->downstream_edm_vc1_noc_y = adapter_spec_vc1.edm_noc_y;
+    this->downstream_edm_vc1_buffer_base_address = adapter_spec_vc1.edm_buffer_base_addr;
+    this->downstream_edm_vc1_semaphore_address = adapter_spec_vc1.edm_l1_sem_addr;
+    this->downstream_edm_vc1_worker_registration_address = adapter_spec_vc1.edm_connection_handshake_addr;
+    this->downstream_edm_vc1_worker_location_info_address = adapter_spec_vc1.edm_worker_location_info_addr;
+    this->downstream_vc1_sender_channel_buffer_index_semaphore_id = adapter_spec_vc1.buffer_index_semaphore_id;
 }
 
 void FabricEriscDatamoverBuilder::teardown_from_host(

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -104,12 +104,12 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     std::size_t channel_buffer_size_bytes,
     std::size_t sender_ratio_size,
     std::size_t receiver_ratio_size,
-    bool ring_topology) :
+    Topology topology) :
     FabricEriscDatamoverConfig() {
     this->num_used_sender_channels = FabricEriscDatamoverConfig::num_sender_channels;
     this->num_used_receiver_channels = FabricEriscDatamoverConfig::num_receiver_channels;
-    this->enable_ring_topology = ring_topology;
-    if (!ring_topology) {
+    this->topology = topology;
+    if (topology != Topology::Ring) {
         this->num_used_sender_channels -= 1;
         this->num_used_receiver_channels -= 1;
     }
@@ -171,7 +171,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     // TODO: Review
     size_t default_pow2_num_sender_buffer_slots = 8;
     size_t default_pow2_num_receiver_buffer_slots = 16;
-    if (ring_topology) {
+    if (topology == Topology::Ring) {
         default_pow2_num_sender_buffer_slots /= 2;
         default_pow2_num_receiver_buffer_slots /= 2;
     }
@@ -413,7 +413,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         this->firmware_context_switch_interval,
         this->enable_first_level_ack,
         this->fuse_receiver_flush_and_completion_ptr,
-        config.enable_ring_topology,
+        config.topology == Topology::Ring,
         is_handshake_master,
         this->handshake_address,
         this->channel_buffer_size,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -282,7 +282,7 @@ struct WriteTransactionIdTracker {
     FORCE_INLINE uint8_t
     update_buffer_slot_to_next_trid_and_advance_trid_counter(tt::tt_fabric::BufferIndex buffer_index) {
         if constexpr (BOTH_PARAMS_ARE_POW2) {
-            uint8_t next_trid = OFFSET + buffer_index & TRID_POW2_MASK;
+            uint8_t next_trid = OFFSET + (buffer_index & TRID_POW2_MASK);
             this->trid_counter.increment();
             return next_trid;
         } else {
@@ -301,7 +301,7 @@ struct WriteTransactionIdTracker {
 
     FORCE_INLINE uint8_t get_buffer_slot_trid(tt::tt_fabric::BufferIndex buffer_index) const {
         if constexpr (BOTH_PARAMS_ARE_POW2) {
-            return OFFSET + buffer_index & TRID_POW2_MASK;
+            return OFFSET + (buffer_index & TRID_POW2_MASK);
         } else {
             return this->buffer_slot_trids[buffer_index];
         }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -25,9 +25,6 @@
 
 using namespace tt::tt_fabric;
 
-static constexpr bool enable_first_level_ack = false;
-static constexpr bool fuse_receiver_flush_and_completion_ptr = true;
-
 /*
 
 The fabric Erisc Data Mover (EDM) is a component that can be used to build *very* simple linear topology fabrics.
@@ -508,6 +505,10 @@ static constexpr uint32_t SWITCH_INTERVAL =
     0;
 #endif
 
+static constexpr bool enable_first_level_ack = get_compile_time_arg_val(1);
+static constexpr bool fuse_receiver_flush_and_completion_ptr = get_compile_time_arg_val(2);
+static constexpr bool enable_ring_support = get_compile_time_arg_val(3);
+
 static constexpr size_t ETH_BYTES_TO_WORDS_SHIFT = 4;
 static constexpr size_t NUM_SENDER_CHANNELS = 3;
 static constexpr size_t NUM_RECEIVER_CHANNELS = 2;
@@ -850,7 +851,13 @@ FORCE_INLINE void run_receiver_channel_step(
             local_receiver_channel.template get_packet_header<PACKET_HEADER_TYPE>(receiver_buffer_index);
 
         ROUTING_FIELDS_TYPE cached_routing_fields = const_cast<PACKET_HEADER_TYPE*>(packet_header)->routing_fields;
-        auto& downstream_edm_interface = downstream_edm_interfaces[extract_vc(cached_routing_fields)];
+        uint32_t vc;
+        if constexpr (enable_ring_support) {
+            vc = extract_vc(cached_routing_fields);
+        } else {
+            vc = 0;
+        }
+        auto& downstream_edm_interface = downstream_edm_interfaces[vc];
         bool can_send_to_all_local_chip_receivers =
             can_forward_packet_completely(cached_routing_fields, downstream_edm_interface);
         bool trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
@@ -1051,21 +1058,23 @@ void run_fabric_edm_main_loop(
                 receiver_channel_pointers[0],
                 receiver_channel_packet_recorders[0],
                 receiver_channel_trid_trackers[0]);
-            run_receiver_channel_step<
-                enable_packet_header_recording,
-                enable_fabric_counters,
-                RECEIVER_NUM_BUFFERS,
-                SENDER_NUM_BUFFERS,
-                NUM_SENDER_CHANNELS,
-                to_receiver_1_pkts_sent_id>(
-                local_receiver_channels[1],
-                remote_sender_channels,
-                downstream_edm_noc_interfaces,
-                receiver_channel_counters_ptrs[1],
-                remote_eth_sender_wrptrs,
-                receiver_channel_pointers[1],
-                receiver_channel_packet_recorders[1],
-                receiver_channel_trid_trackers[1]);
+            if constexpr (enable_ring_support) {
+                run_receiver_channel_step<
+                    enable_packet_header_recording,
+                    enable_fabric_counters,
+                    RECEIVER_NUM_BUFFERS,
+                    SENDER_NUM_BUFFERS,
+                    NUM_SENDER_CHANNELS,
+                    to_receiver_1_pkts_sent_id>(
+                    local_receiver_channels[1],
+                    remote_sender_channels,
+                    downstream_edm_noc_interfaces,
+                    receiver_channel_counters_ptrs[1],
+                    remote_eth_sender_wrptrs,
+                    receiver_channel_pointers[1],
+                    receiver_channel_packet_recorders[1],
+                    receiver_channel_trid_trackers[1]);
+            }
 
             bool did_something_sender1 = run_sender_channel_step<
                 enable_packet_header_recording,
@@ -1081,20 +1090,23 @@ void run_fabric_edm_main_loop(
                 sender_channel_packet_recorders[1],
                 channel_connection_established[1],
                 1);
-            bool did_something_sender2 = run_sender_channel_step<
-                enable_packet_header_recording,
-                enable_fabric_counters,
-                RECEIVER_NUM_BUFFERS,
-                SENDER_NUM_BUFFERS,
-                to_receiver_1_pkts_sent_id>(
-                local_sender_channels[2],
-                local_sender_channel_worker_interfaces[2],
-                outbound_to_receiver_channel_pointers[1],  // High VC
-                remote_receiver_channels[1],
-                sender_channel_counters_ptrs[2],
-                sender_channel_packet_recorders[2],
-                channel_connection_established[2],
-                2);
+            bool did_something_sender2 = false;
+            if constexpr (enable_ring_support) {
+                did_something_sender2 = run_sender_channel_step<
+                    enable_packet_header_recording,
+                    enable_fabric_counters,
+                    RECEIVER_NUM_BUFFERS,
+                    SENDER_NUM_BUFFERS,
+                    to_receiver_1_pkts_sent_id>(
+                    local_sender_channels[2],
+                    local_sender_channel_worker_interfaces[2],
+                    outbound_to_receiver_channel_pointers[1],  // High VC
+                    remote_receiver_channels[1],
+                    sender_channel_counters_ptrs[2],
+                    sender_channel_packet_recorders[2],
+                    channel_connection_established[2],
+                    2);
+            }
 
             did_something = did_something || did_something_sender0 || did_something_sender1 || did_something_sender2;
         }
@@ -1116,8 +1128,8 @@ void kernel_main() {
     //
     // COMMON CT ARGS (not specific to sender or receiver)
     //
-    static constexpr bool is_handshake_sender = get_compile_time_arg_val(1) != 0;
-    static constexpr size_t handshake_addr = get_compile_time_arg_val(2);
+    static constexpr bool is_handshake_sender = get_compile_time_arg_val(4) != 0;
+    static constexpr size_t handshake_addr = get_compile_time_arg_val(5);
     *reinterpret_cast<volatile uint32_t*>(handshake_addr) = 0;
     auto eth_transaction_ack_word_addr = handshake_addr + sizeof(eth_channel_sync_t);
 
@@ -1143,23 +1155,23 @@ void kernel_main() {
     // the size of one of the buffers within a sender channel
     // For example if `channel_buffer_size` = 4k, with `SENDER_NUM_BUFFERS` = 2
     // then the total amount of buffering for that
-    static constexpr size_t channel_buffer_size = get_compile_time_arg_val(3);
+    static constexpr size_t channel_buffer_size = get_compile_time_arg_val(6);
 
-    static constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(4);
-    static constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(5);
-    static constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(6);
-    static constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(7);
-    static constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(8);
-    static constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(9);
-    static constexpr size_t local_sender_2_channel_address = get_compile_time_arg_val(10);
-    static constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(11);
-    static constexpr size_t local_receiver_0_channel_buffer_address = get_compile_time_arg_val(12);
-    static constexpr size_t remote_receiver_0_channel_buffer_address = get_compile_time_arg_val(13);
-    static constexpr size_t local_receiver_1_channel_buffer_address = get_compile_time_arg_val(14);
-    static constexpr size_t remote_receiver_1_channel_buffer_address = get_compile_time_arg_val(15);
-    static constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(16);
-    static constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(17);
-    static constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(18);
+    static constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(7);
+    static constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(8);
+    static constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(9);
+    static constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(10);
+    static constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(11);
+    static constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(12);
+    static constexpr size_t local_sender_2_channel_address = get_compile_time_arg_val(13);
+    static constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(14);
+    static constexpr size_t local_receiver_0_channel_buffer_address = get_compile_time_arg_val(15);
+    static constexpr size_t remote_receiver_0_channel_buffer_address = get_compile_time_arg_val(16);
+    static constexpr size_t local_receiver_1_channel_buffer_address = get_compile_time_arg_val(17);
+    static constexpr size_t remote_receiver_1_channel_buffer_address = get_compile_time_arg_val(18);
+    static constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(19);
+    static constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(20);
+    static constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(21);
 
     DPRINT << "SENDER_NUM_BUFFERS: " << (uint32_t)SENDER_NUM_BUFFERS << "\n";
     DPRINT << "RECEIVER_NUM_BUFFERS: " << (uint32_t)RECEIVER_NUM_BUFFERS << "\n";
@@ -1184,33 +1196,33 @@ void kernel_main() {
 
     // TODO: CONVERT TO SEMAPHORE
     volatile auto termination_signal_ptr =
-        reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(get_compile_time_arg_val(19));
+        reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(get_compile_time_arg_val(22));
     volatile auto edm_status_ptr =
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::EDMStatus*>(get_compile_time_arg_val(20));
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::EDMStatus*>(get_compile_time_arg_val(23));
     // In persistent mode, we must rely on static addresses for our local semaphores that are locally
     // initialized, rather than metal device APIs. This way different subdevice programs can reliably
     // resolve the semaphore addresses on the EDM core
-    static constexpr bool persistent_mode = get_compile_time_arg_val(21) != 0;
+    static constexpr bool persistent_mode = get_compile_time_arg_val(24) != 0;
 
     // Per-channel counters
-    static constexpr bool enable_fabric_counters = get_compile_time_arg_val(22) != 0;
-    static constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(23);
-    static constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(24);
-    static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(25);
-    static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(26);
-    static constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(27);
+    static constexpr bool enable_fabric_counters = get_compile_time_arg_val(25) != 0;
+    static constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(26);
+    static constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(27);
+    static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(28);
+    static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(29);
+    static constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(30);
 
-    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(28) != 0;
-    static constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(29);
-    static constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(30);
-    static constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(31);
-    static constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(32);
-    static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(33);
-    static constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(34);
-    static constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(35);
-    static constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(36);
-    static constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(37);
-    static constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(38);
+    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(31) != 0;
+    static constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(32);
+    static constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(33);
+    static constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(34);
+    static constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(35);
+    static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(36);
+    static constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(37);
+    static constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(38);
+    static constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(39);
+    static constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(40);
+    static constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(41);
 
     std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS> sender_channel_packet_recorders{
         PacketHeaderRecorder(

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -259,16 +259,17 @@ private:
     uint8_t next_trid = 0;
 };
 
-template <size_t NUM_CHANNELS, size_t MAX_TRANSACTION_IDS>
+template <size_t NUM_CHANNELS, size_t MAX_TRANSACTION_IDS, size_t OFFSET>
 struct WriteTransactionIdTracker {
+    static constexpr uint8_t INVALID_TRID = OFFSET + MAX_TRANSACTION_IDS;
     static constexpr bool N_TRIDS_IS_POW2 = is_power_of_2(MAX_TRANSACTION_IDS);
     static constexpr bool N_CHANS_IS_POW2 = is_power_of_2(NUM_CHANNELS);
     static constexpr uint8_t TRID_POW2_MASK = MAX_TRANSACTION_IDS - 1;
     static constexpr bool BOTH_PARAMS_ARE_POW2 = N_TRIDS_IS_POW2 && N_CHANS_IS_POW2;
 
-    WriteTransactionIdTracker(uint8_t base_id) : base_id(base_id), invalid_trid(base_id + MAX_TRANSACTION_IDS) {
+    WriteTransactionIdTracker() {
         for (size_t i = 0; i < NUM_CHANNELS; i++) {
-            this->buffer_slot_trids[i] = this->invalid_trid;
+            this->buffer_slot_trids[i] = INVALID_TRID;
         }
     }
     FORCE_INLINE void set_buffer_slot_trid(uint8_t trid, tt::tt_fabric::BufferIndex buffer_index) {
@@ -281,11 +282,11 @@ struct WriteTransactionIdTracker {
     FORCE_INLINE uint8_t
     update_buffer_slot_to_next_trid_and_advance_trid_counter(tt::tt_fabric::BufferIndex buffer_index) {
         if constexpr (BOTH_PARAMS_ARE_POW2) {
-            uint8_t next_trid = this->base_id + (buffer_index & TRID_POW2_MASK);
+            uint8_t next_trid = OFFSET + buffer_index & TRID_POW2_MASK;
             this->trid_counter.increment();
             return next_trid;
         } else {
-            uint8_t next_trid = this->base_id + this->trid_counter.get();
+            uint8_t next_trid = OFFSET + this->trid_counter.get();
             this->buffer_slot_trids[buffer_index] = next_trid;
             this->trid_counter.increment();
             return next_trid;
@@ -294,13 +295,13 @@ struct WriteTransactionIdTracker {
 
     FORCE_INLINE void clear_trid_at_buffer_slot(tt::tt_fabric::BufferIndex buffer_index) {
         if constexpr (!BOTH_PARAMS_ARE_POW2) {
-            this->buffer_slot_trids[buffer_index] = this->invalid_trid;
+            this->buffer_slot_trids[buffer_index] = INVALID_TRID;
         }
     }
 
     FORCE_INLINE uint8_t get_buffer_slot_trid(tt::tt_fabric::BufferIndex buffer_index) const {
         if constexpr (BOTH_PARAMS_ARE_POW2) {
-            return this->base_id + (buffer_index & TRID_POW2_MASK);
+            return OFFSET + buffer_index & TRID_POW2_MASK;
         } else {
             return this->buffer_slot_trids[buffer_index];
         }
@@ -312,7 +313,7 @@ struct WriteTransactionIdTracker {
         } else {
             // TODO: should be able to remove compare against INVALID_TRID
             auto trid = this->get_buffer_slot_trid(buffer_index);
-            return trid == this->invalid_trid || ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid);
+            return trid == INVALID_TRID || ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid);
         }
     }
     FORCE_INLINE void all_buffer_slot_transactions_acked() const {
@@ -326,8 +327,6 @@ struct WriteTransactionIdTracker {
 private:
     std::array<uint8_t, NUM_CHANNELS> buffer_slot_trids;
     TransactionIdCounter<MAX_TRANSACTION_IDS> trid_counter;
-    const uint8_t base_id = 0;
-    const uint8_t invalid_trid = 0;
 
     // TODO: cleanup - only used for when both params are pow2, else above are used.
     uint8_t next_trid = 0;
@@ -815,7 +814,8 @@ template <
     uint8_t RECEIVER_NUM_BUFFERS,
     uint8_t SENDER_NUM_BUFFERS,
     size_t NUM_SENDER_CHANNELS,
-    uint8_t to_receiver_pkts_sent_id>
+    uint8_t to_receiver_pkts_sent_id,
+    typename WriteTridTracker>
 FORCE_INLINE void run_receiver_channel_step(
     tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& local_receiver_channel,
     std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_sender_channels,
@@ -824,7 +824,7 @@ FORCE_INLINE void run_receiver_channel_step(
     std::array<tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_eth_sender_wrptrs,
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>& receiver_channel_pointers,
     PacketHeaderRecorder& packet_header_recorder,
-    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS>& receiver_channel_trid_tracker) {
+    WriteTridTracker& receiver_channel_trid_tracker) {
     auto& ack_ptr = receiver_channel_pointers.ack_ptr;
     auto pkts_received_since_last_check = get_ptr_val<to_receiver_pkts_sent_id>();
     bool pkts_received = pkts_received_since_last_check > 0;
@@ -978,8 +978,9 @@ void run_fabric_edm_main_loop(
         sender_channel_counters_ptrs,
     std::array<PacketHeaderRecorder, NUM_RECEIVER_CHANNELS>& receiver_channel_packet_recorders,
     std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS>& sender_channel_packet_recorders,
-    std::array<WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS>, NUM_RECEIVER_CHANNELS>&
-        receiver_channel_trid_trackers) {
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS, 0>& receiver_channel_0_trid_tracker,
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS, NUM_TRANSACTION_IDS>&
+        receiver_channel_1_trid_tracker) {
     // std::array<SenderState, NUM_SENDER_CHANNELS> sender_states = {
     //     SenderState::SENDER_WAIT_WORKER_HANDSHAKE, SenderState::SENDER_WAIT_WORKER_HANDSHAKE};
     // size_t sender_channel_index = 0;
@@ -1057,7 +1058,7 @@ void run_fabric_edm_main_loop(
                 remote_eth_sender_wrptrs,
                 receiver_channel_pointers[0],
                 receiver_channel_packet_recorders[0],
-                receiver_channel_trid_trackers[0]);
+                receiver_channel_0_trid_tracker);
             if constexpr (enable_ring_support) {
                 run_receiver_channel_step<
                     enable_packet_header_recording,
@@ -1073,7 +1074,7 @@ void run_fabric_edm_main_loop(
                     remote_eth_sender_wrptrs,
                     receiver_channel_pointers[1],
                     receiver_channel_packet_recorders[1],
-                    receiver_channel_trid_trackers[1]);
+                    receiver_channel_1_trid_tracker);
             }
 
             bool did_something_sender1 = run_sender_channel_step<
@@ -1462,8 +1463,9 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr));
     }
 
-    std::array<WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS>, NUM_RECEIVER_CHANNELS>
-        receiver_channel_trid_trackers = {0, NUM_TRANSACTION_IDS};
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS, 0> receiver_channel_0_trid_tracker;
+    WriteTransactionIdTracker<RECEIVER_NUM_BUFFERS, NUM_TRANSACTION_IDS, NUM_TRANSACTION_IDS>
+        receiver_channel_1_trid_tracker;
 
     if (has_downstream_edm_vc0_buffer_connection) {
         for (auto& downstream_edm_noc_interface : downstream_edm_noc_interfaces) {
@@ -1510,7 +1512,8 @@ void kernel_main() {
         {sender_channel_0_counters_ptr, sender_channel_1_counters_ptr, sender_channel_2_counters_ptr},
         receiver_channel_packet_recorders,
         sender_channel_packet_recorders,
-        receiver_channel_trid_trackers);
+        receiver_channel_0_trid_tracker,
+        receiver_channel_1_trid_tracker);
 
     if constexpr (persistent_mode) {
         // we force these values to a non-zero value so that if we run the fabric back to back,
@@ -1521,9 +1524,8 @@ void kernel_main() {
     }
 
     // make sure all the noc transactions are acked before re-init the noc counters
-    for (auto& receiver_channel_trid_tracker : receiver_channel_trid_trackers) {
-        receiver_channel_trid_tracker.all_buffer_slot_transactions_acked();
-    }
+    receiver_channel_0_trid_tracker.all_buffer_slot_transactions_acked();
+    receiver_channel_1_trid_tracker.all_buffer_slot_transactions_acked();
 
     // re-init the noc counters as the noc api used is not incrementing them
     ncrisc_noc_counters_init();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -604,11 +604,10 @@ FORCE_INLINE bool can_forward_packet_completely(
     // We always check if it is the terminal mcast packet value. We can do this because all unicast packets have the
     // mcast terminal value masked in to the routing field. This simplifies the check here to a single compare.
     bool deliver_locally_only;
-    if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::RoutingFields>) {
-        deliver_locally_only = cached_routing_fields.value == tt::tt_fabric::RoutingFields::LAST_MCAST_VAL;
-    } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::LowLatencyRoutingFields>) {
-        deliver_locally_only = (cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::FIELD_MASK) ==
-                               tt::tt_fabric::LowLatencyRoutingFields::WRITE_ONLY;
+    if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::fabric::RoutingFields>) {
+        deliver_locally_only = cached_routing_fields.value == tt::fabric::RoutingFields::LAST_MCAST_VAL;
+    } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::fabric::LowLatencyRoutingFields>) {
+        deliver_locally_only = (cached_routing_fields.value & tt::fabric::LowLatencyRoutingFields::PATH_ROUTING_FIELD_MASK) == tt::fabric::LowLatencyRoutingFields::WRITE_ONLY;
     }
     return deliver_locally_only || downstream_edm_interface.edm_has_space_for_packet();
 }
@@ -635,8 +634,8 @@ FORCE_INLINE void receiver_forward_packet(
         if (start_distance_is_terminal_value) {
             execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id);
         }
-    } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::LowLatencyRoutingFields>) {
-        uint32_t routing = cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::FIELD_MASK;
+    } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::fabric::LowLatencyRoutingFields>) {
+        uint32_t routing = cached_routing_fields.value & tt::fabric::LowLatencyRoutingFields::PATH_ROUTING_FIELD_MASK;
         uint16_t payload_size_bytes = packet_start->payload_size_bytes;
         switch (routing) {
             case tt::tt_fabric::LowLatencyRoutingFields::WRITE_ONLY:

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include <tt-metalium/fabric_edm_types.hpp>
+
 namespace ttnn {
 namespace ccl {
 
-enum Topology { Ring = 0, Linear = 1, Mesh = 2 };
+// TODO: Remove
+using tt::tt_fabric::Topology;
 
 };  // namespace ccl
 };  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
@@ -24,9 +24,16 @@ void py_bind_common(pybind11::module& module) {
         py::arg("mesh_device"),
         py::kw_only(),
         py::arg("wrap_fabric_around_mesh") = false,
-        py::arg("context_switch_interval_override") = std::nullopt);
+        py::arg("context_switch_interval_override") = std::nullopt,
+        py::arg("topology") = ttnn::ccl::Topology::Linear);
 
-    module.def("teardown_edm_fabric", &ttnn::ccl::teardown_edm_fabric, py::arg("mesh_device"), py::kw_only());
+    module.def(
+        "teardown_edm_fabric",
+        &ttnn::ccl::teardown_edm_fabric,
+        py::arg("mesh_device"),
+        py::kw_only(),
+        py::arg("wrap_fabric_around_mesh") = false,
+        py::arg("topology") = ttnn::ccl::Topology::Linear);
 }
 
 void py_module(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
@@ -27,7 +27,8 @@ public:
         const std::vector<tt::tt_metal::Program*>& program_sequence,
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
-        bool build_in_worker_connection_mode = false);
+        bool build_in_worker_connection_mode = false,
+        bool ring_topology = false);
 
     // Invocable per chip if we want to collectively build the fabric by building this separately per chip
     // (and implicitly building the fabric that way)
@@ -38,20 +39,23 @@ public:
         tt::tt_metal::Program* program,
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links,
-        bool build_in_worker_connection_mode = false);
+        bool build_in_worker_connection_mode = false,
+        bool ring_topology = false);
 
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
         const std::vector<tt::tt_metal::IDevice*>& device_sequence,
         const std::vector<tt::tt_metal::Program*>& program_sequence,
         bool enable_persistent_mode,
-        std::optional<size_t> desired_num_links = std::nullopt);
+        std::optional<size_t> desired_num_links = std::nullopt,
+        bool ring_topology = false);
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
         tt::tt_metal::IDevice* local_device,
         tt::tt_metal::IDevice* forward_device,
         tt::tt_metal::IDevice* backward_device,
         tt::tt_metal::Program* program,
         bool enable_persistent_mode,
-        std::optional<size_t> desired_num_links = std::nullopt);
+        std::optional<size_t> desired_num_links = std::nullopt,
+        bool ring_topology = false);
 
     // Will create a connection adapter for a worker which can be used to pass args to the worker kernel talking to the
     // corresponding fabric endpoint. This interface will guarantee unique connections only so requesting more unique

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/erisc_datamover_builder.hpp>
 
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/distributed/types.hpp"
 
 namespace ttnn {
@@ -28,7 +29,7 @@ public:
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
         bool build_in_worker_connection_mode = false,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     // Invocable per chip if we want to collectively build the fabric by building this separately per chip
     // (and implicitly building the fabric that way)
@@ -40,14 +41,14 @@ public:
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links,
         bool build_in_worker_connection_mode = false,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
         const std::vector<tt::tt_metal::IDevice*>& device_sequence,
         const std::vector<tt::tt_metal::Program*>& program_sequence,
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
         tt::tt_metal::IDevice* local_device,
         tt::tt_metal::IDevice* forward_device,
@@ -55,7 +56,7 @@ public:
         tt::tt_metal::Program* program,
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     // Will create a connection adapter for a worker which can be used to pass args to the worker kernel talking to the
     // corresponding fabric endpoint. This interface will guarantee unique connections only so requesting more unique
@@ -125,8 +126,10 @@ private:
 void initialize_edm_fabric(
     distributed::MeshDevice* mesh_device,
     bool wrap_fabric_around_mesh = false,
-    std::optional<size_t> context_switch_interval_override = std::nullopt);
-void teardown_edm_fabric(distributed::MeshDevice* mesh_device);
+    std::optional<size_t> context_switch_interval_override = std::nullopt,
+    Topology topology = Topology::Linear);
+void teardown_edm_fabric(
+    distributed::MeshDevice* mesh_device, bool wrap_fabric_around_mesh = false, Topology topology = Topology::Linear);
 
 };  // namespace ccl
 };  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -35,9 +35,13 @@ AllGatherAsync create_all_gather_async_struct(
             semaphore = semaphores.at(i);  // Get raw pointer
             if (i != 0) {
                 backward_device = devices.at(i - 1);
+            } else if (topology == ttnn::ccl::Topology::Ring) {
+                backward_device = devices.at(num_devices - 1);
             }
             if (i != num_devices - 1) {
                 forward_device = devices.at(i + 1);
+            } else if (topology == ttnn::ccl::Topology::Ring) {
+                forward_device = devices.at(0);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
@@ -162,16 +162,17 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_multi_core_with_w
                   backward_device.value_or(nullptr),
                   &program,
                   enable_persistent_fabric_mode,
-                  num_links)
+                  num_links,
+                  topology)
             : ccl::EdmLineFabricOpInterface(
                   device,
                   forward_device.value_or(nullptr),
                   backward_device.value_or(nullptr),
                   &program,
                   enable_persistent_fabric_mode,
-                  num_links);
-
-    LineTopology line_topology(ring_size, ring_index);
+                  num_links,
+                  false,
+                  topology);
 
     std::unique_ptr<ccl::CclOpTensorConfig> input_tensor_config =
         ttnn::ccl::CclOpTensorConfig::build_all_gather_tensor_config(input_tensor);
@@ -244,14 +245,24 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_multi_core_with_w
             tt::tt_metal::WriterDataMovementConfig{},
             1,  // num_command_streams
             device->id());
+    size_t num_targets_forward = 0;
+    size_t num_targets_backward = 0;
+    if (topology == ccl::Topology::Linear) {
+        LineTopology line_topology(ring_size, ring_index);
+        num_targets_forward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+        num_targets_backward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    } else if (topology == ccl::Topology::Ring) {
+        // TODO: Commonize
+        num_targets_forward = tt::div_up(ring_size - 1, 2);
+        num_targets_backward = ring_size - 1 - num_targets_forward;
+        if (ring_index % 2 == 0) {
+            std::swap(num_targets_forward, num_targets_backward);
+        }
+    }
 
-    const size_t forward_direction_distance_to_end_of_line =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-    const size_t backward_direction_distance_to_end_of_line =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
-
-    ttnn::ccl::cmd::MulticastCommandDestArgs mcast_dest_args = {
-        forward_direction_distance_to_end_of_line, backward_direction_distance_to_end_of_line};
+    ttnn::ccl::cmd::MulticastCommandDestArgs mcast_dest_args = {num_targets_forward, num_targets_backward};
     log_trace(
         tt::LogOp,
         "[mcast_dest_args] num target forward: {}, num target backward: {}",
@@ -288,27 +299,27 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_multi_core_with_w
         print_tensor_slice(output_worker_slice_v2);
 
         std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> forward_fabric_connection =
-            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !forward_device.has_value()
                 ? std::nullopt
                 : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
         std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> backward_fabric_connection =
-            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !backward_device.has_value()
                 ? std::nullopt
                 : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
 
         log_trace(
             tt::LogOp,
-            "DEBUG: line_index: {}, line_size: {}, forward_fabric_connection: {}",
-            line_topology.line_index(),
-            line_topology.line_size(),
+            "DEBUG: ring_index: {}, ring_size: {}, forward_fabric_connection: {}",
+            ring_index,
+            ring_size,
             forward_fabric_connection.has_value());
         log_trace(
             tt::LogOp,
-            "DEBUG: line_index: {}, line_size: {}, backward_fabric_connection: {}",
-            line_topology.line_index(),
-            line_topology.line_size(),
+            "DEBUG: ring_index: {}, ring_size: {}, backward_fabric_connection: {}",
+            ring_index,
+            ring_size,
             backward_fabric_connection.has_value());
 
         // READER COMMAND STREAM and RT ARGS

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -89,17 +89,29 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             backward_device.value_or(nullptr),
             &program,
             enable_persistent_fabric_mode,
-            num_links);
+            num_links,
+            topology);
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
-    LineTopology line_topology(ring_size, ring_index);
-    const size_t num_targets_forward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-    const size_t num_targets_backward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    size_t num_targets_forward = 0;
+    size_t num_targets_backward = 0;
+    if (topology == ccl::Topology::Linear) {
+        LineTopology line_topology(ring_size, ring_index);
+        num_targets_forward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+        num_targets_backward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    } else if (topology == ccl::Topology::Ring) {
+        // TODO: Commonize
+        num_targets_forward = tt::div_up(ring_size - 1, 2);
+        num_targets_backward = ring_size - 1 - num_targets_forward;
+        if (ring_index % 2 == 0) {
+            std::swap(num_targets_forward, num_targets_backward);
+        }
+    }
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
@@ -193,12 +205,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             drain_sync_core = device->worker_core_from_logical_core(core);
         }
         std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> forward_fabric_connection =
-            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !forward_device.has_value()
                 ? std::nullopt
                 : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
         std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> backward_fabric_connection =
-            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !backward_device.has_value()
                 ? std::nullopt
                 : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
@@ -311,17 +323,29 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
             backward_device.value_or(nullptr),
             &program,
             enable_persistent_fabric_mode,
-            num_links);
+            num_links,
+            topology);
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
-    LineTopology line_topology(ring_size, ring_index);
-    const size_t num_targets_forward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-    const size_t num_targets_backward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    size_t num_targets_forward = 0;
+    size_t num_targets_backward = 0;
+    if (topology == ccl::Topology::Linear) {
+        LineTopology line_topology(ring_size, ring_index);
+        num_targets_forward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+        num_targets_backward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    } else if (topology == ccl::Topology::Ring) {
+        // TODO: Commonize
+        num_targets_forward = tt::div_up(ring_size - 1, 2);
+        num_targets_backward = ring_size - 1 - num_targets_forward;
+        if (ring_index % 2 == 0) {
+            std::swap(num_targets_forward, num_targets_backward);
+        }
+    }
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
@@ -476,12 +500,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
             drain_sync_core = device->worker_core_from_logical_core(core);
         }
         std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> forward_fabric_connection =
-            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !forward_device.has_value()
                 ? std::nullopt
                 : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
         std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> backward_fabric_connection =
-            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !backward_device.has_value()
                 ? std::nullopt
                 : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18798

### Problem description
We need to enable Ring support for 1D fabric to allow for better performance by reducing the number of hops needed. Ex on a T3K configured as an 8 device line, the max number of hops is 7. If it was an 8 device ring, this would be max 4 hops.

### What's changed
Add ring support for 1D EDM fabric.
This adds a new VC, which adds an additional sender receiver channel. Requires reducing the original number of sender/receiver buffer slots in half to support the new channels due to us currently using power of 2 buffer slots.
Large perf drop on Line was observed due to shrinking channel buffer slots, so add a flag to selectively enable ring support for testing. 
Still has an observed perf drop even though ring buffering code should be disabled, investigating.

Current perf numbers:
Line Mcast: ~6.7 B/c (unchanged)
Line Unicast: ~8.4 B/c (unchanged)
Ring Mcast: ~7.6 B/c

TODO:

- Try supporting non-power of 2 buffer slots to enable more buffering for ring buffer (not in this PR)
- Pipe the arg to control when to switch to high VC. We need to determine how we should figure out the optimal switchover point and pipe it into the user kernel to set up the packet header.
- Add more testing of ring support for functionality, and add a test that does deadlock without the second VC, but is resolved with using the second VC.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13835457552
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/13835462915
T3K Fast: https://github.com/tenstorrent/tt-metal/actions/runs/13835572534
TG Unit: https://github.com/tenstorrent/tt-metal/actions/runs/13835587838
Microbench: https://github.com/tenstorrent/tt-metal/actions/runs/13835592831