### PR TITLE
#18798: Convert EDM Ring support to use a global dateline to determine when to switch VCs

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -100,7 +100,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 7.84), (2, 7.48)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.78), (2, 6.65)])
 def test_fabric_edm_mcast_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -131,7 +131,7 @@ def test_fabric_edm_mcast_ring_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.76), (2, 5.9)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.72), (2, 5.87)])
 def test_fabric_edm_mcast_bw(
     num_mcasts,
     num_unicasts,
@@ -162,7 +162,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 8.67), (2, 7.9)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 8.60), (2, 7.78)])
 def test_fabric_edm_unicast_bw(
     num_mcasts,
     num_unicasts,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2036,7 +2036,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
         fabric_handle,
         enable_persistent_fabric,
         num_links);
-    log_info(tt::LogTest, "Lauching op");
+    log_info(tt::LogTest, "launching op");
 
     ttnn::global_semaphore::MultiDeviceGlobalSemaphore multi_device_global_semaphore =
         ttnn::global_semaphore::create_global_semaphore_with_same_address(
@@ -2054,6 +2054,112 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
         num_links,
         operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         ttnn::ccl::Topology::Linear,
+        SubDeviceId(0),
+        true);
+
+    // wait for op completion
+    wait_for_worker_subdevice_program_completion(devices, subdevice_managers);
+    log_info(tt::LogTest, "Main op done");
+
+    log_info(tt::LogTest, "Fabric teardown");
+    persistent_fabric_teardown_sequence(
+        devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
+
+    log_info(tt::LogTest, "Waiting for teardown completion");
+    for (auto d : devices) {
+        tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
+    }
+    log_info(tt::LogTest, "Finished");
+}
+
+void run_ring_all_gather_with_persistent_fabric(
+    const size_t dim, const size_t num_links, const ttnn::Shape& input_shape) {
+    log_info(tt::LogTest, "entering test");
+    constexpr auto layout = Layout::TILE;
+    // DEVICES setuip
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+    constexpr size_t test_expected_num_devices = 8;
+    if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
+        log_info("This test can only be run on T3000 devices");
+        return;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_info("Test must be run on WH");
+        return;
+    }
+    T3000TestDevice test_fixture;
+    auto view = test_fixture.mesh_device_->get_view();
+
+    // build a line of devices
+    std::vector<IDevice*> devices = {
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3)),
+        view.get_device(MeshCoordinate(1, 3)),
+        view.get_device(MeshCoordinate(1, 2)),
+        view.get_device(MeshCoordinate(1, 1)),
+        view.get_device(MeshCoordinate(1, 0))};
+    const size_t num_devices = devices.size();
+    TT_FATAL(
+        test_expected_num_devices == num_devices,
+        "Expected {} devices but got {}",
+        test_expected_num_devices,
+        num_devices);
+    const MemoryConfig in_memory_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::DRAM);
+    const auto num_elems = input_shape.volume();
+
+    // INPUT TENSOR setup
+    log_info(tt::LogTest, "setting up input tensors");
+    size_t page_size = tile_size(DataFormat::Float16);
+    std::vector<Tensor> device_input_tensors;
+    for (size_t i = 0; i < num_devices; i++) {
+        auto t = ttnn::experimental::view(ttnn::arange(0, num_elems, 1), input_shape).to_layout(layout);
+        t.set_tensor_spec(TensorSpec(
+            input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(layout, tt_metal::Tile()), in_memory_config)));
+
+        device_input_tensors.push_back(t.to_device(devices[i]));
+    }
+    // Need to make it a mesh tensor for use with the op
+    const Tensor input_mesh_tensor = ttnn::distributed::aggregate_as_tensor(device_input_tensors, AllGatherTensor{});
+
+    // FABRIC setup
+    const bool enable_persistent_fabric = true;
+
+    std::vector<Program> dummy_worker_programs;
+    std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
+    std::optional<std::vector<Program>> fabric_programs;
+    std::vector<Program*> fabric_program_ptrs;
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear;
+    setup_test_with_persistent_fabric(
+        devices,
+        dummy_worker_programs,
+        subdevice_managers,
+        fabric_programs,
+        fabric_program_ptrs,
+        fabric_handle,
+        enable_persistent_fabric,
+        num_links,
+        topology);
+    log_info(tt::LogTest, "launching op");
+
+    ttnn::global_semaphore::MultiDeviceGlobalSemaphore multi_device_global_semaphore =
+        ttnn::global_semaphore::create_global_semaphore_with_same_address(
+            test_fixture.mesh_device_.get(),
+            devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+            0,                             // initial value
+            tt::tt_metal::BufferType::L1,  // buffer type
+            10                             // attempts
+        );
+
+    auto output_tensor = ttnn::operations::experimental::ccl::all_gather_async(
+        input_mesh_tensor,
+        dim,
+        multi_device_global_semaphore,
+        num_links,
+        operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        topology,
         SubDeviceId(0),
         true);
 
@@ -2393,6 +2499,283 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
         auto d = devices[i];
         auto& program = fabric_programs.value()[i];
         tt_metal::DumpDeviceProfileResults(d, program);
+    }
+    log_info(tt::LogTest, "Finished");
+}
+
+void RunRingDeadlockStabilityTestWithPersistentFabric(
+    size_t num_mcasts,
+    size_t num_links,
+    size_t num_op_invocations,
+    bool has_forward_connection,
+    bool has_backward_connection,
+    size_t packet_payload_size_bytes = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes) {
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices != 8) {
+        log_info("This test can only be run on T3000 devices");
+        return;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_info("Test must be run on WH");
+        return;
+    }
+
+    using namespace ttnn::ccl;
+    auto topology = ttnn::ccl::Topology::Ring;
+    size_t num_unicasts = 0;
+    size_t line_size = num_devices;
+    size_t num_devices_with_workers = line_size;
+    bool line_sync = true;
+
+    auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
+
+    // static constexpr size_t source_l1_buffer_address = 1000000;
+    static constexpr uint32_t packet_header_cb_index = tt::CB::c_in0;
+    static constexpr uint32_t source_payload_cb_index = tt::CB::c_in1;
+    static constexpr size_t packet_header_cb_size_in_headers = 4;
+    static constexpr bool enable_persistent_fabric_mode = true;
+    size_t dest_buffer_size = packet_payload_size_bytes * 4;
+    static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
+
+    T3000TestDevice test_fixture;
+    auto view = test_fixture.mesh_device_->get_view();
+
+    std::vector<IDevice*> devices_ = {
+        view.get_device(MeshCoordinate(0, 0)),
+        view.get_device(MeshCoordinate(0, 1)),
+        view.get_device(MeshCoordinate(0, 2)),
+        view.get_device(MeshCoordinate(0, 3)),
+        view.get_device(MeshCoordinate(1, 3)),
+        view.get_device(MeshCoordinate(1, 2)),
+        view.get_device(MeshCoordinate(1, 1)),
+        view.get_device(MeshCoordinate(1, 0))};
+
+    std::vector<IDevice*> devices;
+    devices.reserve(line_size);
+    for (size_t i = 0; i < line_size; i++) {
+        devices.push_back(devices_[i]);
+    }
+    // build the mesh device
+
+    // Persistent Fabric Setup
+    std::vector<Program> dummy_worker_programs;
+    std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
+    std::optional<std::vector<Program>> fabric_programs;
+    std::vector<Program*> fabric_program_ptrs;
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
+    setup_test_with_persistent_fabric(
+        devices,
+        dummy_worker_programs,
+        subdevice_managers,
+        fabric_programs,
+        fabric_program_ptrs,
+        fabric_handle,
+        enable_persistent_fabric_mode,
+        num_links,
+        topology);
+
+    // Other boiler plate setup
+    CoreRangeSet worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_links - 1, 0)));
+    auto worker_cores_vec = corerange_to_cores(worker_cores, std::nullopt, false);
+    std::vector<CoreCoord> dest_core_coord;
+    dest_core_coord.reserve(num_links);
+    for (size_t l = 0; l < num_links; l++) {
+        dest_core_coord[l] = CoreCoord(0, l + 1);
+    }
+    auto sync_core_coord = CoreCoord(0, 0);
+
+    ttnn::SmallVector<std::shared_ptr<Buffer>> device_dest_buffers;
+    device_dest_buffers.reserve(line_size);
+    for (auto* d : devices) {
+        auto local_input_buffer =
+            CreateBuffer(InterleavedBufferConfig{d, dest_buffer_size, dest_buffer_size, BufferType::L1});
+        device_dest_buffers.push_back(local_input_buffer);
+    }
+
+    size_t dest_bank_addr = device_dest_buffers[0]->address();
+    TT_FATAL(
+        std::all_of(
+            device_dest_buffers.begin(),
+            device_dest_buffers.end(),
+            [dest_bank_addr](const auto& buffer) { return buffer->address() == dest_bank_addr; }),
+        "Test setup error: all destination buffers must have the same bank address across devices");
+
+    std::vector<tt::tt_metal::DeviceAddr> global_semaphore_addrs;
+    global_semaphore_addrs.reserve(line_size + 1);
+    std::vector<ttnn::global_semaphore::MultiDeviceGlobalSemaphore> global_semaphore_handles;
+    for (size_t i = 0; i < line_size * 4; i++) {
+        auto global_semaphores = ttnn::global_semaphore::create_global_semaphore_with_same_address(
+            test_fixture.mesh_device_.get(),
+            devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
+            0,                             // initial value
+            tt::tt_metal::BufferType::L1,  // buffer type
+            1000                           // attempts
+        );
+        global_semaphore_handles.push_back(global_semaphores);
+        auto global_semaphore_addr =
+            ttnn::global_semaphore::get_global_semaphore_address(global_semaphores.global_semaphores.at(0));
+        global_semaphore_addrs.push_back(global_semaphore_addr);
+    }
+
+    std::vector<IDevice*> worker_devices;
+    for (size_t i = 0; i < num_devices_with_workers; i++) {
+        worker_devices.push_back(devices[i]);
+    }
+    // Worker program setup
+    std::vector<Program> programs(num_devices_with_workers);
+    TT_FATAL(
+        programs.size() == worker_devices.size(),
+        "Test misconfiguration. Mismatch in line size and devices. Expected line size of {} but got {} devices "
+        "instead.",
+        line_size,
+        worker_devices.size());
+    std::vector<KernelHandle> worker_kernel_ids;
+    std::vector<size_t> per_device_global_sem_addr_rt_arg;
+    for (size_t i = 0; i < num_devices_with_workers; i++) {
+        const size_t line_index = i;
+        auto& program = programs[i];
+        auto* device = devices[i];
+        const size_t sync_core_noc_x = device->worker_core_from_logical_core(sync_core_coord).x;
+        const size_t sync_core_noc_y = device->worker_core_from_logical_core(sync_core_coord).y;
+
+        IDevice* backward_device;
+        IDevice* forward_device;
+        bool unicast_forward;
+        size_t mcast_fwd_hops;
+        size_t mcast_bwd_hops;
+        size_t unicast_hops;
+
+        backward_device = i == 0 ? devices.back() : devices[i - 1];
+        forward_device = i == line_size - 1 ? devices.front() : devices[i + 1];
+
+        // Initialize the fabric handle for worker connection
+        unicast_forward = false;
+        mcast_fwd_hops = line_size - 1;
+        mcast_bwd_hops = line_size - 1;
+        unicast_hops = mcast_fwd_hops;
+
+        auto local_device_fabric_handle =
+            ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+                device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links, topology);
+
+        // reserve CB
+        tt_metal::CircularBufferConfig cb_src0_config =
+            tt_metal::CircularBufferConfig(
+                packet_header_cb_size_in_headers * sizeof(tt::tt_fabric::PacketHeader),
+                {{packet_header_cb_index, cb_df}})
+                .set_page_size(packet_header_cb_index, sizeof(tt::tt_fabric::PacketHeader));
+        CBHandle sender_workers_cb = CreateCircularBuffer(program, worker_cores, cb_src0_config);
+
+        tt_metal::CircularBufferConfig cb_src1_config =
+            tt_metal::CircularBufferConfig(packet_payload_size_bytes, {{source_payload_cb_index, cb_df}})
+                .set_page_size(source_payload_cb_index, packet_payload_size_bytes);
+        CBHandle sender_workers_payload_cb = CreateCircularBuffer(program, worker_cores, cb_src1_config);
+
+        TT_FATAL(
+            local_device_fabric_handle.get_num_links() == num_links,
+            "Error in test setup. Expected two links between devices but got {} links for device {}",
+            local_device_fabric_handle.get_num_links(),
+            device->id());
+
+        std::vector<uint32_t> worker_ct_args = {line_sync, line_sync};
+
+        auto worker_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp",
+            worker_cores,
+            tt_metal::WriterDataMovementConfig(worker_ct_args));
+        worker_kernel_ids.push_back(worker_kernel_id);
+        for (size_t l = 0; l < num_links; l++) {
+            auto worker_core = worker_cores_vec[l];
+            const size_t dest_noc_x = device->worker_core_from_logical_core(dest_core_coord[l]).x;
+            const size_t dest_noc_y = device->worker_core_from_logical_core(dest_core_coord[l]).y;
+            auto build_connection_args = [&local_device_fabric_handle, device, &program, &worker_core](
+                                             bool is_connected_in_direction,
+                                             ttnn::ccl::EdmLineFabricOpInterface::Direction direction,
+                                             std::vector<uint32_t>& rt_args_out) {
+                rt_args_out.push_back(is_connected_in_direction);
+                if (is_connected_in_direction) {
+                    const auto connection = local_device_fabric_handle.uniquely_connect_worker(device, direction);
+                    const auto new_rt_args =
+                        ttnn::ccl::worker_detail::generate_edm_connection_rt_args(connection, program, {worker_core});
+                    log_info(
+                        tt::LogTest,
+                        "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
+                        device->id(),
+                        direction,
+                        connection.edm_noc_x,
+                        connection.edm_noc_y);
+                    std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args_out));
+                }
+            };
+            // RT ARGS
+            std::vector<uint32_t> rt_args = {
+                dest_bank_addr,
+                packet_payload_size_bytes,
+                dest_noc_x,
+                dest_noc_y,
+
+                num_mcasts,
+                mcast_fwd_hops,
+                mcast_bwd_hops,
+
+                num_unicasts,
+                unicast_hops,
+                unicast_forward,
+
+                source_payload_cb_index,  // source_l1_buffer_address,
+                packet_header_cb_index,
+                packet_header_cb_size_in_headers,
+            };
+
+            build_connection_args(has_forward_connection, ttnn::ccl::EdmLineFabricOpInterface::FORWARD, rt_args);
+            build_connection_args(has_backward_connection, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD, rt_args);
+
+            if (line_sync) {
+                rt_args.push_back(sync_core_noc_x);
+                rt_args.push_back(sync_core_noc_y);
+                if (l == 0) {
+                    per_device_global_sem_addr_rt_arg.push_back(rt_args.size());
+                }
+                TT_FATAL(global_semaphore_addrs.at(0) != -1, "Invalid test setup. Global semaphore address is -1");
+                rt_args.push_back(global_semaphore_addrs.at(0));
+                rt_args.push_back(num_links * num_devices_with_workers);
+            }
+
+            tt_metal::SetRuntimeArgs(program, worker_kernel_id, worker_core, rt_args);
+        }
+    }
+
+    for (size_t i = 0; i < num_op_invocations; i++) {
+        log_info(tt::LogTest, "Iteration: {}", i);
+        if (i != 0 && line_sync) {
+            for (size_t k = 0; k < worker_kernel_ids.size(); k++) {
+                auto& worker_rt_args_by_core = GetRuntimeArgs(programs[k], worker_kernel_ids[k]);
+                auto global_sem_addr_rt_arg_idx = per_device_global_sem_addr_rt_arg[k];
+                for (size_t l = 0; l < num_links; l++) {
+                    auto& worker_rt_args = worker_rt_args_by_core[worker_cores_vec[l].x][worker_cores_vec[l].y];
+                    worker_rt_args.at(global_sem_addr_rt_arg_idx) =
+                        global_semaphore_addrs[i % global_semaphore_addrs.size()];
+                }
+            }
+        }
+
+        build_and_enqueue(worker_devices, programs, i != 0);
+
+        log_info(tt::LogTest, "Waiting for Op finish on all devices");
+        wait_for_worker_subdevice_program_completion(worker_devices, subdevice_managers);
+        log_info(tt::LogTest, "Main op done");
+    }
+
+    TT_FATAL(fabric_programs->size() == devices.size(), "Expected fabric programs size to be same as devices size");
+    log_info(tt::LogTest, "Fabric teardown");
+    persistent_fabric_teardown_sequence(
+        devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
+
+    log_info(tt::LogTest, "Waiting for teardown completion");
+    for (IDevice* d : devices) {
+        tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
     }
     log_info(tt::LogTest, "Finished");
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -920,6 +920,10 @@ TEST(CclAsyncOp, DISABLED_AllGather_PersistentFabric_Dim3_Links2_Shape1_1_32_819
     run_all_gather_with_persistent_fabric(3, 2, ttnn::Shape({1, 1, 32, 8192}));
 }
 
+TEST(CclAsyncOp, RingAllGather_PersistentFabric_Dim3_Links1_Shape1_256_32_8192) {
+    run_ring_all_gather_with_persistent_fabric(3, 1, ttnn::Shape({1, 256, 32, 8192}));
+}
+
 TEST(EdmFabric, BasicMcastThroughputTest_SingleLink_LineSize2_SingleMcast) {
     const size_t num_mcasts = 1;
     const size_t num_unicasts = 2;
@@ -1461,4 +1465,17 @@ TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
     params.line_sync = line_sync;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params);
+}
+
+TEST(EdmFabric, RingDeadlockStabilityTest) {
+    const size_t num_mcasts = 200000;
+    const size_t num_links = 1;
+    const size_t num_op_invocations = 5;
+    const bool line_sync = true;
+    log_trace(tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only");
+    RunRingDeadlockStabilityTestWithPersistentFabric(num_mcasts, num_links, num_op_invocations, true, false);
+    log_trace(tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only");
+    RunRingDeadlockStabilityTestWithPersistentFabric(num_mcasts, num_links, num_op_invocations, false, true);
+    log_trace(tt::LogTest, "Running RingDeadlockStabilityTest with forward and backward mcast");
+    RunRingDeadlockStabilityTestWithPersistentFabric(num_mcasts, num_links, num_op_invocations, true, true);
 }

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -171,7 +171,8 @@ public:
 
         const FabricEriscDatamoverConfig& config,
         bool enable_persistent_mode,
-        bool build_in_worker_connection_mode = false);
+        bool build_in_worker_connection_mode = false,
+        bool dateline_connection = false);
 
     static FabricEriscDatamoverBuilder build(
         tt::tt_metal::IDevice* device,
@@ -181,7 +182,8 @@ public:
         chip_id_t peer_chip_id,
         const FabricEriscDatamoverConfig& config,
         bool enable_persistent_mode,
-        bool build_in_worker_connection_mode = false);
+        bool build_in_worker_connection_mode = false,
+        bool dateline_connection = false);
 
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_worker_channel() const;
     [[nodiscard]] SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t vc) const;
@@ -251,6 +253,7 @@ public:
     size_t firmware_context_switch_interval = default_firmware_context_switch_interval;
     bool enable_first_level_ack = false;
     bool fuse_receiver_flush_and_completion_ptr = true;
+    bool dateline_connection = false;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -361,7 +361,8 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
 
     const FabricEriscDatamoverConfig& config,
     bool enable_persistent_mode,
-    bool build_in_worker_connection_mode) :
+    bool build_in_worker_connection_mode,
+    bool dateline_connection) :
     my_eth_core_logical(my_eth_core_logical),
     my_noc_x(my_noc_x),
     my_noc_y(my_noc_y),
@@ -389,7 +390,8 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     termination_signal_ptr(config.termination_signal_address),
     edm_status_ptr(config.edm_status_address),
     enable_persistent_mode(enable_persistent_mode),
-    build_in_worker_connection_mode(build_in_worker_connection_mode) {}
+    build_in_worker_connection_mode(build_in_worker_connection_mode),
+    dateline_connection(dateline_connection) {}
 
 std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const {
     const bool is_handshake_master = this->my_chip_id < this->peer_chip_id;
@@ -414,6 +416,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         this->enable_first_level_ack,
         this->fuse_receiver_flush_and_completion_ptr,
         config.topology == Topology::Ring,
+        this->dateline_connection,
         is_handshake_master,
         this->handshake_address,
         this->channel_buffer_size,
@@ -510,7 +513,8 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     chip_id_t peer_chip_id,
     const FabricEriscDatamoverConfig& config,
     bool enable_persistent_mode,
-    bool build_in_worker_connection_mode) {
+    bool build_in_worker_connection_mode,
+    bool dateline_connection) {
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_buffer_index_semaphore_id;
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_flow_control_semaphore_id;
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> sender_channels_connection_semaphore_id;
@@ -565,7 +569,8 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
 
             config,
             enable_persistent_mode,
-            build_in_worker_connection_mode);
+            build_in_worker_connection_mode,
+            dateline_connection);
 
     } else {
         for (uint32_t i = 0; i < FabricEriscDatamoverConfig::num_receiver_channels; i++) {
@@ -598,7 +603,8 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
             sender_channels_buffer_index_semaphore_id,
 
             config,
-            enable_persistent_mode);
+            enable_persistent_mode,
+            dateline_connection);
     }
 }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -389,14 +389,6 @@ FORCE_INLINE void init_ptr_val(int32_t val) {
     NOC_STREAM_WRITE_REG(stream_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, val);
 }
 
