### PR TITLE
[1D fabric] Update local handshake sequence

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -115,7 +115,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.66), (4, 2, 6.62)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.88), (4, 2, 6.85)])
 def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -35,10 +35,11 @@ struct FabricEriscDatamoverConfig {
 
     // Global
     static constexpr std::size_t eth_channel_sync_size = 16;
-    std::size_t handshake_addr;
-    std::size_t edm_channel_ack_addr;
-    std::size_t termination_signal_address;  // pad extra bytes to match old EDM so handshake logic will still work
-    std::size_t edm_status_address;
+    std::size_t handshake_addr = 0;
+    std::size_t edm_channel_ack_addr = 0;
+    std::size_t termination_signal_address = 0;  // pad extra bytes to match old EDM so handshake logic will still work
+    std::size_t edm_local_sync_address = 0;
+    std::size_t edm_status_address = 0;
 
     // Debug and Counters
     static constexpr std::size_t receiver_channel_counters_size_bytes =
@@ -227,6 +228,7 @@ public:
     std::array<size_t, FabricEriscDatamoverConfig::num_sender_channels> local_sender_channels_connection_info_addr;
 
     size_t termination_signal_ptr = 0;
+    size_t edm_local_sync_ptr = 0;
     size_t edm_status_ptr = 0;
 
     // Semaphore IDs

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -33,13 +33,16 @@ enum EDMStatus : uint32_t {
     STARTED = 0xA0B0C0D0,
 
     // Handshake complete with remote
-    HANDSHAKE_COMPLETE = 0xA0B1C2D3,
+    REMOTE_HANDSHAKE_COMPLETE = 0xA1B1C1D1,
 
     // Ready to start listening for packets
-    READY_FOR_TRAFFIC = 0xA1B2C3D4,
+    LOCAL_HANDSHAKE_COMPLETE = 0xA2B2C2D2,
+
+    // Ready for traffic
+    READY_FOR_TRAFFIC = 0xA3B3C3D3,
 
     // EDM exiting
-    TERMINATED = 0xA2B3C4D5
+    TERMINATED = 0xA4B4C4D4
 };
 
 // 3 bits

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -41,7 +41,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig() {
     this->termination_signal_address =
         edm_channel_ack_addr +
         (4 * eth_channel_sync_size);  // pad extra bytes to match old EDM so handshake logic will still work
-    this->edm_status_address = termination_signal_address + field_size;
+    this->edm_local_sync_address = termination_signal_address + field_size;
+    this->edm_status_address = edm_local_sync_address + field_size;
 
     uint32_t buffer_address = edm_status_address + field_size;
     for (uint32_t i = 0; i < FabricEriscDatamoverConfig::num_receiver_channels; i++) {
@@ -388,6 +389,7 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     local_receiver_channels_buffer_address(config.receiver_channels_base_address),
 
     termination_signal_ptr(config.termination_signal_address),
+    edm_local_sync_ptr(config.edm_local_sync_address),
     edm_status_ptr(config.edm_status_address),
     enable_persistent_mode(enable_persistent_mode),
     build_in_worker_connection_mode(build_in_worker_connection_mode),
@@ -440,6 +442,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         config.sender_channels_base_address[2],
 
         this->termination_signal_ptr,
+        this->edm_local_sync_ptr,
         this->edm_status_ptr,
         this->enable_persistent_mode,
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "eth_chan_noc_mapping.h"
+#include "tt_metal/hw/inc/ethernet/tunneling.h"
+#include "tt_metal/hw/inc/dataflow_api.h"
+#include "tt_metal/hw/inc/dataflow_api_addrgen.h"
+
+namespace tt::tt_fabric {
+
+FORCE_INLINE void wait_for_notification(uint32_t address, uint32_t value) {
+    volatile tt_l1_ptr uint32_t* poll_addr = (volatile tt_l1_ptr uint32_t*)address;
+    while (*poll_addr != value) {
+        // context switch while waiting to allow slow dispatch traffic to go through
+        run_routing();
+    }
+}
+
+FORCE_INLINE void notify_master_router(uint32_t master_eth_chan, uint32_t address) {
+    // send semaphore increment to master router on this device.
+    // semaphore notifies all other routers that this router has completed
+    // startup handshake with its ethernet peer.
+    uint64_t dest_addr = get_noc_addr_helper(eth_chan_to_noc_xy[noc_index][master_eth_chan], address);
+    noc_fast_atomic_increment<DM_DEDICATED_NOC, true>(
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        dest_addr,
+        NOC_UNICAST_WRITE_VC,
+        1,
+        31,
+        false,
+        false,
+        MEM_NOC_ATOMIC_RET_VAL_ADDR);
+}
+
+FORCE_INLINE void notify_slave_routers(
+    uint32_t router_eth_chans_mask, uint32_t master_eth_chan, uint32_t address, uint32_t notification) {
+    uint32_t remaining_cores = router_eth_chans_mask;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (remaining_cores == 0) {
+            break;
+        }
+        if ((remaining_cores & (0x1 << i)) && (master_eth_chan != i)) {
+            uint64_t dest_addr = get_noc_addr_helper(eth_chan_to_noc_xy[noc_index][i], address);
+            noc_inline_dw_write(dest_addr, notification);
+            remaining_cores &= ~(0x1 << i);
+        }
+    }
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 
 #include "noc_overlay_parameters.h"
 #include "tt_metal/hw/inc/utils/utils.h"
@@ -1261,32 +1262,43 @@ void kernel_main() {
     // TODO: CONVERT TO SEMAPHORE
     volatile auto termination_signal_ptr =
         reinterpret_cast<volatile tt::tt_fabric::TerminationSignal*>(get_compile_time_arg_val(23));
+#ifdef WAIT_FOR_HOST_SIGNAL
+    volatile auto edm_local_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_compile_time_arg_val(24));
+#endif
     volatile auto edm_status_ptr =
-        reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::EDMStatus*>(get_compile_time_arg_val(24));
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::EDMStatus*>(get_compile_time_arg_val(25));
+
     // In persistent mode, we must rely on static addresses for our local semaphores that are locally
     // initialized, rather than metal device APIs. This way different subdevice programs can reliably
     // resolve the semaphore addresses on the EDM core
-    static constexpr bool persistent_mode = get_compile_time_arg_val(25) != 0;
+    static constexpr bool persistent_mode = get_compile_time_arg_val(26) != 0;
 
     // Per-channel counters
-    static constexpr bool enable_fabric_counters = get_compile_time_arg_val(26) != 0;
-    static constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(27);
-    static constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(28);
-    static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(29);
-    static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(30);
-    static constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(31);
+    static constexpr bool enable_fabric_counters = get_compile_time_arg_val(27) != 0;
+    static constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(28);
+    static constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(29);
+    static constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(30);
+    static constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(31);
+    static constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(32);
 
-    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(32) != 0;
-    static constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(33);
-    static constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(34);
-    static constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(35);
-    static constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(36);
-    static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(37);
-    static constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(38);
-    static constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(39);
-    static constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(40);
-    static constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(41);
-    static constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(42);
+    static constexpr bool enable_packet_header_recording = get_compile_time_arg_val(33) != 0;
+    static constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(34);
+    static constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(35);
+    static constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(36);
+    static constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(37);
+    static constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(38);
+    static constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(39);
+    static constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(40);
+    static constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(41);
+    static constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(42);
+    static constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(43);
+
+#ifdef WAIT_FOR_HOST_SIGNAL
+    static constexpr bool is_local_handshake_master = get_compile_time_arg_val(44);
+    static constexpr uint32_t local_handshake_master_eth_chan = get_compile_time_arg_val(45);
+    static constexpr uint32_t num_local_edms = get_compile_time_arg_val(46);
+    static constexpr uint32_t edm_channels_mask = get_compile_time_arg_val(47);
+#endif
 
     std::array<PacketHeaderRecorder, NUM_SENDER_CHANNELS> sender_channel_packet_recorders{
         PacketHeaderRecorder(
@@ -1540,11 +1552,28 @@ void kernel_main() {
         erisc::datamover::handshake::receiver_side_finish(handshake_addr, DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
     }
 
-    *edm_status_ptr = tt::tt_fabric::EDMStatus::HANDSHAKE_COMPLETE;
+    *edm_status_ptr = tt::tt_fabric::EDMStatus::REMOTE_HANDSHAKE_COMPLETE;
 
 #ifdef WAIT_FOR_HOST_SIGNAL
-    while (*edm_status_ptr != tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC) {
-        run_routing_without_noc_sync();
+    if constexpr (is_local_handshake_master) {
+        wait_for_notification((uint32_t)edm_local_sync_ptr, num_local_edms - 1);
+        notify_slave_routers(
+            edm_channels_mask, local_handshake_master_eth_chan, (uint32_t)edm_local_sync_ptr, num_local_edms);
+    } else {
+        notify_master_router(local_handshake_master_eth_chan, (uint32_t)edm_local_sync_ptr);
+        wait_for_notification((uint32_t)edm_local_sync_ptr, num_local_edms);
+    }
+
+    *edm_status_ptr = tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE;
+
+    wait_for_notification((uint32_t)edm_status_ptr, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
+
+    if constexpr (is_local_handshake_master) {
+        notify_slave_routers(
+            edm_channels_mask,
+            local_handshake_master_eth_chan,
+            (uint32_t)edm_status_ptr,
+            tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
     }
 #endif
 
@@ -1573,6 +1602,16 @@ void kernel_main() {
         sender_channel_packet_recorders,
         receiver_channel_0_trid_tracker,
         receiver_channel_1_trid_tracker);
+
+#ifdef WAIT_FOR_HOST_SIGNAL
+    if constexpr (is_local_handshake_master) {
+        notify_slave_routers(
+            edm_channels_mask,
+            local_handshake_master_eth_chan,
+            (uint32_t)termination_signal_ptr,
+            *termination_signal_ptr);
+    }
+#endif
 
     if constexpr (persistent_mode) {
         // we force these values to a non-zero value so that if we run the fabric back to back,

--- a/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
@@ -6,6 +6,7 @@
 #include "dataflow_api.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 // clang-format on
 
 using namespace tt::tt_fabric;
@@ -40,47 +41,7 @@ volatile tt_l1_ptr chan_req_buf* fvc_outbound_req_buf =
 volatile tt_l1_ptr fabric_router_l1_config_t* routing_table =
     reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
 
-volatile uint32_t* sync_sem_addr = (volatile uint32_t*)FABRIC_ROUTER_SYNC_SEM;
-
 #define SWITCH_THRESHOLD 0x3FFF
-
-inline void wait_for_sem(uint32_t value) {
-    while (*sync_sem_addr != value) {
-        // context switch while waiting to allow slow dispatch traffic to go through
-        internal_::risc_context_switch();
-    }
-}
-
-inline void notify_master_router() {
-    // send semaphore increment to master router on this device.
-    // semaphore notifies all other routers that this router has completed
-    // startup handshake with its ethernet peer.
-    uint64_t dest_addr = get_noc_addr_helper(eth_chan_to_noc_xy[noc_index][master_router_chan], FABRIC_ROUTER_SYNC_SEM);
-    noc_fast_atomic_increment<DM_DEDICATED_NOC, true>(
-        noc_index,
-        NCRISC_AT_CMD_BUF,
-        dest_addr,
-        NOC_UNICAST_WRITE_VC,
-        1,
-        31,
-        false,
-        false,
-        MEM_NOC_ATOMIC_RET_VAL_ADDR);
-}
-
-inline void notify_slave_routers(uint32_t notification) {
-    uint32_t remaining_cores = router_mask;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (remaining_cores == 0) {
-            break;
-        }
-        if ((remaining_cores & (0x1 << i)) && (master_router_chan != i)) {
-            uint64_t dest_addr = get_noc_addr_helper(eth_chan_to_noc_xy[noc_index][i], FABRIC_ROUTER_SYNC_SEM);
-            noc_inline_dw_write(dest_addr, notification);
-            remaining_cores &= ~(0x1 << i);
-        }
-    }
-}
 
 void kernel_main() {
     tt_fabric_init();
@@ -152,14 +113,14 @@ void kernel_main() {
     if constexpr (is_master) {
         // wait for all device routers to have incremented the sync semaphore.
         // sync_val is equal to number of tt-fabric routers running on a device.
-        wait_for_sem(sync_val - 1);
-        notify_slave_routers(sync_val);
+        wait_for_notification(FABRIC_ROUTER_SYNC_SEM, sync_val - 1);
+        notify_slave_routers(router_mask, master_router_chan, FABRIC_ROUTER_SYNC_SEM, sync_val);
         // increment the sync sem to signal host that handshake is complete
-        *sync_sem_addr += 1;
+        *((volatile uint32_t*)FABRIC_ROUTER_SYNC_SEM) += 1;
     } else {
-        notify_master_router();
+        notify_master_router(master_router_chan, FABRIC_ROUTER_SYNC_SEM);
         // wait for the signal from the master router
-        wait_for_sem(sync_val);
+        wait_for_notification(FABRIC_ROUTER_SYNC_SEM, sync_val);
     }
 
 #ifndef FVC_MODE_PULL
@@ -259,7 +220,7 @@ void kernel_main() {
                 // terminate signal from host sw.
                 if constexpr (is_master) {
                     if (!terminated_slave_routers) {
-                        notify_slave_routers(0);
+                        notify_slave_routers(router_mask, master_router_chan, FABRIC_ROUTER_SYNC_SEM, 0);
                         terminated_slave_routers = true;
                     }
                 }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -445,40 +445,35 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 void DevicePool::wait_for_fabric_router_sync() const {
     FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D) {
-        using namespace tt::tt_fabric;
         static constexpr std::size_t edm_buffer_size =
             tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
             sizeof(tt::tt_fabric::PacketHeader);
         const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
-        auto routing_directions = {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
         std::vector<uint32_t> signal(1, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
 
         auto wait_for_handshake = [&](IDevice* dev) {
-            auto [mesh_id, chip_id] = tt::Cluster::instance().get_control_plane()->get_mesh_chip_id_from_physical_chip_id(dev->id());
-            for (const auto& direction : routing_directions) {
-                auto fabric_active_eth_chans =
-                    tt::Cluster::instance().get_control_plane()->get_active_fabric_eth_channels_in_direction(mesh_id, chip_id, direction);
-                if (fabric_active_eth_chans.empty()) {
-                    continue;
-                }
-                auto neighbors = tt::Cluster::instance().get_control_plane()->get_intra_chip_neighbors(mesh_id, chip_id, direction);
-                if (neighbors.empty()) {
-                    continue;
-                }
-                for (const auto& eth_chan : fabric_active_eth_chans) {
-                    std::vector<std::uint32_t> router_status{0};
-                    auto eth_logical_core = tt::Cluster::instance().get_soc_desc(dev->id()).get_eth_core_for_channel(
-                        eth_chan, CoordSystem::LOGICAL);
-                    while (router_status[0] != tt::tt_fabric::EDMStatus::HANDSHAKE_COMPLETE) {
-                        tt_metal::detail::ReadFromDeviceL1(
-                            dev, eth_logical_core, edm_config.edm_status_address, 4, router_status, CoreType::ETH);
-                    }
-
-                    // Signal the kernel that it can start listening for packets
-                    tt_metal::detail::WriteToDeviceL1(
-                        dev, eth_logical_core, edm_config.edm_status_address, signal, CoreType::ETH);
-                }
+            std::vector<std::uint32_t> master_router_status{0};
+            auto fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(dev->id());
+            if (fabric_ethernet_channels.empty()) {
+                return;
             }
+
+            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
+            CoreCoord virtual_eth_core =
+                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+            auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
+            while (master_router_status[0] != tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE) {
+                tt_metal::detail::ReadFromDeviceL1(
+                    dev,
+                    fabric_master_router_core,
+                    edm_config.edm_status_address,
+                    4,
+                    master_router_status,
+                    CoreType::ETH);
+            }
+
+            tt_metal::detail::WriteToDeviceL1(
+                dev, fabric_master_router_core, edm_config.edm_status_address, signal, CoreType::ETH);
         };
 
         for (const auto& dev : this->get_all_active_devices()) {
@@ -493,7 +488,11 @@ void DevicePool::wait_for_fabric_router_sync() const {
                     wait_for_handshake(get_device(tunnels_from_mmio[i][j]));
                 }
             }
-            wait_for_handshake(dev);
+
+            if (tt::Cluster::instance().get_cluster_type() != tt::ClusterType::TG) {
+                // 1d fabric is not launched on TG gateways
+                wait_for_handshake(dev);
+            }
         }
     } else if (fabric_config == FabricConfig::FABRIC_2D || fabric_config == FabricConfig::FABRIC_2D_PUSH) {
         auto fabric_router_sync_sem_addr =
@@ -709,34 +708,30 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
     // Terminate fabric routers
     FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D) {
-        using namespace tt::tt_fabric;
-        std::vector<uint32_t> signal(1, tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
+        std::vector<uint32_t> signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
         static constexpr std::size_t edm_buffer_size =
             tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
             sizeof(tt::tt_fabric::PacketHeader);
         const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
-        auto routing_directions = {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
 
+        auto fabric_router_sync_sem_addr = edm_config.termination_signal_address;
         for (const auto& dev : this->get_all_active_devices()) {
-            auto [mesh_id, chip_id] = tt::Cluster::instance().get_control_plane()->get_mesh_chip_id_from_physical_chip_id(dev->id());
-            for (const auto& direction : routing_directions) {
-                auto fabric_active_eth_chans =
-                    tt::Cluster::instance().get_control_plane()->get_active_fabric_eth_channels_in_direction(mesh_id, chip_id, direction);
-                if (fabric_active_eth_chans.size() == 0) {
-                    continue;
-                }
-                auto neighbors = tt::Cluster::instance().get_control_plane()->get_intra_chip_neighbors(mesh_id, chip_id, direction);
-                if (neighbors.size() == 0) {
-                    continue;
-                }
-                for (const auto& eth_chan : fabric_active_eth_chans) {
-                    std::vector<std::uint32_t> router_status{0};
-                    auto eth_logical_core = tt::Cluster::instance().get_soc_desc(dev->id()).get_eth_core_for_channel(
-                        eth_chan, CoordSystem::LOGICAL);
-                    tt_metal::detail::WriteToDeviceL1(
-                        dev, eth_logical_core, edm_config.termination_signal_address, signal, CoreType::ETH);
-                }
+            if (dev->is_mmio_capable() && (tt::Cluster::instance().get_cluster_type() == tt::ClusterType::TG)) {
+                // 1d fabric is not launched on TG gateways
+                continue;
             }
+
+            auto fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(dev->id());
+            if (fabric_ethernet_channels.empty()) {
+                continue;
+            }
+
+            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
+            CoreCoord virtual_eth_core =
+                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+            auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
+            tt_metal::detail::WriteToDeviceL1(
+                dev, fabric_master_router_core, fabric_router_sync_sem_addr, signal, CoreType::ETH);
         }
     } else if (fabric_config == FabricConfig::FABRIC_2D || fabric_config == FabricConfig::FABRIC_2D_PUSH) {
         std::vector<uint32_t> master_router_terminate(1, 0);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19005)

### Problem description
Currently the host polls on the status of each router to determine if the handshake is complete and individually sends them a 'go' signal. This causes a lot of slow dispatch traffic and based on the order of these routers getting the 'go' signal, could delay startup since the context switch interval is long and the base fw routing will suffer.

### What's changed
Designate one of the routers on the chip as a 'master' which synchronizes with the rest on the chip. The host only polls for the status of this 'master' router and only sends the 'go' and termination signal to this master router. The master router is then responsible for relaying the message across to the other routers. This cuts down the slow dispatch traffic and speeds up the setup time.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13958167738)
- [x] microbenchmarks (https://github.com/tenstorrent/tt-metal/actions/runs/13958177874/job/39074411075)
- [x] T3K (https://github.com/tenstorrent/tt-metal/actions/runs/13958183684)
- [x] TG (https://github.com/tenstorrent/tt-metal/actions/runs/13958191326)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes