### PR TITLE
[skip ci] Use Debug for PR Gate :: Smoke

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -36,6 +36,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       version: "22.04"
+      build-type: Debug
 
   find-changed-files:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft


### PR DESCRIPTION
### Ticket
None

### Problem description
We have ASSERTs in our code, but Release builds strip the them.  They're there for a reason, so let's benefit from them.

### What's changed
Change to Debug for the Smoke tests in the PR Gate