### PR TITLE
feat: subalpha device op support 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_subalpha.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_subalpha.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+import ttnn
+from models.utility_functions import torch_random
+from functools import partial
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 64, 64])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("alpha", [1.0, 5.0, 10.0])
+def test_device_subalpha_no_bcast(input_shapes, alpha, device):
+    torch.manual_seed(0)
+    in_data1 = (torch.rand(input_shapes, dtype=torch.bfloat16) * 200) - 100
+    in_data2 = (torch.rand(input_shapes, dtype=torch.bfloat16) * 300) - 150
+
+
+    input_tensor_a = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.experimental.subalpha(input_tensor_a, input_tensor_b, alpha)
+
+    golden_function = ttnn.get_golden_function(ttnn.subalpha)
+    golden_tensor = golden_function(in_data1, in_data2, alpha)
+
+    comp_pass = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+    assert comp_pass >= 0.9998

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -372,6 +372,9 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/subalpha/subalpha.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/binary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/kernels/compute/eltwise_subalpha_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/kernels/compute/eltwise_subalpha_no_bcast.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/negative.h"
+
+namespace NAMESPACE {
+void MAIN {
+
+    using namespace ckernel;
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_input_a = tt::CBIndex::c_0;
+    constexpr auto cb_input_b = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;       // cb for output
+    constexpr auto cb_alpha = tt::CBIndex::c_3;     // cb for alpha
+    constexpr auto cb_inter = tt::CBIndex::c_4;     // intermediate cb
+
+    constexpr uint32_t onetile = 1;
+    binary_op_init_common(cb_input_a, cb_inter, cb_out);
+
+    // wait input cb_alpha tile
+    cb_wait_front(cb_alpha, onetile);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        // wait input cb_input_b tile
+        cb_wait_front(cb_input_b, onetile);
+
+        // reserve cb_inter tile
+        cb_reserve_back(cb_inter, onetile);
+
+        mul_tiles_init(cb_input_b, cb_alpha);
+
+        tile_regs_acquire();
+        mul_tiles(cb_input_b, cb_alpha, 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_inter);
+        tile_regs_release();
+
+        cb_pop_front(cb_input_b, onetile);
+        cb_push_back(cb_inter, onetile);
+
+        cb_wait_front(cb_input_a, onetile);
+
+        cb_wait_front(cb_inter, onetile);
+        cb_reserve_back(cb_out, onetile);
+
+        sub_tiles_init(cb_input_a, cb_inter);
+        tile_regs_acquire();
+        sub_tiles(cb_input_a, cb_inter, 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_inter, onetile);
+        cb_pop_front(cb_input_a, onetile);
+    }
+    cb_pop_front(cb_alpha, onetile);
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t packed_scalar = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(4);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(5);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(6);
+    const uint32_t n_stride = get_arg_val<uint32_t>(7);
+    const uint32_t c_stride = get_arg_val<uint32_t>(8);
+    const uint32_t N = get_arg_val<uint32_t>(9);
+    const uint32_t C = get_arg_val<uint32_t>(10);
+    const uint32_t Ht = get_arg_val<uint32_t>(11);
+    const uint32_t Wt = get_arg_val<uint32_t>(12);
+    const uint32_t cND = get_arg_val<uint32_t>(13);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_alpha = tt::CBIndex::c_3;
+
+    constexpr uint32_t onetile = 1;
+    // we only need to fill a tile with the scalar value once
+    cb_reserve_back(cb_id_src_alpha, onetile);
+    #ifdef FILL_WITH_VALUE_FLOAT
+        const auto float_ptr = reinterpret_cast<const float*>(&packed_scalar);
+        FILL_WITH_VALUE_FLOAT(cb_id_src_alpha, *float_ptr);
+    #endif
+    #ifdef FILL_WITH_VALUE
+        FILL_WITH_VALUE(cb_id_src_alpha, packed_scalar);
+    #endif
+        cb_push_back(cb_id_src_alpha, onetile);
+
+    #if SRC_SHARDED
+        cb_reserve_back(cb_id_src, src_num_tiles);
+        cb_push_back(cb_id_src, src_num_tiles);
+    #else
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_depth = N * C * HtWt;
+    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
+    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
+    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
+    uint32_t tiles_per_channel = HtWt;
+    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
+    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
+    uint32_t start_th = start_t / Wt;                          // H index
+    uint32_t start_tw = start_t % Wt;                          // W index
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
+        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th, tile_offset += Wt) {
+                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                         ++tw, ++num_tiles_read) {
+                        cb_reserve_back(cb_id_src, onetile);
+                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_id_src, onetile);
+                    }
+                    if constexpr (!has_sharding) {
+                        // next row of tiles should start at the first column
+                        start_tw = 0;
+                    }
+                }
+                tile_offset += next_channel_shift;
+            }
+            tile_offset += next_batch_shift;
+        }
+        tile_offset += next_depth_shift;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_device_operation.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "subalpha_device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::binary_ng {
+
+namespace utils {
+bool is_binary_sfpu_op(DataType a, DataType b) {
+    using enum DataType;
+    return (a == FLOAT32 && b == FLOAT32);
+}
+}  // namespace utils
+
+tt::stl::hash::hash_t SubalphaNgDeviceOperation::operation_attributes_t::to_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        memory_config,
+        get_dtype(),
+        compute_kernel_config,
+        subtile_broadcast_type,
+        is_sfpu);
+}
+
+DataType SubalphaNgDeviceOperation::operation_attributes_t::get_dtype() const { return this->input_dtype; }
+
+void SubalphaNgDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    // We don't support sharding for now
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    SubalphaNgDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "First operand to eltwise binary must be tilized");
+
+    bool tensor_a_sharded = input_tensor_a.memory_config().is_sharded();
+    if (not tensor_a_sharded) {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "LHS operand must be either sharded or interleaved");
+    }
+
+    bool output_sharded = attributes.memory_config.is_sharded();
+    if (not output_sharded) {
+        TT_FATAL(
+            attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Output must be interleaved or sharded");
+    }
+
+    bool tensor_b_sharded = false;
+    tensor_b_sharded = input_tensor_b.memory_config().is_sharded();
+    TT_FATAL(
+        input_tensor_a.device() == input_tensor_b.device(),
+        "Operands to eltwise binary need to be on the same device!");
+    TT_FATAL(input_tensor_b.get_layout() == Layout::TILE, "Second operand to eltwise binary must be tilized");
+
+    if (not tensor_b_sharded) {
+        TT_FATAL(
+            input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "RHS operand must be either sharded or interleaved");
+    }
+
+    // Validate that all shard specs match
+    if (tensor_a_sharded) {
+        if (tensor_b_sharded) {
+            validate_sharding(
+                input_tensor_a.memory_config().memory_layout,
+                *input_tensor_a.shard_spec(),
+                input_tensor_b.memory_config().memory_layout,
+                *input_tensor_b.shard_spec(),
+                attributes.subtile_broadcast_type);
+        }
+        if (output_sharded) {
+            validate_sharding(
+                input_tensor_a.memory_config().memory_layout,
+                *input_tensor_a.shard_spec(),
+                attributes.memory_config.memory_layout,
+                *attributes.memory_config.shard_spec,
+                attributes.subtile_broadcast_type);
+        }
+    } else if (tensor_b_sharded and output_sharded) {
+        validate_sharding(
+            input_tensor_b.memory_config().memory_layout,
+            *input_tensor_b.shard_spec(),
+            attributes.memory_config.memory_layout,
+            *attributes.memory_config.shard_spec,
+            attributes.subtile_broadcast_type);
+    }
+}
+
+void SubalphaNgDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    bool has_shard_spec = input_tensor_a.memory_config().is_sharded() ||
+                          (input_tensor_b.memory_config().is_sharded()) ||
+                          attributes.memory_config.is_sharded();
+
+    if (output_tensor.has_value() && !has_shard_spec) {
+        compute_output_specs(attributes, tensor_args);
+    }
+
+    const auto& input_shape_a = input_tensor_a.get_logical_shape();
+    const auto input_shape_b = input_tensor_b.get_logical_shape();
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+    for (int i = -1; i >= -larger_rank; --i) {
+        auto a_dim = (i >= -rank_a) ? input_shape_a[i] : 1;
+        auto b_dim = (i >= -rank_b) ? input_shape_b[i] : 1;
+        TT_FATAL(
+            a_dim == b_dim || a_dim == 1 || b_dim == 1,
+            "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
+            i,
+            a_dim,
+            b_dim);
+
+        if (has_shard_spec and i != -1) {
+            TT_FATAL(
+                a_dim == b_dim,
+                "Cannot broadcast sharded tensors on dims other than W, violation for rank {}, dim a: {}, dim b: {}",
+                i,
+                a_dim,
+                b_dim);
+        }
+    }
+}
+
+SubalphaNgDeviceOperation::spec_return_value_t SubalphaNgDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto input_shape_a = input_tensor_a.logical_shape();
+    const auto& tensor_b = tensor_args.input_tensor_b;
+    const auto input_shape_b = tensor_b.logical_shape();
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+
+    // Broadcasting Rules Overview:
+    // - If the two tensors have different ranks, we virtually pad the smaller-rank tensor's shape
+    //   with ones on the left (i.e., higher-order dimensions) until both shapes have the same length.
+    // - For each dimension (starting from the rightmost), the sizes are compatible if:
+    //     - They are equal, or
+    //     - One of them is 1 (the dimension can be broadcast to match the other size).
+    auto compute_broadcasted_output = [rank_a, rank_b, larger_rank](const auto& shape_a, const auto& shape_b) {
+        SmallVector<uint32_t> output_shape(larger_rank, 1);
+        for (int i = -1; i >= -larger_rank; --i) {
+            auto dim_a = (i >= -rank_a) ? shape_a[i] : 1;
+            auto dim_b = (i >= -rank_b) ? shape_b[i] : 1;
+            if (dim_a != 1 && dim_b != 1) {
+                output_shape[i + larger_rank] = dim_a;
+            } else {
+                output_shape[i + larger_rank] = dim_a + dim_b - 1;
+            }
+        }
+        return ttnn::Shape(output_shape);
+    };
+
+    auto output_shape = compute_broadcasted_output(input_shape_a, input_shape_b);
+
+    if (output_tensor.has_value()) {
+        auto shape = output_tensor.value().logical_shape();
+        TT_FATAL(
+            shape == output_shape,
+            "Shape of Output tensor {} provided does not match the broadcasted output shape {}",
+            shape,
+            output_shape);
+        return output_tensor->get_tensor_spec();
+    }
+
+    if (attributes.memory_config.is_sharded()) {
+        return TensorSpec(
+            output_shape, TensorLayout(attributes.get_dtype(), PageConfig(Layout::TILE), attributes.memory_config));
+    }
+
+    return TensorSpec(
+        output_shape, TensorLayout(attributes.get_dtype(), PageConfig(Layout::TILE), attributes.memory_config));
+}
+
+SubalphaNgDeviceOperation::program_factory_t SubalphaNgDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return SubalphaProgramFactory{};
+}
+
+SubalphaNgDeviceOperation::tensor_return_value_t SubalphaNgDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    if (output_tensor.has_value()) {
+        return output_tensor.value();
+    }
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+}
+
+tt::stl::hash::hash_t SubalphaNgDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    TT_ASSERT(
+        std::holds_alternative<DeviceStorage>(input_tensor_a.get_storage()),
+        "Unexpected type {}",
+        tt::stl::get_active_type_name_in_variant(input_tensor_a.get_storage()));
+
+    TT_ASSERT(
+        std::holds_alternative<DeviceStorage>(input_tensor_b.get_storage()),
+        "Unexpected type {}",
+        tt::stl::get_active_type_name_in_variant(input_tensor_b.get_storage()));
+
+    return operation::hash_operation<SubalphaNgDeviceOperation>(
+        attributes,
+        input_tensor_a.dtype(),
+        std::get<DeviceStorage>(input_tensor_a.storage()).memory_config(),
+        input_tensor_b.dtype(),
+        std::get<DeviceStorage>(input_tensor_b.storage()).memory_config());
+
+    return operation::hash_operation<SubalphaNgDeviceOperation>(
+        attributes, input_tensor_a.dtype(), std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
+}
+
+bool SubalphaNgDeviceOperation::skip_launch(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
+std::tuple<SubalphaNgDeviceOperation::operation_attributes_t, SubalphaNgDeviceOperation::tensor_args_t>
+SubalphaNgDeviceOperation::invoke(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output_tensor) {
+    auto subtile_broadcast_type = get_subtile_broadcast_type(
+        input_tensor_a.get_logical_shape()[-2],
+        input_tensor_a.get_logical_shape()[-1],
+        input_tensor_b.get_logical_shape()[-2],
+        input_tensor_b.get_logical_shape()[-1]);
+
+    DataType dtype1 = input_tensor_a.get_dtype();
+    DataType dtype2 = input_tensor_a.get_dtype();
+    bool device_check = input_tensor_a.device()->arch() != tt::ARCH::GRAYSKULL;
+    bool is_sfpu_op = (utils::is_binary_sfpu_op(dtype1, dtype2) && device_check);
+    return {
+        operation_attributes_t{
+            alpha,
+            memory_config.value_or(output_tensor.has_value() ? output_tensor->memory_config() : MemoryConfig{}),
+            input_tensor_a.get_dtype(),
+            get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor),
+            std::nullopt,
+            subtile_broadcast_type,
+            is_sfpu_op},
+        tensor_args_t{input_tensor_a, input_tensor_b, std::move(output_tensor)}};
+}
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_device_operation.hpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/binary_ng/types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+struct SubalphaNgDeviceOperation {
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct operation_attributes_t {
+        float scalar;
+        tt::tt_metal::MemoryConfig memory_config;
+        DataType input_dtype;
+        const CoreRangeSet worker_grid;
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        SubtileBroadcastType subtile_broadcast_type = SubtileBroadcastType::NONE;
+        bool is_sfpu = false;
+
+        tt::stl::hash::hash_t to_hash() const;
+        DataType get_dtype() const;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input_tensor_a;
+        const Tensor& input_tensor_b;
+        std::optional<Tensor> output_tensor;
+    };
+
+    struct SubalphaProgramFactory {
+        struct shared_variables_t {
+            tt::tt_metal::KernelHandle reader_kernel_id;
+            tt::tt_metal::KernelHandle writer_kernel_id;
+            tt::tt_metal::KernelHandle compute_kernel_id;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<SubalphaProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
+    // tensor-tensor-alpha invocation
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor_a_arg,
+        const Tensor& input_tensor_b_arg,
+        float alpha,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<Tensor>& optional_output_tensor);
+};
+}  // namespace ttnn::operations::binary_ng
+
+namespace ttnn::prim {
+constexpr auto subalpha =
+    ttnn::register_operation<"ttnn::prim::subalpha", ttnn::operations::binary_ng::SubalphaNgDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_program_factory.cpp
@@ -1,0 +1,573 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/work_split.hpp>
+
+#include "subalpha_device_operation.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+
+using namespace tt::tt_metal;
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace ttnn::operations::binary_ng;
+
+// For rank > 4 i.e. dims beyond NCHW will be collapsed into a single dim
+uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
+    const auto& shape = x.get_logical_shape();
+    uint32_t nD_dim = 1;
+    if (out_rank >= 5) {
+        for (int i = -5; i >= -out_rank; --i) {
+            auto dim = shape[i];
+            nD_dim *= dim;
+        }
+    }
+    return nD_dim;
+}
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};
+}
+
+std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
+    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t Ht, uint32_t Wt) {
+    uint32_t start_t = start_tile_id % (Ht * Wt);
+    uint32_t start_tw = start_t % Wt;
+
+    switch (broadcast_type) {
+        case SubtileBroadcastType::NONE:
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::ROW_B: return {1, 0};
+        case SubtileBroadcastType::SCALAR_A:
+        case SubtileBroadcastType::SCALAR_B: return {Ht * Wt, start_t};
+        case SubtileBroadcastType::COL_A:
+        case SubtileBroadcastType::ROW_B_COL_A:
+        case SubtileBroadcastType::COL_B:
+        case SubtileBroadcastType::ROW_A_COL_B: return {Wt, start_tw};
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+struct AllShardSpecs {
+    ShardSpec a_shard_spec;
+    ShardSpec b_shard_spec;
+    ShardSpec c_shard_spec;
+};
+
+ShardSpec adjust_to_shape(const ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape) {
+    auto ret = shard_spec;
+
+    ret.shape[0] = (ret.shape[0] * to_shape[-2]) / from_shape[-2];
+    ret.shape[1] = (ret.shape[1] * to_shape[-1]) / from_shape[-1];
+
+    return ret;
+}
+
+TensorMemoryLayout get_memory_layout(const Tensor& a, const Tensor& b, const Tensor& c) {
+    if (a.memory_config().is_sharded()) {
+        return a.memory_config().memory_layout;
+    }
+    if (b.memory_config().is_sharded()) {
+        return b.memory_config().memory_layout;
+    }
+    if (c.memory_config().is_sharded()) {
+        return c.memory_config().memory_layout;
+    }
+    return TensorMemoryLayout::INTERLEAVED;
+}
+
+std::optional<AllShardSpecs> get_shard_specs(const Tensor& a, const Tensor& b, const Tensor& c) {
+    bool a_sharded = a.memory_config().is_sharded();
+    bool b_sharded = b.memory_config().is_sharded();
+    bool c_sharded = c.memory_config().is_sharded();
+
+    if (!a_sharded && !b_sharded && !c_sharded) {
+        return std::nullopt;
+    }
+
+    auto a_shape = a.padded_shape();
+    auto b_shape = b.padded_shape();
+    auto c_shape = c.padded_shape();
+
+    ShardSpec c_shard_spec = c_sharded   ? *c.shard_spec()
+                             : a_sharded ? adjust_to_shape(*a.shard_spec(), a_shape, c_shape)
+                                         : adjust_to_shape(*b.shard_spec(), b_shape, c_shape);
+
+    return AllShardSpecs{
+        a_sharded ? *a.shard_spec() : adjust_to_shape(c_shard_spec, c_shape, a_shape),
+        b_sharded ? *b.shard_spec() : adjust_to_shape(c_shard_spec, c_shape, b_shape),
+        c_shard_spec};
+}
+
+uint32_t get_shards_per_width(const ShardSpec& shard_spec, TensorMemoryLayout memory_layout) {
+    auto num_cores = shard_spec.grid.num_cores();
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+        return 1;
+    }
+
+    if (memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        return num_cores;
+    }
+
+    const auto& bbox = shard_spec.grid.bounding_box();
+    const auto& start = bbox.start_coord;
+    const auto& end = bbox.end_coord;
+    return (shard_spec.orientation == ShardOrientation::ROW_MAJOR ? end.x - start.x : end.y - start.y) + 1;
+}
+
+class ShardShapeGenerator {
+    CoreCoord end_core;
+    bool row_major;
+    TensorMemoryLayout memory_layout;
+    std::array<uint32_t, 2> shard_shape;
+    std::array<uint32_t, 2> last_shard_shape;
+
+public:
+    ShardShapeGenerator() = default;
+
+    ShardShapeGenerator(const ShardSpec& shard_spec, const Tensor& tensor) :
+    // core ranges are sorted, so the last one is indeed the last core
+        end_core(shard_spec.grid.ranges().rbegin()->end_coord),
+        row_major(shard_spec.orientation == ShardOrientation::ROW_MAJOR),
+        memory_layout(tensor.memory_config().memory_layout) {
+        auto tile_height = tensor.tensor_spec().tile().get_height();
+        auto tile_width = tensor.tensor_spec().tile().get_width();
+
+        shard_shape = {
+            tt::round_up(shard_spec.shape[0], tile_height) / tile_height,
+            tt::round_up(shard_spec.shape[1], tile_width) / tile_width};
+
+        const auto [N, C, Ht, Wt] = get_shape_dims(tensor);
+        const auto unrolled_Ht = N * C * Ht;
+        last_shard_shape = {
+            shard_shape[0] - (tt::round_up(unrolled_Ht, shard_shape[0]) - unrolled_Ht),
+            shard_shape[1] - (tt::round_up(Wt, shard_shape[1]) - Wt),
+        };
+    }
+    std::array<uint32_t, 2> operator()(CoreCoord core) const {
+        const unsigned majorDim = row_major ? 1 : 0;
+        const unsigned minorDim = row_major ? 0 : 1;
+
+        auto current_shape = shard_shape;
+        // for uneven shard, HEIGHT, WIDTH, and BLOCK handling order should be all different in kernel
+        // only HEIGHT sharding works naturally
+        // for eltwise, it should be insignificant to process the padded tile although it is a waste
+        if (core == end_core) {
+            if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+                current_shape[majorDim] = last_shard_shape[majorDim];
+                current_shape[minorDim] = last_shard_shape[minorDim];
+            } else {
+                TT_FATAL(
+                    current_shape[majorDim] == last_shard_shape[majorDim] and
+                        current_shape[minorDim] == last_shard_shape[minorDim],
+                    "no un-even shard size support memory layout {}",
+                    memory_layout);
+            }
+        }
+        return current_shape;
+    }
+};
+
+template <typename F>
+void set_or_update_runtime_arguments(
+    Program& program,
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    KernelHandle compute_kernel_id,
+    const SubalphaNgDeviceOperation::operation_attributes_t& operation_attributes,
+    const SubalphaNgDeviceOperation::tensor_args_t& tensor_args,
+    SubalphaNgDeviceOperation::tensor_return_value_t& c,
+    F handle_args) {
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    const auto out_rank = c.logical_shape().rank();
+    auto aND = extract_nD_dims(a, out_rank);
+    auto bND = extract_nD_dims(b, out_rank);
+    auto cND = extract_nD_dims(c, out_rank);
+
+    const auto [aN, aC, aHt, aWt] = get_shape_dims(a);
+    const auto [bN, bC, bHt, bWt] = get_shape_dims(b);
+    const auto [cN, cC, cHt, cWt] = get_shape_dims(c);
+    const uint32_t cHt_unrolled = cN * cC * cHt;
+
+    const auto shard_specs = get_shard_specs(a, b, c);
+    const bool has_sharding = shard_specs.has_value();
+    auto grid = has_sharding ? shard_specs->a_shard_spec.grid : CoreRangeSet{};
+
+    const auto row_major = has_sharding ? shard_specs->a_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
+
+    // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
+    // as well as having the sharded tensors (if any) start at (0, 0)
+    // This will run the original work/core distribution algorithms that are specifically for this setup, as these
+    // are faster than the generic work/core distribution algorithms that work on arbitrary CoreRangeSets
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid;
+    const auto& all_device_cores = operation_attributes.worker_grid;
+    if (grid.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (has_sharding) {
+                const auto& shard_start_coord = grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    zero_start_grid = true;
+                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                zero_start_grid = true;
+                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+    const uint32_t num_cores_total =
+        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
+
+    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores;
+    std::vector<CoreCoord> cores;
+
+    const uint32_t tile_height = c.tensor_spec().tile().get_height();
+    const uint32_t tile_width = c.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = tile_height * tile_width;
+    const uint32_t c_num_tiles = c.volume() / tile_hw;
+    uint32_t c_shard_height, c_shard_width, num_shards_per_width;
+
+    ShardShapeGenerator a_shard_shape_generator;
+    ShardShapeGenerator b_shard_shape_generator;
+    ShardShapeGenerator c_shard_shape_generator;
+
+    if (has_sharding) {
+        core_group_1 = grid;
+        a_shard_shape_generator = ShardShapeGenerator(shard_specs->a_shard_spec, a);
+        b_shard_shape_generator = ShardShapeGenerator(shard_specs->b_shard_spec, b);
+        c_shard_shape_generator = ShardShapeGenerator(shard_specs->c_shard_spec, c);
+        c_shard_height = shard_specs->c_shard_spec.shape[0] / tile_height;
+        c_shard_width = shard_specs->c_shard_spec.shape[1] / tile_width;
+        num_shards_per_width = get_shards_per_width(shard_specs->c_shard_spec, get_memory_layout(a, b, c));
+
+        if (zero_start_grid) {
+            auto bbox = core_group_1.bounding_box();
+            cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                compute_with_storage_grid.x,
+                compute_with_storage_grid.y,
+                row_major);
+        } else {
+            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
+        }
+    } else if (zero_start_grid) {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid, c_num_tiles, row_major);
+        cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
+    } else {
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(all_device_cores, c_num_tiles, row_major);
+        cores = corerange_to_cores(all_device_cores, {}, row_major);
+    }
+
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        const auto& core = cores[i];
+
+        uint32_t a_num_tiles = 0;
+        uint32_t b_num_tiles = 0;
+        uint32_t c_num_tiles = 0;
+        if (core_group_1.contains(core)) {
+            c_num_tiles = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            c_num_tiles = num_tiles_per_core_group_2;
+        } else {
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 14>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 14>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
+            continue;
+        }
+
+        uint32_t c_start_id = 0;
+        uint32_t c_current_shard_width = 0;
+        if (has_sharding) {
+            auto c_shard_shape = c_shard_shape_generator(core);
+            c_num_tiles = c_shard_shape[0] * c_shard_shape[1];
+            c_current_shard_width = c_shard_shape[1];
+            auto a_shard_shape = a_shard_shape_generator(core);
+            a_num_tiles = a_shard_shape[0] * a_shard_shape[1];
+            c_start_id =
+                (i / num_shards_per_width) * (c_shard_height * cWt) + (i % num_shards_per_width) * c_shard_width;
+        } else {
+            c_start_id = start_tile_id;
+        }
+        // for alpha
+        const float scalar = operation_attributes.scalar;
+        const auto packed_scalar = a.get_dtype() == DataType::FLOAT32 ? std::bit_cast<uint32_t>(scalar)
+                                       : a.get_dtype() == DataType::INT32
+                                           ? std::bit_cast<uint32_t>(static_cast<int32_t>(scalar))
+                                           : pack_two_bfloat16_into_uint32({scalar, scalar});
+
+        std::array reader_runtime_args = {
+            a.buffer()->address(),
+            packed_scalar, // new parameter for float alpha
+            c_start_id,
+            a_num_tiles,
+            c_num_tiles,
+            c_current_shard_width,
+            aHt * aWt * aC * aN * (aND > 1),
+            aHt * aWt * aC * (aN > 1),
+            aHt * aWt * (aC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt,
+            cND};
+        handle_args(program, reader_kernel_id, core, reader_runtime_args);
+
+        if (has_sharding) {
+            auto b_shard_shape = b_shard_shape_generator(core);
+            b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
+        }
+        std::array writer_runtime_args = {
+            b.buffer()->address(),
+            c.buffer()->address(),
+            c_start_id,
+            b_num_tiles,
+            c_num_tiles,
+            c_current_shard_width,
+            bHt * bWt * bC * bN * (bND > 1),
+            bHt * bWt * bC * (bN > 1),
+            bHt * bWt * (bC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt,
+            cND};
+        handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+        auto [freq, counter] =
+            calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
+        std::array compute_runtime_args = {c_num_tiles, freq, counter};
+        handle_args(program, compute_kernel_id, core, compute_runtime_args);
+
+        start_tile_id += c_num_tiles;
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::binary_ng {
+
+// Implements c = a op b
+SubalphaNgDeviceOperation::SubalphaProgramFactory::cached_program_t SubalphaNgDeviceOperation::SubalphaProgramFactory::create(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    const auto a_dtype = a.get_dtype();
+    const auto b_dtype = b.get_dtype();
+    auto is_sfpu_op = operation_attributes.is_sfpu;
+
+    auto program = CreateProgram();
+    auto* device = a.device();
+
+    const auto shard_specs = CMAKE_UNIQUE_NAMESPACE::get_shard_specs(a, b, c);
+    const bool has_sharding = shard_specs.has_value();
+
+    auto tile_hw = c.tensor_spec().tile().get_tile_hw();
+    uint32_t a_num_tiles_per_shard = has_sharding ? shard_specs->a_shard_spec.numel() / tile_hw : 0;
+    uint32_t b_num_tiles_per_shard = has_sharding ? shard_specs->b_shard_spec.numel() / tile_hw : 0;
+    uint32_t c_num_tiles_per_shard = has_sharding ? shard_specs->c_shard_spec.numel() / tile_hw : 0;
+
+    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    auto b_data_format = datatype_to_dataformat_converter(b.get_dtype());
+    auto c_data_format = datatype_to_dataformat_converter(c.get_dtype());
+
+    uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
+    uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
+    uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
+
+    // we parallelize the computation across the output tiles
+    const auto& all_device_cores = operation_attributes.worker_grid;
+
+    Buffer* a_buffer = a.buffer();
+    Buffer* b_buffer = b.buffer();
+    Buffer* c_buffer = c.buffer();
+
+    const auto op_config = is_sfpu_op;
+    std::map<std::string, std::string> compute_kernel_defines;
+    bool a_sharded = a.memory_config().is_sharded();
+    bool b_sharded = b.memory_config().is_sharded();
+    bool c_sharded = c.memory_config().is_sharded();
+
+    // How many tiles to store per input CB (double buffer)
+    auto [a_cb, a_cb_handle] = create_cb(
+        tt::CBIndex::c_0,
+        program,
+        all_device_cores,
+        a_single_tile_size,
+        a_sharded ? a_num_tiles_per_shard : 2,
+        a_data_format,
+        a_sharded ? a_buffer : nullptr);
+
+         auto a_intermediate_format =  a_data_format;
+         uint32_t a_intermediate_single_tile_size = tt_metal::detail::TileSize(a_intermediate_format);
+         auto [a_cb_interim, a_cb_interim_handle] = create_cb(
+             tt::CBIndex::c_3, program, all_device_cores, a_intermediate_single_tile_size, 1, a_intermediate_format);
+
+    // If b is a scalar, we only need one tile in the CB
+    auto [b_cb, b_cb_handle] = create_cb(
+        tt::CBIndex::c_1,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_buffer == nullptr ? 1 : (b_sharded ? b_num_tiles_per_shard : 2),
+        b_data_format,
+        b_sharded ? b_buffer : nullptr);
+
+        auto b_intermediate_format = b_data_format;
+        uint32_t b_intermediate_single_tile_size = tt_metal::detail::TileSize(b_intermediate_format);
+        auto [b_cb_interim, b_cb_interim_handle] = create_cb(
+            tt::CBIndex::c_4, program, all_device_cores, b_intermediate_single_tile_size, 1, b_intermediate_format);
+
+    auto [c_cb, c_cb_handle] = create_cb(
+        tt::CBIndex::c_2,
+        program,
+        all_device_cores,
+        c_single_tile_size,
+        c_sharded ? c_num_tiles_per_shard : 2,
+        c_data_format,
+        c_sharded ? c_buffer : nullptr);
+
+    uint32_t a_is_dram = a_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    uint32_t b_is_dram = false;
+    uint32_t c_is_dram = c_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+
+    auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
+
+    std::map<std::string, std::string> dataflow_defines;
+    if (is_sfpu_op && a_dtype == DataType::FLOAT32) {
+        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
+        dataflow_defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
+    } else if (is_sfpu_op && a_dtype == DataType::INT32) {
+        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<int32_t>";
+        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val<1024, int32_t>";
+    } else {
+        dataflow_defines["FILL_TILE_WITH_FIRST_COLUMN"] = "fill_tile_with_first_column_bfloat16";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ROW"] = "fill_tile_with_first_row_bfloat16";
+        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
+        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    }
+    auto reader_defines = dataflow_defines;
+    reader_defines["SRC_SHARDED"] = a_sharded ? "1" : "0";
+
+    // READER KERNEL
+    std::string reader_subalpha_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/kernels/dataflow/reader_interleaved_no_bcast.cpp";
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        reader_subalpha_kernel_filepath,
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram, has_sharding}, std::move(reader_defines)));
+
+    // WRITER KERNEL
+    auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
+    auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
+    b_is_dram = b_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    writer_kernel = kernel_config.writer_kernel;
+    compute_kernel = kernel_config.compute_kernel;
+    auto writer_defines = dataflow_defines;
+    writer_defines["SRC_SHARDED"] = b_sharded ? "1" : "0";
+    writer_defines["DST_SHARDED"] = c_sharded ? "1" : "0";
+
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(writer_kernel, is_sfpu_op),
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram, has_sharding}, std::move(writer_defines)));
+
+    // COMPUTE KERNEL
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32;
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    uint32_t src0interim_cb_index = tt::CBIndex::c_3;
+    uint32_t src1interim_cb_index = tt::CBIndex::c_4;
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (is_sfpu_op) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src1_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src0interim_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src1interim_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
+
+    const uint32_t num_tiles_per_cycle = 1;  // we produce 1 output tile per read-compute-write cycle
+    std::string compute_subalpha_kernel_filepath;
+    if(kernel_config.compute_kernel == KernelName::ComputeNoBcast){
+        compute_subalpha_kernel_filepath = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/device/kernels/compute/eltwise_subalpha_no_bcast.cpp";
+    }
+    else{
+       TT_THROW("Unexpected KernelName encountered in subalpha compute kernel !!");
+    }
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        compute_subalpha_kernel_filepath,
+        all_device_cores,
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .defines = std::move(compute_kernel_defines)});
+
+    auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        compute_kernel_id,
+        operation_attributes,
+        tensor_args,
+        c,
+        set_runtime_args);
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id}};
+}
+
+void SubalphaNgDeviceOperation::SubalphaProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& c) {
+    auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        auto& all_args = GetRuntimeArgs(program, kernel_id);
+        auto& core_args = all_args.at(core.x).at(core.y);
+        std::copy(args.begin(), args.end(), core_args.data());
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
+        cached_program.shared_variables.compute_kernel_id,
+        operation_attributes,
+        tensor_args,
+        c,
+        update_args);
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/subalpha.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/subalpha.cpp
@@ -1,0 +1,41 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "subalpha.hpp"
+#include "ttnn/operations/eltwise/binary_ng/subalpha/device/subalpha_device_operation.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+namespace utils {
+inline Tensor typecast_to(DataType dtype, const Tensor& input) {
+    return input.get_dtype() == dtype ? input : ttnn::typecast(input, dtype);
+}
+
+inline bool needs_typecast_to_bfloat16(const Tensor& input) {
+    return (input.get_dtype() == DataType::BFLOAT8_B || input.get_dtype() == DataType::BFLOAT4_B);
+}
+}
+
+Tensor Subalpha::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    float alpha,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+
+    bool typecast_a = utils::needs_typecast_to_bfloat16(input_tensor_a);
+    bool typecast_b = utils::needs_typecast_to_bfloat16(input_tensor_b);
+    Tensor input_a = typecast_a ? utils::typecast_to(DataType::BFLOAT16, input_tensor_a) : input_tensor_a;
+    Tensor input_b = typecast_b ? utils::typecast_to(DataType::BFLOAT16, input_tensor_b) : input_tensor_b;
+    return ttnn::prim::subalpha(
+        queue_id,
+        input_a,
+        input_b,
+        alpha,
+        memory_config,
+        optional_output_tensor);
+}
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/subalpha.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/subalpha/subalpha.hpp
@@ -1,0 +1,31 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/eltwise/binary_ng/types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+struct Subalpha {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        float alpha,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
+}  // namespace ttnn::operations::binary_ng
+
+namespace ttnn::experimental {
+
+constexpr auto subalpha =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::experimental::subalpha", ttnn::operations::binary_ng::Subalpha>();
+}  // namespace ttnn::experimental


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
ttnn.subalpha is implemented as a composite op.

### What's changed
Implemented subalpha as a device op in ttnn.experimental.subalpha under binary_ng module.
Current implementation is implemented for bfloat16 version with No Broadcast support.

### Performance Metrics
The project is built with option "--enable-profiler" to collect the performance metrics.
Parameters compared: DEVICE KERNEL DURATION [ns].
Performance of ttnn.subalpha(composite (benchmark)) is compared with ttnn.experimental.subalpha(device op) for:-
1. No Broadcast version
   - Input Tensor shapes [1, 1, 4096, 4096]
   - Analysis: DEVICE KERNEL DURATION [ns]: 44.05% faster than benchmark. (1863363ns vs 3330250ns) 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes