### PR TITLE
#0: Resolve APC failures with MeshTensorTest

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -181,7 +181,6 @@ TEST_P(MultiDeviceTensorCreationTest, Arange) {
         std::ref(*mesh_device));
 
     EXPECT_EQ(tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_EQ(tensor.get_workers().size(), mesh_device->num_devices());
     EXPECT_EQ(tensor.logical_shape(), ttnn::Shape({1024}));
 
     const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(tensor);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -576,13 +576,13 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
     const auto& mesh_buffer = storage.mesh_buffer;
     ttnn::MeshDevice* device = mesh_buffer->device();
     distributed::MeshCommandQueue& mesh_cq = device->mesh_command_queue(*cq_id);
-    const auto num_buffers = device->num_devices();
+    const auto num_buffers = storage.specs.size();
 
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
     std::vector<TensorSpec> specs;
     std::vector<OwnedBuffer> buffers;
-    specs.reserve(num_buffers);
     buffers.reserve(num_buffers);
+    specs.reserve(num_buffers);
     shard_data_transfers.reserve(num_buffers);
     for (const auto& [coord, shard_tensor_spec] : storage.specs) {
         std::vector<T> host_buffer;


### PR DESCRIPTION
N300 `MeshTensor` tests exposed issues with the readback path after being enabled:
- Number of Buffers in `to_host_mesh_tensor` is incorrectly resized (set to num devices, not number of shards to read)
- Calling `buffer.back()` in a for loop where the owning vector is modified is unsafe -> was causing PCC issues

Resolve these issues.