### PR TITLE
#0: Disable CCL unit tests to reduce CI noise

### DIFF
--- a/tests/ttnn/distributed/test_hybrid_data_tensor_parallel_example_T3000.py
+++ b/tests/ttnn/distributed/test_hybrid_data_tensor_parallel_example_T3000.py
@@ -41,6 +41,7 @@ class TtFalconMLP:
 
 
 def test_tensor_parallel_falcon_mlp():
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     if ttnn.get_num_devices() < 8:
         pytest.skip()
 

--- a/tests/ttnn/distributed/test_tensor_parallel_example_T3000.py
+++ b/tests/ttnn/distributed/test_tensor_parallel_example_T3000.py
@@ -31,6 +31,7 @@ class TtFalconMLP:
 
 
 def test_tensor_parallel_falcon_mlp():
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     if ttnn.get_num_devices() < 8:
         pytest.skip()
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -790,6 +790,8 @@ TEST(
 }
 
 TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric "
+                    "(ttnn::operations::experimental::ccl::reduce_scatter)";
     const size_t dim = 3;
     const size_t num_links = 1;
     constexpr auto layout = Layout::TILE;
@@ -902,9 +904,11 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
 }
 
 TEST(CclAsyncOp, AllGather_PersistentFabric_Dim3_Links1_Shape1_1_32_128) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     run_all_gather_with_persistent_fabric(3, 1, ttnn::Shape({1, 1, 32, 128}));
 }
 TEST(CclAsyncOp, AllGather_PersistentFabric_Dim3_Links1_Shape1_1_32_8192) {
+    GTEST_SKIP() << "TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)";
     run_all_gather_with_persistent_fabric(3, 1, ttnn::Shape({1, 1, 32, 8192}));
 }
 // Mesh device setup seems to not provide the correct configuration for multi-link? To be investigated

--- a/tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_perf.py
+++ b/tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_perf.py
@@ -62,6 +62,7 @@ def test_all_gather_on_n300(
     function_level_defaults,
     enable_async,
 ):
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     run_all_gather_on_n300_impl(
         n300_mesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
@@ -208,7 +208,7 @@ def run_all_gather_on_n300_impl(
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
-
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     return run_all_gather_impl(
         mesh_device,
         num_devices,
@@ -253,7 +253,7 @@ def run_all_gather_on_t3000_impl(
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
-
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     return run_all_gather_impl(
         mesh_device,
         num_devices,
@@ -1450,6 +1450,7 @@ def test_all_gather_sharded_post_commit(
     function_level_defaults,
     enable_async,
 ):
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
         num_devices,
@@ -1540,6 +1541,7 @@ def test_all_gather_height_sharded_post_commit(
     function_level_defaults,
     enable_async,
 ):
+    pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
         num_devices,

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -25,7 +25,8 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enable_async, enable_multi_cq):
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
-
+    if use_all_gather:
+        pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     # Trace requires program cache to be enabled
     t3k_mesh_device.enable_async(enable_async)
     t3k_mesh_device.enable_program_cache()
@@ -136,7 +137,8 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
     torch.manual_seed(0)
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
-
+    if use_all_gather:
+        pytest.skip("TODO: #18686 - Skipping because we need CCL port to fabric (ttnn::all_gather)")
     # Trace requires program cache to be enabled
     t3k_mesh_device.enable_async(enable_async)
     t3k_mesh_device.enable_program_cache()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19072)

### Problem description
CCLs are not currently supported by TT-Mesh. Failures cause noise on CI.

### What's changed
Disable CCL tests on TT-Mesh Integration branch to reduce CI noise.