### PR TITLE
Bump UMD for 6U and P300 changes

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -46,7 +46,7 @@ inline std::string get_umd_arch_name() {
         return tt::arch_to_str(init.get_arch_name());
     }
 
-    auto cluster_desc = tt_ClusterDescriptor::create();
+    auto cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
     const std::unordered_set<chip_id_t> &device_ids = cluster_desc->get_all_chips();
     tt::ARCH arch = cluster_desc->get_arch(*device_ids.begin());
     for (auto device_id : device_ids) {

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -16,7 +16,7 @@
 using namespace ttml;
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
+    return tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0) == BoardType::N300;
 }
 
 class N300UtilsTest : public ::testing::Test {

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -23,7 +23,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
+    return tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0) == BoardType::N300;
 }
 
 }  // namespace

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
+    return tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0) == BoardType::N300;
 }
 
 ttml::autograd::TensorPtr get_parameter(auto& parameters, const std::string& name_substring) {

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
+    return tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0) == BoardType::N300;
 }
 
 }  // namespace

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 auto check_board_is_n300() {
-    return tt_ClusterDescriptor::create()->get_board_type(0) == BoardType::N300;
+    return tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0) == BoardType::N300;
 }
 
 class TrivialTnnFixedDistributedTest : public ::testing::Test {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -272,8 +272,7 @@ void Cluster::open_driver(const bool &skip_driver_allocs) {
         const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_);
         // umd::Cluster::detect_available_device_ids only lists MMIO device ids, since we need remote chip ids
         // generate the cluster desc and pull chip ids from there
-        auto temp_cluster_desc =
-            tt_ClusterDescriptor::create_from_yaml(tt_ClusterDescriptor::get_cluster_descriptor_file_path());
+        auto temp_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
         std::unordered_set<chip_id_t> all_chips = temp_cluster_desc->get_all_chips();
         std::set<chip_id_t> all_chips_set(all_chips.begin(), all_chips.end());
         // This is the target/desired number of mem channels per arch/device.


### PR DESCRIPTION
### Ticket

Bump UMD main to Metal. Main feature of the bump is UBB support that was reverted in #19003 and support for P300

### Problem description

Metal changes are changing creation of cluster descriptor to use Cluster path of creating cluster descriptor and changes to support P300 boards.

### What's changed

- Change `tt_ClusterDescriptor::create() ` to `Cluster::create_cluster_descriptor()`
- Bump UMD

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/13837511581
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/13837501376