### PR TITLE
[skip ci] Remove CI as a build type - we never use it

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -17,7 +17,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
       with-retries:
         default: false
         type: boolean

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -23,7 +23,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
   schedule:
     - cron: "0 */2 * * *"
   # Pause this since not enough runners to support every commit to main

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -11,7 +11,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
   schedule:
     - cron: "0 2,11 * * *"
 

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -10,7 +10,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
         default: "Release"
       build-with-tracy:
         required: false

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -10,7 +10,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
         default: "Release"
       extra-tag:
         required: true

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -10,7 +10,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
         default: "Release"
       build-with-tracy:
         required: false

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -21,7 +21,6 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
-          - CI
       tracy:
         required: false
         type: boolean

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         Release
         RelWithDebInfo
         Debug
-        CI
     )
     if(NOT CMAKE_BUILD_TYPE AND NOT isMultiConfig)
         message(STATUS "Setting build type to 'Release' as none was specified.")


### PR DESCRIPTION
### Ticket
None

### Problem description
This is misleading.  It's unused and probably broken.

### What's changed
Removed references to 'CI' as a build type.