### PR TITLE
[skip ci] Only run Smoke tests if TT-Metalium, its tests, or CMake has changed

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -37,8 +37,24 @@ jobs:
     with:
       version: "22.04"
 
+  find-changed-files:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    outputs:
+      cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
+      tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}
+      tt-metalium-or-tt-nn-tests-changed: ${{ steps.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed }}
+    steps:
+      - id: find-changes
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+
   smoke-tests:
-    needs: build
+    needs: [ build, find-changed-files ]
+    if: ${{
+        needs.find-changed-files.outputs.cmake-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+      }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
None

### Problem description
We're wasting resources by running irrelevant tests (eg: TT-Metalium tests even if only TT-NN has changed).
We also are blindly doing an incremental Clang-Tidy scan without regard to whether the goalposts (.clang-tidy config) have moved.

### What's changed
Introduce an action to categorize changed files.
Leverage this new action to skip TT-Metalium Smoke tests when appropriate.

I'll follow-up with improving ClangTidy later.