### PR TITLE
fix: enable LLK tests in build pipeline

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -59,7 +59,7 @@ jobs:
           {name: device, cmd: "./build/test/tt_metal/unit_tests_device"},
           {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth_${{ inputs.arch }}"},
-          {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
+          {name: llk, cmd: "TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_llk"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
           {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }}"},
           {name: lightmetal, cmd: "./build/test/tt_metal/unit_tests_lightmetal"},


### PR DESCRIPTION
### Problem description
It seems like LLK unit tests are not running at all in our pipelines, due to missing `TT_METAL_SLOW_DISPATCH_MODE=1`.
See [here](https://github.com/tenstorrent/tt-metal/actions/runs/13829964923/job/38695351823) and [here](https://github.com/tenstorrent/tt-metal/actions/runs/13832236003/job/38707444033) for example.
Message that indicates this:
```
Test | INFO     | This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE set
/work/tests/tt_metal/tt_metal/common/device_fixture.hpp:45: Skipped
```

As far as I can see, api, eth, user kernel path and maybe some other cpp unit tests have the same problem.

### What's changed
Passing a define should make these tests start to run.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13838547220) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13838586839) CI passes (if applicable)