### PR TITLE
[skip ci] Profile our compile time in build-artifact

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         type: boolean
         default: false
+      profile:
+        required: false
+        type: boolean
+        default: false
+        description: "Profile the compilation"
     outputs:
       ci-build-docker-image:
         description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
@@ -97,6 +102,11 @@ on:
         type: string
         default: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
         description: "Toolchain file to use for build"
+      profile:
+        required: false
+        type: boolean
+        default: false
+        description: "Profile the compilation"
 
 
 jobs:
@@ -199,6 +209,9 @@ jobs:
           if [ "${{ inputs.tracy }}" = "true" ]; then
             build_command="$build_command --enable-profiler"
           fi
+          if [ "${{ inputs.profile }}" = "true" ]; then
+            build_command="$build_command --enable-time-trace"
+          fi
 
           nice -n 19 $build_command
 
@@ -206,6 +219,13 @@ jobs:
         run: |
           # --target install is for the tarball that should get replaced by proper packaging later
           nice -19 cmake --build build --target install
+
+      - name: 🛠️ Profile
+        if: ${{ inputs.profile }}
+        run: |
+          echo "maxNameLength = 300" > ClangBuildAnalyzer.ini
+          nice -n 19 ClangBuildAnalyzer --all build capture.bin
+          nice -n 19 ClangBuildAnalyzer --analyze capture.bin
 
       - name: 📦 Package
         run: |

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -210,7 +210,7 @@ jobs:
             build_command="$build_command --enable-profiler"
           fi
           if [ "${{ inputs.profile }}" = "true" ]; then
-            build_command="$build_command --enable-time-trace"
+            build_command="$build_command --enable-time-trace --disable-unity-builds"
           fi
 
           nice -n 19 $build_command

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -9,7 +9,7 @@ show_help() {
     echo "  -e, --export-compile-commands    Enable CMAKE_EXPORT_COMPILE_COMMANDS."
     echo "  -c, --enable-ccache              Enable ccache for the build."
     echo "  -b, --build-type build_type      Set the build type. Default is Release. Other options are Debug, RelWithDebInfo, and CI."
-    echo "  -t, --trace                      Enable build time trace (clang only)."
+    echo "  -t, --enable-time-trace          Enable build time trace (clang only)."
     echo "  -a, --enable-asan                Enable AddressSanitizer."
     echo "  -m, --enable-msan                Enable MemorySanitizer."
     echo "  -s, --enable-tsan                Enable ThreadSanitizer."


### PR DESCRIPTION
### Ticket
Closes #17457 

### Problem description
Our compile is horribly slow.
Currently its a manual process to analyze the compile time with ClangBuildAnalyzer.

### What's changed
We can profile the compile with a few button clicks using the build-artifact workflow.