### PR TITLE
#19070: [skip ci] Add testcase data for additional workflows

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -51,8 +51,6 @@ jobs:
       matrix:
         test-group: [
           {name: All C++, cmd: ./tests/scripts/run_cpp_unit_tests.sh},
-          {name: tools, cmd: ./tests/scripts/run_tools_tests.sh},
-
           {name: user kernel path, cmd: "rm -rf /tmp/kernels && TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api_${{ inputs.arch }} --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*"},
           {name: api, cmd: "./build/test/tt_metal/unit_tests_api_${{ inputs.arch }}"},
           {name: debug_tools, cmd: "./build/test/tt_metal/unit_tests_debug_tools_${{ inputs.arch }}"},

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -123,6 +123,13 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U06CXU895AP # Michael Chiou
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -74,6 +74,14 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U07ASPTGJTS # Denys
 
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"
+
       - name: Cleanup
         if: always()
         run: |


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Profiler regression and tt-train tests don't upload any testcase data.
sd-unit-tests:tools tests doesn't run any tests (env var TT_METAL_SLOW_DISPATCH_MODE=1 in sd-unit-tests causes the script to bypass any test executables https://github.com/tenstorrent/tt-metal/blob/941ac4bf197c31185f121038fce73221914673df/tests/scripts/run_tools_tests.sh#L15)

### What's changed
Added upload step to profiler-regression and tt-train-tests workflows
Removed sd-unit-tests:tools testgroup (with @tt-dma 's blessing)

### Checklist
- [ ] New/Existing tests provide coverage for changes