### PR TITLE
#0: [skip ci] Fix path to profiler-regression test reports

### DIFF
--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -128,7 +128,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           path: |
-            generated/test_reports/
+            /work/generated/test_reports/
           prefix: "test_reports_"
       - name: Cleanup
         if: always()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Tests are run inside the container, the path to the reports needs `/work` prefixed

### Checklist
- [ ] New/Existing tests provide coverage for changes