### PR TITLE
Add auto sharding in pool2d

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -17,6 +17,8 @@ from tests.sweep_framework.sweep_utils.max_pool2d_common import run_max_pool2d, 
 
 import ttnn
 
+ttnn.set_printoptions(profile="Full")
+
 parameters = {
     "max_pool2d_short_sweep_suite": {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -538,6 +538,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/pool2d_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -39,7 +39,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const MemoryConfig& out_mem_config,
     uint32_t nblocks) {
     TT_FATAL(pool_type == Pool2DType::MAX_POOL2D, "Currently only support max pool2d (#12151)");
-
+    auto tmpsize1 = input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
     // This should allocate a DRAM buffer on the device
     IDevice* device = input.device();
     tt::tt_metal::Buffer* src_dram_buffer = input.buffer();
@@ -217,6 +217,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
             max_pool_partials_cb_npages);
     }
     TT_FATAL(output.memory_config().is_sharded(), "Output memory config needs to be sharded");
+    auto tmpsize2 = input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
 
     auto l1_usage = pool::calculate_L1_usage(
         input, kernel_size_h, kernel_size_w, out_h, out_w, input.memory_config(), output.memory_config());

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -45,36 +45,101 @@ Tensor Pool2DOp<pool_type>::invoke(
     const std::optional<const MemoryConfig>& memory_config,
     const std::optional<const TensorMemoryLayout> applied_shard_scheme,
     bool ceil_mode) {
-    sliding_window::SlidingWindowConfig sliding_window_config{
-            .batch_size = batch_size,
-            .input_hw = {input_h, input_w},
-            .window_hw = {kernel_size.at(0), kernel_size.at(1)},
-            .stride_hw = {stride.at(0), stride.at(1)},
-            .pad_hw = {padding.at(0), padding.at(1)},
-            .dilation_hw = {dilation.at(0), dilation.at(1)},
-            .ceil_mode = ceil_mode,
+
+    Conv2dConfig conv_config = Conv2dConfig();
+    const uint32_t output_height =
+        ((input_h - kernel_size[0] - ((kernel_size[0] - 1) * (dilation[0] - 1)) + 2 * padding[0]) / stride[0]) + 1;
+    const uint32_t output_width =
+        ((input_w - kernel_size[1] - ((kernel_size[0] - 1) * (dilation[0] - 1)) + 2 * padding[1]) / stride[1]) + 1;
+
+    DeviceComputeKernelConfig compute_config = conv::get_conv_default_compute_kernel_config(input_tensor.device());
+
+    const auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+
+    bool auto_shard = false;
+    if (!input_tensor.is_sharded() && !conv_config.shard_layout.has_value()) {
+        // In this case we deduce the shard layout.
+        // Note: function calculate_L1_usage called by function below
+        //       takes weight tensor estimation into consideration,
+        //       which should be omitted in pool op.
+        conv_config = conv::determine_conv_config_for_auto_shard(
+            conv_config,
+            false,  // 1x1 mm
+            batch_size,
+            channels,
+            channels,
+            output_height,
+            output_width,
+            0,  //weight width
+            input_h,
+            input_w,
+            compute_grid_size,
+            input_tensor.layout(),
+            ttnn::is_tensor_on_device_or_multidevice(input_tensor) ? std::make_optional(input_tensor.memory_config())
+                                                                   : std::nullopt,
+            kernel_size,
+            1,  //groups
+            false, //bias enable
+            compute_config);
+        auto_shard = true;
+    }
+
+
+    ShardOrientation shard_orientation =
+        conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+
+    auto [input_tensor_post_tm, parallel_config, output_parallel_config] = conv::shard_or_reshard_tensor_if_required(
+        input_tensor.device(),
+        input_tensor,
+        conv_config,
+        batch_size,
+        output_height,
+        output_width,
+        channels,
+        channels,
+        false,  // 1x1 mm,
+        auto_shard);
+
+    auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = conv::get_conv_configs(
+        conv_config,
+        compute_config,
+        parallel_config,
+        output_parallel_config,
+        channels,
+        channels,
+        batch_size,
+        output_height,
+        output_width,
+        kernel_size,
+        compute_grid_size);
+
+    bool input_is_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_post_tm);
+    TT_ASSERT(input_is_on_device);
+
+    // call halo op
+    SlidingWindowConfig sliding_window_config = SlidingWindowConfig{
+        .batch_size = batch_size,
+        .input_hw = {input_h, input_w},
+        .window_hw = {kernel_size[0], kernel_size[1]},
+        .stride_hw = {stride[0], stride[1]},
+        .pad_hw = {padding[0], padding[1]},
+        .dilation_hw = {dilation[0], dilation[1]},
+        .num_cores_nhw = opt_conv_op_parallel_config.num_cores_nhw,
+        .core_range_set = input_tensor_post_tm.memory_config().shard_spec.value().grid,
+        .snap_to_tile = true,
     };
-    auto output_shape = sliding_window_config.get_output_shape();   // last dim/width is 0
-    auto input_tensor_sharded = input_tensor;
 
-    // pool output is row major
-    bool is_out_tiled = false;
-    bool is_in_tiled = input_tensor.dtype() == DataType::BFLOAT8_B; // input tiled for bfp8_b
+    bool bypass_halo =
+        (parallel_config.shard_scheme == TensorMemoryLayout::WIDTH_SHARDED &&
+            sliding_window_config.pad_hw.first == 0 && sliding_window_config.pad_hw.second == 0);
 
-    sliding_window::ParallelConfig parallel_config;
-    MemoryConfig out_memory_config = input_tensor_sharded.memory_config();
-    uint32_t num_cores_nhw = 0;
-    uint32_t num_cores_c = 0;
-
-    TensorMemoryLayout shard_layout = TensorMemoryLayout::HEIGHT_SHARDED; // default to height sharding
-    if (!out_memory_config.shard_spec.has_value()) {
-        // Input is not sharded. Perform sharding.
-        if (applied_shard_scheme.has_value()) {
-            TT_FATAL((applied_shard_scheme.value() == TensorMemoryLayout::HEIGHT_SHARDED) ||
-                     (applied_shard_scheme.value() == TensorMemoryLayout::WIDTH_SHARDED) ||
-                     (applied_shard_scheme.value() == TensorMemoryLayout::BLOCK_SHARDED),
-                     "Only height, width, or block sharding strategies are supported.");
-            shard_layout = applied_shard_scheme.value();
+    if (bypass_halo) {
+        if (input_tensor_post_tm.layout() == Layout::TILE) {
+            // Reshape is used as a workaround to an issue in to_layout mentioned here :
+            // https://github.com/tenstorrent/tt-metal/issues/16330
+            input_tensor_post_tm = ttnn::reshape(input_tensor_post_tm, input_tensor_post_tm.get_padded_shape());
+            input_tensor_post_tm =
+                ttnn::to_layout(input_tensor_post_tm, Layout::ROW_MAJOR, std::nullopt, std::nullopt, input_tensor_post_tm.device());
         }
         parallel_config = conv::determine_parallel_config(
                                             shard_layout,
@@ -94,61 +159,37 @@ Tensor Pool2DOp<pool_type>::invoke(
         input_tensor_sharded = ttnn::to_memory_config(input_tensor_sharded, sharded_mem_config, std::nullopt); // this converts interleaved to sharded
         out_memory_config = input_tensor_sharded.memory_config();
     } else {
-        // input is already sharded, use it as is
-        const auto shard_grid = out_memory_config.shard_spec.value().grid;
-        const auto shard_scheme = out_memory_config.memory_layout;
-        const auto shard_orientation = out_memory_config.shard_spec.value().orientation;
-        TT_FATAL(!applied_shard_scheme.has_value(), "A sharding scheme should not be specified for a sharded input tensor.");
-        TT_FATAL(shard_orientation == ShardOrientation::ROW_MAJOR, "Only row major orientation is supported.");
-        parallel_config.grid = shard_grid;
-        parallel_config.shard_scheme = shard_scheme;
-        parallel_config.shard_orientation = shard_orientation;
-        num_cores_nhw = conv::get_num_cores_nhw_from_parallel_config(parallel_config);
-        num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);
+        // Call the halo uop
+        Tensor halo_output = ttnn::halo(
+            queue_id,
+            input_tensor_post_tm,
+            sliding_window_config,
+            0,
+            false,
+            parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+            0,
+            input_tensor_post_tm.memory_config(),
+            false);
+
+        if (conv_config.deallocate_activation) {
+            input_tensor_post_tm.deallocate(/*force*/ true);
+        }
+
+        input_tensor_post_tm = std::move(halo_output);
+
+        if (conv_config.reallocate_halo_output) {
+            input_tensor_post_tm = ttnn::move(input_tensor_post_tm);
+        }
     }
 
-    // update the shard spec to match the output shape
-    auto shard_spec = out_memory_config.shard_spec.value();
-    uint32_t output_shard_width_padded = input_tensor.dtype() == DataType::BFLOAT8_B ? tt::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH) : tt::round_up(channels / num_cores_c * tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())), tt::constants::TILE_WIDTH);
-    uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
-    uint32_t output_nhw_padded = tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
-    uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
-    log_debug(tt::LogOp, "output_nhw: {}, output_nhw_padded: {}, output_shard_height_padded: {}, output_shard_width_padded: {}", output_nhw, output_nhw_padded, output_shard_height_padded, output_shard_width_padded);
-    out_memory_config.shard_spec = tt::tt_metal::ShardSpec{shard_spec.grid, {output_shard_height_padded, output_shard_width_padded}, ShardOrientation::ROW_MAJOR};
-
-    sliding_window_config = sliding_window::SlidingWindowConfig{
-            .batch_size = batch_size,
-            .input_hw = {input_h, input_w},
-            .window_hw = {kernel_size.at(0), kernel_size.at(1)},
-            .stride_hw = {stride.at(0), stride.at(1)},
-            .pad_hw = {padding.at(0), padding.at(1)},
-            .dilation_hw = {dilation.at(0), dilation.at(1)},
-            .num_cores_nhw = num_cores_nhw,
-            .num_cores_c = num_cores_c,
-            .core_range_set = parallel_config.grid,
-            .snap_to_tile = false,
-            .ceil_mode = ceil_mode,
-    };
-
-    // Call the halo uop
-    auto haloed_tensor = ttnn::halo(
-        queue_id,
-        input_tensor_sharded,
-        sliding_window_config,
-        get_bf16_pool_init_value(pool_type), // pad_val
-        false,
-        parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-        0,
-        input_tensor_sharded.memory_config(),
-        is_out_tiled);
 
     auto output_tensor = ttnn::prim::pool2d(
         queue_id,
-        haloed_tensor,
+        input_tensor_post_tm,
         sliding_window_config,
         pool_type,
         DataType::BFLOAT16,      // input_tensor.dtype(), // currently only bfp16 output is supported
-        out_memory_config);
+        input_tensor_post_tm.memory_config());
 
     if (memory_config.has_value() && memory_config.value() != out_memory_config) {
         output_tensor = ttnn::to_memory_config(output_tensor, memory_config.value(), std::nullopt);

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -37,18 +37,18 @@ uint32_t get_bf16_pool_init_value(Pool2DType pool_type) {
 template <Pool2DType pool_type>
 Tensor Pool2DOp<pool_type>::invoke(
     QueueId queue_id,
-    const Tensor& input_tensor, //1, 1, 36, 6144
-    uint32_t batch_size,    //1
-    uint32_t input_h,   //6
-    uint32_t input_w,   //6
-    uint32_t channels,  //6144
-    std::array<uint32_t, 2> kernel_size,    //5,5
-    std::array<uint32_t, 2> stride, //1,1
-    std::array<uint32_t, 2> padding, //2, 2
-    std::array<uint32_t, 2> dilation, //1,1
-    const std::optional<const MemoryConfig>& memory_config, //std::nullopt
-    const std::optional<const TensorMemoryLayout> applied_shard_scheme, //HEIGHT_SHARDED
-    bool ceil_mode) {//false
+    const Tensor& input_tensor,
+    uint32_t batch_size,
+    uint32_t input_h,
+    uint32_t input_w,
+    uint32_t channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 2> padding,
+    std::array<uint32_t, 2> dilation,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const TensorMemoryLayout> applied_shard_scheme,
+    bool ceil_mode) {
     sliding_window::SlidingWindowConfig sliding_window_config{
             .batch_size = batch_size,
             .input_hw = {input_h, input_w},
@@ -58,12 +58,12 @@ Tensor Pool2DOp<pool_type>::invoke(
             .dilation_hw = {dilation.at(0), dilation.at(1)},
             .ceil_mode = ceil_mode,
     };
-    auto output_shape = sliding_window_config.get_output_shape();   //1,6,6,0
+    auto output_shape = sliding_window_config.get_output_shape();
     auto input_tensor_sharded = input_tensor;
 
     // pool output is row major
     bool is_out_tiled = false;
-    bool is_in_tiled = input_tensor.dtype() == DataType::BFLOAT8_B; // false
+    bool is_in_tiled = input_tensor.dtype() == DataType::BFLOAT8_B;
 
     sliding_window::ParallelConfig parallel_config;
     MemoryConfig out_memory_config = input_tensor_sharded.memory_config();
@@ -71,7 +71,7 @@ Tensor Pool2DOp<pool_type>::invoke(
     uint32_t num_cores_c = 0;
 
     TensorMemoryLayout shard_layout = TensorMemoryLayout::HEIGHT_SHARDED; // default to height sharding
-    if (!out_memory_config.shard_spec.has_value()) { //true
+    if (!out_memory_config.shard_spec.has_value()) {
         // Input is not sharded. Perform sharding.
         if (applied_shard_scheme.has_value())
         {
@@ -81,17 +81,17 @@ Tensor Pool2DOp<pool_type>::invoke(
                      "Only height, width, or block sharding strategies are supported.");
             shard_layout = applied_shard_scheme.value();
             parallel_config = conv::determine_parallel_config(
-                                                shard_layout,    //HEIGHT_SHARDED
-                                                batch_size,     //1
-                                                channels,       //6144
-                                                output_shape[1],    //6
-                                                output_shape[2],    //6
-                                                channels,       //6144
-                                                input_tensor.device()->compute_with_storage_grid_size(),    //8,8
+                                                shard_layout,
+                                                batch_size,
+                                                channels,
+                                                output_shape[1],
+                                                output_shape[2],
+                                                channels,
+                                                input_tensor.device()->compute_with_storage_grid_size(),
                                                 ShardOrientation::ROW_MAJOR,
                                                 false,
                                                 false,
-                                            false);
+                                                false);
         }
         else { //auto-sharding
             parallel_config = pool::determine_pool_config_for_auto_shard(
@@ -101,13 +101,11 @@ Tensor Pool2DOp<pool_type>::invoke(
                 );
         }
 
-        //parallel_config.grid = {(0,0;7,3),(0,4;3,4)}, shard_scheme = HEIGHT_SHARDED, shard_orientation = ROW_MAJOR,
-        num_cores_nhw = conv::get_num_cores_nhw_from_parallel_config(parallel_config);  //36
-        num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);   //1
+        num_cores_nhw = conv::get_num_cores_nhw_from_parallel_config(parallel_config);
+        num_cores_c = conv::get_num_cores_channels_from_parallel_config(parallel_config);
         auto sharded_mem_config = conv::create_sharded_memory_config_from_parallel_config(input_tensor_sharded.get_padded_shape(), parallel_config, is_in_tiled ? tt::constants::TILE_HEIGHT : 1);
-        //sharded_mem_config:{HEIGHT_SHARDED, L1, {{(0,0;7,3),(0,4;3,4)},{1,6144},ROW_MAJOR,PHYSICAL}}
-        input_tensor_sharded = ttnn::to_memory_config(input_tensor_sharded, sharded_mem_config, std::nullopt); // 1,1,36,6144
-        out_memory_config = input_tensor_sharded.memory_config();   // == sharded_mem_config
+        input_tensor_sharded = ttnn::to_memory_config(input_tensor_sharded, sharded_mem_config, std::nullopt);
+        out_memory_config = input_tensor_sharded.memory_config();
     } else {
         // input is already sharded, use it as is
         const auto shard_grid = out_memory_config.shard_spec.value().grid;
@@ -124,13 +122,12 @@ Tensor Pool2DOp<pool_type>::invoke(
 
     // update the shard spec to match the output shape
     auto shard_spec = out_memory_config.shard_spec.value();
-    uint32_t output_shard_width_padded = input_tensor.dtype() == DataType::BFLOAT8_B ? ccl::cmd::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH) : ccl::cmd::round_up(channels / num_cores_c * tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())), tt::constants::TILE_WIDTH);    //12288
-    uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];  //36
-    uint32_t output_nhw_padded = ccl::cmd::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1)); //36
-    uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;    //1
+    uint32_t output_shard_width_padded = input_tensor.dtype() == DataType::BFLOAT8_B ? ccl::cmd::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH) : ccl::cmd::round_up(channels / num_cores_c * tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())), tt::constants::TILE_WIDTH);
+    uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
+    uint32_t output_nhw_padded = ccl::cmd::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
+    uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
     log_debug(tt::LogOp, "output_nhw: {}, output_nhw_padded: {}, output_shard_height_padded: {}, output_shard_width_padded: {}", output_nhw, output_nhw_padded, output_shard_height_padded, output_shard_width_padded);
     out_memory_config.shard_spec = tt::tt_metal::ShardSpec{shard_spec.grid, {output_shard_height_padded, output_shard_width_padded}, ShardOrientation::ROW_MAJOR};
-    //out_memory_config:{HEIGHT_SHARDED, L1, {{(0,0;7,3),(0,4;3,4)},{1,6144},ROW_MAJOR,PHYSICAL}}
 
     sliding_window_config = sliding_window::SlidingWindowConfig{
             .batch_size = batch_size,
@@ -149,22 +146,22 @@ Tensor Pool2DOp<pool_type>::invoke(
     // Call the halo uop
     auto haloed_tensor = ttnn::halo(
         queue_id,
-        input_tensor_sharded,   //1,1,36,6144
+        input_tensor_sharded,
         sliding_window_config,
-        get_bf16_pool_init_value(pool_type), // pad_val, 65408
+        get_bf16_pool_init_value(pool_type),
         false,
         parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
         0,
         input_tensor_sharded.memory_config(),
-        is_out_tiled);  //halo:1,1,1620,6144
+        is_out_tiled);
 
     auto output_tensor = ttnn::prim::pool2d(
         queue_id,
-        haloed_tensor,  //1,1,100,6144
+        haloed_tensor,
         sliding_window_config,
         pool_type,
         DataType::BFLOAT16,      // input_tensor.dtype(), // currently only bfp16 output is supported
-        out_memory_config); //output_tensor:1,1,36,6144
+        out_memory_config);
 
     if (memory_config.has_value() && memory_config.value() != out_memory_config) {
         output_tensor = ttnn::to_memory_config(output_tensor, memory_config.value(), std::nullopt);

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -90,7 +90,8 @@ Tensor Pool2DOp<pool_type>::invoke(
                                                 input_tensor.device()->compute_with_storage_grid_size(),    //8,8
                                                 ShardOrientation::ROW_MAJOR,
                                                 false,
-                                                false);
+                                                false,
+                                            false);
         }
         else { //auto-sharding
             parallel_config = pool::determine_pool_config_for_auto_shard(

--- a/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.cpp
@@ -1,0 +1,477 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sys/types.h>
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <tuple>
+
+#include "pool2d_utils.hpp"
+#include <tt-metalium/buffer_constants.hpp>
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/hal.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/move/move.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+
+using namespace tt;
+namespace ttnn {
+namespace operations::pool {
+using sliding_window::ParallelConfig;
+using sliding_window::SlidingWindowConfig;
+
+conv::conv_op_l1_usage calculate_L1_usage(
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    const conv::OptimizedConvBlockConfig& block_config,
+    const conv::OptimizedConvParallelizationConfig& pconfig,
+    std::array<uint32_t, 2> kernel_size,
+    const conv::Conv2dConfig& conv_config,
+    const MemoryConfig& output_memory_config,
+    const bool enable_bias,
+    bool is_1d_depthwise_conv) {
+    bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
+
+    // Output of halo op is always ROW_MAJOR, so input for convs is eighter DataType::FLOAT32 or DataType::BFLOAT16
+    const DataType input_dtype = conv_config.dtype == DataType::FLOAT32 ? DataType::FLOAT32 : DataType::BFLOAT16;
+    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(input_dtype));
+    uint32_t weights_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.weights_dtype));
+    uint32_t bias_tile_size = 0;
+    if (enable_bias) {
+        bias_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.weights_dtype));
+    }
+    uint32_t output_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(tt::tt_metal::hal.get_arch(), compute_kernel_config);
+
+    uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
+    uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+    uint32_t act_block_num_tiles = block_config.act_block_h_ntiles * act_block_w_ntiles;
+
+    uint32_t weight_matrix_height = 0;  // weights_shape[2];
+    uint32_t weight_matrix_width = 0;   // weights_shape[3];
+    uint32_t weight_matrix_height_ntiles = weight_matrix_height / tt::constants::TILE_HEIGHT;
+    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
+
+    uint32_t per_core_out_matrix_width_ntiles = pconfig.per_core_out_matrix_width_ntile;
+    uint32_t per_core_out_matrix_height_ntiles = pconfig.per_core_out_matrix_height_ntile;
+
+    uint32_t num_blocks_act_h_per_core =
+        (per_core_out_matrix_height_ntiles + act_block_h_ntiles - 1) / act_block_h_ntiles;
+    uint32_t out_block_h_ntiles_padded = num_blocks_act_h_per_core * act_block_h_ntiles;
+
+    TensorMemoryLayout sharding_scheme = conv_config.shard_layout.value();
+    if (sharding_scheme == TensorMemoryLayout::WIDTH_SHARDED) {
+        uint32_t conv_output_c_per_core = per_core_out_matrix_width_ntiles * tt::constants::TILE_WIDTH;
+
+        uint32_t output_size_per_core_in_bytes = per_core_out_matrix_width_ntiles * per_core_out_matrix_height_ntiles *
+                                                 tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
+
+        uint32_t act_block_num_bytes = act_block_num_tiles * input_tile_size;
+        uint32_t tilized_act_block_num_bytes = act_block_num_tiles * output_tile_size;
+
+        uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
+        uint32_t weight_block_num_tiles = 0;
+        // weight_block_w_ntiles * act_block_w_ntiles;  // act_block_w_ntiles == weight_block_h_ntiles
+        uint32_t weight_block_num_bytes = weight_block_num_tiles * weights_tile_size;
+
+        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
+
+        uint32_t out_block_num_tiles = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles;
+
+        uint32_t num_blocks_act_w = weight_matrix_height_ntiles / act_block_w_ntiles;
+
+        packer_l1_acc = packer_l1_acc && ((enable_bias && num_blocks_act_w > 1) || (num_blocks_act_w > 2));
+
+        auto interm_dtype =
+            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
+
+        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
+
+        uint32_t partials_block_num_bytes = out_block_num_tiles * partial_tile_size;
+
+        // CB 0
+        uint32_t act_cb_0_size = tilized_act_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
+
+        // CB 1
+        uint32_t weights_cb_1_size = weight_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
+
+        // CB 2
+        uint32_t bias_cb_2_size = bias_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
+
+        // CB 5
+        uint32_t l1_scratchpad_cb_5_size = conv::l1_scratchpad_CB_size;
+        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
+
+        // CB 6
+        uint32_t row_major_act_cb_6_size = act_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB6 Size: {}", row_major_act_cb_6_size);
+
+        // CB 24
+        uint32_t matmul_partial_cb_24_size = partials_block_num_bytes;
+        if (interm_dtype == conv_config.dtype) {
+            matmul_partial_cb_24_size = 0;
+        } else {
+            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partial_cb_24_size);
+        }
+
+        // CB 25
+        uint32_t tilized_act_cb_25_size = tilized_act_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
+
+        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
+                                 row_major_act_cb_6_size + matmul_partial_cb_24_size + tilized_act_cb_25_size;
+
+        tt::log_debug(tt::LogOp, "Total CB Size: {}", total_CB_size);
+
+        return conv::conv_op_l1_usage{
+            .tensor_allocation_size = output_size_per_core_in_bytes, .CB_allocation_size = total_CB_size};
+    } else if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t output_size = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * output_tile_size;
+
+        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
+
+        uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
+
+        uint32_t weight_block_w_ntiles = 0;  // per_core_out_matrix_width_ntiles;
+        uint32_t weight_block_h_ntiles = 0;  //(is_1d_depthwise_conv) ? act_block_h_ntiles : act_block_w_ntiles;
+
+        uint32_t act_block_cb_ntiles = act_block_h_ntiles * act_block_w_ntiles;
+
+        uint32_t act_block_cb_size = act_block_cb_ntiles * input_tile_size;
+        uint32_t tilzed_act_cb_size = act_block_cb_ntiles * output_tile_size;
+
+        uint32_t output_block_ntiles = out_block_h_ntiles_padded * per_core_out_matrix_width_ntiles;
+
+        uint32_t num_blocks_act_w = weight_matrix_height_ntiles / act_block_w_ntiles;
+        uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
+        uint32_t in0_num_blocks_w =
+            num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
+
+        packer_l1_acc = packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
+
+        auto interm_dtype =
+            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
+
+        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
+
+        uint32_t act_block_split_last_ntiles = 0;
+        uint32_t act_block_split_ntiles = act_block_cb_ntiles;
+        if (conv_config.enable_split_reader) {
+            uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
+            uint32_t act_block_split_last_ntiles = act_block_cb_ntiles / 2;
+            uint32_t act_block_split_ntiles = act_block_cb_ntiles - act_block_split_last_ntiles;
+        }
+
+        if (conv_config.enable_act_double_buffer) {
+            act_block_split_last_ntiles *= 2;
+            act_block_split_ntiles *= 2;
+        }
+        // CB 0
+        uint32_t act_cb_0_size = act_block_split_ntiles * input_tile_size;
+        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
+
+        // CB 1
+        uint32_t weights_cb_1_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
+        if (num_blocks_act_h > 1) {
+            weights_cb_1_size *= kernel_size[0];
+        }
+        if (num_blocks_act_h <= 1 && conv_config.enable_weights_double_buffer) {
+            weights_cb_1_size *= 2;
+        }
+        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
+
+        // CB 2
+        uint32_t bias_cb_2_size = bias_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
+
+        uint32_t l1_scratchpad_cb_5_size = conv::l1_scratchpad_CB_size;
+        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
+
+        uint32_t split_second_act_reader_cb_7_size = 0;
+
+        split_second_act_reader_cb_7_size = act_block_split_last_ntiles * input_tile_size;
+        tt::log_debug(tt::LogOp, "CB7 Size: {}", split_second_act_reader_cb_7_size);
+
+        // CB 24
+        uint32_t matmul_partials_cb_24_size = output_block_ntiles * partial_tile_size;
+        if (untilize_out == false && interm_dtype == conv_config.dtype) {
+            matmul_partials_cb_24_size = 0;
+        }
+        if (is_1d_depthwise_conv) {
+            matmul_partials_cb_24_size = output_tile_size;
+        }
+        if (matmul_partials_cb_24_size != 0) {
+            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partials_cb_24_size);
+        }
+        // CB 25
+        uint32_t tilized_act_cb_25_size = tilzed_act_cb_size;
+        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
+
+        uint32_t temp_sum_cb_27_size = 0;
+        if (is_1d_depthwise_conv) {
+            temp_sum_cb_27_size = output_tile_size;
+            tt::log_debug(tt::LogOp, "CB27 Size: {}", temp_sum_cb_27_size);
+        }
+        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
+                                 split_second_act_reader_cb_7_size + matmul_partials_cb_24_size +
+                                 tilized_act_cb_25_size + temp_sum_cb_27_size;
+        return conv::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
+    } else if (sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
+        auto output_shard_shape = output_memory_config.shard_spec.value().shape;
+
+        uint32_t output_size = 0;
+        if (untilize_out) {
+            uint32_t per_core_out_width_aligned = pconfig.per_core_out_matrix_width_ntile * tt::constants::TILE_WIDTH;
+            if (conv_config.dtype == DataType::BFLOAT16) {
+                per_core_out_width_aligned *= 2;
+            } else if (conv_config.dtype == DataType::FLOAT32) {
+                per_core_out_width_aligned *= 4;
+            }
+            output_size =
+                round_up(per_core_out_width_aligned, tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1)) *
+                pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT;
+        } else {
+            output_size = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * output_tile_size;
+        }
+
+        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
+
+        uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
+
+        uint32_t weight_block_w_ntiles = 0;  // per_core_out_matrix_width_ntiles;
+        uint32_t weight_block_h_ntiles = 0;  // act_block_w_ntiles;
+
+        uint32_t tilized_act_block_cb_size = act_block_h_ntiles * act_block_w_ntiles * output_tile_size;
+        uint32_t row_major_act_cb_size = act_block_h_ntiles * act_block_w_ntiles * input_tile_size;
+
+        uint32_t output_block_ntiles = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles;
+
+        uint32_t num_blocks_act_w = 1;
+        uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
+        uint32_t in0_num_blocks_w =
+            num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
+
+        packer_l1_acc = packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
+
+        auto interm_dtype =
+            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
+
+        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
+
+        // CB 0
+        uint32_t act_cb_0_size = tilized_act_block_cb_size;
+        if (conv_config.enable_act_double_buffer) {
+            act_cb_0_size *= 2;
+        }
+        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
+
+        // CB 1
+        uint32_t weights_cb_1_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
+        if (conv_config.enable_weights_double_buffer) {
+            weights_cb_1_size *= 2;
+        }
+        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
+
+        // CB 2
+        uint32_t bias_cb_2_size = bias_block_num_bytes;
+        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
+
+        // CB 5
+        uint32_t l1_scratchpad_cb_5_size = conv::l1_scratchpad_CB_size;
+        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
+
+        // CB 6
+        uint32_t cb6_size = row_major_act_cb_size;
+        tt::log_debug(tt::LogOp, "CB6 Size: {}", cb6_size);
+
+        // CB 24
+        uint32_t matmul_partials_cb_24_size = output_block_ntiles * partial_tile_size;
+        if (untilize_out == false && interm_dtype == conv_config.dtype) {
+            matmul_partials_cb_24_size = 0;
+        } else {
+            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partials_cb_24_size);
+        }
+
+        // CB 25
+        uint32_t tilized_act_cb_25_size = tilized_act_block_cb_size;
+        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
+
+        bool need_unpad_after_untilize =
+            output_shard_shape[1] * output_shard_shape[0] <
+            per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * tt::constants::TILE_HW;
+
+        tt::log_debug(tt::LogOp, "Need Unpad after untilize: {}", need_unpad_after_untilize);
+
+        uint32_t cb28_size = 0;
+        if (need_unpad_after_untilize && untilize_out) {
+            cb28_size = output_block_ntiles * output_tile_size;
+            tt::log_debug(tt::LogOp, "CB28 Size: {}", cb28_size);
+        }
+        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
+                                 cb6_size + matmul_partials_cb_24_size + tilized_act_cb_25_size + cb28_size;
+        return conv::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
+    }
+    TT_THROW("Invalid shard layout {}", sharding_scheme);
+}
+
+TensorMemoryLayout determine_pool_config_for_auto_shard(
+    uint32_t batch_size,
+    uint32_t channels,
+    uint32_t output_height,
+    uint32_t output_width,
+    uint32_t input_height,
+    uint32_t input_width,
+    const CoreCoord& compute_grid_size,
+    Layout input_tensor_layout,
+    const std::array<uint32_t, 2>& kernel_size,
+    const DeviceComputeKernelConfig& compute_config,
+    const DataType& input_dtype) {
+    ShardOrientation shard_orientation = ShardOrientation::COL_MAJOR;
+    // const bool is_out_tiled = conv_config.output_layout == Layout::TILE;
+
+    struct core_count_and_size {
+        uint32_t core_count;
+        uint32_t size;
+        conv::Conv2dConfig conv_config;
+    };
+
+    // 1d deptwise convs support only height sharding
+    if (conv::is_1d_deptwise_conv(1 /*groups*/, channels, channels, kernel_size[1], input_width)) {
+        return TensorMemoryLayout::HEIGHT_SHARDED;
+    }
+
+    auto get_l1_usage_for_sharding = [&](TensorMemoryLayout shard_layout) -> core_count_and_size {
+        conv::Conv2dConfig conv_config = conv::Conv2dConfig();
+        conv_config.dtype = input_dtype;
+        conv_config.shard_layout = shard_layout;
+        if (conv_config.act_block_h_override == 0) {
+            conv_config.act_block_h_override = tt::constants::TILE_HEIGHT;
+            if (channels < tt::constants::TILE_WIDTH && shard_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+                input_tensor_layout == Layout::ROW_MAJOR) {
+                log_debug(tt::LogOp, "Auto shard, enable shallow conv");
+                // height sharded, non matmul conv, with input channels < 32, and default setting for
+                // input_channels_alignment
+                // Currently data-movement ops have too many restrictions to support shallow convs with tiled input.
+                conv_config.input_channels_alignment = 8;
+            } else if (shard_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+                conv_config.input_channels_alignment = tt::constants::TILE_WIDTH;
+            }
+
+            // Set act_block_h_override to min value to
+            // be conservative with L1 memory usage.
+            uint32_t act_block_h_override = tt::constants::TILE_HEIGHT;
+        }
+
+        const uint32_t in_channels_padded = ccl::cmd::round_up(channels, conv_config.input_channels_alignment);
+        const uint32_t output_channels_padded = ccl::cmd::round_up(channels, tt::constants::TILE_WIDTH);
+        // Note: These are not exact shapes for weights as prepare_conv_weights will pad the weights depending on the
+        // conv2d params, but these are good enough for L1 usage estimation.
+        // const ttnn::Shape weights_shape(
+        //     {1, 1, in_channels_padded * kernel_size[0] * kernel_size[1], output_channels_padded});
+
+        const sliding_window::ParallelConfig input_parallel_config = conv::determine_parallel_config(
+            shard_layout,
+            batch_size,
+            channels,
+            output_height,
+            output_width,
+            channels,
+            compute_grid_size,
+            shard_orientation,
+            false,
+            false);
+
+        const sliding_window::ParallelConfig output_parallel_config =
+            conv::determine_output_parallel_config(input_parallel_config, compute_grid_size, channels, false);
+
+        auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = conv::get_conv_configs(
+            conv_config,
+            compute_config,
+            input_parallel_config,
+            output_parallel_config,
+            channels,
+            channels,
+            batch_size,
+            output_height,
+            output_width,
+            kernel_size,
+            compute_grid_size);
+
+        if (conv_config.act_block_w_div == 1 && conv_config.shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+            uint32_t width_sharded_num_cores = input_parallel_config.grid.num_cores();
+            // Set act_block_w_div to max value to
+            // be conservative with L1 memory usage.
+            // act_block_w_div == 1 is currently the default value.
+            conv_config.act_block_w_div = tt::div_up(channels, width_sharded_num_cores * tt::constants::TILE_WIDTH);
+        }
+
+        conv::conv_op_l1_usage l1_usage = pool::calculate_L1_usage(
+            compute_config,
+            opt_conv_op_block_config,
+            opt_conv_op_parallel_config,
+            kernel_size,
+            conv_config,
+            conv_out_memory_config,
+            false,
+            false);
+
+        // Since we don't have L1 usage for halo output (input to conv2d)
+        // use approx input tensor size per core as a proxy.
+        uint32_t input_nhw = tt::div_up(batch_size * input_height * input_width, tt::constants::TILE_HEIGHT);
+        uint32_t input_c = tt::div_up(in_channels_padded, tt::constants::TILE_WIDTH);
+        uint32_t approx_input_size =
+            input_nhw * input_c * tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
+        uint32_t approx_input_size_per_core = approx_input_size / input_parallel_config.grid.num_cores();
+
+        l1_usage.tensor_allocation_size += approx_input_size_per_core;
+        log_debug(
+            tt::LogOp,
+            "L1 usage for {}: {}, {}",
+            conv_config.shard_layout,
+            l1_usage.tensor_allocation_size,
+            l1_usage.CB_allocation_size);
+        return core_count_and_size{
+            .core_count = input_parallel_config.grid.num_cores(),
+            .size = l1_usage.CB_allocation_size + l1_usage.tensor_allocation_size,
+            .conv_config = conv_config};
+    };
+
+    core_count_and_size height = get_l1_usage_for_sharding(TensorMemoryLayout::HEIGHT_SHARDED);
+    const core_count_and_size block = get_l1_usage_for_sharding(TensorMemoryLayout::BLOCK_SHARDED);
+    const core_count_and_size width = get_l1_usage_for_sharding(TensorMemoryLayout::WIDTH_SHARDED);
+
+    core_count_and_size& winning_config = height;
+    // Make sure that BS not only has smaller size but provides at least some slicing along the channels.
+    // In case we have BS that would slice the tensor only along the HS conv2d code would fail later on.
+    if (block.size < winning_config.size && block.core_count > compute_grid_size.x) {
+        winning_config = block;
+    }
+    if (width.size < winning_config.size) {
+        winning_config = width;
+    }
+
+    log_debug(tt::LogOp, "Core counts H: {} B: {}, W: {}", height.core_count, block.core_count, width.core_count);
+    log_debug(
+        tt::LogOp, "Selected shard layout: {}, size: {}", winning_config.conv_config.shard_layout, winning_config.size);
+
+    return winning_config.conv_config.shard_layout.value();
+}
+
+}  // namespace operations::pool
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.cpp
@@ -32,445 +32,248 @@ namespace operations::pool {
 using sliding_window::ParallelConfig;
 using sliding_window::SlidingWindowConfig;
 
-conv::conv_op_l1_usage calculate_L1_usage(
-    const DeviceComputeKernelConfig& compute_kernel_config,
-    const conv::OptimizedConvBlockConfig& block_config,
-    const conv::OptimizedConvParallelizationConfig& pconfig,
-    std::array<uint32_t, 2> kernel_size,
-    const conv::Conv2dConfig& conv_config,
-    const MemoryConfig& output_memory_config,
-    const bool enable_bias,
-    bool is_1d_depthwise_conv) {
-    bool untilize_out = conv_config.output_layout == Layout::ROW_MAJOR;
+uint32_t calculate_L1_usage(
+    const Tensor& input,
+    const uint32_t kernel_h,
+    const uint32_t kernel_w,
+    const uint32_t out_h,
+    const uint32_t out_w,
+    const MemoryConfig& input_memory,
+    const MemoryConfig& output_memory) {
+    const auto input_shape = input.get_padded_shape();
 
-    // Output of halo op is always ROW_MAJOR, so input for convs is eighter DataType::FLOAT32 or DataType::BFLOAT16
-    const DataType input_dtype = conv_config.dtype == DataType::FLOAT32 ? DataType::FLOAT32 : DataType::BFLOAT16;
-    uint32_t input_tile_size = tt::tile_size(datatype_to_dataformat_converter(input_dtype));
-    uint32_t weights_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.weights_dtype));
-    uint32_t bias_tile_size = 0;
-    if (enable_bias) {
-        bias_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.weights_dtype));
+    tt::DataFormat in_df = datatype_to_dataformat_converter(input.get_dtype());
+    tt::DataFormat out_df = in_df;
+    uint32_t in_nbytes = datum_size(in_df);
+    uint32_t out_nbytes = datum_size(out_df);
+
+    auto pconfig = input.memory_config();
+    auto grid_size = input.shard_spec().value().grid.bounding_box().grid_size();
+    uint32_t num_shards_c = 0;
+    if (pconfig.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        num_shards_c = 1;
+    } else if (pconfig.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        num_shards_c = input.shard_spec().value().grid.num_cores();
+    } else if (input.shard_spec().value().orientation == ShardOrientation::COL_MAJOR) {
+        num_shards_c = grid_size.y;
+    } else {
+        num_shards_c = grid_size.x;
     }
-    uint32_t output_tile_size = tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(tt::tt_metal::hal.get_arch(), compute_kernel_config);
-
-    uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
-    uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
-    uint32_t act_block_num_tiles = block_config.act_block_h_ntiles * act_block_w_ntiles;
-
-    uint32_t weight_matrix_height = 0;  // weights_shape[2];
-    uint32_t weight_matrix_width = 0;   // weights_shape[3];
-    uint32_t weight_matrix_height_ntiles = weight_matrix_height / tt::constants::TILE_HEIGHT;
-    uint32_t weight_matrix_width_ntiles = weight_matrix_width / tt::constants::TILE_WIDTH;
-
-    uint32_t per_core_out_matrix_width_ntiles = pconfig.per_core_out_matrix_width_ntile;
-    uint32_t per_core_out_matrix_height_ntiles = pconfig.per_core_out_matrix_height_ntile;
-
-    uint32_t num_blocks_act_h_per_core =
-        (per_core_out_matrix_height_ntiles + act_block_h_ntiles - 1) / act_block_h_ntiles;
-    uint32_t out_block_h_ntiles_padded = num_blocks_act_h_per_core * act_block_h_ntiles;
-
-    TensorMemoryLayout sharding_scheme = conv_config.shard_layout.value();
-    if (sharding_scheme == TensorMemoryLayout::WIDTH_SHARDED) {
-        uint32_t conv_output_c_per_core = per_core_out_matrix_width_ntiles * tt::constants::TILE_WIDTH;
-
-        uint32_t output_size_per_core_in_bytes = per_core_out_matrix_width_ntiles * per_core_out_matrix_height_ntiles *
-                                                 tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
-
-        uint32_t act_block_num_bytes = act_block_num_tiles * input_tile_size;
-        uint32_t tilized_act_block_num_bytes = act_block_num_tiles * output_tile_size;
-
-        uint32_t weight_block_w_ntiles = per_core_out_matrix_width_ntiles;
-        uint32_t weight_block_num_tiles = 0;
-        // weight_block_w_ntiles * act_block_w_ntiles;  // act_block_w_ntiles == weight_block_h_ntiles
-        uint32_t weight_block_num_bytes = weight_block_num_tiles * weights_tile_size;
-
-        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
-
-        uint32_t out_block_num_tiles = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles;
-
-        uint32_t num_blocks_act_w = weight_matrix_height_ntiles / act_block_w_ntiles;
-
-        packer_l1_acc = packer_l1_acc && ((enable_bias && num_blocks_act_w > 1) || (num_blocks_act_w > 2));
-
-        auto interm_dtype =
-            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
-
-        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
-
-        uint32_t partials_block_num_bytes = out_block_num_tiles * partial_tile_size;
-
-        // CB 0
-        uint32_t act_cb_0_size = tilized_act_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
-
-        // CB 1
-        uint32_t weights_cb_1_size = weight_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
-
-        // CB 2
-        uint32_t bias_cb_2_size = bias_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
-
-        // CB 5
-        uint32_t l1_scratchpad_cb_5_size = conv::l1_scratchpad_CB_size;
-        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
-
-        // CB 6
-        uint32_t row_major_act_cb_6_size = act_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB6 Size: {}", row_major_act_cb_6_size);
-
-        // CB 24
-        uint32_t matmul_partial_cb_24_size = partials_block_num_bytes;
-        if (interm_dtype == conv_config.dtype) {
-            matmul_partial_cb_24_size = 0;
-        } else {
-            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partial_cb_24_size);
-        }
-
-        // CB 25
-        uint32_t tilized_act_cb_25_size = tilized_act_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
-
-        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
-                                 row_major_act_cb_6_size + matmul_partial_cb_24_size + tilized_act_cb_25_size;
-
-        tt::log_debug(tt::LogOp, "Total CB Size: {}", total_CB_size);
-
-        return conv::conv_op_l1_usage{
-            .tensor_allocation_size = output_size_per_core_in_bytes, .CB_allocation_size = total_CB_size};
-    } else if (sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
-        uint32_t output_size = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * output_tile_size;
-
-        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
-
-        uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
-
-        uint32_t weight_block_w_ntiles = 0;  // per_core_out_matrix_width_ntiles;
-        uint32_t weight_block_h_ntiles = 0;  //(is_1d_depthwise_conv) ? act_block_h_ntiles : act_block_w_ntiles;
-
-        uint32_t act_block_cb_ntiles = act_block_h_ntiles * act_block_w_ntiles;
-
-        uint32_t act_block_cb_size = act_block_cb_ntiles * input_tile_size;
-        uint32_t tilzed_act_cb_size = act_block_cb_ntiles * output_tile_size;
-
-        uint32_t output_block_ntiles = out_block_h_ntiles_padded * per_core_out_matrix_width_ntiles;
-
-        uint32_t num_blocks_act_w = weight_matrix_height_ntiles / act_block_w_ntiles;
-        uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
-        uint32_t in0_num_blocks_w =
-            num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
-
-        packer_l1_acc = packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
-
-        auto interm_dtype =
-            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
-
-        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
-
-        uint32_t act_block_split_last_ntiles = 0;
-        uint32_t act_block_split_ntiles = act_block_cb_ntiles;
-        if (conv_config.enable_split_reader) {
-            uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
-            uint32_t act_block_split_last_ntiles = act_block_cb_ntiles / 2;
-            uint32_t act_block_split_ntiles = act_block_cb_ntiles - act_block_split_last_ntiles;
-        }
-
-        if (conv_config.enable_act_double_buffer) {
-            act_block_split_last_ntiles *= 2;
-            act_block_split_ntiles *= 2;
-        }
-        // CB 0
-        uint32_t act_cb_0_size = act_block_split_ntiles * input_tile_size;
-        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
-
-        // CB 1
-        uint32_t weights_cb_1_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
-        if (num_blocks_act_h > 1) {
-            weights_cb_1_size *= kernel_size[0];
-        }
-        if (num_blocks_act_h <= 1 && conv_config.enable_weights_double_buffer) {
-            weights_cb_1_size *= 2;
-        }
-        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
-
-        // CB 2
-        uint32_t bias_cb_2_size = bias_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
-
-        uint32_t l1_scratchpad_cb_5_size = conv::l1_scratchpad_CB_size;
-        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
-
-        uint32_t split_second_act_reader_cb_7_size = 0;
-
-        split_second_act_reader_cb_7_size = act_block_split_last_ntiles * input_tile_size;
-        tt::log_debug(tt::LogOp, "CB7 Size: {}", split_second_act_reader_cb_7_size);
-
-        // CB 24
-        uint32_t matmul_partials_cb_24_size = output_block_ntiles * partial_tile_size;
-        if (untilize_out == false && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_24_size = 0;
-        }
-        if (is_1d_depthwise_conv) {
-            matmul_partials_cb_24_size = output_tile_size;
-        }
-        if (matmul_partials_cb_24_size != 0) {
-            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partials_cb_24_size);
-        }
-        // CB 25
-        uint32_t tilized_act_cb_25_size = tilzed_act_cb_size;
-        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
-
-        uint32_t temp_sum_cb_27_size = 0;
-        if (is_1d_depthwise_conv) {
-            temp_sum_cb_27_size = output_tile_size;
-            tt::log_debug(tt::LogOp, "CB27 Size: {}", temp_sum_cb_27_size);
-        }
-        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
-                                 split_second_act_reader_cb_7_size + matmul_partials_cb_24_size +
-                                 tilized_act_cb_25_size + temp_sum_cb_27_size;
-        return conv::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
-    } else if (sharding_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
-        auto output_shard_shape = output_memory_config.shard_spec.value().shape;
-
-        uint32_t output_size = 0;
-        if (untilize_out) {
-            uint32_t per_core_out_width_aligned = pconfig.per_core_out_matrix_width_ntile * tt::constants::TILE_WIDTH;
-            if (conv_config.dtype == DataType::BFLOAT16) {
-                per_core_out_width_aligned *= 2;
-            } else if (conv_config.dtype == DataType::FLOAT32) {
-                per_core_out_width_aligned *= 4;
-            }
-            output_size =
-                round_up(per_core_out_width_aligned, tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1)) *
-                pconfig.per_core_out_matrix_height_ntile * tt::constants::TILE_HEIGHT;
-        } else {
-            output_size = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * output_tile_size;
-        }
-
-        uint32_t bias_block_num_bytes = per_core_out_matrix_width_ntiles * bias_tile_size;
-
-        uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
-
-        uint32_t weight_block_w_ntiles = 0;  // per_core_out_matrix_width_ntiles;
-        uint32_t weight_block_h_ntiles = 0;  // act_block_w_ntiles;
-
-        uint32_t tilized_act_block_cb_size = act_block_h_ntiles * act_block_w_ntiles * output_tile_size;
-        uint32_t row_major_act_cb_size = act_block_h_ntiles * act_block_w_ntiles * input_tile_size;
-
-        uint32_t output_block_ntiles = per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles;
-
-        uint32_t num_blocks_act_w = 1;
-        uint32_t num_blocks_act_h = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
-        uint32_t in0_num_blocks_w =
-            num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
-
-        packer_l1_acc = packer_l1_acc && ((enable_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
-
-        auto interm_dtype =
-            packer_l1_acc ? (fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16) : conv_config.dtype;
-
-        uint32_t partial_tile_size = tt::tile_size(datatype_to_dataformat_converter(interm_dtype));
-
-        // CB 0
-        uint32_t act_cb_0_size = tilized_act_block_cb_size;
-        if (conv_config.enable_act_double_buffer) {
-            act_cb_0_size *= 2;
-        }
-        tt::log_debug(tt::LogOp, "CB0 Size: {}", act_cb_0_size);
-
-        // CB 1
-        uint32_t weights_cb_1_size = weight_block_h_ntiles * weight_block_w_ntiles * weights_tile_size;
-        if (conv_config.enable_weights_double_buffer) {
-            weights_cb_1_size *= 2;
-        }
-        tt::log_debug(tt::LogOp, "CB1 Size: {}", weights_cb_1_size);
-
-        // CB 2
-        uint32_t bias_cb_2_size = bias_block_num_bytes;
-        tt::log_debug(tt::LogOp, "CB2 Size: {}", bias_cb_2_size);
-
-        // CB 5
-        uint32_t l1_scratchpad_cb_5_size = conv::l1_scratchpad_CB_size;
-        tt::log_debug(tt::LogOp, "CB5 Size: {}", l1_scratchpad_cb_5_size);
-
-        // CB 6
-        uint32_t cb6_size = row_major_act_cb_size;
-        tt::log_debug(tt::LogOp, "CB6 Size: {}", cb6_size);
-
-        // CB 24
-        uint32_t matmul_partials_cb_24_size = output_block_ntiles * partial_tile_size;
-        if (untilize_out == false && interm_dtype == conv_config.dtype) {
-            matmul_partials_cb_24_size = 0;
-        } else {
-            tt::log_debug(tt::LogOp, "CB24 Size: {}", matmul_partials_cb_24_size);
-        }
-
-        // CB 25
-        uint32_t tilized_act_cb_25_size = tilized_act_block_cb_size;
-        tt::log_debug(tt::LogOp, "CB25 Size: {}", tilized_act_cb_25_size);
-
-        bool need_unpad_after_untilize =
-            output_shard_shape[1] * output_shard_shape[0] <
-            per_core_out_matrix_height_ntiles * per_core_out_matrix_width_ntiles * tt::constants::TILE_HW;
-
-        tt::log_debug(tt::LogOp, "Need Unpad after untilize: {}", need_unpad_after_untilize);
-
-        uint32_t cb28_size = 0;
-        if (need_unpad_after_untilize && untilize_out) {
-            cb28_size = output_block_ntiles * output_tile_size;
-            tt::log_debug(tt::LogOp, "CB28 Size: {}", cb28_size);
-        }
-        uint32_t total_CB_size = act_cb_0_size + weights_cb_1_size + bias_cb_2_size + l1_scratchpad_cb_5_size +
-                                 cb6_size + matmul_partials_cb_24_size + tilized_act_cb_25_size + cb28_size;
-        return conv::conv_op_l1_usage{.tensor_allocation_size = output_size, .CB_allocation_size = total_CB_size};
+    uint32_t in_nbytes_c = input_shape[3] / num_shards_c * in_nbytes;  // row of input (channels)
+    uint32_t out_nbytes_c = out_w / num_shards_c * out_nbytes;         // row of output (channels)
+
+    tt::DataFormat indices_df =
+        tt::DataFormat::RawUInt16;  // datatype_to_dataformat_converter(reader_indices.get_dtype());
+    uint32_t indices_nbytes = datum_size(indices_df);
+
+    uint32_t kernel_size_hw = kernel_h * kernel_w;  // number of valid rows, to read
+    uint32_t kernel_size_hw_padded = tt::round_up(kernel_size_hw, tt::constants::TILE_HEIGHT);
+    uint32_t in_ntiles_hw = (uint32_t)std::ceil((float)kernel_size_hw_padded / tt::constants::TILE_HEIGHT);
+    uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / num_shards_c / tt::constants::TILE_WIDTH);
+    uint32_t out_ntiles_c = (uint32_t)std::ceil((float)out_w / num_shards_c / tt::constants::TILE_WIDTH);
+
+    uint32_t max_rows_for_reduction = 16;
+    // TODO #14588: temporarily disabling 32 row reductions due to issues in large kernels
+    /* uint32_t max_rows_for_reduction = tt::constants::TILE_HEIGHT;
+    // For GRAYSKULL, make reduction for 16 rows at a time.
+    if (device->arch() == tt::ARCH::GRAYSKULL)
+        max_rows_for_reduction /= 2; */
+
+    // Hardware can do reduction of 8 tiles at a time.
+    // CB sizes can be restricted to this in case input channels are more than 256 to perform reduction iteratively.
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    const bool is_large_kernel = kernel_size_hw > max_rows_for_reduction;
+    const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
+
+    uint32_t nblocks = 1;
+    // TT_FATAL(nblocks == 1, "Multiple blocks not yet supported");
+
+    uint32_t tile_w = tt::constants::TILE_WIDTH;
+    if (input_shape[3] < tt::constants::TILE_WIDTH) {
+        TT_FATAL(input_shape[3] == 16, "Error");
+        tile_w = tt::constants::FACE_WIDTH;
     }
-    TT_THROW("Invalid shard layout {}", sharding_scheme);
+    uint32_t out_w_loop_count = std::ceil((float)out_w / nblocks);
+
+    // distributing out_hw across the grid
+    auto all_cores = input_memory.shard_spec.value().grid;
+    uint32_t ncores = all_cores.num_cores();
+    auto core_range = all_cores;
+    uint32_t in_nhw_per_core = input_memory.shard_spec.value().shape[0];
+    uint32_t out_nhw_per_core = output_memory.shard_spec.value().shape[0];
+
+    // TODO: support generic nblocks
+    TT_FATAL(
+        out_nhw_per_core % nblocks == 0,
+        "number of sticks per core ({}) should be divisible by nblocks ({})",
+        out_nhw_per_core,
+        nblocks);
+
+    // CBs
+    uint32_t multi_buffering_factor = 2;
+
+    uint32_t split_reader = 1;
+
+    // scalar CB as coefficient of reduce
+    uint32_t in_scalar_cb_pagesize = tile_size(in_df);
+    uint32_t in_scalar_cb_npages = 1;
+    uint32_t in_scalar_cb_config_size = in_scalar_cb_npages /*1*/ * in_scalar_cb_pagesize /*2048*/;
+
+    // incoming data is the input cb instead of raw l1/dram addr
+    // this input shard has halo and padding inserted.
+    auto raw_in_cb_id = tt::CBIndex::c_2;
+    uint32_t raw_in_cb_npages = input_memory.shard_spec.value().shape[0];
+    uint32_t raw_in_cb_pagesize = in_nbytes_c;
+    uint32_t raw_in_cb_config_size = raw_in_cb_npages /*100*/ * raw_in_cb_pagesize /*192*/;
+
+    // reader indices
+    uint32_t in_reader_indices_cb_pagesize =
+        tt::round_up(out_nhw_per_core * indices_nbytes, 4);  // pagesize needs to be multiple of 4
+    uint32_t in_reader_indices_cb_npages = 1;
+    uint32_t in_reader_indices_cb_config_size =
+        in_reader_indices_cb_npages /*1*/ * in_reader_indices_cb_pagesize /*72*/;
+
+    uint32_t in_cb_sz = 0;
+    uint32_t in_nblocks_c = 1;
+    if (is_wide_reduction) {
+        in_cb_sz = MAX_TILES_PER_REDUCTION * tt::constants::TILE_HW;
+        in_nblocks_c = std::ceil((float)in_ntiles_c / MAX_TILES_PER_REDUCTION);
+    } else {
+        in_cb_sz = in_ntiles_c * tt::constants::TILE_HW;
+    }
+
+    uint32_t in_cb_page_padded = tt::round_up(
+        in_cb_sz,
+        tt::constants::TILE_HW);  // NOTE: ceil to tile size since triscs work with tilesize instead of pagesize
+    uint32_t in_cb_pagesize = in_nbytes * in_cb_page_padded;
+    uint32_t in_cb_npages = multi_buffering_factor * nblocks;
+    uint32_t in_cb_config_0_size = in_cb_npages /*2*/ * in_cb_pagesize /*6144*/;
+    uint32_t in_cb_config_1_size = 0;
+
+    if (split_reader) {
+        in_cb_config_1_size = in_cb_npages /*2*/ * in_cb_pagesize /*6144*/;
+    }
+
+    // after reduction
+    uint32_t out_cb_pagesize = std::min(tt::constants::TILE_WIDTH, output_memory.shard_spec.value().shape[1]) *
+                               out_nbytes;  // there is just one row of channels after each reduction (or 1 block
+                                            // of c if its greater than 8 tiles)
+    uint32_t out_cb_npages = output_memory.shard_spec.value().shape[0] * in_ntiles_c;
+    uint32_t out_cb_config_size = out_cb_npages /*108*/ * out_cb_pagesize /*62*/;
+
+    uint32_t max_pool_partials_cb_config_size = 0;
+    if (is_large_kernel) {
+        uint32_t max_pool_partials_cb_pagesize = out_cb_pagesize;
+        uint32_t max_pool_partials_cb_npages = nblocks;
+        max_pool_partials_cb_config_size = max_pool_partials_cb_npages /*1*/ * max_pool_partials_cb_pagesize /*64*/;
+    }
+
+    return in_scalar_cb_config_size
+           // + raw_in_cb_config_size
+           // + in_reader_indices_cb_config_size
+           + in_cb_config_0_size +
+           in_cb_config_1_size
+           // + out_cb_config_size
+           + max_pool_partials_cb_config_size;
 }
 
-TensorMemoryLayout determine_pool_config_for_auto_shard(
-    uint32_t batch_size,
-    uint32_t channels,
-    uint32_t output_height,
-    uint32_t output_width,
-    uint32_t input_height,
-    uint32_t input_width,
-    const CoreCoord& compute_grid_size,
-    Layout input_tensor_layout,
-    const std::array<uint32_t, 2>& kernel_size,
-    const DeviceComputeKernelConfig& compute_config,
-    const DataType& input_dtype) {
-    ShardOrientation shard_orientation = ShardOrientation::COL_MAJOR;
-    // const bool is_out_tiled = conv_config.output_layout == Layout::TILE;
+sliding_window::ParallelConfig determine_pool_config_for_auto_shard(
+    const Tensor& input_tensor, const sliding_window::SlidingWindowConfig& sliding_window_config, uint32_t channels) {
+    auto batch_size = sliding_window_config.batch_size;
+    auto output_shape = sliding_window_config.get_output_shape();
+    auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
 
-    struct core_count_and_size {
-        uint32_t core_count;
-        uint32_t size;
-        conv::Conv2dConfig conv_config;
+    auto input_parallel_config_height = conv::determine_parallel_config(
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        batch_size,
+        channels,
+        output_shape[1],
+        output_shape[2],
+        channels,
+        compute_grid_size,
+        ShardOrientation::ROW_MAJOR,
+        false,
+        false);
+
+    auto input_parallel_config_width = conv::determine_parallel_config(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        batch_size,
+        channels,
+        output_shape[1],
+        output_shape[2],
+        channels,
+        compute_grid_size,
+        ShardOrientation::ROW_MAJOR,
+        false,
+        false);
+    auto output_parallel_config_width =
+        conv::determine_output_parallel_config(input_parallel_config_width, compute_grid_size, channels, false);
+
+    auto input_parallel_config_block = conv::determine_parallel_config(
+        TensorMemoryLayout::BLOCK_SHARDED,
+        batch_size,
+        channels,
+        output_shape[1],
+        output_shape[2],
+        channels,
+        compute_grid_size,
+        ShardOrientation::COL_MAJOR,
+        false,
+        false);
+
+    auto get_memconfig = [&](const ParallelConfig& parallel_config) {
+        uint32_t nhw = batch_size * output_shape[1] * output_shape[2];
+        uint32_t out_channeal_padded = tt::round_up(
+            channels, conv::get_num_cores_channels_from_parallel_config(parallel_config) * tt::constants::TILE_WIDTH);
+        return conv::create_sharded_memory_config_from_parallel_config(
+            ttnn::Shape({1, 1, nhw, out_channeal_padded}), parallel_config, tt::constants::TILE_HEIGHT);
     };
 
-    // 1d deptwise convs support only height sharding
-    if (conv::is_1d_deptwise_conv(1 /*groups*/, channels, channels, kernel_size[1], input_width)) {
-        return TensorMemoryLayout::HEIGHT_SHARDED;
-    }
+    uint32_t l1_usage_height = calculate_L1_usage(
+        input_tensor,
+        sliding_window_config.window_hw.first,
+        sliding_window_config.window_hw.second,
+        sliding_window_config.get_output_shape()[1],
+        sliding_window_config.get_output_shape()[2],
+        get_memconfig(input_parallel_config_height),
+        get_memconfig(input_parallel_config_height));
 
-    auto get_l1_usage_for_sharding = [&](TensorMemoryLayout shard_layout) -> core_count_and_size {
-        conv::Conv2dConfig conv_config = conv::Conv2dConfig();
-        conv_config.dtype = input_dtype;
-        conv_config.shard_layout = shard_layout;
-        if (conv_config.act_block_h_override == 0) {
-            conv_config.act_block_h_override = tt::constants::TILE_HEIGHT;
-            if (channels < tt::constants::TILE_WIDTH && shard_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
-                input_tensor_layout == Layout::ROW_MAJOR) {
-                log_debug(tt::LogOp, "Auto shard, enable shallow conv");
-                // height sharded, non matmul conv, with input channels < 32, and default setting for
-                // input_channels_alignment
-                // Currently data-movement ops have too many restrictions to support shallow convs with tiled input.
-                conv_config.input_channels_alignment = 8;
-            } else if (shard_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
-                conv_config.input_channels_alignment = tt::constants::TILE_WIDTH;
-            }
+    uint32_t l1_usage_width = calculate_L1_usage(
+        input_tensor,
+        sliding_window_config.window_hw.first,
+        sliding_window_config.window_hw.second,
+        sliding_window_config.get_output_shape()[1],
+        sliding_window_config.get_output_shape()[2],
+        get_memconfig(input_parallel_config_width),
+        get_memconfig(output_parallel_config_width));
 
-            // Set act_block_h_override to min value to
-            // be conservative with L1 memory usage.
-            uint32_t act_block_h_override = tt::constants::TILE_HEIGHT;
-        }
+    uint32_t l1_usage_block = calculate_L1_usage(
+        input_tensor,
+        sliding_window_config.window_hw.first,
+        sliding_window_config.window_hw.second,
+        sliding_window_config.get_output_shape()[1],
+        sliding_window_config.get_output_shape()[2],
+        get_memconfig(input_parallel_config_block),
+        get_memconfig(input_parallel_config_block));
 
-        const uint32_t in_channels_padded = ccl::cmd::round_up(channels, conv_config.input_channels_alignment);
-        const uint32_t output_channels_padded = ccl::cmd::round_up(channels, tt::constants::TILE_WIDTH);
-        // Note: These are not exact shapes for weights as prepare_conv_weights will pad the weights depending on the
-        // conv2d params, but these are good enough for L1 usage estimation.
-        // const ttnn::Shape weights_shape(
-        //     {1, 1, in_channels_padded * kernel_size[0] * kernel_size[1], output_channels_padded});
+    uint32_t ncores_height = input_parallel_config_height.grid.num_cores();
+    uint32_t ncores_width = input_parallel_config_width.grid.num_cores();
+    uint32_t ncores_block = input_parallel_config_block.grid.num_cores();
 
-        const sliding_window::ParallelConfig input_parallel_config = conv::determine_parallel_config(
-            shard_layout,
-            batch_size,
-            channels,
-            output_height,
-            output_width,
-            channels,
-            compute_grid_size,
-            shard_orientation,
-            false,
-            false);
-
-        const sliding_window::ParallelConfig output_parallel_config =
-            conv::determine_output_parallel_config(input_parallel_config, compute_grid_size, channels, false);
-
-        auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = conv::get_conv_configs(
-            conv_config,
-            compute_config,
-            input_parallel_config,
-            output_parallel_config,
-            channels,
-            channels,
-            batch_size,
-            output_height,
-            output_width,
-            kernel_size,
-            compute_grid_size);
-
-        if (conv_config.act_block_w_div == 1 && conv_config.shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-            uint32_t width_sharded_num_cores = input_parallel_config.grid.num_cores();
-            // Set act_block_w_div to max value to
-            // be conservative with L1 memory usage.
-            // act_block_w_div == 1 is currently the default value.
-            conv_config.act_block_w_div = tt::div_up(channels, width_sharded_num_cores * tt::constants::TILE_WIDTH);
-        }
-
-        conv::conv_op_l1_usage l1_usage = pool::calculate_L1_usage(
-            compute_config,
-            opt_conv_op_block_config,
-            opt_conv_op_parallel_config,
-            kernel_size,
-            conv_config,
-            conv_out_memory_config,
-            false,
-            false);
-
-        // Since we don't have L1 usage for halo output (input to conv2d)
-        // use approx input tensor size per core as a proxy.
-        uint32_t input_nhw = tt::div_up(batch_size * input_height * input_width, tt::constants::TILE_HEIGHT);
-        uint32_t input_c = tt::div_up(in_channels_padded, tt::constants::TILE_WIDTH);
-        uint32_t approx_input_size =
-            input_nhw * input_c * tt::tile_size(datatype_to_dataformat_converter(conv_config.dtype));
-        uint32_t approx_input_size_per_core = approx_input_size / input_parallel_config.grid.num_cores();
-
-        l1_usage.tensor_allocation_size += approx_input_size_per_core;
-        log_debug(
-            tt::LogOp,
-            "L1 usage for {}: {}, {}",
-            conv_config.shard_layout,
-            l1_usage.tensor_allocation_size,
-            l1_usage.CB_allocation_size);
-        return core_count_and_size{
-            .core_count = input_parallel_config.grid.num_cores(),
-            .size = l1_usage.CB_allocation_size + l1_usage.tensor_allocation_size,
-            .conv_config = conv_config};
-    };
-
-    core_count_and_size height = get_l1_usage_for_sharding(TensorMemoryLayout::HEIGHT_SHARDED);
-    const core_count_and_size block = get_l1_usage_for_sharding(TensorMemoryLayout::BLOCK_SHARDED);
-    const core_count_and_size width = get_l1_usage_for_sharding(TensorMemoryLayout::WIDTH_SHARDED);
-
-    core_count_and_size& winning_config = height;
+    uint32_t winning_l1_usage = l1_usage_height;
+    auto winning_config = input_parallel_config_height;
     // Make sure that BS not only has smaller size but provides at least some slicing along the channels.
     // In case we have BS that would slice the tensor only along the HS conv2d code would fail later on.
-    if (block.size < winning_config.size && block.core_count > compute_grid_size.x) {
-        winning_config = block;
+    if (l1_usage_block < l1_usage_height && ncores_block > compute_grid_size.x) {
+        winning_l1_usage = l1_usage_block;
+        winning_config = input_parallel_config_block;
     }
-    if (width.size < winning_config.size) {
-        winning_config = width;
+    if (l1_usage_width < winning_l1_usage) {
+        winning_config = input_parallel_config_width;
     }
 
-    log_debug(tt::LogOp, "Core counts H: {} B: {}, W: {}", height.core_count, block.core_count, width.core_count);
-    log_debug(
-        tt::LogOp, "Selected shard layout: {}, size: {}", winning_config.conv_config.shard_layout, winning_config.size);
-
-    return winning_config.conv_config.shard_layout.value();
+    return winning_config;
 }
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/operations/matmul/device/matmul_op.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn {
+
+namespace operations::pool {
+
+TensorMemoryLayout determine_pool_config_for_auto_shard(
+    uint32_t batch_size,
+    uint32_t channels,
+    uint32_t output_height,
+    uint32_t output_width,
+    uint32_t input_height,
+    uint32_t input_width,
+    const CoreCoord& compute_grid_size,
+    Layout input_tensor_layout,
+    const std::array<uint32_t, 2>& kernel_size,
+    const DeviceComputeKernelConfig& compute_config,
+    const DataType& input_dtype);
+
+}  // namespace operations::pool
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.hpp
@@ -16,18 +16,16 @@ namespace ttnn {
 
 namespace operations::pool {
 
-TensorMemoryLayout determine_pool_config_for_auto_shard(
-    uint32_t batch_size,
-    uint32_t channels,
-    uint32_t output_height,
-    uint32_t output_width,
-    uint32_t input_height,
-    uint32_t input_width,
-    const CoreCoord& compute_grid_size,
-    Layout input_tensor_layout,
-    const std::array<uint32_t, 2>& kernel_size,
-    const DeviceComputeKernelConfig& compute_config,
-    const DataType& input_dtype);
+sliding_window::ParallelConfig determine_pool_config_for_auto_shard(
+    const Tensor& input_tensor, const sliding_window::SlidingWindowConfig& sliding_window_config, uint32_t channels);
 
+uint32_t calculate_L1_usage(
+    const Tensor& input,
+    const uint32_t kernel_h,
+    const uint32_t kernel_w,
+    const uint32_t out_h,
+    const uint32_t out_w,
+    const MemoryConfig& input_memory,
+    const MemoryConfig& output_memory);
 }  // namespace operations::pool
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/pool2d_utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <optional>
 
-#include "ttnn/operations/matmul/device/matmul_op.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14436)

### Problem description
Currently, pool2d only support height sharding. We would like to extend this functionality to width and block sharding.

### What's changed
I added width/block sharding in `tt-metal/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp` and test it by `tt-metal/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes