### PR TITLE
[skip ci] Skip the PR Gate Status job if the entire workflow was skipped

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
-        uses: tenstorrent/tt-metal/.github/actions/workflow-status@${{ github.sha }}
+        uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "build"
           optional-jobs: "smoke-tests"

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -55,12 +55,20 @@ jobs:
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
   workflow-status:
     name: PR Gate Status
-    if: always() # Force this job to run so GH can 'see' it
+    # Force this job to run so GH can 'see' it, provided some other job has actually run.
+    # Otherwise if the entire workflow has been skipped (eg: the PR was in Draft), then this will
+    # report FAILED instead of SKIPPED.
+    if: >-
+      ${{
+        always() &&
+        contains(join(needs.*.result, ','), 'success') ||
+        contains(join(needs.*.result, ','), 'failure')
+      }}
     needs: [build, smoke-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
-        uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
+        uses: tenstorrent/tt-metal/.github/actions/workflow-status@${{ github.sha }}
         with:
           required-jobs: "build"
           optional-jobs: "smoke-tests"


### PR DESCRIPTION
### Ticket
None

### Problem description
The PR Gate status check introduced in #18831 would report FAILED if the workflow was skipped (as is done for Draft PRs).  This is super misleading.

### What's changed
Conditionally run the job iff some previous job has actually run.