### PR TITLE
Enable TTNN and Metal distributed tests on N150/P150

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_allocator.cpp
+++ b/tests/tt_metal/distributed/test_mesh_allocator.cpp
@@ -10,7 +10,7 @@
 
 namespace tt::tt_metal::distributed::test {
 
-using MeshAllocatorTest = T3000MeshDeviceFixture;
+using MeshAllocatorTest = GenericMeshDeviceFixture;
 
 TEST_F(MeshAllocatorTest, BasicAllocationSanityCheck) {
     const size_t allocation_size = 1024 * 8;  // 1KB

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -105,6 +105,9 @@ TEST_F(MeshEventsTestT3000, ShardedAsyncIO) {
 }
 
 TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     uint32_t num_iters = 5;
     std::vector<std::shared_ptr<MeshBuffer>> src0_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> src1_bufs = {};
@@ -186,6 +189,9 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
 }
 
 TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     uint32_t NUM_TILES = 1000;
     uint32_t num_iterations = 20;
     int32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::UInt32);

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -204,6 +204,9 @@ TEST_F(MeshTraceTestT3000, EltwiseBinaryMeshTrace) {
 }
 
 TEST_F(MeshTraceTestSuite, SyncWorkloadsOnSubDeviceTrace) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
 
@@ -299,6 +302,9 @@ TEST_F(MeshTraceTestSuite, SyncWorkloadsOnSubDeviceTrace) {
 }
 
 TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     // Create 4 SubDevices
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {0, 0}))});  // Sync with host
     SubDevice sub_device_2(std::array{CoreRangeSet(CoreRange({1, 1}, {1, 1}))});  // Run datacopy

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -147,6 +147,10 @@ using MeshWorkloadTestTG = TGMeshDeviceFixture;
 using MeshWorkloadTestSuite = GenericMeshDeviceFixture;
 
 TEST_F(MeshWorkloadTestSuite, MeshWorkloadOnActiveEthAsserts) {
+    if (mesh_device_->num_devices() == 1) {
+        // Unit mesh devices (such as N150) do not have ethernet cores.
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     // A MeshWorkload cannot be run on ethernet core - Runtime should assert if the
     // user tries this. Verify this functionality here.
     std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
@@ -359,7 +363,8 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
+// TODO: #19149 - Re-enable the test.
+TEST_F(MeshWorkloadTestSuite, DISABLED_RandomizedMeshWorkload) {
     uint32_t num_programs = 60;
     uint32_t num_iterations = 1500;
     auto random_seed = 10;

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -4,6 +4,7 @@
 
 #include <random>
 
+#include <stdexcept>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -13,11 +14,15 @@
 
 #include "env_lib.hpp"
 
+#include "gmock/gmock.h"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/distributed/utils.hpp"
 
 namespace tt::tt_metal::distributed::test {
 namespace {
+
+using ::testing::HasSubstr;
+using ::testing::ThrowsMessage;
 
 struct CBConfig {
     uint32_t cb_id = 0;
@@ -156,6 +161,23 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadOnActiveEthAsserts) {
         AddProgramToMeshWorkload(*workload, std::move(*programs[0]), MeshCoordinateRange(coord, coord));
     }
     EXPECT_THROW(EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false), std::exception);
+}
+
+TEST_F(MeshWorkloadTestSuite, OverlappingProgramRanges) {
+    MeshWorkload workload;
+
+    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+        /*num_programs=*/2, mesh_device_->compute_with_storage_grid_size(), /*seed=*/0);
+    uint32_t num_rows_in_workload = mesh_device_->num_rows() / 2;
+    auto mesh_workload = CreateMeshWorkload();
+
+    MeshCoordinate zero_coord = MeshCoordinate::zero_coordinate(mesh_device_->shape().dims());
+    MeshCoordinateRange devices_range = MeshCoordinateRange(zero_coord, zero_coord);
+
+    AddProgramToMeshWorkload(mesh_workload, std::move(*programs[0]), devices_range);
+    EXPECT_THAT(
+        ([&]() { AddProgramToMeshWorkload(mesh_workload, std::move(*programs[1]), devices_range); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("overlaps with the previously added range")));
 }
 
 // Test running different configurations of heterogenous MeshWorkloads on T3000.
@@ -337,7 +359,6 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-// MeshWorkload tests on N300 and T3000
 TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
     uint32_t num_programs = 60;
     uint32_t num_iterations = 1500;
@@ -377,6 +398,9 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
 }
 
 TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     std::vector<std::shared_ptr<MeshBuffer>> src0_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> src1_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> output_bufs = {};
@@ -435,6 +459,9 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
 }
 
 TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     uint32_t single_tile_size = ::tt::tt_metal::detail::TileSize(DataFormat::Float16_b);
 
@@ -606,6 +633,9 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreSanity) {
 }
 
 TEST_F(MeshWorkloadTestSuite, MeshWorkloadSemaphoreDifferentPrograms) {
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     auto worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     auto full_grid = CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     Program program0;

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -91,6 +91,9 @@ protected:
     using MeshShape = ::tt::tt_metal::distributed::MeshShape;
 
     enum class MeshDeviceType {
+        // 150 devices opened as 1x1 meshes.
+        N150,
+        P150,
         N300,
         P300,
         T3000,
@@ -162,6 +165,8 @@ private:
     // Returns the mesh shape for a given mesh device type.
     MeshShape get_mesh_shape(MeshDeviceType mesh_device_type) {
         switch (mesh_device_type) {
+            case MeshDeviceType::N150:
+            case MeshDeviceType::P150: return MeshShape(1, 1);
             case MeshDeviceType::N300:
             case MeshDeviceType::P300: return MeshShape(2, 1);
             case MeshDeviceType::T3000: return MeshShape(2, 4);
@@ -173,6 +178,13 @@ private:
     // Determines the mesh device type based on the number of devices.
     std::optional<MeshDeviceType> derive_mesh_device_type(size_t num_devices, tt::ARCH arch) {
         switch (num_devices) {
+            case 150: {
+                switch (arch) {
+                    case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N150;
+                    case tt::ARCH::BLACKHOLE: return MeshDeviceType::P150;
+                    default: return std::nullopt;
+                }
+            }
             case 2: {
                 switch (arch) {
                     case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N300;
@@ -214,11 +226,6 @@ protected:
 // Fixtures that specify the mesh device type explicitly.
 // The associated test will be run if the cluster topology matches
 // what is specified.
-class N300MeshDeviceFixture : public MeshDeviceFixtureBase {
-protected:
-    N300MeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::N300}}) {}
-};
-
 class T3000MeshDeviceFixture : public MeshDeviceFixtureBase {
 protected:
     T3000MeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::T3000}}) {}
@@ -227,12 +234,6 @@ protected:
 class TGMeshDeviceFixture : public MeshDeviceFixtureBase {
 protected:
     TGMeshDeviceFixture() : MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::TG}}) {}
-};
-
-class N300MultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {
-protected:
-    N300MultiCQMeshDeviceFixture() :
-        MeshDeviceFixtureBase(Config{.mesh_device_types = {MeshDeviceType::N300}, .num_cqs = 2}) {}
 };
 
 class T3000MultiCQMeshDeviceFixture : public MeshDeviceFixtureBase {

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -91,7 +91,7 @@ protected:
     using MeshShape = ::tt::tt_metal::distributed::MeshShape;
 
     enum class MeshDeviceType {
-        // 150 devices opened as 1x1 meshes.
+        // N150/P150 devices opened as 1x1 meshes.
         N150,
         P150,
         N300,
@@ -178,7 +178,7 @@ private:
     // Determines the mesh device type based on the number of devices.
     std::optional<MeshDeviceType> derive_mesh_device_type(size_t num_devices, tt::ARCH arch) {
         switch (num_devices) {
-            case 150: {
+            case 1: {
                 switch (arch) {
                     case tt::ARCH::WORMHOLE_B0: return MeshDeviceType::N150;
                     case tt::ARCH::BLACKHOLE: return MeshDeviceType::P150;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -21,6 +20,10 @@
 namespace ttnn::distributed::test {
 namespace {
 
+using ::testing::Each;
+using ::testing::Eq;
+using ::testing::FloatEq;
+using ::testing::Pointwise;
 using ::testing::SizeIs;
 using ::tt::tt_metal::BufferType;
 using ::tt::tt_metal::Layout;
@@ -36,16 +39,12 @@ TEST_P(MultiDeviceTensorCreationTest, Empty) {
 
     const Tensor mesh_replicated_tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
-    EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
-    EXPECT_EQ(mesh_replicated_tensor.get_workers().size(), mesh_device->num_devices());
-
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
 TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
@@ -56,7 +55,7 @@ TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
 
     const Tensor tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         mesh_device->get_devices().at(0),
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
@@ -66,16 +65,12 @@ TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
 
     const Tensor mesh_replicated_tensor = ttnn::empty_like(
         tensor,
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         *mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
-    EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(mesh_device->num_devices()));
-
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
 TEST_P(MultiDeviceTensorCreationTest, Full) {
@@ -85,19 +80,22 @@ TEST_P(MultiDeviceTensorCreationTest, Full) {
     const Tensor mesh_replicated_tensor = ttnn::full(
         ttnn::Shape({32, 32}),
         /*fill_value=*/42,
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         std::ref(*mesh_device),
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
 
-    EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(mesh_device->num_devices()));
-    EXPECT_EQ(mesh_replicated_tensor.logical_shape(), ttnn::Shape({32, 32}));
-    EXPECT_EQ(mesh_replicated_tensor.dtype(), DataType::BFLOAT16);
-    EXPECT_EQ(mesh_replicated_tensor.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(mesh_replicated_tensor.get_logical_shape(), ttnn::Shape({32, 32}));
+    EXPECT_EQ(mesh_replicated_tensor.get_dtype(), DataType::FLOAT32);
+    EXPECT_EQ(mesh_replicated_tensor.get_layout(), Layout::ROW_MAJOR);
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    auto device_tensors = get_device_tensors(mesh_replicated_tensor);
+    EXPECT_THAT(device_tensors, SizeIs(mesh_device->num_devices()));
+    for (const auto& device_tensor : device_tensors) {
+        auto values = device_tensor.to_vector<float>();
+        EXPECT_THAT(values, SizeIs(32 * 32));
+        EXPECT_THAT(values, Each(Eq(42.0f)));
+    }
 }
 
 TEST_P(MultiDeviceTensorCreationTest, FullLike) {
@@ -108,13 +106,10 @@ TEST_P(MultiDeviceTensorCreationTest, FullLike) {
 
     Tensor tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         mesh_device->get_devices().at(0),
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
-
-    EXPECT_EQ(tensor.storage_type(), StorageType::DEVICE);
-    EXPECT_THAT(tensor.get_workers(), SizeIs(1));
 
     Tensor mesh_replicated_tensor = ttnn::full_like(
         tensor,
@@ -123,15 +118,18 @@ TEST_P(MultiDeviceTensorCreationTest, FullLike) {
         /*layout=*/std::nullopt,
         std::ref(*mesh_device));
 
-    EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(mesh_device->num_devices()));
-    EXPECT_EQ(mesh_replicated_tensor.logical_shape(), tensor.logical_shape());
-    EXPECT_EQ(mesh_replicated_tensor.padded_shape(), tensor.padded_shape());
-    EXPECT_EQ(mesh_replicated_tensor.dtype(), tensor.dtype());
-    EXPECT_EQ(mesh_replicated_tensor.layout(), tensor.layout());
+    EXPECT_EQ(mesh_replicated_tensor.get_logical_shape(), tensor.get_logical_shape());
+    EXPECT_EQ(mesh_replicated_tensor.get_padded_shape(), tensor.get_padded_shape());
+    EXPECT_EQ(mesh_replicated_tensor.get_dtype(), tensor.get_dtype());
+    EXPECT_EQ(mesh_replicated_tensor.get_layout(), tensor.get_layout());
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    auto device_tensors = get_device_tensors(mesh_replicated_tensor);
+    EXPECT_THAT(device_tensors, SizeIs(mesh_device->num_devices()));
+    for (const auto& device_tensor : device_tensors) {
+        auto values = device_tensor.to_vector<float>();
+        EXPECT_THAT(values, SizeIs(32 * 32));
+        EXPECT_THAT(values, Each(Eq(42.0f)));
+    }
 }
 
 TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
@@ -142,7 +140,7 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
 
     Tensor tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         mesh_device->get_devices().at(0),
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
@@ -152,7 +150,7 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
 
     Tensor opt_output = ttnn::empty(
         ttnn::Shape({32, 32}),
-        DataType::BFLOAT16,
+        DataType::FLOAT32,
         Layout::ROW_MAJOR,
         mesh_device,
         MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
@@ -166,15 +164,12 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
         /*memory_config=*/std::nullopt,
         opt_output);
 
-    EXPECT_EQ(mesh_replicated_tensor.storage_type(), StorageType::MULTI_DEVICE);
-    EXPECT_THAT(mesh_replicated_tensor.get_workers(), SizeIs(mesh_device->num_devices()));
-    EXPECT_EQ(mesh_replicated_tensor.logical_shape(), tensor.logical_shape());
-    EXPECT_EQ(mesh_replicated_tensor.padded_shape(), tensor.padded_shape());
-    EXPECT_EQ(mesh_replicated_tensor.dtype(), tensor.dtype());
-    EXPECT_EQ(mesh_replicated_tensor.layout(), tensor.layout());
+    EXPECT_EQ(mesh_replicated_tensor.get_logical_shape(), tensor.get_logical_shape());
+    EXPECT_EQ(mesh_replicated_tensor.get_padded_shape(), tensor.get_padded_shape());
+    EXPECT_EQ(mesh_replicated_tensor.get_dtype(), tensor.get_dtype());
+    EXPECT_EQ(mesh_replicated_tensor.get_layout(), tensor.get_layout());
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(mesh_replicated_tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
 TEST_P(MultiDeviceTensorCreationTest, Arange) {
@@ -185,15 +180,20 @@ TEST_P(MultiDeviceTensorCreationTest, Arange) {
         /*start=*/0,
         /*end=*/1024,
         /*step=*/1,
-        ttnn::DataType::BFLOAT16,
+        ttnn::DataType::FLOAT32,
         std::ref(*mesh_device));
 
-    EXPECT_EQ(tensor.storage_type(), StorageType::MULTI_DEVICE);
-    EXPECT_EQ(tensor.get_workers().size(), mesh_device->num_devices());
-    EXPECT_EQ(tensor.logical_shape(), ttnn::Shape({1024}));
+    EXPECT_EQ(tensor.get_logical_shape(), ttnn::Shape({1024}));
 
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(tensor);
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    EXPECT_THAT(get_device_tensors(tensor), SizeIs(mesh_device->num_devices()));
+
+    std::vector<float> expected(1024);
+    std::iota(expected.begin(), expected.end(), 0.0f);
+    for (const auto& device_tensor : get_device_tensors(tensor)) {
+        auto values = device_tensor.to_vector<float>();
+        EXPECT_THAT(values, SizeIs(1024));
+        EXPECT_THAT(values, Pointwise(FloatEq(), expected));
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(AllTests, MultiDeviceTensorCreationTest, ::testing::Bool());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -73,7 +73,8 @@ TEST_F(TensorDistributionTest, DistributeToDevice) {
 
     // If no device is provided, the tensor is kept on host.
     EXPECT_TRUE(distribute_tensor(input_tensor, *mapper).storage_type() == StorageType::MULTI_DEVICE_HOST);
-    EXPECT_TRUE(distribute_tensor(input_tensor, *mapper, *mesh_device_).storage_type() == StorageType::MULTI_DEVICE);
+    EXPECT_TRUE(
+        distribute_tensor(input_tensor, *mapper, *mesh_device_).storage_type() != StorageType::MULTI_DEVICE_HOST);
 }
 
 TEST_F(TensorDistributionTest, Replication) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
More test coverage for 1x1 mesh devices (N150 and P150 BH).

### What's changed
* Extend the mesh device fixture to automatically create a 1x1 device, when connected to N150 / P150.
* Catch a corner case of the user trying to enqueue programs on the overlapping ranges of devices.
* Improve some TTNN tests to work correctly with 1x1 mesh.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13865166560)