-// not in symbol table - because not used
-constexpr std::array<uint32_t, 3> to_sender_packets_acked_streams = {
-    {to_sender_0_pkts_acked_id, to_sender_1_pkts_acked_id, to_sender_2_pkts_acked_id}};
-
-// data section
-constexpr std::array<uint32_t, 3> to_sender_packets_completed_streams = {
-    {to_sender_0_pkts_completed_id, to_sender_1_pkts_completed_id, to_sender_2_pkts_completed_id}};
-
 /*
  * Tracks receiver channel pointers (from sender side)
  */
@@ -509,12 +501,19 @@ static constexpr uint32_t SWITCH_INTERVAL =
 static constexpr bool enable_first_level_ack = get_compile_time_arg_val(1);
 static constexpr bool fuse_receiver_flush_and_completion_ptr = get_compile_time_arg_val(2);
 static constexpr bool enable_ring_support = get_compile_time_arg_val(3);
+static constexpr bool dateline_connection = get_compile_time_arg_val(4);
 
 static constexpr size_t ETH_BYTES_TO_WORDS_SHIFT = 4;
 static constexpr size_t NUM_SENDER_CHANNELS = 3;
 static constexpr size_t NUM_RECEIVER_CHANNELS = 2;
 // TODO: Pipe from host
-static constexpr size_t NUM_VCS = enable_ring_support ? NUM_RECEIVER_CHANNELS : NUM_RECEIVER_CHANNELS - 1;
+static constexpr size_t NUM_USED_SENDER_CHANNELS = enable_ring_support ? NUM_SENDER_CHANNELS : NUM_SENDER_CHANNELS - 1;
+static constexpr size_t NUM_USED_RECEIVER_CHANNELS =
+    enable_ring_support ? NUM_RECEIVER_CHANNELS : NUM_RECEIVER_CHANNELS - 1;
+static constexpr size_t VC0_RECEIVER_CHANNEL = dateline_connection ? 1 : 0;
+// On a dateline connection, we would never forward through the dateline on VC1
+static constexpr size_t VC1_RECEIVER_CHANNEL = 1;
+
 static constexpr size_t num_workers_ctor = 1;
 static constexpr size_t num_messages_to_move_ctor_value = 1;
 // Doesn't REALLY matter but for consistency I picked the next available ID
@@ -525,6 +524,17 @@ static constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 // did_something=true (i.e. no progress was made), then we allow for context switch in case
 // the link is down
 bool did_something;
+
+static constexpr std::array<uint32_t, NUM_RECEIVER_CHANNELS> to_receiver_packets_sent_streams = {
+    to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id};
+
+// not in symbol table - because not used
+static constexpr std::array<uint32_t, NUM_SENDER_CHANNELS> to_sender_packets_acked_streams = {
+    {to_sender_0_pkts_acked_id, to_sender_1_pkts_acked_id, to_sender_2_pkts_acked_id}};
+
+// data section
+static constexpr std::array<uint32_t, NUM_SENDER_CHANNELS> to_sender_packets_completed_streams = {
+    {to_sender_0_pkts_completed_id, to_sender_1_pkts_completed_id, to_sender_2_pkts_completed_id}};
 
 /////////////////////////////////////////////
 //   SENDER SIDE HELPERS
@@ -615,14 +625,6 @@ FORCE_INLINE void receiver_send_completion_ack(
     remote_sender_completion_ptr.increment();
 }
 
-uint32_t extract_vc(ROUTING_FIELDS_TYPE cached_routing_fields) {
-    if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::RoutingFields>) {
-        return 0;  // TODO: Add support for VC in RoutingFields
-    } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::LowLatencyRoutingFields>) {
-        return (cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::VC_FIELD_MASK) != 0;
-    }
-}
-
 template <uint8_t SENDER_NUM_BUFFERS>
 FORCE_INLINE bool can_forward_packet_completely(
     ROUTING_FIELDS_TYPE cached_routing_fields,
@@ -633,9 +635,8 @@ FORCE_INLINE bool can_forward_packet_completely(
     if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::RoutingFields>) {
         deliver_locally_only = cached_routing_fields.value == tt::tt_fabric::RoutingFields::LAST_MCAST_VAL;
     } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::LowLatencyRoutingFields>) {
-        deliver_locally_only =
-            (cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::PATH_ROUTING_FIELD_MASK) ==
-            tt::tt_fabric::LowLatencyRoutingFields::WRITE_ONLY;
+        deliver_locally_only = (cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::FIELD_MASK) ==
+                               tt::tt_fabric::LowLatencyRoutingFields::WRITE_ONLY;
     }
     return deliver_locally_only || downstream_edm_interface.edm_has_space_for_packet();
 }
@@ -663,8 +664,7 @@ FORCE_INLINE void receiver_forward_packet(
             execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id);
         }
     } else if constexpr (std::is_same_v<ROUTING_FIELDS_TYPE, tt::tt_fabric::LowLatencyRoutingFields>) {
-        uint32_t routing =
-            cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::PATH_ROUTING_FIELD_MASK;
+        uint32_t routing = cached_routing_fields.value & tt::tt_fabric::LowLatencyRoutingFields::FIELD_MASK;
         uint16_t payload_size_bytes = packet_start->payload_size_bytes;
         switch (routing) {
             case tt::tt_fabric::LowLatencyRoutingFields::WRITE_ONLY:
@@ -825,7 +825,7 @@ template <
 FORCE_INLINE void run_receiver_channel_step(
     tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>& local_receiver_channel,
     std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_sender_channels,
-    std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_VCS>& downstream_edm_interfaces,
+    tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>& downstream_edm_interface,
     volatile tt::tt_fabric::EdmFabricReceiverChannelCounters* receiver_channel_counters_ptr,
     std::array<tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_eth_sender_wrptrs,
     ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>& receiver_channel_pointers,
@@ -857,13 +857,6 @@ FORCE_INLINE void run_receiver_channel_step(
             local_receiver_channel.template get_packet_header<PACKET_HEADER_TYPE>(receiver_buffer_index);
 
         ROUTING_FIELDS_TYPE cached_routing_fields = const_cast<PACKET_HEADER_TYPE*>(packet_header)->routing_fields;
-        uint32_t vc;
-        if constexpr (enable_ring_support) {
-            vc = extract_vc(cached_routing_fields);
-        } else {
-            vc = 0;
-        }
-        auto& downstream_edm_interface = downstream_edm_interfaces[vc];
         bool can_send_to_all_local_chip_receivers =
             can_forward_packet_completely(cached_routing_fields, downstream_edm_interface);
         bool trid_flushed = receiver_channel_trid_tracker.transaction_flushed(receiver_buffer_index);
@@ -939,20 +932,36 @@ bool all_channels_drained(
     std::array<tt::tt_fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>&
         local_sender_channel_worker_interfaces,
     std::array<ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS>& receiver_channel_pointers) {
-    bool eth_buffers_drained =
-        local_sender_channel_worker_interfaces[0].all_eth_packets_completed() &&
-        local_sender_channel_worker_interfaces[1].all_eth_packets_completed() &&
-        local_sender_channel_worker_interfaces[2].all_eth_packets_completed() &&
-        !local_sender_channel_worker_interfaces[0].has_unsent_payload() &&
-        !local_sender_channel_worker_interfaces[1].has_unsent_payload() &&
-        !local_sender_channel_worker_interfaces[2].has_unsent_payload() &&
-        receiver_channel_pointers[0].completion_ptr.is_caught_up_to(receiver_channel_pointers[0].ack_ptr) &&
-        receiver_channel_pointers[1].completion_ptr.is_caught_up_to(receiver_channel_pointers[1].ack_ptr) &&
-        get_ptr_val<to_receiver_0_pkts_sent_id>() == 0 && get_ptr_val<to_receiver_1_pkts_sent_id>() == 0 &&
-        get_ptr_val<to_sender_0_pkts_acked_id>() == 0 && get_ptr_val<to_sender_1_pkts_acked_id>() == 0 &&
-        get_ptr_val<to_sender_2_pkts_acked_id>() == 0 && get_ptr_val<to_sender_0_pkts_completed_id>() == 0 &&
-        get_ptr_val<to_sender_1_pkts_completed_id>() == 0 && get_ptr_val<to_sender_2_pkts_completed_id>() == 0;
-
+    bool eth_buffers_drained = local_sender_channel_worker_interfaces[0].all_eth_packets_completed() &&
+                               local_sender_channel_worker_interfaces[1].all_eth_packets_completed() &&
+                               !local_sender_channel_worker_interfaces[0].has_unsent_payload() &&
+                               !local_sender_channel_worker_interfaces[1].has_unsent_payload() &&
+                               get_ptr_val<to_sender_packets_acked_streams[0]>() == 0 &&
+                               get_ptr_val<to_sender_packets_acked_streams[1]>() == 0 &&
+                               get_ptr_val<to_sender_packets_completed_streams[0]>() == 0 &&
+                               get_ptr_val<to_sender_packets_completed_streams[1]>() == 0;
+    // Reeiver 0 enabled
+    if constexpr (!dateline_connection) {
+        eth_buffers_drained =
+            eth_buffers_drained &&
+            (get_ptr_val<to_receiver_packets_sent_streams[0]>() == 0 &&
+             receiver_channel_pointers[0].completion_ptr.is_caught_up_to(receiver_channel_pointers[0].ack_ptr));
+    }
+    // Receiver 1 enabled
+    if constexpr (enable_ring_support) {
+        eth_buffers_drained =
+            eth_buffers_drained &&
+            (get_ptr_val<to_receiver_packets_sent_streams[1]>() == 0 &&
+             receiver_channel_pointers[1].completion_ptr.is_caught_up_to(receiver_channel_pointers[1].ack_ptr));
+    }
+    // Sender 2 enabled
+    if constexpr (enable_ring_support && !dateline_connection) {
+        eth_buffers_drained =
+            eth_buffers_drained && (local_sender_channel_worker_interfaces[2].all_eth_packets_completed() &&
+                                    !local_sender_channel_worker_interfaces[2].has_unsent_payload() &&
+                                    get_ptr_val<to_sender_packets_acked_streams[2]>() == 0 &&
+                                    get_ptr_val<to_sender_packets_completed_streams[2]>() == 0);
+    }
     return eth_buffers_drained;
 }
 
@@ -974,7 +983,8 @@ void run_fabric_edm_main_loop(
     std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& local_sender_channels,
     std::array<tt::tt_fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>&
         local_sender_channel_worker_interfaces,
-    std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_VCS>& downstream_edm_noc_interfaces,
+    std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_USED_RECEIVER_CHANNELS>&
+        downstream_edm_noc_interfaces,
     std::array<tt::tt_fabric::EthChannelBuffer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS>& remote_sender_channels,
     std::array<tt::tt_fabric::EthChannelBuffer<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS>& remote_receiver_channels,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
@@ -998,10 +1008,7 @@ void run_fabric_edm_main_loop(
     //       (probably better) pack most of these into single words (e.g. we could hold a read, write, and ackptr in a
     //       single word) this way - especially if power of 2 wraps, we can handle both channels literally at once with
     //       math ops on single individual words (or half words)
-    std::array<tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> remote_eth_sender_wrptrs{
-        tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>(),
-        tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>(),
-        tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>()};
+    std::array<tt::tt_fabric::ChannelBufferPointer<SENDER_NUM_BUFFERS>, NUM_SENDER_CHANNELS> remote_eth_sender_wrptrs;
     std::array<OutboundReceiverChannelPointers<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS>
         outbound_to_receiver_channel_pointers;
     std::array<ReceiverChannelPointers<RECEIVER_NUM_BUFFERS>, NUM_RECEIVER_CHANNELS> receiver_channel_pointers;
@@ -1041,30 +1048,32 @@ void run_fabric_edm_main_loop(
                 enable_fabric_counters,
                 RECEIVER_NUM_BUFFERS,
                 SENDER_NUM_BUFFERS,
-                to_receiver_0_pkts_sent_id>(
+                to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL]>(
                 local_sender_channels[0],
                 local_sender_channel_worker_interfaces[0],
-                outbound_to_receiver_channel_pointers[0],  // Low VC
-                remote_receiver_channels[0],
+                outbound_to_receiver_channel_pointers[VC0_RECEIVER_CHANNEL],
+                remote_receiver_channels[VC0_RECEIVER_CHANNEL],
                 sender_channel_counters_ptrs[0],
                 sender_channel_packet_recorders[0],
                 channel_connection_established[0],
                 0);
-            run_receiver_channel_step<
-                enable_packet_header_recording,
-                enable_fabric_counters,
-                RECEIVER_NUM_BUFFERS,
-                SENDER_NUM_BUFFERS,
-                NUM_SENDER_CHANNELS,
-                to_receiver_0_pkts_sent_id>(
-                local_receiver_channels[0],
-                remote_sender_channels,
-                downstream_edm_noc_interfaces,
-                receiver_channel_counters_ptrs[0],
-                remote_eth_sender_wrptrs,
-                receiver_channel_pointers[0],
-                receiver_channel_packet_recorders[0],
-                receiver_channel_0_trid_tracker);
+            if constexpr (!dateline_connection) {
+                run_receiver_channel_step<
+                    enable_packet_header_recording,
+                    enable_fabric_counters,
+                    RECEIVER_NUM_BUFFERS,
+                    SENDER_NUM_BUFFERS,
+                    NUM_SENDER_CHANNELS,
+                    to_receiver_packets_sent_streams[0]>(
+                    local_receiver_channels[0],
+                    remote_sender_channels,
+                    downstream_edm_noc_interfaces[0],
+                    receiver_channel_counters_ptrs[0],
+                    remote_eth_sender_wrptrs,
+                    receiver_channel_pointers[0],
+                    receiver_channel_packet_recorders[0],
+                    receiver_channel_0_trid_tracker);
+            }
             if constexpr (enable_ring_support) {
                 run_receiver_channel_step<
                     enable_packet_header_recording,
@@ -1072,10 +1081,10 @@ void run_fabric_edm_main_loop(
                     RECEIVER_NUM_BUFFERS,
                     SENDER_NUM_BUFFERS,
                     NUM_SENDER_CHANNELS,
-                    to_receiver_1_pkts_sent_id>(
-                    local_receiver_channels[1],
+                    to_receiver_packets_sent_streams[1]>(
+                    local_receiver_channels[VC1_RECEIVER_CHANNEL],
                     remote_sender_channels,
-                    downstream_edm_noc_interfaces,
+                    downstream_edm_noc_interfaces[1],
                     receiver_channel_counters_ptrs[1],
                     remote_eth_sender_wrptrs,
                     receiver_channel_pointers[1],
@@ -1088,26 +1097,26 @@ void run_fabric_edm_main_loop(
                 enable_fabric_counters,
                 RECEIVER_NUM_BUFFERS,
                 SENDER_NUM_BUFFERS,
-                to_receiver_0_pkts_sent_id>(
+                to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL]>(
                 local_sender_channels[1],
                 local_sender_channel_worker_interfaces[1],
-                outbound_to_receiver_channel_pointers[0],  // Low VC
-                remote_receiver_channels[0],
+                outbound_to_receiver_channel_pointers[VC0_RECEIVER_CHANNEL],
+                remote_receiver_channels[VC0_RECEIVER_CHANNEL],
                 sender_channel_counters_ptrs[1],
                 sender_channel_packet_recorders[1],
                 channel_connection_established[1],
                 1);
-            if constexpr (enable_ring_support) {
+            if constexpr (enable_ring_support && !dateline_connection) {
                 run_sender_channel_step<
                     enable_packet_header_recording,
                     enable_fabric_counters,
                     RECEIVER_NUM_BUFFERS,
                     SENDER_NUM_BUFFERS,
-                    to_receiver_1_pkts_sent_id>(
+                    to_receiver_packets_sent_streams[VC1_RECEIVER_CHANNEL]>(
                     local_sender_channels[2],
                     local_sender_channel_worker_interfaces[2],
-                    outbound_to_receiver_channel_pointers[1],  // High VC
-                    remote_receiver_channels[1],
+                    outbound_to_receiver_channel_pointers[VC1_RECEIVER_CHANNEL],
+                    remote_receiver_channels[VC1_RECEIVER_CHANNEL],
                     sender_channel_counters_ptrs[2],
                     sender_channel_packet_recorders[2],
                     channel_connection_established[2],
@@ -1182,22 +1191,22 @@ void kernel_main() {
     //
     // COMMON CT ARGS (not specific to sender or receiver)
     //
-    static constexpr bool is_handshake_sender = get_compile_time_arg_val(4) != 0;
-    static constexpr size_t handshake_addr = get_compile_time_arg_val(5);
+    static constexpr bool is_handshake_sender = get_compile_time_arg_val(5) != 0;
+    static constexpr size_t handshake_addr = get_compile_time_arg_val(6);
     *reinterpret_cast<volatile uint32_t*>(handshake_addr) = 0;
     auto eth_transaction_ack_word_addr = handshake_addr + sizeof(eth_channel_sync_t);
 
     // Initialize stream register state for credit management across the Ethernet link.
     // We make sure to do this before we handshake to guarantee that the registers are
     // initialized before the other side has any possibility of modifying them.
-    init_ptr_val<to_receiver_0_pkts_sent_id>(0);
-    init_ptr_val<to_receiver_1_pkts_sent_id>(0);
-    init_ptr_val<to_sender_0_pkts_acked_id>(0);
-    init_ptr_val<to_sender_1_pkts_acked_id>(0);
-    init_ptr_val<to_sender_2_pkts_acked_id>(0);
-    init_ptr_val<to_sender_0_pkts_completed_id>(0);
-    init_ptr_val<to_sender_1_pkts_completed_id>(0);
-    init_ptr_val<to_sender_2_pkts_completed_id>(0);
+    init_ptr_val<to_receiver_packets_sent_streams[0]>(0);
+    init_ptr_val<to_receiver_packets_sent_streams[1]>(0);
+    init_ptr_val<to_sender_packets_acked_streams[0]>(0);
+    init_ptr_val<to_sender_packets_acked_streams[1]>(0);
+    init_ptr_val<to_sender_packets_acked_streams[2]>(0);
+    init_ptr_val<to_sender_packets_completed_streams[0]>(0);
+    init_ptr_val<to_sender_packets_completed_streams[1]>(0);
+    init_ptr_val<to_sender_packets_completed_streams[2]>(0);
 
     static constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
     if constexpr (is_handshake_sender) {
@@ -1209,23 +1218,23 @@ void kernel_main() {
     // the size of one of the buffers within a sender channel
     // For example if `channel_buffer_size` = 4k, with `SENDER_NUM_BUFFERS` = 2
     // then the total amount of buffering for that
-    static constexpr size_t channel_buffer_size = get_compile_time_arg_val(6);
+    static constexpr size_t channel_buffer_size = get_compile_time_arg_val(7);
 
-    static constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(7);
-    static constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(8);
-    static constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(9);
-    static constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(10);
-    static constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(11);
-    static constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(12);
-    static constexpr size_t local_sender_2_channel_address = get_compile_time_arg_val(13);
-    static constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(14);
-    static constexpr size_t local_receiver_0_channel_buffer_address = get_compile_time_arg_val(15);
-    static constexpr size_t remote_receiver_0_channel_buffer_address = get_compile_time_arg_val(16);
-    static constexpr size_t local_receiver_1_channel_buffer_address = get_compile_time_arg_val(17);
-    static constexpr size_t remote_receiver_1_channel_buffer_address = get_compile_time_arg_val(18);
-    static constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(19);
-    static constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(20);
-    static constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(21);
+    static constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(8);
+    static constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(9);
+    static constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(10);
+    static constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(11);
+    static constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(12);
+    static constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(13);
+    static constexpr size_t local_sender_2_channel_address = get_compile_time_arg_val(14);
+    static constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(15);
+    static constexpr size_t local_receiver_0_channel_buffer_address = get_compile_time_arg_val(16);
+    static constexpr size_t remote_receiver_0_channel_buffer_address = get_compile_time_arg_val(17);
+    static constexpr size_t local_receiver_1_channel_buffer_address = get_compile_time_arg_val(18);
+    static constexpr size_t remote_receiver_1_channel_buffer_address = get_compile_time_arg_val(19);
+    static constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(20);
+    static constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(21);
+    static constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(22);
 
     DPRINT << "SENDER_NUM_BUFFERS: " << (uint32_t)SENDER_NUM_BUFFERS << "\n";
     DPRINT << "RECEIVER_NUM_BUFFERS: " << (uint32_t)RECEIVER_NUM_BUFFERS << "\n";
@@ -1250,33 +1259,33 @@ void kernel_main() {
 
     // TODO: CONVERT TO SEMAPHORE
     volatile auto termination_signal_ptr =
-        reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(get_compile_time_arg_val(22));
+        reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(get_compile_time_arg_val(23));
     volatile auto edm_status_ptr =
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::EDMStatus*>(get_compile_time_arg_val(23));
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::EDMStatus*>(get_compile_time_arg_val(24));
     // In persistent mode, we must rely on static addresses for our local semaphores that are locally
     // initialized, rather than metal device APIs. This way different subdevice programs can reliably
     // resolve the semaphore addresses on the EDM core
-    static constexpr bool persistent_mode = get_compile_time_arg_val(24) != 0;
+    static constexpr bool persistent_mode = get_compile_time_arg_val(25) != 0;
 
     // Per-channel counters
-    static constexpr bool enable_fabric_counters = get_compile_time_arg_val(25) != 0;
-    static constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(26);
-    static constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(27);
-    static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(28);
-    static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(29);
-    static constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(30);
+    static constexpr bool enable_fabric_counters = get_compile_time_arg_val(26) != 0;
+    static constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(27);
+    static constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(28);
+    static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(29);
+    static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(30);
+    static constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(31);
 
-    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(31) != 0;
-    static constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(32);
-    static constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(33);
-    static constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(34);
-    static constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(35);
-    static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(36);
-    static constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(37);
-    static constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(38);
-    static constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(39);
-    static constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(40);
-    static constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(41);
+    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(32) != 0;
+    static constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(33);
+    static constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(34);
+    static constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(35);
+    static constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(36);
+    static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(37);
+    static constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(38);
+    static constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(39);
+    static constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(40);
+    static constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(41);
+    static constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(42);
 
     std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS> sender_channel_packet_recorders{
         PacketHeaderRecorder(
@@ -1437,7 +1446,8 @@ void kernel_main() {
         connection_worker_info_ptr->edm_rdptr = 0;
     }
 
-    std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_VCS> downstream_edm_noc_interfaces;
+    std::array<tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>, NUM_USED_RECEIVER_CHANNELS>
+        downstream_edm_noc_interfaces;
     if (has_downstream_edm_vc0_buffer_connection) {
         new (&downstream_edm_noc_interfaces[0]) tt::tt_fabric::EdmToEdmSender<SENDER_NUM_BUFFERS>(
             // persistent_mode -> hardcode to false because for EDM -> EDM


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18798

### Problem description
The original dynamic dateline algorithm does not prevent deadlock with rings 😞 

### What's changed
Switch to a global dateline to determine when to switch to a different VC to avoid deadlock.

For ring 1/2 links, mcast perf is lower than the faulty algorithm:
7.84B/c->6.78B/c, 7.48B/c->6.65B/c

There's been some minor perf regression in line with these changes, but unclear the root cause(s). Could be due to code shuffling. This will be investigated as follow up.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13845479303
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
T3K unit: https://github.com/tenstorrent/tt-metal/actions/runs/13863130725
Microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/13863127657