### PR TITLE
#17361: Fix remainder low pcc

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_forge.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_forge.py
@@ -20,7 +20,7 @@ from models.utility_functions import torch_random
 
 
 parameters = {
-    "xfail": {
+    "nightly": {
         "input_shape": [[1]],
         "input_a_dtype": [ttnn.int32],
         "input_b_dtype": [ttnn.int32],

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_forge.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_forge.py
@@ -20,7 +20,7 @@ from models.utility_functions import torch_random
 
 
 parameters = {
-    "nightly": {
+    "xfail": {
         "input_shape": [[1]],
         "input_a_dtype": [ttnn.int32],
         "input_b_dtype": [ttnn.int32],

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
@@ -6,8 +6,10 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
-from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_grayskull
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
+from models.utility_functions import skip_for_grayskull, torch_random
+from functools import partial
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 
 @skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
@@ -47,3 +49,68 @@ def test_broken_remainder1(input_shapes, device):
     tt_result = ttnn.remainder(tt_lhs, tt_rhs)
     result = ttnn.to_torch(tt_result)  # all 0.5
     assert torch.allclose(result, golden, atol=0.01, rtol=0)
+
+
+@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 10, 10])),),
+)
+def test_remainder_scalar(input_shapes, device):
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), ttnn.bfloat16
+    )(input_shapes)
+    scalar = 2
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.remainder)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar, device=device)
+
+    output_tensor = ttnn.remainder(input_tensor_a, scalar)
+    output_tensor = ttnn.to_torch(output_tensor)
+    print("tt input a: ", input_tensor_a)
+    print("Torch out: ", torch_output_tensor)
+    print("TT out: ", output_tensor)
+    print("Diff: ", torch_output_tensor - output_tensor)
+    diff = torch.abs(torch_output_tensor - output_tensor)
+    max_atol = torch.max(diff)
+    print(f"Max absolute tolerance (atol): {max_atol.item()}")
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
+
+
+def test_remainder_small_matrix(device):
+    torch_input_tensor_a = torch.tensor([[5, 2], [3, 4]], dtype=torch.bfloat16)
+    print("torch input: ", torch_input_tensor_a)
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    scalar = 0.003
+    # golden_function = ttnn.get_golden_function(ttnn.remainder)
+    # torch_output_tensor = golden_function(torch_input_tensor_a, scalar, device=device)
+    torch_output_tensor = torch.remainder(torch_input_tensor_a.float(), scalar).bfloat16()
+    output_tensor = ttnn.remainder(input_tensor_a, scalar)
+    print("tt input: ", input_tensor_a)
+    print("Torch input: ", torch_input_tensor_a)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    print("Torch out: ", torch_output_tensor)
+    print("TT out: ", output_tensor)
+    print("Diff: ", torch_output_tensor - output_tensor)
+    diff = torch.abs(torch_output_tensor - output_tensor)
+    max_atol = torch.max(diff)
+    print(f"Max absolute tolerance (atol): {max_atol.item()}")
+
+    # assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
+    assert torch.allclose(output_tensor, torch_output_tensor, atol=0.01, rtol=0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
@@ -5,8 +5,6 @@
 import torch
 import pytest
 import ttnn
-from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
 from models.utility_functions import skip_for_grayskull, torch_random
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -51,16 +49,30 @@ def test_broken_remainder1(input_shapes, device):
     assert torch.allclose(result, golden, atol=0.01, rtol=0)
 
 
+# This test was added for #17361
+# If input is a multiple of the scalar, the result should be 0, but both Torch and TT output either 0 or the scalar value itself depending on the operands.
+# This inconsistency is persistent due to some fp precision loss in both Torch and TT.
+# Eg: torch.remainder of (3, 1.5) = 0.0 and of (3, 0.003) = 0.003
+# Eg: ttnn.remainder of (4, 0.004) = 0.004 and of (3, 0.003) = 0.0
 @skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 @pytest.mark.parametrize(
     "input_shapes",
-    ((torch.Size([1, 1, 10, 10])),),
+    (
+        (torch.Size([6, 5, 90, 112])),
+        (torch.Size([2, 1, 120, 11])),
+        (torch.Size([3, 123, 115])),
+        (torch.Size([69, 178])),
+    ),
 )
-def test_remainder_scalar(input_shapes, device):
+@pytest.mark.parametrize(
+    "scalar", [-0.002, -0.001, -0.0006, -0.0005, -0.0003, 0.0, 0.0003, 0.0005, 0.0006, 0.001, 0.002]
+)
+def test_remainder_scalar(input_shapes, scalar, device):
+    torch.manual_seed(0)
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), ttnn.bfloat16
     )(input_shapes)
-    scalar = 2
+
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=ttnn.bfloat16,
@@ -74,43 +86,8 @@ def test_remainder_scalar(input_shapes, device):
 
     output_tensor = ttnn.remainder(input_tensor_a, scalar)
     output_tensor = ttnn.to_torch(output_tensor)
-    print("tt input a: ", input_tensor_a)
-    print("Torch out: ", torch_output_tensor)
-    print("TT out: ", output_tensor)
-    print("Diff: ", torch_output_tensor - output_tensor)
-    diff = torch.abs(torch_output_tensor - output_tensor)
-    max_atol = torch.max(diff)
-    print(f"Max absolute tolerance (atol): {max_atol.item()}")
 
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
-
-
-def test_remainder_small_matrix(device):
-    torch_input_tensor_a = torch.tensor([[5, 2], [3, 4]], dtype=torch.bfloat16)
-    print("torch input: ", torch_input_tensor_a)
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=ttnn.bfloat16,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    scalar = 0.003
-    # golden_function = ttnn.get_golden_function(ttnn.remainder)
-    # torch_output_tensor = golden_function(torch_input_tensor_a, scalar, device=device)
-    torch_output_tensor = torch.remainder(torch_input_tensor_a.float(), scalar).bfloat16()
-    output_tensor = ttnn.remainder(input_tensor_a, scalar)
-    print("tt input: ", input_tensor_a)
-    print("Torch input: ", torch_input_tensor_a)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    print("Torch out: ", torch_output_tensor)
-    print("TT out: ", output_tensor)
-    print("Diff: ", torch_output_tensor - output_tensor)
-    diff = torch.abs(torch_output_tensor - output_tensor)
-    max_atol = torch.max(diff)
-    print(f"Max absolute tolerance (atol): {max_atol.item()}")
-
-    # assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
-    assert torch.allclose(output_tensor, torch_output_tensor, atol=0.01, rtol=0)
+    if scalar == 0.0:
+        assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
+    else:
+        assert torch.allclose(output_tensor, torch_output_tensor, atol=0.001, rtol=0)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -14,17 +14,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+template <bool APPROXIMATION_MODE>
+inline void init_remainder(const uint value, const uint recip) {
+    // load vConstFloatPrgm0 = value
+    _sfpu_load_config32_(0xC, (value >> 16) & 0xFFFF, value & 0xFFFF);
+    // load vConstFloatPrgm1 = recip
+    _sfpu_load_config32_(0xD, (recip >> 16) & 0xFFFF, recip & 0xFFFF);
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder(const uint value, const uint recip) {
     // SFPU microcode
-    Converter c_value;
-    c_value.u = value;
-    vFloat s = c_value.f;
+    vFloat s = vConstFloatPrgm0;
+    vFloat recip_val = vConstFloatPrgm1;
     vFloat value_tmp = s;
     s = sfpi::abs(s);
-
-    c_value.u = recip;
-    vFloat recip_val = c_value.f;
     recip_val = sfpi::abs(recip_val);
 
 #pragma GCC unroll 0
@@ -32,13 +36,21 @@ inline void calculate_remainder(const uint value, const uint recip) {
         vFloat val = dst_reg[0];
         vFloat v = sfpi::abs(val);
 
-        vFloat quotient = v * recip_val;
+        vFloat quotient;
+        vInt exp = exexp(v * recip_val);
+        v_if(exp < 0) { quotient = vConst0; }
+        v_elseif(exp < 23) {
+            quotient =
+                reinterpret<vFloat>(shft((shft(reinterpret<vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
+        }
+        v_else { quotient = v * recip_val; }
+        v_endif
 
-        vInt tmp = float_to_int16(quotient);  // TODO: Replace float_to_int16 to float_to_int32 once it is available
-        vFloat newquotient = int32_to_float(tmp);
-        v_if(newquotient > quotient) { newquotient = newquotient - 1; }
+        v_if(quotient > v * recip_val) {
+            quotient = quotient - 1;
+        }
         v_endif;
-        v = v - newquotient * s;
+        v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_remainder.h
@@ -13,8 +13,9 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_remainder_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::remainder, APPROXIMATE>();
+inline void llk_math_eltwise_unary_sfpu_remainder_init(uint param0, uint param1) {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::remainder, APPROXIMATE>(
+        sfpu::init_remainder<APPROXIMATE>, param0, param1);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -14,17 +14,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+template <bool APPROXIMATION_MODE>
+inline void _init_remainder_(const uint value, const uint recip) {
+    // load vConstFloatPrgm0 = value
+    _sfpu_load_config32_(0xC, (value >> 16) & 0xFFFF, value & 0xFFFF);
+    // load vConstFloatPrgm1 = recip
+    _sfpu_load_config32_(0xD, (recip >> 16) & 0xFFFF, recip & 0xFFFF);
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder(const uint value, const uint recip) {
     // SFPU microcode
-    Converter c_value;
-    c_value.u = value;
-    vFloat s = c_value.f;
+    vFloat s = vConstFloatPrgm0;
+    vFloat recip_val = vConstFloatPrgm1;
     vFloat value_tmp = s;
     s = sfpi::abs(s);
-
-    c_value.u = recip;
-    vFloat recip_val = c_value.f;
     recip_val = sfpi::abs(recip_val);
 
 #pragma GCC unroll 0
@@ -32,13 +36,21 @@ inline void calculate_remainder(const uint value, const uint recip) {
         vFloat val = dst_reg[0];
         vFloat v = sfpi::abs(val);
 
-        vFloat quotient = v * recip_val;
+        vFloat quotient;
+        vInt exp = exexp(v * recip_val);
+        v_if(exp < 0) { quotient = vConst0; }
+        v_elseif(exp < 23) {
+            quotient =
+                reinterpret<vFloat>(shft((shft(reinterpret<vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
+        }
+        v_else { quotient = v * recip_val; }
+        v_endif
 
-        vInt tmp = float_to_int16(quotient);  // TODO: Replace float_to_int16 to float_to_int32 once it is available
-        vFloat newquotient = int32_to_float(tmp);
-        v_if(newquotient > quotient) { newquotient = newquotient - 1; }
+        v_if(quotient > v * recip_val) {
+            quotient = quotient - 1;
+        }
         v_endif;
-        v = v - newquotient * s;
+        v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void _init_remainder_(const uint value, const uint recip) {
+inline void init_remainder(const uint value, const uint recip) {
     // load vConstFloatPrgm0 = value
     _sfpu_load_config32_(0xC, (value >> 16) & 0xFFFF, value & 0xFFFF);
     // load vConstFloatPrgm1 = recip

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_remainder.h
@@ -13,8 +13,9 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_remainder_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::remainder, APPROXIMATE>();
+inline void llk_math_eltwise_unary_sfpu_remainder_init(uint param0 = 1, uint param1 = 1) {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::remainder, APPROXIMATE>(
+        sfpu::_init_remainder_<APPROXIMATE>, param0, param1);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_remainder.h
@@ -13,9 +13,9 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_remainder_init(uint param0 = 1, uint param1 = 1) {
+inline void llk_math_eltwise_unary_sfpu_remainder_init(uint param0, uint param1) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::remainder, APPROXIMATE>(
-        sfpu::_init_remainder_<APPROXIMATE>, param0, param1);
+        sfpu::init_remainder<APPROXIMATE>, param0, param1);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/remainder.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/remainder.h
@@ -26,7 +26,7 @@ namespace ckernel {
  *
  * | Argument       | Description                                                                 | Type     | Valid Range                                           | Required |
  * |----------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform remainder operation | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst           | The index of the tile in DST register buffer to perform remainder operation | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0         | Denominator value to perform remainder operation                            | uint32_t |                                                       | True     |
  * | param1         | Reciprocal of param0, calculated on-host                                    | uint32_t |                                                       | False    |
  */
@@ -38,6 +38,8 @@ ALWI void remainder_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void remainder_tile_init() { MATH((llk_math_eltwise_unary_sfpu_remainder_init<APPROX>())); }
+ALWI void remainder_tile_init(uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_remainder_init<APPROX>(param0, param1)));
+}
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -141,7 +141,10 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             break;
         case UnaryOpType::REMAINDER:
             op_init_and_name = {
-                "remainder_tile_init();",
+                fmt::format(
+                    "remainder_tile_init({:#x}u, {:#x}u);",
+                    std::bit_cast<uint32_t>(param0),
+                    std::bit_cast<uint32_t>(1.0f / param0)),
                 fmt::format(
                     "remainder_tile({}, {:#x}u, {:#x}u);",
                     idst,

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -333,12 +333,21 @@ ttnn.attach_golden_function(ttnn.floor_div, golden_function=_golden_function_flo
 def _golden_function_remainder(input_tensor_a, input_tensor_b, *args, device, **kwargs):
     import torch
 
-    return torch.nan_to_num(
+    input_dtype = input_tensor_a.dtype
+    if not torch.is_tensor(input_tensor_b):
+        if input_dtype == torch.bfloat16:
+            input_tensor_a = input_tensor_a.float()
+
+    result = torch.nan_to_num(
         torch.remainder(input_tensor_a, input_tensor_b),
         nan=device.sfpu_nan(),
         posinf=device.sfpu_inf(),
         neginf=-device.sfpu_inf(),
     )
+
+    if input_dtype == torch.bfloat16:
+        result = result.bfloat16()
+    return result
 
 
 ttnn.attach_golden_function(ttnn.remainder, golden_function=_golden_function_remainder)


### PR DESCRIPTION
### Ticket
#17361

### Problem description
ttnn.remainder unary low PCC when scalar is between -0.003 and 0.003

### What's changed
As per [comment](https://github.com/tenstorrent/tt-metal/issues/17361#issuecomment-2691371528), to increase the overall accuracy of ttnn.remainder
- floor operation has been reworked in remainder kernel
- `value` and `recip` are loaded as fp32
- Updated golden function for bf16 since torch.bfloat16 was giving inaccurate torch results for tensor-scalar case

### Increase in Overall Accuracy
I tested 10 scalar values in the range [-100, 100] with original logic and with current logic (in this PR). Here are the results:
**Input tensor shape:** [1, 1, 32, 32]
**Input tensor range:** [-100, 100]
**Scalar range:** [-100, 100]
<img width="317" alt="Screenshot 2025-03-28 at 15 57 01" src="https://github.com/user-attachments/assets/6eb1178c-5270-438c-ba85-67e4f86e3c1a" />

### Observation
Inconsistency in Torch and TT outputs when the input is a multiple of the scalar value (in which case result must be 0).
**Examples in Torch:** 
torch.remainder(torch.tensor([3]), 1.5) = 0.0
torch.remainder(torch.tensor([3]), 0.003) = 0.003
**Examples in TT:**
ttnn.remainder([3], 0.003) = 0.0
ttnn.remainder([4], 0.004) = 0.004

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14127030333) - PASSED
- [x] [Blackhole Post commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/14123091510) - PASSED
- [ ] [(Single-card) Tests for new models](https://github.com/tenstorrent/tt-metal/actions/runs/13923359778) 
- [x] New/Existing tests provide coverage for changes