### PR TITLE
#19042: Fix building for non unity builds

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -7,6 +7,7 @@
 #include "device_fixture.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 
 // FIXME: ARCH_NAME specific
 #include "dev_mem_map.h"

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/circular_buffer_constants.h>
 
 using std::vector;

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -6,6 +6,7 @@
 #include "device_fixture.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/circular_buffer.hpp>
 

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -11,6 +11,7 @@
 #include "device_fixture.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "buffer_test_utils.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 
 using tt::tt_metal::IDevice;

--- a/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
@@ -7,6 +7,7 @@
 #include "buffer_test_utils.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 
 using tt::tt_metal::IDevice;

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -6,6 +6,7 @@
 
 #include "device_fixture.hpp"
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/kernel.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "umd/device/tt_soc_descriptor.h"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -7,6 +7,7 @@
 #include "dispatch_fixture.hpp"
 
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/allocator.hpp>
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -24,6 +24,7 @@
 #include <random>
 
 #include "command_queue_fixture.hpp"
+#include <tt-metalium/allocator.hpp>
 
 namespace tt::tt_metal {
 struct CBConfig {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/command_queue.hpp>

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -7,6 +7,7 @@
 #include "dispatch_fixture.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/tilize_utils.hpp>

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <cstdint>
 #include <vector>
 #include <optional>
 #include <functional>

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <algorithm>
 
 using namespace tt::constants;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 using namespace tt::constants;
 using namespace tt::tt_metal;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_common.hpp"
 #include <tt-metalium/work_split.hpp>
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/allocator.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
 


### PR DESCRIPTION
### Ticket
#19042 

### Problem description
Build fails due to missing includes. My assumption is due to unity builds, the missing headers gets automatically included via other translation units.

### What's changed
Add missing includes to make non unity builds work.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes