### PR TITLE
Make Logical and SubDevice Logical XY available in kernel

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -141,6 +141,7 @@ target_sources(
             test_kernels/misc/watcher_pause.cpp
             test_kernels/misc/watcher_ringbuf.cpp
             test_kernels/misc/watcher_waypoints.cpp
+            test_kernels/misc/read_my_coordinates.cpp
 )
 
 install(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <cstdint>
 #include <array>
-#include <tuple>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -28,6 +26,12 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceAllocations) {
     CoreRangeSet sharded_cores_1 = CoreRange({0, 0}, {2, 2});
     CoreRangeSet sharded_cores_2 = CoreRange({4, 4}, {4, 4});
 
+    auto device = devices_[0];
+    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1}, local_l1_size);
+    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
+    DeviceAddr l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    DeviceAddr max_addr = l1_unreserved_base + local_l1_size;
+
     auto sharded_cores_1_vec = corerange_to_cores(sharded_cores_1, std::nullopt, true);
     auto sharded_cores_2_vec = corerange_to_cores(sharded_cores_2, std::nullopt, true);
 
@@ -35,7 +39,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceAllocations) {
         ShardSpecBuffer(sharded_cores_1, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {sharded_cores_1.num_cores(), 1});
     uint32_t page_size_1 = 32;
     ShardedBufferConfig shard_config_1 = {
-        nullptr,
+        device,
         sharded_cores_1.num_cores() * page_size_1,
         page_size_1,
         BufferType::L1,
@@ -48,7 +52,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceAllocations) {
         ShardSpecBuffer(sharded_cores_2, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {sharded_cores_2.num_cores(), 1});
     uint32_t page_size_2 = 64;
     ShardedBufferConfig shard_config_2 = {
-        nullptr,
+        device,
         sharded_cores_2.num_cores() * page_size_2,
         page_size_2,
         BufferType::L1,
@@ -59,19 +63,9 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceAllocations) {
 
     uint32_t page_size_3 = 1024;
     InterleavedBufferConfig interleaved_config = {
-        nullptr, page_size_3, page_size_3, BufferType::L1, TensorMemoryLayout::INTERLEAVED};
+        device, page_size_3, page_size_3, BufferType::L1, TensorMemoryLayout::INTERLEAVED};
     auto input_3 =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, interleaved_config.size / sizeof(uint32_t));
-
-    auto device = devices_[0];
-    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1}, local_l1_size);
-    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
-    DeviceAddr l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    DeviceAddr max_addr = l1_unreserved_base + local_l1_size;
-
-    shard_config_1.device = device;
-    shard_config_2.device = device;
-    interleaved_config.device = device;
 
     std::vector<CoreCoord> physical_cores_1;
     physical_cores_1.reserve(sharded_cores_1_vec.size());

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -729,15 +729,14 @@ IncrementKernelsSet create_increment_kernels(
     const auto [unique_args_addr, common_args_addr] = get_args_addr(device, riscv, idle_eth);
     std::vector<uint32_t> compile_args{num_unique_rt_args, num_common_rt_args, unique_args_addr, common_args_addr};
 
+    const std::string increment_kernel_path =
+        riscv == tt::RISCV::COMPUTE ? "tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp"
+                                    : "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp";
+
     // CreateKernel on each core range set
     for (const auto& program_config : program_configs) {
         const auto& cr_set = program_config.cr_set;
-        KernelHandle kernel_id = create_kernel(
-            riscv,
-            program,
-            cr_set,
-            compile_args,
-            "tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp");
+        KernelHandle kernel_id = create_kernel(riscv, program, cr_set, compile_args, increment_kernel_path);
 
         kernels.push_back(kernel_id);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1453,13 +1453,6 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixIncrementRuntimeArgsSanityMul
     }
 }
 
-// Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesCompute) {
-    for (IDevice* device : devices_) {
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
-    }
-}
-
 // Ensure the data movement core can access their own logical coordinate. Same binary enqueued to multiple cores.
 TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesDataMovement) {
     for (IDevice* device : devices_) {
@@ -1472,14 +1465,6 @@ TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesDataMovement)
 TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesEth) {
     for (IDevice* device : devices_) {
         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC);
-    }
-}
-
-// Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
-TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
-    for (IDevice* device : devices_) {
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
-        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1463,6 +1463,10 @@ TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesDataMovement)
 // Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
 TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesEth) {
     for (IDevice* device : devices_) {
+        if (!does_device_have_active_eth_cores(device)) {
+            GTEST_SKIP() << "Skipping test because device " << device->id()
+                         << " does not have any active ethernet cores";
+        }
         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC);
     }
 }
@@ -1480,6 +1484,10 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesDataMo
 // Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
 TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesEth) {
     for (IDevice* device : devices_) {
+        if (!does_device_have_active_eth_cores(device)) {
+            GTEST_SKIP() << "Skipping test because device " << device->id()
+                         << " does not have any active ethernet cores";
+        }
         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 0);
         local_test_functions::test_my_coordinates(device, tt::RISCV::ERISC, 1);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -18,13 +18,11 @@
 //      EnqueueProgram(p, device)
 // This makes it non-trivial to share the host-setup code across tests.
 
-#include <algorithm>
 #include <cmath>
-#include <functional>
-#include <random>
 
 #include "command_queue_fixture.hpp"
 #include <tt-metalium/allocator.hpp>
+#include "tt_align.hpp"
 
 namespace tt::tt_metal {
 struct CBConfig {
@@ -60,18 +58,26 @@ std::shared_ptr<Program> create_program_multi_core_rta(
     uint32_t rta_base_dm0 = base_addr;
     uint32_t rta_base_dm1 = rta_base_dm0 + 1024 * sizeof(uint32_t);
     uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
+
+    uint32_t coord_base_dm0 = tt::align(base_addr + 4096 * sizeof(uint32_t), hal.get_alignment(HalMemType::L1));
+    uint32_t coord_base_dm1 = coord_base_dm0 + 1024 * sizeof(uint32_t);
+    uint32_t coord_base_compute = coord_base_dm1 + 2048 * sizeof(uint32_t);
+
     std::map<string, string> dm_defines0 = {
         {"DATA_MOVEMENT", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm0)}};
+        {"RESULTS_ADDR", std::to_string(rta_base_dm0)},
+        {"COORDS_ADDR", std::to_string(coord_base_dm0)}};
     std::map<string, string> dm_defines1 = {
         {"DATA_MOVEMENT", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm1)}};
+        {"RESULTS_ADDR", std::to_string(rta_base_dm1)},
+        {"COORDS_ADDR", std::to_string(coord_base_dm1)}};
     std::map<string, string> compute_defines = {
         {"COMPUTE", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_compute)}};
+        {"RESULTS_ADDR", std::to_string(rta_base_compute)},
+        {"COORDS_ADDR", std::to_string(coord_base_compute)}};
 
     auto dummy_kernel0 = CreateKernel(
         *program,
@@ -127,7 +133,7 @@ std::shared_ptr<Program> create_program_multi_core_rta(
 }
 
 TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
-    // Sanity test: Create a program with Semaphores, CBs, RTAs and Kernel Binaries.
+    // Sanity test: Create a program with Semaphores, CBs, RTAs, Core Coords, and Kernel Binaries.
     // Enqueue Program across all devices.
     // Read L1 directly to ensure that all program attributes are correctly present.
     if (devices_[0]->arch() != ARCH::WORMHOLE_B0) {
@@ -173,9 +179,16 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
     auto program = create_program_multi_core_rta(
         rta_program_config, sem_program_config, dummy_cr0_args, dummy_cr1_args, dummy_sems, cb_config, rta_base_addr);
 
+    constexpr uint32_t coordinate_readback_size = 2 * 3 * sizeof(uint32_t);  // (X,Y) x (Virtual, Logical, Relative) = 6
+    // Below addresses are copied from create_program_multi_core_rta
     uint32_t rta_base_dm0 = rta_base_addr;
     uint32_t rta_base_dm1 = rta_base_dm0 + 1024 * sizeof(uint32_t);
     uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
+
+    // Put the coordinates way above the maximum RTAs
+    uint32_t coord_base_dm0 = tt::align(rta_base_addr + 4096 * sizeof(uint32_t), hal.get_alignment(HalMemType::L1));
+    uint32_t coord_base_dm1 = coord_base_dm0 + 1024 * sizeof(uint32_t);
+    uint32_t coord_base_compute = coord_base_dm1 + 2048 * sizeof(uint32_t);
     uint32_t semaphore_buffer_size = dummy_sems.size() * hal.get_alignment(HalMemType::L1);
     uint32_t cb_config_buffer_size =
         NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
@@ -183,8 +196,14 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
         log_info(LogTest, "Running test on {}", device->id());
         EnqueueProgram(device->command_queue(), *program, false);
         Finish(device->command_queue());
+        tt::Cluster::instance().l1_barrier(device->id());
 
         for (const CoreCoord& core_coord : cr0) {
+            const auto& virtual_core_coord = device->worker_core_from_logical_core(core_coord);
+            std::vector<uint32_t> expected_core_coordinates_dm{
+                virtual_core_coord.x, virtual_core_coord.y, core_coord.x, core_coord.y, core_coord.x, core_coord.y};
+            std::vector<uint32_t> expected_core_coordinates_compute{
+                0, 0, core_coord.x, core_coord.y, core_coord.x, core_coord.y};
             std::vector<uint32_t> dummy_kernel0_args_readback;
             detail::ReadFromDeviceL1(
                 device,
@@ -193,6 +212,11 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
                 num_runtime_args_for_cr0 * sizeof(uint32_t),
                 dummy_kernel0_args_readback);
             EXPECT_EQ(dummy_cr0_args, dummy_kernel0_args_readback);
+
+            std::vector<uint32_t> dummy_kernel0_coords_readback;
+            detail::ReadFromDeviceL1(
+                device, core_coord, coord_base_dm0, coordinate_readback_size, dummy_kernel0_coords_readback);
+            EXPECT_EQ(expected_core_coordinates_dm, dummy_kernel0_coords_readback);
 
             std::vector<uint32_t> dummy_kernel1_args_readback;
             detail::ReadFromDeviceL1(
@@ -203,6 +227,11 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
                 dummy_kernel1_args_readback);
             EXPECT_EQ(dummy_cr0_args, dummy_kernel1_args_readback);
 
+            std::vector<uint32_t> dummy_kernel1_coords_readback;
+            detail::ReadFromDeviceL1(
+                device, core_coord, coord_base_dm1, coordinate_readback_size, dummy_kernel1_coords_readback);
+            EXPECT_EQ(expected_core_coordinates_dm, dummy_kernel1_coords_readback);
+
             std::vector<uint32_t> dummy_compute_args_readback;
             detail::ReadFromDeviceL1(
                 device,
@@ -211,6 +240,11 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
                 num_runtime_args_for_cr0 * sizeof(uint32_t),
                 dummy_compute_args_readback);
             EXPECT_EQ(dummy_cr0_args, dummy_compute_args_readback);
+
+            std::vector<uint32_t> dummy_compute_coords_readback;
+            detail::ReadFromDeviceL1(
+                device, core_coord, coord_base_compute, coordinate_readback_size, dummy_compute_coords_readback);
+            EXPECT_EQ(expected_core_coordinates_compute, dummy_compute_coords_readback);
         }
 
         for (const CoreCoord& core_coord : cr1) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -1,8 +1,7 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <cstdint>
 #include <array>
 #include <tuple>
@@ -14,6 +13,12 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/event.hpp>
 #include <tt-metalium/sub_device.hpp>
+#include "hal.hpp"
+#include "hal_exp.hpp"
+#include "host_api.hpp"
+#include "kernel_types.hpp"
+#include "sub_device_types.hpp"
+#include "tt_backend_api_types.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
 #include "sub_device_test_utils.hpp"
@@ -21,9 +26,11 @@
 
 namespace tt::tt_metal {
 
+constexpr uint32_t k_local_l1_size = 3200;
+const std::string k_coordinates_kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp";
+
 TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
     auto* device = devices_[0];
-    uint32_t local_l1_size = 3200;
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
     CoreRangeSet sharded_cores_1 = CoreRange({0, 0}, {2, 2});
@@ -45,7 +52,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
 
     std::array sub_device_ids_to_block = {SubDeviceId{0}};
 
-    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
 
     shard_config_1.device = device;
 
@@ -94,17 +101,17 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
 }
 
 TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicPrograms) {
+    constexpr uint32_t k_num_iters = 5;
     auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
-    uint32_t num_iters = 5;
-    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
     device->load_sub_device_manager(sub_device_manager);
 
     auto [waiter_program, syncer_program, incrementer_program, global_sem] =
         create_basic_sync_program(device, sub_device_1, sub_device_2);
 
-    for (uint32_t i = 0; i < num_iters; i++) {
+    for (uint32_t i = 0; i < k_num_iters; i++) {
         EnqueueProgram(device->command_queue(), waiter_program, false);
         device->set_sub_device_stall_group({SubDeviceId{0}});
         // Test blocking on one sub-device
@@ -127,7 +134,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthProgra
     SubDevice sub_device_2(std::array{
         CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}),
         CoreRangeSet(CoreRange(eth_core, eth_core))});
-    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
     device->load_sub_device_manager(sub_device_manager);
 
     auto [waiter_program, syncer_program, incrementer_program, global_sem] =
@@ -146,10 +153,121 @@ TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthProgra
 }
 
 // Ensure each core in the sub device aware of their own logical coordinate. Same binary used in multiple sub devices.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordinates) {}
+TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordinates) {
+    auto* device = devices_[0];
+    uint32_t local_l1_size = 3200;
+    // Make 2 sub devices.
+    // origin means top left.
+    // for sub_device_1 = 0,0. so relative coordinates are the same as logical.
+    // for sub_device_2 = 3,3. so relative coordinates are offset by x=3,y=3 from logical.
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {6, 6})})});
 
-// Ensure each core in the sub device aware of their own sub device logical coordinate. Same binary used in multiple sub
-// devices.
-TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMySubDeviceLogicalCoordinates) {}
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
+    device->load_sub_device_manager(sub_device_manager);
+
+    const auto sub_device_1_cores = device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
+    const auto sub_device_2_cores = device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{1});
+
+    uint32_t cb_addr = experimental::hal::get_tensix_l1_unreserved_base();
+    std::vector<uint32_t> compile_args{cb_addr};
+
+    // Start kernels on each sub device and verify their coordinates
+    Program program_1 = tt::tt_metal::CreateProgram();
+    tt::tt_metal::CreateKernel(
+        program_1,
+        k_coordinates_kernel_path,
+        sub_device_1_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = compile_args});
+
+    Program program_2 = tt::tt_metal::CreateProgram();
+    tt::tt_metal::CreateKernel(
+        program_2,
+        k_coordinates_kernel_path,
+        sub_device_2_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = compile_args});
+
+    EnqueueProgram(device->command_queue(), program_1, false);
+    EnqueueProgram(device->command_queue(), program_2, false);
+    Finish(device->command_queue());
+    device->reset_sub_device_stall_group();
+    Synchronize(device);  // Ensure this CQ is cleared. Each CQ can only work on 1 sub device
+
+    // Check coordinates
+    tt::tt_metal::verify_kernel_coordinates(
+        tt::BRISC, sub_device_1_cores, device, tt::tt_metal::SubDeviceId{0}, cb_addr);
+    tt::tt_metal::verify_kernel_coordinates(
+        tt::NCRISC, sub_device_2_cores, device, tt::tt_metal::SubDeviceId{1}, cb_addr);
+}
+
+TEST_F(CommandQueueSingleCardProgramFixture, TensixActiveEthTestSubDeviceMyLogicalCoordinates) {
+    auto* device = devices_[0];
+    CoreRangeSet sub_device_1_worker_cores{CoreRange({0, 0}, {2, 2})};
+    SubDevice sub_device_1(std::array{sub_device_1_worker_cores});
+    uint32_t num_iters = 5;
+    if (!does_device_have_active_eth_cores(device)) {
+        GTEST_SKIP() << "Skipping test because device " << device->id() << " does not have any active ethernet cores";
+    }
+    auto eth_core = *device->get_active_ethernet_cores(true).begin();
+    CoreRangeSet sub_device_2_worker_cores{std::vector{CoreRange{{3, 3}, {3, 3}}, CoreRange{{4, 4}, {4, 4}}}};
+    CoreRangeSet sub_device_2_eth_cores{CoreRange(eth_core, eth_core)};
+
+    SubDevice sub_device_2(std::array{sub_device_2_worker_cores, sub_device_2_eth_cores});
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
+    device->load_sub_device_manager(sub_device_manager);
+
+    uint32_t cb_addr_eth = experimental::hal::get_erisc_l1_unreserved_base();
+    uint32_t cb_addr_worker = experimental::hal::get_tensix_l1_unreserved_base();
+
+    // Start kernels on each sub device and verify their coordinates
+    Program program_1 = tt::tt_metal::CreateProgram();
+    tt::tt_metal::CreateKernel(
+        program_1,
+        k_coordinates_kernel_path,
+        sub_device_1_worker_cores,
+        DataMovementConfig{
+            .noc = NOC::RISCV_0_default,
+            .compile_args = {
+                cb_addr_worker,
+            }});
+
+    Program program_2 = tt::tt_metal::CreateProgram();
+    tt::tt_metal::CreateKernel(
+        program_2,
+        k_coordinates_kernel_path,
+        sub_device_2_worker_cores,
+        DataMovementConfig{
+            .noc = NOC::RISCV_1_default,
+            .compile_args = {
+                cb_addr_worker,
+            }});
+
+    tt::tt_metal::CreateKernel(
+        program_2,
+        k_coordinates_kernel_path,
+        sub_device_2_eth_cores,
+        EthernetConfig{
+            .noc = NOC::RISCV_0_default,
+            .processor = DataMovementProcessor::RISCV_0,
+            .compile_args = {
+                cb_addr_eth,
+            }});
+
+    EnqueueProgram(device->command_queue(), program_1, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    EnqueueProgram(device->command_queue(), program_2, false);
+    Finish(device->command_queue());
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
+
+    tt::tt_metal::verify_kernel_coordinates(
+        tt::RISCV::BRISC, sub_device_1_worker_cores, device, tt::tt_metal::SubDeviceId{0}, cb_addr_worker);
+    tt::tt_metal::verify_kernel_coordinates(
+        tt::RISCV::NCRISC, sub_device_2_worker_cores, device, tt::tt_metal::SubDeviceId{1}, cb_addr_worker);
+    tt::tt_metal::verify_kernel_coordinates(
+        tt::RISCV::ERISC, sub_device_2_eth_cores, device, tt::tt_metal::SubDeviceId{1}, cb_addr_eth);
+}
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -145,4 +145,11 @@ TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthProgra
     detail::DumpDeviceProfileResults(device);
 }
 
+// Ensure each core in the sub device aware of their own logical coordinate. Same binary used in multiple sub devices.
+TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordinates) {}
+
+// Ensure each core in the sub device aware of their own sub device logical coordinate. Same binary used in multiple sub
+// devices.
+TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMySubDeviceLogicalCoordinates) {}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -239,7 +239,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixActiveEthTestSubDeviceMyLogic
         k_coordinates_kernel_path,
         sub_device_2_worker_cores,
         DataMovementConfig{
-            .noc = NOC::RISCV_1_default,
+            .noc = NOC::RISCV_0_default,
             .compile_args = {
                 cb_addr_worker,
             }});

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <gtest/gtest.h>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel.hpp>
+#include "llrt.hpp"
 
 namespace tt::tt_metal {
 
@@ -14,6 +16,17 @@ struct TestBufferConfig {
     uint32_t page_size;
     BufferType buftype;
 };
+
+struct CoreCoordsL1 {
+    uint32_t my_x;
+    uint32_t my_y;
+    uint32_t my_logical_x;
+    uint32_t my_logical_y;
+    uint32_t my_sub_device_x;
+    uint32_t my_sub_device_y;
+};
+
+static_assert(sizeof(CoreCoordsL1) == 24);  // Must match kernel
 
 inline std::vector<uint32_t> generate_arange_vector(uint32_t size_bytes, uint32_t start = 0) {
     TT_FATAL(size_bytes % sizeof(uint32_t) == 0, "Error");
@@ -94,6 +107,47 @@ inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_ar
         force_max_size);
 
     return create_runtime_args(num_rt_args_unique, num_rt_args_common, unique_base, common_base);
+}
+
+inline void verify_kernel_coordinates(
+    tt::RISCV processor_class,
+    const CoreRangeSet& cr_set,
+    const tt::tt_metal::IDevice* device,
+    tt::tt_metal::SubDeviceId sub_device_id,
+    uint32_t cb_addr,
+    bool idle_eth = false) {
+    tt::Cluster::instance().l1_barrier(device->id());
+    tt::tt_metal::HalProgrammableCoreType hal_core_type = processor_class == tt::RISCV::ERISC
+                                                              ? tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH
+                                                              : tt::tt_metal::HalProgrammableCoreType::TENSIX;
+    hal_core_type = idle_eth ? tt::tt_metal::HalProgrammableCoreType::IDLE_ETH : hal_core_type;
+
+    CoreType core_type = processor_class == tt::RISCV::ERISC ? CoreType::ETH : CoreType::WORKER;
+    core_type = idle_eth ? CoreType::IDLE_ETH : core_type;
+
+    const auto& sub_device_origin = device->worker_cores(hal_core_type, sub_device_id).bounding_box().start_coord;
+    for (const auto& cr : cr_set.ranges()) {
+        for (auto core = cr.begin(); core != cr.end(); ++core) {
+            const auto& logical_coord = *core;
+            const auto& virtual_coord = device->virtual_core_from_logical_core(logical_coord, core_type);
+            CoreCoord relative_coord{logical_coord.x - sub_device_origin.x, logical_coord.y - sub_device_origin.y};
+
+            auto read_coords_raw = tt::llrt::read_hex_vec_from_core(
+                device->id(), virtual_coord, cb_addr, sizeof(tt::tt_metal::CoreCoordsL1));
+            auto read_coords = reinterpret_cast<volatile tt::tt_metal::CoreCoordsL1*>(read_coords_raw.data());
+
+            if (processor_class != tt::RISCV::COMPUTE) {
+                // my_x and my_y are not available on compute
+                EXPECT_EQ(read_coords->my_x, virtual_coord.x) << "Virtual X";
+                EXPECT_EQ(read_coords->my_y, virtual_coord.y) << "Virtual Y";
+            }
+            EXPECT_EQ(read_coords->my_logical_x, logical_coord.x) << "Logical X";
+            EXPECT_EQ(read_coords->my_logical_y, logical_coord.y) << "Logical Y";
+
+            EXPECT_EQ(read_coords->my_sub_device_x, (relative_coord).x) << "SubDevice Logical X";
+            EXPECT_EQ(read_coords->my_sub_device_y, (relative_coord).y) << "SubDevice Logical Y";
+        }
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Test kernel reads my_x, my_y. my_logical_x, my_logical_y, my_sub_device_x, and my_sub_device_y
+//
+// compile time arg 0: where to write the values that were read in the order above
+// required space = 24B
+//
+
+#include "compile_time_args.h"
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
+    defined(COMPILE_FOR_IDLE_ERISC)
+#define ANY_KERNEL_BEGIN void kernel_main() {
+#define ANY_KERNEL_END }
+#else
+#include "compute_kernel_api/common.h"
+#define ANY_KERNEL_BEGIN  \
+    namespace NAMESPACE { \
+    void MAIN {
+#define ANY_KERNEL_END \
+    }                  \
+    }
+#endif
+
+ANY_KERNEL_BEGIN
+
+volatile uint32_t* results = reinterpret_cast<volatile uint32_t*>(get_compile_time_arg_val(0));
+
+#ifndef COMPILE_FOR_TRISC
+results[0] = my_x[noc_index];
+results[1] = my_y[noc_index];
+#endif
+
+results[2] = my_logical_x;
+results[3] = my_logical_y;
+results[4] = my_sub_device_x;
+results[5] = my_sub_device_y;
+
+ANY_KERNEL_END

--- a/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
@@ -8,36 +8,17 @@
 // compile time arg 0: where to write the values that were read in the order above
 // required space = 24B
 //
+// Applicable for Data Movement cores only
+//
 
-#include "compile_time_args.h"
-#include "risc_common.h"
+#include "hw/inc/dataflow_api.h"
 
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
-    defined(COMPILE_FOR_IDLE_ERISC)
-#define ANY_KERNEL_BEGIN void kernel_main() {
-#define ANY_KERNEL_END }
-#else
-#include "compute_kernel_api/common.h"
-#define ANY_KERNEL_BEGIN  \
-    namespace NAMESPACE { \
-    void MAIN {
-#define ANY_KERNEL_END \
-    }                  \
-    }
-#endif
-
-ANY_KERNEL_BEGIN
-
-volatile uint32_t* results = reinterpret_cast<volatile uint32_t*>(get_compile_time_arg_val(0));
-
-#ifndef COMPILE_FOR_TRISC
-results[0] = my_x[noc_index];
-results[1] = my_y[noc_index];
-#endif
-
-results[2] = my_logical_x;
-results[3] = my_logical_y;
-results[4] = my_sub_device_x;
-results[5] = my_sub_device_y;
-
-ANY_KERNEL_END
+void kernel_main() {
+    volatile tt_l1_ptr uint32_t* results = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_compile_time_arg_val(0));
+    results[0] = my_x[noc_index];
+    results[1] = my_y[noc_index];
+    results[2] = get_absolute_logical_x();
+    results[3] = get_absolute_logical_y();
+    results[4] = get_relative_logical_x();
+    results[5] = get_relative_logical_y();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
@@ -10,6 +10,7 @@
 //
 
 #include "compile_time_args.h"
+#include "risc_common.h"
 
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
     defined(COMPILE_FOR_IDLE_ERISC)

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -31,24 +31,15 @@ void kernel_main() {
         }
 
 #ifdef COORDS_ADDR
-        volatile uint32_t tt_l1_ptr* coords = (volatile uint32_t tt_l1_ptr*)COORDS_ADDR;
 #ifdef DATA_MOVEMENT
+        volatile uint32_t tt_l1_ptr* coords = (volatile uint32_t tt_l1_ptr*)COORDS_ADDR;
         coords[0] = my_x[noc_index];
         coords[1] = my_y[noc_index];
-#else
-#ifdef COMPUTE
-        coords[0] = 0;
-        coords[1] = 0;
-#else
-        coords[0] = 0xdeadbeef;
-        coords[1] = 0xdeadbeef;
+        coords[2] = get_absolute_logical_x();
+        coords[3] = get_absolute_logical_y();
+        coords[4] = get_relative_logical_x();
+        coords[5] = get_relative_logical_y();
 #endif
-#endif
-
-        coords[2] = my_logical_x;
-        coords[3] = my_logical_y;
-        coords[4] = my_sub_device_x;
-        coords[5] = my_sub_device_y;
 #endif
     }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-
+#include "risc_attribs.h"
+#include "debug/dprint.h"
 // TODO FIXME: this build system is ridiculously stupid
 #ifdef COMPILE_FOR_TRISC
 #include "compute_kernel_api/tile_move_copy.h"
@@ -20,12 +21,34 @@ void kernel_main() {
     void MAIN {
 #endif
         volatile uint32_t tt_l1_ptr* results = (volatile uint32_t tt_l1_ptr*)RESULTS_ADDR;
-        for (int i = 0; i < NUM_RUNTIME_ARGS; i++) {
+        int i;
+        for (i = 0; i < NUM_RUNTIME_ARGS; i++) {
 #ifdef COMMON_RUNTIME_ARGS
             results[i] = get_common_arg_val<uint32_t>(i);
 #else
-    results[i] = get_arg_val<uint32_t>(i);
+            results[i] = get_arg_val<uint32_t>(i);
 #endif
         }
+
+#ifdef COORDS_ADDR
+        volatile uint32_t tt_l1_ptr* coords = (volatile uint32_t tt_l1_ptr*)COORDS_ADDR;
+#ifdef DATA_MOVEMENT
+        coords[0] = my_x[noc_index];
+        coords[1] = my_y[noc_index];
+#else
+#ifdef COMPUTE
+        coords[0] = 0;
+        coords[1] = 0;
+#else
+        coords[0] = 0xdeadbeef;
+        coords[1] = 0xdeadbeef;
+#endif
+#endif
+
+        coords[2] = my_logical_x;
+        coords[3] = my_logical_y;
+        coords[4] = my_sub_device_x;
+        coords[5] = my_sub_device_y;
+#endif
     }
     }

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -128,7 +128,9 @@ struct kernel_config_msg_t {
     volatile uint8_t min_remote_cb_start_index;
     volatile uint8_t exit_erisc_kernel;
     volatile uint8_t enables;
-    volatile uint8_t pad2[8];
+    volatile uint8_t sub_device_origin_x;  // Logical X coordinate of the sub device origin
+    volatile uint8_t sub_device_origin_y;  // Logical Y coordinate of the sub device origin
+    volatile uint8_t pad2[6];
     volatile uint8_t preload;  // Must be at end, so it's only written when all other data is written.
 } __attribute__((packed));
 
@@ -334,7 +336,9 @@ struct core_info_msg_t {
     volatile uint8_t noc_size_y;
     volatile uint8_t worker_grid_size_x;
     volatile uint8_t worker_grid_size_y;
-    volatile uint8_t pad[25];
+    volatile uint8_t absolute_logical_x;  // Logical X coordinate of this core
+    volatile uint8_t absolute_logical_y;  // Logical Y coordinate of this core
+    volatile uint8_t pad[23];
 };
 
 constexpr uint32_t launch_msg_buffer_num_entries = 8;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -96,7 +96,9 @@ public:
 
     virtual CoreCoord compute_with_storage_grid_size() const = 0;
 
+    // Returns a logical CoreRangeSet of the worker cores in the specified sub device that was previously loaded.
     virtual CoreRangeSet worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const = 0;
+    // Returns the number of worker cores in the specified sub device that was previously loaded.
     virtual uint32_t num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const = 0;
 
     virtual const std::unique_ptr<Allocator>& allocator() const = 0;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -74,21 +74,38 @@ public:
 
     // Given a Virtual coordinate in noc_index space, get the equivalent coordinate in Virtual NOC0 space
     virtual CoreCoord virtual_noc_coordinate(uint8_t noc_index, CoreCoord coord) const = 0;
+
     // Given a coordinate in Virtual NOC0 Space, get the equivalent coordinate in Virtual noc_index space
     virtual CoreCoord virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const = 0;
 
+    // Convert logical coordinates to virtual coordinates for worker coordinates
     virtual std::vector<CoreCoord> worker_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const = 0;
+
+    // Convert logical coordinates to virtaul coordinates for ethernet coordinates
     virtual std::vector<CoreCoord> ethernet_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const = 0;
+
+    // Returns the optimal DRAM bank coordinates to logical worker assignment
     virtual std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment() = 0;
 
+    // Convert a logical coordinate to virtual coordinate
     virtual CoreCoord virtual_core_from_logical_core(const CoreCoord &logical_coord, const CoreType& core_type) const = 0;
+
+    // Convert a logical coordinate to a virtual coordinate for a worker coordinate
     virtual CoreCoord worker_core_from_logical_core(const CoreCoord &logical_core) const = 0;
 
-    // Ethernet API
+    // Convert a logical coordinate to virtual coordinate for an ethernet coordinate
     virtual CoreCoord ethernet_core_from_logical_core(const CoreCoord &logical_core) const = 0;
+
+    // Convert a virtual ethernet coordinate to logical coordinate
     virtual CoreCoord logical_core_from_ethernet_core(const CoreCoord &ethernet_core) const = 0;
+
+    // Returns virtual coordinates of active ethernet cores. Some ethernet cores may be reserved for dispatch use.
     virtual std::unordered_set<CoreCoord> get_active_ethernet_cores(bool skip_reserved_tunnel_cores=false) const = 0;
+
+    // Returns virtual coordinates of inactive ethernet cores
     virtual std::unordered_set<CoreCoord> get_inactive_ethernet_cores() const = 0;
+
+    // Returns true if the ethernet core is active
     virtual bool is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_tunnel_cores=false) const = 0;
     virtual std::tuple<chip_id_t, CoreCoord> get_connected_ethernet_core(CoreCoord eth_core) const = 0;
     virtual std::vector<CoreCoord> get_ethernet_sockets(chip_id_t connected_chip_id) const = 0;

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -52,10 +52,10 @@ uint8_t my_logical_x __attribute__((used));
 uint8_t my_logical_y __attribute__((used));
 
 // Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
+uint8_t my_relative_x __attribute__((used));
 
 // Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
+uint8_t my_relative_y __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
@@ -86,10 +86,10 @@ int main() {
 
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
     noc_index = 0;
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    my_relative_x_ = 0xab;
+    my_relative_y_ = 0xcd;
 
     risc_init();
 
@@ -133,8 +133,8 @@ int main() {
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
 
             noc_index = launch_msg_address->kernel_config.brisc_noc_id;
-            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
-            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
+            my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
 
             flush_erisc_icache();
 

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -39,22 +39,11 @@ uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
-// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
-
-// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
-
-// Set during FW initialization. Available before main begins.
 uint8_t my_logical_x __attribute__((used));
-
-// Set during FW initialization. Available before main begins.
 uint8_t my_logical_y __attribute__((used));
-
-// Updated by the launch message for the kernel.
 uint8_t my_relative_x __attribute__((used));
-
-// Updated by the launch message for the kernel.
 uint8_t my_relative_y __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
@@ -88,8 +77,6 @@ int main() {
     noc_index = 0;
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
-    my_relative_x_ = 0xab;
-    my_relative_y_ = 0xcd;
 
     risc_init();
 

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -88,6 +88,8 @@ int main() {
     noc_index = 0;
     my_logical_x = mailboxes->core_info.absolute_logical_x;
     my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
 
     risc_init();
 

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -39,8 +39,23 @@ uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
+// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
+
+// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_x __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_y __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_x __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_y __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
@@ -71,6 +86,8 @@ int main() {
 
     mailboxes->launch_msg_rd_ptr = 0;  // Initialize the rdptr to 0
     noc_index = 0;
+    my_logical_x = mailboxes->core_info.absolute_logical_x;
+    my_logical_y = mailboxes->core_info.absolute_logical_y;
 
     risc_init();
 
@@ -114,6 +131,8 @@ int main() {
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
 
             noc_index = launch_msg_address->kernel_config.brisc_noc_id;
+            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
 
             flush_erisc_icache();
 

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -60,8 +60,23 @@ volatile tt_l1_ptr uint32_t* instrn_buf[MAX_THREADS];
 volatile tt_l1_ptr uint32_t* pc_buf[MAX_THREADS];
 volatile tt_l1_ptr uint32_t* mailbox[MAX_THREADS];
 
+// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
+
+// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_x __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_y __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_x __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_y __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
@@ -381,6 +396,8 @@ int main() {
 
     mailboxes->launch_msg_rd_ptr = 0; // Initialize the rdptr to 0
     noc_index = 0;
+    my_logical_x = mailboxes->core_info.absolute_logical_x;
+    my_logical_y = mailboxes->core_info.absolute_logical_y;
     risc_init();
     device_setup();
 
@@ -479,6 +496,8 @@ int main() {
 
             noc_index = launch_msg_address->kernel_config.brisc_noc_id;
             noc_mode = launch_msg_address->kernel_config.brisc_noc_mode;
+            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
 
             // re-initialize the NoCs
             uint8_t cmd_buf;

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -66,17 +66,17 @@ uint8_t my_x[NUM_NOCS] __attribute__((used));
 // Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
-// Set during FW initialization. Available before main begins.
-uint8_t my_logical_x __attribute__((used));
+// Logical X coordinate relative to the physical origin. Set during FW initialization.
+uint8_t my_logical_x_ __attribute__((used));
 
-// Set during FW initialization. Available before main begins.
-uint8_t my_logical_y __attribute__((used));
+// Logical Y coordinate relative to the physical origin. Set during FW initialization.
+uint8_t my_logical_y_ __attribute__((used));
 
-// Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
+// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
+uint8_t my_relative_x_ __attribute__((used));
 
-// Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
+// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
+uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
@@ -396,10 +396,10 @@ int main() {
 
     mailboxes->launch_msg_rd_ptr = 0; // Initialize the rdptr to 0
     noc_index = 0;
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    my_relative_x_ = 0xab;
+    my_relative_y_ = 0xcd;
     risc_init();
     device_setup();
 
@@ -498,8 +498,8 @@ int main() {
 
             noc_index = launch_msg_address->kernel_config.brisc_noc_id;
             noc_mode = launch_msg_address->kernel_config.brisc_noc_mode;
-            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
-            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
+            my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
 
             // re-initialize the NoCs
             uint8_t cmd_buf;

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -60,22 +60,11 @@ volatile tt_l1_ptr uint32_t* instrn_buf[MAX_THREADS];
 volatile tt_l1_ptr uint32_t* pc_buf[MAX_THREADS];
 volatile tt_l1_ptr uint32_t* mailbox[MAX_THREADS];
 
-// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
-
-// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
-
-// Logical X coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_y_ __attribute__((used));
-
-// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
@@ -398,8 +387,7 @@ int main() {
     noc_index = 0;
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
-    my_relative_x_ = 0xab;
-    my_relative_y_ = 0xcd;
+
     risc_init();
     device_setup();
 

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -398,6 +398,8 @@ int main() {
     noc_index = 0;
     my_logical_x = mailboxes->core_info.absolute_logical_x;
     my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
     risc_init();
     device_setup();
 

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -28,17 +28,17 @@ uint8_t my_x[NUM_NOCS] __attribute__((used));
 // Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
-// Set during FW initialization. Available before main begins.
-uint8_t my_logical_x __attribute__((used));
+// Logical X coordinate relative to the physical origin. Set during FW initialization.
+uint8_t my_logical_x_ __attribute__((used));
 
-// Set during FW initialization. Available before main begins.
-uint8_t my_logical_y __attribute__((used));
+// Logical Y coordinate relative to the physical origin. Set during FW initialization.
+uint8_t my_logical_y_ __attribute__((used));
 
-// Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
+// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
+uint8_t my_relative_x_ __attribute__((used));
 
-// Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
+// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
+uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
@@ -93,10 +93,10 @@ void __attribute__((noinline)) Application(void) {
 
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    my_relative_x_ = 0xab;
+    my_relative_y_ = 0xcd;
 
     noc_bank_table_init(eth_l1_mem::address_map::ERISC_MEM_BANK_TO_NOC_SCRATCH);
 
@@ -131,8 +131,8 @@ void __attribute__((noinline)) Application(void) {
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
             // Note that a core may get "GO" w/ enable false to keep its launch_msg's in sync
             enum dispatch_core_processor_masks enables = (enum dispatch_core_processor_masks)launch_msg_address->kernel_config.enables;
-            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
-            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
+            my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
             if (enables & DISPATCH_CLASS_MASK_ETH_DM0) {
                 WAYPOINT("R");
                 firmware_config_init(mailboxes, ProgrammableCoreType::ACTIVE_ETH, DISPATCH_CLASS_ETH_DM0);

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -22,22 +22,11 @@ namespace kernel_profiler {
 
 uint8_t noc_index = 0;  // TODO: remove hardcoding
 
-// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
-
-// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
-
-// Logical X coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_y_ __attribute__((used));
-
-// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
@@ -95,8 +84,6 @@ void __attribute__((noinline)) Application(void) {
 
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
-    my_relative_x_ = 0xab;
-    my_relative_y_ = 0xcd;
 
     noc_bank_table_init(eth_l1_mem::address_map::ERISC_MEM_BANK_TO_NOC_SCRATCH);
 

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -21,8 +21,24 @@ namespace kernel_profiler {
 #endif
 
 uint8_t noc_index = 0;  // TODO: remove hardcoding
+
+// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
+
+// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_x __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_y __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_x __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_y __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
@@ -77,6 +93,9 @@ void __attribute__((noinline)) Application(void) {
 
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
+    my_logical_x = mailboxes->core_info.absolute_logical_x;
+    my_logical_y = mailboxes->core_info.absolute_logical_y;
+
     noc_bank_table_init(eth_l1_mem::address_map::ERISC_MEM_BANK_TO_NOC_SCRATCH);
 
     risc_init();
@@ -110,6 +129,8 @@ void __attribute__((noinline)) Application(void) {
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
             // Note that a core may get "GO" w/ enable false to keep its launch_msg's in sync
             enum dispatch_core_processor_masks enables = (enum dispatch_core_processor_masks)launch_msg_address->kernel_config.enables;
+            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
             if (enables & DISPATCH_CLASS_MASK_ETH_DM0) {
                 WAYPOINT("R");
                 firmware_config_init(mailboxes, ProgrammableCoreType::ACTIVE_ETH, DISPATCH_CLASS_ETH_DM0);

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -95,6 +95,8 @@ void __attribute__((noinline)) Application(void) {
 
     my_logical_x = mailboxes->core_info.absolute_logical_x;
     my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
 
     noc_bank_table_init(eth_l1_mem::address_map::ERISC_MEM_BANK_TO_NOC_SCRATCH);
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -38,22 +38,11 @@ uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
-// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
-
-// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
-
-// Logical X coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_y_ __attribute__((used));
-
-// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_y_ __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
@@ -126,8 +115,6 @@ int main() {
 
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
-    my_relative_x_ = 0xab;
-    my_relative_y_ = 0xcd;
 
     risc_init();
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -38,8 +38,23 @@ uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
+// Register
 uint8_t my_x[NUM_NOCS] __attribute__((used));
+
+// Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_x __attribute__((used));
+
+// Set during FW initialization. Available before main begins.
+uint8_t my_logical_y __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_x __attribute__((used));
+
+// Updated by the launch message for the kernel.
+uint8_t my_sub_device_y __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
@@ -109,6 +124,11 @@ int main() {
 
     noc_bank_table_init(MEM_IERISC_BANK_TO_NOC_SCRATCH);
 
+    my_logical_x = mailboxes->core_info.absolute_logical_x;
+    my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
+
     risc_init();
 
     mailboxes->slave_sync.all = RUN_SYNC_MSG_ALL_SLAVES_DONE;
@@ -145,6 +165,8 @@ int main() {
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
 
             noc_index = launch_msg_address->kernel_config.brisc_noc_id;
+            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
 
             flush_erisc_icache();
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -44,17 +44,17 @@ uint8_t my_x[NUM_NOCS] __attribute__((used));
 // Register
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
-// Set during FW initialization. Available before main begins.
-uint8_t my_logical_x __attribute__((used));
+// Logical X coordinate relative to the physical origin. Set during FW initialization.
+uint8_t my_logical_x_ __attribute__((used));
 
-// Set during FW initialization. Available before main begins.
-uint8_t my_logical_y __attribute__((used));
+// Logical Y coordinate relative to the physical origin. Set during FW initialization.
+uint8_t my_logical_y_ __attribute__((used));
 
-// Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
+// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
+uint8_t my_relative_x_ __attribute__((used));
 
-// Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
+// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
+uint8_t my_relative_y_ __attribute__((used));
 
 // These arrays are stored in local memory of FW, but primarily used by the kernel which shares
 // FW symbols. Hence mark these as 'used' so that FW compiler doesn't optimize it out.
@@ -124,10 +124,10 @@ int main() {
 
     noc_bank_table_init(MEM_IERISC_BANK_TO_NOC_SCRATCH);
 
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    my_relative_x_ = 0xab;
+    my_relative_y_ = 0xcd;
 
     risc_init();
 
@@ -165,8 +165,8 @@ int main() {
             DeviceZoneSetCounter(launch_msg_address->kernel_config.host_assigned_id);
 
             noc_index = launch_msg_address->kernel_config.brisc_noc_id;
-            my_sub_device_x = my_logical_x - launch_msg_address->kernel_config.sub_device_origin_x;
-            my_sub_device_y = my_logical_y - launch_msg_address->kernel_config.sub_device_origin_y;
+            my_relative_x_ = my_logical_x_ - launch_msg_address->kernel_config.sub_device_origin_x;
+            my_relative_y_ = my_logical_y_ - launch_msg_address->kernel_config.sub_device_origin_y;
 
             flush_erisc_icache();
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -136,6 +136,8 @@ int main(int argc, char *argv[]) {
 
     my_logical_x = mailboxes->core_info.absolute_logical_x;
     my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -29,22 +29,11 @@ uint32_t halt_stack_ptr_save;
 tt_l1_ptr mailboxes_t *const mailboxes = (tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE);
 volatile tt_l1_ptr uint8_t *const ncrisc_run = &mailboxes->slave_sync.dm1;
 
-// Virtual X coordinate
 uint8_t my_x[NUM_NOCS] __attribute__((used));
-
-// Virtual Y coordinate
 uint8_t my_y[NUM_NOCS] __attribute__((used));
-
-// Logical X coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_y_ __attribute__((used));
-
-// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
@@ -136,8 +125,6 @@ int main(int argc, char *argv[]) {
 
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
-    my_relative_x_ = 0xab;
-    my_relative_y_ = 0xcd;
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -36,16 +36,16 @@ uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
 // Logical X coordinate relative to the physical origin. Set during FW initialization.
-uint8_t my_logical_x __attribute__((used));
+uint8_t my_logical_x_ __attribute__((used));
 
 // Logical Y coordinate relative to the physical origin. Set during FW initialization.
-uint8_t my_logical_y __attribute__((used));
+uint8_t my_logical_y_ __attribute__((used));
 
 // Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
+uint8_t my_relative_x_ __attribute__((used));
 
 // Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
+uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
@@ -134,10 +134,10 @@ int main(int argc, char *argv[]) {
     // Need to save address to jump to after BRISC resumes NCRISC
     set_ncrisc_resume_addr();
 
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    my_relative_x_ = 0xab;
+    my_relative_y_ = 0xcd;
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
@@ -168,8 +168,8 @@ int main(int argc, char *argv[]) {
         end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
         // NOC argument is unused
         experimental::setup_remote_cb_interfaces<false>(cb_l1_base, end_cb_index, 0, 0, 0, 0);
-        my_sub_device_x = my_logical_x - launch_msg->kernel_config.sub_device_origin_x;
-        my_sub_device_y = my_logical_y - launch_msg->kernel_config.sub_device_origin_y;
+        my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
+        my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 
         WAYPOINT("R");
 

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -24,22 +24,11 @@ volatile tt_l1_ptr uint8_t *const slave_idle_erisc_run = &mailboxes->slave_sync.
 
 uint8_t noc_index = 0;  // TODO: hardcoding needed for profiler
 
-// Virtual X coordinate
 uint8_t my_x[NUM_NOCS] __attribute__((used));
-
-// Virtual Y coordinate
 uint8_t my_y[NUM_NOCS] __attribute__((used));
-
-// Logical X coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the physical origin. Set during FW initialization.
 uint8_t my_logical_y_ __attribute__((used));
-
-// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_x_ __attribute__((used));
-
-// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
 uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
@@ -84,8 +73,6 @@ int main(int argc, char *argv[]) {
 
     my_logical_x_ = mailboxes->core_info.absolute_logical_x;
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
-    my_relative_x_ = 0xab;
-    my_relative_y_ = 0xcd;
     risc_init();
 
     // Cleanup profiler buffer incase we never get the go message

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -84,6 +84,8 @@ int main(int argc, char *argv[]) {
 
     my_logical_x = mailboxes->core_info.absolute_logical_x;
     my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
     risc_init();
 
     // Cleanup profiler buffer incase we never get the go message

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -31,16 +31,16 @@ uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
 // Logical X coordinate relative to the physical origin. Set during FW initialization.
-uint8_t my_logical_x __attribute__((used));
+uint8_t my_logical_x_ __attribute__((used));
 
 // Logical Y coordinate relative to the physical origin. Set during FW initialization.
-uint8_t my_logical_y __attribute__((used));
+uint8_t my_logical_y_ __attribute__((used));
 
 // Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
+uint8_t my_relative_x_ __attribute__((used));
 
 // Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
+uint8_t my_relative_y_ __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
@@ -82,10 +82,10 @@ int main(int argc, char *argv[]) {
 
     noc_bank_table_init(MEM_IERISC_BANK_TO_NOC_SCRATCH);
 
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+    my_relative_x_ = 0xab;
+    my_relative_y_ = 0xcd;
     risc_init();
 
     // Cleanup profiler buffer incase we never get the go message
@@ -99,10 +99,10 @@ int main(int argc, char *argv[]) {
         flush_erisc_icache();
 
         uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::IDLE_ETH, DISPATCH_CLASS_ETH_DM1);
-        my_sub_device_x =
-            my_logical_x - mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.sub_device_origin_x;
-        my_sub_device_y =
-            my_logical_y - mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.sub_device_origin_y;
+        my_relative_x_ =
+            my_logical_x_ - mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.sub_device_origin_x;
+        my_relative_y_ =
+            my_logical_y_ - mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.sub_device_origin_y;
 
         WAYPOINT("R");
         int index = static_cast<std::underlying_type<EthProcessorTypes>::type>(EthProcessorTypes::DM1);

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -74,18 +74,6 @@ constexpr bool cb_init_write = true;
 constexpr bool cb_init_write = false;
 #endif
 
-// Logical X coordinate relative to the physical origin. Set during FW initialization.
-uint8_t my_logical_x __attribute__((used));
-
-// Logical Y coordinate relative to the physical origin. Set during FW initialization.
-uint8_t my_logical_y __attribute__((used));
-
-// Logical X coordinate relative to the sub device origin. Updated by the launch message for the kernel.
-uint8_t my_sub_device_x __attribute__((used));
-
-// Logical Y coordinate relative to the sub device origin. Updated by the launch message for the kernel.
-uint8_t my_sub_device_y __attribute__((used));
-
 using namespace ckernel;
 
 void init_sync_registers() {
@@ -111,11 +99,6 @@ int main(int argc, char *argv[]) {
     for (int i = 0; i < 64; i++) regfile[i] = 0;
 
     reset_cfg_state_id();
-
-    my_logical_x = mailboxes->core_info.absolute_logical_x;
-    my_logical_y = mailboxes->core_info.absolute_logical_y;
-    my_sub_device_x = 0xab;
-    my_sub_device_y = 0xcd;
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
@@ -150,10 +133,9 @@ int main(int argc, char *argv[]) {
 
         rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
             launch_msg->kernel_config.rta_offset[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
-        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
-            launch_msg->kernel_config.rta_offset[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
-        my_sub_device_x = my_logical_x - launch_msg->kernel_config.sub_device_origin_x;
-        my_sub_device_y = my_logical_y - launch_msg->kernel_config.sub_device_origin_y;
+        crta_l1_base =
+            (uint32_t tt_l1_ptr*)(kernel_config_base +
+                                  launch_msg->kernel_config.rta_offset[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
 
         WAYPOINT("R");
         int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::MATH0) + thread_id;

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -114,6 +114,8 @@ int main(int argc, char *argv[]) {
 
     my_logical_x = mailboxes->core_info.absolute_logical_x;
     my_logical_y = mailboxes->core_info.absolute_logical_y;
+    my_sub_device_x = 0xab;
+    my_sub_device_y = 0xcd;
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -22,7 +22,7 @@
 #include "debug/waypoint.h"
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
-#include "hw/inc/risc_attribs.h"
+#include "risc_attribs.h"
 #include "utils/utils.h"
 #include "debug/assert.h"
 #include "dev_msgs.h"

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,7 +22,7 @@
 #include "debug/waypoint.h"
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
-#include "risc_attribs.h"
+#include "hw/inc/risc_attribs.h"
 #include "utils/utils.h"
 #include "debug/assert.h"
 #include "dev_msgs.h"
@@ -38,8 +38,10 @@
  * Return value: X coordinate value.
  */
 // clang-format on
-FORCE_INLINE
-uint32_t get_absolute_logical_x() { return 0; }
+inline uint8_t get_absolute_logical_x() {
+    extern uint8_t my_logical_x_;  // Set in FW
+    return my_logical_x_;
+}
 
 // clang-format off
 /**
@@ -49,32 +51,36 @@ uint32_t get_absolute_logical_x() { return 0; }
  * Return value: Y coordinate value.
  */
 // clang-format on
-FORCE_INLINE
-uint32_t get_absolute_logical_y() { return 0; }
+inline uint8_t get_absolute_logical_y() {
+    extern uint8_t my_logical_y_;  // Set in FW
+    return my_logical_y_;
+}
 
 // clang-format off
 /**
  * Returns the relative logical X coordinate value that this kernel is running on. The relative coordinate
- * is the one relative to the origin of the sub device. If there is no sub device then this is equivalent
- * to the absolute logical coordinate.
+ * is with respect to the origin of the sub device for this core type.
  *
  * Return value: X coordinate value.
  */
 // clang-format on
-FORCE_INLINE
-uint32_t get_relative_logical_x() { return 0; }
+inline uint8_t get_relative_logical_x() {
+    extern uint8_t my_relative_x_;  // Set in FW
+    return my_relative_x_;
+}
 
 // clang-format off
 /**
  * Returns the relative logical Y coordinate value that this kernel is running on. The relative coordinate
- * is the one relative to the origin of the sub device. If there is no sub device then this is equivalent
- * to the absolute logical coordinate.
+ * is with respect to the origin of the sub device for this core type.
  *
  * Return value: Y coordinate value.
  */
 // clang-format on
-FORCE_INLINE
-uint32_t get_relative_logical_y() { return 0; }
+inline uint8_t get_relative_logical_y() {
+    extern uint8_t my_relative_y_;  // Set in FW
+    return my_relative_y_;
+}
 
 // clang-format off
 /**

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -32,6 +32,52 @@
 
 // clang-format off
 /**
+ * Returns the absolute logical X coordinate value that this kernel is running on. The absolute coordinate
+ * is the one relative to the origin of the physical grid.
+ *
+ * Return value: X coordinate value.
+ */
+// clang-format on
+FORCE_INLINE
+uint32_t get_absolute_logical_x() { return 0; }
+
+// clang-format off
+/**
+ * Returns the absolute logical Y coordinate value that this kernel is running on. The absolute coordinate
+ * is the one relative to the origin of the physical grid.
+ *
+ * Return value: Y coordinate value.
+ */
+// clang-format on
+FORCE_INLINE
+uint32_t get_absolute_logical_y() { return 0; }
+
+// clang-format off
+/**
+ * Returns the relative logical X coordinate value that this kernel is running on. The relative coordinate
+ * is the one relative to the origin of the sub device. If there is no sub device then this is equivalent
+ * to the absolute logical coordinate.
+ *
+ * Return value: X coordinate value.
+ */
+// clang-format on
+FORCE_INLINE
+uint32_t get_relative_logical_x() { return 0; }
+
+// clang-format off
+/**
+ * Returns the relative logical Y coordinate value that this kernel is running on. The relative coordinate
+ * is the one relative to the origin of the sub device. If there is no sub device then this is equivalent
+ * to the absolute logical coordinate.
+ *
+ * Return value: Y coordinate value.
+ */
+// clang-format on
+FORCE_INLINE
+uint32_t get_relative_logical_y() { return 0; }
+
+// clang-format off
+/**
  * Returns the address in L1 for a given runtime argument index for unique (per core) runtime arguments set via
  * SetRuntimeArgs() API.
  *
@@ -43,6 +89,7 @@
  */
 // clang-format on
 static FORCE_INLINE uint32_t get_arg_addr(int arg_idx) { return (uint32_t)&rta_l1_base[arg_idx]; }
+
 // clang-format off
 /**
  * Returns the address in L1 for a given runtime argument index for common (all cores) runtime arguments set via

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -34,8 +34,25 @@ const uint32_t STREAM_RESTART_CHECK_MASK = (0x1 << 3) - 1;
 
 const uint32_t MAX_TILES_PER_PHASE = 2048;
 
+// These values are defined in each core type's FW .cc file
+
+// Virtual X coordinate
 extern uint8_t my_x[NUM_NOCS];
+
+// Virtual Y coordinate
 extern uint8_t my_y[NUM_NOCS];
+
+// Logical X coordinate relative to the physical origin.
+extern uint8_t my_logical_x;
+
+// Logical Y coordinate relative to the physical origin.
+extern uint8_t my_logical_y;
+
+// Logical X coordinate relative to the sub device origin.
+extern uint8_t my_sub_device_x;
+
+// Logical Y coordinate relative to the sub device origin.
+extern uint8_t my_sub_device_y;
 
 inline void WRITE_REG(uint32_t addr, uint32_t val) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -42,18 +42,6 @@ extern uint8_t my_x[NUM_NOCS];
 // Virtual Y coordinate
 extern uint8_t my_y[NUM_NOCS];
 
-// Logical X coordinate relative to the physical origin.
-extern uint8_t my_logical_x;
-
-// Logical Y coordinate relative to the physical origin.
-extern uint8_t my_logical_y;
-
-// Logical X coordinate relative to the sub device origin.
-extern uint8_t my_sub_device_x;
-
-// Logical Y coordinate relative to the sub device origin.
-extern uint8_t my_sub_device_y;
-
 inline void WRITE_REG(uint32_t addr, uint32_t val) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;
     ptr[0] = val;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -693,6 +693,12 @@ void Device::initialize_and_launch_firmware() {
             CoreCoord logical_core(x, y);
             if (!this->storage_only_cores_.count(logical_core)) {
                 CoreCoord worker_core = this->worker_core_from_logical_core(logical_core);
+                // Setup the absolute logical coordinates of this worker which are relative to true origin. not the sub
+                // device. When running the user kernel, which potentially is on a sub device, send that info using the
+                // launch message using dispatch.
+                core_info->absolute_logical_x = logical_core.x;
+                core_info->absolute_logical_y = logical_core.y;
+                // Must write to core before starting it
                 tt::llrt::write_hex_vec_to_core(
                     this->id(), worker_core, core_info_vec, this->get_dev_addr(worker_core, HalL1MemAddrType::CORE_INFO));
                 this->initialize_firmware(HalProgrammableCoreType::TENSIX, worker_core, &launch_msg, &go_msg);
@@ -716,6 +722,8 @@ void Device::initialize_and_launch_firmware() {
     std::unordered_set<CoreCoord> active_eth_cores;
     for (const auto &eth_core : this->get_active_ethernet_cores()) {
         CoreCoord phys_eth_core = this->ethernet_core_from_logical_core(eth_core);
+        core_info->absolute_logical_x = eth_core.x;
+        core_info->absolute_logical_y = eth_core.y;
         tt::llrt::write_hex_vec_to_core(
             this->id(), phys_eth_core, core_info_vec, this->get_dev_addr(phys_eth_core, HalL1MemAddrType::CORE_INFO));
         this->initialize_firmware(HalProgrammableCoreType::ACTIVE_ETH, phys_eth_core, &launch_msg, &go_msg);
@@ -727,6 +735,8 @@ void Device::initialize_and_launch_firmware() {
 
     for (const auto &eth_core : this->get_inactive_ethernet_cores()) {
         CoreCoord phys_eth_core = this->ethernet_core_from_logical_core(eth_core);
+        core_info->absolute_logical_x = eth_core.x;
+        core_info->absolute_logical_y = eth_core.y;
         tt::llrt::write_hex_vec_to_core(
             this->id(), phys_eth_core, core_info_vec, this->get_dev_addr(phys_eth_core, HalL1MemAddrType::CORE_INFO));
         this->initialize_firmware(HalProgrammableCoreType::IDLE_ETH, phys_eth_core, &launch_msg, &go_msg);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -28,7 +28,11 @@ CoreCoord get_sub_device_worker_origin(
     const tt::tt_metal::IDevice* device,
     tt::tt_metal::SubDeviceId sub_device_id,
     tt::tt_metal::HalProgrammableCoreType core_type) {
-    return device->worker_cores(core_type, sub_device_id).bounding_box().start_coord;
+    const auto grid = device->worker_cores(core_type, sub_device_id);
+    if (grid.empty()) {
+        return {0, 0};
+    }
+    return grid.bounding_box().start_coord;
 }
 };  // namespace
 

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp
@@ -8,7 +8,7 @@
 void kernel_main() {
     // Nothing to move. Print respond message.
     // Make sure to export TT_METAL_DPRINT_CORES=0,0 before runtime.
-
+    DPRINT << "My logical coordinates are " << get_absolute_logical_x() << "," << get_absolute_logical_y() << ENDL();
     DPRINT_DATA0(DPRINT << "Hello, Master, I am running a void data movement kernel on NOC 0." << ENDL());
     DPRINT_DATA1(DPRINT << "Hello, Master, I am running a void data movement kernel on NOC 1." << ENDL());
 }

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp
@@ -8,7 +8,8 @@
 void kernel_main() {
     // Nothing to move. Print respond message.
     // Make sure to export TT_METAL_DPRINT_CORES=0,0 before runtime.
-    DPRINT << "My logical coordinates are " << get_absolute_logical_x() << "," << get_absolute_logical_y() << ENDL();
+    DPRINT << "My logical coordinates are " << (uint32_t)get_absolute_logical_x() << ","
+           << (uint32_t)get_absolute_logical_y() << ENDL();
     DPRINT_DATA0(DPRINT << "Hello, Master, I am running a void data movement kernel on NOC 0." << ENDL());
     DPRINT_DATA1(DPRINT << "Hello, Master, I am running a void data movement kernel on NOC 1." << ENDL());
 }


### PR DESCRIPTION
Kernels can access their virtual coordinates using my_x, my_y right now. This change will also allow kernels to access their logical (relative to physical origin) and sub logical (relative to sub device origin).

### Ticket
N/A

### Problem description
- Virtual coordinates available in kernel with `my_x` and `my_y` but logical coordinates not available.

### What's changed
- Two pairs of new functions in Data Movement and Ethernet kernels in `dataflow_api.h`
  - `get_absolute_logical_x()`
  - `get_absolute_logical_y()`
    - Returns the XY value of the logical coordinate that this kernel is running on
  - `get_relative_logical_x()`
  - `get_relative_logical_y()`
    - Returns the XY value, relative to the sub device origin (top-left) that this kernel is running on. The default sub device is the entire grid of each core type.
    - Even if the sub device region is non-contiguous, this will still be relative to the origin.
- Logical XY does not change. Can be setup during FW initialization
- Relative XY may change. Values will be passed in with the `launch_msg_t` in Program dispatch. Calculated as `logical xy - sub device origin xy`
- Added test cases for Single CQ, Multi CQ, and Sub Device for Data Movement and Ethernet

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes