### PR TITLE
Add MeshCommandQueue::terminate, cleanup API surface for CommandQueue

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -26,8 +26,6 @@ class CommandQueue {
 public:
     virtual ~CommandQueue() = default;
 
-    virtual const CoreCoord& virtual_enqueue_program_dispatch_core() const = 0;
-
     virtual void record_begin(const uint32_t tid, const std::shared_ptr<TraceDescriptor>& ctx) = 0;
     virtual void record_end() = 0;
 
@@ -35,9 +33,6 @@ public:
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,
         const vector_memcpy_aligned<uint32_t>& go_signal_noc_data) = 0;
-
-    virtual void set_go_signal_noc_data_and_dispatch_sems(
-        uint32_t num_dispatch_sems, const vector_memcpy_aligned<uint32_t>& noc_mcast_unicast_data) = 0;
 
     virtual uint32_t id() const = 0;
     virtual std::optional<uint32_t> tid() const = 0;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -194,7 +194,6 @@ public:
     virtual void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) = 0;
     virtual void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) = 0;
     virtual void clear_loaded_sub_device_manager() = 0;
-    virtual CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const = 0;
     virtual const std::vector<SubDeviceId> &get_sub_device_ids() const = 0;
     virtual const std::vector<SubDeviceId> &get_sub_device_stall_group() const = 0;
     virtual void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -189,7 +189,6 @@ public:
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void clear_loaded_sub_device_manager() override;
-    CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const override;
     const std::vector<SubDeviceId> &get_sub_device_ids() const override;
     const std::vector<SubDeviceId> &get_sub_device_stall_group() const override;
     void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -207,6 +207,7 @@ public:
     void drain_events_from_completion_queue();
     void verify_reported_events_after_draining(const MeshEvent& event);
     void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    void terminate();
     void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -210,7 +210,6 @@ public:
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) override;
     void clear_loaded_sub_device_manager() override;
-    CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const override;
     const std::vector<SubDeviceId>& get_sub_device_ids() const override;
     const std::vector<SubDeviceId>& get_sub_device_stall_group() const override;
     void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -777,11 +777,6 @@ SubDeviceManagerId MeshDevice::get_active_sub_device_manager_id() const {
 SubDeviceManagerId MeshDevice::get_default_sub_device_manager_id() const {
     return sub_device_manager_tracker_->get_default_sub_device_manager()->id();
 }
-CoreCoord MeshDevice::virtual_program_dispatch_core(uint8_t cq_id) const {
-    return validate_and_get_reference_value(scoped_devices_->root_devices(), [cq_id](const auto& device) {
-        return device->virtual_program_dispatch_core(cq_id);
-    });
-}
 const std::vector<SubDeviceId>& MeshDevice::get_sub_device_ids() const {
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_ids();
 }

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -2,6 +2,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager_tracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -34,6 +34,8 @@ public:
     const std::vector<CoreCoord>& get_logical_storage_cores(uint32_t device_id) const;
     const std::vector<CoreCoord>& get_logical_dispatch_cores(uint32_t device_id) const;
     tt_cxy_pair get_dispatch_core(uint8_t cq_id) const;
+    tt_cxy_pair get_dispatch_s_core(uint8_t cq_id) const;
+    tt_cxy_pair enqueue_program_dispatch_core(uint8_t cq_id) const;
 
 private:
     void reset(uint8_t num_hw_cqs);
@@ -47,6 +49,7 @@ private:
     // Make this mutable, since this is JIT populated
     // through a const instance when queried
     mutable std::vector<tt_cxy_pair> dispatch_cores_;
+    mutable std::vector<tt_cxy_pair> dispatch_s_cores_;
     mutable std::mutex modifier_mutex;
 };
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -27,8 +27,6 @@ public:
 
     ~HWCommandQueue() override;
 
-    const CoreCoord& virtual_enqueue_program_dispatch_core() const override;
-
     void record_begin(const uint32_t tid, const std::shared_ptr<TraceDescriptor>& ctx) override;
     void record_end() override;
 
@@ -36,9 +34,6 @@ public:
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,
         const vector_memcpy_aligned<uint32_t>& go_signal_noc_data) override;
