### PR TITLE
#0: fix t3k test and revert to use noc0 in edm

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -14,8 +14,8 @@ int main(int argc, char** argv) {
     std::size_t line_size = std::stoi(argv[arg_idx++]);
     std::size_t packet_payload_size_bytes = std::stoi(argv[arg_idx++]);
 
-    uint32_t test_expected_num_devices = 32;
-    if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
+    uint32_t min_test_num_devices = 8;
+    if (tt::tt_metal::GetNumAvailableDevices() < min_test_num_devices) {
         tt::log_warning("This test can only be run on T3000 or TG devices");
         return 1;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -16,7 +16,7 @@ static constexpr size_t DESTINATION_HOP_COUNT = 1;
 // TODO: make 0 and the associated field to num mcast destinations
 static constexpr size_t LAST_MCAST_DESTINATION = 1;
 
-static constexpr uint8_t edm_to_local_chip_noc = 1;
+static constexpr uint8_t edm_to_local_chip_noc = 0;
 
 FORCE_INLINE void print_pkt_hdr_routing_fields(volatile tt::fabric::PacketHeader *const packet_start) {
 #ifdef DEBUG_PRINT_ENABLED


### PR DESCRIPTION
### Checklist
- [ ] t3k bench https://github.com/tenstorrent/tt-metal/actions/runs/13812385937