### PR TITLE
Unify GlobalSemaphore and GlobalCircularBuffer MeshDevice support

### DIFF
--- a/tt_metal/api/tt-metalium/global_circular_buffer_impl.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer_impl.hpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <variant>
 
 #include "core_coord.hpp"
 #include "buffer_constants.hpp"
@@ -53,8 +52,8 @@ private:
 
     // GlobalCircularBuffer is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
-    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> cb_buffer_;
-    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> cb_config_buffer_;
+    distributed::AnyBuffer cb_buffer_;
+    distributed::AnyBuffer cb_config_buffer_;
     IDevice* device_;
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping_;
     CoreRangeSet sender_cores_;

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -10,11 +10,9 @@
 #include "core_coord.hpp"
 #include "buffer_constants.hpp"
 #include "hal.hpp"
+#include "mesh_buffer.hpp"
 
 namespace tt::tt_metal {
-
-class Buffer;
-class IDevice;
 
 class GlobalSemaphore {
 public:
@@ -44,7 +42,7 @@ private:
 
     // GlobalSemaphore is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
-    std::shared_ptr<Buffer> buffer_;
+    distributed::AnyBuffer buffer_;
     IDevice* device_;
     CoreRangeSet cores_;
 };

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -99,6 +99,10 @@ public:
     const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
 
     std::shared_ptr<Buffer> get_device_buffer(const MeshCoordinate& device_coord) const;
+
+    // TODO: Remove this method, once there is no need to interop MeshBuffer with Buffer.
+    std::shared_ptr<Buffer> get_reference_buffer() const;
+
     uint32_t datum_size_bytes() const;
     Shape2D physical_shard_shape() const;
     std::pair<bool, bool> replicated_dims() const;
@@ -156,6 +160,24 @@ private:
     struct DeallocatedState {};
     using MeshBufferState = std::variant<OwnedBufferState, ExternallyOwnedState, DeallocatedState>;
     MeshBufferState state_;
+};
+
+class AnyBuffer {
+public:
+    AnyBuffer() = default;
+    static AnyBuffer create(const tt::tt_metal::ShardedBufferConfig& config);
+    static AnyBuffer create(const tt::tt_metal::InterleavedBufferConfig& config);
+
+    Buffer* get_buffer() const;
+    bool is_mesh_buffer() const;
+    std::shared_ptr<MeshBuffer> get_mesh_buffer() const;
+
+private:
+    AnyBuffer(std::shared_ptr<Buffer> buffer);
+    AnyBuffer(std::shared_ptr<MeshBuffer> buffer);
+
+    Buffer* buffer_ = nullptr;
+    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> holder_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -8,6 +8,7 @@
 #include <mesh_device_view.hpp>
 #include <overloaded.hpp>
 #include <tt_metal.hpp>
+#include <host_api.hpp>
 
 namespace tt::tt_metal::distributed {
 namespace {
@@ -159,6 +160,8 @@ std::shared_ptr<Buffer> MeshBuffer::get_device_buffer(const MeshCoordinate& devi
     return buffers_.at(device_coord);
 }
 
+std::shared_ptr<Buffer> MeshBuffer::get_reference_buffer() const { return buffers_.values().front(); }
+
 DeviceAddr MeshBuffer::size() const {
     return std::visit(
         tt::stl::overloaded{
@@ -199,6 +202,57 @@ std::pair<bool, bool> MeshBuffer::replicated_dims() const {
         this->global_layout() == MeshBufferLayout::SHARDED,
         "Can only query replicated dims for buffers sharded across the Mesh");
     return this->global_shard_spec().replicated_dims();
+}
+
+AnyBuffer::AnyBuffer(std::shared_ptr<Buffer> buffer) : buffer_(buffer.get()), holder_(std::move(buffer)) {}
+AnyBuffer::AnyBuffer(std::shared_ptr<MeshBuffer> buffer) :
+    buffer_(buffer->get_reference_buffer().get()), holder_(std::move(buffer)) {}
+
+AnyBuffer AnyBuffer::create(const tt::tt_metal::ShardedBufferConfig& config) {
+    auto mesh_device = dynamic_cast<MeshDevice*>(config.device);
+    if (!mesh_device) {
+        return AnyBuffer{CreateBuffer(config)};
+    }
+    MeshBufferConfig mesh_config = ReplicatedBufferConfig{
+        .size = config.size,
+    };
+    DeviceLocalBufferConfig local_config{
+        .page_size = config.page_size,
+        .buffer_type = config.buffer_type,
+        .buffer_layout = config.buffer_layout,
+        .shard_parameters = config.shard_parameters,
+    };
+    return MeshBuffer::create(mesh_config, local_config, mesh_device);
+}
+
+AnyBuffer AnyBuffer::create(const tt::tt_metal::InterleavedBufferConfig& config) {
+    auto mesh_device = dynamic_cast<MeshDevice*>(config.device);
+    if (!mesh_device) {
+        return AnyBuffer{CreateBuffer(config)};
+    }
+    MeshBufferConfig mesh_config = ReplicatedBufferConfig{
+        .size = config.size,
+    };
+    DeviceLocalBufferConfig local_config{
+        .page_size = config.page_size,
+        .buffer_type = config.buffer_type,
+        .buffer_layout = config.buffer_layout,
+    };
+    return MeshBuffer::create(mesh_config, local_config, mesh_device);
+}
+
+Buffer* AnyBuffer::get_buffer() const { return buffer_; }
+
+bool AnyBuffer::is_mesh_buffer() const { return get_mesh_buffer() != nullptr; }
+
+std::shared_ptr<MeshBuffer> AnyBuffer::get_mesh_buffer() const {
+    if (auto mesh_buffer_ptr = std::get_if<std::shared_ptr<MeshBuffer>>(&holder_)) {
+        auto mesh_buffer = *mesh_buffer_ptr;
+        if (mesh_buffer->is_allocated()) {
+            return mesh_buffer;
+        }
+    }
+    return nullptr;
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -24,37 +24,6 @@
 namespace tt::tt_metal {
 namespace experimental {
 
-namespace {
-Buffer* extract_buffer(
-    const std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>>& buffer_variant) {
-    return std::visit(
-        tt::stl::overloaded{
-            [](const std::shared_ptr<Buffer>& buffer) { return buffer.get(); },
-            [](const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer) {
-                auto shape = mesh_buffer->device()->shape();
-                return mesh_buffer->get_device_buffer(*distributed::MeshCoordinateRange(shape).begin()).get();
-            }},
-        buffer_variant);
-}
-std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> create_cb_buffer(
-    const ShardedBufferConfig& config) {
-    auto mesh_device = dynamic_cast<distributed::MeshDevice*>(config.device);
-    if (!mesh_device) {
-        return CreateBuffer(config);
-    }
-    distributed::MeshBufferConfig mesh_config = distributed::ReplicatedBufferConfig{
-        .size = config.size,
-    };
-    distributed::DeviceLocalBufferConfig local_config{
-        .page_size = config.page_size,
-        .buffer_type = config.buffer_type,
-        .buffer_layout = config.buffer_layout,
-        .shard_parameters = config.shard_parameters,
-    };
-    return distributed::MeshBuffer::create(mesh_config, local_config, mesh_device);
-}
-}  // namespace
-
 GlobalCircularBuffer::GlobalCircularBuffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
@@ -98,7 +67,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = shard_parameters,
     };
-    cb_buffer_ = create_cb_buffer(cb_buffer_shard_config);
+    cb_buffer_ = distributed::AnyBuffer::create(cb_buffer_shard_config);
 
     auto l1_alignment = hal.get_alignment(HalMemType::L1);
     // is_sender, receiver_val, fifo_start_addr, fifo_size, fifo_ptr, noc_xy coords, and pages_sent
@@ -115,7 +84,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    cb_config_buffer_ = create_cb_buffer(cb_config_buffer_shard_config);
+    cb_config_buffer_ = distributed::AnyBuffer::create(cb_config_buffer_shard_config);
 
     // Write the config buffer to the device
     // Only block for the slow dispatch case
@@ -129,8 +98,8 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
                        cb_config_buffer = cb_config_buffer_,
                        size = size_,
                        sender_receiver_core_mapping = sender_receiver_core_mapping_] {
-        auto config_buffer_address = extract_buffer(cb_config_buffer)->address();
-        const auto& core_to_core_id = extract_buffer(cb_config_buffer)->get_buffer_page_mapping()->core_to_core_id_;
+        auto config_buffer_address = cb_config_buffer.get_buffer()->address();
+        const auto& core_to_core_id = cb_config_buffer.get_buffer()->get_buffer_page_mapping()->core_to_core_id_;
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
         uint32_t noc_xy_address = config_buffer_address + num_config_elements * sizeof(uint32_t);
         uint32_t pages_sent_address = tt::align(noc_xy_address + num_noc_xy_words * sizeof(uint32_t), l1_alignment);
@@ -167,23 +136,22 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
                 cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
             }
         }
-        if (std::holds_alternative<std::shared_ptr<distributed::MeshBuffer>>(cb_config_buffer)) {
-            auto mesh_buffer = std::get<std::shared_ptr<distributed::MeshBuffer>>(cb_config_buffer);
+        if (auto mesh_buffer = cb_config_buffer.get_mesh_buffer()) {
             distributed::EnqueueWriteMeshBuffer(
                 mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
         } else {
             if (device->using_slow_dispatch()) {
-                detail::WriteToBuffer(*extract_buffer(cb_config_buffer), cb_config_host_buffer);
+                detail::WriteToBuffer(*cb_config_buffer.get_buffer(), cb_config_host_buffer);
                 tt::Cluster::instance().l1_barrier(device->id());
             } else {
                 EnqueueWriteBuffer(
-                    device->command_queue(), *extract_buffer(cb_config_buffer), cb_config_host_buffer.data(), false);
+                    device->command_queue(), *cb_config_buffer.get_buffer(), cb_config_host_buffer.data(), false);
             }
         }
     });
 }
 
-const Buffer& GlobalCircularBuffer::cb_buffer() const { return *extract_buffer(cb_buffer_); }
+const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_.get_buffer(); }
 
 const CoreRangeSet& GlobalCircularBuffer::sender_cores() const { return sender_cores_; }
 
@@ -193,7 +161,7 @@ const CoreRangeSet& GlobalCircularBuffer::all_cores() const { return all_cores_;
 
 DeviceAddr GlobalCircularBuffer::buffer_address() const { return cb_buffer().address(); }
 
-DeviceAddr GlobalCircularBuffer::config_address() const { return extract_buffer(cb_config_buffer_)->address(); }
+DeviceAddr GlobalCircularBuffer::config_address() const { return cb_config_buffer_.get_buffer()->address(); }
 
 uint32_t GlobalCircularBuffer::size() const { return size_; }
 

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -50,14 +50,14 @@ void GlobalSemaphore::setup_buffer(uint32_t initial_value, BufferType buffer_typ
         .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
         .shard_parameters = std::move(shard_parameters),
     };
-    buffer_ = CreateBuffer(sem_shard_config);
+    buffer_ = distributed::AnyBuffer::create(sem_shard_config);
 
     this->reset_semaphore_value(initial_value);
 }
 
 IDevice* GlobalSemaphore::device() const { return device_; }
 
-DeviceAddr GlobalSemaphore::address() const { return buffer_->address(); }
+DeviceAddr GlobalSemaphore::address() const { return buffer_.get_buffer()->address(); }
 
 void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     // Write the initial value to the semaphore to the device
@@ -66,28 +66,14 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     device->push_work([device, reset_value, num_cores = cores_.num_cores(), buffer = buffer_] {
         std::vector<uint32_t> host_buffer(num_cores, reset_value);
         if (device->using_slow_dispatch()) {
-            detail::WriteToBuffer(*buffer, host_buffer);
+            detail::WriteToBuffer(*buffer.get_buffer(), host_buffer);
             tt::Cluster::instance().l1_barrier(device->id());
         } else {
-            // Dynamic resolution of device types is unclean and poor design. This will be cleaned up
-            // when MeshBuffer + Buffer and MeshCommandQueue + CommandQueue are unified under the same
-            // API
-            if (dynamic_cast<distributed::MeshDevice*>(device)) {
-                distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
-
-                distributed::ReplicatedBufferConfig replicated_buffer_config{.size = buffer->size()};
-                distributed::DeviceLocalBufferConfig local_config{
-                    .page_size = buffer->page_size(),
-                    .buffer_type = buffer->buffer_type(),
-                    .buffer_layout = buffer->buffer_layout(),
-                    .shard_parameters = buffer->shard_spec(),
-                    .bottom_up = buffer->bottom_up()};
-                auto mesh_buffer = distributed::MeshBuffer::create(
-                    replicated_buffer_config, local_config, mesh_device, buffer->address());
-                distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), mesh_buffer, host_buffer);
-                // mesh_device->mesh_command_queue().enqueue_write_buffer_broadcast(buffer, host_buffer.data(), false);
+            if (auto mesh_buffer = buffer.get_mesh_buffer()) {
+                distributed::EnqueueWriteMeshBuffer(
+                    mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer);
             } else {
-                EnqueueWriteBuffer(device->command_queue(), buffer, host_buffer, false);
+                EnqueueWriteBuffer(device->command_queue(), *buffer.get_buffer(), host_buffer, false);
             }
         }
     });


### PR DESCRIPTION
### Ticket

### Problem description
Unify GlobalSemaphore and GlobalCircularBuffer support for MeshDevice introducing AnyBuffer abstraction
The same abstraction will be reused for the profiler support in the future

### What's changed
Moved out common code to allocate either single buffer or mesh buffer into AnyBuffer

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13820456033)
- [x] New/Existing tests provide coverage for changes