### PR TITLE
#18453: Delete usages of compilation reports because looks like we didn't delete them the first time around

### DIFF
--- a/models/demos/bert/demo/demo.py
+++ b/models/demos/bert/demo/demo.py
@@ -10,7 +10,6 @@ from loguru import logger
 import transformers
 import ttnn
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -280,7 +279,6 @@ def test_demo(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference(
         device=device,
@@ -309,7 +307,6 @@ def test_demo_squadv2(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference_squad_v2(
         device=device,

--- a/models/demos/bert_tiny/demo/demo.py
+++ b/models/demos/bert_tiny/demo/demo.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -261,7 +260,6 @@ def test_demo(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference(
         device=device,
@@ -292,7 +290,6 @@ def test_demo_squadv2(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference_squad_v2(
         device=device,

--- a/models/demos/distilbert/demo/demo.py
+++ b/models/demos/distilbert/demo/demo.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -293,7 +292,6 @@ def test_demo(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_distilbert_question_and_answering_inference(
         device=device,
@@ -322,7 +320,6 @@ def test_demo_squadv2(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_distilbert_question_and_answering_inference_squad_v2(
         device=device,

--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -20,7 +20,6 @@ from models.demos.falcon7b_common.tests.test_utils import (
 )
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf, check_tokens_match
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     nearest_32,
@@ -154,7 +153,6 @@ def run_falcon_demo_kv(
         N_warmup_iter = {}
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     num_devices = get_num_devices(mesh_device)
     global_batch = batch_size * num_devices

--- a/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
@@ -12,7 +12,7 @@ from models.demos.falcon7b_common.tests.run_falcon_end_to_end import (
 )
 from models.demos.falcon7b_common.tt.model_config import get_model_config
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
-from models.utility_functions import disable_compilation_reports, disable_persistent_kernel_cache, skip_for_grayskull
+from models.utility_functions import disable_persistent_kernel_cache, skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,6 @@ def test_device_perf_wh_bare_metal(
     )
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     if llm_mode == "prefill":
         expected_output_pcc, expected_k_cache_pcc, expected_v_cache_pcc = PREFILL_CONFIG_TO_PCC[

--- a/models/demos/falcon7b_common/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_end_to_end.py
@@ -19,7 +19,6 @@ from models.demos.falcon7b_common.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b_common.tt.falcon_common import PytorchFalconCausalLM
 from models.demos.falcon7b_common.tt.model_config import get_model_config
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     is_e75,
@@ -347,7 +346,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     )
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         mesh_device,

--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -15,7 +15,6 @@ from models.demos.falcon7b_common.tt.model_config import (
 )
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     is_e75,
     skip_for_grayskull,
@@ -86,7 +85,6 @@ class TestParametrized:
         )
 
         disable_persistent_kernel_cache()
-        disable_compilation_reports()
 
         if llm_mode == "prefill":
             expected_output_pcc, expected_k_cache_pcc, expected_v_cache_pcc = PREFILL_CONFIG_TO_PCC[
@@ -139,7 +137,6 @@ class TestParametrized:
         )
 
         disable_persistent_kernel_cache()
-        disable_compilation_reports()
 
         run_test_FalconCausalLM_end_to_end(
             mesh_device,

--- a/models/demos/grayskull/functional_bloom/demo/demo_causal_lm.py
+++ b/models/demos/grayskull/functional_bloom/demo/demo_causal_lm.py
@@ -10,7 +10,6 @@ import numpy as np
 from loguru import logger
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -236,7 +235,6 @@ def test_demo(
     num_tokens_to_decode=10,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bloom_causal_LM_inference(
         model_version="bigscience/bloom-560m",
@@ -267,7 +265,6 @@ def test_demo_hellaswag(
     num_tokens_to_decode=10,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bloom_causal_LM_inference_hellaswag(
         model_version="bigscience/bloom-560m",

--- a/models/demos/grayskull/functional_bloom/demo/demo_qa.py
+++ b/models/demos/grayskull/functional_bloom/demo/demo_qa.py
@@ -9,7 +9,6 @@ import evaluate
 from loguru import logger
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -291,7 +290,6 @@ def test_demo(
     num_tokens_to_decode=10,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bloom_qa_inference(
         model_version="bigscience/bloom-560m",
@@ -321,7 +319,6 @@ def test_demo_squadv2(
     num_tokens_to_decode=10,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bloom_qa_inference_squad(
         model_version="bigscience/bloom-560m",

--- a/models/demos/grayskull/t5/demo/conditional_generation_demo.py
+++ b/models/demos/grayskull/t5/demo/conditional_generation_demo.py
@@ -17,7 +17,6 @@ from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -246,7 +245,6 @@ def test_t5_demo_for_summarize(
     input_path, device, use_program_cache, batch_size, sequence_length, max_tokens, model_name
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_summarization_inference(input_path, device, batch_size, sequence_length, max_tokens, model_name)
 
@@ -260,6 +258,5 @@ def test_t5_demo_for_summarize(
 )
 def test_t5_demo_for_summarize_dataset(device, use_program_cache, batch_size, sequence_length, max_tokens, model_name):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_summarization_dataset_inference(device, batch_size, sequence_length, max_tokens, model_name)

--- a/models/demos/grayskull/t5/demo/question_answering_demo.py
+++ b/models/demos/grayskull/t5/demo/question_answering_demo.py
@@ -17,7 +17,6 @@ from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -363,7 +362,6 @@ def test_functional_t5_demo(
     device, use_program_cache, batch_size, sequence_length, max_tokens, model_name, input_path, use_optimized_version
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_functional_t5_question_and_answering_inference(
         device, batch_size, sequence_length, max_tokens, model_name, input_path, use_optimized_version
@@ -378,7 +376,6 @@ def test_functional_t5_demo_squadv2(
     device, use_program_cache, batch_size, sequence_length, max_tokens, model_name, use_optimized_version
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_functional_t5_question_and_answering_inference_squadv2(
         device, batch_size, sequence_length, max_tokens, model_name, use_optimized_version

--- a/models/demos/grayskull/t5/test_demo.py
+++ b/models/demos/grayskull/t5/test_demo.py
@@ -15,7 +15,6 @@ from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
 )
@@ -133,6 +132,5 @@ def run_summarization_inference(device, batch_size, sequence_length, max_tokens,
 )
 def test_t5_demo_for_summarize(device, use_program_cache, batch_size, sequence_length, max_tokens, model_name):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_summarization_inference(device, batch_size, sequence_length, max_tokens, model_name)

--- a/models/demos/metal_BERT_large_11/demo/demo.py
+++ b/models/demos/metal_BERT_large_11/demo/demo.py
@@ -10,7 +10,6 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     profiler,
@@ -375,7 +374,6 @@ def test_demo(
     model_config_str = "BFLOAT8_B-SHARDED"
     skip_unsupported_config(device, model_config_str, batch)
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference(
         model_version="phiyodr/bert-large-finetuned-squad2",
@@ -401,7 +399,6 @@ def test_demo_squadv2(model_location_generator, device, use_program_cache, batch
     model_config_str = "BFLOAT8_B-SHARDED"
     skip_unsupported_config(device, model_config_str, batch)
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference_squadv2(
         model_version="phiyodr/bert-large-finetuned-squad2",

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -19,7 +19,6 @@ from models.demos.metal_BERT_large_11.tt.model_config import (
 
 from models.utility_functions import (
     enable_persistent_kernel_cache,
-    disable_compilation_reports,
     comp_pcc,
     comp_allclose,
     disable_persistent_kernel_cache,
@@ -300,7 +299,6 @@ def test_bert_batch_dram(
     PERF_CNT = 1
     assert PERF_CNT == 1, "Bert does not support internal perf count no more."
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_bert_question_and_answering_inference(
         model_version,
@@ -382,7 +380,6 @@ def test_bert_batch_dram_with_program_cache(
     PERF_CNT = 1
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_bert_question_and_answering_inference(
         model_version,

--- a/models/demos/roberta/demo/demo.py
+++ b/models/demos/roberta/demo/demo.py
@@ -10,7 +10,6 @@ import transformers
 import ttnn
 import evaluate
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -275,7 +274,6 @@ def run_roberta_question_and_answering_inference_squad_v2(
 )
 def test_demo(device, use_program_cache, model_name, input_loc, bert, batch_size, sequence_size):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_roberta_question_and_answering_inference(
         device=device,
@@ -303,7 +301,6 @@ def test_demo_squadv2(
     n_iterations,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_roberta_question_and_answering_inference_squad_v2(
         device=device,

--- a/models/demos/squeezebert/demo/demo.py
+++ b/models/demos/squeezebert/demo/demo.py
@@ -13,7 +13,6 @@ from ttnn.model_preprocessing import *
 from models.utility_functions import (
     profiler,
     skip_for_wormhole_b0,
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
 )
 from ttnn.model_preprocessing import preprocess_model_parameters
@@ -281,7 +280,6 @@ def run_squeezebert_question_and_answering_inference_squad_v2(
 @pytest.mark.parametrize("squeezebert", [ttnn_functional_squeezebert])
 def test_demo(input_loc, batch_size, sequence_size, model_name, squeezebert, device, use_program_cache, reset_seeds):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_squeezebert_question_and_answering_inference(
         device=device,
@@ -311,7 +309,6 @@ def test_demo_squadv2(
     batch_size, sequence_size, model_name, squeezebert, n_iterations, device, use_program_cache, reset_seeds
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_squeezebert_question_and_answering_inference_squad_v2(
         device=device,

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -21,7 +21,6 @@ from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconConf
 from models.demos.t3000.falcon40b.tt.falcon_common import PytorchFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model_config_entries
 from models.utility_functions import (
-    disable_compilation_reports,
     enable_persistent_kernel_cache,
     profiler,
     torch2tt_tensor,
@@ -583,7 +582,6 @@ def test_demo(
     use_program_cache,
 ):
     # disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_falcon_demo_kv(
         user_input=user_input,

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -10,7 +10,6 @@ from models.demos.t3000.falcon40b.tt.model_config import (
 )
 from models.utility_functions import (
     disable_persistent_kernel_cache,
-    disable_compilation_reports,
     skip_for_grayskull,
 )
 
@@ -107,7 +106,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     )
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         t3k_mesh_device,

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -10,7 +10,6 @@ from models.demos.t3000.falcon40b.tt.model_config import (
 )
 from models.utility_functions import (
     disable_persistent_kernel_cache,
-    disable_compilation_reports,
     skip_for_grayskull,
 )
 
@@ -133,7 +132,6 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
             token_pcc = 0.99
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         t3k_mesh_device,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -26,7 +26,6 @@ from models.utility_functions import (
     profiler,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
-    disable_compilation_reports,
     skip_for_grayskull,
 )
 
@@ -531,7 +530,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     )
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         t3k_mesh_device,

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -23,7 +23,6 @@ from models.utility_functions import (
     profiler,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
-    disable_compilation_reports,
     skip_for_grayskull,
 )
 from models.perf.perf_utils import prep_perf_report
@@ -387,7 +386,6 @@ def test_perf_bare_metal(
     )
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         t3k_mesh_device,
@@ -461,7 +459,6 @@ def test_device_perf_bare_metal(
     )
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         t3k_mesh_device,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
@@ -22,7 +22,6 @@ from models.utility_functions import (
     profiler,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
-    disable_compilation_reports,
     nearest_32,
     skip_for_grayskull,
     get_devices_for_t3000,
@@ -315,7 +314,6 @@ def test_Llama_perf_host(
 
     t3k_mesh_device.enable_async(True)
     t3k_mesh_device.enable_program_cache()
-    disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(
         t3k_mesh_device,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -229,7 +229,6 @@ def test_Llama_perf_host(
 
     t3k_mesh_device.enable_async(True)
 
-
     run_test_LlamaModel_end_to_end(
         t3k_mesh_device,
         llama_version,
@@ -437,7 +436,6 @@ def test_Llama_perf_hybrid_data_tensor_parallel(
 
     check_mesh_device(mesh_device, model_config)
     mesh_device.enable_async(True)
-
 
     run_test_LlamaModel_end_to_end_hybrid_data_tensor_parallel(
         mesh_device,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -22,7 +22,6 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 )
 from models.utility_functions import (
     profiler,
-    disable_compilation_reports,
     skip_for_grayskull,
     is_wormhole_b0,
 )
@@ -230,7 +229,6 @@ def test_Llama_perf_host(
 
     t3k_mesh_device.enable_async(True)
 
-    disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(
         t3k_mesh_device,
@@ -440,7 +438,6 @@ def test_Llama_perf_hybrid_data_tensor_parallel(
     check_mesh_device(mesh_device, model_config)
     mesh_device.enable_async(True)
 
-    disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end_hybrid_data_tensor_parallel(
         mesh_device,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
@@ -143,7 +143,6 @@ def test_Llama_stress_test(
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
     t3k_mesh_device.enable_program_cache()
-    disable_compilation_reports()
     run_test_LlamaModel_stress_test(
         devices,
         batch,

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -19,7 +19,6 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 
 from models.utility_functions import (
     profiler,
-    disable_compilation_reports,
     skip_for_grayskull,
     profiler,
     enable_persistent_kernel_cache,
@@ -197,7 +196,6 @@ def test_Llama_perf_host(
     check_mesh_device(mesh_device, model_config)
     mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
-    disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(
         mesh_device,

--- a/models/demos/ttnn_falcon7b/demo/demo.py
+++ b/models/demos/ttnn_falcon7b/demo/demo.py
@@ -17,7 +17,6 @@ from models.demos.ttnn_falcon7b.tt.common import create_custom_preprocessor
 from models.demos.ttnn_falcon7b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.ttnn_falcon7b.tt.model_config import get_model_config, get_tt_cache_path, model_config_entries
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     profiler,
@@ -449,7 +448,6 @@ def test_demo(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_falcon_demo_kv(
         user_input=user_input,

--- a/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
@@ -31,7 +31,6 @@ from models.utility_functions import (
     profiler,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
-    disable_compilation_reports,
     is_e75,
     is_wormhole_b0,
     is_wormhole_b0,
@@ -407,7 +406,6 @@ def test_perf_bare_metal(
     tt_cache_path = get_tt_cache_path(model_version)
 
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
         device,

--- a/models/demos/ttnn_resnet/demo/demo.py
+++ b/models/demos/ttnn_resnet/demo/demo.py
@@ -112,7 +112,6 @@ def run_resnet_inference(
     model_config=resnet_model_config,
     model_version="microsoft/resnet-50",
 ):
-
     # set up image processor
     image_processor = AutoImageProcessor.from_pretrained(model_version)
 

--- a/models/demos/ttnn_resnet/demo/demo.py
+++ b/models/demos/ttnn_resnet/demo/demo.py
@@ -10,7 +10,6 @@ import pytest
 import ttnn
 
 from models.utility_functions import (
-    disable_compilation_reports,
     profiler,
 )
 
@@ -35,7 +34,6 @@ def run_resnet_imagenet_inference(
     model_config=resnet_model_config,
     model_version="microsoft/resnet-50",
 ):
-    disable_compilation_reports()
     profiler.clear()
 
     # set up image processor
@@ -114,7 +112,6 @@ def run_resnet_inference(
     model_config=resnet_model_config,
     model_version="microsoft/resnet-50",
 ):
-    disable_compilation_reports()
 
     # set up image processor
     image_processor = AutoImageProcessor.from_pretrained(model_version)

--- a/models/demos/vgg/demo/demo.py
+++ b/models/demos/vgg/demo/demo.py
@@ -12,7 +12,6 @@ import tt_lib
 import torch.nn as nn
 
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     profiler,
@@ -42,7 +41,6 @@ def run_vgg_imagenet_inference_vgg(
     model_config=vgg_model_config,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
     profiler.clear()
 
     # Setup model

--- a/models/demos/wormhole/bert_tiny/demo/demo.py
+++ b/models/demos/wormhole/bert_tiny/demo/demo.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -276,7 +275,6 @@ def test_demo(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference(
         mesh_device=mesh_device,
@@ -305,7 +303,6 @@ def test_demo_squadv2(
     use_program_cache,
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     return run_bert_question_and_answering_inference_squad_v2(
         mesh_device=mesh_device,

--- a/models/demos/wormhole/distilbert/demo/demo.py
+++ b/models/demos/wormhole/distilbert/demo/demo.py
@@ -6,7 +6,6 @@ import torch
 from loguru import logger
 import ttnn
 from models.utility_functions import (
-    disable_compilation_reports,
     disable_persistent_kernel_cache,
     profiler,
 )
@@ -307,7 +306,6 @@ def run_distilbert_question_and_answering_inference_squad_v2(
 @pytest.mark.parametrize("distilbert", [ttnn_optimized_distilbert])
 def test_demo(input_loc, model_name, distilbert, batch_size, model_location_generator, mesh_device):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     if ttnn.GetNumAvailableDevices() == 2:
         batch_size = batch_size * 2
@@ -335,7 +333,6 @@ def test_demo_squadv2(
     model_name, distilbert, batch_size, n_iterations, model_location_generator, use_program_cache, mesh_device
 ):
     disable_persistent_kernel_cache()
-    disable_compilation_reports()
 
     if ttnn.GetNumAvailableDevices() == 2:
         batch_size = batch_size * 2


### PR DESCRIPTION
### Ticket

#18453 

### Problem description

Quite a few Python usages such as in models did not have `disable_compilation_reports` deleted for some reason

### What's changed

`rg "disable_compilation_reports" -l | xargs sed -i '/disable_compilation_reports/d'`

there was one falcon7b that import all its functions in one line, so I manually dealt with that

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/13812661743
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes