### PR TITLE
Remove `get_platform_architecture.hpp` from public API

### DIFF
--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -59,7 +59,7 @@ inline tt::ARCH get_platform_architecture() {
         auto devices_info = PCIDevice::enumerate_devices_info();
         if (devices_info.size() > 0) {
             arch = devices_info.begin()->second.get_arch();
-            for (auto &[device_id, device_info] : devices_info) {
+            for (auto& [device_id, device_info] : devices_info) {
                 tt::ARCH detected_arch = device_info.get_arch();
                 TT_FATAL(
                     arch == detected_arch,


### PR DESCRIPTION
### Ticket
Closes #18440 

### Problem description
This header file does not need to be public

### What's changed
I like to move it move it

### Checklist
No functional change, build works