### PR TITLE
#18832: Use DeviceCommandCalculator instead of host alignment

### DIFF
--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -18,13 +18,13 @@
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
-#include "hal.hpp"
 #include "hal_types.hpp"
 #include "logger.hpp"
 #include "strong_type.hpp"
 #include "sub_device_types.hpp"
 #include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/tt_xy_pair.h>
@@ -54,24 +54,33 @@ void issue_record_event_commands(
     std::vector<uint32_t> event_payload(DispatchSettings::EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
     event_payload[0] = event_id;
 
-    uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
-    uint32_t packed_event_payload_sizeB =
-        align(sizeof(CQDispatchCmd) + num_command_queues * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment) +
-        (align(DispatchSettings::EVENT_PADDED_SIZE, l1_alignment) * num_command_queues);
-    uint32_t packed_write_sizeB = align(sizeof(CQPrefetchCmd) + packed_event_payload_sizeB, pcie_alignment);
-    uint32_t num_worker_counters = sub_device_ids.size();
+    const uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    const uint32_t num_worker_counters = sub_device_ids.size();
+    const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
-    uint32_t cmd_sequence_sizeB =
-        hal_ref.get_alignment(HalMemType::HOST) *
-            num_worker_counters +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
-        packed_write_sizeB +       // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PACKED +
-                                   // unicast subcmds + event payload
-        align(
-            sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE,
-            pcie_alignment) *
-            notify_host;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_LINEAR_HOST + event ID ===> Write
-                          // event notification back to host, if requested by user
+    // Calculate the packed event payload size
+    uint32_t packed_event_payload_sizeB;
+    {
+        tt::tt_metal::DeviceCommandCalculator event_payload_calculator;
+        event_payload_calculator.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+            num_command_queues, DispatchSettings::EVENT_PADDED_SIZE, packed_write_max_unicast_sub_cmds, false);
+        packed_event_payload_sizeB =
+            tt::align(event_payload_calculator.write_offset_bytes() - sizeof(CQPrefetchCmd), l1_alignment);
+    }
+
+    // Calculate the actual command size
+    tt::tt_metal::DeviceCommandCalculator calculator;
+    for (int i = 0; i < num_worker_counters; ++i) {
+        calculator.add_dispatch_wait();
+    }
+
+    calculator.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+        num_command_queues, DispatchSettings::EVENT_PADDED_SIZE, packed_write_max_unicast_sub_cmds, false);
+
+    if (notify_host) {
+        calculator.add_dispatch_write_linear_host_event(DispatchSettings::EVENT_PADDED_SIZE);
+    }
+    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 
@@ -115,7 +124,6 @@ void issue_record_event_commands(
         DispatchMemMap::get(dispatch_core_type)
             .get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q1_LAST_EVENT);
     uint32_t address = cq_id == 0 ? completion_q0_last_event_addr : completion_q1_last_event_addr;
-    const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
     command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
         num_command_queues,
         address,
@@ -139,8 +147,9 @@ void issue_record_event_commands(
 
 void issue_wait_for_event_commands(
     uint8_t cq_id, uint8_t event_cq_id, SystemMemoryManager& sysmem_manager, uint32_t event_id) {
-    uint32_t cmd_sequence_sizeB =
-        hal_ref.get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
+    tt::tt_metal::DeviceCommandCalculator calculator;
+    calculator.add_dispatch_wait();
+    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();


### PR DESCRIPTION
### Ticket
#18832

### Problem description
Using host alignment as the command size is not robust. The command size or alignment could become mismatched.

### What's changed
- Use the `DeviceCommandCalculator` to calculate the required space to reserve on hugepage. This way is more clear on which dispatch commands are being used for each API

### Checklist
Single
https://github.com/tenstorrent/tt-metal/actions/runs/14048562025
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14048567143
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14048563998
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14048565874
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14048568162