### PR TITLE
`ttnn::arange` bug fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -270,7 +270,7 @@ def test_full_multi_device(mesh_device, input_shape, fill_value, layout):
 )
 @pytest.mark.parametrize(
     "end",
-    [100, 200, 300],
+    [100, 103, 200, 259, 300],
 )
 @pytest.mark.parametrize(
     "step",
@@ -290,8 +290,7 @@ def test_arange(device, start, end, step):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     output_tensor = output_tensor[-1, -1, -1, :]
-    if divup((end - start), step) % 2 != 0:
-        output_tensor = output_tensor[:-1]
+
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
@@ -301,7 +300,7 @@ def test_arange(device, start, end, step):
 )
 @pytest.mark.parametrize(
     "end",
-    [100, 200, 300],
+    [100, 103, 200, 259, 300],
 )
 @pytest.mark.parametrize(
     "step",
@@ -323,8 +322,7 @@ def test_arange_multi_device(mesh_device, start, end, step):
     output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(output_tensor.cpu())]
     for output_tensor in output_tensors:
         output_tensor = output_tensor[-1, -1, -1, :]
-        if divup((end - start), step) % 2 != 0:
-            output_tensor = output_tensor[:-1]
+
         assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -266,54 +266,51 @@ def test_full_multi_device(mesh_device, input_shape, fill_value, layout):
 
 @pytest.mark.parametrize(
     "start",
-    [4, 8, 16, 32],
+    [4, 8, 16, 0, 201, 135, 98],
 )
 @pytest.mark.parametrize(
     "end",
-    [100, 103, 200, 259, 300],
+    [100, 103, 226, 300, 3, 1, 0],
 )
 @pytest.mark.parametrize(
     "step",
-    [1, 2, 3, 4, 5],
+    [1, 2, 3, 5, 0, -1, -3, -4],
 )
 def test_arange(device, start, end, step):
-    torch_input_tensor = torch.rand((start, end, step), dtype=torch.bfloat16)
+    if (start > end and step > 0) or (start < end and step < 0) or (step == 0):
+        pytest.skip(f"Skipping invalid case: start={start}, end={end}, step={step}")
+
     torch_output_tensor = torch.arange(start, end, step)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
-    input_tensor = ttnn.to_device(input_tensor, device)
-
-    output_tensor = ttnn.arange(
-        input_tensor.shape[0], input_tensor.shape[1], input_tensor.shape[2], ttnn.bfloat16, device
-    )
+    output_tensor = ttnn.arange(start, end, step, ttnn.bfloat16, device)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor[-1, -1, -1, :]
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
 @pytest.mark.parametrize(
     "start",
-    [4, 8, 16, 32],
+    [4, 8, 16, 0, 201, 135, 98],
 )
 @pytest.mark.parametrize(
     "end",
-    [100, 103, 200, 259, 300],
+    [100, 103, 226, 300, 3, 1, 0],
 )
 @pytest.mark.parametrize(
     "step",
-    [1, 2, 3, 4, 5],
+    [1, 2, 3, 5, 0, -1, -3, -4],
 )
 def test_arange_multi_device(mesh_device, start, end, step):
-    torch_input_tensor = torch.rand((start, end, step), dtype=torch.bfloat16)
+    if (start > end and step > 0) or (start < end and step < 0) or (step == 0):
+        pytest.skip(f"Skipping invalid case: start={start}, end={end}, step={step}")
     torch_output_tensor = torch.arange(start, end, step)
 
     output_tensor = ttnn.arange(
-        torch_input_tensor.shape[0],
-        torch_input_tensor.shape[1],
-        torch_input_tensor.shape[2],
+        start,
+        end,
+        step,
         ttnn.bfloat16,
         mesh_device,
     )
@@ -321,8 +318,6 @@ def test_arange_multi_device(mesh_device, start, end, step):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(output_tensor.cpu())]
     for output_tensor in output_tensors:
-        output_tensor = output_tensor[-1, -1, -1, :]
-
         assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 

--- a/ttnn/cpp/pybind11/operations/creation.hpp
+++ b/ttnn/cpp/pybind11/operations/creation.hpp
@@ -356,7 +356,7 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
         Example:
             >>> tensor = ttnn.arange(start=0, end=10, step=2, dtype=ttnn.float32)
             >>> print(tensor)
-            ttnn.Tensor([[[[0.00000,  2.00000,  ...,  8.00000,  0.00000]]]], shape=Shape([1, 1, 1, 6]), dtype=DataType::FLOAT32, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[[[0.00000,  2.00000,  ...,  6.00000,  8.00000]]]], shape=Shape([1, 1, 1, 5]), dtype=DataType::FLOAT32, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 

--- a/ttnn/cpp/pybind11/operations/creation.hpp
+++ b/ttnn/cpp/pybind11/operations/creation.hpp
@@ -356,7 +356,7 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
         Example:
             >>> tensor = ttnn.arange(start=0, end=10, step=2, dtype=ttnn.float32)
             >>> print(tensor)
-            ttnn.Tensor([[[[0.00000,  2.00000,  ...,  6.00000,  8.00000]]]], shape=Shape([1, 1, 1, 5]), dtype=DataType::FLOAT32, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([ 0.00000,  2.00000,  ...,  6.00000,  8.00000], shape=Shape([5]), dtype=DataType::FLOAT32, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -83,9 +83,6 @@ static Tensor arange_impl(
     TT_ASSERT(step > 0, "Step must be greater than 0");
     TT_ASSERT(start < stop, "Start must be less than step");
     auto size = tt::div_up((stop - start), step);
-    if (size % 2 != 0) {
-        size++;
-    }
     auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(size);
 
     auto index = 0;

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -80,10 +80,11 @@ static Tensor arange_impl(
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
     constexpr DataType data_type = tt::tt_metal::convert_to_data_type<T>();
 
-    TT_ASSERT(step != 0, "Step must be nonzero");
-    if ((step > 0 && start > stop) || (step < 0 && start < stop)) {
-        TT_ASSERT(false, "Invalid range: Step direction does not match range bounds");
-    }
+    TT_FATAL(step != 0, "Step must be nonzero");
+    TT_FATAL(
+        !((step > 0 && start > stop) || (step < 0 && start < stop)),
+        "Invalid range: Step direction does not match range bounds");
+
     auto size = std::max<int64_t>(0, tt::div_up(std::abs(stop - start), std::abs(step)));
     auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(size);
 

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -79,14 +79,16 @@ static Tensor arange_impl(
     const MemoryConfig& output_mem_config = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
     constexpr DataType data_type = tt::tt_metal::convert_to_data_type<T>();
-    // Current implementation restrictions
-    TT_ASSERT(step > 0, "Step must be greater than 0");
-    TT_ASSERT(start < stop, "Start must be less than step");
-    auto size = tt::div_up((stop - start), step);
+
+    TT_ASSERT(step != 0, "Step must be nonzero");
+    if ((step > 0 && start > stop) || (step < 0 && start < stop)) {
+        TT_ASSERT(false, "Invalid range: Step direction does not match range bounds");
+    }
+    auto size = std::max<int64_t>(0, tt::div_up(std::abs(stop - start), std::abs(step)));
     auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(size);
 
     auto index = 0;
-    for (auto value = start; value < stop; value += step) {
+    for (auto value = start; (step > 0) ? (value < stop) : (value > stop); value += step) {
         if constexpr (std::is_same_v<T, ::bfloat16>) {
             owned_buffer[index++] = T(static_cast<float>(value));
         } else {
@@ -94,8 +96,7 @@ static Tensor arange_impl(
         }
     }
     auto output =
-        Tensor(
-            OwnedStorage{owned_buffer}, ttnn::Shape{1, 1, 1, static_cast<uint32_t>(size)}, data_type, Layout::ROW_MAJOR)
+        Tensor(OwnedStorage{owned_buffer}, ttnn::Shape{static_cast<uint32_t>(size)}, data_type, Layout::ROW_MAJOR)
             .to_layout(layout);
     if (device.has_value()) {
         output = output.to_device(device->get_devices(), output_mem_config);


### PR DESCRIPTION
### Ticket
#18648 

### Problem description
ttnn.arange doesn't work for the odd number of elements

### What's changed

- [x] Fixed the bug mentioned in the issue
- [x] Removed the current limitations in ttnn op and matched with torch op
- [x] Added unit test for the fixes and improvements
- [x] Modified documentation to reflect the same

<img width="1512" alt="Screenshot 2025-03-11 at 4 07 08 PM" src="https://github.com/user-attachments/assets/df0ebcaf-9b02-4c24-8fa0-b2ad5e2f6729" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13787198100
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/13785663485
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/13784908795
- [x] New/Existing tests provide coverage for changes