### PR TITLE
Revert commit 57ba436 to avoid hangs in Llama3 on BH

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -404,15 +404,6 @@ int main() {
     uint8_t prev_noc_mode = DM_DEDICATED_NOC;
     trigger_sync_register_init();
 
-
-#if defined(ARCH_BLACKHOLE)
-    // When dispatch_s is on an ethernet core on blockhole, we've been seeing
-    // issues where posted atomic incremenets seem to fail to complete.
-    const bool post_atomic_increments = false;
-#else
-    const bool post_atomic_increments = true;
-#endif
-
     while (1) {
         reset_ncrisc_with_iram();
 
@@ -450,7 +441,7 @@ int main() {
                     1,
                     31 /*wrap*/,
                     false /*linked*/,
-                    post_atomic_increments /*posted*/);
+                    true /*posted*/);
             }
         }
 
@@ -520,7 +511,7 @@ int main() {
                     (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.remote_cb_offset);
                 end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;
                 experimental::setup_remote_cb_interfaces<true>(
-                    cb_l1_base, end_cb_index, noc_index, noc_mode, post_atomic_increments, cmd_buf);
+                    cb_l1_base, end_cb_index, noc_index, noc_mode, true, cmd_buf);
                 start_ncrisc_kernel_run(enables);
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
                 void (*kernel_address)(uint32_t) = (void (*)(uint32_t))
@@ -542,7 +533,7 @@ int main() {
                         (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.remote_cb_offset);
                     uint32_t end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;
                     experimental::setup_remote_cb_interfaces<true>(
-                        cb_l1_base, end_cb_index, noc_index, noc_mode, post_atomic_increments, cmd_buf);
+                        cb_l1_base, end_cb_index, noc_index, noc_mode, true, cmd_buf);
                 }
                 start_ncrisc_kernel_run(enables);
                 wait_for_go_message();
@@ -600,7 +591,7 @@ int main() {
                     1,
                     31 /*wrap*/,
                     false /*linked*/,
-                    post_atomic_increments /*posted*/);
+                    true /*posted*/);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
         }


### PR DESCRIPTION
Separate PR for reverting brisc changes to avoid LLama3 hangs on BH.
This is required to have a functional demo of Llama3.

See PR: https://github.com/tenstorrent/tt-metal/pull/18697
See issue: https://github.com/tenstorrent/tt-metal/issues/18481

- [x] [BH All-post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/13786207836)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13786202739)