### PR TITLE
Fix specifying pad_value for from_torch for 0/1 rank tensors

### DIFF
--- a/tests/ttnn/unit_tests/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/test_to_and_from_torch.py
@@ -98,9 +98,12 @@ def test_from_torch_large(device):
 )
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_to_for_01_rank(shape, layout, dtype):
+@pytest.mark.parametrize("pad_value", [None, 1])
+def test_to_for_01_rank(shape, layout, dtype, pad_value):
+    if pad_value != None and layout != ttnn.TILE_LAYOUT:
+        pytest.skip("Pad value is only supported for tile layout")
     torch_input_tensor = torch.rand(shape, dtype=dtype)
-    tensor = ttnn.from_torch(torch_input_tensor, layout=layout)
+    tensor = ttnn.from_torch(torch_input_tensor, layout=layout, pad_value=pad_value)
     torch_output_tensor = ttnn.to_torch(tensor)
     assert torch_input_tensor.shape == torch_output_tensor.shape
     assert torch.allclose(torch_input_tensor, torch_output_tensor)
@@ -118,9 +121,12 @@ def test_to_for_01_rank(shape, layout, dtype):
 )
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_to_for_01_rank_on_device(device, shape, layout, dtype):
+@pytest.mark.parametrize("pad_value", [None, 1])
+def test_to_for_01_rank_on_device(device, shape, layout, dtype, pad_value):
+    if pad_value != None and layout != ttnn.TILE_LAYOUT:
+        pytest.skip("Pad value is only supported for tile layout")
     torch_input_tensor = torch.rand(shape, dtype=dtype)
-    tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+    tensor = ttnn.from_torch(torch_input_tensor, layout=layout, pad_value=pad_value, device=device)
     torch_output_tensor = ttnn.to_torch(tensor)
     assert torch_input_tensor.shape == torch_output_tensor.shape
     assert torch.allclose(torch_input_tensor, torch_output_tensor)

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -1215,7 +1215,10 @@ Tensor pad(
     }
 
     auto pad_value_ = static_cast<T>(pad_value);
-    const auto input_padded_shape = tensor.get_padded_shape();
+    auto input_padded_shape = tensor.get_padded_shape();
+    if (input_padded_shape.rank() < 2) {
+        input_padded_shape = input_padded_shape.to_rank(2);
+    }
     const auto input_strides = tensor.strides();
     const auto input_data_type = tensor.get_dtype();
 
@@ -1287,7 +1290,7 @@ Tensor pad(
         tensor.get_storage());
     return Tensor(
         OwnedStorage{output_buffer},
-        tensor.get_padded_shape(),
+        tensor.get_logical_shape(),
         output_padded_shape,
         tensor.get_dtype(),
         tensor.get_layout(),

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -291,7 +291,7 @@ Tensor tensor_pad_to_tile(const Tensor& input_tensor, float pad_value) {
     ttnn::SmallVector<uint32_t> padded_shape;
     ttnn::SmallVector<uint32_t> input_tensor_start;
 
-    for (auto index = 0; index < input_tensor.get_padded_shape().rank() - 2; index++) {
+    for (auto index = 0; index < static_cast<int>(input_tensor.get_padded_shape().rank()) - 2; index++) {
         padded_shape.push_back(input_tensor.get_padded_shape()[index]);
         input_tensor_start.push_back(0);
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18849

### Problem description
Currently a call to `ttnn.from_torch` throws an exception if pad_value is specified for 0/1 rank tensors

### What's changed
Properly handle 0/1 rank tensors in tensor pad
Added tests for specifying a pad value

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13781023579)
- [x] New/Existing tests provide coverage for changes