### PR TITLE
#17725: Force 8x8 grid for SD and fix up utility and tests

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_basic_transformer_block.py
@@ -39,6 +39,7 @@ def test_basic_transformer_block_512x512(
     block,
     block_index,
     attention_index,
+    use_program_cache,
 ):
     torch.manual_seed(0)
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attention.py
@@ -42,6 +42,7 @@ def test_cross_attention_512x512(
     block,
     block_index,
     attention_index,
+    use_program_cache,
 ):
     torch.manual_seed(0)
     device.enable_program_cache()

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_downblock_2d.py
@@ -34,7 +34,16 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
 def test_cross_attention_downblock_512x512(
-    reset_seeds, device, block_index, hidden_states, shard_layout, shard_end_core, shard_shape, out_channels, temb
+    reset_seeds,
+    device,
+    block_index,
+    hidden_states,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    out_channels,
+    temb,
+    use_program_cache,
 ):
     # Initialize PyTorch component
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_midblock_2d.py
@@ -30,7 +30,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
 def test_cross_attention_midblock_512x512(
-    reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb
+    reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb, use_program_cache
 ):
     # Initialize PyTorch component
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)

--- a/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_cross_attn_up_block_2d.py
@@ -84,6 +84,7 @@ def test_cross_attn_up_block_2d_512x512(
     out_channels,
     shard_end_core,
     shard_shape,
+    use_program_cache,
 ):
     # TODO
     # setup pytorch model

--- a/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downblock_2d.py
@@ -31,7 +31,9 @@ from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_
     "hidden_states, shard_layout, shard_end_core, shard_shape", (DOWN_MID_UP_BLOCKS_HIDDEN_STATES_INFO,)
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
-def test_downblock_512x512(reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb):
+def test_downblock_512x512(
+    reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, temb, use_program_cache
+):
     # Initialize PyTorch component
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
     unet = pipe.unet

--- a/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_downsample_2d.py
@@ -35,7 +35,9 @@ from models.demos.wormhole.stable_diffusion.tests.parameterizations import CROSS
         CROSS_DOWN_BLOCKS_HIDDEN_STATES_INFO[2] + (2,),
     ),
 )
-def test_downsample_512x512(reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, block_index):
+def test_downsample_512x512(
+    reset_seeds, device, hidden_states, shard_layout, shard_end_core, shard_shape, block_index, use_program_cache
+):
     # Initialize PyTorch component
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
     unet = pipe.unet

--- a/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_embedding.py
@@ -18,9 +18,7 @@ import pytest
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_embeddings(
-    device,
-):
+def test_embeddings(device, use_program_cache):
     torch.manual_seed(0)
     # setup pytorch model
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)

--- a/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_feedforward.py
@@ -40,6 +40,7 @@ def test_feedforward_512x512(
     block,
     block_index,
     attention_index,
+    use_program_cache,
 ):
     model = UNet2DConditionModel.from_pretrained(model_name, subfolder="unet").eval()
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_geglu.py
@@ -40,6 +40,7 @@ def test_geglu_512x512(
     block,
     block_index,
     attention_index,
+    use_program_cache,
 ):
     model = UNet2DConditionModel.from_pretrained(model_name, subfolder="unet").eval()
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -226,6 +226,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
         wh_arch_yaml_backup = os.environ["WH_ARCH_YAML"]
 
     os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
+    os.environ["SLOW_MATMULS"] = "1"
     post_processed_results = run_device_perf(command, subdir, iterations, cols, batch, has_signposts=True)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
     prep_device_perf_report(

--- a/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_resnet_block_2d.py
@@ -83,6 +83,7 @@ def test_resnet_block_2d_512x512(
     block_name,
     block_index,
     resnet_index,
+    use_program_cache,
 ):
     load_from_disk = False
     if not load_from_disk:

--- a/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_transformer_2d_model.py
@@ -41,6 +41,7 @@ def test_transformer_2d_model_512x512(
     block_index,
     attention_index,
     reset_seeds,
+    use_program_cache,
 ):
     torch.manual_seed(0)
     encoder_hidden_states = [1, 2, 77, 768]

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -72,9 +72,6 @@ def unsqueeze_all_params_to_4d(params):
 )
 def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_height, input_width):
     device.enable_program_cache()
-
-    os.environ["SLOW_MATMULS"] = "1"
-
     # setup envvar if testing on N300
     wh_arch_yaml_org = None
     if device.core_grid.y == 7:

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -70,8 +70,7 @@ def unsqueeze_all_params_to_4d(params):
         (2, 4, 64, 64),
     ],
 )
-def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_height, input_width):
-    device.enable_program_cache()
+def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_height, input_width, use_program_cache):
     # setup envvar if testing on N300
     wh_arch_yaml_org = None
     if device.core_grid.y == 7:

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -36,7 +36,15 @@ from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_
 )
 @pytest.mark.parametrize("temb", [[1, 1, 2, 1280]])
 def test_upblock_512x512(
-    reset_seeds, device, res_hidden_states_tuple, hidden_states, shard_layout, shard_end_core, shard_shape, temb
+    reset_seeds,
+    device,
+    res_hidden_states_tuple,
+    hidden_states,
+    shard_layout,
+    shard_end_core,
+    shard_shape,
+    temb,
+    use_program_cache,
 ):
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
     unet = pipe.unet

--- a/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upblock_2d.py
@@ -38,8 +38,6 @@ from models.demos.wormhole.stable_diffusion.tests.parameterizations import DOWN_
 def test_upblock_512x512(
     reset_seeds, device, res_hidden_states_tuple, hidden_states, shard_layout, shard_end_core, shard_shape, temb
 ):
-    os.environ["SLOW_MATMULS"] = "1"
-
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
     unet = pipe.unet
     unet.eval()

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_2d.py
@@ -45,7 +45,7 @@ def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_upsample2d_512x512(device, input_shape, shard_layout, shard_end_core, shard_shape, index):
+def test_upsample2d_512x512(device, input_shape, shard_layout, shard_end_core, shard_shape, index, use_program_cache):
     # setup pytorch model
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
 

--- a/models/demos/wormhole/stable_diffusion/tests/test_upsample_nearest_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_upsample_nearest_2d.py
@@ -19,7 +19,7 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("input_shape", [(2, 1280, 8, 8), (2, 1280, 16, 16), (2, 640, 32, 32)])
 @pytest.mark.parametrize("scale_factor", [2])
-def test_upsample_nearest2d_512x512(reset_seeds, device, input_shape, scale_factor):
+def test_upsample_nearest2d_512x512(reset_seeds, device, input_shape, scale_factor, use_program_cache):
     torch_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output = torch.repeat_interleave(torch_tensor, scale_factor, dim=3)
     torch_output = torch.repeat_interleave(torch_output, scale_factor, dim=2)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -80,6 +80,8 @@ class resnetBlock2D:
         self.conv1s = []
         self.conv1s_weights = []
         self.conv1s_bias = []
+        # TODO: instead of hardcoding grid size in many components, configure it in a single place
+        self.grid_size = (8, 8)
 
         self.fallback_on_groupnorm = os.environ.get("FALLBACK_ON_GROUPNORM", "0") == "1"
         parameters.conv1.weight, parameters.conv1.bias = permute_conv_parameters(
@@ -126,7 +128,7 @@ class resnetBlock2D:
                 output_height=self.conv1_output_height,
                 output_width=self.conv1_output_width,
                 output_channels=self.conv1_out_channels,
-                compute_grid_size=self.device.compute_with_storage_grid_size(),
+                compute_grid_size=self.grid_size,
                 block_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 enable_channels_padding=False,
                 is_out_tiled=True,
@@ -204,7 +206,7 @@ class resnetBlock2D:
                 output_height=self.conv2_input_height,
                 output_width=self.conv2_input_width,
                 output_channels=self.conv2_out_channels,
-                compute_grid_size=self.device.compute_with_storage_grid_size(),
+                compute_grid_size=self.grid_size,
                 block_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 enable_channels_padding=False,
                 is_out_tiled=True,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import ttnn
 import torch
 from typing import Optional, Dict
@@ -42,6 +43,9 @@ class transformer_2d_model:
         self.proj_in_conv_bias = ttnn.from_torch(parameters.proj_in.bias, ttnn.float32)
         out_channels = parameters.proj_in.weight.shape[0]
         in_channels = parameters.proj_in.weight.shape[1]
+
+        # TODO: instead of hardcoding grid size in many components, configure it in a single place
+        self.grid_size = (8, 8)
 
         self.fallback_on_groupnorm = os.environ.get("FALLBACK_ON_GROUPNORM", "0") == "1"
 
@@ -237,6 +241,16 @@ class transformer_2d_model:
             dtype=ttnn.bfloat8_b,
         )
 
+        # enforce same core grid on BH as we use on WH for now
+        end_x = 7 if attention_head_dim == 160 else 4
+        core_grid = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(end_x, 7),
+                ),
+            }
+        )
         conv_config = ttnn.Conv2dConfig(
             dtype=ttnn.bfloat8_b,
             weights_dtype=ttnn.bfloat8_b,
@@ -244,6 +258,9 @@ class transformer_2d_model:
             shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             input_channels_alignment=32,
             transpose_shards=False,
+            reshard_if_not_optimal=False,
+            override_sharding_config=True,
+            core_grid=core_grid,
         )
         compute_config = ttnn.init_device_compute_kernel_config(
             self.device.arch(),
@@ -319,6 +336,15 @@ class transformer_2d_model:
         out_channels = in_channels if out_channels is None else out_channels
         if is_input_continuous:
             if not use_linear_projection:
+                conv_config = ttnn.Conv2dConfig(
+                    dtype=ttnn.bfloat8_b,
+                    weights_dtype=ttnn.bfloat8_b,
+                    activation="",
+                    shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                    input_channels_alignment=32,
+                    transpose_shards=False,
+                )
+
                 conv_kwargs_1 = {
                     "in_channels": self.proj_out_in_channels,
                     "out_channels": self.proj_out_out_channels,


### PR DESCRIPTION
### Ticket
#17725

### What's changed

- Forcing 8x8 grid in resnet and transformer blocks
- Simplify utility functions to avoid initialization hangs on BH
- Add program cache to all unit tests
- Remove didt workaround for slow matmuls inside a couple of tests - it is already applied with SLOW_MATMULS env var on the CI

### Checklist
Nightly ttnn and models: https://github.com/tenstorrent/tt-metal/actions/runs/13834653564
Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/13834657050
Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/13840935439
Demo: https://github.com/tenstorrent/tt-metal/actions/runs/13835069426