### PR TITLE
Scope out LaunchMessageRingBufferState from SystemMemoryManager

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -158,8 +158,8 @@ public:
     uint32_t prefetch_d_pages_;  // prefetch_d_buffer_size_ / PREFETCH_D_BUFFER_LOG_PAGE_SIZE
 
     // cq_dispatch
-    uint32_t dispatch_size_;             // total buffer size
-    uint32_t dispatch_pages_;            // total buffer size / page size
+    uint32_t dispatch_size_;   // total buffer size
+    uint32_t dispatch_pages_;  // total buffer size / page size
     uint32_t dispatch_s_buffer_size_;
     uint32_t dispatch_s_buffer_pages_;  // dispatch_s_buffer_size_ / DISPATCH_S_BUFFER_LOG_PAGE_SIZE
 
@@ -169,5 +169,9 @@ public:
 
     CoreType core_type_;  // Which core this settings is for
 };
+
+// Convenience type alias for arrays of `DISPATCH_MESSAGE_ENTRIES` size.
+template <typename T>
+using DispatchArray = std::array<T, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>;
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -99,20 +99,24 @@ private:
         bool mcast_go_signals,
         bool unicast_go_signals);
     // Access a reference system memory manager, which acts as a global host side state manager for
-    // specific MeshCommandQueue attributes (launch_message_buffer_state, event counter, etc.)
+    // specific MeshCommandQueue attributes.
     // TODO: All Mesh level host state managed by this class should be moved out, since its not
-    // tied to system memory anyway.
+    // tied to system memory anyway. Move out:
+    // 1. Event ID managment.
+    // 2. Bypass mode tracker.
     SystemMemoryManager& reference_sysmem_manager();
     MultiProducerSingleConsumerQueue<CompletionReaderVariant>& get_read_descriptor_queue(IDevice* device);
 
-    std::array<tt::tt_metal::WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> config_buffer_mgr_;
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed_;
+    // Shared across all MeshCommandQueue instances for a MeshDevice.
+    std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>> worker_launch_message_buffer_state_;
 
-    std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>
-        worker_launch_message_buffer_state_reset_;
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES> expected_num_workers_completed_reset_;
-    std::array<tt::tt_metal::WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>
-        config_buffer_mgr_reset_;
+    DispatchArray<uint32_t> expected_num_workers_completed_;
+    DispatchArray<tt::tt_metal::WorkerConfigBufferMgr> config_buffer_mgr_;
+
+    DispatchArray<LaunchMessageRingBufferState> worker_launch_message_buffer_state_reset_;
+    DispatchArray<uint32_t> expected_num_workers_completed_reset_;
+    DispatchArray<tt::tt_metal::WorkerConfigBufferMgr> config_buffer_mgr_reset_;
+
     // The following data structures are only popiulated when the MeshCQ is being used to trace workloads
     // i.e. between record_begin() and record_end() being called
     std::optional<MeshTraceId> trace_id_;
@@ -158,7 +162,8 @@ public:
         MeshDevice* mesh_device,
         uint32_t id,
         std::shared_ptr<ThreadPool>& dispatch_thread_pool,
-        std::shared_ptr<ThreadPool>& reader_thread_pool);
+        std::shared_ptr<ThreadPool>& reader_thread_pool,
+        std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>>& worker_launch_message_buffer_state);
 
     MeshCommandQueue(const MeshCommandQueue& other) = delete;
     MeshCommandQueue& operator=(const MeshCommandQueue& other) = delete;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "device.hpp"
@@ -15,6 +16,7 @@
 #include "mesh_coord.hpp"
 #include "mesh_device_view.hpp"
 #include "mesh_trace_id.hpp"
+#include "small_vector.hpp"
 #include "sub_device_types.hpp"
 #include "span.hpp"
 
@@ -68,7 +70,9 @@ private:
     // Submesh keeps the parent mesh alive. Parent_mesh_ is null if the current mesh is the parent mesh.
     std::shared_ptr<MeshDevice> parent_mesh_;
     std::vector<std::weak_ptr<MeshDevice>> submeshes_;
