### PR TITLE
Move All Post Commit From Ubuntu 20.04 to Ubuntu 22.04

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -8,7 +8,7 @@ inputs:
   docker_os_arch:
     description: 'Docker image architecture'
     required: false
-    default: tt-metalium/ubuntu-20.04-amd64
+    default: tt-metalium/ubuntu-22.04-amd64
   docker_image:
     description: 'Specify Docker image to use.'
     required: false

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -214,17 +214,9 @@ jobs:
     strategy:
       matrix:
         config:
-          - version: "20.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "Debug"
-            publish-artifact: false
-          - version: "20.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "RelWithDebInfo"
-            publish-artifact: false
           - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-            build-type: "Release"
+            build-type: "Debug"
             publish-artifact: false
           - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -44,12 +44,14 @@ jobs:
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
+      version: 22.04
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
       tracy: true
+      version: 22.04
     secrets: inherit
 
   smoke-tests:
@@ -82,6 +84,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
+      os: ubuntu-22.04
   # Fast Dispatch Unit Tests
   fast-dispatch-unit-tests:
     needs: build-artifact
@@ -95,7 +98,7 @@ jobs:
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
-      os: ubuntu-20.04
+      os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
   # Fabric Unit Tests
@@ -110,7 +113,7 @@ jobs:
         ]
     uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
     with:
-      os: ubuntu-20.04
+      os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
   # TTNN FD Unit tests
@@ -158,6 +161,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
+      os: ubuntu-22.04
   code-analysis:
     uses: ./.github/workflows/code-analysis.yaml
     secrets: inherit

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -55,7 +55,7 @@ jobs:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
       tracy: true
-      version: "20.04"
+      version: "22.04"
   run-profiler-regression:
     needs: build-artifact-profiler
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -40,7 +40,7 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
         test-group: [
           {name: model},
         ]
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
         test-group: [
           {name: model},
         ]

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -49,7 +49,7 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
         test-group:
           - name: ttnn group 1
             cmd: pytest tests/ttnn/unit_tests -xv --splits ${{ inputs.num-groups }} --group 1 -m "not disable_fast_runtime_mode"


### PR DESCRIPTION
### Ticket
Closes #14392

### Problem description
Ubuntu 20.04 end of life is approaching

### What's changed
Move our primary CI workflows to test on Ubuntu 22.04 docker images

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13822911644) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (good enough for me, because profiler tests pass)