-
-    void set_go_signal_noc_data_and_dispatch_sems(
-        uint32_t num_dispatch_sems, const vector_memcpy_aligned<uint32_t>& noc_mcast_unicast_data) override;
 
     uint32_t id() const override;
     std::optional<uint32_t> tid() const override;

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -96,22 +96,6 @@ public:
     constexpr bool has_side_effects() { return true; }
 };
 
-class EnqueueTerminateCommand : public Command {
-private:
-    uint32_t command_queue_id;
-    IDevice* device;
-    SystemMemoryManager& manager;
-
-public:
-    EnqueueTerminateCommand(uint32_t command_queue_id, IDevice* device, SystemMemoryManager& manager);
-
-    void process();
-
-    EnqueueCommandType type() { return EnqueueCommandType::TERMINATE; }
-
-    constexpr bool has_side_effects() { return false; }
-};
-
 }  // namespace tt::tt_metal
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::EnqueueCommandType& type);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1823,121 +1823,31 @@ void reset_config_buf_mgrs_and_expected_workers(
     std::fill(expected_num_workers_completed.begin(), expected_num_workers_completed.begin() + num_entries_to_reset, 0);
 }
 
-void reset_worker_dispatch_state_on_device(
-    IDevice* device,
-    SystemMemoryManager& manager,
-    uint8_t cq_id,
-    CoreCoord dispatch_core,
-    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    bool reset_launch_msg_state) {
-    auto num_sub_devices = device->num_sub_devices();
-    uint32_t go_signals_cmd_size = 0;
-    if (reset_launch_msg_state) {
-        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
-        go_signals_cmd_size = align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
-    }
-    uint32_t cmd_sequence_sizeB =
-        reset_launch_msg_state * DispatchQueryManager::instance().dispatch_s_enabled() *
-            hal.get_alignment(
-                HalMemType::HOST) +  // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
-        go_signals_cmd_size +        // go signal cmd
-        (hal.get_alignment(
-             HalMemType::HOST) +  // wait to ensure that reset go signal was processed (dispatch_d)
-                                  // when dispatch_s and dispatch_d are running on 2 cores, workers update dispatch_s.
-                                  // dispatch_s is responsible for resetting worker count and giving dispatch_d the
-                                  // latest worker state. This is encapsulated in the dispatch_s wait command (only to
-                                  // be sent when dispatch is distributed on 2 cores)
-         DispatchQueryManager::instance().distributed_dispatcher() * hal.get_alignment(HalMemType::HOST)) *
-            num_sub_devices;
-    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
-    bool clear_count = true;
-    DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
-    const auto& dispatch_core_config = DispatchQueryManager::instance().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    uint32_t dispatch_message_base_addr =
-        DispatchMemMap::get(dispatch_core_type)
-            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-    if (reset_launch_msg_state) {
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
-            uint16_t index_bitmask = 0;
-            for (uint32_t i = 0; i < num_sub_devices; ++i) {
-                index_bitmask |= 1 << i;
-            }
-            command_sequence.add_notify_dispatch_s_go_signal_cmd(false, index_bitmask);
-            dispatcher_for_go_signal = DispatcherSelect::DISPATCH_SLAVE;
-        }
-        go_msg_t reset_launch_message_read_ptr_go_signal;
-        reset_launch_message_read_ptr_go_signal.signal = RUN_MSG_RESET_READ_PTR;
-        reset_launch_message_read_ptr_go_signal.master_x = (uint8_t)dispatch_core.x;
-        reset_launch_message_read_ptr_go_signal.master_y = (uint8_t)dispatch_core.y;
-        for (uint32_t i = 0; i < num_sub_devices; ++i) {
-            reset_launch_message_read_ptr_go_signal.dispatch_message_offset =
-                (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
-            uint32_t dispatch_message_addr =
-                dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
-            // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
-            SubDeviceId sub_device_id(static_cast<uint8_t>(i));
-            command_sequence.add_dispatch_go_signal_mcast(
-                expected_num_workers_completed[i],
-                *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal),
-                dispatch_message_addr,
-                device->num_noc_mcast_txns(sub_device_id),
-                device->num_noc_unicast_txns(sub_device_id),
-                device->noc_data_start_index(sub_device_id),
-                dispatcher_for_go_signal);
-        }
-    }
-    // Wait to ensure that all workers have reset their read_ptr. dispatch_d will stall until all workers have completed
-    // this step, before sending kernel config data to workers or notifying dispatch_s that its safe to send the
-    // go_signal. Clear the dispatch <--> worker semaphore, since trace starts at 0.
-    for (uint32_t i = 0; i < num_sub_devices; ++i) {
-        uint32_t dispatch_message_addr =
-            dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
-        SubDeviceId sub_device_id(static_cast<uint8_t>(i));
-        uint32_t expected_num_workers = expected_num_workers_completed[i] +
-                                        device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) +
-                                        device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
-        if (DispatchQueryManager::instance().distributed_dispatcher()) {
-            command_sequence.add_dispatch_wait(
-                false, dispatch_message_addr, expected_num_workers, clear_count, false, true, 1);
-        }
-        command_sequence.add_dispatch_wait(false, dispatch_message_addr, expected_num_workers, clear_count);
-    }
-    manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
-    manager.fetch_queue_reserve_back(cq_id);
-    manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
-}
-
-void set_num_worker_sems_on_dispatch(
-    IDevice* device, SystemMemoryManager& manager, uint8_t cq_id, uint32_t num_worker_sems) {
-    // Not needed for regular dispatch kernel
-    if (!DispatchQueryManager::instance().dispatch_s_enabled()) {
-        return;
-    }
+void issue_terminate_command(SystemMemoryManager& manager, uint8_t cq_id) {
+    // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_TERMINATE
+    // CQ_PREFETCH_CMD_TERMINATE
+    TT_FATAL(!manager.get_bypass_mode(), "Terminate cannot be used with tracing");
     uint32_t cmd_sequence_sizeB = hal.get_alignment(HalMemType::HOST);
+
+    // dispatch and prefetch terminate commands each needs to be a separate fetch queue entry
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
-    command_sequence.add_dispatch_set_num_worker_sems(num_worker_sems, DispatcherSelect::DISPATCH_SLAVE);
+    HugepageDeviceCommand dispatch_d_command_sequence(cmd_region, cmd_sequence_sizeB);
+    dispatch_d_command_sequence.add_dispatch_terminate(DispatcherSelect::DISPATCH_MASTER);
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
     manager.fetch_queue_reserve_back(cq_id);
     manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
-}
-
-void set_go_signal_noc_data_on_dispatch(
-    IDevice* device,
-    const vector_memcpy_aligned<uint32_t>& go_signal_noc_data,
-    SystemMemoryManager& manager,
-    uint8_t cq_id) {
-    uint32_t pci_alignment = hal.get_alignment(HalMemType::HOST);
-    uint32_t cmd_sequence_sizeB = align(
-        sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) + go_signal_noc_data.size() * sizeof(uint32_t), pci_alignment);
-    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
-    DispatcherSelect dispatcher_for_go_signal = DispatchQueryManager::instance().dispatch_s_enabled()
-                                                    ? DispatcherSelect::DISPATCH_SLAVE
-                                                    : DispatcherSelect::DISPATCH_MASTER;
-    command_sequence.add_dispatch_set_go_signal_noc_data(go_signal_noc_data, dispatcher_for_go_signal);
+    if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        // Terminate dispatch_s if enabled
+        cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+        HugepageDeviceCommand dispatch_s_command_sequence(cmd_region, cmd_sequence_sizeB);
+        dispatch_s_command_sequence.add_dispatch_terminate(DispatcherSelect::DISPATCH_SLAVE);
+        manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+        manager.fetch_queue_reserve_back(cq_id);
+        manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+    }
+    cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+    HugepageDeviceCommand prefetch_command_sequence(cmd_region, cmd_sequence_sizeB);
+    prefetch_command_sequence.add_prefetch_terminate();
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
     manager.fetch_queue_reserve_back(cq_id);
     manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -115,22 +115,7 @@ void reset_config_buf_mgrs_and_expected_workers(
     std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
     uint32_t num_entries_to_reset);
 
