### PR TITLE
Revert "Add initial support for Llama3-8B & 70B on BH"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -182,7 +182,7 @@ def set_fabric(fabric_config):
 
 
 @pytest.fixture(scope="function")
-def mesh_device(request, silicon_arch_name, device_params):
+def mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
     """
     Pytest fixture to set up a device mesh for tests.
 
@@ -193,6 +193,7 @@ def mesh_device(request, silicon_arch_name, device_params):
     Args:
         request: Pytest request object.
         silicon_arch_name: Name of the silicon architecture.
+        silicon_arch_wormhole_b0: Silicon architecture parameter.
         device_params: Additional device configuration parameters.
 
     Yields:
@@ -406,7 +407,6 @@ ALL_ARCHS = set(
     [
         "grayskull",
         "wormhole_b0",
-        "blackhole",
     ]
 )
 
@@ -418,7 +418,7 @@ def pytest_addoption(parser):
         "--tt-arch",
         choices=[*ALL_ARCHS],
         default=ttnn.get_arch_name(),
-        help="Target arch, ex. grayskull, wormhole_b0, blackhole",
+        help="Target arch, ex. grayskull, wormhole_b0",
     )
     parser.addoption(
         "--pipeline-type",
@@ -521,11 +521,6 @@ def pytest_generate_tests(metafunc):
         "silicon_arch_wormhole_b0": set(
             [
                 "wormhole_b0",
-            ]
-        ),
-        "silicon_arch_blackhole": set(
-            [
-                "blackhole",
             ]
         ),
     }

--- a/models/tt_transformers/lt
+++ b/models/tt_transformers/lt
@@ -81,9 +81,9 @@ def get_device():
     total_devices = count_devices(smi_ls_output)
 
     if total_devices == 1:
-        device = "N150" if "Wormhole" in smi_ls_output else "P150"  # Blackhole
+        device = "N150"
     elif total_devices == 2:
-        device = "N300" if "Wormhole" in smi_ls_output else "P300"  # Blackhole
+        device = "N150"
     elif total_devices == 8:
         device = "T3K"
     else:  # TG has 36 devices
@@ -106,11 +106,7 @@ def list_supported_devices(device):
         return "n150, n300, t3k"
     elif device == "N300":
         return "n150, n300"
-    elif device == "P300":
-        return "p150, p300"
-    elif device == "P150":
-        return "p150"
-    else:
+    else:  # N150
         return "n150"
 
 
@@ -122,7 +118,7 @@ def count_devices(output):
 
     # Count total PCI devices (ignoring N/A)
     total_pci_devices = len(
-        [line for line in available_boards.split("\n") if any(word in line for word in ["Blackhole", "Wormhole"])]
+        [line for line in available_boards.split("\n") if ("Wormhole" or "Grayskull" or "Blackhole") in line]
     )
 
     return total_pci_devices
@@ -488,10 +484,10 @@ def main(stdscr):
 
                         # Generate combinations (reordered)
                         # Ignore invalid combinations:
-                        # - 11b and 11b-b models on n150/p150 device
-                        # - 70b and 70b-r1 model on n150/n300 & p150/p300 devices
-                        # - 72b model on n150/n300 and p150/p300 devices
-                        # - q7b on anything other than n300/p300
+                        # - 11b and 11b-b models on n150 device
+                        # - 70b and 70b-r1 model on n150 and n300 devices
+                        # - 72b model on n150 and n300 devices
+                        # - q7b on anything other than N300
                         # - Vision commands on non-vision (11b) models
                         combinations = [
                             (c, m, d)
@@ -499,11 +495,11 @@ def main(stdscr):
                             for m in models
                             for d in devices
                             if not (
-                                (m in ["11b", "11b-b"] and d in ["n150", "p150"])
-                                or (m == "70b" and d in ["n150", "n300", "p150", "p300"])
-                                or (m == "70b-r1" and d in ["n150", "n300", "p150", "p300"])
-                                or (m == "q72b" and d in ["n150", "n300", "p150", "p300"])
-                                or (m == "q7b" and d in ["n300", "p300"])
+                                (m in ["11b", "11b-b"] and d == "n150")
+                                or (m == "70b" and d in ["n150", "n300"])
+                                or (m == "70b-r1" and d in ["n150", "n300"])
+                                or (m == "q72b" and d in ["n150", "n300"])
+                                or (m == "q7b" and d != "n300")
                                 or ("vision" in c and m not in ["11b", "11b-b"])
                             )
                         ]

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -81,9 +81,9 @@ class MLP(LightweightModule):
                 pc_2 = self.model_config["DECODE_MLP_W2_PRG_CONFIG"]
                 pc_3 = self.model_config["DECODE_MLP_W1_W3_PRG_CONFIG"]
         else:  # Update the program configs based for prefill
-            if seq_len >= self.args.prefill_len_cutoff:  # 512 if Blackhole, 1024 if Wormhole
+            if seq_len >= 1024:
                 # Reshape input to to fit on device and parallelize computation
-                x = ttnn.reshape(x, [1, seq_len // self.args.prefill_len_cutoff, self.args.prefill_len_cutoff, -1])
+                x = ttnn.reshape(x, [1, seq_len // 1024, 1024, -1])
             pc_1 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
             pc_2 = self.model_config["PREFILL_MLP_W2_PRG_CONFIG"](seq_len)
             pc_3 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
@@ -172,7 +172,6 @@ class MLP(LightweightModule):
             dtype=ttnn.bfloat8_b,
             memory_config=w1_out.memory_config(),
         )
-
         if mode == "decode" and not TG:
             # w2 may use a different core grid, this is a no-op if they already match
             w2_in = ttnn.to_memory_config(w2_in, self.model_config["SHARDED_MLP2_INPUT_MEMCFG"])

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -97,7 +97,6 @@ class Transformer(LightweightModule):
             state_dict=state_dict,
             state_dict_prefix=state_dict_prefix,
             weight_cache_path=weight_cache_path,
-            max_columns_per_device=self.args.max_columns_per_device_lm_head,
         )
 
     def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -109,24 +109,13 @@ class ModelArgs:
     ):
         self.num_devices = mesh_device.get_num_devices() if mesh_device else 0
         self.mesh_device = mesh_device
-        self.arch_name = ttnn.get_arch_name()
-        self.device_name = {
-            0: "CPU",
-            1: "P150" if self.arch_name == "blackhole" else "N150",
-            2: "P300" if self.arch_name == "blackhole" else "N300",
-            4: "P150x4",  # Config only exists in BH at the moment
-            8: "T3K",
-            32: "TG",
-        }[self.num_devices]
+        self.device_name = {0: "CPU", 1: "N150", 2: "N300", 4: "N150x4", 8: "T3K", 32: "TG"}[self.num_devices]
         self.model_name = "Unknown"  # Llama model name will be dependent on the checkpoint directory
         self.max_seq_len = max_seq_len
         self.max_batch_size = max_batch_size
         self.tile_size = 32
         self.is_70b = False
         self.from_hf_url = False  # updated below if true
-        self.prefill_len_cutoff = 512 if self.arch_name == "blackhole" else 1024
-        # TODO the following is parametrized for a vocab size of 128256 (used in LLama3). Should generalize for other models
-        self.max_columns_per_device_lm_head = 128256 // 8 if self.arch_name == "blackhole" else 128256 // 4
 
         assert not os.getenv(
             "FAKE_DEVICE"
@@ -213,18 +202,17 @@ class ModelArgs:
         # Set the max number of tokens for each prefill chunk based on the model and device
         max_prefill_chunk_size_div1024 = os.getenv("MAX_PREFILL_CHUNK_SIZE")
         if max_prefill_chunk_size_div1024 is None:
-            # TODO Improve this to be more general to more devices and models
             MAX_PREFILL_CHUNK_SIZES_DIV1024 = {
-                "Llama3.2-1B": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
-                "Llama3.2-3B": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
-                "Llama3.1-8B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
-                "Llama3.2-11B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
-                "Llama3.1-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128, "P150x4": 128},
-                "DeepSeek-R1-Distill-Llama-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128, "P150x4": 128},
-                "Qwen2.5-7B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
-                "Qwen2.5-72B": {"N150": None, "N300": None, "T3K": 32, "TG": 128, "P150x4": 128},
-                "Phi-3.5-mini-instruct": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
-                "QwQ-32B": {"N150": None, "N300": None, "T3K": 64, "TG": 128, "P150x4": 128},
+                "Llama3.2-1B": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128},
+                "Llama3.2-3B": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128},
+                "Llama3.1-8B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
+                "Llama3.2-11B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
+                "Llama3.1-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128},
+                "DeepSeek-R1-Distill-Llama-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128},
+                "Qwen2.5-7B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
+                "Qwen2.5-72B": {"N150": None, "N300": None, "T3K": 32, "TG": 128},
+                "Phi-3.5-mini-instruct": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128},
+                "QwQ-32B": {"N150": None, "N300": None, "T3K": 64, "TG": 128},
             }
             try:
                 max_prefill_chunk_size_div1024 = MAX_PREFILL_CHUNK_SIZES_DIV1024[self.base_model_name][self.device_name]
@@ -401,7 +389,7 @@ class ModelArgs:
 
             # For maximum performance, set the prefill grid row to 8, even if it can fit in a smaller grid
             # prefill_rows = lambda seq_len: min(seq_len, 1024) // self.tile_size
-            prefill_rows = 8  # TODO if BH = 10, if wh = 8
+            prefill_rows = 8
             mlp1_3_grid = lambda seq_len: (
                 (8, min(min(seq_len, 1024) // 32, 4))
                 if self.is_galaxy
@@ -414,13 +402,13 @@ class ModelArgs:
             )
 
             self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"] = lambda seq_len: self.matmul_config(
-                m=min(seq_len, self.prefill_len_cutoff),  # 512 if BH, 1024 if WH
+                m=min(seq_len, 1024),
                 k=self.dim // self.cluster_shape[0],
                 n=self.hidden_dim // self.cluster_shape[1],
                 grid_size=mlp1_3_grid(seq_len),
             )
             self.model_config["PREFILL_MLP_W2_PRG_CONFIG"] = lambda seq_len: self.matmul_config(
-                m=min(seq_len, self.prefill_len_cutoff),  # 512 if BH, 1024 if WH
+                m=min(seq_len, 1024),
                 k=self.hidden_dim // (self.cluster_shape[1] if self.is_galaxy else 1),
                 n=self.dim,
                 grid_size=mlp2_grid(seq_len),
@@ -1244,7 +1232,7 @@ class ModelArgs:
 
     def create_dram_sharded_mem_config(self, k, n):
         """Create DRAM-sharded memory config for width-sharded tensors"""
-        dram_cores = 8 if self.arch_name == "blackhole" else 12  # WH has 12 dram cores
+        dram_cores = 12
         padded_size = math.ceil(n / (self.tile_size * dram_cores)) * (self.tile_size * dram_cores)
         shard_spec = ttnn.ShardSpec(
             self.dram_weight_grid, (k, padded_size // dram_cores), ttnn.ShardOrientation.ROW_MAJOR
@@ -1332,7 +1320,6 @@ class ModelArgs:
         """
         max_rows = 8
         max_cols = 8
