### PR TITLE
Add ring topology support to All Gather

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     params.line_size = line_size;
-    params.ring_topology = ring_topology;
+    params.topology = ring_topology ? ttnn::ccl::Topology::Ring : ttnn::ccl::Topology::Linear;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params, packet_payload_size_bytes);
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -1074,7 +1074,7 @@ void setup_test_with_persistent_fabric(
     std::optional<ttnn::ccl::EdmLineFabricOpInterface>& line_fabric,
     bool enable_persistent_fabric,
     std::optional<size_t> num_links = std::nullopt,
-    bool ring_topology = false) {
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear) {
     if (enable_persistent_fabric) {
         log_info(tt::LogTest, "Enabling persistent fabric");
         fabric_programs = std::vector<Program>(devices.size());
@@ -1089,7 +1089,7 @@ void setup_test_with_persistent_fabric(
     }
 
     line_fabric = ttnn::ccl::EdmLineFabricOpInterface(
-        devices, fabric_program_ptrs, enable_persistent_fabric, num_links.value_or(1), false, ring_topology);
+        devices, fabric_program_ptrs, enable_persistent_fabric, num_links.value_or(1), false, topology);
     line_fabric->set_firmware_context_switch_interval(0);
 
     if (enable_persistent_fabric) {
@@ -2068,7 +2068,7 @@ struct WriteThroughputStabilityTestWithPersistentFabricParams {
     size_t line_size = 4;
     size_t num_devices_with_workers = 0;
     bool line_sync = true;
-    bool ring_topology = false;
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear;
 };
 
 void RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -2089,7 +2089,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
         return;
     }
 
-    bool ring_topology = params.ring_topology;
+    auto topology = params.topology;
 
     size_t line_size = params.line_size;
     size_t num_devices_with_workers = params.num_devices_with_workers;
@@ -2140,7 +2140,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
         fabric_handle,
         enable_persistent_fabric_mode,
         num_links,
-        ring_topology);
+        topology);
 
     // Other boiler plate setup
     CoreRangeSet worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_links - 1, 0)));
@@ -2212,7 +2212,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
         size_t mcast_fwd_hops;
         size_t mcast_bwd_hops;
         size_t unicast_hops;
-        if (ring_topology) {
+        if (topology == ttnn::ccl::Topology::Ring) {
             backward_device = i == 0 ? devices.back() : devices[i - 1];
             forward_device = i == line_size - 1 ? devices.front() : devices[i + 1];
 
@@ -2243,13 +2243,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
 
         auto local_device_fabric_handle =
             ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
-                device,
-                forward_device,
-                backward_device,
-                &program,
-                enable_persistent_fabric_mode,
-                num_links,
-                ring_topology);
+                device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links, topology);
 
         // reserve CB
         tt_metal::CircularBufferConfig cb_src0_config =

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
@@ -14,6 +14,7 @@ def create_and_load_sub_device_manager_with_fabric_interface(
     enable_persistent_fabric=True,
     wrap_fabric_around_mesh=False,
     context_switch_interval_override=None,
+    topology=ttnn.Topology.Linear,
 ):
     assert ccl_worker_sub_device_id < len(worker_sub_devices)
     mesh_sub_device_manager_id, fabric_subdevice_id = mesh_device.create_sub_device_manager_with_fabric(
@@ -26,13 +27,14 @@ def create_and_load_sub_device_manager_with_fabric_interface(
             mesh_device,
             wrap_fabric_around_mesh=wrap_fabric_around_mesh,
             context_switch_interval_override=context_switch_interval_override,
+            topology=topology,
         )
     return mesh_sub_device_manager_id
 
 
-def teardown_fabric_interface(mesh_device):
+def teardown_fabric_interface(mesh_device, wrap_fabric_around_mesh=False, topology=ttnn.Topology.Linear):
     logger.debug(f"Tearing down fabric (this may take a while if context switch interval is large)")
-    ttnn.teardown_edm_fabric(mesh_device)
+    ttnn.teardown_edm_fabric(mesh_device, wrap_fabric_around_mesh, topology=topology)
     ttnn.synchronize_device(mesh_device)
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
@@ -34,7 +34,7 @@ def create_and_load_sub_device_manager_with_fabric_interface(
 
 def teardown_fabric_interface(mesh_device, wrap_fabric_around_mesh=False, topology=ttnn.Topology.Linear):
     logger.debug(f"Tearing down fabric (this may take a while if context switch interval is large)")
-    ttnn.teardown_edm_fabric(mesh_device, wrap_fabric_around_mesh, topology=topology)
+    ttnn.teardown_edm_fabric(mesh_device, wrap_fabric_around_mesh=wrap_fabric_around_mesh, topology=topology)
     ttnn.synchronize_device(mesh_device)
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -173,6 +173,7 @@ def run_all_gather_impl(
             0,
             enable_persistent_fabric,
             wrap_fabric_around_mesh=wrap_fabric_around_mesh,
+            topology=all_gather_topology,
         )
         mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
@@ -334,7 +335,9 @@ def run_all_gather_impl(
 
     if enable_persistent_fabric and teardown_persistent_fabric:
         mesh_device.reset_sub_device_stall_group()
-        teardown_fabric_interface(mesh_device)
+        teardown_fabric_interface(
+            mesh_device, wrap_fabric_around_mesh=wrap_fabric_around_mesh, topology=all_gather_topology
+        )
 
     if not passed:
         assert eq, f"{i} FAILED: {output}"
@@ -516,6 +519,80 @@ def test_all_gather_sharded(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        rand_tensor=True,
+        input_shard_shape=input_shard_shape,
+        input_shard_grid=input_shard_grid,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+        wrap_fabric_around_mesh=True,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        (
+            4,
+            [1, 4, 32, 1280],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 320),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 4))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [False])
+def test_all_gather_sharded_ring(
+    pcie_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    if num_links > 1:
+        assert f"num_links > 1 not supported for sharded all gather test function which is currently using the pcie_mesh_device (and hence only has 1 link available for use)"
+
+    run_all_gather_impl(
+        pcie_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
         enable_async=enable_async,
         rand_tensor=True,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
@@ -24,9 +24,16 @@ void py_bind_common(pybind11::module& module) {
         py::arg("mesh_device"),
         py::kw_only(),
         py::arg("wrap_fabric_around_mesh") = false,
-        py::arg("context_switch_interval_override") = std::nullopt);
+        py::arg("context_switch_interval_override") = std::nullopt,
+        py::arg("topology") = ttnn::ccl::Topology::Linear);
 
-    module.def("teardown_edm_fabric", &ttnn::ccl::teardown_edm_fabric, py::arg("mesh_device"), py::kw_only());
+    module.def(
+        "teardown_edm_fabric",
+        &ttnn::ccl::teardown_edm_fabric,
+        py::arg("mesh_device"),
+        py::kw_only(),
+        py::arg("wrap_fabric_around_mesh") = false,
+        py::arg("topology") = ttnn::ccl::Topology::Linear);
 }
 
 void py_module(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -10,6 +10,7 @@
 
 #include "ttnn/distributed/types.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
+#include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"
 #include "cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_header.hpp"
@@ -97,7 +98,7 @@ struct FabricEriscDatamoverConfig {
         std::size_t channel_buffer_size_bytes,
         std::size_t sender_ratio_size,
         std::size_t receiver_ratio_size,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     std::size_t channel_buffer_size_bytes = 0;
     std::size_t channel_buffer_size_bytes_with_channel_sync = 0;
@@ -113,7 +114,7 @@ struct FabricEriscDatamoverConfig {
     std::size_t num_used_sender_channels = 0;
     std::size_t num_used_receiver_channels = 0;
 
-    bool enable_ring_topology = false;
+    Topology topology = Topology::Linear;
 
 private:
     FabricEriscDatamoverConfig();
@@ -274,7 +275,7 @@ public:
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
         bool build_in_worker_connection_mode = false,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     // Invocable per chip if we want to collectively build the fabric by building this separately per chip
     // (and implicitly building the fabric that way)
@@ -286,14 +287,14 @@ public:
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links,
         bool build_in_worker_connection_mode = false,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
         const std::vector<tt::tt_metal::IDevice*>& device_sequence,
         const std::vector<tt::tt_metal::Program*>& program_sequence,
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
     static EdmLineFabricOpInterface build_program_builder_worker_connection_fabric(
         tt::tt_metal::IDevice* local_device,
         tt::tt_metal::IDevice* forward_device,
@@ -301,7 +302,7 @@ public:
         tt::tt_metal::Program* program,
         bool enable_persistent_mode,
         std::optional<size_t> desired_num_links = std::nullopt,
-        bool ring_topology = false);
+        Topology topology = Topology::Linear);
 
     // Will create a connection adapter for a worker which can be used to pass args to the worker kernel talking to the
     // corresponding fabric endpoint. This interface will guarantee unique connections only so requesting more unique
@@ -369,8 +370,10 @@ private:
 void initialize_edm_fabric(
     distributed::MeshDevice* mesh_device,
     bool wrap_fabric_around_mesh = false,
-    std::optional<size_t> context_switch_interval_override = std::nullopt);
-void teardown_edm_fabric(distributed::MeshDevice* mesh_device);
+    std::optional<size_t> context_switch_interval_override = std::nullopt,
+    Topology topology = Topology::Linear);
+void teardown_edm_fabric(
+    distributed::MeshDevice* mesh_device, bool wrap_fabric_around_mesh = false, Topology topology = Topology::Linear);
 
 };  // namespace ccl
 };  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -35,9 +35,13 @@ AllGatherAsync create_all_gather_async_struct(
             semaphore = semaphores.at(i);  // Get raw pointer
             if (i != 0) {
                 backward_device = devices.at(i - 1);
+            } else if (topology == ttnn::ccl::Topology::Ring) {
+                backward_device = devices.at(num_devices - 1);
             }
             if (i != num_devices - 1) {
                 forward_device = devices.at(i + 1);
+            } else if (topology == ttnn::ccl::Topology::Ring) {
+                forward_device = devices.at(0);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -89,17 +89,29 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             backward_device.value_or(nullptr),
             &program,
             enable_persistent_fabric_mode,
-            num_links);
+            num_links,
+            topology);
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
-    LineTopology line_topology(ring_size, ring_index);
-    const size_t num_targets_forward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-    const size_t num_targets_backward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    size_t num_targets_forward = 0;
+    size_t num_targets_backward = 0;
+    if (topology == ccl::Topology::Linear) {
+        LineTopology line_topology(ring_size, ring_index);
+        num_targets_forward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+        num_targets_backward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    } else if (topology == ccl::Topology::Ring) {
+        // TODO: Commonize
+        num_targets_forward = tt::div_up(ring_size - 1, 2);
+        num_targets_backward = ring_size - 1 - num_targets_forward;
+        if (ring_index % 2 == 0) {
+            std::swap(num_targets_forward, num_targets_backward);
+        }
+    }
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
@@ -193,12 +205,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             drain_sync_core = device->worker_core_from_logical_core(core);
         }
         std::optional<ttnn::ccl::SenderWorkerAdapterSpec> forward_fabric_connection =
-            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !forward_device.has_value()
                 ? std::nullopt
                 : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
         std::optional<ttnn::ccl::SenderWorkerAdapterSpec> backward_fabric_connection =
-            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !backward_device.has_value()
                 ? std::nullopt
                 : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
@@ -311,17 +323,29 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
             backward_device.value_or(nullptr),
             &program,
             enable_persistent_fabric_mode,
-            num_links);
+            num_links,
+            topology);
 
     // Get OP Config, topology config
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
-    LineTopology line_topology(ring_size, ring_index);
-    const size_t num_targets_forward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-    const size_t num_targets_backward =
-        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    size_t num_targets_forward = 0;
+    size_t num_targets_backward = 0;
+    if (topology == ccl::Topology::Linear) {
+        LineTopology line_topology(ring_size, ring_index);
+        num_targets_forward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+        num_targets_backward =
+            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+    } else if (topology == ccl::Topology::Ring) {
+        // TODO: Commonize
+        num_targets_forward = tt::div_up(ring_size - 1, 2);
+        num_targets_backward = ring_size - 1 - num_targets_forward;
+        if (ring_index % 2 == 0) {
+            std::swap(num_targets_forward, num_targets_backward);
+        }
+    }
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
@@ -476,12 +500,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
             drain_sync_core = device->worker_core_from_logical_core(core);
         }
         std::optional<ttnn::ccl::SenderWorkerAdapterSpec> forward_fabric_connection =
-            line_topology.is_first_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !forward_device.has_value()
                 ? std::nullopt
                 : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
         std::optional<ttnn::ccl::SenderWorkerAdapterSpec> backward_fabric_connection =
-            line_topology.is_last_device_in_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD)
+            !backward_device.has_value()
                 ? std::nullopt
                 : std::optional<ttnn::ccl::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
                       device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18798

### Problem description
Add support for 1D ring for all gather.

### What's changed
Change ring_topology boolean to Topology enum.
Update initialize/teardown fabric apis to support ring topology.
Update all_gather_async to support ring topology and add unit test.
Currently this only tests the `all_gather_async_multi_core_with_workers` variant. Need to add tests for the minimal variants.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes