### PR TITLE
#0: Adjust sfpi codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,7 +74,7 @@ tests/tt_metal/distributed/**/requirements*.txt @tenstorrent/metalium-developers
 
 # metal - fw, llks, risc-v
 tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
-tt_metal/hw/cmake/sfpi-version.cmake @nathan-TT @pgkeller
+tt_metal/hw/cmake/sfpi-version.cmake @nathan-TT
 tt_metal/hw/firmware/riscv/common/dataflow_internals.h @davorchap @mywoodstock
 tt_metal/hw/firmware/src/*erisc* @aliuTT @ubcheema
 tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema


### PR DESCRIPTION
### Ticket
NA

### Problem description
Follow up from: https://github.com/tenstorrent/tt-metal/pull/18991
Having 2 code owners means that they review each other's PRs, which is not helpful here.

### What's changed
Having exactly one code owner allows that owner to be auto-approved.  Which is what we want here.
It's on me to communicate updates to metal developers anyway.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes