### PR TITLE
Ensure test_ccl_multi_cq_multi_device has Boost asio and lockfree

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -27,11 +27,12 @@ CPMAddPackage(
         "BOOST_ENABLE_CMAKE ON"
         "BOOST_SKIP_INSTALL_RULES ON"
         "BUILD_SHARED_LIBS OFF"
-        "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess\\\;asio"
+        "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess\\\;asio\\\;lockfree"
     FIND_PACKAGE_ARGUMENTS "CONFIG REQUIRED"
 )
 
 ensureboosttarget(asio)
+ensureboosttarget(lockfree)
 ensureboosttarget(core)
 ensureboosttarget(container)
 ensureboosttarget(smart_ptr)

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -54,6 +54,13 @@ add_executable(
     ${CMAKE_CURRENT_SOURCE_DIR}/multi_thread/test_utils.cpp
 )
 
+target_link_libraries(
+    test_ccl_multi_cq_multi_device
+    PRIVATE
+        Boost::asio
+        Boost::lockfree
+)
+
 # Set up properties for all targets
 setup_ttnn_test_target(unit_tests_ttnn)
 setup_ttnn_test_target(unit_tests_ttnn_ccl)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Cannot build since https://github.com/tenstorrent/tt-metal/commit/d91b4c8c8c4394b681406801d272253b5783eea9#diff-32608ca48c939ea1b3d8a025bfa6e95bc8e5e3706801061dc969a1797a63b78d got merged

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes