### PR TITLE
#0: Increase ringbuffer and reduce lm_head buffer

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -292,7 +292,7 @@ def run_llama3_demo(
     # Compile
     logger.info(f"Compiling model trace...")
     if layers == 1:
-        num_compile_iters = 24
+        num_compile_iters = 10
     else:
         num_compile_iters = 1
     for i in range(num_compile_iters):
@@ -595,6 +595,9 @@ def test_llama_demo(
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
+    # TODO: When support for ring buffer size setup is added, remove the flag
+    # set ringbuffer to 120KB instead of 69KB
+    os.environ["TT_METAL_WORKER_RINGBUFFER_SIZE"] = "122880"
     mesh_device.enable_async(True)
 
     if paged_attention:

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -522,7 +522,7 @@ def run_llama3_demo(
             1,  # repeat_batches
             1024,  # max_seq_len
             32,  # batch_size
-            200,  # max_generated_tokens
+            5,  # max_generated_tokens
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
@@ -595,9 +595,6 @@ def test_llama_demo(
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
-    # TODO: When support for ring buffer size setup is added, remove the flag
-    # set ringbuffer to 120KB instead of 69KB
-    os.environ["TT_METAL_WORKER_RINGBUFFER_SIZE"] = "122880"
     mesh_device.enable_async(True)
 
     if paged_attention:

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -522,7 +522,7 @@ def run_llama3_demo(
             1,  # repeat_batches
             1024,  # max_seq_len
             32,  # batch_size
-            5,  # max_generated_tokens
+            200,  # max_generated_tokens
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -117,7 +117,8 @@ class TT_CCL:
             persistent_buffers[cluster_axis].append(tt_buffer)
 
         # Create persistent buffer for lm_head
-        N_per_shard = (16 * 1024) // 16 * cluster_shape[cluster_axis]  # LM Head
+        num_cores_after_lm_head = 32  # Use 32 cores instead of 16 to reduce L1 memory usage per core
+        N_per_shard = (16 * 1024) // num_cores_after_lm_head * cluster_shape[cluster_axis]  # LM Head
         self.lm_head_buffer_mem_cfg = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.L1,
@@ -132,7 +133,7 @@ class TT_CCL:
             torch.zeros((*cluster_shape, M, N_per_shard * num_cores)),
             device=self.mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat16,
+            dtype=ttnn.bfloat8_b,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
         )

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -13,7 +13,7 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py --timeout 5000; fail+=$?
+    LLAMA_DIR=$llama_dir TT_METAL_WORKER_RINGBUFFER_SIZE=122880 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py --timeout 5000; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 


### PR DESCRIPTION
### Problem description
- SDPA op produces 8us uncovered dispatch time. With increasing ringbuffer size 69KB -> 120KB dispatch time falls below 1us.
- Model is pretty tight with L1 memory and LM Head persistent buffer was sharded across 16 instead of 32 cores which reduces L1 mem_usage per core and changing dtype to bfp8p from bfloat16 reduces mem_usage for another significant portion. 
- Number of compile iterations doesn't need to be >10 for 1L so it's reduced due to potential issues with getting perf report.
### Checklist
- [x] TG unit test: https://github.com/tenstorrent/tt-metal/actions/runs/13836528177/job/38713339420
- [ ] TG frequent test: https://github.com/tenstorrent/tt-metal/actions/runs/13854435979
- [ ] TG demo test: https://github.com/tenstorrent/tt-metal/actions/runs/13857587956