### PR TITLE
[skip ci] New action to categorize changes on a branch

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -1,0 +1,31 @@
+name: "Find changed files"
+description: "Find which files have changed on this branch (compared to main)"
+
+outputs:
+  cmake-changed:
+    value: ${{ steps.find-changed-files.outputs.cmake-changed }}
+  clang-tidy-config-changed:
+    value: ${{ steps.find-changed-files.outputs.clang-tidy-config-changed }}
+  tt-metalium-changed:
+    value: ${{ steps.find-changed-files.outputs.tt-metalium-changed }}
+  tt-nn-changed:
+    value: ${{ steps.find-changed-files.outputs.tt-nn-changed }}
+  tt-metalium-or-tt-nn-tests-changed:
+    value: ${{ steps.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed }}
+  tt-train-changed:
+    value: ${{ steps.find-changed-files.outputs.tt-train-changed }}
+  submodule-changed:
+    value: ${{ steps.find-changed-files.outputs.submodule-changed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: false
+    - name: Find changed files
+      id: find-changed-files
+      shell: bash
+      run: .github/scripts/utils/find-changed-files.sh

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the merge-base between main and the current branch
+MERGE_BASE=$(git merge-base origin/main HEAD)
+
+# Get the list of files changed since the merge-base, ignoring changes on main
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "${MERGE_BASE}..HEAD")
+
+# Check for specific file patterns
+CMAKE_CHANGED=false
+CLANG_TIDY_CONFIG_CHANGED=false
+TTMETALIUM_CHANGED=false
+TTNN_CHANGED=false
+TTMETALIUM_OR_TTNN_TESTS_CHANGED=false
+TTTRAIN_CHANGED=false
+
+while IFS= read -r FILE; do
+    case "$FILE" in
+        **/CMakeLists.txt|**/*.cmake)
+            CMAKE_CHANGED=true
+            ;;
+        **/.clang-tidy)
+            CLANG_TIDY_CONFIG_CHANGED=true
+            ;;
+        tt_metal/**/*.h|tt_metal/**/*.hpp|tt_metal/**/*.c|tt_metal/**/*.cpp)
+            TTMETALIUM_CHANGED=true
+            ;;
+        ttnn/**/*.h|ttnn/**/*.hpp|ttnn/**/*.c|ttnn/**/*.cpp)
+            TTNN_CHANGED=true
+            ;;
+        tests/**/*.h|tests/**/*.hpp|tests/**/*.c|tests/**/*.cpp)
+            TTMETALIUM_OR_TTNN_TESTS_CHANGED=true
+            ;;
+        tt-train/**/*.h|tt-train/**/*.hpp|tt-train/**/*.c|tt-train/**/*.cpp)
+            TTTRAIN_CHANGED=true
+            ;;
+    esac
+done <<< "$CHANGED_FILES"
+
+# FIXME: Can we do this better?
+SUBMODULE_PATHS=$(git config --file .gitmodules --get-regexp path | awk '{print $2}')
+SUBMODULE_CHANGED=false
+for submodule_path in $SUBMODULE_PATHS; do
+    if echo "$CHANGED_FILES" | grep -q "^$submodule_path"; then
+        SUBMODULE_CHANGED=true
+        break
+    fi
+done
+if [[ "$SUBMODULE_CHANGED" = true ]]; then
+    # Treat any submodule change as a change to everything; not going to manage dependency trees for this
+    TTMETALIUM_CHANGED=true
+    TTNN_CHANGED=true
+    TTMETALIUM_OR_TTNN_TESTS_CHANGED=true
+    TTTRAIN_CHANGED=true
+fi
+
+declare -A changes=(
+    [cmake-changed]=$CMAKE_CHANGED
+    [clang-tidy-config-changed]=$CLANG_TIDY_CONFIG_CHANGED
+    [tt-metalium-changed]=$TTMETALIUM_CHANGED
+    [tt-nn-changed]=$TTNN_CHANGED
+    [tt-metalium-or-tt-nn-tests-changed]=$TTMETALIUM_OR_TTNN_TESTS_CHANGED
+    [tt-train-changed]=$TTTRAIN_CHANGED
+    [submodule-changed]=$SUBMODULE_CHANGED
+)
+
+for var in "${!changes[@]}"; do
+    echo "$var=${changes[$var]}"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        # Output results in GitHub Actions format when run in GHA
+        echo "$var=${changes[$var]}" >> "$GITHUB_OUTPUT"
+    fi
+done


### PR DESCRIPTION
### Ticket
None

### Problem description
We're wasting resources by running irrelevant tests (eg: TT-Metalium tests even if only TT-NN has changed).
We also are blindly doing an incremental Clang-Tidy scan without regard to whether the goalposts (.clang-tidy config) have moved.

### What's changed
Introduce an action to categorize changed files.
Will leverage this action in subsequent PRs.