### PR TITLE
[skip ci] Add python3-venv as a runtime dependency

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -76,6 +76,7 @@ ub_runtime_packages()
 {
     UB_RUNTIME_LIST=(\
      python3-pip \
+     python3-venv \
      libhwloc-dev \
      libnuma-dev \
      libc++-17-dev \


### PR DESCRIPTION
### Ticket
Closes #19024

### Problem description
People want python3-venv in the Docker container

### What's changed
Give the people what they want.

The other angle here, is we might need venv inside docker for python3.12

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13849978153) CI passes
- [x] New/Existing tests provide coverage for changes