-        # TODO Improve configuration for BH (higher core grid than WH)
 
         # Find number of cols that evenly divides into the number of columns
         cols = None

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -2377,7 +2377,7 @@ def test_interleaved_2_sharded_DRAM(device, dtype, y):
     yt = ttnn.interleaved_to_sharded(xt, shard_grid, (y // 8, 18 * 32), shard_scheme, ttnn.ShardOrientation.ROW_MAJOR)
 
 
-@skip_for_grayskull()
+@run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "seq_len",
     (32,),
@@ -2423,30 +2423,19 @@ def test_llama_mlp_width_sharded_to_interleaved_pcc_err(device, seq_len, use_pro
         {
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(11, 0) if is_wormhole_b0() else ttnn.CoreCoord(7, 0),  # Blackhole coord
+                ttnn.CoreCoord(11, 0),
             ),
         }
     )
-    if is_wormhole_b0():
-        w1_w3_shard_spec = ttnn.ShardSpec(dram_core_range_set, (4096, 320), ttnn.ShardOrientation.ROW_MAJOR)
-    else:
-        assert is_blackhole()
-        w1_w3_shard_spec = ttnn.ShardSpec(dram_core_range_set, (4096, 448), ttnn.ShardOrientation.ROW_MAJOR)
     w1_w3_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.DRAM,
-        w1_w3_shard_spec,
+        ttnn.ShardSpec(dram_core_range_set, (4096, 320), ttnn.ShardOrientation.ROW_MAJOR),
     )
-
-    if is_wormhole_b0():
-        w2_shard_spec = ttnn.ShardSpec(dram_core_range_set, (3584, 352), ttnn.ShardOrientation.ROW_MAJOR)
-    else:
-        assert is_blackhole()
-        w2_shard_spec = ttnn.ShardSpec(dram_core_range_set, (3584, 512), ttnn.ShardOrientation.ROW_MAJOR)
     w2_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.DRAM,
-        w2_shard_spec,
+        ttnn.ShardSpec(dram_core_range_set, (3584, 352), ttnn.ShardOrientation.ROW_MAJOR),
     )
     pc_1 = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
         in0_block_w=4,


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#18697
deterministic errors in post-commit stemming from here
https://github.com/tenstorrent/tt-metal/pull/18697
Log attached
https://github.com/tenstorrent/tt-metal/actions/runs/13839854758/job/38724790632
https://github.com/tenstorrent/tt-metal/actions/runs/13839854758/job/38724790632
https://github.com/tenstorrent/tt-metal/actions/runs/13840286527/job/38726270066
Profiler-regression issue (edited) 

[#18697 Add initial support for Llama3-8B & 70B on BH](https://github.com/tenstorrent/tt-metal/pull/18697)