-    std::vector<std::unique_ptr<MeshCommandQueue>> mesh_command_queues_;
+
+    tt::stl::SmallVector<std::unique_ptr<MeshCommandQueue>> mesh_command_queues_;
+
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
     std::unordered_map<MeshTraceId, std::shared_ptr<MeshTraceBuffer>> trace_buffer_pool_;
     uint32_t trace_buffers_size_ = 0;

--- a/tt_metal/api/tt-metalium/system_memory_manager.hpp
+++ b/tt_metal/api/tt-metalium/system_memory_manager.hpp
@@ -87,12 +87,6 @@ public:
 
     void fetch_queue_write(uint32_t command_size_B, uint8_t cq_id, bool stall_prefetcher = false);
 
-    using WorkerLaunchMessageBufferState =
-        std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>;
-    WorkerLaunchMessageBufferState& get_worker_launch_message_buffer_state();
-
-    void reset_worker_launch_message_buffer_state(uint32_t num_entries);
-
 private:
     chip_id_t device_id = 0;
     uint8_t num_hw_cqs = 0;
@@ -113,8 +107,6 @@ private:
     bool bypass_enable = false;
     std::vector<uint32_t> bypass_buffer;
     uint32_t bypass_buffer_write_offset = 0;
-    std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>
-        worker_launch_message_buffer_state;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -703,14 +703,22 @@ bool MeshDevice::initialize(
     auto sub_devices = {
         SubDevice(std::array{CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}))})};
 
+    // Resource shared across mesh command queues.
+    auto worker_launch_message_buffer_state = std::make_shared<DispatchArray<LaunchMessageRingBufferState>>();
+
     const auto& allocator = reference_device()->allocator();
     sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
         this, std::make_unique<L1BankingAllocator>(allocator->get_config()), sub_devices);
     mesh_command_queues_.reserve(this->num_hw_cqs());
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(
-                std::make_unique<MeshCommandQueue>(this, cq_id, dispatch_thread_pool_, reader_thread_pool_));
+            mesh_command_queues_.push_back(std::make_unique<MeshCommandQueue>(
+                this,
+                cq_id,
+                dispatch_thread_pool_,
+                reader_thread_pool_,
+                worker_launch_message_buffer_state  //
+                ));
         }
     }
     return true;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -897,15 +897,15 @@ void Device::update_dispatch_cores_for_multi_cq_eth_dispatch() {
 void Device::init_command_queue_host() {
     using_fast_dispatch_ = true;
     sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, this->num_hw_cqs());
+    auto worker_launch_message_buffer_state = std::make_shared<DispatchArray<LaunchMessageRingBufferState>>();
     command_queues_.reserve(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
-        command_queues_.push_back(
-            std::make_unique<HWCommandQueue>(this, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
+        command_queues_.push_back(std::make_unique<HWCommandQueue>(
+            this, worker_launch_message_buffer_state, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
     }
 }
 
 void Device::init_command_queue_device() {
-
     if (llrt::RunTimeOptions::get_instance().get_skip_loading_fw()) {
         detail::EnablePersistentKernelCache();
         this->compile_command_queue_programs();

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -416,15 +416,4 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     this->prefetch_q_dev_ptrs[cq_id] += sizeof(DispatchSettings::prefetch_q_entry_type);
 }
 
-SystemMemoryManager::WorkerLaunchMessageBufferState& SystemMemoryManager::get_worker_launch_message_buffer_state() {
-    return this->worker_launch_message_buffer_state;
-}
-
-void SystemMemoryManager::reset_worker_launch_message_buffer_state(const uint32_t num_entries) {
-    std::for_each(
-        this->worker_launch_message_buffer_state.begin(),
-        this->worker_launch_message_buffer_state.begin() + num_entries,
-        std::mem_fn(&LaunchMessageRingBufferState::reset));
-}
-
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1813,8 +1813,8 @@ uint32_t program_base_addr_on_core(
 }
 
 void reset_config_buf_mgrs_and_expected_workers(
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgrs,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgrs,
+    DispatchArray<uint32_t>& expected_num_workers_completed,
     uint32_t num_entries_to_reset) {
     for (uint32_t i = 0; i < num_entries_to_reset; ++i) {
         config_buffer_mgrs[i] = WorkerConfigBufferMgr();
@@ -1828,7 +1828,7 @@ void reset_worker_dispatch_state_on_device(
     SystemMemoryManager& manager,
     uint8_t cq_id,
     CoreCoord dispatch_core,
-    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    const DispatchArray<uint32_t>& expected_num_workers_completed,
     bool reset_launch_msg_state) {
     auto num_sub_devices = device->num_sub_devices();
     uint32_t go_signals_cmd_size = 0;

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -111,8 +111,8 @@ void write_program_command_sequence(
 KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle);
 
 void reset_config_buf_mgrs_and_expected_workers(
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgrs,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgrs,
+    DispatchArray<uint32_t>& expected_num_workers_completed,
     uint32_t num_entries_to_reset);
 
 void reset_worker_dispatch_state_on_device(
@@ -120,7 +120,7 @@ void reset_worker_dispatch_state_on_device(
     SystemMemoryManager& manager,
     uint8_t cq_id,
     CoreCoord dispatch_core,
-    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    const DispatchArray<uint32_t>& expected_num_workers_completed,
     bool reset_launch_msg_state);
 
 void set_num_worker_sems_on_dispatch(

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -12,13 +12,12 @@ namespace tt::tt_metal::trace_dispatch {
 
 void reset_host_dispatch_state_for_trace(
     uint32_t num_sub_devices,
-    SystemMemoryManager& sysmem_manager,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr,
-    std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>&
-        worker_launch_message_buffer_state_reset,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed_reset,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr_reset) {
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state,
+    DispatchArray<uint32_t>& expected_num_workers_completed,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr,
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state_reset,
+    DispatchArray<uint32_t>& expected_num_workers_completed_reset,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr_reset) {
     // Record the original value of expected_num_workers_completed, and reset it to 0.
     std::copy(
         expected_num_workers_completed.begin(),
@@ -27,7 +26,6 @@ void reset_host_dispatch_state_for_trace(
     std::fill(expected_num_workers_completed.begin(), expected_num_workers_completed.begin() + num_sub_devices, 0);
 
     // Record original value of launch msg buffer
-    auto& worker_launch_message_buffer_state = sysmem_manager.get_worker_launch_message_buffer_state();
     std::copy(
         worker_launch_message_buffer_state.begin(),
         worker_launch_message_buffer_state.begin() + num_sub_devices,
@@ -47,13 +45,12 @@ void reset_host_dispatch_state_for_trace(
 
 void load_host_dispatch_state(
     uint32_t num_sub_devices,
-    SystemMemoryManager& sysmem_manager,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr,
-    std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>&
-        worker_launch_message_buffer_state_reset,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed_reset,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr_reset) {
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state,
+    DispatchArray<uint32_t>& expected_num_workers_completed,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr,
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state_reset,
+    DispatchArray<uint32_t>& expected_num_workers_completed_reset,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr_reset) {
     std::copy(
         expected_num_workers_completed_reset.begin(),
         expected_num_workers_completed_reset.begin() + num_sub_devices,
@@ -61,7 +58,7 @@ void load_host_dispatch_state(
     std::copy(
         worker_launch_message_buffer_state_reset.begin(),
         worker_launch_message_buffer_state_reset.begin() + num_sub_devices,
-        sysmem_manager.get_worker_launch_message_buffer_state().begin());
+        worker_launch_message_buffer_state.begin());
     std::copy(
         config_buffer_mgr_reset.begin(), config_buffer_mgr_reset.begin() + num_sub_devices, config_buffer_mgr.begin());
 }
@@ -71,7 +68,7 @@ void issue_trace_commands(
     SystemMemoryManager& sysmem_manager,
     const TraceDispatchMetadata& dispatch_md,
     uint8_t cq_id,
-    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    const DispatchArray<uint32_t>& expected_num_workers_completed,
     CoreCoord dispatch_core) {
     void* cmd_region = sysmem_manager.issue_queue_reserve(dispatch_md.cmd_sequence_sizeB, cq_id);
 
@@ -189,9 +186,9 @@ uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
 
 void update_worker_state_post_trace_execution(
     const std::unordered_map<SubDeviceId, TraceWorkerDescriptor>& trace_worker_descriptors,
-    SystemMemoryManager& manager,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed) {
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr,
+    DispatchArray<uint32_t>& expected_num_workers_completed) {
     for (const auto& [id, desc] : trace_worker_descriptors) {
         auto index = *id;
         // Update the expected worker cores counter due to trace programs completion
@@ -200,12 +197,13 @@ void update_worker_state_post_trace_execution(
         // Update the wptr on host to match state. If the trace doesn't execute on a
         // class of worker (unicast or multicast), it doesn't reset or modify the
         // state for those workers.
-        auto& worker_launch_message_buffer_state = manager.get_worker_launch_message_buffer_state()[index];
         if (desc.num_traced_programs_needing_go_signal_multicast) {
-            worker_launch_message_buffer_state.set_mcast_wptr(desc.num_traced_programs_needing_go_signal_multicast);
+            worker_launch_message_buffer_state[index].set_mcast_wptr(
+                desc.num_traced_programs_needing_go_signal_multicast);
         }
         if (desc.num_traced_programs_needing_go_signal_unicast) {
-            worker_launch_message_buffer_state.set_unicast_wptr(desc.num_traced_programs_needing_go_signal_unicast);
+            worker_launch_message_buffer_state[index].set_unicast_wptr(
+                desc.num_traced_programs_needing_go_signal_unicast);
         }
         // The config buffer manager is unaware of what memory is used inside the trace, so mark all memory as used so
         // that it will force a stall and avoid stomping on in-use state.

--- a/tt_metal/impl/trace/dispatch.hpp
+++ b/tt_metal/impl/trace/dispatch.hpp
@@ -35,39 +35,37 @@ struct TraceDispatchMetadata {
 
 void reset_host_dispatch_state_for_trace(
     uint32_t num_sub_devices,
-    SystemMemoryManager& sysmem_manager,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr,
-    std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>&
-        worker_launch_message_buffer_state_reset,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed_reset,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr_reset);
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state,
+    DispatchArray<uint32_t>& expected_num_workers_completed,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr,
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state_reset,
+    DispatchArray<uint32_t>& expected_num_workers_completed_reset,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr_reset);
 
 void load_host_dispatch_state(
     uint32_t num_sub_devices,
-    SystemMemoryManager& sysmem_manager,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr,
-    std::array<LaunchMessageRingBufferState, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>&
-        worker_launch_message_buffer_state_reset,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed_reset,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr_reset);
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state,
+    DispatchArray<uint32_t>& expected_num_workers_completed,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr,
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state_reset,
+    DispatchArray<uint32_t>& expected_num_workers_completed_reset,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr_reset);
 
 void issue_trace_commands(
     IDevice* device,
     SystemMemoryManager& sysmem_manager,
     const TraceDispatchMetadata& dispatch_md,
     uint8_t cq_id,
-    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    const DispatchArray<uint32_t>& expected_num_workers_completed,
     CoreCoord dispatch_core);
 
 uint32_t compute_trace_cmd_size(uint32_t num_sub_devices);
 
 void update_worker_state_post_trace_execution(
     const std::unordered_map<SubDeviceId, TraceWorkerDescriptor>& trace_worker_descriptors,
-    SystemMemoryManager& manager,
-    std::array<WorkerConfigBufferMgr, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& config_buffer_mgr,
-    std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed);
+    DispatchArray<LaunchMessageRingBufferState>& worker_launch_message_buffer_state,
+    DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgr,
+    DispatchArray<uint32_t>& expected_num_workers_completed);
 
 std::size_t compute_interleaved_trace_buf_page_size(uint32_t buf_size, const uint32_t num_banks);
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`SystemMemoryManager` keeps `LaunchMessageRingBufferState`, which is used as a global object inside of `MeshCommandQueue`. This forces us to have a "reference" `SystemMemoryManager`.

### What's changed
* Separate `LaunchMessageRingBufferState` from `SystemMemoryManager`.
* `DispatchArray` to make these `std::array` types more human readable.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13775451858)
- [X] Ran T3K trace / events tests locally
- [X] New/Existing tests provide coverage for changes