### PR TITLE
Track device tensor specs using mesh coordinate ranges

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -163,6 +163,8 @@ TEST(MeshCoordinateRangeTest, FromShape) {
     MeshShape shape(2, 3);
     MeshCoordinateRange range(shape);
 
+    EXPECT_EQ(range.size(), shape.mesh_size());
+
     std::vector<MeshCoordinate> coords;
     for (const auto& coord : range) {
         coords.push_back(coord);
@@ -183,6 +185,8 @@ TEST(MeshCoordinateRangeTest, Subrange) {
     MeshCoordinate start(1, 1, 1);
     MeshCoordinate end(2, 1, 4);
     MeshCoordinateRange range(start, end);
+
+    EXPECT_EQ(range.size(), 8);
 
     std::vector<MeshCoordinate> coords;
     for (const auto& coord : range) {
@@ -206,6 +210,8 @@ TEST(MeshCoordinateRangeTest, SubrangeOneElement) {
     MeshCoordinate start(1, 1, 1);
     MeshCoordinate end(1, 1, 1);
     MeshCoordinateRange range(start, end);
+
+    EXPECT_EQ(range.size(), 1);
 
     std::vector<MeshCoordinate> coords;
     for (const auto& coord : range) {

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -116,6 +116,9 @@ public:
     const MeshCoordinate& start_coord() const;
     const MeshCoordinate& end_coord() const;
 
+    // Returns the number of coordinates in the range.
+    size_t size() const;
+
     // Returns true if the range contains the given coordinate.
     bool contains(const MeshCoordinate& coord) const;
 
@@ -167,6 +170,7 @@ private:
 class MeshCoordinateRangeSet {
 public:
     MeshCoordinateRangeSet() = default;
+    explicit MeshCoordinateRangeSet(const MeshCoordinateRange& range);
 
     // Merges the given range into the set.
     void merge(const MeshCoordinateRange& range);

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -166,6 +166,14 @@ size_t MeshCoordinateRange::dims() const { return start_.dims(); }
 const MeshCoordinate& MeshCoordinateRange::start_coord() const { return start_; }
 const MeshCoordinate& MeshCoordinateRange::end_coord() const { return end_; }
 
+size_t MeshCoordinateRange::size() const {
+    size_t range_size = 1;
+    for (size_t i = 0; i < dims(); ++i) {
+        range_size *= end_[i] - start_[i] + 1;
+    }
+    return range_size;
+}
+
 bool MeshCoordinateRange::contains(const MeshCoordinate& coord) const {
     TT_FATAL(coord.dims() == dims(), "Coordinate dimensions do not match: {} != {}", coord.dims(), dims());
     for (int i = 0; i < coord.dims(); ++i) {
@@ -263,6 +271,8 @@ size_t to_linear_index(const MeshShape& shape, const MeshCoordinate& coord) {
     }
     return linear_index;
 }
+
+MeshCoordinateRangeSet::MeshCoordinateRangeSet(const MeshCoordinateRange& range) { merge(range); }
 
 void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
     TT_FATAL(

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -835,12 +835,10 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
     TT_FATAL(
         tt::tt_metal::detail::InMainThread(), "Allocation of a tensor on mesh must be called from the main thread");
     auto mesh_buffer = tensor_impl::allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
-    std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
-    specs.reserve(mesh_device->shape().mesh_size());
-    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-        specs.push_back(std::make_pair(coord, tensor_spec));
-    }
-    DeviceStorage device_storage(std::move(mesh_buffer), ReplicateTensor(), std::move(specs));
+    DeviceStorage device_storage(
+        std::move(mesh_buffer),
+        ReplicateTensor(),
+        TensorSpecMapping(tensor_spec, distributed::MeshCoordinateRange(mesh_device->shape())));
     return Tensor(std::move(device_storage), tensor_spec);
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
One very common case is a tensor allocated on the entire mesh uniformly (same tensor specs).

Tracking metadata for entire ranges of devices is therefore beneficial.

### What's changed
* `TensorSpecMapping` (please advice on the name) that encapsulates the details of how tensor specs are mapped to devices.
* Plumb the infra to read/write/allocation APIs, as well as `reshape` and `transform` facility.
* Long term plan: we can get rid of tracking tensor spec at tensor level, and instead move this concept down to storage, where we are aware of potential non-uniformity.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [X] New/Existing tests provide coverage for changes