### PR TITLE
Add TT-NN Op Infra Support For Heterogeneous Programs in MeshWorkload

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -24,6 +24,7 @@ namespace tt::tt_metal {
 
 class SubDeviceManagerTracker;
 class ThreadPool;
+class ProgramCache;
 
 namespace distributed {
 
@@ -81,6 +82,7 @@ private:
     std::shared_ptr<ThreadPool> reader_thread_pool_;
 
     std::recursive_mutex push_work_mutex_;
+    std::unique_ptr<program_cache::detail::ProgramCache> program_cache_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;
 

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -62,7 +62,6 @@ public:
     MeshWorkload();
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
     std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
-    Program& get_program(const MeshCoordinateRange& device_range) { return programs_.at(device_range); }
 
     // For testing purposes only
     void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -62,6 +62,7 @@ public:
     MeshWorkload();
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
     std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
+    Program& get_program(const MeshCoordinateRange& device_range) { return programs_.at(device_range); }
 
     // For testing purposes only
     void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -38,9 +38,9 @@ struct CachedProgram {
 
 template <typename shared_variables_t>
 struct CachedProgramRef {
-    tt::tt_metal::Program& program;
+    std::reference_wrapper<tt::tt_metal::Program> program;
     // Cached program needs to share shared_variables between create and override_runtime_arguments functions
-    shared_variables_t& shared_variables;
+    std::reference_wrapper<shared_variables_t> shared_variables;
 
     CachedProgramRef(tt::tt_metal::Program& program, shared_variables_t& shared_variables) :
         program{program}, shared_variables{shared_variables} {}
@@ -73,8 +73,7 @@ private:
         // careful, this is an unordered map so the "first" element is arbitrary
         auto& map = cached_mesh_workload.coordinate_range_to_shared_variables;
         TT_FATAL(!map.empty(), "Shared variables map is empty");
-        auto& first_shared_variables_pair = *map.begin();
-        return first_shared_variables_pair.second;
+        return map.begin()->second;
     }
 
 public:

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -15,10 +15,15 @@ template <typename shared_variables_t>
 struct CachedMeshWorkload {
     tt::tt_metal::distributed::MeshWorkload workload;
     // Shared variables between create and override_runtime_arguments functions
-    shared_variables_t shared_variables;
+    std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t>
+        coordinate_range_to_shared_variables;
 
-    CachedMeshWorkload(tt::tt_metal::distributed::MeshWorkload&& workload, shared_variables_t&& shared_variables) :
-        workload{std::move(workload)}, shared_variables{std::forward<shared_variables_t>(shared_variables)} {}
+    CachedMeshWorkload(
+        tt::tt_metal::distributed::MeshWorkload&& workload,
+        std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t>&&
+            coordinate_range_to_shared_variables) :
+        workload{std::move(workload)},
+        coordinate_range_to_shared_variables{std::move(coordinate_range_to_shared_variables)} {}
 };
 
 template <typename shared_variables_t>
@@ -31,11 +36,24 @@ struct CachedProgram {
         program{std::move(program)}, shared_variables{std::forward<shared_variables_t>(shared_variables)} {}
 };
 
+template <typename shared_variables_t>
+struct CachedProgramRef {
+    tt::tt_metal::Program& program;
+    // Cached program needs to share shared_variables between create and override_runtime_arguments functions
+    shared_variables_t& shared_variables;
+
+    CachedProgramRef(tt::tt_metal::Program& program, shared_variables_t& shared_variables) :
+        program{program}, shared_variables{shared_variables} {}
+};
+
 // Adapter that provides a unified interface for both CachedProgram and CachedMeshWorkload
 template <typename shared_variables_t>
 class ProgramAdapter {
 private:
-    using CachedObject = std::variant<CachedMeshWorkload<shared_variables_t>, CachedProgram<shared_variables_t>>;
+    using CachedObject = std::variant<
+        CachedMeshWorkload<shared_variables_t>,
+        CachedProgram<shared_variables_t>,
+        CachedProgramRef<shared_variables_t>>;
     CachedObject cached_object_;
     // Helper to retrieve the first program from a mesh workload
     static tt::tt_metal::Program& get_first_program(CachedMeshWorkload<shared_variables_t>& cached_mesh_workload) {
@@ -49,6 +67,15 @@ private:
         auto& first_program_pair = *programs.begin();
         return first_program_pair.second;
     }
+    static shared_variables_t& get_first_shared_variables(
+        CachedMeshWorkload<shared_variables_t>& cached_mesh_workload) {
+        // Get the first shared variables from the map
+        // careful, this is an unordered map so the "first" element is arbitrary
+        auto& map = cached_mesh_workload.coordinate_range_to_shared_variables;
+        TT_FATAL(!map.empty(), "Shared variables map is empty");
+        auto& first_shared_variables_pair = *map.begin();
+        return first_shared_variables_pair.second;
+    }
 
 public:
     // These are references to the original objects
@@ -60,27 +87,44 @@ public:
         cached_object_(std::move(cached_program)),
         program(std::get<CachedProgram<shared_variables_t>>(cached_object_).program),
         shared_variables(std::get<CachedProgram<shared_variables_t>>(cached_object_).shared_variables) {}
+    ProgramAdapter(CachedProgramRef<shared_variables_t>&& cached_program_ref) :
+        cached_object_(std::move(cached_program_ref)),
+        program(std::get<CachedProgramRef<shared_variables_t>>(cached_object_).program),
+        shared_variables(std::get<CachedProgramRef<shared_variables_t>>(cached_object_).shared_variables) {}
 
-    // Constructor for Program and shared variables
+    // Constructor for CachedProgram, CachedProgramRef, and CachedMeshWorkload
     ProgramAdapter(tt::tt_metal::Program&& program, shared_variables_t&& shared_vars) :
         ProgramAdapter(CachedProgram<shared_variables_t>{std::move(program), std::move(shared_vars)}) {}
-
-    // Constructor for CachedMeshWorkload
+    ProgramAdapter(tt::tt_metal::Program& program, shared_variables_t& shared_vars) :
+        ProgramAdapter(CachedProgramRef<shared_variables_t>{program, shared_vars}) {}
     ProgramAdapter(CachedMeshWorkload<shared_variables_t>&& cached_mesh_workload) :
         cached_object_(std::move(cached_mesh_workload)),
         program(get_first_program(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_))),
-        shared_variables(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_).shared_variables) {}
+        shared_variables(get_first_shared_variables(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_))) {
+    }
 
     ProgramAdapter(ProgramAdapter&& other) noexcept :
         cached_object_{std::move(other.cached_object_)},
-        program{
-            (cached_object_.index() == 0)
-                ? get_first_program(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_))
-                : std::get<CachedProgram<shared_variables_t>>(cached_object_).program},
-        shared_variables{
-            (cached_object_.index() == 0)
-                ? std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_).shared_variables
-                : std::get<CachedProgram<shared_variables_t>>(cached_object_).shared_variables} {}
+        program{[&]() -> tt::tt_metal::Program& {
+            const size_t idx = cached_object_.index();
+            if (idx == 0) {
+                return get_first_program(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_));
+            } else if (idx == 1) {
+                return std::get<CachedProgram<shared_variables_t>>(cached_object_).program;
+            } else {
+                return std::get<CachedProgramRef<shared_variables_t>>(cached_object_).program;
+            }
+        }()},
+        shared_variables{[&]() -> shared_variables_t& {
+            const size_t idx = cached_object_.index();
+            if (idx == 0) {
+                return get_first_shared_variables(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_));
+            } else if (idx == 1) {
+                return std::get<CachedProgram<shared_variables_t>>(cached_object_).shared_variables;
+            } else {
+                return std::get<CachedProgramRef<shared_variables_t>>(cached_object_).shared_variables;
+            }
+        }()} {}
 
     // Get the CachedMeshWorkload (throws if not a mesh workload)
     CachedMeshWorkload<shared_variables_t>& get_cached_mesh_workload() {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -152,6 +152,7 @@ MeshDevice::MeshDevice(
     view_(std::move(mesh_device_view)),
     mesh_id_(generate_unique_mesh_id()),
     parent_mesh_(std::move(parent_mesh)),
+    program_cache_(std::make_unique<program_cache::detail::ProgramCache>()),
     dispatch_thread_pool_(create_default_thread_pool(scoped_devices_->root_devices())),
     reader_thread_pool_(create_default_thread_pool(scoped_devices_->root_devices(), view_->shape().mesh_size())) {}
 
@@ -449,25 +450,11 @@ void MeshDevice::enable_async(bool enable) {
     */
 }
 
-void MeshDevice::enable_program_cache() {
-    for (auto device : this->get_devices()) {
-        device->enable_program_cache();
-    }
-}
+void MeshDevice::enable_program_cache() { program_cache_->enable(); }
 
-void MeshDevice::disable_and_clear_program_cache() {
-    for (auto device : this->get_devices()) {
-        device->disable_and_clear_program_cache();
-    }
-}
+void MeshDevice::disable_and_clear_program_cache() { program_cache_->clear(); }
 
-size_t MeshDevice::num_program_cache_entries() {
-    size_t total_entries = 0;
-    for (auto device : this->get_devices()) {
-        total_entries += device->num_program_cache_entries();
-    }
-    return total_entries;
-}
+size_t MeshDevice::num_program_cache_entries() { return program_cache_->num_entries(); }
 
 SubDeviceManagerId MeshDevice::create_sub_device_manager(
     tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
@@ -779,7 +766,7 @@ void MeshDevice::push_work(std::function<void()> work, bool blocking) {
     std::lock_guard lock(push_work_mutex_);
     work();
 }
-program_cache::detail::ProgramCache& MeshDevice::get_program_cache() { return reference_device()->get_program_cache(); }
+program_cache::detail::ProgramCache& MeshDevice::get_program_cache() { return *program_cache_; }
 HalProgrammableCoreType MeshDevice::get_programmable_core_type(CoreCoord virtual_core) const { return reference_device()->get_programmable_core_type(virtual_core); }
 std::vector<std::pair<transfer_info_cores, uint32_t>> MeshDevice::extract_dst_noc_multicast_info(
     const std::vector<CoreRange>& ranges, const CoreType core_type) {

--- a/ttnn/cpp/ttnn/attribute_customizer_helpers.hpp
+++ b/ttnn/cpp/ttnn/attribute_customizer_helpers.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include "ttnn/mesh_device_operation_adapter.hpp"
+
+namespace ttnn {
+
+/**
+ * RAII wrapper for attribute customizers that automatically resets the customizer when it goes out of scope.
+ * This makes it easy to apply a dynamic customizer for a specific scope without worrying about cleanup.
+ *
+ * @tparam MeshDeviceOpT The mesh device operation type that will use the customizer
+ * @tparam AttributeType The attribute type being customized
+ */
+template <typename MeshDeviceOpT, typename AttributeType>
+class ScopedAttributeCustomizer {
+public:
+    /**
+     * Creates a scoped attribute customizer from any callable that satisfies the AttributeCustomizerCallable concept.
+     *
+     * @tparam F The callable type (typically a lambda)
+     * @param func The customization function
+     */
+    template <AttributeCustomizerCallable<AttributeType> F>
+    ScopedAttributeCustomizer(F&& func) {
+        MeshDeviceOpT::set_attribute_customizer(make_attribute_customizer<AttributeType>(std::forward<F>(func)));
+    }
+
+    /**
+     * Creates a scoped attribute customizer from an existing customizer instance.
+     *
+     * @param customizer A shared pointer to an AttributeCustomizerBase
+     */
+    ScopedAttributeCustomizer(std::shared_ptr<AttributeCustomizerBase<AttributeType>> customizer) {
+        MeshDeviceOpT::set_attribute_customizer(std::move(customizer));
+    }
+
+    /**
+     * Destructor - automatically resets the customizer when the object goes out of scope.
+     */
+    ~ScopedAttributeCustomizer() { MeshDeviceOpT::reset_attribute_customizer(); }
+
+    // Prevent copying and moving
+    ScopedAttributeCustomizer(const ScopedAttributeCustomizer&) = delete;
+    ScopedAttributeCustomizer& operator=(const ScopedAttributeCustomizer&) = delete;
+    ScopedAttributeCustomizer(ScopedAttributeCustomizer&&) = delete;
+    ScopedAttributeCustomizer& operator=(ScopedAttributeCustomizer&&) = delete;
+};
+
+/**
+ * Helper function that creates a scoped attribute customizer with a simpler interface.
+ * The customizer is automatically cleaned up when it goes out of scope.
+ *
+ * @tparam OperationType The operation to apply the customizer to
+ * @tparam F Type of the customizer function (automatically deduced)
+ * @param func The customizer function that modifies attributes per device
+ * @return A scoped guard that applies and cleans up the customizer
+ */
+template <typename OperationType, typename F>
+    requires AttributeCustomizerCallable<F, typename OperationType::operation_attributes_t>
+[[nodiscard]] auto with_customizer(F&& func) {
+    using attribute_type = typename OperationType::operation_attributes_t;
+    return ScopedAttributeCustomizer<OperationType, attribute_type>(std::forward<F>(func));
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -7,19 +7,19 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"  // TTNN_TENSOR_PRINT_PROFILE
 #include "ttnn/tensor/types.hpp"
-#include "ttnn/operation.hpp"
 #include "ttnn/config.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn {
 
-using tt::tt_metal::operation::OptionalConstTensors;
-using tt::tt_metal::operation::OptionalTensors;
-using tt::tt_metal::operation::Tensors;
+using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
+using OptionalTensors = std::vector<std::optional<Tensor>>;
+using Tensors = std::vector<Tensor>;
 
 using tt::tt_metal::is_tensor_on_device;
 using tt::tt_metal::is_tensor_on_device_or_multidevice;

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -576,6 +576,14 @@ void launch_on_mesh_device(
     }
 }
 
+/**
+ * @brief Concept that defines a device operation that has a mesh device adapter.
+ *
+ * This concept requires that the type satisfies both the DeviceOperationConcept
+ * and the MeshDeviceOperationAdapterType concept. It represents operations that
+ * can be executed across multiple devices in a mesh configuration using the
+ * adapter pattern.
+ */
 template <typename device_operation_t>
 concept DeviceOperationWithMeshDeviceAdapter =
     DeviceOperationConcept<device_operation_t> && MeshDeviceOperationAdapterType<device_operation_t>;
@@ -780,7 +788,7 @@ typename device_operation_t::tensor_return_value_t launch_on_single_device(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
 
-    // Automatically use mesh adapter version if not already an adapter
+    // TODO(jchu): Revisit whether we should automatically use mesh adapter version if not already an adapter
     /*
     if constexpr (!is_mesh_device_operation_adapter<device_operation_t>::value) {
         using MeshCompatibleOp = MeshDeviceOperationAdapter<device_operation_t>;

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -6,6 +6,7 @@
 
 #include <concepts>
 #include <optional>
+#include <random>
 #include "ttnn/tensor/tensor.hpp"
 
 #include <tt-metalium/program_cache.hpp>
@@ -17,6 +18,7 @@
 #include "ttnn/distributed/api.hpp"
 #include <tt-metalium/distributed.hpp>
 #include "tools/profiler/op_profiler.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
 
 namespace ttnn {
 
@@ -207,16 +209,20 @@ inline auto& create_or_get_meshworkload_from_cache(
                 auto mesh_workload = tt::tt_metal::distributed::CreateMeshWorkload();
 
                 // Move the program from the cached_program into the mesh workload
+                auto coordinate_range = tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape());
                 tt::tt_metal::distributed::AddProgramToMeshWorkload(
                     mesh_workload,
                     std::move(cached_program.program),  // Move the program
-                    tt::tt_metal::distributed::MeshCoordinateRange(
-                        {0, 0}, {mesh_device->num_rows() - 1, mesh_device->num_cols() - 1}));
+                    coordinate_range);
 
                 // Create a cached mesh workload with the mesh workload and shared variables
+                std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, typename program_factory_t::shared_variables_t>
+                    coordinate_range_to_shared_variables;
+                coordinate_range_to_shared_variables[coordinate_range] = std::move(cached_program.shared_variables);
+
                 auto cached_mesh_workload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<
                     typename program_factory_t::shared_variables_t>(
-                    std::move(mesh_workload), std::move(cached_program.shared_variables));
+                    std::move(mesh_workload), std::move(coordinate_range_to_shared_variables));
 
                 // Create a program adapter to wrap the cached mesh workload
                 tt::tt_metal::program_cache::detail::ProgramAdapter<typename program_factory_t::shared_variables_t>
@@ -270,9 +276,11 @@ inline auto& create_or_get_meshworkload_from_cache(
                 program_factory_t::override_runtime_arguments(
                     adapter, operation_attributes, tensor_args, tensor_return_value);
 
-                adapter.program.set_runtime_id(device_operation_id);
-
-                tt::tt_metal::GraphTracker::instance().track_program(&adapter.program, mesh_device);
+                // Set runtime ID for all programs
+                for (auto& [_, program] : adapter.get_cached_mesh_workload().workload.get_programs()) {
+                    program.set_runtime_id(device_operation_id);
+                    tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
+                }
 
                 // Return the mesh workload from the cached factory
                 return adapter.get_cached_mesh_workload().workload;
@@ -355,7 +363,13 @@ inline void log_operation(
 
 
 template <DeviceOperationConcept device_operation_t>
-void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& operation_attributes, const auto& tensor_args, auto &tensor_return_value, auto& device) {
+void launch_on_worker_thread(
+    ttnn::QueueId cq_id,
+    uint64_t device_operation_id,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    typename device_operation_t::tensor_return_value_t& tensor_return_value,
+    tt::tt_metal::IDevice* device) {
     ZoneScopedN("TT_DNN_DEVICE_OP");
 
     if constexpr (HasSkipLaunch<device_operation_t>) {
@@ -460,12 +474,12 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
 
 template <DeviceOperationConcept device_operation_t>
 void launch_on_mesh_device(
-    auto cq_id,
-    auto device_operation_id,
-    const auto& operation_attributes,
-    const auto& tensor_args,
-    auto& tensor_return_value,
-    auto& device) {
+    ttnn::QueueId cq_id,
+    uint64_t device_operation_id,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    typename device_operation_t::tensor_return_value_t& tensor_return_value,
+    tt::tt_metal::distributed::MeshDevice* device) {
     ZoneScopedN("TT_DNN_DEVICE_OP");
 
     if constexpr (HasSkipLaunch<device_operation_t>) {
@@ -544,14 +558,11 @@ void launch_on_mesh_device(
         if (tt::tt_metal::GraphTracker::instance().hook_program(program.get())) {
             return;
         }
-        auto mesh_device = dynamic_cast<tt::tt_metal::distributed::MeshDevice*>(device);
-        TT_FATAL(mesh_device != nullptr, "Device is not a MeshDevice");
-        auto mesh_workload = tt::tt_metal::distributed::CreateMeshWorkload();
-        tt::tt_metal::distributed::AddProgramToMeshWorkload(
-            mesh_workload,
-            std::move(*program),
-            tt::tt_metal::distributed::MeshCoordinateRange(
-                {0, 0}, {mesh_device->num_rows() - 1, mesh_device->num_cols() - 1}));
+        auto mesh_workload = tt::tt_metal::distributed::MeshWorkload();
+        mesh_workload.add_program(
+            tt::tt_metal::distributed::MeshCoordinateRange(device->shape()),
+            std::move(*program));
+
         enqueue_mesh_workload(mesh_workload);
 
         TracyOpTTNNDevice(
@@ -565,11 +576,218 @@ void launch_on_mesh_device(
     }
 }
 
+template <typename device_operation_t>
+concept DeviceOperationWithMeshDeviceAdapter =
+    DeviceOperationConcept<device_operation_t> && MeshDeviceOperationAdapterType<device_operation_t>;
+
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void handle_mesh_adapter_cache_hit(
+    uint64_t device_operation_id,
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
+    tt::stl::hash::hash_t program_hash) {
+    ZoneScopedN("MeshDeviceAdapter Cache Hit");
+    mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+
+    auto& cached_program_factory = program_cache.get(program_hash);
+    auto program_factory_index = cached_program_factory.program_factory_index;
+
+    using program_factory_variant_t =
+        decltype(mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
+    auto program_factory = map_index_to_variant(program_factory_index, program_factory_variant_t{});
+
+    std::visit([&](auto&& concrete_factory) {
+        using concrete_factory_t = std::decay_t<decltype(concrete_factory)>;
+        using shared_variables_t = typename concrete_factory_t::shared_variables_t;
+
+        // Get the adapter from cache with the correct shared variables type
+        auto& adapter = cached_program_factory.cached_program.template get<
+            tt::tt_metal::program_cache::detail::ProgramAdapter<shared_variables_t>>();
+
+        // Override runtime arguments using the MeshDeviceOperationAdapter interface
+        mesh_device_operation_t::override_mesh_runtime_arguments(
+            adapter.get_cached_mesh_workload(),
+            mesh_device,
+            operation_attributes,
+            tensor_args,
+            tensor_return_value);
+
+        // Set runtime ID for all programs
+        for (auto& [_, program] : adapter.get_cached_mesh_workload().workload.get_programs()) {
+            program.set_runtime_id(device_operation_id);
+            tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
+            if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
+                return;
+            }
+        }
+
+        tt::tt_metal::distributed::EnqueueMeshWorkload(
+            mesh_device->mesh_command_queue(), adapter.get_cached_mesh_workload().workload, false);
+
+        if (!adapter.get_cached_mesh_workload().workload.get_programs().empty()) {
+            const auto& first_program = adapter.get_cached_mesh_workload().workload.get_programs().begin()->second;
+            TracyOpTTNNDevice(
+                mesh_device_operation_t{},
+                device_operation_id,
+                mesh_device->id(),
+                first_program,
+                operation_attributes,
+                tensor_args,
+                tensor_return_value);
+        }
+    }, program_factory);
+}
+
+// Helper for creating and caching a mesh workload
+template <DeviceOperationConcept mesh_device_operation_t>
+void create_and_cache_mesh_workload(
+    uint64_t device_operation_id,
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
+    tt::stl::hash::hash_t program_hash) {
+
+    ZoneScopedN("MeshDeviceAdapter Cache Miss");
+
+    mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+
+    auto cached_workload = mesh_device_operation_t::create_mesh_workload(
+        mesh_device,operation_attributes, tensor_args, tensor_return_value);
+
+    // Set runtime ID for all programs
+    for (auto& [_, program] : cached_workload.workload.get_programs()) {
+        program.set_runtime_id(device_operation_id);
+        tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
+        if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
+            return;
+        }
+    }
+
+    if (program_cache.is_enabled()) {
+        auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
+        auto program_factory_index = program_factory.index();
+
+        std::visit([&](auto&& concrete_factory) {
+            using concrete_factory_t = std::decay_t<decltype(concrete_factory)>;
+            using concrete_shared_vars_t = typename concrete_factory_t::shared_variables_t;
+
+            using namespace tt::tt_metal::program_cache::detail;
+            auto cmw = CachedMeshWorkload<concrete_shared_vars_t>(
+                std::move(cached_workload.workload),
+                std::move(cached_workload.coordinate_range_to_shared_variables));
+
+            ProgramAdapter<concrete_shared_vars_t> adapter(std::move(cmw));
+
+            program_cache.insert(
+                program_hash,
+                CachedProgramFactory{std::move(adapter), program_factory_index});
+
+            auto& cached_program_factory = program_cache.get(program_hash);
+            auto& cached_adapter = cached_program_factory.cached_program.template get<
+                tt::tt_metal::program_cache::detail::ProgramAdapter<concrete_shared_vars_t>>();
+
+            // Enqueue the workload
+            tt::tt_metal::distributed::EnqueueMeshWorkload(
+                mesh_device->mesh_command_queue(), cached_adapter.get_cached_mesh_workload().workload, false);
+
+            // Log the first program for profiling
+            const auto& programs = cached_adapter.get_cached_mesh_workload().workload.get_programs();
+            if (!programs.empty()) {
+                const auto& first_program = programs.begin()->second;
+                TracyOpTTNNDevice(
+                    mesh_device_operation_t{},
+                    device_operation_id,
+                    mesh_device->id(),
+                    first_program,
+                    operation_attributes,
+                    tensor_args,
+                    tensor_return_value);
+            }
+        }, program_factory);
+    } else {
+        // Enqueue the workload directly (no caching)
+        tt::tt_metal::distributed::EnqueueMeshWorkload(
+            mesh_device->mesh_command_queue(), cached_workload.workload, false);
+
+        // Log the first program for profiling
+        if (!cached_workload.workload.get_programs().empty()) {
+            const auto& first_program = cached_workload.workload.get_programs().begin()->second;
+            TracyOpTTNNDevice(
+                mesh_device_operation_t{},
+                device_operation_id,
+                mesh_device->id(),
+                first_program,
+                operation_attributes,
+                tensor_args,
+                tensor_return_value);
+        }
+    }
+}
+
+// Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void launch_operation_with_adapter(
+    QueueId cq_id,
+    uint64_t device_operation_id,
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    ZoneScopedN("Launch With MeshDeviceAdapter");
+
+    // Skip if operation should be skipped
+    if constexpr (HasSkipLaunch<mesh_device_operation_t>) {
+        if (mesh_device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)) {
+            return;
+        }
+    }
+
+    auto& program_cache = mesh_device->get_program_cache();
+    auto program_hash = 0;
+    bool program_cache_hit = false;
+
+    auto is_program_cache_enabled = program_cache.is_enabled();
+    if (is_program_cache_enabled) {
+        // Use device_operation's compute_program_hash if available
+        program_hash = mesh_device_operation_t::compute_mesh_workload_hash(mesh_device, operation_attributes, tensor_args);
+        program_cache_hit = program_cache.contains(program_hash);
+    }
+
+    log_operation<mesh_device_operation_t>(
+        device_operation_id, mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
+
+    tt::stl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
+
+    if (program_cache_hit) {
+        handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
+            device_operation_id, operation_attributes, tensor_args, tensor_return_value,
+            mesh_device, program_cache, program_hash);
+    } else {
+        create_and_cache_mesh_workload<mesh_device_operation_t>(
+            device_operation_id, operation_attributes, tensor_args, tensor_return_value,
+            mesh_device, program_cache, program_hash);
+    }
+}
+
 template <DeviceOperationConcept device_operation_t>
 typename device_operation_t::tensor_return_value_t launch_on_single_device(
     QueueId cq_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
+
+    // Automatically use mesh adapter version if not already an adapter
+    /*
+    if constexpr (!is_mesh_device_operation_adapter<device_operation_t>::value) {
+        using MeshCompatibleOp = MeshDeviceOperationAdapter<device_operation_t>;
+        return launch_on_single_device<MeshCompatibleOp>(cq_id, operation_attributes, tensor_args);
+    }
+    */
+
     ZoneScopedN("Launch Device Operation");
     auto device_operation_id = ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id();
 
@@ -577,9 +795,13 @@ typename device_operation_t::tensor_return_value_t launch_on_single_device(
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);
     auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     if (auto mesh_device = first_tensor.mesh_device(); mesh_device != nullptr) {
-        auto& cq = mesh_device->mesh_command_queue();
-        launch_on_mesh_device<device_operation_t>(
-            cq_id, device_operation_id, operation_attributes, tensor_args, tensor_return_value, mesh_device);
+        if constexpr (MeshDeviceOperationAdapterType<device_operation_t>) {
+            launch_operation_with_adapter<device_operation_t>(
+                cq_id, device_operation_id, operation_attributes, tensor_args, tensor_return_value, mesh_device);
+        } else {
+            launch_on_mesh_device<device_operation_t>(
+                cq_id, device_operation_id, operation_attributes, tensor_args, tensor_return_value, mesh_device);
+        }
     } else {
         auto device = first_tensor.device();
         launch_on_worker_thread<device_operation_t>(
@@ -606,16 +828,13 @@ typename device_operation_t::tensor_return_value_t invoke(
     auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     const auto& storage = first_tensor.get_storage();
 
-    auto tensor_return_value = std::visit(
-        [&cq_id, &operation_attributes, &tensor_args](auto&& storage) -> tensor_return_value_t {
-            using storage_t = std::remove_cvref_t<decltype(storage)>;
-            if constexpr (std::is_same_v<storage_t, tt::tt_metal::DeviceStorage>) {
-                return detail::launch_on_single_device<device_operation_t>(cq_id, operation_attributes, tensor_args);
-            } else {
-                TT_THROW("Unsupported storage type");
-            }
-        },
-        storage);
+    tensor_return_value_t tensor_return_value;
+
+    if (std::holds_alternative<tt::tt_metal::DeviceStorage>(storage)) {
+        tensor_return_value = detail::launch_on_single_device<device_operation_t>(cq_id, operation_attributes, tensor_args);
+    } else {
+        TT_THROW("Unsupported storage type");
+    }
 
     // Should every output tensor be tracked?
     /*

--- a/ttnn/cpp/ttnn/device_operation_helper.hpp
+++ b/ttnn/cpp/ttnn/device_operation_helper.hpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <unordered_map>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/program_cache.hpp>
+
+namespace ttnn::device_operation {
+
+template <typename T>
+using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<T>;
+
+// This class is used to encapsulate default behavior for mesh device operations.
+class MeshDeviceOperationHelper {
+private:
+    // Apply override_runtime_arguments in a uniform way across different program factory interfaces because
+    // we have many different program factory interfaces we're currently supporting.
+    template <typename ProgramFactoryT, typename AttributesT, typename TensorArgsT, typename ReturnValueT>
+    static void apply_override_runtime_arguments(
+        ProgramFactoryT& factory,
+        tt::tt_metal::Program& program,
+        typename ProgramFactoryT::shared_variables_t& shared_vars,
+        const AttributesT& attrs,
+        const TensorArgsT& tensor_args,
+        ReturnValueT& return_value) {
+        if constexpr (requires {
+                          typename ProgramFactoryT::cached_program_t;
+                          factory.override_runtime_arguments(
+                              std::declval<typename ProgramFactoryT::cached_program_t&>(),
+                              attrs,
+                              tensor_args,
+                              return_value);
+                      }) {
+            typename ProgramFactoryT::cached_program_t cached_program{program, shared_vars};
+            factory.override_runtime_arguments(cached_program, attrs, tensor_args, return_value);
+        } else {
+            factory.override_runtime_arguments(program, shared_vars, attrs, tensor_args, return_value);
+        }
+    }
+
+public:
+    template <typename ProgramFactoryT, typename AttributesT, typename TensorArgsT, typename ReturnValueT>
+    static ttnn::device_operation::CachedMeshWorkload<typename ProgramFactoryT::shared_variables_t>
+    create_mesh_workload(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const AttributesT& attrs,
+        const TensorArgsT& tensor_args,
+        ReturnValueT& tensor_return_value,
+        std::function<AttributesT(
+            const AttributesT&,
+            const tt::tt_metal::distributed::MeshCoordinate&,
+            tt::tt_metal::distributed::MeshDevice*)> per_device_attribute_customizer = nullptr) {
+        using shared_vars_t = typename ProgramFactoryT::shared_variables_t;
+        auto mesh_workload = tt::tt_metal::distributed::CreateMeshWorkload();
+        ProgramFactoryT program_factory;
+
+        std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_vars_t>
+            coordinate_range_to_shared_variables;
+
+        if (per_device_attribute_customizer) {
+            // Create separate programs for each device with customized attributes
+            for (auto coordinate : tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape())) {
+                auto device_attrs = per_device_attribute_customizer(attrs, coordinate, mesh_device);
+                auto cached_program = program_factory.create(device_attrs, tensor_args, tensor_return_value);
+                auto coordinate_range = tt::tt_metal::distributed::MeshCoordinateRange(coordinate, coordinate);
+                mesh_workload.add_program(coordinate_range, std::move(cached_program.program));
+                coordinate_range_to_shared_variables[coordinate_range] = std::move(cached_program.shared_variables);
+            }
+        } else {
+            // Create a single program for all devices
+            auto cached_program = program_factory.create(attrs, tensor_args, tensor_return_value);
+
+            auto coordinate_range = tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape());
+            mesh_workload.add_program(coordinate_range, std::move(cached_program.program));
+            coordinate_range_to_shared_variables[coordinate_range] = std::move(cached_program.shared_variables);
+        }
+
+        return ttnn::device_operation::CachedMeshWorkload<shared_vars_t>{
+            std::move(mesh_workload), std::move(coordinate_range_to_shared_variables)};
+    }
+
+    template <typename ProgramFactoryT, typename AttributesT, typename TensorArgsT>
+    static tt::stl::hash::hash_t compute_mesh_workload_hash(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const AttributesT& attrs,
+        const TensorArgsT& tensor_args,
+        std::function<AttributesT(
+            const AttributesT&,
+            const tt::tt_metal::distributed::MeshCoordinate&,
+            tt::tt_metal::distributed::MeshDevice*)> attribute_customizer = nullptr) {
+        ProgramFactoryT program_factory;
+
+        auto hash = tt::stl::hash::hash_objects_with_default_seed(
+            tt::stl::hash::type_hash<ProgramFactoryT>, attrs, tensor_args);
+
+        if (attribute_customizer) {
+            for (auto coordinate : tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape())) {
+                auto device_attrs = attribute_customizer(attrs, coordinate, mesh_device);
+                tt::utils::hash_combine(
+                    hash,
+                    tt::stl::hash::hash_objects_with_default_seed(tt::stl::hash::type_hash<AttributesT>, device_attrs));
+            }
+        }
+
+        return hash;
+    }
+
+    template <typename ProgramFactoryT, typename AttributesT, typename TensorArgsT, typename ReturnValueT>
+    static void override_mesh_runtime_arguments(
+        ttnn::device_operation::CachedMeshWorkload<typename ProgramFactoryT::shared_variables_t>& cached_workload,
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const AttributesT& attrs,
+        const TensorArgsT& tensor_args,
+        ReturnValueT& tensor_return_value,
+        std::function<AttributesT(
+            const AttributesT&,
+            const tt::tt_metal::distributed::MeshCoordinate&,
+            tt::tt_metal::distributed::MeshDevice*)> attribute_customizer = nullptr) {
+        ProgramFactoryT program_factory;
+
+        for (auto& [coordinate_range, shared_variables] : cached_workload.coordinate_range_to_shared_variables) {
+            auto& mesh_workload = cached_workload.workload;
+            auto& program = mesh_workload.get_program(coordinate_range);
+
+            if (attribute_customizer) {
+                for (auto coordinate : coordinate_range) {
+                    auto device_attrs = attribute_customizer(attrs, coordinate, mesh_device);
+
+                    apply_override_runtime_arguments(
+                        program_factory, program, shared_variables, device_attrs, tensor_args, tensor_return_value);
+                }
+            } else {
+                apply_override_runtime_arguments(
+                    program_factory, program, shared_variables, attrs, tensor_args, tensor_return_value);
+            }
+        }
+    }
+};
+
+}  // namespace ttnn::device_operation

--- a/ttnn/cpp/ttnn/device_operation_helper.hpp
+++ b/ttnn/cpp/ttnn/device_operation_helper.hpp
@@ -96,9 +96,8 @@ public:
             tt::tt_metal::distributed::MeshDevice*)> attribute_customizer = nullptr) {
         ProgramFactoryT program_factory;
 
-        for (auto& [coordinate_range, shared_variables] : cached_workload.coordinate_range_to_shared_variables) {
-            auto& mesh_workload = cached_workload.workload;
-            auto& program = mesh_workload.get_program(coordinate_range);
+        for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+            auto& shared_variables = cached_workload.coordinate_range_to_shared_variables[coordinate_range];
 
             if (attribute_customizer) {
                 for (auto coordinate : coordinate_range) {

--- a/ttnn/cpp/ttnn/device_operation_helper.hpp
+++ b/ttnn/cpp/ttnn/device_operation_helper.hpp
@@ -83,32 +83,6 @@ public:
             std::move(mesh_workload), std::move(coordinate_range_to_shared_variables)};
     }
 
-    template <typename ProgramFactoryT, typename AttributesT, typename TensorArgsT>
-    static tt::stl::hash::hash_t compute_mesh_workload_hash(
-        tt::tt_metal::distributed::MeshDevice* mesh_device,
-        const AttributesT& attrs,
-        const TensorArgsT& tensor_args,
-        std::function<AttributesT(
-            const AttributesT&,
-            const tt::tt_metal::distributed::MeshCoordinate&,
-            tt::tt_metal::distributed::MeshDevice*)> attribute_customizer = nullptr) {
-        ProgramFactoryT program_factory;
-
-        auto hash = tt::stl::hash::hash_objects_with_default_seed(
-            tt::stl::hash::type_hash<ProgramFactoryT>, attrs, tensor_args);
-
-        if (attribute_customizer) {
-            for (auto coordinate : tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape())) {
-                auto device_attrs = attribute_customizer(attrs, coordinate, mesh_device);
-                tt::utils::hash_combine(
-                    hash,
-                    tt::stl::hash::hash_objects_with_default_seed(tt::stl::hash::type_hash<AttributesT>, device_attrs));
-            }
-        }
-
-        return hash;
-    }
-
     template <typename ProgramFactoryT, typename AttributesT, typename TensorArgsT, typename ReturnValueT>
     static void override_mesh_runtime_arguments(
         ttnn::device_operation::CachedMeshWorkload<typename ProgramFactoryT::shared_variables_t>& cached_workload,

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <functional>
+#include <tt-metalium/program_cache.hpp>
+#include "ttnn/device_operation_helper.hpp"
+
+namespace ttnn {
+
+template <typename AttributeType>
+struct AttributeCustomizerBase {
+    virtual ~AttributeCustomizerBase() = default;
+    virtual AttributeType customize(
+        const AttributeType& attrs,
+        const tt::tt_metal::distributed::MeshCoordinate& coordinate,
+        tt::tt_metal::distributed::MeshDevice* mesh_device) const = 0;
+};
+
+/**
+ * A generic adapter that adds mesh device capabilities to any existing device operation.
+ * This adapter delegates to the base operation for standard functionality while providing
+ * default implementations for mesh-specific operations.
+ *
+ * Usage:
+ * 1. From an existing device operation, derive a new operation that uses this adapter
+ * 2. The operation will now work correctly on mesh devices without additional code
+ * 3. (Optional) Provide a custom attribute customizer to the adapter by specifying it as the CustomizerType:
+ *    e.g., using MyMeshOperation = MeshDeviceOperationAdapter<MyDeviceOperation, MyCustomizer>;
+ *    This will be used to customize the attributes for each device in the mesh, which in turn allows
+ *    different programs per-device in the mesh.
+ */
+template <typename DeviceOperation, typename CustomizerType = void>
+struct MeshDeviceOperationAdapter {
+    // Add type aliases to identify the template parameters
+    using device_operation_t = DeviceOperation;
+    using attribute_customizer_t = CustomizerType;
+
+    // Inherit all typedefs from base operation
+    using operation_attributes_t = typename DeviceOperation::operation_attributes_t;
+    using tensor_args_t = typename DeviceOperation::tensor_args_t;
+    using spec_return_value_t = typename DeviceOperation::spec_return_value_t;
+    using tensor_return_value_t = typename DeviceOperation::tensor_return_value_t;
+    using program_factory_t = typename DeviceOperation::program_factory_t;
+
+    // Extension point for customizing attribute transformation
+    // Using the base class from device_operation_helper.hpp to avoid circular dependencies
+    using AttributeCustomizer = ttnn::AttributeCustomizerBase<operation_attributes_t>;
+
+    // Delegate to base operation methods
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        return DeviceOperation::select_program_factory(attrs, tensor_args);
+    }
+
+    template <typename... Args>
+    static auto invoke(Args&&... args) {
+        return DeviceOperation::invoke(std::forward<Args>(args)...);
+    }
+
+    static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+    }
+
+    static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+    }
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        return DeviceOperation::compute_output_specs(attrs, tensor_args);
+    }
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        return DeviceOperation::create_output_tensors(attrs, tensor_args);
+    }
+
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
+            return DeviceOperation::compute_program_hash(attrs, tensor_args);
+        } else {
+            return tt::stl::hash::hash_objects_with_default_seed(
+                tt::stl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+        }
+    }
+
+    static auto create_mesh_workload(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {
+        auto customizer_func = create_attribute_customizer_function();
+        auto factory = select_program_factory(attrs, tensor_args);
+
+        return std::visit(
+            [&](auto&& concrete_factory) {
+                using ConcreteFactory = std::decay_t<decltype(concrete_factory)>;
+                using concrete_shared_vars_t = typename ConcreteFactory::shared_variables_t;
+
+                return device_operation::MeshDeviceOperationHelper::create_mesh_workload<ConcreteFactory>(
+                    mesh_device, attrs, tensor_args, tensor_return_value, customizer_func);
+            },
+            factory);
+    }
+
+    template <typename ConcreteWorkload>
+    static void override_mesh_runtime_arguments(
+        ConcreteWorkload& cached_workload,
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {
+        auto customizer_func = create_attribute_customizer_function();
+        auto factory = select_program_factory(attrs, tensor_args);
+
+        std::visit(
+            [&](auto&& concrete_factory) {
+                using ConcreteFactory = std::decay_t<decltype(concrete_factory)>;
+                device_operation::MeshDeviceOperationHelper::override_mesh_runtime_arguments<ConcreteFactory>(
+                    cached_workload, mesh_device, attrs, tensor_args, tensor_return_value, customizer_func);
+            },
+            factory);
+    }
+
+    static tt::stl::hash::hash_t compute_mesh_workload_hash(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args) {
+        auto customizer_func = create_attribute_customizer_function();
+        auto factory = select_program_factory(attrs, tensor_args);
+
+        return std::visit(
+            [&](auto&& concrete_factory) {
+                using ConcreteFactory = std::decay_t<decltype(concrete_factory)>;
+                return device_operation::MeshDeviceOperationHelper::compute_mesh_workload_hash<ConcreteFactory>(
+                    mesh_device, attrs, tensor_args, customizer_func);
+            },
+            factory);
+    }
+
+private:
+    static std::shared_ptr<AttributeCustomizer> get_attribute_customizer() {
+        // Use the CustomizerType if provided, otherwise return nullptr
+        if constexpr (!std::is_same_v<CustomizerType, void>) {
+            // Create a shared pointer of CustomizerType and then cast it to AttributeCustomizer
+            return std::static_pointer_cast<
+                typename MeshDeviceOperationAdapter<DeviceOperation, CustomizerType>::AttributeCustomizer>(
+                std::make_shared<CustomizerType>());
+        }
+        return nullptr;
+    }
+
+    static auto create_attribute_customizer_function() {
+        using customizer_function_t = std::function<operation_attributes_t(
+            const operation_attributes_t&,
+            const tt::tt_metal::distributed::MeshCoordinate&,
+            tt::tt_metal::distributed::MeshDevice*)>;
+
+        customizer_function_t customizer_func;
+        if (auto customizer = get_attribute_customizer()) {
+            customizer_func = [customizer](
+                                  const operation_attributes_t& attrs,
+                                  const tt::tt_metal::distributed::MeshCoordinate& coord,
+                                  tt::tt_metal::distributed::MeshDevice* device) {
+                return customizer->customize(attrs, coord, device);
+            };
+        }
+        return customizer_func;
+    }
+};
+
+template <typename T>
+concept MeshDeviceOperationAdapterType = requires {
+    typename T::device_operation_t;
+    typename T::attribute_customizer_t;
+    typename T::operation_attributes_t;
+    typename T::tensor_args_t;
+    typename T::spec_return_value_t;
+    typename T::tensor_return_value_t;
+    typename T::program_factory_t;
+
+    // Check for the existence of key mesh-related methods
+    requires requires(
+        typename T::operation_attributes_t attrs,
+        typename T::tensor_args_t tensor_args,
+        typename T::tensor_return_value_t tensor_return_value,
+        tt::tt_metal::distributed::MeshDevice* mesh_device) {
+        T::create_mesh_workload(mesh_device, attrs, tensor_args, tensor_return_value);
+        T::compute_mesh_workload_hash(mesh_device, attrs, tensor_args);
+    };
+};
+
+template <typename T>
+struct is_mesh_device_operation_adapter : std::false_type {};
+
+template <typename DeviceOp, typename Customizer>
+struct is_mesh_device_operation_adapter<MeshDeviceOperationAdapter<DeviceOp, Customizer>> : std::true_type {};
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/mesh_execution.hpp
+++ b/ttnn/cpp/ttnn/mesh_execution.hpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/attribute_customizer_helpers.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
+#include "ttnn/decorators.hpp"  // Required for register_mesh_operation
+
+namespace ttnn {
+
+/**
+ * Specialized version for registered operations (like ttnn::prim::dropout).
+ *
+ * This overload accepts operations created with ttnn::register_operation, allowing
+ * direct passing of registered operations without wrapping them in lambdas.
+ *
+ * @tparam OpType The mesh device operation type that will be customized
+ * @tparam F Type of the customizer function (deduced)
+ * @tparam Name Name of the registered operation (deduced)
+ * @tparam RegOp Registered operation type (deduced)
+ * @tparam Args Argument types for the operation (deduced)
+ *
+ * @param customizer_func Function that constructs attributes per device
+ * @param registered_op The registered operation to execute
+ * @param args Arguments to pass to the operation
+ * @return The result of executing the operation
+ */
+template <typename OpType, typename F, reflect::fixed_string Name, typename RegOp, typename... Args>
+auto launch_mesh_workload(
+    F&& customizer_func, const decorators::registered_operation_t<Name, RegOp>& registered_op, Args&&... args)
+    -> decltype(registered_op(std::declval<Args>()...)) {
+    // Adapt the simplified customizer to the full form expected by with_customizer
+    auto adapter = [customizer_func = std::forward<F>(customizer_func)](
+                       const typename OpType::operation_attributes_t& /*attrs*/,
+                       const tt::tt_metal::distributed::MeshCoordinate& coord,
+                       tt::tt_metal::distributed::MeshDevice* device) { return customizer_func(coord, device); };
+
+    // Apply the customizer and execute the operation
+    auto guard = with_customizer<OpType>(std::move(adapter));
+    return registered_op(std::forward<Args>(args)...);
+}
+
+/**
+ * Variant of launch_mesh_workload that accepts a lambda operation instead of a function pointer.
+ *
+ * This version is useful when the operation isn't a direct function call or requires additional setup.
+ *
+ * @tparam OpType The mesh device operation type that will be customized
+ * @tparam F Type of the customizer function (deduced)
+ * @tparam OpLambda Type of the operation lambda (deduced)
+ *
+ * @param customizer_func Function that constructs attributes per device
+ * @param op_lambda Lambda function that executes the operation
+ * @return The result of executing the operation
+ */
+template <typename OpType, typename F, typename OpLambda>
+auto launch_mesh_workload(F&& customizer_func, OpLambda&& op_lambda) -> decltype(op_lambda()) {
+    // Adapt the simplified customizer to the full form expected by with_customizer
+    auto adapter = [customizer_func = std::forward<F>(customizer_func)](
+                       const typename OpType::operation_attributes_t& /*attrs*/,
+                       const tt::tt_metal::distributed::MeshCoordinate& coord,
+                       tt::tt_metal::distributed::MeshDevice* device) { return customizer_func(coord, device); };
+
+    // Apply the customizer and execute the operation
+    auto guard = with_customizer<OpType>(std::move(adapter));
+    return op_lambda();
+}
+
+/**
+ * Registers a device operation and automatically creates a mesh adapter for it.
+ * This is a convenience function that allows registering operations with mesh support
+ * without manually creating the adapter type.
+ *
+ * @tparam Name The fully qualified name for the operation
+ * @tparam DeviceOp The device operation type
+ * @return A registered operation with mesh support
+ */
+template <reflect::fixed_string Name, typename DeviceOp>
+constexpr auto register_mesh_operation() {
+    // Define the mesh-adapted operation type on the fly
+    using MeshOpAdapter = MeshDeviceOperationAdapter<DeviceOp>;
+
+    // Register the operation with the mesh adapter
+    return decorators::register_operation<Name, MeshOpAdapter>();
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -12,14 +12,9 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/mesh_device_operation_adapter.hpp"
+#include "ttnn/mesh_execution.hpp"
 
 #include "dropout_device_operation_types.hpp"
-
-namespace tt::tt_metal::distributed {
-class MeshDevice;
-class MeshCoordinate;
-}  // namespace tt::tt_metal::distributed
 
 namespace ttnn::operations::experimental::dropout {
 
@@ -53,11 +48,9 @@ struct DropoutDeviceOperation {
         const std::optional<Tensor>& preallocated_output = std::nullopt);
 };
 
-struct DropoutMeshDeviceOperation : public ttnn::MeshDeviceOperationAdapter<DropoutDeviceOperation> {};
-
 }  // namespace ttnn::operations::experimental::dropout
 
 namespace ttnn::prim {
 constexpr auto dropout = ttnn::
-    register_operation<"ttnn::prim::dropout", ttnn::operations::experimental::dropout::DropoutMeshDeviceOperation>();
+    register_mesh_operation<"ttnn::prim::dropout", ttnn::operations::experimental::dropout::DropoutDeviceOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -53,25 +53,11 @@ struct DropoutDeviceOperation {
         const std::optional<Tensor>& preallocated_output = std::nullopt);
 };
 
-struct DropoutAttributeCustomizer : public ttnn::AttributeCustomizerBase<operation_attributes_t> {
-    operation_attributes_t customize(
-        const operation_attributes_t& attrs,
-        const tt::tt_metal::distributed::MeshCoordinate& mesh_coordinate,
-        tt::tt_metal::distributed::MeshDevice* mesh_device) const override {
-        auto device_attrs = attrs;
-        device_attrs.seed = attrs.seed + mesh_device->get_device(mesh_coordinate)->id();
-        return device_attrs;
-    }
-};
-struct DropoutMeshDeviceOperation
-    : public ttnn::MeshDeviceOperationAdapter<DropoutDeviceOperation, DropoutAttributeCustomizer> {};
+struct DropoutMeshDeviceOperation : public ttnn::MeshDeviceOperationAdapter<DropoutDeviceOperation> {};
 
 }  // namespace ttnn::operations::experimental::dropout
 
 namespace ttnn::prim {
-constexpr auto dropout =
-    ttnn::register_operation<"ttnn::prim::dropout", ttnn::operations::experimental::dropout::DropoutDeviceOperation>();
-
-constexpr auto mdropout = ttnn::
-    register_operation<"ttnn::prim::mdropout", ttnn::operations::experimental::dropout::DropoutMeshDeviceOperation>();
+constexpr auto dropout = ttnn::
+    register_operation<"ttnn::prim::dropout", ttnn::operations::experimental::dropout::DropoutMeshDeviceOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
@@ -6,24 +6,38 @@
 #include "device/dropout_device_operation.hpp"
 #include "dropout.hpp"
 #include "ttnn/attribute_customizer_helpers.hpp"
+#include "ttnn/mesh_execution.hpp"
 
 namespace ttnn::operations::experimental {
 
 Tensor DropoutOperation::invoke(
     const Tensor& input_tensor, float prob, float scale, uint32_t seed, bool use_per_device_seed) {
-    // Create a scoped customizer that only modifies the seed if use_per_device_seed is true
-    auto customizer_guard = ttnn::with_customizer<dropout::DropoutMeshDeviceOperation>(
-        [use_per_device_seed](const auto& attrs, const auto& coord, auto* device) {
-            if (use_per_device_seed) {
-                auto device_attrs = attrs;
-                device_attrs.seed = attrs.seed + device->get_device(coord)->id();
-                return device_attrs;
-            }
-            return attrs;
-        });
+    // If we don't need per-device seeds, call dropout directly
+    if (!use_per_device_seed) {
+        return ttnn::prim::dropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
+    }
 
-    // Single call path - customizer is only active if use_per_device_seed was true
-    return ttnn::prim::dropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
+    // Get the automatically created mesh operation adapter type
+    using DropoutDeviceOp = dropout::DropoutDeviceOperation;
+    using DropoutOp = ttnn::MeshDeviceOperationAdapter<DropoutDeviceOp>;
+    using DropoutAttrs = typename DropoutOp::operation_attributes_t;
+
+    return ttnn::launch_mesh_workload<DropoutOp>(
+        [seed, prob, scale](const auto& coord, auto* device) -> DropoutAttrs {
+            auto seed_offset = device->get_device(coord)->id();
+            return DropoutAttrs{
+                .output_dtype = DataType::BFLOAT16,
+                .output_memory_config = MemoryConfig{},
+                .seed = seed + seed_offset,
+                .prob = prob,
+                .scale = scale};
+        },
+        ttnn::prim::dropout,
+        input_tensor,
+        prob,
+        scale,
+        seed,
+        DataType::BFLOAT16);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
@@ -9,9 +9,11 @@ namespace ttnn::operations::experimental {
 
 Tensor DropoutOperation::invoke(
     const Tensor& input_tensor, float prob, float scale, uint32_t seed, bool use_per_device_seed) {
-    auto chip_id = static_cast<uint32_t>(input_tensor.device()->id());
-    return ttnn::prim::dropout(
-        input_tensor, prob, scale, use_per_device_seed ? seed + chip_id : seed, DataType::BFLOAT16);
+    if (use_per_device_seed) {
+        return ttnn::prim::mdropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
+    } else {
+        return ttnn::prim::dropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
+    }
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
@@ -5,15 +5,25 @@
 
 #include "device/dropout_device_operation.hpp"
 #include "dropout.hpp"
+#include "ttnn/attribute_customizer_helpers.hpp"
+
 namespace ttnn::operations::experimental {
 
 Tensor DropoutOperation::invoke(
     const Tensor& input_tensor, float prob, float scale, uint32_t seed, bool use_per_device_seed) {
-    if (use_per_device_seed) {
-        return ttnn::prim::mdropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
-    } else {
-        return ttnn::prim::dropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
-    }
+    // Create a scoped customizer that only modifies the seed if use_per_device_seed is true
+    auto customizer_guard = ttnn::with_customizer<dropout::DropoutMeshDeviceOperation>(
+        [use_per_device_seed](const auto& attrs, const auto& coord, auto* device) {
+            if (use_per_device_seed) {
+                auto device_attrs = attrs;
+                device_attrs.seed = attrs.seed + device->get_device(coord)->id();
+                return device_attrs;
+            }
+            return attrs;
+        });
+
+    // Single call path - customizer is only active if use_per_device_seed was true
+    return ttnn::prim::dropout(input_tensor, prob, scale, seed, DataType::BFLOAT16);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -588,8 +588,6 @@ void launch_op_func(
     // Send host side op compile and run to the worker queue
     // Assert to ensure that worker threads are specified.
     ZoneScopedN("LaunchOp");
-    auto& workers = detail::get_workers(output_tensors);
-    std::size_t workers_size = workers.size();
     output_tensors = op_func(input_tensors, optional_input_tensors, optional_output_tensors);
     return;
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
- Previously, the mesh op-dispatch infrastructure only supports having a single program broadcast to every device in the mesh (SPMD). 
- This fails to work in cases where we need different programs per device that needs to get launched as a single MeshWorkload or in cases where we need to send different RTA per device.
- ttnn::dropout operation demonstrates an example where `seed` value config differs across devices.
- Much of program creation relies on`operation_attributes_t`. 

```
        static cached_program_t ProgramFactoryT::create(
            const operation_attributes_t& operation_attributes,
            const tensor_args_t& tensor_args,
            tensor_return_value_t& tensor_return_value);
```
We would like a way to adapt existing `DeviceOperation` to work nicely with `MeshWorkload` and supporting the use-case for having heterogeneous programs in a `MeshWorkload` that we enqueue to the MeshDevice

### What's changed
- Add program-caching at the MeshDevice level instead of deferring to single-device.
- Created `mesh_device_operation_adapter.hpp`,  to provide a generic adapter to take an existing `DeviceOperation` and enhance it into a compatible `MeshDeviceOperation`
- A `MeshDeviceOperation` implements three primary behaviors: `create_mesh_workload`, `compute_mesh_workload_hash` and `override_mesh_runtime_arguments`. The default behavior follows the standard SPMD where we compile a program once and we broadcast it to every device in the mesh.
- Updated dropout operation to demonstrate mesh device operation adapter usage.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes