### PR TITLE
#18867: Dprint tile define typo fix

### DIFF
--- a/tt_metal/hw/inc/debug/dprint_tile.h
+++ b/tt_metal/hw/inc/debug/dprint_tile.h
@@ -40,7 +40,7 @@ typedef bool dprint_tslice_ptr_t;
 #define TSLICE_WR_PTR false
 typedef bool dprint_tslice_cb_t;
 #define TSLICE_INPUT_CB true
-#define TSLICE_OUTPUT_SB false
+#define TSLICE_OUTPUT_CB false
 
 typedef struct {
     uint32_t tile_dim_r;


### PR DESCRIPTION
Just a typo

CI: https://github.com/tenstorrent/tt-metal/actions/runs/13776850046