### PR TITLE
#0: Add an option to early-return from all kernels

### DIFF
--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -118,6 +118,9 @@ class RunTimeOptions {
     std::string profiler_noc_events_report_path;
 
     bool null_kernels = false;
+    // Kernels should return early, skipping the rest of the kernel. Kernels
+    // should remain the same size as normal, unlike with null_kernels.
+    bool kernels_early_return = false;
 
     bool clear_l1 = false;
 
@@ -302,6 +305,9 @@ public:
 
     inline void set_kernels_nullified(bool v) { null_kernels = v; }
     inline bool get_kernels_nullified() { return null_kernels; }
+
+    inline void set_kernels_early_return(bool v) { kernels_early_return = v; }
+    inline bool get_kernels_early_return() { return kernels_early_return; }
 
     inline bool get_clear_l1() { return clear_l1; }
     inline void set_clear_l1(bool clear) { clear_l1 = clear; }

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -44,6 +44,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
     wait_for_go_message();
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
+        EARLY_RETURN_FOR_DEBUG
         kernel_main();
     }
 #endif

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -52,6 +52,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
 #endif
     wait_for_go_message();
     DeviceZoneScopedMainChildN("NCRISC-KERNEL");
+    EARLY_RETURN_FOR_DEBUG
     kernel_main();
     if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
         WAYPOINT("NKFW");

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -59,6 +59,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
 #endif
     wait_for_go_message();
     DeviceZoneScopedMainChildN("TRISC-KERNEL");
+    EARLY_RETURN_FOR_DEBUG
     run_kernel();
 #endif
 }

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -110,3 +110,21 @@ FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_
     );
 }
 #endif
+
+#if defined(DEBUG_EARLY_RETURN_KERNELS) && !defined(DISPATCH_KERNEL)
+// Used to early-return when NULLing out kernels. Will always return true while a kernel is running, but can't be
+// optimized away.
+FORCE_INLINE
+bool is_message_go() {
+    tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
+
+    return mailboxes->go_message.signal == RUN_MSG_GO;
+}
+
+#define EARLY_RETURN_FOR_DEBUG \
+    if (is_message_go()) {     \
+        return;                \
+    }
+#else
+#define EARLY_RETURN_FOR_DEBUG
+#endif

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -193,6 +193,10 @@ void JitBuildEnv::init(
         this->defines_ += "-DDEBUG_NULL_KERNELS ";
     }
 
+    if (tt::llrt::RunTimeOptions::get_instance().get_kernels_early_return()) {
+        this->defines_ += "-DDEBUG_EARLY_RETURN_KERNELS ";
+    }
+
     if (tt::llrt::RunTimeOptions::get_instance().get_watcher_debug_delay()) {
         this->defines_ +=
             "-DWATCHER_DEBUG_DELAY=" + to_string(tt::llrt::RunTimeOptions::get_instance().get_watcher_debug_delay()) +

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -102,6 +102,8 @@ RunTimeOptions::RunTimeOptions() {
 
     null_kernels = (std::getenv("TT_METAL_NULL_KERNELS") != nullptr);
 
+    kernels_early_return = (std::getenv("TT_METAL_KERNELS_EARLY_RETURN") != nullptr);
+
     clear_l1 = false;
     const char* clear_l1_enabled_str = std::getenv("TT_METAL_CLEAR_L1");
     if (clear_l1_enabled_str != nullptr) {


### PR DESCRIPTION

### Problem description
We'd like to be able to determine dispatch time if kernels aren't running. We have a TT_METAL_NULL_KERNELS flag, but it's targeted towards unit tests and optimizes out the kernel body.

### What's changed
Setting TT_METAL_KERNELS_EARLY_RETURN will cause all workers to early-return instead of running, allowing measurement if the minimum dispatch overhead.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes