### PR TITLE
#0: sfpi update 6.5.0

### DIFF
--- a/tt_metal/hw/cmake/sfpi-version.cmake
+++ b/tt_metal/hw/cmake/sfpi-version.cmake
@@ -1,6 +1,6 @@
 # Define the SFPI version to use
 
 set(SFPI_x86_64_Linux_RELEASE
-    "v6.2.0/sfpi-release.tgz"
-    "c546b57c3161b06d03de7473c4add5e5"
+    "v6.5.0/sfpi-release.tgz"
+    "abbc526ce5f45aafd2a6d67b6247d616"
 )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14604

### Problem description
The first implementation caused a t3k regression.

### What's changed
Adjusted the optimization to 
a) avoid the regression
b) cover more cases

### Checklist
- [ YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

I also ran the t3k tests that had failed