### PR TITLE
Auto detect whether to do an incremental or a full scan with ClangTidy

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -16,6 +16,8 @@ outputs:
     value: ${{ steps.find-changed-files.outputs.tt-train-changed }}
   submodule-changed:
     value: ${{ steps.find-changed-files.outputs.submodule-changed }}
+  any-code-changed:
+    value: ${{ steps.find-changed-files.outputs.any-code-changed }}
 
 runs:
   using: "composite"

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -14,26 +14,31 @@ TTMETALIUM_CHANGED=false
 TTNN_CHANGED=false
 TTMETALIUM_OR_TTNN_TESTS_CHANGED=false
 TTTRAIN_CHANGED=false
+ANY_CODE_CHANGED=false
 
 while IFS= read -r FILE; do
     case "$FILE" in
         **/CMakeLists.txt|**/*.cmake)
             CMAKE_CHANGED=true
             ;;
-        **/.clang-tidy)
+        .clang-tidy|**/.clang-tidy)
             CLANG_TIDY_CONFIG_CHANGED=true
             ;;
         tt_metal/**/*.h|tt_metal/**/*.hpp|tt_metal/**/*.c|tt_metal/**/*.cpp)
             TTMETALIUM_CHANGED=true
+            ANY_CODE_CHANGED=true
             ;;
         ttnn/**/*.h|ttnn/**/*.hpp|ttnn/**/*.c|ttnn/**/*.cpp)
             TTNN_CHANGED=true
+            ANY_CODE_CHANGED=true
             ;;
         tests/**/*.h|tests/**/*.hpp|tests/**/*.c|tests/**/*.cpp)
             TTMETALIUM_OR_TTNN_TESTS_CHANGED=true
+            ANY_CODE_CHANGED=true
             ;;
         tt-train/**/*.h|tt-train/**/*.hpp|tt-train/**/*.c|tt-train/**/*.cpp)
             TTTRAIN_CHANGED=true
+            ANY_CODE_CHANGED=true
             ;;
     esac
 done <<< "$CHANGED_FILES"
@@ -53,6 +58,7 @@ if [[ "$SUBMODULE_CHANGED" = true ]]; then
     TTNN_CHANGED=true
     TTMETALIUM_OR_TTNN_TESTS_CHANGED=true
     TTTRAIN_CHANGED=true
+    ANY_CODE_CHANGED=true
 fi
 
 declare -A changes=(
@@ -63,6 +69,7 @@ declare -A changes=(
     [tt-metalium-or-tt-nn-tests-changed]=$TTMETALIUM_OR_TTNN_TESTS_CHANGED
     [tt-train-changed]=$TTTRAIN_CHANGED
     [submodule-changed]=$SUBMODULE_CHANGED
+    [any-code-changed]=$ANY_CODE_CHANGED
 )
 
 for var in "${!changes[@]}"; do

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -15,10 +15,6 @@ on:
         required: false
         type: string
         default: "amd64"
-      full-scan:
-        required: false
-        type: boolean
-        default: false
   workflow_dispatch:
     inputs:
       distro:
@@ -33,12 +29,27 @@ on:
         required: false
         type: string
         default: "amd64"
-      full-scan:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
+  determine-scan-type:
+    runs-on: ubuntu-latest
+    outputs:
+      do-full-scan: ${{ steps.compute-outputs.outputs.do-full-scan }}
+      do-scan: ${{ steps.compute-outputs.outputs.do-scan }}
+    steps:
+      - id: find-changes
+        uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
+
+      - id: compute-outputs
+        shell: bash
+        run: |
+          do_full_scan=$([[ "${{ github.ref_name }}" == "main" || "${{ steps.find-changes.outputs.clang-tidy-config-changed }}" == "true" ]] && echo "true" || echo "false")
+          do_scan=$([[ "$do_full_scan" == "true" || "${{ steps.find-changes.outputs.any-code-changed }}" == "true" || "${{ steps.find-changes.outputs.cmake-changed }}" == "true" ]] && echo "true" || echo "false")
+          echo "Do a scan: $do_scan"
+          echo "Do a full scan: $do_full_scan"
+          echo "do-full-scan=$do_full_scan" >> "$GITHUB_OUTPUT"
+          echo "do-scan=$do_scan" >> "$GITHUB_OUTPUT"
+
   build-docker-image:
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
@@ -46,9 +57,11 @@ jobs:
       distro: ${{ inputs.distro }}
       version: ${{ inputs.version }}
       architecture: ${{ inputs.architecture }}
+
   clang-tidy:
     name: 🤖 Clang Tidy
-    needs: build-docker-image
+    needs: [ build-docker-image, determine-scan-type ]
+    if: ${{ needs.determine-scan-type.outputs.do-scan == 'true' }}
     runs-on:
       - build
       - in-service
@@ -97,7 +110,7 @@ jobs:
           clean: true
 
       - name: Determine merge base
-        if: github.ref_name != 'main' && !inputs.full-scan
+        if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
         run: |
           echo "Current branch: ${{ github.ref_name }}"
           MERGE_BASE=$(git merge-base ${{ github.ref_name }} origin/main)
@@ -105,7 +118,7 @@ jobs:
           echo "MERGE_BASE=$MERGE_BASE" >> $GITHUB_ENV
 
       - name: Check out baseline
-        if: github.ref_name != 'main' && !inputs.full-scan
+        if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ env.MERGE_BASE }}
@@ -125,19 +138,19 @@ jobs:
           cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
 
       - name: Prepare baseline ccache summary
-        if: github.ref_name != 'main' && !inputs.full-scan
+        if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
         run: |
           # Zero out the stats so we can see how we did this build
           # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
           ccache -z
 
       - name: 🛠️ Baseline Build
-        if: github.ref_name != 'main' && !inputs.full-scan
+        if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
         run: |
           nice -n 19 cmake --build --preset clang-tidy
 
       - name: Publish Ccache summary
-        if: github.ref_name != 'main' && !inputs.full-scan
+        if: ${{ needs.determine-scan-type.outputs.do-full-scan != 'true' }}
         run: |
           echo '## CCache Summary' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Ticket
None

### Problem description
We blindly scan with ClangTidy even when no code has changed.
We blindly do an incremental scan even when the goalposts (.clang-tidy config) has changed.

### What's changed
Be more smart about how much we scan with ClangTidy.  This should reduce our load on the builders.