### PR TITLE
feat: add python3.8-venv to dev container dependencies so developers …

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -247,7 +247,7 @@ FROM ci-test AS dev
 
 # Need this to build GDB
 RUN apt-get -y update \
-    && apt-get install -y libmpfr-dev \
+    && apt-get install -y libmpfr-dev python3.8-venv \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the gdb that is compatible with clang-17


### PR DESCRIPTION
feat: add python3.8-venv to dev container dependencies so developers don't have to work around it

### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/19024)

### Problem description

Developers are saying they have to add venv as a dependency. I know you can import venv, but we can't run `python3 -m venv venv` without an error regarding `ensurepip`

### What's changed
We add the `python3.8-venv` package, obviating the need to install in runtime

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes