### PR TITLE
#18055: Added override runtime args callback to Width Sharded Conv2D

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -93,6 +93,7 @@ def run_conv(
     enable_split_reader=False,
     activation="",
     preprocess_weights_on_device=True,
+    run_twice=False,
 ):
     if isinstance(device, ttnn.MeshDevice):
         assert input_mesh_mapper is not None, "Expected mesh mapper for input tensor when using device mesh"
@@ -215,6 +216,30 @@ def run_conv(
         return_output_dim=True,
         return_weights_and_bias=True,
     )
+    if run_twice:
+        [tt_output_tensor_on_device, [out_height, out_width], [d_w, d_b]] = ttnn.conv2d(
+            input_tensor=tt_input_tensor,
+            weight_tensor=tt_weight_tensor,
+            in_channels=input_channels,
+            out_channels=output_channels,
+            device=device,
+            bias_tensor=tt_bias_tensor,
+            kernel_size=(filter_height, filter_width),
+            stride=(stride_h, stride_w),
+            padding=(pad_h, pad_w),
+            dilation=(dilation, dilation),
+            batch_size=batch_size,
+            input_height=input_height,
+            input_width=input_width,
+            conv_config=conv_config,
+            compute_config=compute_config,
+            conv_op_cache=reader_patterns_cache,
+            debug=debug,
+            groups=groups,
+            memory_config=memory_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+        )
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
     torch_output_tensor = ttnn.to_torch(tt_output_tensor, mesh_composer=output_mesh_composer)
 
@@ -457,6 +482,7 @@ def test_conv_features(
         fp32_accum=fp32_accum,
         packer_l1_acc=packer_l1_acc,
         preprocess_weights_on_device=True,
+        run_twice=True,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -622,7 +622,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     log_debug(LogOp, "CB for L1 Array CB: {}, npages: {}, pagesize: {}", cb_indices.cb_for_l1_array, 1, 32 * 2);
 
     cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
-    tt::tt_metal::create_cb(
+    auto[_, cb_input] = std::tt::tt_metal::create_cb(
         cb_indices.sharded_act_cb,
         program,
         all_cores,
@@ -917,13 +917,41 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     }
 
     // Capture conv_reader_indices_buffer to cache this with the program
-    auto empty_callback = [conv_reader_indices_buffer](
-                              const void* operation,
-                              tt::tt_metal::Program& program,
-                              const std::vector<Tensor>& input_tensors,
-                              const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                              const std::vector<Tensor>& output_tensors) {};
-    return {.program = std::move(program), .override_runtime_arguments_callback = empty_callback};
+    auto override_runtime_arguments_callback =
+        [conv_reader_indices_buffer, cb_input, cb_output, has_bias, full_core_grid, total_num_cores, weights_kernel_id](
+            const void* operation,
+            tt::tt_metal::Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            bool src_a_is_sharded = input_tensors[0].is_sharded();
+            bool out_sharded = output_tensors[0].is_sharded();
+
+            auto src_buffer_a = input_tensors.at(0).buffer();
+            auto src_buffer_b = input_tensors.at(1).buffer();
+            auto dst_buffer = output_tensors.at(0).buffer();
+
+            auto weights_kernel_runtime_args = GetRuntimeArgs(program, weights_kernel_id);
+            for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
+                uint32_t core_x = core_index % full_core_grid.x;
+                uint32_t core_y = core_index / full_core_grid.x;
+
+                auto this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
+                this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
+                if (has_bias) {
+                    this_core_weights_kernel_runtime_args[2] = optional_input_tensors.at(0).value().buffer()->address();
+                }
+            }
+
+            if (src_a_is_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_input, *src_buffer_a);
+            }
+
+            if (out_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            }
+        };
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
 }  // namespace conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -622,7 +622,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     log_debug(LogOp, "CB for L1 Array CB: {}, npages: {}, pagesize: {}", cb_indices.cb_for_l1_array, 1, 32 * 2);
 
     cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
-    auto[_, cb_input] = std::tt::tt_metal::create_cb(
+    auto [_, cb_input] = tt::tt_metal::create_cb(
         cb_indices.sharded_act_cb,
         program,
         all_cores,


### PR DESCRIPTION
### Ticket 
#18055 

### Problem description
Width Sharded Conv2D didn't implement the override runtime args callback, leading to problems when the same op was called multiple times. 

### What's changed
Implemented the callback. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes