### PR TITLE
Support get_device_tensors / aggregate_as_tensor for mesh tensors

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -39,7 +39,6 @@ TEST_P(MultiDeviceTensorCreationTest, Empty) {
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_EQ(mesh_replicated_tensor.get_workers().size(), 1);
 
     const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
     EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
@@ -55,11 +54,10 @@ TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
         ttnn::Shape({32, 32}),
         DataType::BFLOAT16,
         Layout::ROW_MAJOR,
-        mesh_device->get_devices().at(0),
+        mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
     EXPECT_EQ(tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(tensor.get_workers(), SizeIs(1));
 
     const Tensor mesh_replicated_tensor = ttnn::empty_like(
         tensor,
@@ -69,7 +67,6 @@ TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(mesh_device->num_devices()));
 
     const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
     EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
@@ -88,7 +85,6 @@ TEST_P(MultiDeviceTensorCreationTest, Full) {
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(1));
     EXPECT_EQ(mesh_replicated_tensor.logical_shape(), ttnn::Shape({32, 32}));
     EXPECT_EQ(mesh_replicated_tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(mesh_replicated_tensor.layout(), Layout::ROW_MAJOR);
@@ -107,11 +103,10 @@ TEST_P(MultiDeviceTensorCreationTest, FullLike) {
         ttnn::Shape({32, 32}),
         DataType::BFLOAT16,
         Layout::ROW_MAJOR,
-        mesh_device->get_devices().at(0),
+        mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
     EXPECT_EQ(tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(tensor.get_workers(), SizeIs(1));
 
     Tensor mesh_replicated_tensor = ttnn::full_like(
         tensor,
@@ -121,7 +116,6 @@ TEST_P(MultiDeviceTensorCreationTest, FullLike) {
         std::ref(*mesh_device));
 
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(1));
     EXPECT_EQ(mesh_replicated_tensor.logical_shape(), tensor.logical_shape());
     EXPECT_EQ(mesh_replicated_tensor.padded_shape(), tensor.padded_shape());
     EXPECT_EQ(mesh_replicated_tensor.dtype(), tensor.dtype());
@@ -141,11 +135,10 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
         ttnn::Shape({32, 32}),
         DataType::BFLOAT16,
         Layout::ROW_MAJOR,
-        mesh_device->get_devices().at(0),
+        mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
     EXPECT_EQ(tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_EQ(tensor.get_workers().size(), 1);
 
     Tensor opt_output = ttnn::empty(
         ttnn::Shape({32, 32}),
@@ -164,7 +157,6 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
         opt_output);
 
     EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(1));
     EXPECT_EQ(mesh_replicated_tensor.logical_shape(), tensor.logical_shape());
     EXPECT_EQ(mesh_replicated_tensor.padded_shape(), tensor.padded_shape());
     EXPECT_EQ(mesh_replicated_tensor.dtype(), tensor.dtype());
@@ -186,7 +178,6 @@ TEST_P(MultiDeviceTensorCreationTest, Arange) {
         std::ref(*mesh_device));
 
     EXPECT_EQ(tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_EQ(tensor.get_workers().size(), 1);
     EXPECT_EQ(tensor.logical_shape(), ttnn::Shape({1, 1, 1, 1024}));
 
     const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(tensor);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -102,7 +102,7 @@ TEST_F(MeshTensorTest, ReplicateOwnedTensor) {
     EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST);
     EXPECT_EQ(output_host_tensor.get_tensor_spec().logical_shape(), shape);
 
-    for (const auto& tensor : get_tensors_from_multi_device_storage(output_host_tensor)) {
+    for (const auto& tensor : get_device_tensors(output_host_tensor)) {
         EXPECT_EQ(tensor.get_tensor_spec().logical_shape(), shape);
         EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
     }

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -22,7 +22,10 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::FloatEq;
+using ::testing::HasSubstr;
 using ::testing::Pointwise;
+using ::testing::SizeIs;
+using ::testing::ThrowsMessage;
 
 using MeshTensorTest = T3kMultiDeviceFixture;
 
@@ -89,6 +92,7 @@ TEST_F(MeshTensorTest, ReplicateOwnedTensor) {
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(device_storage, nullptr);
     EXPECT_NE(device_storage->mesh_buffer, nullptr);
+    EXPECT_THAT(device_storage->specs, SizeIs(8));
     for (const auto& [coord, spec] : device_storage->specs) {
         EXPECT_THAT(spec.logical_shape(), Eq(ttnn::Shape{1, 1, 32, 32}));
     }
@@ -102,6 +106,101 @@ TEST_F(MeshTensorTest, ReplicateOwnedTensor) {
         EXPECT_EQ(tensor.get_tensor_spec().logical_shape(), shape);
         EXPECT_THAT(tensor.to_vector<float>(), Pointwise(FloatEq(), host_data));
     }
+}
+
+TEST_F(MeshTensorTest, GetDeviceTensors) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    std::iota(host_data.begin(), host_data.end(), 0);
+
+    Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
+
+    Tensor device_tensor =
+        tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
+    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor));
+    auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
+    ASSERT_NE(device_storage, nullptr);
+    EXPECT_NE(device_storage->mesh_buffer, nullptr);
+    EXPECT_THAT(device_storage->specs, SizeIs(8));
+
+    // Validate each tensor shard.
+    std::vector<Tensor> device_tensors = get_device_tensors(device_tensor);
+    std::vector<distributed::MeshCoordinate> device_shard_coords;
+    EXPECT_THAT(device_tensors, SizeIs(8));
+    for (const auto& tensor_shard : device_tensors) {
+        auto* shard_storage = std::get_if<tt::tt_metal::DeviceStorage>(&tensor_shard.get_storage());
+        ASSERT_NE(shard_storage, nullptr);
+        EXPECT_NE(shard_storage->mesh_buffer, nullptr);
+        EXPECT_THAT(shard_storage->specs, SizeIs(1));
+        device_shard_coords.push_back(shard_storage->specs.front().first);
+        EXPECT_THAT(tensor_shard.to_vector<float>(), Pointwise(FloatEq(), host_data));
+    }
+
+    // Expect coordiantes to cover the entire mesh.
+    std::vector<::testing::Matcher<distributed::MeshCoordinate>> coord_matchers;
+    for (const auto& expected_coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
+        coord_matchers.push_back(Eq(expected_coord));
+    }
+    EXPECT_THAT(device_shard_coords, ElementsAreArray(coord_matchers));
+}
+
+TEST_F(MeshTensorTest, AggregateAsTensor) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    std::iota(host_data.begin(), host_data.end(), 0);
+
+    Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
+
+    Tensor device_tensor1 =
+        tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
+    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor1));
+    Tensor device_tensor2 =
+        tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
+    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor2));
+
+    auto device_tensors1 = get_device_tensors(device_tensor1);
+    auto device_tensors2 = get_device_tensors(device_tensor2);
+
+    EXPECT_THAT(device_tensors1, SizeIs(8));
+    EXPECT_THAT(device_tensors2, SizeIs(8));
+
+    // Try to aggregate shards from different mesh buffers.
+    EXPECT_THAT(
+        ([&]() {
+            std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
+            aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
+
+    // Try to aggregate the same shard twice
+    EXPECT_THAT(
+        ([&]() {
+            std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors1[0]};
+            aggregate_as_tensor(shards_to_aggregate, AllGatherTensor{});
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordiante")));
+
+    // Aggregate every second shard into a new mesh tensor.
+    auto partial_tensor = aggregate_as_tensor(
+        std::vector<Tensor>{device_tensors1[6], device_tensors1[4], device_tensors1[2], device_tensors1[0]},
+        AllGatherTensor{});
+
+    auto* partial_device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&partial_tensor.get_storage());
+    ASSERT_NE(partial_device_storage, nullptr);
+    EXPECT_NE(partial_device_storage->mesh_buffer, nullptr);
+
+    // Validate the shards are sorted, and are as expected.
+    ASSERT_THAT(partial_device_storage->specs, SizeIs(4));
+    EXPECT_EQ(partial_device_storage->specs[0].first, (distributed::MeshCoordinate{0, 0}));
+    EXPECT_EQ(partial_device_storage->specs[1].first, (distributed::MeshCoordinate{0, 2}));
+    EXPECT_EQ(partial_device_storage->specs[2].first, (distributed::MeshCoordinate{1, 0}));
+    EXPECT_EQ(partial_device_storage->specs[3].first, (distributed::MeshCoordinate{1, 2}));
 }
 
 struct MeshTensorWriteTestParams {

--- a/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
@@ -27,7 +27,7 @@ TEST_F(T3kMultiDeviceFixture, TestGetTensorsFromMultiDeviceStorage) {
     MeshDevice* mesh_device = this->mesh_device_.get();
     const auto input_tensor = ttnn::ones(ttnn::Shape({32, 32}), DataType::BFLOAT16);
     const auto replicated_tensor = create_host_multi_device_tensor(input_tensor, ReplicateTensor(8));
-    const auto device_tensors = get_tensors_from_multi_device_storage(replicated_tensor);
+    const auto device_tensors = get_device_tensors(replicated_tensor);
 
     EXPECT_EQ(device_tensors.size(), 8);
 }

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -5,6 +5,8 @@
 #include "ttnn_ops.hpp"
 
 #include <core/ttnn_all_includes.hpp>
+#include <ttnn/distributed/api.hpp>
+#include <ttnn/tensor/tensor.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
@@ -46,10 +48,8 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
     }
 
     auto device_grid_shape = current_device->shape();
-    // const auto& storage = std::get<tt::tt_metal::MultiDeviceStorage>(tensor.get_storage());
-    // auto num_tensor_buffers = storage.num_buffers();
-    //  TODO(jchu): fix me
-    auto num_tensor_buffers = 1;
+    const auto& storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
+    const auto num_tensor_buffers = storage.specs.size();
 
     if (num_devices != num_tensor_buffers) {
         throw std::logic_error(fmt::format(
@@ -84,23 +84,22 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
     ttnn::SmallVector<uint32_t> end{tensor_shape[0], tensor_shape[1], tensor_shape[2], tensor_shape[3]};
     ttnn::SmallVector<uint32_t> stride{1U, 1U, 1U, 1U};
 
-    /*std::vector<tt::tt_metal::Tensor> scattered_tensors;
-    scattered_tensors.reserve(num_tensor_buffers);
-    for (size_t device_index = 0; device_index < num_tensor_buffers; ++device_index) {
-        auto device = storage.get_buffer_for_device_id(device_index)->device();
-        auto tensor_on_device =
-            tt::tt_metal::Tensor(storage.get_buffer_for_device(device), storage.get_tensor_spec_for_device(device));
+    ttnn::SmallVector<uint32_t> shape{tensor_shape[0], tensor_shape[1], tensor_shape[2], tensor_shape[3]};
+    shape[dim] = split_size_per_device;
 
-        start[dim] = split_size_per_device * device_index;
-        end[dim] = split_size_per_device * (device_index + 1);
+    ttnn::Tensor scattered_tensor = tt::tt_metal::allocate_tensor_on_mesh(
+        ttnn::TensorSpec(ttnn::Shape(shape), tensor.get_tensor_spec().tensor_layout()), current_device);
+    std::vector<tt::tt_metal::Tensor> scattered_tensors = ttnn::distributed::get_device_tensors(scattered_tensor);
 
-        auto sliced_tensor = ttnn::slice(tensor_on_device, start, end, stride);
-        scattered_tensors.push_back(sliced_tensor);
+    size_t idx = 0;
+    for (const auto& tensor_shard : ttnn::distributed::get_device_tensors(tensor)) {
+        start[dim] = split_size_per_device * idx;
+        end[dim] = split_size_per_device * (idx + 1);
+
+        ttnn::slice(tensor_shard, start, end, stride, std::nullopt, scattered_tensors[idx]);
+        ++idx;
     }
-    auto distributed_tensor = ttnn::distributed::create_multi_device_tensor(
-        scattered_tensors, ttnn::StorageType::MULTI_DEVICE, storage.strategy);
-    return distributed_tensor;*/
-    TT_THROW("Not implemented");
+    return ttnn::distributed::aggregate_as_tensor(scattered_tensors, tt::tt_metal::AllGatherTensor{});
 }
 
 }  // namespace ttml::ttnn_fixed::distributed

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_device->close(); }
 
-std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor) {
+std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
     if (std::holds_alternative<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage())) {
         std::vector<ttnn::Tensor> tensors;
         auto& host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());
@@ -61,7 +61,6 @@ std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor) {
     } else {
         return {tensor};
     }
-    TT_THROW("Expected tensor to be on MultiDeviceHostStorage type!");
 }
 
 Tensor aggregate_as_tensor(
@@ -141,7 +140,9 @@ Tensor aggregate_as_tensor(
         auto storage = DeviceStorage(mesh_buffer, AllGatherTensor{}, specs);
         return Tensor(std::move(storage), reference_shard.get_tensor_spec());
     } else {
-        TT_THROW("TODO(jchu): Not implemented");
+        TT_THROW(
+            "Unsupported storage type for multi-device tensor: {}",
+            tt::stl::get_active_type_name_in_variant(reference_shard.get_storage()));
     }
 }
 
@@ -193,65 +194,24 @@ DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& 
             "Unexpected type {}",
             tt::stl::get_active_type_name_in_variant(tensor.get_storage()));
         return multi_device_host_storage->strategy;
+    } else if (tensor.storage_type() == StorageType::DEVICE) {
+        const auto& device_storage = std::get<DeviceStorage>(tensor.get_storage());
+        TT_FATAL(device_storage.mesh_buffer != nullptr, "Device storage must be on a mesh buffer");
+        return device_storage.strategy;
+    } else {
+        TT_THROW("Tensor is not a multi-device tensor");
     }
-    TT_THROW("Tensor is not a multi-device tensor");
 }
 
 bool is_host_mesh_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST; }
 
-bool is_multi_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST; }
+bool is_multi_device_tensor(const Tensor& tensor) {
+    return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST || is_mesh_buffer_tensor(tensor);
+}
 
 bool is_mesh_buffer_tensor(const Tensor& tensor) {
     auto* device_storage = std::get_if<DeviceStorage>(&tensor.get_storage());
     return device_storage != nullptr && device_storage->mesh_buffer != nullptr;
-}
-
-std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_device_tensor) {
-    std::vector<ttnn::Tensor> tensors;
-    if (multi_device_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST) {
-        TT_ASSERT(
-            std::holds_alternative<MultiDeviceHostStorage>(multi_device_tensor.get_storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(multi_device_tensor.get_storage()));
-        const auto& tensor_storage = std::get<MultiDeviceHostStorage>(multi_device_tensor.get_storage());
-        for (int i = 0; i < tensor_storage.num_buffers(); ++i) {
-            tensors.push_back(Tensor{OwnedStorage{tensor_storage.get_buffer(i)}, tensor_storage.specs[i]});
-        }
-    } else {
-        TT_THROW("get_tensors_from_multi_device_storage only support multi device tensors");
-    }
-    return tensors;
-}
-
-Tensor create_multi_device_tensor(
-    const std::vector<Tensor>& tensors, StorageType storage_type, const DistributedTensorConfig& strategy) {
-    if (tensors.empty()) {
-        TT_THROW("Cannot create multi-device tensor with empty tensor list");
-    }
-    if (storage_type == StorageType::MULTI_DEVICE_HOST) {
-        std::vector<OwnedBuffer> owned_buffers;
-        std::vector<ttnn::TensorSpec> specs;
-        for (const auto& tensor : tensors) {
-            TT_ASSERT(
-                std::holds_alternative<OwnedStorage>(tensor.get_storage()),
-                "Unexpected type {}",
-                tt::stl::get_active_type_name_in_variant(tensor.get_storage()));
-            owned_buffers.push_back(std::get<OwnedStorage>(tensor.get_storage()).buffer);
-            specs.push_back(tensor.get_tensor_spec());
-        }
-        return Tensor{
-            MultiDeviceHostStorage{strategy, owned_buffers, specs},
-            TensorSpec(
-                tensors.at(0).get_logical_shape(),
-                TensorLayout::fromPaddedShape(
-                    tensors.at(0).get_dtype(),
-                    PageConfig(tensors.at(0).get_layout()),
-                    MemoryConfig{},
-                    tensors.at(0).get_logical_shape(),
-                    tensors.at(0).get_padded_shape()))};
-    } else {
-        TT_THROW("Invalid storage type for multi-device tensor");
-    }
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -120,16 +120,15 @@ Tensor aggregate_as_tensor(
         auto mesh_buffer = std::get<DeviceStorage>(reference_shard.get_storage()).mesh_buffer;
         TT_FATAL(
             mesh_buffer != nullptr,
-            "Does not support aggregating tensor shards that are not backed by a mesh buffer. Consider moving tensors "
-            "to host, aggregating, and re-uploading on device storage.");
+            "Error aggregating multichip tensors: tensors shards must be allocated on a mesh buffer.");
         std::vector<std::pair<MeshCoordinate, TensorSpec>> specs;
 
         for (const auto& shard : tensor_shards) {
             const auto& shard_storage = std::get<DeviceStorage>(shard.get_storage());
             TT_FATAL(
                 shard_storage.mesh_buffer == mesh_buffer,
-                "Does not support aggregating tensor shards, allocated on different mesh buffers. Consider moving "
-                "tensors to host, aggregating, and re-uploading on device storage.");
+                "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
+                "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
             for (const auto& [coord, shard_spec] : shard_storage.specs) {
                 specs.push_back(std::make_pair(coord, shard_spec));
             }

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -24,7 +24,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);
 
 // Given a multi-device tensor, returns a list of individual per-device tensors.
-std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);
+std::vector<Tensor> get_device_tensors(const Tensor& tensor);
 
 // Given a list of per-device shards, returns multi-device tensor.
 Tensor aggregate_as_tensor(
@@ -35,7 +35,7 @@ std::vector<int> get_t3k_physical_device_ids_ring();
 // Maps a tensor to the set of devices in the device-mesh that the shards will be distributed across.
 std::vector<tt::tt_metal::IDevice*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_device);
 
-// Get the distributed tensor config from a tensor.
+// Returns the distributed tensor config from a tensor.
 tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
 
 // Returns true has MultiDeviceHost/MultiDevice Storage
@@ -45,14 +45,5 @@ bool is_multi_device_tensor(const Tensor& tensor);
 // Returns true if tensor has MultiDevice storage type and is allocated on a mesh buffer.
 // TODO: remove when the infrastructure uniformly works with mesh buffer backed tensors.
 bool is_mesh_buffer_tensor(const Tensor& tensor);
-
-// Given a multi-device tensor and a device, returns a list of per-device tensors.
-std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_device_tensor);
-
-// Given a list of per-device shards, return a multi-device tensor
-Tensor create_multi_device_tensor(
-    const std::vector<Tensor>& tensors,
-    tt::tt_metal::StorageType storage_type,
-    const tt::tt_metal::DistributedTensorConfig& strategy);
 
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor.cpp
@@ -200,8 +200,7 @@ Tensor distribute_tensor(
 }
 
 Tensor aggregate_tensor(const Tensor& tensor, const MeshToTensor& composer) {
-    return is_host_mesh_tensor(tensor) ? composer.compose(get_tensors_from_multi_device_storage(tensor))
-                                       : composer.compose({tensor});
+    return composer.compose(get_device_tensors(tensor.cpu()));
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/tensor/tensor_impl.hpp"
+#include <fmt/format.h>
 #include <optional>
 
 #include "tt-metalium/mesh_buffer.hpp"
@@ -432,7 +433,7 @@ std::string to_string(
     const auto dtype = original_dtype.value_or(tensor.get_dtype());
     const auto layout = original_layout.value_or(tensor.get_layout());
 
-    if (not tensor.is_allocated()) {
+    if (!tensor.is_allocated()) {
         return fmt::format(
             "{}(<buffer is not allocated>, shape={}, dtype={}, layout={})",
             detail::TENSOR_TYPE_STRING,
@@ -441,14 +442,9 @@ std::string to_string(
             layout);
     }
 
-    if (is_tensor_on_device(tensor)) {
-        return to_string<T>(tensor.cpu(), dtype, layout);
-    }
-
     return std::visit(
-        [&](auto&& storage) -> std::string {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (std::is_same_v<StorageType, OwnedStorage> || std::is_same_v<StorageType, BorrowedStorage>) {
+        tt::stl::overloaded{
+            [&]<OwnedOrBorrowedStorage StorageType>(const StorageType& storage) -> std::string {
                 if (tensor.get_layout() != Layout::ROW_MAJOR) {
                     if (tensor.get_dtype() == DataType::BFLOAT8_B || tensor.get_dtype() == DataType::BFLOAT4_B) {
                         return to_string<float>(ttnn::to_dtype(tensor, DataType::FLOAT32), dtype, layout);
@@ -461,16 +457,27 @@ std::string to_string(
                 }
 
                 const auto strides = tensor.get_tensor_spec().compute_strides();
-                if constexpr (std::is_same_v<StorageType, OwnedStorage>) {
-                    const auto buffer = owned_buffer::get_as<T>(storage.buffer);
-                    return detail::to_string(buffer, shape, strides, dtype, layout);
-                } else {
-                    const auto buffer = borrowed_buffer::get_as<T>(storage.buffer);
-                    return detail::to_string(buffer, shape, strides, dtype, layout);
+                const auto buffer = host_buffer::get_as<T>(storage.buffer);
+                return detail::to_string(buffer, shape, strides, dtype, layout);
+            },
+            [&](const DeviceStorage& storage) -> std::string {
+                if (storage.mesh_buffer == nullptr) {
+                    // Use owned buffer path above.
+                    return to_string<T>(tensor.cpu());
                 }
-            } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
-                TT_THROW("Cannot print a device tensor!");
-            } else if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
+
+                auto* mesh_device = storage.mesh_buffer->device();
+                const auto& specs = storage.specs;
+                auto specs_it = specs.begin();
+                std::stringstream ss;
+                apply(tensor.cpu(), [&](const Tensor& device_shard) {
+                    const distributed::MeshCoordinate coord = (specs_it++)->first;
+                    ss << "device_id: " << mesh_device->get_device(coord)->id() << ", " << coord << std::endl;
+                    ss << to_string<T>(device_shard) << std::endl;
+                });
+                return ss.str();
+            },
+            [&](const MultiDeviceHostStorage& storage) -> std::string {
                 std::stringstream ss;
                 auto device_tensors = ttnn::distributed::get_tensors_from_multi_device_storage(tensor);
                 for (size_t i = 0; i < device_tensors.size(); i++) {
@@ -480,10 +487,7 @@ std::string to_string(
                     }
                 }
                 return ss.str();
-            } else {
-                // raise_unsupported_storage<StorageType>();
-            }
-        },
+            }},
         tensor.get_storage());
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -479,7 +479,7 @@ std::string to_string(
             },
             [&](const MultiDeviceHostStorage& storage) -> std::string {
                 std::stringstream ss;
-                auto device_tensors = ttnn::distributed::get_tensors_from_multi_device_storage(tensor);
+                auto device_tensors = ttnn::distributed::get_device_tensors(tensor);
                 for (size_t i = 0; i < device_tensors.size(); i++) {
                     ss << to_string<T>(device_tensors[i]);
                     if (i + 1 != device_tensors.size()) {

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -237,6 +237,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
 
 void tensor_print(const Tensor& input_tensor) {
     GraphTracker::instance().track_function_start("Tensor::print", input_tensor);
+    std::cout << input_tensor.write_to_string() << std::endl;
     GraphTracker::instance().track_function_end();
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -208,7 +208,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
                     "to(layout) must be called on host tensors with MULTI_DEVICE_HOST_STORAGE when multiple "
                     "workers "
                     "are specified");
-                ;
+
                 auto shard = get_shard_for_device(input_tensor, worker, worker_index);
                 shard = tensor_impl::to_layout_wrapper(shard, target_layout);
                 insert_buffer_and_shape_for_device(worker, shard, tensor_modified_layout, worker_index);

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -4,6 +4,8 @@
 
 #include "ttnn/tensor/tensor_utils.hpp"
 
+#include <tt-metalium/overloaded.hpp>
+
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -83,50 +85,23 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
     }
 }
 
-uint32_t num_buffers_in_tensor(const Tensor& tensor) {
-    if (std::holds_alternative<MultiDeviceHostStorage>(tensor.get_storage())) {
-        auto host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());
-        return host_storage.num_buffers();
-    } else if (std::holds_alternative<DeviceStorage>(tensor.get_storage())) {
-        TT_THROW("Not implemented");
-        return 1;
-    } else if (
-        std::holds_alternative<OwnedStorage>(tensor.get_storage()) ||
-        std::holds_alternative<BorrowedStorage>(tensor.get_storage())) {
-        return 1;
-    } else {
-        TT_THROW("num_buffers_in_tensor only supports multi-device or device tensors");
-    }
-}
-
 Tensor get_shard_for_device(const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index) {
     ZoneScopedN("GetShardForDevice");
     auto& storage = tensor.tensor_attributes->storage;
     return std::visit(
-        [target_device, buffer_index, &tensor](auto&& s) {
-            using T = std::decay_t<decltype(s)>;
-            // Stalling reads for tensor data-type and layout are needed here
-            // since some worker might have raced ahead to these lookups, while
-            // another worker is populating this metadata.
-            /*
-            if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
-                return Tensor{
-                    DeviceStorage{s.get_buffer_for_device(target_device)}, s.get_tensor_spec_for_device(target_device)};
-            } else {
-            */
-            // TODO(jchu): Handle buffer_index.
-            if constexpr (std::is_same_v<T, MultiDeviceHostStorage>) {
+        tt::stl::overloaded{
+            [buffer_index](const MultiDeviceHostStorage& s) {
                 return Tensor{
                     OwnedStorage{s.get_buffer(buffer_index.value())}, s.get_tensor_spec(buffer_index.value())};
-            } else if constexpr (
-                std::is_same_v<T, OwnedStorage> || std::is_same_v<T, BorrowedStorage> ||
-                std::is_same_v<T, DeviceStorage>) {
-                return tensor;
-            } else {
-                TT_THROW("get_shard_for_device only supports multi-device or device tensors");
+            },
+            [&tensor]<OwnedOrBorrowedStorage T>(const T&) { return tensor; },
+            [](const DeviceStorage& s) {
+                TT_FATAL(s.mesh_buffer != nullptr, "get_shard_for_device does not support mesh buffer backed tensors");
                 return Tensor();
-            }
-        },
+            },
+            [](const auto&) -> Tensor {
+                TT_THROW("get_shard_for_device only supports multi-device or device tensors");
+            }},
         storage);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -68,7 +68,7 @@ bool is_cpu_tensor(const Tensor& tensor) {
 
 bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
 
-Tensor transform(const Tensor& tensor, std::function<Tensor(const Tensor&)> transform_func) {
+Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)>& transform_func) {
     auto input_tensors = ttnn::distributed::get_tensors_from_multi_device_storage(tensor);
     std::vector<Tensor> output_tensors(input_tensors.size());
     std::transform(input_tensors.begin(), input_tensors.end(), output_tensors.begin(), [&](const auto& device_tensor) {

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -97,10 +97,7 @@ Tensor get_shard_for_device(const Tensor& tensor, IDevice* target_device, std::o
                     OwnedStorage{s.get_buffer(buffer_index.value())}, s.get_tensor_spec(buffer_index.value())};
             },
             [&tensor]<OwnedOrBorrowedStorage T>(const T&) { return tensor; },
-            [&tensor](const DeviceStorage& s) {
-                TT_FATAL(s.mesh_buffer == nullptr, "get_shard_for_device does not support mesh buffer backed tensors");
-                return tensor;
-            },
+            [&tensor](const DeviceStorage& s) { return tensor; },
             [](const auto&) -> Tensor {
                 TT_THROW("get_shard_for_device only supports multi-device or device tensors");
             }},

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -58,7 +58,7 @@ bool is_device_tensor(const Tensor& tensor);
 
 // Given a multi-device tensor, and a function that transforms a tensor, applies the function to all per-device
 // tensors.
-Tensor transform(const Tensor& tensor, std::function<Tensor(const Tensor&)> transform_func);
+Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)>& transform_func);
 
 // Given a multi-device tensor, and a callable, applies the function to all per-device tensors.
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -63,9 +63,10 @@ Tensor transform(const Tensor& tensor, std::function<Tensor(const Tensor&)> tran
 // Given a multi-device tensor, and a callable, applies the function to all per-device tensors.
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);
 
-uint32_t num_buffers_in_tensor(const Tensor& tensor);
-
-Tensor get_shard_for_device(
+// This function is used in legacy context of launching per-device work via push_work threads.
+// This won't be supported. In the long-term, tensor shards for Device tensors should be referred to using
+// `MeshCoordinate`.
+[[deprecated]] Tensor get_shard_for_device(
     const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index = std::nullopt);
 
 void insert_buffer_and_shape_for_device(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The support for `get_device_tensors` and `aggregate_as_tensor` is needed for some of the existing use cases. 

### What's changed
* Extend `get_device_tensors` to return a collection of tensors with just coordinate populated.
* Extend `aggregate_as_tensor` to allow aggregating tensors if they were allocated on the same mesh buffer, and if they belong to different shards (different coordinate).
* Fix the tensor printing function.
* Tests

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13812909605)
- [X] New/Existing tests provide coverage for changes