### PR TITLE
#17725: Fix golden functions

### DIFF
--- a/ttnn/ttnn/experimental_loader/golden_functions.py
+++ b/ttnn/ttnn/experimental_loader/golden_functions.py
@@ -20,7 +20,7 @@ def _golden_function(
     input_tensor,
     kv_input_tensor,
     *,
-    num_q_heads,
+    num_heads,
     num_kv_heads,
     transpose_k_heads=True,
     **_,
@@ -28,12 +28,12 @@ def _golden_function(
     import torch
 
     if num_kv_heads is None:
-        num_kv_heads = num_q_heads
+        num_kv_heads = num_heads
 
     batch_size, Z, sequence_size, hidden_size = input_tensor.shape
-    head_size = hidden_size // num_q_heads
+    head_size = hidden_size // num_heads
 
-    query = torch.reshape(input_tensor, (batch_size, sequence_size, num_q_heads, head_size))
+    query = torch.reshape(input_tensor, (batch_size, sequence_size, num_heads, head_size))
     query = torch.permute(query, (0, 2, 1, 3)).contiguous().clone()
 
     batch_size, Z, sequence_size, hidden_size = kv_input_tensor.shape
@@ -66,6 +66,19 @@ def _golden_function(tensor, grid_size, shard_spec, num_slices, slice, *args, **
 
 
 ttnn.attach_golden_function(ttnn.interleaved_to_sharded_partial, _golden_function)
+
+
+def _golden_function(slice, tensor, num_slices, slice_id, *args, **kwargs):
+    original_shape = tensor.shape
+    tensor = tensor.reshape(1, 1, -1, tensor.shape[-1])
+    slice_size = tensor.shape[-2] // num_slices
+    start = slice_id * slice_size
+    stop = start + slice_size
+    tensor[:, :, start:stop, :] = slice
+    return tensor.reshape(original_shape)
+
+
+ttnn.attach_golden_function(ttnn.sharded_to_interleaved_partial, _golden_function)
 
 
 def _golden_function(in0, in1, op, dir, *args, **kwargs):

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -11,10 +11,10 @@ from tt_lib.utils import find_closest_largest_divisor
 import math
 
 
-def _golden_function(input_tensor: ttnn.Tensor, dim: int, **_):
+def _golden_function(input_tensor: ttnn.Tensor, dim: Optional[int] = None, **_):
     import torch
 
-    return torch.softmax(input_tensor, dim)
+    return torch.nn.Softmax(dim)(input_tensor)
 
 
 ttnn.attach_golden_function(


### PR DESCRIPTION
### Ticket
Needed for Stable Diffusion PCC debug on BH (#17725)

### What's changed
- `softmax` was updated to allow None for dim parameter
- `create_qkv_heads_from_separate_tensors` was updated to match argument name in ttnn
- `sharded_to_interleaved_partial` golden function was implemented since we didn't have it before

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13831330657)