### PR TITLE
Consolidate Dispatch/S/Prefetch/Packet Queue NOC settings

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -34,10 +34,6 @@ enum DispatchWorkerType : uint32_t {
     COUNT = 17
 };
 
-// NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
-// is required when setting up Command Queue objects on host.
-static constexpr NOC dispatch_downstream_noc = NOC::NOC_0;
-
 enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
 
 enum class DispatchCoreAxis { ROW, COL, COUNT };

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -216,7 +216,7 @@ void populate_sharded_buffer_write_dispatch_cmds(
     Buffer& buffer,
     ShardedBufferWriteDispatchParams& dispatch_params) {
     uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
-    auto noc_index = dispatch_downstream_noc;
+    auto noc_index = k_dispatch_downstream_noc;
     const CoreCoord virtual_core =
         buffer.device()->virtual_core_from_logical_core(dispatch_params.core, buffer.core_type());
     command_sequence.add_dispatch_write_linear(
@@ -671,7 +671,7 @@ void issue_read_buffer_dispatch_command_sequence(
         const CoreCoord virtual_core =
             buffer.device()->virtual_core_from_logical_core(dispatch_params.core, buffer.core_type());
         command_sequence.add_prefetch_relay_linear(
-            dispatch_params.device->get_noc_unicast_encoding(dispatch_downstream_noc, virtual_core),
+            dispatch_params.device->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core),
             dispatch_params.padded_page_size * dispatch_params.pages_per_txn,
             dispatch_params.address);
     } else {

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -6,6 +6,7 @@
 #include "assert.hpp"
 #include "dispatch.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
 
 #include <tt-metalium/command_queue_interface.hpp>
 #include "tt_metal/impl/dispatch/device_command.hpp"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -900,7 +900,7 @@ void Device::init_command_queue_host() {
     command_queues_.reserve(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
         command_queues_.push_back(
-            std::make_unique<HWCommandQueue>(this, cq_id, dispatch_downstream_noc, completion_queue_reader_core_));
+            std::make_unique<HWCommandQueue>(this, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
     }
 }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -17,7 +17,7 @@
 #include <tt_metal.hpp>
 #include "dprint_server.hpp"
 #include "impl/debug/watcher_server.hpp"
-#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
 #include <utils.hpp>
 #include "llrt.hpp"
 #include <dev_msgs.h>

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -168,6 +168,10 @@ void DispatchKernel::GenerateStaticConfigs() {
 }
 
 void DispatchKernel::GenerateDependentConfigs() {
+    TT_FATAL(
+        noc_selection_.non_dispatch_noc != DispatchQueryManager::instance().go_signal_noc(),
+        "Dispatch noc_selection_ must NOT be equal to go_signal_noc in DispatchQueryManager. Reason: Dispatch is using "
+        "stateful APIs. Using the same NOC will cause collisions.");
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         // Upstream
         TT_ASSERT(upstream_kernels_.size() == 1);

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -70,7 +70,7 @@ public:
         FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
         auto& core_manager = tt::tt_metal::dispatch_core_manager::instance();  // Not thread safe
         TT_FATAL(
-            noc_selection.downstream_noc == tt::tt_metal::dispatch_downstream_noc,
+            noc_selection.downstream_noc == tt::tt_metal::k_dispatch_downstream_noc,
             "Invalid downstream NOC specified for Dispatcher kernel");
         TT_FATAL(
             noc_selection.upstream_noc != noc_selection.downstream_noc,

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #pragma once
+
 #include "fd_kernel.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
 
 typedef struct dispatch_static_config {
     std::optional<uint32_t> dispatch_cb_base;  // 0

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #pragma once
+
 #include "fd_kernel.hpp"
 
 typedef struct prefetch_static_config {
@@ -68,9 +70,7 @@ public:
         static_config_.is_h_variant = h_variant;
         static_config_.is_d_variant = d_variant;
         uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-        TT_FATAL(
-            noc_selection.downstream_noc == tt::tt_metal::dispatch_downstream_noc,
-            "Invalid downstream NOC specified for Prefetcher kernel");
+
         if (h_variant && d_variant) {
             this->logical_core_ = core_manager.prefetcher_core(device_id, channel, cq_id);
         } else if (h_variant) {

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -51,9 +51,9 @@ constexpr noc_selection_t k_prefetcher_noc = {
 };
 
 //
-// Dispatcher NOC selections
+// Dispatcher NOC selections. NOTE: Upstream and downstream NOCs cannot be the same.
 //
-// Non Dispatch NOC: acquire pages on local semaphore
+// Non Dispatch NOC: acquire pages on local semaphore and send go/done
 //
 // Upstream: sync sem with tunnel and/or dispatch_d variant and/or prefetch_d
 //
@@ -62,12 +62,11 @@ constexpr noc_selection_t k_prefetcher_noc = {
 constexpr noc_selection_t k_dispatcher_noc = {
     .non_dispatch_noc = tt::tt_metal::NOC::NOC_0,
     .upstream_noc = tt::tt_metal::NOC::NOC_1,
-    .downstream_noc = dispatch_downstream_noc,  // Needs to be dispatch_downstream_noc. Used from the host side to sent
-                                                // data to dispatcher
+    .downstream_noc = dispatch_downstream_noc,
 };
 
 //
-// Dispatch S NOC selections
+// Dispatch S NOC selections.
 //
 // Non Dispatch NOC: acquire pages on local semaphore
 //
@@ -80,6 +79,11 @@ constexpr noc_selection_t k_dispatcher_s_noc = {
     .upstream_noc = tt::tt_metal::NOC::NOC_1,
     .downstream_noc = tt::tt_metal::NOC::NOC_1,
 };
+
+// Must be on different NOCs because Dispatch+S may be running on the same
+// core. They are using stateful APIs. Running on the same NOC will mess up
+// requests sent/to free count.
+static_assert(k_dispatcher_noc.non_dispatch_noc != k_dispatcher_s_noc.non_dispatch_noc);
 
 //
 // Packet Queue NOC selections

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -62,7 +62,8 @@ constexpr noc_selection_t k_prefetcher_noc = {
 constexpr noc_selection_t k_dispatcher_noc = {
     .non_dispatch_noc = tt::tt_metal::NOC::NOC_0,
     .upstream_noc = tt::tt_metal::NOC::NOC_1,
-    .downstream_noc = tt::tt_metal::NOC::NOC_0,
+    .downstream_noc = dispatch_downstream_noc,  // Needs to be dispatch_downstream_noc. Used from the host side to sent
+                                                // data to dispatcher
 };
 
 //

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -3,15 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "topology.hpp"
+#include "data_types.hpp"
 #include "kernel_config/fd_kernel.hpp"
 #include <device_pool.hpp>
 #include <tt_metal.hpp>
 #include <host_api.hpp>
 #include "kernel_config/fd_kernel.hpp"
-#include "kernel_config/prefetch.hpp"
-#include "kernel_config/dispatch.hpp"
-#include "kernel_config/dispatch_s.hpp"
-#include "kernel_config/mux.hpp"
 #include "kernel_config/demux.hpp"
 #include "kernel_config/eth_router.hpp"
 #include "kernel_config/eth_tunneler.hpp"
@@ -38,349 +35,411 @@ void increment_node_ids(DispatchKernelNode& node, uint32_t inc) {
     }
 }
 
+//
+// Prefetcher NOC selections
+//
+// Non Dispatch NOC: acquire pages on local semaphore
+//
+// Upstream: sync sem with tunnel and/or prefetch_h variant
+//
+// Downstream: send data to tunnel and/or prefetch_d variant and/or dispatch_d
+//
+constexpr noc_selection_t k_prefetcher_noc = {
+    .non_dispatch_noc = tt::tt_metal::NOC::NOC_0,
+    .upstream_noc = tt::tt_metal::NOC::NOC_0,
+    .downstream_noc = tt::tt_metal::NOC::NOC_0,
+};
+
+//
+// Dispatcher NOC selections
+//
+// Non Dispatch NOC: acquire pages on local semaphore
+//
+// Upstream: sync sem with tunnel and/or dispatch_d variant and/or prefetch_d
+//
+// Downstream: relay data from dispatch_d to dispatch_h (return to host) and/or dispatch_s
+//
+constexpr noc_selection_t k_dispatcher_noc = {
+    .non_dispatch_noc = tt::tt_metal::NOC::NOC_0,
+    .upstream_noc = tt::tt_metal::NOC::NOC_1,
+    .downstream_noc = tt::tt_metal::NOC::NOC_0,
+};
+
+//
+// Dispatch S NOC selections
+//
+// Non Dispatch NOC: acquire pages on local semaphore
+//
+// Upstream: sync sem with prefetcher_d and dispatcher_d
+//
+// Downstream: relay data from dispatch_d to dispatch_h (return to host) and/or dispatch_s
+//
+constexpr noc_selection_t k_dispatcher_s_noc = {
+    .non_dispatch_noc = tt::tt_metal::NOC::NOC_1,
+    .upstream_noc = tt::tt_metal::NOC::NOC_1,
+    .downstream_noc = tt::tt_metal::NOC::NOC_1,
+};
+
+//
+// Packet Queue NOC selections
+//
+// Non Dispatch NOC: Sync semaphore and relaying data between upstream and downstream components
+//
+// Upstream: UNUSED
+//
+// Downstream: UNUSED
+//
+constexpr noc_selection_t k_packet_queue_noc = {
+    .non_dispatch_noc = tt::tt_metal::NOC::NOC_0,
+    .upstream_noc = tt::tt_metal::NOC::NOC_0,
+    .downstream_noc = tt::tt_metal::NOC::NOC_0,
+};
+
+// clang-format off
 static const std::vector<DispatchKernelNode> single_chip_arch_1cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_dispatcher_noc},
+    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_dispatcher_s_noc},
 };
 
 static const std::vector<DispatchKernelNode> single_chip_arch_2cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {2, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {3, 0, 0, 1, DISPATCH_HD, {1, x, x, x}, {x, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {2, x, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, x, x, x}, k_prefetcher_noc},
+    {2, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, k_dispatcher_noc},
+    {3, 0, 0, 1, DISPATCH_HD, {1, x, x, x}, {x, x, x, x}, k_dispatcher_noc},
 };
 
 static const std::vector<DispatchKernelNode> single_chip_arch_2cq_dispatch_s = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 4, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {4, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {2, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, 5, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {3, 0, 0, 1, DISPATCH_HD, {2, x, x, x}, {5, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {4, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {5, 0, 0, 1, DISPATCH_S, {2, x, x, x}, {3, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 4, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {4, x, x, x}, k_dispatcher_noc},
+    {2, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, 5, x, x}, k_prefetcher_noc},
+    {3, 0, 0, 1, DISPATCH_HD, {2, x, x, x}, {5, x, x, x}, k_dispatcher_noc},
+    {4, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_dispatcher_s_noc},
+    {5, 0, 0, 1, DISPATCH_S, {2, x, x, x}, {3, x, x, x}, k_dispatcher_s_noc},
 };
 
 static const std::vector<DispatchKernelNode> two_chip_arch_1cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_dispatcher_noc},
+    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_dispatcher_s_noc},
 
-    {3, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {5, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {4, 0, 1, 0, DISPATCH_H, {6, x, x, x}, {3, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {3, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {5, x, x, x}, k_prefetcher_noc},
+    {4, 0, 1, 0, DISPATCH_H, {6, x, x, x}, {3, x, x, x}, k_dispatcher_noc},
 
-    {5, 0, 1, 0, PACKET_ROUTER_MUX, {3, x, x, x}, {7, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {6, 0, 1, 0, DEMUX, {7, x, x, x}, {4, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {7, 0, 1, 0, US_TUNNELER_REMOTE, {11, 5, x, x}, {11, 6, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {5, 0, 1, 0, PACKET_ROUTER_MUX, {3, x, x, x}, {7, x, x, x}, k_packet_queue_noc},
+    {6, 0, 1, 0, DEMUX, {7, x, x, x}, {4, x, x, x}, k_packet_queue_noc},
+    {7, 0, 1, 0, US_TUNNELER_REMOTE, {11, 5, x, x}, {11, 6, x, x}, k_packet_queue_noc},
 
-    {8, 1, x, 0, PREFETCH_D, {13, x, x, x}, {9, 10, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {9, 1, x, 0, DISPATCH_D, {8, x, x, x}, {10, 12, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {10, 1, x, 0, DISPATCH_S, {8, x, x, x}, {9, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {8, 1, x, 0, PREFETCH_D, {13, x, x, x}, {9, 10, x, x}, k_prefetcher_noc},
+    {9, 1, x, 0, DISPATCH_D, {8, x, x, x}, {10, 12, x, x}, k_dispatcher_noc},
+    {10, 1, x, 0, DISPATCH_S, {8, x, x, x}, {9, x, x, x}, k_dispatcher_s_noc},
 
-    {11, 1, x, 0, US_TUNNELER_LOCAL, {7, 12, x, x}, {7, 13, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {12, 1, x, 0, MUX_D, {9, x, x, x}, {11, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {13, 1, x, 0, PACKET_ROUTER_DEMUX, {11, x, x, x}, {8, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {11, 1, x, 0, US_TUNNELER_LOCAL, {7, 12, x, x}, {7, 13, x, x}, k_packet_queue_noc},
+    {12, 1, x, 0, MUX_D, {9, x, x, x}, {11, x, x, x}, k_packet_queue_noc},
+    {13, 1, x, 0, PACKET_ROUTER_DEMUX, {11, x, x, x}, {8, x, x, x}, k_packet_queue_noc},
 };
 
 static const std::vector<DispatchKernelNode> two_chip_arch_2cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {2, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {3, 0, 0, 1, DISPATCH_HD, {1, x, x, x}, {x, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {2, x, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, x, x, x}, k_prefetcher_noc},
+    {2, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, k_dispatcher_noc},
+    {3, 0, 0, 1, DISPATCH_HD, {1, x, x, x}, {x, x, x, x}, k_dispatcher_noc},
 
-    {4, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {8, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {5, 0, 1, 1, PREFETCH_H, {x, x, x, x}, {8, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {6, 0, 1, 0, DISPATCH_H, {9, x, x, x}, {4, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {7, 0, 1, 1, DISPATCH_H, {9, x, x, x}, {5, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {4, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {8, x, x, x}, k_prefetcher_noc},
+    {5, 0, 1, 1, PREFETCH_H, {x, x, x, x}, {8, x, x, x}, k_prefetcher_noc},
+    {6, 0, 1, 0, DISPATCH_H, {9, x, x, x}, {4, x, x, x}, k_dispatcher_noc},
+    {7, 0, 1, 1, DISPATCH_H, {9, x, x, x}, {5, x, x, x}, k_dispatcher_noc},
 
-    {8, 0, 1, 0, PACKET_ROUTER_MUX, {4, 5, x, x}, {10, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {9, 0, 1, 0, DEMUX, {10, x, x, x}, {6, 7, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {10, 0, 1, 0, US_TUNNELER_REMOTE, {15, 8, x, x}, {15, 9, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {8, 0, 1, 0, PACKET_ROUTER_MUX, {4, 5, x, x}, {10, x, x, x}, k_packet_queue_noc},
+    {9, 0, 1, 0, DEMUX, {10, x, x, x}, {6, 7, x, x}, k_packet_queue_noc},
+    {10, 0, 1, 0, US_TUNNELER_REMOTE, {15, 8, x, x}, {15, 9, x, x}, k_packet_queue_noc},
 
-    {11, 1, x, 0, PREFETCH_D, {17, x, x, x}, {13, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {12, 1, x, 1, PREFETCH_D, {17, x, x, x}, {14, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {13, 1, x, 0, DISPATCH_D, {11, x, x, x}, {16, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {14, 1, x, 1, DISPATCH_D, {12, x, x, x}, {16, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {11, 1, x, 0, PREFETCH_D, {17, x, x, x}, {13, x, x, x}, k_prefetcher_noc},
+    {12, 1, x, 1, PREFETCH_D, {17, x, x, x}, {14, x, x, x}, k_prefetcher_noc},
+    {13, 1, x, 0, DISPATCH_D, {11, x, x, x}, {16, x, x, x}, k_dispatcher_noc},
+    {14, 1, x, 1, DISPATCH_D, {12, x, x, x}, {16, x, x, x}, k_dispatcher_noc},
 
-    {15, 1, x, 0, US_TUNNELER_LOCAL, {10, 16, x, x}, {10, 17, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {16, 1, x, 0, MUX_D, {13, 14, x, x}, {15, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {17, 1, x, 0, PACKET_ROUTER_DEMUX, {15, x, x, x}, {11, 12, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {15, 1, x, 0, US_TUNNELER_LOCAL, {10, 16, x, x}, {10, 17, x, x}, k_packet_queue_noc},
+    {16, 1, x, 0, MUX_D, {13, 14, x, x}, {15, x, x, x}, k_packet_queue_noc},
+    {17, 1, x, 0, PACKET_ROUTER_DEMUX, {15, x, x, x}, {11, 12, x, x}, k_packet_queue_noc},
 
 };
 
 static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_1cq = {
     // For MMIO chip, TODO: investigate removing these, they aren't needed
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_dispatcher_noc},
+    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_dispatcher_s_noc},
 
     // Sevicing remote chips 1-4
-    {3, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {4, 0, 1, 0, DISPATCH_H, {13, x, x, x}, {3, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {5, 0, 2, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {6, 0, 2, 0, DISPATCH_H, {13, x, x, x}, {5, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {7, 0, 3, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {8, 0, 3, 0, DISPATCH_H, {14, x, x, x}, {7, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {9, 0, 4, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {10, 0, 4, 0, DISPATCH_H, {14, x, x, x}, {9, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {11, 0, 1, 0, PACKET_ROUTER_MUX, {3, 5, 7, 9}, {15, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {12, 0, 1, 0, DEMUX, {15, x, x, x}, {13, 14, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {13, 0, 1, 0, DEMUX, {12, x, x, x}, {4, 6, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {14, 0, 1, 0, DEMUX, {12, x, x, x}, {8, 10, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {15, 0, 1, 0, US_TUNNELER_REMOTE, {29, 11, x, x}, {29, 12, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {3, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, k_prefetcher_noc},
+    {4, 0, 1, 0, DISPATCH_H, {13, x, x, x}, {3, x, x, x}, k_dispatcher_noc},
+    {5, 0, 2, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, k_prefetcher_noc},
+    {6, 0, 2, 0, DISPATCH_H, {13, x, x, x}, {5, x, x, x}, k_dispatcher_noc},
+    {7, 0, 3, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, k_prefetcher_noc},
+    {8, 0, 3, 0, DISPATCH_H, {14, x, x, x}, {7, x, x, x}, k_dispatcher_noc},
+    {9, 0, 4, 0, PREFETCH_H, {x, x, x, x}, {11, x, x, x}, k_prefetcher_noc},
+    {10, 0, 4, 0, DISPATCH_H, {14, x, x, x}, {9, x, x, x}, k_dispatcher_noc},
+    {11, 0, 1, 0, PACKET_ROUTER_MUX, {3, 5, 7, 9}, {15, x, x, x}, k_packet_queue_noc},
+    {12, 0, 1, 0, DEMUX, {15, x, x, x}, {13, 14, x, x}, k_packet_queue_noc},
+    {13, 0, 1, 0, DEMUX, {12, x, x, x}, {4, 6, x, x}, k_packet_queue_noc},
+    {14, 0, 1, 0, DEMUX, {12, x, x, x}, {8, 10, x, x}, k_packet_queue_noc},
+    {15, 0, 1, 0, US_TUNNELER_REMOTE, {29, 11, x, x}, {29, 12, x, x}, k_packet_queue_noc},
 
     // Servicing remote chips 5-8
-    {16, 0, 5, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {17, 0, 5, 0, DISPATCH_H, {26, x, x, x}, {16, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {18, 0, 6, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {19, 0, 6, 0, DISPATCH_H, {26, x, x, x}, {18, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {20, 0, 7, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {21, 0, 7, 0, DISPATCH_H, {27, x, x, x}, {20, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {22, 0, 8, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {23, 0, 8, 0, DISPATCH_H, {27, x, x, x}, {22, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {24, 0, 5, 0, PACKET_ROUTER_MUX, {16, 18, 20, 22}, {28, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {25, 0, 5, 0, DEMUX, {28, x, x, x}, {26, 27, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {26, 0, 5, 0, DEMUX, {25, x, x, x}, {17, 19, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {27, 0, 5, 0, DEMUX, {25, x, x, x}, {21, 23, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {28, 0, 5, 0, US_TUNNELER_REMOTE, {59, 24, x, x}, {59, 25, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {16, 0, 5, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, k_prefetcher_noc},
+    {17, 0, 5, 0, DISPATCH_H, {26, x, x, x}, {16, x, x, x}, k_dispatcher_noc},
+    {18, 0, 6, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, k_prefetcher_noc},
+    {19, 0, 6, 0, DISPATCH_H, {26, x, x, x}, {18, x, x, x}, k_dispatcher_noc},
+    {20, 0, 7, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, k_prefetcher_noc},
+    {21, 0, 7, 0, DISPATCH_H, {27, x, x, x}, {20, x, x, x}, k_dispatcher_noc},
+    {22, 0, 8, 0, PREFETCH_H, {x, x, x, x}, {24, x, x, x}, k_prefetcher_noc},
+    {23, 0, 8, 0, DISPATCH_H, {27, x, x, x}, {22, x, x, x}, k_dispatcher_noc},
+    {24, 0, 5, 0, PACKET_ROUTER_MUX, {16, 18, 20, 22}, {28, x, x, x}, k_packet_queue_noc},
+    {25, 0, 5, 0, DEMUX, {28, x, x, x}, {26, 27, x, x}, k_packet_queue_noc},
+    {26, 0, 5, 0, DEMUX, {25, x, x, x}, {17, 19, x, x}, k_packet_queue_noc},
+    {27, 0, 5, 0, DEMUX, {25, x, x, x}, {21, 23, x, x}, k_packet_queue_noc},
+    {28, 0, 5, 0, US_TUNNELER_REMOTE, {59, 24, x, x}, {59, 25, x, x}, k_packet_queue_noc},
 
     // Remote chip 1
-    {29, 1, x, 0, US_TUNNELER_LOCAL, {15, 30, x, x}, {15, 31, 32, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {30, 1, x, 0, MUX_D, {34, 36, x, x}, {29, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {31, 1, x, 0, PACKET_ROUTER_DEMUX, {29, x, x, x}, {33, 36, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {32, 1, x, 0, PACKET_ROUTER_DEMUX, {29, x, x, x}, {36, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {33, 1, x, 0, PREFETCH_D, {31, x, x, x}, {34, 35, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {34, 1, x, 0, DISPATCH_D, {33, x, x, x}, {35, 30, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {35, 1, x, 0, DISPATCH_S, {33, x, x, x}, {34, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {36, 1, x, 0, US_TUNNELER_REMOTE, {37, 31, 32, x}, {37, 30, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {29, 1, x, 0, US_TUNNELER_LOCAL, {15, 30, x, x}, {15, 31, 32, x}, k_packet_queue_noc},
+    {30, 1, x, 0, MUX_D, {34, 36, x, x}, {29, x, x, x}, k_packet_queue_noc},
+    {31, 1, x, 0, PACKET_ROUTER_DEMUX, {29, x, x, x}, {33, 36, x, x}, k_packet_queue_noc},
+    {32, 1, x, 0, PACKET_ROUTER_DEMUX, {29, x, x, x}, {36, x, x, x}, k_packet_queue_noc},
+    {33, 1, x, 0, PREFETCH_D, {31, x, x, x}, {34, 35, x, x}, k_prefetcher_noc},
+    {34, 1, x, 0, DISPATCH_D, {33, x, x, x}, {35, 30, x, x}, k_dispatcher_noc},
+    {35, 1, x, 0, DISPATCH_S, {33, x, x, x}, {34, x, x, x}, k_dispatcher_s_noc},
+    {36, 1, x, 0, US_TUNNELER_REMOTE, {37, 31, 32, x}, {37, 30, x, x}, k_packet_queue_noc},
 
     // Remote chip 2
-    {37, 2, x, 0, US_TUNNELER_LOCAL, {36, 38, x, x}, {36, 39, 40, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {38, 2, x, 0, MUX_D, {42, 44, x, x}, {37, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {39, 2, x, 0, PACKET_ROUTER_DEMUX, {37, x, x, x}, {41, 44, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {40, 2, x, 0, PACKET_ROUTER_DEMUX, {37, x, x, x}, {44, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {41, 2, x, 0, PREFETCH_D, {39, x, x, x}, {42, 43, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {42, 2, x, 0, DISPATCH_D, {41, x, x, x}, {43, 38, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {43, 2, x, 0, DISPATCH_S, {41, x, x, x}, {42, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {44, 2, x, 0, US_TUNNELER_REMOTE, {45, 39, 40, x}, {45, 38, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {37, 2, x, 0, US_TUNNELER_LOCAL, {36, 38, x, x}, {36, 39, 40, x}, k_packet_queue_noc},
+    {38, 2, x, 0, MUX_D, {42, 44, x, x}, {37, x, x, x}, k_packet_queue_noc},
+    {39, 2, x, 0, PACKET_ROUTER_DEMUX, {37, x, x, x}, {41, 44, x, x}, k_packet_queue_noc},
+    {40, 2, x, 0, PACKET_ROUTER_DEMUX, {37, x, x, x}, {44, x, x, x}, k_packet_queue_noc},
+    {41, 2, x, 0, PREFETCH_D, {39, x, x, x}, {42, 43, x, x}, k_prefetcher_noc},
+    {42, 2, x, 0, DISPATCH_D, {41, x, x, x}, {43, 38, x, x}, k_dispatcher_noc},
+    {43, 2, x, 0, DISPATCH_S, {41, x, x, x}, {42, x, x, x}, k_dispatcher_s_noc},
+    {44, 2, x, 0, US_TUNNELER_REMOTE, {45, 39, 40, x}, {45, 38, x, x}, k_packet_queue_noc},
 
     // Remote chip 3
-    {45, 3, x, 0, US_TUNNELER_LOCAL, {44, 46, x, x}, {44, 47, 48, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {46, 3, x, 0, MUX_D, {50, 52, x, x}, {45, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {47, 3, x, 0, PACKET_ROUTER_DEMUX, {45, x, x, x}, {49, 52, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {48, 3, x, 0, PACKET_ROUTER_DEMUX, {45, x, x, x}, {52, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {49, 3, x, 0, PREFETCH_D, {47, x, x, x}, {50, 51, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {50, 3, x, 0, DISPATCH_D, {49, x, x, x}, {51, 46, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {51, 3, x, 0, DISPATCH_S, {49, x, x, x}, {50, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {52, 3, x, 0, US_TUNNELER_REMOTE, {53, 47, 48, x}, {53, 46, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {45, 3, x, 0, US_TUNNELER_LOCAL, {44, 46, x, x}, {44, 47, 48, x}, k_packet_queue_noc},
+    {46, 3, x, 0, MUX_D, {50, 52, x, x}, {45, x, x, x}, k_packet_queue_noc},
+    {47, 3, x, 0, PACKET_ROUTER_DEMUX, {45, x, x, x}, {49, 52, x, x}, k_packet_queue_noc},
+    {48, 3, x, 0, PACKET_ROUTER_DEMUX, {45, x, x, x}, {52, x, x, x}, k_packet_queue_noc},
+    {49, 3, x, 0, PREFETCH_D, {47, x, x, x}, {50, 51, x, x}, k_prefetcher_noc},
+    {50, 3, x, 0, DISPATCH_D, {49, x, x, x}, {51, 46, x, x}, k_dispatcher_noc},
+    {51, 3, x, 0, DISPATCH_S, {49, x, x, x}, {50, x, x, x}, k_dispatcher_s_noc},
+    {52, 3, x, 0, US_TUNNELER_REMOTE, {53, 47, 48, x}, {53, 46, x, x}, k_packet_queue_noc},
 
     // Remote chip 4
-    {53, 4, x, 0, US_TUNNELER_LOCAL, {52, 54, x, x}, {52, 55, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {54, 4, x, 0, MUX_D, {57, x, x, x}, {53, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {55, 4, x, 0, PACKET_ROUTER_DEMUX, {53, x, x, x}, {56, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {56, 4, x, 0, PREFETCH_D, {55, x, x, x}, {57, 58, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {57, 4, x, 0, DISPATCH_D, {56, x, x, x}, {58, 54, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {58, 4, x, 0, DISPATCH_S, {56, x, x, x}, {57, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {53, 4, x, 0, US_TUNNELER_LOCAL, {52, 54, x, x}, {52, 55, x, x}, k_packet_queue_noc},
+    {54, 4, x, 0, MUX_D, {57, x, x, x}, {53, x, x, x}, k_packet_queue_noc},
+    {55, 4, x, 0, PACKET_ROUTER_DEMUX, {53, x, x, x}, {56, x, x, x}, k_packet_queue_noc},
+    {56, 4, x, 0, PREFETCH_D, {55, x, x, x}, {57, 58, x, x}, k_prefetcher_noc},
+    {57, 4, x, 0, DISPATCH_D, {56, x, x, x}, {58, 54, x, x}, k_dispatcher_noc},
+    {58, 4, x, 0, DISPATCH_S, {56, x, x, x}, {57, x, x, x}, k_dispatcher_s_noc},
 
     // Remote chip 5
-    {59, 5, x, 0, US_TUNNELER_LOCAL, {28, 60, x, x}, {28, 61, 62, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {60, 5, x, 0, MUX_D, {64, 66, x, x}, {59, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {61, 5, x, 0, PACKET_ROUTER_DEMUX, {59, x, x, x}, {63, 66, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {62, 5, x, 0, PACKET_ROUTER_DEMUX, {59, x, x, x}, {66, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {63, 5, x, 0, PREFETCH_D, {61, x, x, x}, {64, 65, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {64, 5, x, 0, DISPATCH_D, {63, x, x, x}, {65, 60, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {65, 5, x, 0, DISPATCH_S, {63, x, x, x}, {64, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {66, 5, x, 0, US_TUNNELER_REMOTE, {67, 61, 62, x}, {67, 60, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {59, 5, x, 0, US_TUNNELER_LOCAL, {28, 60, x, x}, {28, 61, 62, x}, k_packet_queue_noc},
+    {60, 5, x, 0, MUX_D, {64, 66, x, x}, {59, x, x, x}, k_packet_queue_noc},
+    {61, 5, x, 0, PACKET_ROUTER_DEMUX, {59, x, x, x}, {63, 66, x, x}, k_packet_queue_noc},
+    {62, 5, x, 0, PACKET_ROUTER_DEMUX, {59, x, x, x}, {66, x, x, x}, k_packet_queue_noc},
+    {63, 5, x, 0, PREFETCH_D, {61, x, x, x}, {64, 65, x, x}, k_prefetcher_noc},
+    {64, 5, x, 0, DISPATCH_D, {63, x, x, x}, {65, 60, x, x}, k_dispatcher_noc},
+    {65, 5, x, 0, DISPATCH_S, {63, x, x, x}, {64, x, x, x}, k_dispatcher_s_noc},
+    {66, 5, x, 0, US_TUNNELER_REMOTE, {67, 61, 62, x}, {67, 60, x, x}, k_packet_queue_noc},
 
     // Remote chip 6
-    {67, 6, x, 0, US_TUNNELER_LOCAL, {66, 68, x, x}, {66, 69, 70, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {68, 6, x, 0, MUX_D, {72, 74, x, x}, {67, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {69, 6, x, 0, PACKET_ROUTER_DEMUX, {67, x, x, x}, {71, 74, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {70, 6, x, 0, PACKET_ROUTER_DEMUX, {67, x, x, x}, {74, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {71, 6, x, 0, PREFETCH_D, {69, x, x, x}, {72, 73, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {72, 6, x, 0, DISPATCH_D, {71, x, x, x}, {73, 68, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {73, 6, x, 0, DISPATCH_S, {71, x, x, x}, {72, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {74, 6, x, 0, US_TUNNELER_REMOTE, {75, 69, 70, x}, {75, 68, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {67, 6, x, 0, US_TUNNELER_LOCAL, {66, 68, x, x}, {66, 69, 70, x}, k_packet_queue_noc},
+    {68, 6, x, 0, MUX_D, {72, 74, x, x}, {67, x, x, x}, k_packet_queue_noc},
+    {69, 6, x, 0, PACKET_ROUTER_DEMUX, {67, x, x, x}, {71, 74, x, x}, k_packet_queue_noc},
+    {70, 6, x, 0, PACKET_ROUTER_DEMUX, {67, x, x, x}, {74, x, x, x}, k_packet_queue_noc},
+    {71, 6, x, 0, PREFETCH_D, {69, x, x, x}, {72, 73, x, x}, k_prefetcher_noc},
+    {72, 6, x, 0, DISPATCH_D, {71, x, x, x}, {73, 68, x, x}, k_dispatcher_noc},
+    {73, 6, x, 0, DISPATCH_S, {71, x, x, x}, {72, x, x, x}, k_dispatcher_s_noc},
+    {74, 6, x, 0, US_TUNNELER_REMOTE, {75, 69, 70, x}, {75, 68, x, x}, k_packet_queue_noc},
 
     // Remote chip 7
-    {75, 7, x, 0, US_TUNNELER_LOCAL, {74, 76, x, x}, {74, 77, 78, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {76, 7, x, 0, MUX_D, {80, 82, x, x}, {75, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {77, 7, x, 0, PACKET_ROUTER_DEMUX, {75, x, x, x}, {79, 82, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {78, 7, x, 0, PACKET_ROUTER_DEMUX, {75, x, x, x}, {82, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {79, 7, x, 0, PREFETCH_D, {77, x, x, x}, {80, 81, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {80, 7, x, 0, DISPATCH_D, {79, x, x, x}, {81, 76, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {81, 7, x, 0, DISPATCH_S, {79, x, x, x}, {80, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {82, 7, x, 0, US_TUNNELER_REMOTE, {83, 77, 78, x}, {83, 76, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {75, 7, x, 0, US_TUNNELER_LOCAL, {74, 76, x, x}, {74, 77, 78, x}, k_packet_queue_noc},
+    {76, 7, x, 0, MUX_D, {80, 82, x, x}, {75, x, x, x}, k_packet_queue_noc},
+    {77, 7, x, 0, PACKET_ROUTER_DEMUX, {75, x, x, x}, {79, 82, x, x}, k_packet_queue_noc},
+    {78, 7, x, 0, PACKET_ROUTER_DEMUX, {75, x, x, x}, {82, x, x, x}, k_packet_queue_noc},
+    {79, 7, x, 0, PREFETCH_D, {77, x, x, x}, {80, 81, x, x}, k_prefetcher_noc},
+    {80, 7, x, 0, DISPATCH_D, {79, x, x, x}, {81, 76, x, x}, k_dispatcher_noc},
+    {81, 7, x, 0, DISPATCH_S, {79, x, x, x}, {80, x, x, x}, k_dispatcher_s_noc},
+    {82, 7, x, 0, US_TUNNELER_REMOTE, {83, 77, 78, x}, {83, 76, x, x}, k_packet_queue_noc},
 
     // Remote chip 8
-    {83, 8, x, 0, US_TUNNELER_LOCAL, {82, 84, x, x}, {82, 85, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {84, 8, x, 0, MUX_D, {87, x, x, x}, {83, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {85, 8, x, 0, PACKET_ROUTER_DEMUX, {83, x, x, x}, {86, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {86, 8, x, 0, PREFETCH_D, {85, x, x, x}, {87, 88, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {87, 8, x, 0, DISPATCH_D, {86, x, x, x}, {88, 84, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {88, 8, x, 0, DISPATCH_S, {86, x, x, x}, {87, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {83, 8, x, 0, US_TUNNELER_LOCAL, {82, 84, x, x}, {82, 85, x, x}, k_packet_queue_noc},
+    {84, 8, x, 0, MUX_D, {87, x, x, x}, {83, x, x, x}, k_packet_queue_noc},
+    {85, 8, x, 0, PACKET_ROUTER_DEMUX, {83, x, x, x}, {86, x, x, x}, k_packet_queue_noc},
+    {86, 8, x, 0, PREFETCH_D, {85, x, x, x}, {87, 88, x, x}, k_prefetcher_noc},
+    {87, 8, x, 0, DISPATCH_D, {86, x, x, x}, {88, 84, x, x}, k_dispatcher_noc},
+    {88, 8, x, 0, DISPATCH_S, {86, x, x, x}, {87, x, x, x}, k_dispatcher_s_noc},
 };
 
 static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq = {
     // For MMIO chip
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {2, 4, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, 5, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {4, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {3, 0, 0, 1, DISPATCH_HD, {1, x, x, x}, {5, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {4, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {2, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {5, 0, 0, 1, DISPATCH_S, {1, x, x, x}, {3, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {2, 4, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, 5, x, x}, k_prefetcher_noc},
+    {2, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {4, x, x, x}, k_dispatcher_noc},
+    {3, 0, 0, 1, DISPATCH_HD, {1, x, x, x}, {5, x, x, x}, k_dispatcher_noc},
+    {4, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {2, x, x, x}, k_dispatcher_s_noc},
+    {5, 0, 0, 1, DISPATCH_S, {1, x, x, x}, {3, x, x, x}, k_dispatcher_s_noc},
 
     // Servicing remote chips 1-4
-    {6, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {7, 0, 1, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {8, 0, 1, 0, DISPATCH_H, {25, x, x, x}, {6, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {9, 0, 1, 1, DISPATCH_H, {25, x, x, x}, {7, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {10, 0, 2, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {11, 0, 2, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {12, 0, 2, 0, DISPATCH_H, {25, x, x, x}, {10, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {13, 0, 2, 1, DISPATCH_H, {25, x, x, x}, {11, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {14, 0, 3, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {15, 0, 3, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {16, 0, 3, 0, DISPATCH_H, {26, x, x, x}, {14, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {17, 0, 3, 1, DISPATCH_H, {26, x, x, x}, {15, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {18, 0, 4, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {19, 0, 4, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {20, 0, 4, 0, DISPATCH_H, {26, x, x, x}, {18, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {21, 0, 4, 1, DISPATCH_H, {26, x, x, x}, {19, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {22, 0, 1, 0, PACKET_ROUTER_MUX, {6, 10, 14, 18}, {27, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {23, 0, 1, 0, PACKET_ROUTER_MUX, {7, 11, 15, 19}, {27, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {24, 0, 1, 0, DEMUX, {27, x, x, x}, {25, 26, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {25, 0, 1, 0, DEMUX, {24, x, x, x}, {8, 9, 12, 13}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {26, 0, 1, 0, DEMUX, {24, x, x, x}, {16, 17, 20, 21}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {27, 0, 1, 0, US_TUNNELER_REMOTE, {50, 22, 23, x}, {50, 24, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {6, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, k_prefetcher_noc},
+    {7, 0, 1, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, k_prefetcher_noc},
+    {8, 0, 1, 0, DISPATCH_H, {25, x, x, x}, {6, x, x, x}, k_dispatcher_noc},
+    {9, 0, 1, 1, DISPATCH_H, {25, x, x, x}, {7, x, x, x}, k_dispatcher_noc},
+    {10, 0, 2, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, k_prefetcher_noc},
+    {11, 0, 2, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, k_prefetcher_noc},
+    {12, 0, 2, 0, DISPATCH_H, {25, x, x, x}, {10, x, x, x}, k_dispatcher_noc},
+    {13, 0, 2, 1, DISPATCH_H, {25, x, x, x}, {11, x, x, x}, k_dispatcher_noc},
+    {14, 0, 3, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, k_prefetcher_noc},
+    {15, 0, 3, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, k_prefetcher_noc},
+    {16, 0, 3, 0, DISPATCH_H, {26, x, x, x}, {14, x, x, x}, k_dispatcher_noc},
+    {17, 0, 3, 1, DISPATCH_H, {26, x, x, x}, {15, x, x, x}, k_dispatcher_noc},
+    {18, 0, 4, 0, PREFETCH_H, {x, x, x, x}, {22, x, x, x}, k_prefetcher_noc},
+    {19, 0, 4, 1, PREFETCH_H, {x, x, x, x}, {23, x, x, x}, k_prefetcher_noc},
+    {20, 0, 4, 0, DISPATCH_H, {26, x, x, x}, {18, x, x, x}, k_dispatcher_noc},
+    {21, 0, 4, 1, DISPATCH_H, {26, x, x, x}, {19, x, x, x}, k_dispatcher_noc},
+    {22, 0, 1, 0, PACKET_ROUTER_MUX, {6, 10, 14, 18}, {27, x, x, x}, k_packet_queue_noc},
+    {23, 0, 1, 0, PACKET_ROUTER_MUX, {7, 11, 15, 19}, {27, x, x, x}, k_packet_queue_noc},
+    {24, 0, 1, 0, DEMUX, {27, x, x, x}, {25, 26, x, x}, k_packet_queue_noc},
+    {25, 0, 1, 0, DEMUX, {24, x, x, x}, {8, 9, 12, 13}, k_packet_queue_noc},
+    {26, 0, 1, 0, DEMUX, {24, x, x, x}, {16, 17, 20, 21}, k_packet_queue_noc},
+    {27, 0, 1, 0, US_TUNNELER_REMOTE, {50, 22, 23, x}, {50, 24, x, x}, k_packet_queue_noc},
 
     // Servicing remote chips 5-8
-    {28, 0, 5, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {29, 0, 5, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {30, 0, 5, 0, DISPATCH_H, {47, x, x, x}, {28, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {31, 0, 5, 1, DISPATCH_H, {47, x, x, x}, {29, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {32, 0, 6, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {33, 0, 6, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {34, 0, 6, 0, DISPATCH_H, {47, x, x, x}, {32, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {35, 0, 6, 1, DISPATCH_H, {47, x, x, x}, {33, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {36, 0, 7, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {37, 0, 7, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {38, 0, 7, 0, DISPATCH_H, {48, x, x, x}, {36, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {39, 0, 7, 1, DISPATCH_H, {48, x, x, x}, {37, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {40, 0, 8, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {41, 0, 8, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {42, 0, 8, 0, DISPATCH_H, {48, x, x, x}, {40, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {43, 0, 8, 1, DISPATCH_H, {48, x, x, x}, {41, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {44, 0, 5, 0, PACKET_ROUTER_MUX, {28, 32, 36, 40}, {49, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {45, 0, 5, 0, PACKET_ROUTER_MUX, {29, 33, 37, 41}, {49, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {46, 0, 5, 0, DEMUX, {49, x, x, x}, {47, 48, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {47, 0, 5, 0, DEMUX, {46, x, x, x}, {30, 31, 34, 35}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {48, 0, 5, 0, DEMUX, {46, x, x, x}, {38, 39, 42, 43}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {49, 0, 5, 0, US_TUNNELER_REMOTE, {93, 44, 45, x}, {93, 46, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {28, 0, 5, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, k_prefetcher_noc},
+    {29, 0, 5, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, k_prefetcher_noc},
+    {30, 0, 5, 0, DISPATCH_H, {47, x, x, x}, {28, x, x, x}, k_dispatcher_noc},
+    {31, 0, 5, 1, DISPATCH_H, {47, x, x, x}, {29, x, x, x}, k_dispatcher_noc},
+    {32, 0, 6, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, k_prefetcher_noc},
+    {33, 0, 6, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, k_prefetcher_noc},
+    {34, 0, 6, 0, DISPATCH_H, {47, x, x, x}, {32, x, x, x}, k_dispatcher_noc},
+    {35, 0, 6, 1, DISPATCH_H, {47, x, x, x}, {33, x, x, x}, k_dispatcher_noc},
+    {36, 0, 7, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, k_prefetcher_noc},
+    {37, 0, 7, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, k_prefetcher_noc},
+    {38, 0, 7, 0, DISPATCH_H, {48, x, x, x}, {36, x, x, x}, k_dispatcher_noc},
+    {39, 0, 7, 1, DISPATCH_H, {48, x, x, x}, {37, x, x, x}, k_dispatcher_noc},
+    {40, 0, 8, 0, PREFETCH_H, {x, x, x, x}, {44, x, x, x}, k_prefetcher_noc},
+    {41, 0, 8, 1, PREFETCH_H, {x, x, x, x}, {45, x, x, x}, k_prefetcher_noc},
+    {42, 0, 8, 0, DISPATCH_H, {48, x, x, x}, {40, x, x, x}, k_dispatcher_noc},
+    {43, 0, 8, 1, DISPATCH_H, {48, x, x, x}, {41, x, x, x}, k_dispatcher_noc},
+    {44, 0, 5, 0, PACKET_ROUTER_MUX, {28, 32, 36, 40}, {49, x, x, x}, k_packet_queue_noc},
+    {45, 0, 5, 0, PACKET_ROUTER_MUX, {29, 33, 37, 41}, {49, x, x, x}, k_packet_queue_noc},
+    {46, 0, 5, 0, DEMUX, {49, x, x, x}, {47, 48, x, x}, k_packet_queue_noc},
+    {47, 0, 5, 0, DEMUX, {46, x, x, x}, {30, 31, 34, 35}, k_packet_queue_noc},
+    {48, 0, 5, 0, DEMUX, {46, x, x, x}, {38, 39, 42, 43}, k_packet_queue_noc},
+    {49, 0, 5, 0, US_TUNNELER_REMOTE, {93, 44, 45, x}, {93, 46, x, x}, k_packet_queue_noc},
 
     // Remote chip 1
-    {50, 1, x, 0, US_TUNNELER_LOCAL, {27, 51, x, x}, {27, 52, 53, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {51, 1, x, 0, MUX_D, {56, 57, 60, x}, {50, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {52, 1, x, 0, PACKET_ROUTER_DEMUX, {50, x, x, x}, {54, 60, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {53, 1, x, 0, PACKET_ROUTER_DEMUX, {50, x, x, x}, {55, 60, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {54, 1, x, 0, PREFETCH_D, {52, x, x, x}, {56, 58, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {55, 1, x, 1, PREFETCH_D, {53, x, x, x}, {57, 59, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {56, 1, x, 0, DISPATCH_D, {54, x, x, x}, {58, 51, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {57, 1, x, 1, DISPATCH_D, {55, x, x, x}, {59, 51, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {58, 1, x, 0, DISPATCH_S, {54, x, x, x}, {56, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {50, 1, x, 0, US_TUNNELER_LOCAL, {27, 51, x, x}, {27, 52, 53, x}, k_packet_queue_noc},
+    {51, 1, x, 0, MUX_D, {56, 57, 60, x}, {50, x, x, x}, k_packet_queue_noc},
+    {52, 1, x, 0, PACKET_ROUTER_DEMUX, {50, x, x, x}, {54, 60, x, x}, k_packet_queue_noc},
+    {53, 1, x, 0, PACKET_ROUTER_DEMUX, {50, x, x, x}, {55, 60, x, x}, k_packet_queue_noc},
+    {54, 1, x, 0, PREFETCH_D, {52, x, x, x}, {56, 58, x, x}, k_prefetcher_noc},
+    {55, 1, x, 1, PREFETCH_D, {53, x, x, x}, {57, 59, x, x}, k_prefetcher_noc},
+    {56, 1, x, 0, DISPATCH_D, {54, x, x, x}, {58, 51, x, x}, k_dispatcher_noc},
+    {57, 1, x, 1, DISPATCH_D, {55, x, x, x}, {59, 51, x, x}, k_dispatcher_noc},
+    {58, 1, x, 0, DISPATCH_S, {54, x, x, x}, {56, x, x, x}, k_dispatcher_s_noc},
     // TODO: Why does the second dispatch S connect to the first dispatch D? Keep same as previous implementation for
     // now
-    {59, 1, x, 1, DISPATCH_S, {54, x, x, x}, {56, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {60, 1, x, 0, US_TUNNELER_REMOTE, {61, 52, 53, x}, {61, 51, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {59, 1, x, 1, DISPATCH_S, {54, x, x, x}, {56, x, x, x}, k_dispatcher_s_noc},
+    {60, 1, x, 0, US_TUNNELER_REMOTE, {61, 52, 53, x}, {61, 51, x, x}, k_packet_queue_noc},
 
     // Remote chip 2
-    {61, 2, x, 0, US_TUNNELER_LOCAL, {60, 62, x, x}, {60, 63, 64, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {62, 2, x, 0, MUX_D, {67, 68, 71, x}, {61, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {63, 2, x, 0, PACKET_ROUTER_DEMUX, {61, x, x, x}, {65, 71, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {64, 2, x, 0, PACKET_ROUTER_DEMUX, {61, x, x, x}, {66, 71, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {65, 2, x, 0, PREFETCH_D, {63, x, x, x}, {67, 69, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {66, 2, x, 1, PREFETCH_D, {64, x, x, x}, {68, 70, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {67, 2, x, 0, DISPATCH_D, {65, x, x, x}, {69, 62, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {68, 2, x, 1, DISPATCH_D, {66, x, x, x}, {70, 62, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {69, 2, x, 0, DISPATCH_S, {65, x, x, x}, {67, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {70, 2, x, 1, DISPATCH_S, {65, x, x, x}, {67, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {71, 2, x, 0, US_TUNNELER_REMOTE, {72, 63, 64, x}, {72, 62, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {61, 2, x, 0, US_TUNNELER_LOCAL, {60, 62, x, x}, {60, 63, 64, x}, k_packet_queue_noc},
+    {62, 2, x, 0, MUX_D, {67, 68, 71, x}, {61, x, x, x}, k_packet_queue_noc},
+    {63, 2, x, 0, PACKET_ROUTER_DEMUX, {61, x, x, x}, {65, 71, x, x}, k_packet_queue_noc},
+    {64, 2, x, 0, PACKET_ROUTER_DEMUX, {61, x, x, x}, {66, 71, x, x}, k_packet_queue_noc},
+    {65, 2, x, 0, PREFETCH_D, {63, x, x, x}, {67, 69, x, x}, k_prefetcher_noc},
+    {66, 2, x, 1, PREFETCH_D, {64, x, x, x}, {68, 70, x, x}, k_prefetcher_noc},
+    {67, 2, x, 0, DISPATCH_D, {65, x, x, x}, {69, 62, x, x}, k_dispatcher_noc},
+    {68, 2, x, 1, DISPATCH_D, {66, x, x, x}, {70, 62, x, x}, k_dispatcher_noc},
+    {69, 2, x, 0, DISPATCH_S, {65, x, x, x}, {67, x, x, x}, k_dispatcher_s_noc},
+    {70, 2, x, 1, DISPATCH_S, {65, x, x, x}, {67, x, x, x}, k_dispatcher_s_noc},
+    {71, 2, x, 0, US_TUNNELER_REMOTE, {72, 63, 64, x}, {72, 62, x, x}, k_packet_queue_noc},
 
     // Remote chip 3
-    {72, 3, x, 0, US_TUNNELER_LOCAL, {71, 73, x, x}, {71, 74, 75, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {73, 3, x, 0, MUX_D, {78, 79, 82, x}, {72, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {74, 3, x, 0, PACKET_ROUTER_DEMUX, {72, x, x, x}, {76, 82, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {75, 3, x, 0, PACKET_ROUTER_DEMUX, {72, x, x, x}, {77, 82, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {76, 3, x, 0, PREFETCH_D, {74, x, x, x}, {78, 80, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {77, 3, x, 1, PREFETCH_D, {75, x, x, x}, {79, 81, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {78, 3, x, 0, DISPATCH_D, {76, x, x, x}, {80, 73, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {79, 3, x, 1, DISPATCH_D, {77, x, x, x}, {81, 73, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {80, 3, x, 0, DISPATCH_S, {76, x, x, x}, {78, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {81, 3, x, 1, DISPATCH_S, {76, x, x, x}, {78, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {82, 3, x, 0, US_TUNNELER_REMOTE, {83, 74, 75, x}, {83, 73, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {72, 3, x, 0, US_TUNNELER_LOCAL, {71, 73, x, x}, {71, 74, 75, x}, k_packet_queue_noc},
+    {73, 3, x, 0, MUX_D, {78, 79, 82, x}, {72, x, x, x}, k_packet_queue_noc},
+    {74, 3, x, 0, PACKET_ROUTER_DEMUX, {72, x, x, x}, {76, 82, x, x}, k_packet_queue_noc},
+    {75, 3, x, 0, PACKET_ROUTER_DEMUX, {72, x, x, x}, {77, 82, x, x}, k_packet_queue_noc},
+    {76, 3, x, 0, PREFETCH_D, {74, x, x, x}, {78, 80, x, x}, k_prefetcher_noc},
+    {77, 3, x, 1, PREFETCH_D, {75, x, x, x}, {79, 81, x, x}, k_prefetcher_noc},
+    {78, 3, x, 0, DISPATCH_D, {76, x, x, x}, {80, 73, x, x}, k_dispatcher_noc},
+    {79, 3, x, 1, DISPATCH_D, {77, x, x, x}, {81, 73, x, x}, k_dispatcher_noc},
+    {80, 3, x, 0, DISPATCH_S, {76, x, x, x}, {78, x, x, x}, k_dispatcher_s_noc},
+    {81, 3, x, 1, DISPATCH_S, {76, x, x, x}, {78, x, x, x}, k_dispatcher_s_noc},
+    {82, 3, x, 0, US_TUNNELER_REMOTE, {83, 74, 75, x}, {83, 73, x, x}, k_packet_queue_noc},
 
     // Remote chip 4
-    {83, 4, x, 0, US_TUNNELER_LOCAL, {82, 84, x, x}, {82, 85, 86, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {84, 4, x, 0, MUX_D, {89, 90, x, x}, {83, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {85, 4, x, 0, PACKET_ROUTER_DEMUX, {83, x, x, x}, {87, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {86, 4, x, 0, PACKET_ROUTER_DEMUX, {83, x, x, x}, {88, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {87, 4, x, 0, PREFETCH_D, {85, x, x, x}, {89, 91, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {88, 4, x, 1, PREFETCH_D, {86, x, x, x}, {90, 92, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {89, 4, x, 0, DISPATCH_D, {87, x, x, x}, {91, 84, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {90, 4, x, 1, DISPATCH_D, {88, x, x, x}, {92, 84, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {91, 4, x, 0, DISPATCH_S, {87, x, x, x}, {89, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {92, 4, x, 1, DISPATCH_S, {87, x, x, x}, {89, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {83, 4, x, 0, US_TUNNELER_LOCAL, {82, 84, x, x}, {82, 85, 86, x}, k_packet_queue_noc},
+    {84, 4, x, 0, MUX_D, {89, 90, x, x}, {83, x, x, x}, k_packet_queue_noc},
+    {85, 4, x, 0, PACKET_ROUTER_DEMUX, {83, x, x, x}, {87, x, x, x}, k_packet_queue_noc},
+    {86, 4, x, 0, PACKET_ROUTER_DEMUX, {83, x, x, x}, {88, x, x, x}, k_packet_queue_noc},
+    {87, 4, x, 0, PREFETCH_D, {85, x, x, x}, {89, 91, x, x}, k_prefetcher_noc},
+    {88, 4, x, 1, PREFETCH_D, {86, x, x, x}, {90, 92, x, x}, k_prefetcher_noc},
+    {89, 4, x, 0, DISPATCH_D, {87, x, x, x}, {91, 84, x, x}, k_dispatcher_noc},
+    {90, 4, x, 1, DISPATCH_D, {88, x, x, x}, {92, 84, x, x}, k_dispatcher_noc},
+    {91, 4, x, 0, DISPATCH_S, {87, x, x, x}, {89, x, x, x}, k_dispatcher_s_noc},
+    {92, 4, x, 1, DISPATCH_S, {87, x, x, x}, {89, x, x, x}, k_dispatcher_s_noc},
 
     // Remote chip 5
-    {93, 5, x, 0, US_TUNNELER_LOCAL, {49, 94, x, x}, {49, 95, 96, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {94, 5, x, 0, MUX_D, {99, 100, 103, x}, {93, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {95, 5, x, 0, PACKET_ROUTER_DEMUX, {93, x, x, x}, {97, 103, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {96, 5, x, 0, PACKET_ROUTER_DEMUX, {93, x, x, x}, {98, 103, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {97, 5, x, 0, PREFETCH_D, {95, x, x, x}, {99, 101, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {98, 5, x, 1, PREFETCH_D, {96, x, x, x}, {100, 102, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {99, 5, x, 0, DISPATCH_D, {97, x, x, x}, {101, 94, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {100, 5, x, 1, DISPATCH_D, {98, x, x, x}, {102, 94, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {101, 5, x, 0, DISPATCH_S, {97, x, x, x}, {99, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {102, 5, x, 1, DISPATCH_S, {97, x, x, x}, {99, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {103, 5, x, 0, US_TUNNELER_REMOTE, {104, 95, 96, x}, {104, 94, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {93, 5, x, 0, US_TUNNELER_LOCAL, {49, 94, x, x}, {49, 95, 96, x}, k_packet_queue_noc},
+    {94, 5, x, 0, MUX_D, {99, 100, 103, x}, {93, x, x, x}, k_packet_queue_noc},
+    {95, 5, x, 0, PACKET_ROUTER_DEMUX, {93, x, x, x}, {97, 103, x, x}, k_packet_queue_noc},
+    {96, 5, x, 0, PACKET_ROUTER_DEMUX, {93, x, x, x}, {98, 103, x, x}, k_packet_queue_noc},
+    {97, 5, x, 0, PREFETCH_D, {95, x, x, x}, {99, 101, x, x}, k_prefetcher_noc},
+    {98, 5, x, 1, PREFETCH_D, {96, x, x, x}, {100, 102, x, x}, k_prefetcher_noc},
+    {99, 5, x, 0, DISPATCH_D, {97, x, x, x}, {101, 94, x, x}, k_dispatcher_noc},
+    {100, 5, x, 1, DISPATCH_D, {98, x, x, x}, {102, 94, x, x}, k_dispatcher_noc},
+    {101, 5, x, 0, DISPATCH_S, {97, x, x, x}, {99, x, x, x}, k_dispatcher_s_noc},
+    {102, 5, x, 1, DISPATCH_S, {97, x, x, x}, {99, x, x, x}, k_dispatcher_s_noc},
+    {103, 5, x, 0, US_TUNNELER_REMOTE, {104, 95, 96, x}, {104, 94, x, x}, k_packet_queue_noc},
 
     // Remote chip 6
-    {104, 6, x, 0, US_TUNNELER_LOCAL, {103, 105, x, x}, {103, 106, 107, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {105, 6, x, 0, MUX_D, {110, 111, 114, x}, {104, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {106, 6, x, 0, PACKET_ROUTER_DEMUX, {104, x, x, x}, {108, 114, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {107, 6, x, 0, PACKET_ROUTER_DEMUX, {104, x, x, x}, {109, 114, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {108, 6, x, 0, PREFETCH_D, {106, x, x, x}, {110, 112, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {109, 6, x, 1, PREFETCH_D, {107, x, x, x}, {111, 113, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {110, 6, x, 0, DISPATCH_D, {108, x, x, x}, {112, 105, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {111, 6, x, 1, DISPATCH_D, {109, x, x, x}, {113, 105, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {112, 6, x, 0, DISPATCH_S, {108, x, x, x}, {110, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {113, 6, x, 1, DISPATCH_S, {108, x, x, x}, {110, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {114, 6, x, 0, US_TUNNELER_REMOTE, {115, 106, 107, x}, {115, 105, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {104, 6, x, 0, US_TUNNELER_LOCAL, {103, 105, x, x}, {103, 106, 107, x}, k_packet_queue_noc},
+    {105, 6, x, 0, MUX_D, {110, 111, 114, x}, {104, x, x, x}, k_packet_queue_noc},
+    {106, 6, x, 0, PACKET_ROUTER_DEMUX, {104, x, x, x}, {108, 114, x, x}, k_packet_queue_noc},
+    {107, 6, x, 0, PACKET_ROUTER_DEMUX, {104, x, x, x}, {109, 114, x, x}, k_packet_queue_noc},
+    {108, 6, x, 0, PREFETCH_D, {106, x, x, x}, {110, 112, x, x}, k_prefetcher_noc},
+    {109, 6, x, 1, PREFETCH_D, {107, x, x, x}, {111, 113, x, x}, k_prefetcher_noc},
+    {110, 6, x, 0, DISPATCH_D, {108, x, x, x}, {112, 105, x, x}, k_dispatcher_noc},
+    {111, 6, x, 1, DISPATCH_D, {109, x, x, x}, {113, 105, x, x}, k_dispatcher_noc},
+    {112, 6, x, 0, DISPATCH_S, {108, x, x, x}, {110, x, x, x}, k_dispatcher_s_noc},
+    {113, 6, x, 1, DISPATCH_S, {108, x, x, x}, {110, x, x, x}, k_dispatcher_s_noc},
+    {114, 6, x, 0, US_TUNNELER_REMOTE, {115, 106, 107, x}, {115, 105, x, x}, k_packet_queue_noc},
 
     // Remote chip 7
-    {115, 7, x, 0, US_TUNNELER_LOCAL, {114, 116, x, x}, {114, 117, 118, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {116, 7, x, 0, MUX_D, {121, 122, 125, x}, {115, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {117, 7, x, 0, PACKET_ROUTER_DEMUX, {115, x, x, x}, {119, 125, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {118, 7, x, 0, PACKET_ROUTER_DEMUX, {115, x, x, x}, {120, 125, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {119, 7, x, 0, PREFETCH_D, {117, x, x, x}, {121, 123, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {120, 7, x, 1, PREFETCH_D, {118, x, x, x}, {122, 124, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {121, 7, x, 0, DISPATCH_D, {119, x, x, x}, {123, 116, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {122, 7, x, 1, DISPATCH_D, {120, x, x, x}, {124, 116, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {123, 7, x, 0, DISPATCH_S, {119, x, x, x}, {121, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {124, 7, x, 1, DISPATCH_S, {119, x, x, x}, {121, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {125, 7, x, 0, US_TUNNELER_REMOTE, {126, 117, 118, x}, {126, 116, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {115, 7, x, 0, US_TUNNELER_LOCAL, {114, 116, x, x}, {114, 117, 118, x}, k_packet_queue_noc},
+    {116, 7, x, 0, MUX_D, {121, 122, 125, x}, {115, x, x, x}, k_packet_queue_noc},
+    {117, 7, x, 0, PACKET_ROUTER_DEMUX, {115, x, x, x}, {119, 125, x, x}, k_packet_queue_noc},
+    {118, 7, x, 0, PACKET_ROUTER_DEMUX, {115, x, x, x}, {120, 125, x, x}, k_packet_queue_noc},
+    {119, 7, x, 0, PREFETCH_D, {117, x, x, x}, {121, 123, x, x}, k_prefetcher_noc},
+    {120, 7, x, 1, PREFETCH_D, {118, x, x, x}, {122, 124, x, x}, k_prefetcher_noc},
+    {121, 7, x, 0, DISPATCH_D, {119, x, x, x}, {123, 116, x, x}, k_dispatcher_noc},
+    {122, 7, x, 1, DISPATCH_D, {120, x, x, x}, {124, 116, x, x}, k_dispatcher_noc},
+    {123, 7, x, 0, DISPATCH_S, {119, x, x, x}, {121, x, x, x}, k_dispatcher_s_noc},
+    {124, 7, x, 1, DISPATCH_S, {119, x, x, x}, {121, x, x, x}, k_dispatcher_s_noc},
+    {125, 7, x, 0, US_TUNNELER_REMOTE, {126, 117, 118, x}, {126, 116, x, x}, k_packet_queue_noc},
 
     // Remote chip 8
-    {126, 8, x, 0, US_TUNNELER_LOCAL, {125, 127, x, x}, {125, 128, 129, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {127, 8, x, 0, MUX_D, {132, 133, x, x}, {126, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {128, 8, x, 0, PACKET_ROUTER_DEMUX, {126, x, x, x}, {130, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {129, 8, x, 0, PACKET_ROUTER_DEMUX, {126, x, x, x}, {131, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {130, 8, x, 0, PREFETCH_D, {128, x, x, x}, {132, 134, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {131, 8, x, 1, PREFETCH_D, {129, x, x, x}, {133, 135, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {132, 8, x, 0, DISPATCH_D, {130, x, x, x}, {134, 127, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {133, 8, x, 1, DISPATCH_D, {131, x, x, x}, {135, 127, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {134, 8, x, 0, DISPATCH_S, {130, x, x, x}, {132, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
-    {135, 8, x, 1, DISPATCH_S, {130, x, x, x}, {132, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {126, 8, x, 0, US_TUNNELER_LOCAL, {125, 127, x, x}, {125, 128, 129, x}, k_packet_queue_noc},
+    {127, 8, x, 0, MUX_D, {132, 133, x, x}, {126, x, x, x}, k_packet_queue_noc},
+    {128, 8, x, 0, PACKET_ROUTER_DEMUX, {126, x, x, x}, {130, x, x, x}, k_packet_queue_noc},
+    {129, 8, x, 0, PACKET_ROUTER_DEMUX, {126, x, x, x}, {131, x, x, x}, k_packet_queue_noc},
+    {130, 8, x, 0, PREFETCH_D, {128, x, x, x}, {132, 134, x, x}, k_prefetcher_noc},
+    {131, 8, x, 1, PREFETCH_D, {129, x, x, x}, {133, 135, x, x}, k_prefetcher_noc},
+    {132, 8, x, 0, DISPATCH_D, {130, x, x, x}, {134, 127, x, x}, k_dispatcher_noc},
+    {133, 8, x, 1, DISPATCH_D, {131, x, x, x}, {135, 127, x, x}, k_dispatcher_noc},
+    {134, 8, x, 0, DISPATCH_S, {130, x, x, x}, {132, x, x, x}, k_dispatcher_s_noc},
+    {135, 8, x, 1, DISPATCH_S, {130, x, x, x}, {132, x, x, x}, k_dispatcher_s_noc},
 };
+// clang-format on
 
 std::vector<FDKernel*> node_id_to_kernel;
 
@@ -531,12 +590,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     for (const auto& node : nodes) {
         TT_ASSERT(node_id_to_kernel.size() == node.id);
         node_id_to_kernel.push_back(FDKernel::Generate(
-            node.id,
-            node.device_id,
-            node.servicing_device_id,
-            node.cq_id,
-            {node.my_noc, node.upstream_noc, node.downstream_noc},
-            node.kernel_type));
+            node.id, node.device_id, node.servicing_device_id, node.cq_id, node.noc_selection, node.kernel_type));
         if (tt::Cluster::instance().get_associated_mmio_device(node.device_id) == node.device_id) {
             mmio_device_ids.insert(node.device_id);
         }
@@ -546,12 +600,12 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
 
     // Connect the graph with upstream/downstream kernels
     for (const auto& node : nodes) {
-        for (int idx = 0; idx < DISPATCH_MAX_UPSTREAM_KERNELS; idx++) {
+        for (int idx = 0; idx < k_dispatch_max_upstream_kernels; idx++) {
             if (node.upstream_ids[idx] >= 0) {
                 node_id_to_kernel.at(node.id)->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
             }
         }
-        for (int idx = 0; idx < DISPATCH_MAX_DOWNSTREAM_KERNELS; idx++) {
+        for (int idx = 0; idx < k_dispatch_max_downstream_kernels; idx++) {
             if (node.downstream_ids[idx] >= 0) {
                 node_id_to_kernel.at(node.id)->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
             }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -62,7 +62,7 @@ constexpr noc_selection_t k_prefetcher_noc = {
 constexpr noc_selection_t k_dispatcher_noc = {
     .non_dispatch_noc = tt::tt_metal::NOC::NOC_0,
     .upstream_noc = tt::tt_metal::NOC::NOC_1,
-    .downstream_noc = dispatch_downstream_noc,
+    .downstream_noc = k_dispatch_downstream_noc,
 };
 
 //

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -13,7 +13,7 @@ constexpr uint32_t k_dispatch_max_downstream_kernels = 4;
 
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
 // is required when setting up Command Queue objects on host.
-static constexpr NOC dispatch_downstream_noc = NOC::NOC_0;
+constexpr NOC k_dispatch_downstream_noc = NOC::NOC_0;
 
 struct DispatchKernelNode {
     int id;

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 #include <device.hpp>
+#include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
 
 namespace tt::tt_metal {
 
 // Max number of upstream/downstream dispatch kernels that can be connected to a single dispatch kernel.
-#define DISPATCH_MAX_UPSTREAM_KERNELS 4
-#define DISPATCH_MAX_DOWNSTREAM_KERNELS 4
+constexpr uint32_t k_dispatch_max_upstream_kernels = 4;
+constexpr uint32_t k_dispatch_max_downstream_kernels = 4;
 
 struct DispatchKernelNode {
     int id;
@@ -16,11 +17,9 @@ struct DispatchKernelNode {
     chip_id_t servicing_device_id;   // Remote device that this kernel services, used for kernels on MMIO
     uint8_t cq_id;                   // CQ this kernel implements
     DispatchWorkerType kernel_type;  // Type of dispatch kernel this is
-    int upstream_ids[DISPATCH_MAX_UPSTREAM_KERNELS];      // Upstream dispatch kernels
-    int downstream_ids[DISPATCH_MAX_DOWNSTREAM_KERNELS];  // Downstream dispatch kernels
-    NOC my_noc;                                           // NOC this kernel uses to dispatch kernels
-    NOC upstream_noc;                                     // NOC used to communicate upstream
-    NOC downstream_noc;                                   // NOC used to communicate downstream
+    int upstream_ids[k_dispatch_max_upstream_kernels];      // Upstream dispatch kernels
+    int downstream_ids[k_dispatch_max_downstream_kernels];  // Downstream dispatch kernels
+    noc_selection_t noc_selection;                          // NOC selection
 };
 
 // Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -11,6 +11,10 @@ namespace tt::tt_metal {
 constexpr uint32_t k_dispatch_max_upstream_kernels = 4;
 constexpr uint32_t k_dispatch_max_downstream_kernels = 4;
 
+// NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
+// is required when setting up Command Queue objects on host.
+static constexpr NOC dispatch_downstream_noc = NOC::NOC_0;
+
 struct DispatchKernelNode {
     int id;
     chip_id_t device_id;             // Device that this kernel is located on

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -89,7 +89,7 @@ void issue_record_event_commands(
         tt_cxy_pair dispatch_location = DispatchQueryManager::instance().get_dispatch_core(cq_id);
         CoreCoord dispatch_virtual_core = device->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
         unicast_sub_cmds[cq_id] = CQDispatchWritePackedUnicastSubCmd{
-            .noc_xy_addr = device->get_noc_unicast_encoding(dispatch_downstream_noc, dispatch_virtual_core)};
+            .noc_xy_addr = device->get_noc_unicast_encoding(k_dispatch_downstream_noc, dispatch_virtual_core)};
         event_payloads[cq_id] = {event_payload.data(), event_payload.size() * sizeof(uint32_t)};
     }
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include <tt-metalium/program_impl.hpp>
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
 #include <tt_align.hpp>
 
 #include "tt_cluster.hpp"

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -533,7 +533,7 @@ void generate_runtime_args_cmds(
 void assemble_runtime_args_commands(
     ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device) {
     static const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
-    NOC noc_index = dispatch_downstream_noc;
+    NOC noc_index = k_dispatch_downstream_noc;
     auto dispatch_core_config = DispatchQueryManager::instance().get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
     const uint32_t max_prefetch_command_size = DispatchMemMap::get(dispatch_core_type).max_prefetch_command_size();
@@ -789,7 +789,7 @@ void assemble_device_commands(
     DeviceCommandCalculator calculator;
     auto dispatch_core_config = DispatchQueryManager::instance().get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
-    NOC noc_index = dispatch_downstream_noc;
+    NOC noc_index = k_dispatch_downstream_noc;
     const uint32_t max_prefetch_command_size = DispatchMemMap::get(dispatch_core_type).max_prefetch_command_size();
     static const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
     const auto& program_transfer_info = program.get_program_transfer_info();

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -17,6 +17,7 @@
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 
 namespace tt::tt_metal {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Repeated NOC0/NOC1 code making it hard to try out different NOC settings for the FD topology

### What's changed
- Consolidate them to use the existing `noc_selection_t` struct in topology
- Add some static and runtime asserts to make sure it'll work. Because dispatch and dispatch_s uses the stateful NOC APIs, they can't be on the same NOC otherwise their local book keeping like "writes sent" will become incorrect.
- NOTE: Dispatch go signal NOC needs to be the same as what's used in `DispatchQueryManager` to get the right go signal mcast addr. Assertion + comment added

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes