### PR TITLE
Handle multi-device storage in transform, reshape

### DIFF
--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -206,11 +206,13 @@ DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& 
 bool is_host_mesh_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST; }
 
 bool is_multi_device_tensor(const Tensor& tensor) {
-    return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST || is_mesh_buffer_tensor(tensor);
+    const auto* device_storage = std::get_if<DeviceStorage>(&tensor.get_storage());
+    return (tensor.storage_type() == StorageType::MULTI_DEVICE_HOST) ||
+           (device_storage != nullptr && device_storage->specs.size() > 1);
 }
 
 bool is_mesh_buffer_tensor(const Tensor& tensor) {
-    auto* device_storage = std::get_if<DeviceStorage>(&tensor.get_storage());
+    const auto* device_storage = std::get_if<DeviceStorage>(&tensor.get_storage());
     return device_storage != nullptr && device_storage->mesh_buffer != nullptr;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -121,7 +121,7 @@ Tensor tensor_reshape(
                                 new_logical_shape,
                                 new_padded_shape));
 
-                        return update_tensor_specs(Tensor(device_storage, new_spec), upd_spec);
+                        return update_tensor_specs(Tensor(device_storage, upd_spec), upd_spec);
                     }
                 } else {
                     return update_tensor_specs(Tensor(tensor.get_storage(), new_spec), new_spec);

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -61,30 +61,28 @@ Tensor tensor_reshape(
                 return Tensor(updated_storage, new_spec);
             }
             if constexpr (std::is_same_v<T, tt::tt_metal::DeviceStorage>) {
-                auto device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
-                if (device_storage.mesh_buffer != nullptr) {
-                    auto updated_storage = device_storage;
-                    for (auto& [_, spec] : updated_storage.specs) {
-                        const auto& prev_spec = spec;
-                        TensorSpec new_spec(
-                            new_logical_shape,
-                            TensorLayout::fromPaddedShape(
-                                prev_spec.data_type(),
-                                prev_spec.page_config(),
-                                prev_spec.memory_config(),
-                                new_logical_shape,
-                                new_padded_shape));
-                        spec = new_spec;
+                auto update_tensor_specs = [](const Tensor& tensor, const TensorSpec& new_spec) {
+                    auto device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
+                    if (device_storage.mesh_buffer != nullptr) {
+                        auto updated_storage = device_storage;
+                        for (auto& [_, spec] : updated_storage.specs) {
+                            spec = new_spec;
+                        }
+                        return Tensor(std::move(updated_storage), new_spec);
+                    } else {
+                        return tensor;
                     }
-                    return Tensor(std::move(updated_storage), new_spec);
-                } else if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
+                };
+
+                if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
+                    auto device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
                     if (tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
                         tt::tt_metal::DeviceStorage device_storage = std::get<T>(tensor.get_storage());
                         auto device_buffer = device_storage.get_buffer();
                         const auto& tensor_spec = tensor.tensor_spec();
                         auto page_size_bytes = tensor_spec.compute_page_size_bytes();
                         device_buffer->set_page_size(page_size_bytes);
-                        return Tensor(device_storage, new_spec);
+                        return update_tensor_specs(Tensor(device_storage, new_spec), new_spec);
                     } else {
                         tt::tt_metal::DeviceStorage device_storage = std::get<T>(tensor.get_storage());
                         auto device_buffer = device_storage.get_buffer();
@@ -123,10 +121,10 @@ Tensor tensor_reshape(
                                 new_logical_shape,
                                 new_padded_shape));
 
-                        return Tensor(device_storage, upd_spec);
+                        return update_tensor_specs(Tensor(device_storage, new_spec), upd_spec);
                     }
                 } else {
-                    return Tensor(tensor.get_storage(), new_spec);
+                    return update_tensor_specs(Tensor(tensor.get_storage(), new_spec), new_spec);
                 }
             } else {
                 return Tensor(tensor.get_storage(), new_spec);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -1223,11 +1223,6 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
 
     return std::visit(
         [&tensor, &target_layout](auto&& storage) -> Tensor {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (
-                !std::is_same_v<StorageType, OwnedStorage> && !std::is_same_v<StorageType, MultiDeviceHostStorage>) {
-                // raise_unsupported_storage<StorageType>();
-            }
             return Tensor(
                 storage,
                 TensorSpec(
@@ -1283,7 +1278,7 @@ Tensor pad(
     const ttnn::Shape& output_padded_shape,
     const ttnn::Shape& input_tensor_start,
     float pad_value) {
-    if (ttnn::distributed::is_host_mesh_tensor(tensor)) {
+    if (ttnn::distributed::is_multi_device_tensor(tensor)) {
         return transform(tensor, [&](const Tensor& device_tensor) {
             return pad<T>(device_tensor, output_padded_shape, input_tensor_start, pad_value);
         });


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some model demos are hitting issues with `transform`, and `reshape` when using mesh tensor.

### What's changed
* `is_multi_device_tensor` is a tensor allocated on mesh that has more than 1 spec
* `reshape` needs to update tensor specs per shard. Note this would be an issue on main, but we run the code through `launch_op` infra that launches ops on individual devices with individual tensor shards.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13822671898/job/38672141767)
- [X] New/Existing tests provide coverage for changes