### PR TITLE
#18887: Add job validator, skip metalium smoke test report

### DIFF
--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -63,6 +63,12 @@ def create_cicd_json_for_data_analysis(
 
         logger.info(f"Processing raw GitHub job {github_job_id}")
 
+        # https://github.com/tenstorrent/tt-metal/issues/18887
+        # Skip the smoketest report jobs
+        if raw_job["name"] == "Metalium  smoke tests":
+            logger.warning(f"Job id:{github_job_id} Skipping Metalium smoke test report")
+            continue
+
         test_report_exists = github_job_id in github_job_id_to_test_reports
         if test_report_exists:
             tests = []

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -142,6 +142,20 @@ class Pipeline(BaseModel):
     orchestrator: Optional[str] = Field(None, description="CI/CD pipeline orchestration platform.")
     jobs: List[Job] = []
 
+    # Model validator to check the unique combination constraint
+    @model_validator(mode="before")
+    def check_unique_jobs(cls, values):
+        jobs = values.get("jobs", [])
+        seen_combinations = set()
+
+        for job in jobs:
+            # for each pipeline, the job constraint is (name, job_submission_ts, job_start_ts, job_end_ts)
+            job_combination = (job.name, job.job_submission_ts, job.job_start_ts, job.job_end_ts)
+            if job_combination in seen_combinations:
+                raise ValueError(f"Duplicate job combination found: {job_combination}")
+            seen_combinations.add(job_combination)
+        return values
+
 
 class BenchmarkMeasurement(BaseModel):
     """


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18887

### Problem description
Metalium smoke test report jobs are generated at the exact same time with the exact same name.
The data pipeline will upload these jobs, which violates the table constraint.

### What's changed
Add model validator to ensure jobs will not violate the constraint before uploading the pipeline JSON.
Workaround: skip metalium smoke tests jobs until we can comply with the table constraint (uniquefy on test report title?)

### Checklist
- [x] Re-upload pipeline for data team to confirm
 https://github.com/tenstorrent/tt-metal/actions/runs/13771522733