### PR TITLE
#18890 - Device Profiler NoC Tracing Feature

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -351,6 +351,24 @@ def test_timestamped_events():
         assert eventCount in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong event count"
 
 
+def test_noc_event_profiler():
+    ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
+    assert ENV_VAR_ARCH_NAME in ["grayskull", "wormhole_b0", "blackhole"]
+
+    testCommand = f"build/{PROG_EXMP_DIR}/test_noc_event_profiler"
+    clear_profiler_runtime_artifacts()
+    nocEventProfilerEnv = "TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1"
+    profilerRun = os.system(f"cd {TT_METAL_HOME} && {nocEventProfilerEnv} {testCommand}")
+    assert profilerRun == 0
+
+    expected_trace_file = f"{PROFILER_LOGS_DIR}/noc_trace_dev0_ID0.json"
+    assert os.path.isfile(expected_trace_file)
+
+    with open(expected_trace_file, "r") as nocTraceJson:
+        noc_trace_data = json.load(nocTraceJson)
+        assert len(noc_trace_data) == 8
+
+
 def test_sub_device_profiler():
     ARCH_NAME = os.getenv("ARCH_NAME")
     run_gtest_profiler_test(

--- a/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
+++ b/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "map"
+
+class ProfilerOptionalMetadata {
+    using RuntimeID = uint32_t;
+
+public:
+    ProfilerOptionalMetadata(std::map<std::pair<chip_id_t, RuntimeID>, std::string>&& runtime_map) :
+        runtime_id_to_opname_(std::move(runtime_map)) {}
+
+    const std::string& get_op_name(chip_id_t device_id, RuntimeID runtime_id) const {
+        static const std::string empty_string;
+        auto key = std::make_pair(device_id, runtime_id);
+        auto it = runtime_id_to_opname_.find(key);
+        if (it != runtime_id_to_opname_.end()) {
+            return it->second;
+        }
+        return empty_string;
+    }
+
+private:
+    std::map<std::pair<chip_id_t, RuntimeID>, std::string> runtime_id_to_opname_;
+};

--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -114,6 +114,8 @@ class RunTimeOptions {
     bool profile_dispatch_cores = false;
     bool profiler_sync_enabled = false;
     bool profiler_buffer_usage_enabled = false;
+    bool profiler_noc_events_enabled = false;
+    std::string profiler_noc_events_report_path;
 
     bool null_kernels = false;
 
@@ -295,6 +297,8 @@ public:
     inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
     inline bool get_profiler_sync_enabled() { return profiler_sync_enabled; }
     inline bool get_profiler_buffer_usage_enabled() { return profiler_buffer_usage_enabled; }
+    inline bool get_profiler_noc_events_enabled() { return profiler_noc_events_enabled; }
+    inline std::string get_profiler_noc_events_report_path() { return profiler_noc_events_report_path; }
 
     inline void set_kernels_nullified(bool v) { null_kernels = v; }
     inline bool get_kernels_nullified() { return null_kernels; }

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -14,6 +14,7 @@
 #include "buffer.hpp"
 #include "profiler_types.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "profiler_optional_metadata.hpp"
 
 namespace tt::tt_metal {
 class Program;
@@ -218,7 +219,10 @@ void ProfilerSync(ProfilerSyncState state);
  * | satate        | Dumpprofiler various states                       | ProfilerDumpState |                  | False |
  * */
 void DumpDeviceProfileResults(
-    IDevice* device, std::vector<CoreCoord>& worker_cores, ProfilerDumpState = ProfilerDumpState::NORMAL);
+    IDevice* device,
+    std::vector<CoreCoord>& worker_cores,
+    ProfilerDumpState = ProfilerDumpState::NORMAL,
+    const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 /**
  * Traverse all cores and read device side profiler data and dump results into device side CSV log
@@ -230,7 +234,7 @@ void DumpDeviceProfileResults(
  * | device        | The device holding the program being profiled.    | Device * |                           | True |
  * | satate        | Dumpprofiler various states                       | ProfilerDumpState |                  | False |
  * */
-void DumpDeviceProfileResults(IDevice* device, ProfilerDumpState = ProfilerDumpState::NORMAL);
+void DumpDeviceProfileResults(IDevice* device, ProfilerDumpState = ProfilerDumpState::NORMAL, const std::optional<ProfilerOptionalMetadata>& metadata = {});
 
 /**
  * Set the directory for device-side CSV logs produced by the profiler instance in the tt-metal module

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 // clang-format off
+#undef PROFILE_NOC_EVENTS
 #include "risc_common.h"
 #include "tensix.h"
 #include "tensix_types.h"

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -28,6 +28,7 @@
 #include "dev_msgs.h"
 #include "dataflow_api_common.h"
 #include "dataflow_api_addrgen.h"
+#include "tools/profiler/kernel_profiler.hpp"
 
 // clang-format off
 /**
@@ -500,6 +501,8 @@ inline void noc_async_read(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ,src_noc_addr,size, -1);
+
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
         noc_async_read_one_packet(src_noc_addr, dst_local_l1_addr, size, noc);
     } else {
@@ -518,6 +521,7 @@ void noc_async_read_one_packet_set_state(std::uint64_t src_noc_addr, std::uint32
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, src_noc_addr, size, -1);
 
     WAYPOINT("RP3W");
     while (!noc_cmd_buf_ready(noc, read_cmd_buf));
@@ -553,6 +557,7 @@ FORCE_INLINE void noc_async_read_one_packet_with_state(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_WITH_STATE, static_cast<uint64_t>(src_noc_addr), 0, -1);
 
     WAYPOINT("RP4W");
     while (!noc_cmd_buf_ready(noc, read_cmd_buf));
@@ -585,6 +590,7 @@ void noc_async_read_set_state(std::uint64_t src_noc_addr, uint8_t noc = noc_inde
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE,src_noc_addr,0,-1);
 
     WAYPOINT("RP5W");
     while (!noc_cmd_buf_ready(noc, read_cmd_buf));
@@ -618,6 +624,8 @@ FORCE_INLINE void noc_async_read_with_state(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_WITH_STATE,src_noc_addr,size,-1);
+
     WAYPOINT("NAVW");
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
@@ -678,6 +686,8 @@ void noc_async_read_inc_num_issued(std::uint32_t num_issued_reads_inc, uint8_t n
 FORCE_INLINE
 void noc_async_write_one_packet(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_,dst_noc_addr,size,NOC_UNICAST_WRITE_VC);
+
     WAYPOINT("NWPW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
@@ -722,6 +732,8 @@ void noc_async_write_multicast_one_packet(
     bool linked = false,
     bool multicast_path_reserve = true,
     uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_MULTICAST,dst_noc_addr_multicast,size, NOC_MULTICAST_WRITE_VC);
+
     WAYPOINT("NWPW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
@@ -760,6 +772,8 @@ void noc_async_write_multicast_one_packet(
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
     std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc);
+
     WAYPOINT("NWPW");
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
     WAYPOINT("NWPD");
@@ -787,6 +801,8 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
     std::uint32_t src_local_l1_addr, std::uint32_t dst_noc_addr, uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
+
     WAYPOINT("NWPW");
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
     WAYPOINT("NWPD");
@@ -820,6 +836,8 @@ FORCE_INLINE void noc_async_read_page(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, s.page_size, -1);
+
     s.noc_async_read_page(id, dst_local_l1_addr, offset, noc);
 }
 
@@ -834,6 +852,8 @@ FORCE_INLINE void noc_async_read_tile(
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, s.page_size, -1);
+
     s.noc_async_read_tile(id, dst_local_l1_addr, offset, noc);
 }
 
@@ -863,6 +883,8 @@ inline void noc_async_write(
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
         noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size, noc);
     } else {
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, NOC_UNICAST_WRITE_VC);
+
         WAYPOINT("NAWW");
         DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
         ncrisc_noc_fast_write_any_len<noc_mode>(
@@ -877,6 +899,8 @@ FORCE_INLINE void noc_async_write_tile(
     const InterleavedAddrGenFast<DRAM, tile_hw>& s,
     std::uint32_t src_local_l1_addr,
     uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, s.page_size, NOC_UNICAST_WRITE_VC);
+
     s.noc_async_write_tile(id, src_local_l1_addr, noc);
 }
 
@@ -952,6 +976,7 @@ inline void noc_async_write_multicast(
     } else {
         WAYPOINT("NMWW");
         DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_MULTICAST, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC);
         ncrisc_noc_fast_write_any_len<noc_mode>(
             noc,
             write_cmd_buf,
@@ -1164,6 +1189,8 @@ inline void noc_async_write_multicast_exclude_region(
  * Return value: None
  */
 void noc_async_read_barrier(uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_START);
+
     WAYPOINT("NRBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         while (!ncrisc_dynamic_noc_reads_flushed(noc)) {
@@ -1174,6 +1201,8 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
     }
     invalidate_l1_cache();
     WAYPOINT("NRBD");
+
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_END);
 }
 
 /**
@@ -1186,6 +1215,8 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_write_barrier(uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_START);
+
     WAYPOINT("NWBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         while (!ncrisc_dynamic_noc_nonposted_writes_flushed(noc)) {
@@ -1196,6 +1227,8 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
     }
     invalidate_l1_cache();
     WAYPOINT("NWBD");
+
+    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_END);
 }
 
 /**
@@ -1205,6 +1238,8 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_writes_flushed(uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH);
+
     WAYPOINT("NWFW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         while (!ncrisc_dynamic_noc_nonposted_writes_sent(noc)) {
@@ -1246,6 +1281,8 @@ void noc_async_posted_writes_flushed(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::ATOMIC_BARRIER);
+
     WAYPOINT("NABW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         while (!ncrisc_dynamic_noc_nonposted_atomics_flushed(noc_idx)) {
@@ -1269,6 +1306,7 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
 FORCE_INLINE
 void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
     invalidate_l1_cache();
+    RECORD_NOC_EVENT(NocEventType::FULL_BARRIER);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         WAYPOINT("NFBW");
         while (!ncrisc_dynamic_noc_reads_flushed(noc_idx));
@@ -1313,6 +1351,8 @@ void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT);
+
     WAYPOINT("NSW");
     do {
         invalidate_l1_cache();
@@ -1337,6 +1377,8 @@ void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT);
+
     WAYPOINT("NSMW");
     do {
         invalidate_l1_cache();
@@ -1361,6 +1403,8 @@ void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val)
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET);
+
     // set semaphore value to val
     (*sem_addr) = val;
 }
@@ -1389,6 +1433,8 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 // clang-format on
 FORCE_INLINE
 void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF, uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_INLINE, addr, 32, NOC_UNICAST_WRITE_VC);
+
     WAYPOINT("NWIW");
     DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
     noc_fast_write_dw_inline<noc_mode>(
@@ -1425,6 +1471,8 @@ void noc_semaphore_inc(uint64_t addr, uint32_t incr, uint8_t noc_id = noc_index)
     [REFER TO grayskull/noc/noc.h for the documentation of noc_atomic_increment()]
     Generic increment with 32-bit wrap.
   */
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::SEMAPHORE_INC,addr,0, NOC_UNICAST_WRITE_VC);
+
     WAYPOINT("NSIW");
     DEBUG_SANITIZE_NOC_ADDR(noc_id, addr, 4);
     DEBUG_INSERT_DELAY(TransactionAtomic);
@@ -1464,6 +1512,9 @@ FORCE_INLINE uint32_t noc_async_read_tile_dram_sharded_set_state(
     src_addr_ = bank_base_address + bank_to_dram_offset[bank_id];
     src_noc_xy = dram_bank_to_noc_xy[noc][bank_id];
 
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::READ_DRAM_SHARDED_SET_STATE, uint64_t(src_noc_xy) << 32, page_size, (use_vc) ? vc : -1);
+
     WAYPOINT("NRTW");
     while (!noc_cmd_buf_ready(noc, read_cmd_buf));
     WAYPOINT("NRTD");
@@ -1483,6 +1534,8 @@ FORCE_INLINE uint32_t noc_async_read_tile_dram_sharded_set_state(
 FORCE_INLINE
 void noc_async_read_tile_dram_sharded_with_state(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::READ_DRAM_SHARDED_WITH_STATE);
+
     uint32_t src_addr_;
 
     src_addr_ = src_base_addr + src_addr;
@@ -1504,6 +1557,8 @@ void noc_async_read_tile_dram_sharded_with_state(
 FORCE_INLINE
 void noc_async_read_tile_dram_sharded_with_state_with_trid(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::READ_DRAM_SHARDED_WITH_STATE);
+
     WAYPOINT("NRDW");
 #ifndef ARCH_GRAYSKULL
     ncrisc_noc_fast_read_with_transaction_id<noc_mode>(noc, read_cmd_buf, src_base_addr, src_addr, dest_addr, trid);
@@ -1513,6 +1568,8 @@ void noc_async_read_tile_dram_sharded_with_state_with_trid(
 
 FORCE_INLINE
 void noc_async_read_tile_dram_sharded_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT(NocEventType::READ_SET_TRID);
+
     WAYPOINT("NSTW");
 #ifndef ARCH_GRAYSKULL
     ncrisc_noc_set_transaction_id(noc, read_cmd_buf, trid);
@@ -1523,6 +1580,7 @@ void noc_async_read_tile_dram_sharded_set_trid(uint32_t trid = 0, uint8_t noc = 
 FORCE_INLINE
 void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTW");
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_WITH_TRID);
 #ifndef ARCH_GRAYSKULL
     while (!ncrisc_noc_read_with_transaction_id_flushed(noc, trid));
 #endif
@@ -1534,6 +1592,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
     std::uint64_t dst_noc_addr, uint8_t cmd_buf = write_cmd_buf, uint8_t noc = noc_index) {
 #ifndef ARCH_GRAYSKULL
     WAYPOINT("NAWW");
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, dst_noc_addr, 0, NOC_UNICAST_WRITE_VC);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NAWD");
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
@@ -1560,6 +1619,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     uint8_t noc = noc_index) {
 #ifndef ARCH_GRAYSKULL
     WAYPOINT("NWPW");
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_WITH_STATE, 0ull, size, -1);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NWPD");
 
@@ -1580,6 +1640,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     std::uint32_t trid,
     uint8_t noc = noc_index) {
     WAYPOINT("NAWW");
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size, -1);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
 #ifndef ARCH_GRAYSKULL
     ncrisc_noc_fast_write_any_len<noc_mode, true, true>(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -17,6 +17,7 @@
 #include <dev_msgs.h>
 #include "tracy/Tracy.hpp"
 #include <device.hpp>
+#include "tools/profiler/event_metadata.hpp"
 
 #include "llrt.hpp"
 
@@ -28,11 +29,15 @@ static kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
     return static_cast<kernel_profiler::PacketTypes>((timer_id >> 16) & 0x7);
 }
 
-void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_core) {
+void DeviceProfiler::readRiscProfilerResults(
+    IDevice* device,
+    const CoreCoord& worker_core,
+    const std::optional<ProfilerOptionalMetadata>& metadata,
+    std::ofstream& log_file_ofs,
+    nlohmann::ordered_json& noc_trace_json_log) {
     ZoneScoped;
-    auto device_id = device->id();
+    chip_id_t device_id = device->id();
 
-    my_device_id = device_id;
     HalProgrammableCoreType CoreType;
     int riscCount;
 
@@ -64,6 +69,14 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
         (control_buffer[kernel_profiler::HOST_BUFFER_END_INDEX_NC] == 0)) {
         return;
     }
+
+    // helper function to lookup opname from runtime id if metadata is available
+    auto getOpNameIfAvailable = [&metadata](auto device_id, auto runtime_id) {
+        return (metadata.has_value()) ? metadata->get_op_name(device_id, runtime_id) : "";
+    };
+
+    // translate worker core virtual coord to phys coordinates
+    auto phys_coord = getPhysicalAddressFromVirtual(device_id, worker_core);
 
     int riscNum = 0;
     for (int riscEndIndex = 0; riscEndIndex < riscCount; riscEndIndex++) {
@@ -98,6 +111,7 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
 
             uint32_t opTime_H = 0;
             uint32_t opTime_L = 0;
+            std::string opname;
             for (int index = bufferRiscShift; index < (bufferRiscShift + bufferEndIndex);
                  index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE) {
                 if (!newRunStart && profile_buffer[index] == 0 && profile_buffer[index + 1] == 0) {
@@ -112,6 +126,8 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
                     coreFlatIDRead = (profile_buffer[index] >> 3) & 0xFF;
                     runCounterRead = profile_buffer[index + 1] & 0xFFFF;
                     runHostCounterRead = (profile_buffer[index + 1] >> 16) & 0xFFFF;
+
+                    opname = getOpNameIfAvailable(device_id, runHostCounterRead);
 
                 } else {
                     uint32_t timer_id = (profile_buffer[index] >> 12) & 0x7FFFF;
@@ -148,11 +164,14 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
                                     worker_core.y,
                                     runCounterRead);
 
-                                dumpResultToFile(
+                                logPacketData(
+                                    log_file_ofs,
+                                    noc_trace_json_log,
                                     runCounterRead,
                                     runHostCounterRead,
+                                    opname,
                                     device_id,
-                                    worker_core,
+                                    phys_coord,
                                     coreFlatID,
                                     riscType,
                                     0,
@@ -165,11 +184,14 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
 
                             uint32_t time_H = opTime_H;
                             uint32_t time_L = opTime_L;
-                            dumpResultToFile(
+                            logPacketData(
+                                log_file_ofs,
+                                noc_trace_json_log,
                                 runCounterRead,
                                 runHostCounterRead,
+                                opname,
                                 device_id,
-                                worker_core,
+                                phys_coord,
                                 coreFlatID,
                                 riscType,
                                 sum,
@@ -184,11 +206,14 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
                             index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
                             uint32_t data_H = profile_buffer[index];
                             uint32_t data_L = profile_buffer[index + 1];
-                            dumpResultToFile(
+                            logPacketData(
+                                log_file_ofs,
+                                noc_trace_json_log,
                                 runCounterRead,
                                 runHostCounterRead,
+                                opname,
                                 device_id,
-                                worker_core,
+                                phys_coord,
                                 coreFlatID,
                                 riscType,
                                 (uint64_t(data_H) << 32) | data_L,
@@ -199,11 +224,14 @@ void DeviceProfiler::readRiscProfilerResults(IDevice* device, CoreCoord& worker_
                         case kernel_profiler::TS_EVENT: {
                             uint32_t time_H = profile_buffer[index] & 0xFFF;
                             uint32_t time_L = profile_buffer[index + 1];
-                            dumpResultToFile(
+                            logPacketData(
+                                log_file_ofs,
+                                noc_trace_json_log,
                                 runCounterRead,
                                 runHostCounterRead,
+                                opname,
                                 device_id,
-                                worker_core,
+                                phys_coord,
                                 coreFlatID,
                                 riscType,
                                 0,
@@ -233,20 +261,19 @@ void DeviceProfiler::firstTimestamp(uint64_t timestamp) {
     }
 }
 
-void DeviceProfiler::dumpResultToFile(
+void DeviceProfiler::logPacketData(
+    std::ofstream& log_file_ofs,
+    nlohmann::ordered_json& noc_trace_json_log,
     uint32_t run_id,
     uint32_t run_host_id,
-    int device_id,
+    const std::string& opname,
+    chip_id_t device_id,
     CoreCoord core,
     int core_flat,
     int risc_num,
     uint64_t data,
     uint32_t timer_id,
     uint64_t timestamp) {
-    std::pair<uint32_t, CoreCoord> deviceCore = {device_id, core};
-    std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
-    std::ofstream log_file;
-
     kernel_profiler::PacketTypes packet_type = get_packet_type(timer_id);
     uint32_t t_id = timer_id & 0xFFFF;
     std::string zone_name = "";
@@ -291,20 +318,8 @@ void DeviceProfiler::dumpResultToFile(
 
     firstTimestamp(timestamp);
 
-    if (!std::filesystem::exists(log_path)) {
-        log_file.open(log_path);
-        log_file << "ARCH: " << get_string_lowercase(device_architecture)
-                 << ", CHIP_FREQ[MHz]: " << device_core_frequency << std::endl;
-        log_file << "PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], data, run ID, "
-                    "run host ID,  zone name, type, source line, source file"
-                 << std::endl;
-    } else {
-        log_file.open(log_path, std::ios_base::app);
-    }
-
-    // log_file << fmt::format("{:4},{:3},{:3},{:>7},{:7},{:15},{:15},{:5},{:>25},{:>6},{:6},{}",
-    log_file << fmt::format(
-        "{},{},{},{},{},{},{},{},{},{},{},{},{}",
+    logPacketDataToCSV(
+        log_file_ofs,
         device_id,
         core.x,
         core.y,
@@ -314,12 +329,233 @@ void DeviceProfiler::dumpResultToFile(
         data,
         run_id,
         run_host_id,
+        opname,
         zone_name,
-        magic_enum::enum_name(packet_type),
+        packet_type,
         source_line,
         source_file);
-    log_file << std::endl;
-    log_file.close();
+
+    logNocTracePacketDataToJson(
+        noc_trace_json_log,
+        device_id,
+        core.x,
+        core.y,
+        tracy::riscName[risc_num],
+        t_id,
+        timestamp,
+        data,
+        run_id,
+        run_host_id,
+        opname,
+        zone_name,
+        packet_type,
+        source_line,
+        source_file);
+}
+
+void DeviceProfiler::logPacketDataToCSV(
+    std::ofstream& log_file_ofs,
+    chip_id_t device_id,
+    int core_x,
+    int core_y,
+    const std::string_view risc_name,
+    uint32_t timer_id,
+    uint64_t timestamp,
+    uint64_t data,
+    uint32_t run_id,
+    uint32_t run_host_id,
+    const std::string_view opname,
+    const std::string_view zone_name,
+    kernel_profiler::PacketTypes packet_type,
+    uint64_t source_line,
+    const std::string_view source_file) {
+    log_file_ofs << fmt::format(
+                        "{},{},{},{},{},{},{},{},{},{},{},{},{}",
+                        device_id,
+                        core_x,
+                        core_y,
+                        risc_name,
+                        timer_id,
+                        timestamp,
+                        data,
+                        run_id,
+                        run_host_id,
+                        zone_name,
+                        magic_enum::enum_name(packet_type),
+                        source_line,
+                        source_file)
+                 << std::endl;
+}
+
+void DeviceProfiler::logNocTracePacketDataToJson(
+    nlohmann::ordered_json& noc_trace_json_log,
+    chip_id_t device_id,
+    int core_x,
+    int core_y,
+    const std::string_view risc_name,
+    uint32_t timer_id,
+    uint64_t timestamp,
+    uint64_t data,
+    uint32_t run_id,
+    uint32_t run_host_id,
+    const std::string_view opname,
+    const std::string_view zone_name,
+    kernel_profiler::PacketTypes packet_type,
+    uint64_t source_line,
+    const std::string_view source_file) {
+    if (packet_type == kernel_profiler::ZONE_START || packet_type == kernel_profiler::ZONE_END) {
+        if ((risc_name == "NCRISC" || risc_name == "BRISC") &&
+            (zone_name.starts_with("TRUE-KERNEL-END") || zone_name.ends_with("-KERNEL"))) {
+            tracy::TTDeviceEventPhase zone_phase = (packet_type == kernel_profiler::ZONE_END)
+                                                       ? tracy::TTDeviceEventPhase::end
+                                                       : tracy::TTDeviceEventPhase::begin;
+            noc_trace_json_log.push_back(nlohmann::ordered_json{
+                {"run_id", run_id},
+                {"run_host_id", run_host_id},
+                {"op_name", opname},
+                {"proc", risc_name},
+                {"zone", zone_name},
+                {"zone_phase", magic_enum::enum_name(zone_phase)},
+                {"sx", core_x},
+                {"sy", core_y},
+                {"timestamp", timestamp},
+            });
+        }
+
+    } else if (packet_type == kernel_profiler::TS_DATA) {
+        KernelProfilerNocEventMetadata ev_md(data);
+
+        nlohmann::ordered_json data = {
+            {"run_id", run_id},
+            {"run_host_id", run_host_id},
+            {"op_name", opname},
+            {"proc", risc_name},
+            {"noc", magic_enum::enum_name(ev_md.noc_type)},
+            {"vc", int(ev_md.noc_vc)},
+            {"sx", core_x},
+            {"sy", core_y},
+            {"num_bytes", uint32_t(ev_md.num_bytes)},
+            {"type", magic_enum::enum_name(ev_md.noc_xfer_type)},
+            {"timestamp", timestamp},
+        };
+
+        // handle dst coordinates correctly for different NocEventType
+        if (ev_md.dst_x == -1 || ev_md.dst_y == -1 ||
+            ev_md.noc_xfer_type == KernelProfilerNocEventMetadata::NocEventType::READ_WITH_STATE ||
+            ev_md.noc_xfer_type == KernelProfilerNocEventMetadata::NocEventType::WRITE_WITH_STATE) {
+            // DO NOT emit destination coord; it isn't meaningful
+
+        } else if (ev_md.noc_xfer_type == KernelProfilerNocEventMetadata::NocEventType::WRITE_MULTICAST) {
+            auto phys_start_coord = getPhysicalAddressFromVirtual(device_id, {ev_md.dst_x, ev_md.dst_y});
+            data["mcast_start_x"] = phys_start_coord.x;
+            data["mcast_start_y"] = phys_start_coord.y;
+            auto phys_end_coord =
+                getPhysicalAddressFromVirtual(device_id, {ev_md.mcast_end_dst_x, ev_md.mcast_end_dst_y});
+            data["mcast_end_x"] = phys_end_coord.x;
+            data["mcast_end_y"] = phys_end_coord.y;
+        } else {
+            auto phys_coord = getPhysicalAddressFromVirtual(device_id, {ev_md.dst_x, ev_md.dst_y});
+            data["dx"] = phys_coord.x;
+            data["dy"] = phys_coord.y;
+        }
+
+        noc_trace_json_log.push_back(std::move(data));
+    }
+}
+
+void DeviceProfiler::emitCSVHeader(
+    std::ofstream& log_file_ofs, const tt::ARCH& device_architecture, int device_core_frequency) const {
+    log_file_ofs << "ARCH: " << get_string_lowercase(device_architecture)
+                 << ", CHIP_FREQ[MHz]: " << device_core_frequency << std::endl;
+    log_file_ofs << "PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], data, run ID, "
+                    "run host ID,  zone name, type, source line, source file"
+                 << std::endl;
+}
+
+void DeviceProfiler::serializeJsonNocTraces(
+    const nlohmann::ordered_json& noc_trace_json_log, const std::filesystem::path& output_dir, chip_id_t device_id) {
+    // create output directory if it does not exist
+    std::filesystem::create_directories(output_dir);
+    if (!std::filesystem::is_directory(output_dir)) {
+        log_error(
+            "Could not write noc event json trace to '{}' because the directory path could not be created!",
+            output_dir);
+        return;
+    }
+
+    // bin events by runtime id
+    using RuntimeID = uint32_t;
+    std::unordered_map<RuntimeID, nlohmann::json::array_t> events_by_opname;
+    for (auto& json_event : noc_trace_json_log) {
+        RuntimeID runtime_id = json_event.value("run_host_id", -1);
+        events_by_opname[runtime_id].push_back(json_event);
+    }
+
+    // sort events in each opname group by proc first, then timestamp
+    for (auto& [runtime_id, events] : events_by_opname) {
+        std::sort(events.begin(), events.end(), [](const auto& a, const auto& b) {
+            auto sx_a = a.value("sx", 0);
+            auto sy_a = a.value("sy", 0);
+            auto sx_b = b.value("sx", 0);
+            auto sy_b = b.value("sy", 0);
+            auto proc_a = a.value("proc", "");
+            auto proc_b = b.value("proc", "");
+            auto timestamp_a = a.value("timestamp", 0);
+            auto timestamp_b = b.value("timestamp", 0);
+            return std::tie(sx_a, sy_a, proc_a, timestamp_a) < std::tie(sx_b, sy_b, proc_b, timestamp_b);
+        });
+    }
+
+    // for each opname in events_by_opname, adjust timestamps to be relative to the smallest timestamp within the group
+    // with identical sx,sy,proc
+    for (auto& [runtime_id, events] : events_by_opname) {
+        std::tuple<int, int, std::string> reference_event_loc;
+        uint64_t reference_timestamp = 0;
+        for (auto& event : events) {
+            std::string zone = event.value("zone", "");
+            std::string zone_phase = event.value("zone_phase", "");
+            uint64_t curr_timestamp = event.value("timestamp", 0);
+            // if -KERNEL::begin event is found, reset the reference timestamp
+            if (zone.ends_with("-KERNEL") && zone_phase == "begin") {
+                reference_timestamp = curr_timestamp;
+            }
+
+            // fix timestamp to be relative to reference_timestamp
+            event["timestamp"] = curr_timestamp - reference_timestamp;
+        }
+    }
+
+    log_info("Writing profiler noc traces to '{}'", output_dir);
+    for (auto& [runtime_id, events] : events_by_opname) {
+        // dump events to a json file inside directory output_dir named after the opname
+        std::filesystem::path rpt_path = output_dir;
+        std::string op_name = events.front().value("op_name", "UnknownOP");
+        if (!op_name.empty()) {
+            rpt_path /= fmt::format("noc_trace_dev{}_{}_ID{}.json", device_id, op_name, runtime_id);
+        } else {
+            rpt_path /= fmt::format("noc_trace_dev{}_ID{}.json", device_id, runtime_id);
+        }
+        std::ofstream rpt_ofs(rpt_path);
+        if (!rpt_ofs) {
+            log_error("Could not write noc event json trace to '{}'", rpt_path);
+            return;
+        }
+        rpt_ofs << nlohmann::json(std::move(events)).dump(4) << std::endl;
+    }
+}
+
+CoreCoord DeviceProfiler::getPhysicalAddressFromVirtual(chip_id_t device_id, const CoreCoord& c) const {
+    bool coord_is_translated = c.x >= hal.get_virtual_worker_start_x() && c.y >= hal.get_virtual_worker_start_y();
+    if (device_architecture == tt::ARCH::WORMHOLE_B0 && coord_is_translated) {
+        const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+        // disable linting here; slicing is __intended__
+        // NOLINTBEGIN
+        return soc_desc.translate_coord_to(c, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+        // NOLINTEND
+    } else {
+        // tt:ARCH::BLACKHOLE currently doesn't have any translated coordinate adjustment
+        return c;
+    }
 }
 
 DeviceProfiler::DeviceProfiler(const bool new_logs) {
@@ -392,7 +628,11 @@ void DeviceProfiler::generateZoneSourceLocationsHashes() {
     }
 }
 
-void DeviceProfiler::dumpResults(IDevice* device, const std::vector<CoreCoord>& worker_cores, ProfilerDumpState state) {
+void DeviceProfiler::dumpResults(
+    IDevice* device,
+    const std::vector<CoreCoord>& worker_cores,
+    ProfilerDumpState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
@@ -417,8 +657,37 @@ void DeviceProfiler::dumpResults(IDevice* device, const std::vector<CoreCoord>& 
             }
         }
 
-        for (auto worker_core : worker_cores) {
-            readRiscProfilerResults(device, worker_core);
+        // open CSV log file
+        std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
+        std::ofstream log_file_ofs;
+
+        // append to existing CSV log file if it already exists
+        if (std::filesystem::exists(log_path)) {
+            log_file_ofs.open(log_path, std::ios_base::app);
+        } else {
+            log_file_ofs.open(log_path);
+            emitCSVHeader(log_file_ofs, device_architecture, device_core_frequency);
+        }
+
+        // create nlohmann json log object
+        nlohmann::ordered_json noc_trace_json_log = nlohmann::json::array();
+
+        if (!log_file_ofs) {
+            log_error("Could not open kernel profiler dump file '{}'", log_path);
+        } else {
+            for (const auto& worker_core : worker_cores) {
+                readRiscProfilerResults(device, worker_core, metadata, log_file_ofs, noc_trace_json_log);
+            }
+
+            // if defined, used profiler_noc_events_report_path to write json log. otherwise use output_dir
+            auto rpt_path = tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_report_path();
+            if (rpt_path.empty()) {
+                rpt_path = output_dir;
+            }
+
+            if (tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_enabled()) {
+                serializeJsonNocTraces(noc_trace_json_log, rpt_path, device_id);
+            }
         }
     } else {
         log_warning("DRAM profiler buffer is not initialized");
@@ -444,7 +713,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
     static uint64_t cpuTime = 0;
 
     for (auto& device_core : device_cores) {
-        int device_id = device_core.first;
+        chip_id_t device_id = device_core.first;
         CoreCoord worker_core = device_core.second;
 
         if (device_core_sync_info.find(worker_core) != device_core_sync_info.end()) {
@@ -461,7 +730,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
     }
 
     for (auto& device_core : device_cores) {
-        int device_id = device_core.first;
+        chip_id_t device_id = device_core.first;
         CoreCoord worker_core = device_core.second;
 
         if (delay == 0.0 || frequency == 0.0) {

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -15,8 +15,11 @@
 #include "profiler_state.hpp"
 #include "profiler_types.hpp"
 #include "profiler_paths.hpp"
+#include "profiler_optional_metadata.hpp"
 #include "tracy/TracyTTDevice.hpp"
 #include "common/TracyTTDeviceData.hpp"
+
+#include <nlohmann/json.hpp>
 
 using std::chrono::duration;
 using std::chrono::duration_cast;
@@ -59,11 +62,24 @@ private:
     // Iterate through all zone source locations and generate hash
     void generateZoneSourceLocationsHashes();
 
+    // serialize all noc trace data into per-op json trace files
+    void serializeJsonNocTraces(
+        const nlohmann::ordered_json& noc_trace_json_log, const std::filesystem::path& output_dir, chip_id_t device_id);
+
+    void emitCSVHeader(
+        std::ofstream& log_file_ofs, const tt::ARCH& device_architecture, int device_core_frequency) const;
+
+    // translates potentially-virtual coordinates recorded on Device into physical coordinates
+    CoreCoord getPhysicalAddressFromVirtual(chip_id_t device_id, const CoreCoord& c) const;
+
     // Dumping profile result to file
-    void dumpResultToFile(
+    void logPacketData(
+        std::ofstream& log_file_ofs,
+        nlohmann::ordered_json& noc_trace_json_log,
         uint32_t runID,
         uint32_t runHostID,
-        int device_id,
+        const std::string& opname,
+        chip_id_t device_id,
         CoreCoord core,
         int core_flat,
         int risc_num,
@@ -71,8 +87,49 @@ private:
         uint32_t timer_id,
         uint64_t timestamp);
 
+    // logs packet data to CSV file
+    void logPacketDataToCSV(
+        std::ofstream& log_file_ofs,
+        chip_id_t device_id,
+        int core_x,
+        int core_y,
+        const std::string_view risc_name,
+        uint32_t timer_id,
+        uint64_t timestamp,
+        uint64_t data,
+        uint32_t run_id,
+        uint32_t run_host_id,
+        const std::string_view opname,
+        const std::string_view zone_name,
+        kernel_profiler::PacketTypes packet_type,
+        uint64_t source_line,
+        const std::string_view source_file);
+
+    // dump noc trace related profile data to json file
+    void logNocTracePacketDataToJson(
+        nlohmann::ordered_json& noc_trace_json_log,
+        chip_id_t device_id,
+        int core_x,
+        int core_y,
+        const std::string_view risc_name,
+        uint32_t timer_id,
+        uint64_t timestamp,
+        uint64_t data,
+        uint32_t run_id,
+        uint32_t run_host_id,
+        const std::string_view opname,
+        const std::string_view zone_name,
+        kernel_profiler::PacketTypes packet_type,
+        uint64_t source_line,
+        const std::string_view source_file);
+
     // Helper function for reading risc profile results
-    void readRiscProfilerResults(IDevice* device, CoreCoord& worker_core);
+    void readRiscProfilerResults(
+        IDevice* device,
+        const CoreCoord& worker_core,
+        const std::optional<ProfilerOptionalMetadata>& metadata,
+        std::ofstream& log_file_ofs,
+        nlohmann::ordered_json& noc_trace_json_log);
 
     // Push device results to tracy
     void pushTracyDeviceResults();
@@ -110,8 +167,6 @@ public:
     // frequency scale
     double freqScale = 1.0;
 
-    uint32_t my_device_id = 0;
-
     // Freshen device logs
     void freshDeviceLog();
 
@@ -125,7 +180,8 @@ public:
     void dumpResults(
         IDevice* device,
         const std::vector<CoreCoord>& worker_cores,
-        ProfilerDumpState state = ProfilerDumpState::NORMAL);
+        ProfilerDumpState state = ProfilerDumpState::NORMAL,
+        const std::optional<ProfilerOptionalMetadata>& metadata = {});
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -624,7 +624,7 @@ void InitDeviceProfiler(IDevice* device) {
 #endif
 }
 
-void DumpDeviceProfileResults(IDevice* device, ProfilerDumpState state) {
+void DumpDeviceProfileResults(IDevice* device, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
     std::vector<CoreCoord> workerCores;
@@ -639,8 +639,8 @@ void DumpDeviceProfileResults(IDevice* device, ProfilerDumpState state) {
         auto virtualCore = device->virtual_core_from_logical_core(core, CoreType::ETH);
         workerCores.push_back(virtualCore);
     }
-    device->push_work([device, workerCores, state]() mutable {
-        DumpDeviceProfileResults(device, workerCores, state);
+    device->push_work([device, workerCores, state, metadata]() mutable {
+        DumpDeviceProfileResults(device, workerCores, state, metadata);
         if (deviceDeviceTimePair.find(device->id()) != deviceDeviceTimePair.end() and
             state == ProfilerDumpState::CLOSE_DEVICE_SYNC) {
             for (auto& connected_device : deviceDeviceTimePair.at(device->id())) {
@@ -653,7 +653,7 @@ void DumpDeviceProfileResults(IDevice* device, ProfilerDumpState state) {
 #endif
 }
 
-void DumpDeviceProfileResults(IDevice* device, std::vector<CoreCoord>& worker_cores, ProfilerDumpState state) {
+void DumpDeviceProfileResults(IDevice* device, std::vector<CoreCoord>& worker_cores, ProfilerDumpState state, const std::optional<ProfilerOptionalMetadata>& metadata) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
     std::string name = fmt::format("Device Dump {}", device->id());
@@ -739,7 +739,7 @@ void DumpDeviceProfileResults(IDevice* device, std::vector<CoreCoord>& worker_co
                 }
             }
             tt_metal_device_profiler_map.at(device_id).setDeviceArchitecture(device->arch());
-            tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores, state);
+            tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores, state, metadata);
 
             if (state == ProfilerDumpState::LAST_CLOSE_DEVICE) {
                 // Process is ending, no more device dumps are coming, reset your ref on the buffer so deallocate is the

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -161,6 +161,13 @@ void JitBuildEnv::init(
             this->defines_ += "-DPROFILE_KERNEL=1 ";
         }
     }
+    if (tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_enabled()) {
+        // force profiler on if noc events are being profiled
+        if (not tt::tt_metal::getDeviceProfilerState()) {
+            this->defines_ += "-DPROFILE_KERNEL=1 ";
+        }
+        this->defines_ += "-DPROFILE_NOC_EVENTS=1 ";
+    }
 
     if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
         this->defines_ += "-DWATCHER_ENABLED ";

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -79,7 +79,19 @@ RunTimeOptions::RunTimeOptions() {
             profiler_sync_enabled = true;
         }
     }
-    const char* profile_buffer_usage_str = std::getenv("TT_METAL_MEM_PROFILER");
+
+    const char *profiler_noc_events_str = std::getenv("TT_METAL_DEVICE_PROFILER_NOC_EVENTS");
+    if (profiler_noc_events_str != nullptr && profiler_noc_events_str[0] == '1') {
+        profiler_enabled = true;
+        profiler_noc_events_enabled = true;
+    }
+
+    const char *profiler_noc_events_report_path_str = std::getenv("TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH");
+    if (profiler_noc_events_report_path_str != nullptr) {
+        profiler_noc_events_report_path = profiler_noc_events_report_path_str;
+    }
+
+    const char *profile_buffer_usage_str = std::getenv("TT_METAL_MEM_PROFILER");
     if (profile_buffer_usage_str != nullptr && profile_buffer_usage_str[0] == '1') {
         profiler_buffer_usage_enabled = true;
     }

--- a/tt_metal/programming_examples/profiler/CMakeLists.txt
+++ b/tt_metal/programming_examples/profiler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PROFILER_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_op/test_multi_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_cores/test_dispatch_cores.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_timestamped_events/test_timestamped_events.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_noc_event_profiler/test_noc_event_profiler.cpp
 )
 
 CREATE_PGM_EXAMPLES_EXE("${PROFILER_EXAMPLES_SRCS}" "profiler")

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/kernels/loopback_dram_copy.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/kernels/loopback_dram_copy.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+void kernel_main() {
+    // misc runtime args setup
+    std::uint32_t l1_buffer_addr = get_arg_val<uint32_t>(0);
+    std::uint32_t dram_buffer_src_addr = get_arg_val<uint32_t>(1);
+    std::uint32_t dram_buffer_src_bank = get_arg_val<uint32_t>(2);
+    std::uint32_t dram_buffer_dst_addr = get_arg_val<uint32_t>(3);
+    std::uint32_t dram_buffer_dst_bank = get_arg_val<uint32_t>(4);
+    std::uint32_t dram_buffer_size = get_arg_val<uint32_t>(5);
+    std::uint64_t dram_buffer_src_noc_addr =
+        get_noc_addr_from_bank_id<true>(dram_buffer_src_bank, dram_buffer_src_addr);
+
+    // Below are some examples of dataflow_api.h function calls that are captured by the noc event profiler
+
+    // this call will get captured by noc tracing as a 'READ' event
+    noc_async_read(dram_buffer_src_noc_addr, l1_buffer_addr, dram_buffer_size);
+    // this call will get captured by noc tracing as a 'READ_BARRIER_START' and 'READ_BARRIER_END' event
+    noc_async_read_barrier();
+
+    std::uint64_t dram_buffer_dst_noc_addr =
+        get_noc_addr_from_bank_id<true>(dram_buffer_dst_bank, dram_buffer_dst_addr);
+
+    // this call will get captured by noc tracing as a 'WRITE_' event
+    noc_async_write(l1_buffer_addr, dram_buffer_dst_noc_addr, dram_buffer_size);
+    // this call will get captured by noc tracing as a 'WRITE_BARRIER_START' and 'WRITE_BARRIER_END' event
+    noc_async_write_barrier();
+}

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/bfloat16.hpp>
+
+using namespace tt::tt_metal;
+
+/*
+ * This test serves as a simple, stable tt_metal executable that issues both
+ * reads and writes from Tensix to the NoC. It is used to do sanity checking of
+ * the Device Profiler's NoC event capture feature during CI in
+ * test_device_profiler.py.
+ */
+
+int main(int argc, char** argv) {
+    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
+        TT_THROW("Test not supported w/ slow dispatch, exiting");
+    }
+
+    bool pass = true;
+
+    try {
+        constexpr int device_id = 0;
+        IDevice* device = CreateDevice(device_id);
+        CommandQueue& cq = device->command_queue();
+        Program program = CreateProgram();
+
+        constexpr CoreCoord core = {0, 0};
+
+        // See kernel cpp code for details on which noc calls are captured
+        KernelHandle dram_copy_kernel_id = CreateKernel(
+            program,
+            "tt_metal/programming_examples/profiler/test_noc_event_profiler/kernels/loopback_dram_copy.cpp",
+            core,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+        // boilerplate setup for reading and writing multiple tiles from DRAM
+        constexpr uint32_t single_tile_size = 2 * (32 * 32);
+        constexpr uint32_t num_tiles = 5;
+        constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
+
+        tt::tt_metal::InterleavedBufferConfig dram_config{
+            .device = device,
+            .size = dram_buffer_size,
+            .page_size = dram_buffer_size,
+            .buffer_type = tt::tt_metal::BufferType::DRAM};
+        tt::tt_metal::InterleavedBufferConfig l1_config{
+            .device = device,
+            .size = dram_buffer_size,
+            .page_size = dram_buffer_size,
+            .buffer_type = tt::tt_metal::BufferType::L1};
+
+        auto l1_buffer = CreateBuffer(l1_config);
+
+        auto input_dram_buffer = CreateBuffer(dram_config);
+        const uint32_t input_dram_buffer_addr = input_dram_buffer->address();
+
+        auto output_dram_buffer = CreateBuffer(dram_config);
+        const uint32_t output_dram_buffer_addr = output_dram_buffer->address();
+
+        // Since all interleaved buffers have size == page_size, they are entirely contained in the first DRAM bank
+        const uint32_t input_bank_id = 0;
+        const uint32_t output_bank_id = 0;
+
+        const std::vector<uint32_t> runtime_args = {
+            l1_buffer->address(),
+            input_dram_buffer->address(),
+            input_bank_id,
+            output_dram_buffer->address(),
+            output_bank_id,
+            l1_buffer->size()};
+        SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
+
+        EnqueueProgram(cq, program, false);
+        Finish(cq);
+
+        // It is necessary to explictly dump profile results at the end of the
+        // program to get noc traces for standalone tt_metal programs.  For
+        // ttnn, this is called _automatically_
+        DumpDeviceProfileResults(device, program);
+
+        pass &= CloseDevice(device);
+
+    } catch (const std::exception& e) {
+        tt::log_error(tt::LogTest, "Test failed with exception!");
+        tt::log_error(tt::LogTest, "{}", e.what());
+
+        throw;
+    }
+
+    if (pass) {
+        tt::log_info(tt::LogTest, "Test Passed");
+    } else {
+        TT_THROW("Test Failed");
+    }
+
+    return 0;
+}

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>  // for std::memcpy
+
+struct alignas(uint64_t) KernelProfilerNocEventMetadata {
+    enum class NocEventType : unsigned char {
+        UNDEF = 0,
+        READ,
+        READ_SET_STATE,
+        READ_SET_TRID,
+        READ_WITH_STATE,
+        READ_WITH_STATE_AND_TRID,
+        READ_BARRIER_START,
+        READ_BARRIER_END,
+        READ_BARRIER_WITH_TRID,
+        READ_DRAM_SHARDED_SET_STATE,
+        READ_DRAM_SHARDED_WITH_STATE,
+
+        WRITE_,
+        WRITE_WITH_TRID,
+        WRITE_INLINE,
+        WRITE_MULTICAST,
+        WRITE_SET_STATE,
+        WRITE_WITH_STATE,
+        WRITE_WITH_TRID_SET_STATE,
+        WRITE_WITH_TRID_WITH_STATE,
+        WRITE_BARRIER_START,
+        WRITE_BARRIER_END,
+        WRITE_BARRIER_WITH_TRID,
+        WRITE_FLUSH,
+
+        FULL_BARRIER,
+
+        ATOMIC_BARRIER,
+        SEMAPHORE_INC,
+        SEMAPHORE_WAIT,
+        SEMAPHORE_SET,
+
+        UNSUPPORTED
+    };
+    enum class NocType : unsigned char { UNDEF = 0, NOC_0 = 1, NOC_1 = 2 };
+    using NocVirtualChannel = int8_t;
+    static constexpr int8_t INVALID_COORD_VAL = -1;
+
+    KernelProfilerNocEventMetadata() = default;
+
+    // used during deserialization
+    explicit KernelProfilerNocEventMetadata(const uint64_t raw_data) {
+        std::memcpy(this, &raw_data, sizeof(KernelProfilerNocEventMetadata));
+    }
+
+    // these can be compressed to bit-fields if needed, but byte orientated has less overhead
+    int8_t dst_x = INVALID_COORD_VAL;
+    int8_t dst_y = INVALID_COORD_VAL;
+    int8_t mcast_end_dst_x = INVALID_COORD_VAL;
+    int8_t mcast_end_dst_y = INVALID_COORD_VAL;
+    NocEventType noc_xfer_type;
+    NocType noc_type : 4;
+    NocVirtualChannel noc_vc : 4;
+    uint16_t num_bytes;
+
+    uint64_t asU64() const {
+        uint64_t ret;
+        std::memcpy(&ret, this, sizeof(uint64_t));
+        return ret;
+    }
+};
+static_assert(sizeof(KernelProfilerNocEventMetadata) == sizeof(uint64_t));

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(PROFILE_NOC_EVENTS) && (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || \
+                                    defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+
+#include <utility>
+#include <tuple>
+#include "event_metadata.hpp"
+#include "risc_attribs.h"
+#include <algorithm>
+
+namespace noc_event_profiler {
+
+FORCE_INLINE
+std::pair<uint32_t, uint32_t> decode_noc_coord_reg_to_coord(uint16_t noc_xy_bits) {
+    constexpr uint32_t NOC_COORD_MASK = 0x3F;
+    uint32_t x = noc_xy_bits & NOC_COORD_MASK;
+    uint32_t y = (noc_xy_bits >> NOC_ADDR_NODE_ID_BITS) & NOC_COORD_MASK;
+    return {x, y};
+}
+
+FORCE_INLINE
+std::pair<uint32_t, uint32_t> decode_noc_xy_to_coord(uint32_t noc_xy) {
+    // shift so that coordinate is in LSB
+    return decode_noc_coord_reg_to_coord(noc_xy >> NOC_COORD_REG_OFFSET);
+}
+
+FORCE_INLINE
+std::pair<uint32_t, uint32_t> decode_noc_addr_to_coord(uint64_t noc_addr) {
+    return decode_noc_coord_reg_to_coord(noc_addr >> NOC_ADDR_LOCAL_BITS);
+}
+
+FORCE_INLINE
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> decode_noc_addr_to_multicast_coord(uint64_t noc_addr) {
+    // coordinates are stored as two packed pairs. End coordinate is in lower
+    // bits like normal noc address; Start coordinate is in higher bits
+    auto [xend, yend] = decode_noc_coord_reg_to_coord(noc_addr >> NOC_ADDR_LOCAL_BITS);
+    auto [xstart, ystart] =
+        decode_noc_coord_reg_to_coord(noc_addr >> NOC_ADDR_LOCAL_BITS + (2 * NOC_ADDR_NODE_ID_BITS));
+
+    return {xstart, ystart, xend, yend};
+}
+
+template <bool DRAM>
+FORCE_INLINE std::pair<uint32_t, uint32_t> decode_noc_id_into_coord(uint32_t id, uint8_t noc = noc_index) {
+    uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
+    uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
+    return decode_noc_xy_to_coord(interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc));
+}
+
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordNocEvent(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    int32_t dst_x = -1,
+    int32_t dst_y = -1,
+    uint32_t num_bytes = 0,
+    int8_t vc = -1,
+    uint8_t noc = noc_index) {
+    KernelProfilerNocEventMetadata ev_md;
+    ev_md.dst_x = dst_x;
+    ev_md.dst_y = dst_y;
+    ev_md.noc_xfer_type = noc_event_type;
+    ev_md.num_bytes = std::min(std::numeric_limits<std::uint32_t>::max(), num_bytes);
+    ev_md.noc_vc = vc;
+    ev_md.noc_type =
+        (noc == 1) ? KernelProfilerNocEventMetadata::NocType::NOC_1 : KernelProfilerNocEventMetadata::NocType::NOC_0;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+}
+
+template <uint32_t STATIC_ID = 12345>
+FORCE_INLINE void recordMulticastNocEvent(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
+    int32_t mcast_dst_start_x,
+    int32_t mcast_dst_start_y,
+    int32_t mcast_dst_end_x,
+    int32_t mcast_dst_end_y,
+    uint32_t num_bytes,
+    int8_t vc = -1,
+    uint8_t noc = noc_index) {
+    KernelProfilerNocEventMetadata ev_md;
+    ev_md.dst_x = mcast_dst_start_x;
+    ev_md.dst_y = mcast_dst_start_y;
+    ev_md.mcast_end_dst_x = mcast_dst_end_x;
+    ev_md.mcast_end_dst_y = mcast_dst_end_y;
+
+    ev_md.noc_xfer_type = noc_event_type;
+    ev_md.num_bytes = std::min(std::numeric_limits<std::uint32_t>::max(), num_bytes);
+
+    ev_md.noc_vc = vc;
+    ev_md.noc_type =
+        (noc == 1) ? KernelProfilerNocEventMetadata::NocType::NOC_1 : KernelProfilerNocEventMetadata::NocType::NOC_0;
+
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+}
+
+template <bool DRAM, typename NocIDU32>
+void recordNocEventWithID(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type, NocIDU32 noc_id, uint32_t num_bytes, int8_t vc) {
+    static_assert(std::is_same_v<NocIDU32, uint32_t>);
+    auto [decoded_x, decoded_y] = decode_noc_id_into_coord<DRAM>(noc_id);
+    recordNocEvent(noc_event_type, decoded_x, decoded_y, num_bytes, vc);
+}
+
+template <typename NocAddrU64>
+void recordNocEventWithAddr(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type, NocAddrU64 noc_addr, uint32_t num_bytes, int8_t vc) {
+    static_assert(std::is_same_v<NocAddrU64, uint64_t>);
+    auto [decoded_x, decoded_y] = decode_noc_addr_to_coord(noc_addr);
+    recordNocEvent(noc_event_type, decoded_x, decoded_y, num_bytes, vc);
+}
+
+}  // namespace noc_event_profiler
+
+#define RECORD_NOC_EVENT_WITH_ADDR(event_type, noc_addr, num_bytes, vc)                                             \
+    {                                                                                                               \
+        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                                          \
+        if constexpr (event_type != NocEventType::WRITE_MULTICAST) {                                                \
+            noc_event_profiler::recordNocEventWithAddr(event_type, noc_addr, num_bytes, vc);                        \
+        } else {                                                                                                    \
+            auto [mcast_dst_start_x, mcast_dst_start_y, mcast_dst_end_x, mcast_dst_end_y] =                         \
+                noc_event_profiler::decode_noc_addr_to_multicast_coord(noc_addr);                                   \
+            noc_event_profiler::recordMulticastNocEvent(                                                            \
+                event_type, mcast_dst_start_x, mcast_dst_start_y, mcast_dst_end_x, mcast_dst_end_y, num_bytes, vc); \
+        }                                                                                                           \
+    }
+
+#define RECORD_NOC_EVENT_WITH_ID(event_type, noc_id, num_bytes, vc)                        \
+    {                                                                                      \
+        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                 \
+        noc_event_profiler::recordNocEventWithID<DRAM>(event_type, noc_id, num_bytes, vc); \
+    }
+
+#define RECORD_NOC_EVENT(event_type)                                       \
+    {                                                                      \
+        using NocEventType = KernelProfilerNocEventMetadata::NocEventType; \
+        noc_event_profiler::recordNocEvent(event_type);                    \
+    }
+
+#else
+
+// null macros when noc tracing is disabled
+#define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, num_bytes, vc)
+#define RECORD_NOC_EVENT(type)
+
+#endif

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -19,12 +19,17 @@
 #include <tt-metalium/trace.hpp>
 #include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 #include <tt-metalium/hal_exp.hpp>
+#include "tools/profiler/op_profiler.hpp"
+
 using namespace tt::tt_metal;
 
 namespace py = pybind11;
 
 namespace {
-inline void DumpDeviceProfiler(IDevice* device) { tt::tt_metal::detail::DumpDeviceProfileResults(device); }
+void DumpDeviceProfiler(IDevice* device) {
+    ProfilerOptionalMetadata prof_metadata(tt::tt_metal::op_profiler::runtime_id_to_opname_.export_map());
+    tt::tt_metal::detail::DumpDeviceProfileResults(device, ProfilerDumpState::NORMAL, prof_metadata);
+}
 }  // namespace
 
 namespace ttnn {

--- a/ttnn/tools/profiler/op_profiler.hpp
+++ b/ttnn/tools/profiler/op_profiler.hpp
@@ -107,6 +107,62 @@ inline auto compute_program_hash(
 }
 #endif
 
+class RuntimeIDToOpName {
+    using RuntimeID = uint32_t;
+    using KeyType = std::pair<chip_id_t, RuntimeID>;
+    using MapType = std::map<KeyType, std::string>;
+
+public:
+    MapType::iterator find(chip_id_t device_id, RuntimeID runtime_id) {
+        std::scoped_lock<std::mutex> lock(map_mutex);
+        return map.find({device_id, runtime_id});
+    }
+    std::string at(chip_id_t device_id, RuntimeID runtime_id) {
+        std::scoped_lock<std::mutex> lock(map_mutex);
+        return map.at({device_id, runtime_id});
+    }
+    void insert(KeyType key, std::string opname) {
+        std::scoped_lock<std::mutex> lock(map_mutex);
+        map.emplace(key, std::move(opname));
+    }
+    MapType export_map() {
+        // thread-safe copy of internal map contents
+        std::scoped_lock<std::mutex> lock(map_mutex);
+        return map;
+    }
+
+private:
+    std::mutex map_mutex;
+    MapType map;
+};
+
+inline RuntimeIDToOpName runtime_id_to_opname_{};
+
+class ProgramHashToOpName {
+    using KeyType = std::pair<chip_id_t, tt::stl::hash::hash_t>;
+
+public:
+    std::string find_if_exists(const KeyType& key) {
+        std::scoped_lock<std::mutex> lock(map_mutex);
+        auto it = map.find(key);
+        if (it != map.end()) {
+            return it->second;
+        } else {
+            return "";
+        }
+    }
+    void insert(const KeyType& key, std::string opname) {
+        std::scoped_lock<std::mutex> lock(map_mutex);
+        map.emplace(key, std::move(opname));
+    }
+
+private:
+    std::mutex map_mutex;
+    std::map<KeyType, std::string> map;
+};
+
+inline ProgramHashToOpName program_hash_to_opname_{};
+
 static void start_tracy_zone(const string& source, const string& functName, uint32_t lineNum, uint32_t color = 0) {
 #if defined(TRACY_ENABLE)
     auto tracySrcLoc =
@@ -383,6 +439,10 @@ inline std::string op_meta_data_serialized_json(
         j["op_hash"] = program_hash;
         j["kernel_info"] = get_kernels_json(device_id, program);
 
+        auto opname = j["op_code"].template get<std::string>();
+        runtime_id_to_opname_.insert({device_id, program.get_runtime_id()}, opname);
+        program_hash_to_opname_.insert({device_id, program_hash}, opname);
+
         j["optional_input_tensors"] = std::vector<json>{};
 
         auto perfModel = [&]() {
@@ -411,6 +471,8 @@ inline std::string op_meta_data_serialized_json(
         std::string ser = j.dump(4);
         return fmt::format("{}{} ->\n{}`", short_str, operation_id, ser);
     } else {
+        auto opname = program_hash_to_opname_.find_if_exists({device_id, program_hash});
+        runtime_id_to_opname_.insert({device_id, program.get_runtime_id()}, std::move(opname));
         return fmt::format("{}{}`", cached_ops.at(device_id).at(program_hash), operation_id);
     }
 }


### PR DESCRIPTION
### Problem Description
This PR adds support for recording detailed traces of all NoC activity initiated by Tensix worker cores. This data is then written to a JSON format file. These JSON traces can be either analyzed directly (as a sort of log file) or consumed by either flows (e.g. used to verify software noc performance estimator).

### What's Changed
NoC tracing builds on top of the timestamped data packets (`PacketType::TS_DATA`) feature in the kernel profiler.

NoC tracing can be enabled on top of normal kernel profiling by setting the ENV variable `TT_METAL_DEVICE_PROFILER_NOC_EVENTS=1`.

The directory NoC traces are written to is configurable using the ENV variable `TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH`.

A timestamped packet is recorded on each worker core for each call to `dataflow_api.h:noc_async_*` functions. All arguments to the dataflow_api.h function are bit-packed into the TS_DATA payload. This is done by adding new stripped-by-default macros to each noc_async* call of interest in dataflow_api.h.

```cpp
  // example of RECORD macro within dataflow_api.h
  inline void noc_async_read(...) {
      // if TT_METAL_DEVICE_PROFILER_NOC_EVENTS != 1, the following macro is stripped out
      RECORD_NOC_EVENT_WITH_ADDR(...);
      // noc_async_read continues unmodified here ... 
  }
  ```

#### Checklist
 - [X] Post commit CI passes
 - [X] Blackhole post commit CI passes
 - [X] Device Perf, uBenchmark, and multi-device (T3K) tests pass