### PR TITLE
Fix conv2d in NO_DISPATCH mode.

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -333,8 +333,13 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             l1_usage.CB_allocation_size,
             actual_cb_size);
 
+        // For now assume that if post_op_l1_allocation_size == 0 op is being run
+        // in graph capture NO_DISPATCH mode.
+        // ToDo: Device should offer an API to inform the op if it is running in NO_DISPATCH mode.
+        bool is_graph_capture_no_dispathch_mode = post_op_l1_allocation_size == 0;
         TT_FATAL(
-            post_op_l1_allocation_size == (this->pre_op_l1_allocation_size_bytes + l1_usage.tensor_allocation_size),
+            post_op_l1_allocation_size == (this->pre_op_l1_allocation_size_bytes + l1_usage.tensor_allocation_size) ||
+                is_graph_capture_no_dispathch_mode,
             "Mismatch!! L1 Allocation Pre Op =  {}, Post Op = {} Calculated Size = {}",
             this->pre_op_l1_allocation_size_bytes,
             post_op_l1_allocation_size,


### PR DESCRIPTION
Within graph capture NO_DISPATCH mode, the conv2d
is not going to allocate the output tensor.
Conv2d op has logic to calculate memory
footprint in advance, and after op execution it
asserts that this memory was calculated correctly, based on real usage obtained from allocaator.

In graph capture NO_DISPATCH mode, this checks
breaks, because the output tensor is not allocated. Currently op can't inffer that it's being executed in this mode.

As a stop gap solution, op now assumes this mode
of execution if the amount of allocated memory
returned by allocator is zero.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18886)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13812357162) CI passes