### PR TITLE
Aliu/fabric init infra

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -24,6 +24,7 @@ class ControlPlaneFixture : public ::testing::Test {
                    "Control plane test suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
                GTEST_SKIP();
            }
+           tt::tt_metal::detail::InitializeFabricConfig(tt::FabricConfig::FABRIC_2D);
        }
 
        void TearDown() override {}

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -21,7 +21,7 @@ TEST_F(Fabric1DFixture, TestUnicast) {
     std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
     chip_id_t dst_physical_device_id;
 
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     bool connection_found = false;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <memory>
-#include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/fabric_host_interface.h>
 
@@ -26,7 +25,7 @@ TEST_F(Fabric2DFixture, TestAsyncWrite) {
     std::pair<mesh_id_t, chip_id_t> end_mesh_chip_id;
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     bool connection_found = false;
@@ -186,7 +185,7 @@ TEST_F(Fabric2DFixture, TestAtomicInc) {
     std::pair<mesh_id_t, chip_id_t> end_mesh_chip_id;
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     bool connection_found = false;
@@ -345,7 +344,7 @@ TEST_F(Fabric2DFixture, TestAsyncWriteAtomicInc) {
     std::pair<mesh_id_t, chip_id_t> end_mesh_chip_id;
     chip_id_t physical_end_device_id;
 
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
 
     // Find a device with a neighbour in the East direction
     bool connection_found = false;
@@ -527,7 +526,7 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticast) {
     auto routing_direction = RoutingDirection::E;
     mcast_hops[routing_direction] = 1;
 
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
 
     // Find a device with enough neighbours in the specified direction
     bool connection_found = false;
@@ -749,7 +748,7 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticastMultidirectional) {
     mcast_hops[RoutingDirection::E] = 1;
     mcast_hops[RoutingDirection::W] = 2;
 
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
 
     // Find a device with enough neighbours in the specified direction
     bool connection_found = false;

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -23,6 +23,19 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
         std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+}
+
+TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
+    const auto control_plane = tt::Cluster::instance().get_control_plane();
+    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    EXPECT_EQ(user_meshes.size(), 1);
+    EXPECT_EQ(user_meshes[0], 4);
+    EXPECT_EQ(control_plane->get_physical_mesh_shape(0), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane->get_physical_mesh_shape(1), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane->get_physical_mesh_shape(2), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane->get_physical_mesh_shape(3), tt::tt_metal::distributed::MeshShape(1, 1));
+    EXPECT_EQ(control_plane->get_physical_mesh_shape(4), tt::tt_metal::distributed::MeshShape(4, 8));
 }
 
 TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
@@ -30,6 +43,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
         std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 3);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 4, 31, chan);
@@ -48,6 +62,7 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
         std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
@@ -55,6 +70,7 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
         std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 0, 7, chan);
@@ -70,6 +86,7 @@ TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
         std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(quanta_galaxy_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 }  // namespace fabric_router_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
             std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
             "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
         auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(tg_mesh_graph_desc_path.string());
-        control_plane->configure_routing_tables();
+        control_plane->write_routing_tables_to_all_chips();
 
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id_l >= num_devices) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -147,10 +147,10 @@ typedef struct test_board {
         }
         device_handle_map = tt::tt_metal::detail::CreateDevices(available_chip_ids);
         if (metal_fabric_init_level == 0) {
-            _init_control_plane(mesh_graph_descriptor);
-            control_plane->configure_routing_tables();
+            control_plane = tt::Cluster::instance().get_control_plane();
+            control_plane->write_routing_tables_to_all_chips();
         } else {
-            control_plane = tt::DevicePool::instance().get_control_plane();
+            control_plane = tt::Cluster::instance().get_control_plane();
         }
 
         if (num_chips_to_use != available_chip_ids.size()) {

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -5,9 +5,9 @@
 #pragma once
 
 #include "routing_table_generator.hpp"
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/rtoptions.hpp>
 #include <tt-metalium/fabric_host_interface.h>
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace tt::tt_fabric {
 
@@ -17,19 +17,22 @@ class ControlPlane {
        ~ControlPlane() = default;
        void initialize_from_mesh_graph_desc_file(const std::string& mesh_graph_desc_file);
 
-       // Takes RoutingTableGenerator table and converts to routing tables for each ethernet port
-       void convert_fabric_routing_table_to_chip_routing_table();
-
        void write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chip_id) const;
-       void configure_routing_tables() const;
+       void write_routing_tables_to_all_chips() const;
 
        // Printing functions
        void print_routing_tables() const;
        void print_ethernet_channels() const;
 
+       // Converts chip level routing tables to per ethernet channel
+       void configure_routing_tables_for_fabric_ethernet_channels();
+
        // Return mesh_id, chip_id from physical chip id
        std::pair<mesh_id_t, chip_id_t> get_mesh_chip_id_from_physical_chip_id(chip_id_t physical_chip_id) const;
        chip_id_t get_physical_chip_id_from_mesh_chip_id(const std::pair<mesh_id_t, chip_id_t>& mesh_chip_id) const;
+
+       std::vector<mesh_id_t> get_user_physical_mesh_ids() const;
+       tt::tt_metal::distributed::MeshShape get_physical_mesh_shape(mesh_id_t mesh_id) const;
 
        // Return valid ethernet channels on the specificed routing plane
        std::vector<chan_id_t> get_valid_eth_chans_on_routing_plane(
@@ -82,6 +85,9 @@ class ControlPlane {
 
        std::tuple<mesh_id_t, chip_id_t, chan_id_t> get_connected_mesh_chip_chan_ids(
            mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t chan_id) const;
+
+       // Takes RoutingTableGenerator table and converts to routing tables for each ethernet port
+       void convert_fabric_routing_table_to_chip_routing_table();
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -57,8 +57,6 @@ public:
     void unregister_worker_thread_for_device(tt_metal::IDevice* device);
     const std::unordered_set<std::thread::id>& get_worker_thread_ids() const;
 
-    tt::tt_fabric::ControlPlane* get_control_plane() const;
-
 private:
     ~DevicePool();
     DevicePool();
@@ -79,8 +77,6 @@ private:
     bool skip_remote_devices;
     std::unordered_set<uint32_t> firmware_built_keys;
 
-    std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane;
-
     // Determine which CPU cores the worker threads need to be placed on for each device
     std::unordered_map<uint32_t, uint32_t> worker_thread_to_cpu_core_map;
     std::unordered_map<uint32_t, uint32_t> completion_queue_reader_to_cpu_core_map;
@@ -94,9 +90,6 @@ private:
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
     void wait_for_fabric_router_sync() const;
     tt_metal::IDevice* get_device(chip_id_t id) const;
-
-    // Fabric setup helper functions
-    void initialize_control_plane();
 
     static DevicePool* _inst;
 };

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -54,12 +54,8 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     // Initialize the control plane routers based on mesh graph
     this->initialize_from_mesh_graph_desc_file(mesh_graph_desc_file);
 
-    this->convert_fabric_routing_table_to_chip_routing_table();
-
     // Printing, only enabled with log_debug
     this->print_ethernet_channels();
-    // Printing, only enabled with log_debug
-    this->print_routing_tables();
 }
 
 std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
@@ -213,73 +209,6 @@ void ControlPlane::initialize_from_mesh_graph_desc_file(const std::string& mesh_
     // Main board
     this->logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back(
         this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, num_ports_per_side, nw_chip_physical_chip_id));
-
-    // From here, should be production init
-    const auto& intra_mesh_connectivity = this->routing_table_generator_->get_intra_mesh_connectivity();
-    const auto& inter_mesh_connectivity = this->routing_table_generator_->get_inter_mesh_connectivity();
-
-    auto add_ethernet_channel_to_router_mapping = [&](mesh_id_t mesh_id,
-                                                      chip_id_t chip_id,
-                                                      const CoreCoord& eth_core,
-                                                      RoutingDirection direction) {
-        auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
-        auto fabric_router_channels_on_chip = tt::Cluster::instance().get_fabric_ethernet_channels(physical_chip_id);
-        auto chan_id = tt::Cluster::instance().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
-        // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
-        if (fabric_router_channels_on_chip.contains(chan_id)) {
-            this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id][direction].push_back(chan_id);
-        } else {
-            log_debug(
-                tt::LogFabric, "Control Plane: Disabling router on M{}D{} eth channel {}", mesh_id, chip_id, chan_id);
-        }
-    };
-
-    // Initialize the bookkeeping for mapping from mesh/chip/direction to physical ethernet channels
-    this->router_port_directions_to_physical_eth_chan_map_.resize(intra_mesh_connectivity.size());
-    for (mesh_id_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
-        this->router_port_directions_to_physical_eth_chan_map_[mesh_id].resize(intra_mesh_connectivity[mesh_id].size());
-        for (chip_id_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
-            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
-            const auto& connected_chips_and_eth_cores =
-                tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
-            for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[mesh_id][chip_id]) {
-                const auto& physical_connected_chip_id =
-                    this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_connected_chip_id];
-                const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
-                TT_FATAL(
-                    connected_eth_cores.size() == edge.connected_chip_ids.size(),
-                    "Expected {} eth links from physical chip {} to physical chip {}",
-                    edge.connected_chip_ids.size(),
-                    physical_chip_id,
-                    physical_connected_chip_id);
-
-                for (const auto& eth_core : connected_eth_cores) {
-                    // There could be an optimization here to create entry for both chips here, assuming links are
-                    // bidirectional
-                    add_ethernet_channel_to_router_mapping(mesh_id, chip_id, eth_core, edge.port_direction);
-                }
-            }
-        }
-    }
-    for (mesh_id_t mesh_id = 0; mesh_id < inter_mesh_connectivity.size(); mesh_id++) {
-        for (chip_id_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
-            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
-            const auto& connected_chips_and_eth_cores =
-                tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
-            for (const auto& [connected_mesh_id, edge] : inter_mesh_connectivity[mesh_id][chip_id]) {
-                // Loop over edges connected chip ids, they could connect to different chips for intermesh traffic
-                for (const auto& logical_connected_chip_id : edge.connected_chip_ids) {
-                    const auto& physical_connected_chip_id =
-                        this->logical_mesh_chip_id_to_physical_chip_id_mapping_[connected_mesh_id]
-                                                                               [logical_connected_chip_id];
-                    const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
-                    for (const auto& eth_core : connected_eth_cores) {
-                        add_ethernet_channel_to_router_mapping(mesh_id, chip_id, eth_core, edge.port_direction);
-                    }
-                }
-            }
-        }
-    }
 }
 
 routing_plane_id_t ControlPlane::get_routing_plane_id(chan_id_t eth_chan_id) const {
@@ -315,6 +244,7 @@ chan_id_t ControlPlane::get_downstream_eth_chan_id(
 void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     // Routing tables contain direction from chip to chip
     // Convert it to be unique per ethernet channel
+
     const auto& router_intra_mesh_routing_table = this->routing_table_generator_->get_intra_mesh_table();
     this->intra_mesh_routing_tables_.resize(router_intra_mesh_routing_table.size());
     for (mesh_id_t mesh_id = 0; mesh_id < router_intra_mesh_routing_table.size(); mesh_id++) {
@@ -417,6 +347,81 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
             }
         }
     }
+    // Printing, only enabled with log_debug
+    this->print_routing_tables();
+}
+
+void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
+    this->intra_mesh_routing_tables_.clear();
+    this->inter_mesh_routing_tables_.clear();
+    this->router_port_directions_to_physical_eth_chan_map_.clear();
+
+    const auto& intra_mesh_connectivity = this->routing_table_generator_->get_intra_mesh_connectivity();
+    const auto& inter_mesh_connectivity = this->routing_table_generator_->get_inter_mesh_connectivity();
+
+    auto add_ethernet_channel_to_router_mapping = [&](mesh_id_t mesh_id,
+                                                      chip_id_t chip_id,
+                                                      const CoreCoord& eth_core,
+                                                      RoutingDirection direction) {
+        auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+        auto fabric_router_channels_on_chip = tt::Cluster::instance().get_fabric_ethernet_channels(physical_chip_id);
+        auto chan_id = tt::Cluster::instance().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
+        // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
+        if (fabric_router_channels_on_chip.contains(chan_id)) {
+            this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id][direction].push_back(chan_id);
+        } else {
+            log_debug(
+                tt::LogFabric, "Control Plane: Disabling router on M{}D{} eth channel {}", mesh_id, chip_id, chan_id);
+        }
+    };
+
+    // Initialize the bookkeeping for mapping from mesh/chip/direction to physical ethernet channels
+    this->router_port_directions_to_physical_eth_chan_map_.resize(intra_mesh_connectivity.size());
+    for (mesh_id_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
+        this->router_port_directions_to_physical_eth_chan_map_[mesh_id].resize(intra_mesh_connectivity[mesh_id].size());
+        for (chip_id_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
+            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+            const auto& connected_chips_and_eth_cores =
+                tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+            for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[mesh_id][chip_id]) {
+                const auto& physical_connected_chip_id =
+                    this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_connected_chip_id];
+                const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
+                TT_FATAL(
+                    connected_eth_cores.size() == edge.connected_chip_ids.size(),
+                    "Expected {} eth links from physical chip {} to physical chip {}",
+                    edge.connected_chip_ids.size(),
+                    physical_chip_id,
+                    physical_connected_chip_id);
+
+                for (const auto& eth_core : connected_eth_cores) {
+                    // There could be an optimization here to create entry for both chips here, assuming links are
+                    // bidirectional
+                    add_ethernet_channel_to_router_mapping(mesh_id, chip_id, eth_core, edge.port_direction);
+                }
+            }
+        }
+    }
+    for (mesh_id_t mesh_id = 0; mesh_id < inter_mesh_connectivity.size(); mesh_id++) {
+        for (chip_id_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
+            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+            const auto& connected_chips_and_eth_cores =
+                tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+            for (const auto& [connected_mesh_id, edge] : inter_mesh_connectivity[mesh_id][chip_id]) {
+                // Loop over edges connected chip ids, they could connect to different chips for intermesh traffic
+                for (const auto& logical_connected_chip_id : edge.connected_chip_ids) {
+                    const auto& physical_connected_chip_id =
+                        this->logical_mesh_chip_id_to_physical_chip_id_mapping_[connected_mesh_id]
+                                                                               [logical_connected_chip_id];
+                    const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
+                    for (const auto& eth_core : connected_eth_cores) {
+                        add_ethernet_channel_to_router_mapping(mesh_id, chip_id, eth_core, edge.port_direction);
+                    }
+                }
+            }
+        }
+    }
+    this->convert_fabric_routing_table_to_chip_routing_table();
 }
 
 void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chip_id) const {
@@ -660,7 +665,7 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction
     return {};
 }
 
-void ControlPlane::configure_routing_tables() const {
+void ControlPlane::write_routing_tables_to_all_chips() const {
     // Configure the routing tables on the chips
     TT_ASSERT(
         this->intra_mesh_routing_tables_.size() == this->inter_mesh_routing_tables_.size(),
@@ -675,6 +680,33 @@ void ControlPlane::configure_routing_tables() const {
         }
     }
 }
+
+std::vector<mesh_id_t> ControlPlane::get_user_physical_mesh_ids() const {
+    std::vector<mesh_id_t> physical_mesh_ids;
+    const auto user_chips = tt::Cluster::instance().get_user_chip_ethernet_coordinates();
+    for (int mesh_id = 0; mesh_id < this->logical_mesh_chip_id_to_physical_chip_id_mapping_.size(); mesh_id++) {
+        bool add_mesh = true;
+        for (int chip_id = 0; chip_id < this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id].size();
+             chip_id++) {
+            if (user_chips.find(this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id]) ==
+                user_chips.end()) {
+                add_mesh = false;
+                break;
+            }
+        }
+        if (add_mesh) {
+            physical_mesh_ids.push_back(mesh_id);
+        }
+    }
+
+    return physical_mesh_ids;
+}
+
+tt::tt_metal::distributed::MeshShape ControlPlane::get_physical_mesh_shape(mesh_id_t mesh_id) const {
+    uint32_t x = this->routing_table_generator_->get_mesh_ns_size(mesh_id);
+    uint32_t y = this->routing_table_generator_->get_mesh_ew_size(mesh_id);
+    return tt::tt_metal::distributed::MeshShape(x, y);
+};
 
 void ControlPlane::print_routing_tables() const {
     std::stringstream ss;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -17,7 +17,6 @@
 #include "dispatch_settings.hpp"
 #include "dprint_server.hpp"
 #include "host_api.hpp"
-#include "control_plane.hpp"
 #include "erisc_datamover_builder.hpp"
 #include <tt_metal.hpp>
 #include "tt_metal/impl/debug/noc_logging.hpp"
@@ -293,15 +292,9 @@ void DevicePool::initialize_active_devices() const {
     FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D || fabric_config == FabricConfig::FABRIC_2D ||
         fabric_config == FabricConfig::FABRIC_2D_PUSH) {
-        // Initialize control plane, does not configure kernels/routing tables
-        // We always need a control plane for mapping of logical devices to physical devices
-        // TODO: add single device support
-        _inst->initialize_control_plane();  // not const
-
         if (fabric_config == FabricConfig::FABRIC_2D || fabric_config == FabricConfig::FABRIC_2D_PUSH) {
             // write routing tables to all ethernet cores
-            // TODO: writing to device normally goes through cluster
-            this->control_plane->configure_routing_tables();
+            tt::Cluster::instance().get_control_plane()->write_routing_tables_to_all_chips();
         }
 
         // Initialize fabric on mmio device
@@ -461,14 +454,14 @@ void DevicePool::wait_for_fabric_router_sync() const {
         std::vector<uint32_t> signal(1, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
 
         auto wait_for_handshake = [&](IDevice* dev) {
-            auto [mesh_id, chip_id] = this->control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
+            auto [mesh_id, chip_id] = tt::Cluster::instance().get_control_plane()->get_mesh_chip_id_from_physical_chip_id(dev->id());
             for (const auto& direction : routing_directions) {
                 auto fabric_active_eth_chans =
-                    control_plane->get_active_fabric_eth_channels_in_direction(mesh_id, chip_id, direction);
+                    tt::Cluster::instance().get_control_plane()->get_active_fabric_eth_channels_in_direction(mesh_id, chip_id, direction);
                 if (fabric_active_eth_chans.empty()) {
                     continue;
                 }
-                auto neighbors = this->control_plane->get_intra_chip_neighbors(mesh_id, chip_id, direction);
+                auto neighbors = tt::Cluster::instance().get_control_plane()->get_intra_chip_neighbors(mesh_id, chip_id, direction);
                 if (neighbors.empty()) {
                     continue;
                 }
@@ -518,8 +511,10 @@ void DevicePool::wait_for_fabric_router_sync() const {
                 tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
 
-            auto [mesh_id, chip_id] = this->control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
-            auto num_routers = this->control_plane->get_num_active_fabric_routers(mesh_id, chip_id);
+            auto [mesh_id, chip_id] =
+                tt::Cluster::instance().get_control_plane()->get_mesh_chip_id_from_physical_chip_id(dev->id());
+            auto num_routers =
+                tt::Cluster::instance().get_control_plane()->get_num_active_fabric_routers(mesh_id, chip_id);
             while (master_router_status[0] != num_routers) {
                 tt_metal::detail::ReadFromDeviceL1(
                     dev,
@@ -607,29 +602,6 @@ void DevicePool::init_firmware_on_active_devices() const {
 
     this->initialize_active_devices();
 }
-
-void DevicePool::initialize_control_plane() {
-    // Default mode, auto select mesh graph descriptor. In future, we can add a way for user to specify custom
-    // descriptors
-    std::string mesh_graph_descriptor;
-    switch (tt::Cluster::instance().get_cluster_type()) {
-        case tt::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::GALAXY: mesh_graph_descriptor = "quanta_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
-        default: TT_THROW("Unknown cluster type");
-    }
-    const std::filesystem::path mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
-        "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
-
-    this->control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(mesh_graph_desc_path.string());
-}
-
-tt::tt_fabric::ControlPlane* DevicePool::get_control_plane() const {
-    return this->control_plane.get();
-}  // TODO: Don't use get to expose the raw pointer
 
 DevicePool::DevicePool() {
     ZoneScoped;
@@ -746,14 +718,14 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
         auto routing_directions = {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
 
         for (const auto& dev : this->get_all_active_devices()) {
-            auto [mesh_id, chip_id] = this->control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
+            auto [mesh_id, chip_id] = tt::Cluster::instance().get_control_plane()->get_mesh_chip_id_from_physical_chip_id(dev->id());
             for (const auto& direction : routing_directions) {
                 auto fabric_active_eth_chans =
-                    control_plane->get_active_fabric_eth_channels_in_direction(mesh_id, chip_id, direction);
+                    tt::Cluster::instance().get_control_plane()->get_active_fabric_eth_channels_in_direction(mesh_id, chip_id, direction);
                 if (fabric_active_eth_chans.size() == 0) {
                     continue;
                 }
-                auto neighbors = this->control_plane->get_intra_chip_neighbors(mesh_id, chip_id, direction);
+                auto neighbors = tt::Cluster::instance().get_control_plane()->get_intra_chip_neighbors(mesh_id, chip_id, direction);
                 if (neighbors.size() == 0) {
                     continue;
                 }

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -23,7 +23,7 @@ void FabricRouterVC::GenerateDependentConfigs() {
     TT_ASSERT(
         upstream_kernels_.size() == downstream_kernels_.size(),
         "Fabric Router VC requires upstream.size() == downstream.size()");
-    const auto& control_plane = tt::DevicePool::instance().get_control_plane();
+    const auto& control_plane = tt::Cluster::instance().get_control_plane();
     TT_FATAL(control_plane, "Control plane is nullptr. Is fabric initialized yet?");
 
     // Zip upstream and downstream kernels together

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -955,7 +955,7 @@ void configure_2d_fabric_cores(IDevice* device) {
 std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, bool wrap_around_mesh = true) {
     using namespace tt_fabric;
     std::unique_ptr<Program> fabric_program_ptr;
-    auto control_plane = tt::DevicePool::instance().get_control_plane();
+    auto control_plane = tt::Cluster::instance().get_control_plane();
     std::pair<mesh_id_t, chip_id_t> mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
     std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, chip_id_t> chip_neighbors;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -969,6 +969,13 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
     return active_ethernet_cores;
 }
 
+tt::tt_fabric::ControlPlane* Cluster::get_control_plane() {
+    if (control_plane_.get() == nullptr) {
+        this->initialize_control_plane();
+    }
+    return control_plane_.get();
+}
+
 void Cluster::initialize_fabric_config(FabricConfig fabric_config) {
     this->fabric_config_ = fabric_config;
     if (fabric_config != FabricConfig::DISABLED) {
@@ -976,6 +983,7 @@ void Cluster::initialize_fabric_config(FabricConfig fabric_config) {
     } else {
         this->release_ethernet_cores_for_fabric_routers();
     }
+    tt::Cluster::instance().get_control_plane()->configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 void Cluster::reserve_ethernet_cores_for_fabric_routers() {
@@ -1208,6 +1216,25 @@ uint32_t Cluster::get_mmio_device_tunnel_count(chip_id_t mmio_device) const {
 uint32_t Cluster::get_device_tunnel_depth(chip_id_t chip_id) const {
     chip_id_t mmio_device_id = this->get_associated_mmio_device(chip_id);
     return (mmio_device_id == chip_id) ? 0 : this->cluster_desc_->get_ethernet_link_distance(chip_id, mmio_device_id);
+}
+
+void Cluster::initialize_control_plane() {
+    // Default mode, auto select mesh graph descriptor. In future, we can add a way for user to specify custom
+    // descriptors
+    std::string mesh_graph_descriptor;
+    switch (this->cluster_type_) {
+        case tt::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::GALAXY: mesh_graph_descriptor = "quanta_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
+        default: TT_THROW("Unknown cluster type");
+    }
+    const std::filesystem::path mesh_graph_desc_path =
+        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
+
+    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(mesh_graph_desc_path.string());
 }
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/fabric_host_interface.h>
+#include <tt-metalium/control_plane.hpp>
 #include "umd/device/device_api_metal.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
@@ -48,7 +49,7 @@ enum class EthRouterMode : uint32_t {
     FABRIC_ROUTER = 2,
 };
 
-enum class FabricConfig { DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, FABRIC_2D_PUSH = 3, CUSTOM = 4 };
+enum class FabricConfig : uint32_t { DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, FABRIC_2D_PUSH = 3, CUSTOM = 4 };
 
 class Cluster {
 public:
@@ -250,6 +251,8 @@ public:
         return this->tunnels_from_mmio_device.at(mmio_chip_id);
     }
 
+    tt::tt_fabric::ControlPlane* get_control_plane();
+
     void initialize_fabric_config(FabricConfig fabric_config);
 
     // Returns whether we are running on Galaxy.
@@ -296,6 +299,9 @@ private:
 
     void initialize_ethernet_sockets();
 
+    // Initialize control plane, which has mapping of physical device id to MeshGraph config
+    void initialize_control_plane();
+
     // Set tunnels from mmio
     void set_tunnels_from_mmio_device();
 
@@ -336,6 +342,8 @@ private:
     void release_ethernet_cores_for_fabric_routers();
 
     FabricConfig fabric_config_ = FabricConfig::DISABLED;
+
+    std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
 
     // Tunnels setup in cluster
     std::map<chip_id_t, std::vector<std::vector<chip_id_t>>> tunnels_from_mmio_device = {};


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19035) 
### Problem description
Add some apis to get mesh info to support MeshDevice creation when there are no ethernet coords.
### What's changed
ControlPlane moved to Cluster, easier to get.
Added apis to get user meshes and the shape of meshes.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes