### PR TITLE
#18191: Optimize mish op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -387,7 +387,8 @@ def test_unary_composite_log1p_ttnn(input_shapes, device):
     ),
 )
 def test_unary_composite_mish_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -20, 100, device)
+    in_data1 = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.mish(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn.mish)
     golden_tensor = golden_function(in_data1)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -91,7 +91,8 @@ enum class UnaryOpType {
     DROPOUT,
     FILL,
     PRELU_SFPU,
-    ZERO_POINT
+    ZERO_POINT,
+    MISH,
 };
 
 struct UnaryWithParam {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -442,4 +442,11 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
     defines[get_macro_definition(op_type)] = "1";
 }
 
+std::string get_compute_kernel_path(UnaryOpType op_type, const std::string& compute_root) {
+    switch (op_type) {
+        case UnaryOpType::MISH: return fmt::format("{}/{}", compute_root, "mish_kernel.cpp");
+        default: return fmt::format("{}/{}", compute_root, "eltwise_sfpu.cpp");
+    }
+}
+
 }  // namespace ttnn::operations::unary::utils

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -339,6 +339,7 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, std:
         case UnaryOpType::NEG:
             op_init_and_name = {"negative_tile_init();", fmt::format("negative_tile({});", idst)};
             break;
+        case UnaryOpType::MISH: op_init_and_name = {}; break;
         default: TT_THROW("Undefined non-parametrized op type {}", op_type);
     }
     return op_init_and_name;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -73,4 +73,6 @@ bool is_parametrized_type(T val) {
 
 void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines);
 
+std::string get_compute_kernel_path(UnaryOpType op_type, const std::string& compute_root);
+
 }  // namespace ttnn::operations::unary::utils

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
+#include "compute_kernel_api/eltwise_unary/exp.h"
+#include "compute_kernel_api.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+
+    constexpr auto cb_input = tt::CBIndex::c_0;
+    constexpr auto cb_output = tt::CBIndex::c_2;
+
+    init_sfpu(cb_input, cb_output);
+
+    for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+        for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
+            cb_reserve_back(cb_output, per_core_block_dim);
+            cb_wait_front(cb_input, per_core_block_dim);
+            tile_regs_acquire();
+
+            // Pop tile after tile, copy to DST and pack
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 0);
+
+            exp_tile_init<1u>();
+            exp_tile<1u>(0);
+            binop_with_scalar_tile_init();
+            add_unary_tile(0, 0x3f800000u);
+            log_tile_init();
+            log_tile(0);
+            tanh_tile_init();
+
+            tanh_tile(0);
+
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_input, 0, 0);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
+
+            pack_tile(0, cb_output);
+
+            tile_regs_release();
+
+            cb_pop_front(cb_input, per_core_block_dim);
+            cb_push_back(cb_output, per_core_block_dim);
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -11,7 +11,6 @@
 #include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #include "compute_kernel_api/eltwise_unary/exp.h"
 #include "compute_kernel_api.h"
-#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
 
 namespace NAMESPACE {
 void MAIN {
@@ -20,7 +19,7 @@ void MAIN {
 
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
-
+    constexpr uint32_t one = 0x3f800000u;  // Represents 1.0f
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
@@ -36,7 +35,7 @@ void MAIN {
             exp_tile_init<1u>();
             exp_tile<1u>(0);
             binop_with_scalar_tile_init();
-            add_unary_tile(0, 0x3f800000u);
+            add_unary_tile(0, one);
             log_tile_init();
             log_tile(0);
             tanh_tile_init();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -24,9 +24,9 @@ void MAIN {
     init_sfpu(cb_input, cb_output);
 
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+        cb_reserve_back(cb_output, per_core_block_dim);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-            cb_reserve_back(cb_output, per_core_block_dim);
-            cb_wait_front(cb_input, per_core_block_dim);
+            cb_wait_front(cb_input, 1);
             tile_regs_acquire();
 
             // Pop tile after tile, copy to DST and pack
@@ -55,9 +55,9 @@ void MAIN {
 
             tile_regs_release();
 
-            cb_pop_front(cb_input, per_core_block_dim);
-            cb_push_back(cb_output, per_core_block_dim);
+            cb_pop_front(cb_input, 1);
         }
+        cb_push_back(cb_output, per_core_block_dim);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -301,21 +301,6 @@ Tensor _log1p(const Tensor& x, const std::optional<MemoryConfig>& output_mem_con
     return result_log1p;
 }
 
-// log[exp[x] + 1] => softplus[x]
-// mish[x] = x*tanh[softplus[x]]
-Tensor ExecuteMish::invoke(const Tensor& x, const std::optional<MemoryConfig>& output_mem_config) {
-    using ttnn::operations::unary::UnaryOpType;
-    using ttnn::operations::unary::UnaryWithParam;
-    std::vector<UnaryWithParam> ops_chain = {
-        UnaryWithParam{UnaryOpType::EXP, 1.0f},
-        UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-        UnaryWithParam{UnaryOpType::LOG},
-        UnaryWithParam{UnaryOpType::TANH}};
-    Tensor result = ttnn::unary_chain(x, ops_chain, output_mem_config);
-    Tensor mish_x = ttnn::multiply(x, result, std::nullopt, output_mem_config);
-    return mish_x;
-}
-
 // multivariate log-gamma function
 // Ref : https://pytorch.org/docs/stable/special.html#torch.special.multigammaln
 Tensor _multigammaln(const Tensor& x, const std::optional<MemoryConfig>& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -12,6 +12,10 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 
+const std::string BASE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/";
+
+std::string get_kernel_path(const std::string& kernel_filename) { return BASE_KERNEL_PATH + kernel_filename; }
+
 namespace ttnn::operations::unary::program {
 
 using namespace tt::constants;
@@ -40,7 +44,6 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
-
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = 2;
     tt::tt_metal::CircularBufferConfig cb_src0_config =
@@ -57,7 +60,6 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     auto src_buffer = input.buffer();
-
     auto dst_buffer = output.buffer();
 
     bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
@@ -90,9 +92,13 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     bool math_approx_mode = std::all_of(
         args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.op_type); });
     std::map<string, string> unary_defines = utils::get_block_defines(args.op_chain);
+    auto path = get_kernel_path("eltwise_sfpu.cpp");
+    if (ops_chain[0].op_type == UnaryOpType::MISH) {
+        path = get_kernel_path("mish_kernel.cpp");
+    }
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
+        path,
         core_group_1,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
@@ -111,7 +117,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
         auto eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
             program,
-            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
+            path,
             core_group_2,
             tt::tt_metal::ComputeConfig{
                 .math_fidelity = MathFidelity::HiFi4,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -12,11 +12,9 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 
-const std::string BASE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/";
-
-std::string get_kernel_path(const std::string& kernel_filename) { return BASE_KERNEL_PATH + kernel_filename; }
-
 namespace ttnn::operations::unary::program {
+
+static const std::string compute_root = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/";
 
 using namespace tt::constants;
 
@@ -92,10 +90,8 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     bool math_approx_mode = std::all_of(
         args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.op_type); });
     std::map<string, string> unary_defines = utils::get_block_defines(args.op_chain);
-    auto path = get_kernel_path("eltwise_sfpu.cpp");
-    if (ops_chain[0].op_type == UnaryOpType::MISH) {
-        path = get_kernel_path("mish_kernel.cpp");
-    }
+    auto path = utils::get_compute_kernel_path(ops_chain[0].op_type, compute_root);
+
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         path,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -14,6 +14,8 @@
 
 namespace ttnn::operations::unary::program {
 
+static const std::string compute_root_sharded = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/";
+
 using namespace tt::constants;
 using namespace tt::tt_metal::experimental;
 
@@ -121,10 +123,8 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     bool math_approx_mode = std::all_of(
         args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.op_type); });
     std::map<string, string> unary_defines = utils::get_block_defines(args.op_chain);
-    auto path = get_kernel_path("eltwise_sfpu.cpp");
-    if (ops_chain[0].op_type == UnaryOpType::MISH) {
-        path = get_kernel_path("mish_kernel.cpp");
-    }
+    auto path = utils::get_compute_kernel_path(ops_chain[0].op_type, compute_root_sharded);
+
     auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         path,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -22,6 +22,7 @@ inline Tensor unary_impl(
     const std::vector<UnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
+    TT_FATAL(op_chain.size() > 0, "Op chain cannot be empty");
     DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST)
                                 ? static_cast<DataType>(op_chain[0].params[1])
                                 : input_tensor.get_dtype();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -271,6 +271,16 @@ Tensor Ceil::invoke(
     return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
+Tensor Mish::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::MISH;
+
+    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+}
+
 template <UnaryOpType unary_op_type, typename T>
 Tensor ExecuteUnaryWithIntegerParameter<unary_op_type, T>::invoke(
     QueueId queue_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -176,6 +176,14 @@ struct AsymmetricBinop {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Mish {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 }  // namespace unary
 }  // namespace operations
 
@@ -278,6 +286,7 @@ constexpr auto abs = ttnn::register_operation_with_auto_launch_op<"ttnn::abs", t
 constexpr auto floor =
     ttnn::register_operation_with_auto_launch_op<"ttnn::floor", ttnn::operations::unary::Floor>();
 constexpr auto ceil = ttnn::register_operation_with_auto_launch_op<"ttnn::ceil", ttnn::operations::unary::Ceil>();
+constexpr auto mish = ttnn::register_operation_with_auto_launch_op<"ttnn::mish", ttnn::operations::unary::Mish>();
 constexpr auto softplus =
     ttnn::register_operation_with_auto_launch_op<"ttnn::softplus", ttnn::operations::unary::Softplus>();
 constexpr auto prelu_sfpu =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -120,10 +120,6 @@ struct ExecuteRdiv {
         std::optional<Tensor> optional_output_tensor = std::nullopt);
 };
 
-struct ExecuteMish {
-    static Tensor invoke(const Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config = std::nullopt);
-};
-
 }  // namespace unary
 }  // namespace operations
 
@@ -205,7 +201,6 @@ constexpr auto lgamma = ttnn::register_operation_with_auto_launch_op<
 constexpr auto log1p = ttnn::register_operation_with_auto_launch_op<
     "ttnn::log1p",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOG1P>>();
-constexpr auto mish = ttnn::register_operation_with_auto_launch_op<"ttnn::mish", operations::unary::ExecuteMish>();
 constexpr auto multigammaln = ttnn::register_operation_with_auto_launch_op<
     "ttnn::multigammaln",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MULTIGAMMALN>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1617,6 +1617,7 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::eqz, R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ == 0}}))doc");
     detail::bind_unary_operation(module, ttnn::floor, R"doc(\mathrm{{output\_tensor}}_i = \verb|floor|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(Supported only for Wormhole_B0.)doc");
     detail::bind_unary_operation(module, ttnn::ceil, R"doc(\mathrm{{output\_tensor}}_i = \verb|ceil|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(Supported only for Wormhole_B0.)doc");
+    detail::bind_unary_operation(module, ttnn::mish, R"doc(\mathrm{{output\_tensor}}_i = \verb|mish|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(Supported only for Wormhole_B0. [supported range -20 to inf].)doc");
     detail::bind_unary_operation(module, ttnn::gez, R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ >= 0}}))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::gtz, R"doc(\mathrm{{output\_tensor}}_i= (\mathrm{{input\_tensor_i\ > 0}}))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
 
@@ -1748,8 +1749,6 @@ void py_module(py::module& module) {
         R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(TILE)doc", R"doc(2, 3, 4)doc", "", R"doc(torch.tensor([[2, 3], [4, 5]], dtype=torch.bfloat16))doc");
     detail::bind_unary_composite(module, ttnn::lgamma, R"doc(Performs lgamma function on :attr:`input_tensor`.)doc", "[supported for value greater than 0].", R"doc(BFLOAT16)doc");
     detail::bind_unary_composite(module, ttnn::log1p, R"doc(Performs log1p function on :attr:`input_tensor`.)doc", "[supported range -1 to 1].", R"doc(BFLOAT16, BFLOAT8_B)doc");
-    detail::bind_unary_composite(module, ttnn::mish, R"doc(Performs mish function on :attr:`input_tensor`.)doc", "[supported range -20 to inf].", R"doc(BFLOAT16, BFLOAT8_B)doc",
-        R"doc(TILE)doc", R"doc(2, 3, 4)doc", R"doc(Not supported on Grayskull.)doc");
     detail::bind_unary_composite(module, ttnn::multigammaln, R"doc(Performs multigammaln function on :attr:`input_tensor`.)doc", "[supported range 1.6 to inf].", R"doc(BFLOAT16)doc",
         R"doc(TILE)doc", R"doc(2, 3, 4)doc", "", R"doc(torch.tensor([[2, 3], [4, 5]], dtype=torch.bfloat16))doc");
     detail::bind_unary_composite(module, ttnn::sinh, R"doc(Performs sinh function on :attr:`input_tensor`.)doc", "[supported range -9 to 9].", R"doc(BFLOAT16, BFLOAT8_B)doc");


### PR DESCRIPTION
### Ticket
Link to Github Issue #18191 

### Problem description
ttnn.mish is currently slow. 

### What's changed

- Instead of composite structure, updated the op into a device operation.

### Performance comparison of Mish

<img width="281" alt="Screenshot 2025-03-14 at 6 20 44 PM" src="https://github.com/user-attachments/assets/1d88013a-ad14-4d63-83b7-54821b977cf7" />

![Screenshot 2025-03-20 at 12 50 24 PM](https://github.com/user-attachments/assets/7641d647-ac9c-4917-9dbc-04c06b87d9f9)


So It is 54% faster compared to previous approach.

### Performance Reports:
Composite Op - 
[Mish_composite _op.csv](https://github.com/user-attachments/files/19340420/Mish_composite._op.csv)

Device Op - 
[Mish_Op.csv](https://github.com/user-attachments/files/19360787/Mish_Op.csv)


### Checklist
- [x] All Post commit CI