-void reset_worker_dispatch_state_on_device(
-    IDevice* device,
-    SystemMemoryManager& manager,
-    uint8_t cq_id,
-    CoreCoord dispatch_core,
-    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
-    bool reset_launch_msg_state);
-
-void set_num_worker_sems_on_dispatch(
-    IDevice* device, SystemMemoryManager& manager, uint8_t cq_id, uint32_t num_worker_sems);
-
-void set_go_signal_noc_data_on_dispatch(
-    IDevice* device,
-    const vector_memcpy_aligned<uint32_t>& go_signal_noc_data,
-    SystemMemoryManager& manager,
-    uint8_t cq_id);
+void issue_terminate_command(SystemMemoryManager& manager, uint8_t cq_id);
 
 }  // namespace program_dispatch
 

--- a/tt_metal/impl/sub_device/dispatch.cpp
+++ b/tt_metal/impl/sub_device/dispatch.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <dev_msgs.h>
+
+#include "tt_metal/impl/sub_device/dispatch.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/impl/program/program_command_sequence.hpp"
+
+namespace tt::tt_metal {
+namespace subdevice_dispatch {
+
+void set_num_worker_sems_on_dispatch(
+    IDevice* device, SystemMemoryManager& manager, uint8_t cq_id, uint32_t num_worker_sems) {
+    // Not needed for regular dispatch kernel
+    if (!DispatchQueryManager::instance().dispatch_s_enabled()) {
+        return;
+    }
+    uint32_t cmd_sequence_sizeB = hal.get_alignment(HalMemType::HOST);
+    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    command_sequence.add_dispatch_set_num_worker_sems(num_worker_sems, DispatcherSelect::DISPATCH_SLAVE);
+    manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+    manager.fetch_queue_reserve_back(cq_id);
+    manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+}
+
+void set_go_signal_noc_data_on_dispatch(
+    IDevice* device,
+    const vector_memcpy_aligned<uint32_t>& go_signal_noc_data,
+    SystemMemoryManager& manager,
+    uint8_t cq_id) {
+    uint32_t pci_alignment = hal.get_alignment(HalMemType::HOST);
+    uint32_t cmd_sequence_sizeB = align(
+        sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) + go_signal_noc_data.size() * sizeof(uint32_t), pci_alignment);
+    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    DispatcherSelect dispatcher_for_go_signal = DispatchQueryManager::instance().dispatch_s_enabled()
+                                                    ? DispatcherSelect::DISPATCH_SLAVE
+                                                    : DispatcherSelect::DISPATCH_MASTER;
+    command_sequence.add_dispatch_set_go_signal_noc_data(go_signal_noc_data, dispatcher_for_go_signal);
+    manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+    manager.fetch_queue_reserve_back(cq_id);
+    manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+}
+
+void reset_worker_dispatch_state_on_device(
+    IDevice* device,
+    SystemMemoryManager& manager,
+    uint8_t cq_id,
+    CoreCoord dispatch_core,
+    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    bool reset_launch_msg_state) {
+    auto num_sub_devices = device->num_sub_devices();
+    uint32_t go_signals_cmd_size = 0;
+    if (reset_launch_msg_state) {
+        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
+        go_signals_cmd_size = align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
+    }
+    uint32_t cmd_sequence_sizeB =
+        reset_launch_msg_state * DispatchQueryManager::instance().dispatch_s_enabled() *
+            hal.get_alignment(
+                HalMemType::HOST) +  // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
+        go_signals_cmd_size +        // go signal cmd
+        (hal.get_alignment(
+             HalMemType::HOST) +  // wait to ensure that reset go signal was processed (dispatch_d)
+                                  // when dispatch_s and dispatch_d are running on 2 cores, workers update dispatch_s.
+                                  // dispatch_s is responsible for resetting worker count and giving dispatch_d the
+                                  // latest worker state. This is encapsulated in the dispatch_s wait command (only to
+                                  // be sent when dispatch is distributed on 2 cores)
+         DispatchQueryManager::instance().distributed_dispatcher() * hal.get_alignment(HalMemType::HOST)) *
+            num_sub_devices;
+    void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
+    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    bool clear_count = true;
+    DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
+    const auto& dispatch_core_config = DispatchQueryManager::instance().get_dispatch_core_config();
+    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    uint32_t dispatch_message_base_addr =
+        DispatchMemMap::get(dispatch_core_type)
+            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
+    if (reset_launch_msg_state) {
+        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+            uint16_t index_bitmask = 0;
+            for (uint32_t i = 0; i < num_sub_devices; ++i) {
+                index_bitmask |= 1 << i;
+            }
+            command_sequence.add_notify_dispatch_s_go_signal_cmd(false, index_bitmask);
+            dispatcher_for_go_signal = DispatcherSelect::DISPATCH_SLAVE;
+        }
+        go_msg_t reset_launch_message_read_ptr_go_signal;
+        reset_launch_message_read_ptr_go_signal.signal = RUN_MSG_RESET_READ_PTR;
+        reset_launch_message_read_ptr_go_signal.master_x = (uint8_t)dispatch_core.x;
+        reset_launch_message_read_ptr_go_signal.master_y = (uint8_t)dispatch_core.y;
+        for (uint32_t i = 0; i < num_sub_devices; ++i) {
+            reset_launch_message_read_ptr_go_signal.dispatch_message_offset =
+                (uint8_t)DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
+            uint32_t dispatch_message_addr =
+                dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
+            // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
+            SubDeviceId sub_device_id(static_cast<uint8_t>(i));
+            command_sequence.add_dispatch_go_signal_mcast(
+                expected_num_workers_completed[i],
+                *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal),
+                dispatch_message_addr,
+                device->num_noc_mcast_txns(sub_device_id),
+                device->num_noc_unicast_txns(sub_device_id),
+                device->noc_data_start_index(sub_device_id),
+                dispatcher_for_go_signal);
+        }
+    }
+    // Wait to ensure that all workers have reset their read_ptr. dispatch_d will stall until all workers have completed
+    // this step, before sending kernel config data to workers or notifying dispatch_s that its safe to send the
+    // go_signal. Clear the dispatch <--> worker semaphore, since trace starts at 0.
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        uint32_t dispatch_message_addr =
+            dispatch_message_base_addr + DispatchMemMap::get(dispatch_core_type).get_dispatch_message_offset(i);
+        SubDeviceId sub_device_id(static_cast<uint8_t>(i));
+        uint32_t expected_num_workers = expected_num_workers_completed[i] +
+                                        device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) +
+                                        device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
+        if (DispatchQueryManager::instance().distributed_dispatcher()) {
+            command_sequence.add_dispatch_wait(
+                false, dispatch_message_addr, expected_num_workers, clear_count, false, true, 1);
+        }
+        command_sequence.add_dispatch_wait(false, dispatch_message_addr, expected_num_workers, clear_count);
+    }
+    manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
+    manager.fetch_queue_reserve_back(cq_id);
+    manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
+}
+
+}  // namespace subdevice_dispatch
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/dispatch.hpp
+++ b/tt_metal/impl/sub_device/dispatch.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <device.hpp>
+
+namespace tt::tt_metal {
+
+namespace subdevice_dispatch {
+
+void reset_worker_dispatch_state_on_device(
+    IDevice* device,
+    SystemMemoryManager& manager,
+    uint8_t cq_id,
+    CoreCoord dispatch_core,
+    const std::array<uint32_t, DispatchSettings::DISPATCH_MESSAGE_ENTRIES>& expected_num_workers_completed,
+    bool reset_launch_msg_state);
+
+void set_num_worker_sems_on_dispatch(
+    IDevice* device, SystemMemoryManager& manager, uint8_t cq_id, uint32_t num_worker_sems);
+
+void set_go_signal_noc_data_on_dispatch(
+    IDevice* device,
+    const vector_memcpy_aligned<uint32_t>& go_signal_noc_data,
+    SystemMemoryManager& manager,
+    uint8_t cq_id);
+
+}  // namespace subdevice_dispatch
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- `MeshCommandQueue::terminate` does not currently exist on main. TT-Mesh relies on each `Device` calling terminate when it goes out of scope, to teardown dispatch infra. This will not work when we stop initializing single device CQs.
- API surface for `CommandQueue` contains functions that should either be in the query layer or in dispatch cmd generation files. These include:
   - `const CoreCoord& virtual_enqueue_program_dispatch_core();`
   - `void set_go_signal_noc_data_and_dispatch_sems(
        uint32_t num_dispatch_sems, const vector_memcpy_aligned<uint32_t>& noc_mcast_unicast_data);`
- When the MeshCommandQueue is the only interface to devices (single device CQs removed), we will use the MeshCQ::terminate API during teardown
 
### What's changed
- Add terminate API and move required functions from CQ API surface.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes