### PR TITLE
Replacing circular buffer creation code blocks by util function in conv2d program factories

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/circular_buffer_types.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
@@ -93,14 +94,15 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
         // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
         TT_FATAL(
             shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
-        cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_sharded_act_config =
-            CircularBufferConfig(
-                shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{cb_indices.sharded_act_cb, act_df}})
-                .set_page_size(cb_indices.sharded_act_cb, shard_shape[1] * num_bytes_for_df);
         // incoming data is the input cb instead of raw l1/dram addr
-        cb_sharded_act_config.set_globally_allocated_address(*input.buffer());
-        cb_sharded_act = tt_metal::CreateCircularBuffer(program, core, cb_sharded_act_config);
+        std::tie(cb_indices.sharded_act_cb, cb_sharded_act) = tt::tt_metal::create_cb(
+            cb_indices.get_next_cb_index(),
+            program,
+            core,
+            shard_shape[1] * num_bytes_for_df,
+            shard_shape[0],
+            act_df,
+            input.buffer());
 
         if (weight_width_sliced) {
             // For 2D convs, each core creates and tilizes full input matrix then mcasts round robin style
@@ -110,21 +112,15 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
 
             // num_cb0_tiles is double buffered
             cb_indices.act_cb = cb_indices.get_next_cb_index();
-            CircularBufferConfig cb_act_config =
-                CircularBufferConfig(num_cb0_tiles * tilized_act_tile_size, {{cb_indices.act_cb, tilized_act_df}})
-                    .set_page_size(cb_indices.act_cb, tilized_act_tile_size);
-            auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+            tt::tt_metal::create_cb(
+                cb_indices.act_cb, program, core, tilized_act_tile_size, num_cb0_tiles, tilized_act_df);
             log_debug(
                 LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, tilized_act_tile_size);
 
             // num_cb0_tilized_tiles is single buffered
             cb_indices.act_cb_row_major_bfloat16 = cb_indices.get_next_cb_index();
-            CircularBufferConfig cb_act_row_major_bfloat16_config =
-                CircularBufferConfig(
-                    num_cb0_tilized_tiles * act_tile_size, {{cb_indices.act_cb_row_major_bfloat16, act_df}})
-                    .set_page_size(cb_indices.act_cb_row_major_bfloat16, act_tile_size);
-            auto cb_act_row_major_bfloat16 =
-                tt_metal::CreateCircularBuffer(program, core, cb_act_row_major_bfloat16_config);
+            tt::tt_metal::create_cb(
+                cb_indices.act_cb_row_major_bfloat16, program, core, act_tile_size, num_cb0_tilized_tiles, act_df);
             log_debug(
                 LogOp,
                 "Act CB Row Major BFLOAT16: {}, npages: {}, pagesize: {}",
@@ -139,11 +135,8 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
             // In this case, the regular reader only does first half of reads along output block h
             if (split_reader) {
                 cb_indices.act_cb_second_reader = cb_indices.get_next_cb_index();
-                CircularBufferConfig cb_act_config =
-                    CircularBufferConfig(
-                        num_cb0_second_reader_tiles * act_tile_size, {{cb_indices.act_cb_second_reader, act_df}})
-                        .set_page_size(cb_indices.act_cb_second_reader, act_tile_size);
-                auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+                tt::tt_metal::create_cb(
+                    cb_indices.act_cb_second_reader, program, core, act_tile_size, num_cb0_second_reader_tiles, act_df);
                 log_debug(
                     LogOp,
                     "Act CB Second Reader: {}, npages: {}, pagesize: {}",
@@ -152,28 +145,24 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
                     act_tile_size);
             }
             cb_indices.act_cb = cb_indices.get_next_cb_index();
-            CircularBufferConfig cb_act_config =
-                CircularBufferConfig(num_cb0_tiles * act_tile_size, {{cb_indices.act_cb, act_df}})
-                    .set_page_size(cb_indices.act_cb, act_tile_size);
-            auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+            tt::tt_metal::create_cb(cb_indices.act_cb, program, core, act_tile_size, num_cb0_tiles, act_df);
             log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, act_tile_size);
         }
     } else {
         TT_THROW("Input must be sharded!");
     }
 
-    CircularBufferConfig cb_weight_config =
-        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{cb_indices.weight_cb, weight_df}})
-            .set_page_size(cb_indices.weight_cb, weight_tile_size);
-    auto cb_weight = tt_metal::CreateCircularBuffer(program, core, cb_weight_config);
+    tt::tt_metal::create_cb(cb_indices.weight_cb, program, core, weight_tile_size, num_cb1_tiles, weight_df);
     log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", cb_indices.weight_cb, num_cb1_tiles, weight_tile_size);
 
     // Used for placing tilized activations
-    CircularBufferConfig cb_src0_tilized_config =
-        CircularBufferConfig(
-            num_cb0_tilized_tiles * tilized_act_tile_size, {{cb_indices.tilize_mode_tilized_act_cb, tilized_act_df}})
-            .set_page_size(cb_indices.tilize_mode_tilized_act_cb, tilized_act_tile_size);
-    auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, core, cb_src0_tilized_config);
+    tt::tt_metal::create_cb(
+        cb_indices.tilize_mode_tilized_act_cb,
+        program,
+        core,
+        tilized_act_tile_size,
+        num_cb0_tilized_tiles,
+        tilized_act_df);
     log_debug(
         LogOp,
         "Tilized Act CB: {}, npages: {}, pagesize: {}",
@@ -182,13 +171,9 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
         tilized_act_tile_size);
 
     if (untilize_out) {
-        cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
         auto output_shard_shape = output.shard_spec().value().shape;
-        CircularBufferConfig cb_matmul_partials_config =
-            CircularBufferConfig(
-                num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
-                .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
-        cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+        std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) = tt::tt_metal::create_cb(
+            cb_indices.get_next_cb_index(), program, core, interm0_single_tile_size, num_output_tiles, interm0_df);
         log_debug(
             LogOp,
             "Matmul Partials CB: {}, npages: {}, pagesize: {}",
@@ -202,28 +187,31 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
         auto shard_shape = output.shard_spec().value().shape;
         uint32_t aligned_output_stick_nbytes = out_tile_size;
         uint32_t aligned_output_num_pages = num_writer_output_tiles;
-        cb_indices.out0_cb = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_output_config =
-            CircularBufferConfig(aligned_output_num_pages * aligned_output_stick_nbytes, {{cb_indices.out0_cb, out_df}})
-                .set_page_size(cb_indices.out0_cb, aligned_output_stick_nbytes);
-        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-        cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+        std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
+            cb_indices.get_next_cb_index(),
+            program,
+            core,
+            aligned_output_stick_nbytes,
+            aligned_output_num_pages,
+            out_df,
+            output.buffer());
     } else {
         // Share buffer if same data format
         if (interm0_df == out_df) {
-            CoreRangeSet cores(std::set<CoreRange>({core}));
-            cb_indices.out0_cb = cb_indices.get_next_cb_index();
             cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
-            std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {
-                {cb_indices.out0_cb, out_df}, {cb_indices.matmul_partials_cb, out_df}};
+            cb_indices.out0_cb = cb_indices.get_next_cb_index();
+            auto cb_tuple = tt::tt_metal::create_cb(
+                {cb_indices.matmul_partials_cb, cb_indices.out0_cb},
+                program,
+                core,
+                out_tile_size,
+                num_output_tiles,
+                out_df,
+                output.is_sharded() ? output.buffer() : nullptr);
 
-            CircularBufferConfig cb_matmul_partials_config =
-                CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
-                    .set_page_size(cb_indices.out0_cb, out_tile_size)
-                    .set_page_size(cb_indices.matmul_partials_cb, out_tile_size);
-            if (output.is_sharded()) {
-                cb_matmul_partials_config = cb_matmul_partials_config.set_globally_allocated_address(*output.buffer());
-            } else {
+            cb_output = cb_matmul_partials = std::get<1>(cb_tuple);
+
+            if (!output.is_sharded()) {
                 log_debug(
                     LogOp,
                     "Matmul Partials CB: {}, npages: {}, pagesize: {}",
@@ -231,16 +219,10 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
                     num_output_tiles,
                     out_tile_size);
             }
-            cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_matmul_partials_config);
-            cb_matmul_partials = cb_output;
         } else {
             // Separate buffer if not same data format
-            cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
-            CircularBufferConfig cb_matmul_partials_config =
-                CircularBufferConfig(
-                    num_output_tiles * interm0_single_tile_size, {{cb_indices.matmul_partials_cb, interm0_df}})
-                    .set_page_size(cb_indices.matmul_partials_cb, interm0_single_tile_size);
-            cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+            std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) = tt::tt_metal::create_cb(
+                cb_indices.get_next_cb_index(), program, core, interm0_single_tile_size, num_output_tiles, interm0_df);
             log_debug(
                 LogOp,
                 "Matmul Partials CB: {}, npages: {}, pagesize: {}",
@@ -248,14 +230,14 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
                 num_output_tiles,
                 interm0_single_tile_size);
 
-            cb_indices.out0_cb = cb_indices.get_next_cb_index();
-            CircularBufferConfig cb_output_config =
-                CircularBufferConfig(num_output_tiles * out_tile_size, {{cb_indices.out0_cb, out_df}})
-                    .set_page_size(cb_indices.out0_cb, out_tile_size);
-            if (output.is_sharded()) {
-                cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-            }
-            cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+            std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
+                cb_indices.get_next_cb_index(),
+                program,
+                core,
+                out_tile_size,
+                num_output_tiles,
+                out_df,
+                output.is_sharded() ? output.buffer() : nullptr);
         }
     }
 
@@ -264,11 +246,7 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
         // bias input
         uint32_t bias_pagesize = bias_tile_size;
         cb_indices.bias_cb = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_bias_config =
-            CircularBufferConfig(bias_ntiles * bias_pagesize, {{cb_indices.bias_cb, bias_df}})
-                .set_page_size(cb_indices.bias_cb, bias_pagesize);
-        auto cb_bias = tt_metal::CreateCircularBuffer(program, core, cb_bias_config);
-
+        tt::tt_metal::create_cb(cb_indices.bias_cb, program, core, bias_pagesize, bias_ntiles, bias_df);
         log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", cb_indices.bias_cb, bias_ntiles, bias_pagesize);
     }
 
@@ -276,7 +254,8 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
 }
 
 // TODO: Add namespace for utilities?
-std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandle> create_CBs_for_depthwise_sharded_input(
+std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandle>
+create_CBs_for_depthwise_sharded_input(
     tt_metal::Program& program,
     const Tensor& input,
     CoreRange core,
@@ -320,40 +299,37 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
         // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
         TT_FATAL(
             shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
-        cb_indices.sharded_act_cb = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_sharded_act_config =
-            CircularBufferConfig(
-                shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{cb_indices.sharded_act_cb, act_df}})
-                .set_page_size(cb_indices.sharded_act_cb, shard_shape[1] * num_bytes_for_df);
         // incoming data is the input cb instead of raw l1/dram addr
-        cb_sharded_act_config.set_globally_allocated_address(*input.buffer());
-        cb_sharded_act = tt_metal::CreateCircularBuffer(program, core, cb_sharded_act_config);
+        std::tie(cb_indices.sharded_act_cb, cb_sharded_act) = tt::tt_metal::create_cb(
+            cb_indices.get_next_cb_index(),
+            program,
+            core,
+            shard_shape[1] * num_bytes_for_df,
+            shard_shape[0],
+            act_df,
+            input.buffer());
 
         // For 1D convs, locally create act matrix in act_cb, which is always ROW_MAJOR BFLOAT16
         // Then, tilize input in compute
         cb_indices.act_cb = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_act_config =
-            CircularBufferConfig(num_cb0_tiles * act_tile_size, {{cb_indices.act_cb, act_df}})
-                .set_page_size(cb_indices.act_cb, act_tile_size);
-        auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+        tt::tt_metal::create_cb(cb_indices.act_cb, program, core, act_tile_size, num_cb0_tiles, act_df);
         log_debug(LogOp, "Act CB: {}, npages: {}, pagesize: {}", cb_indices.act_cb, num_cb0_tiles, act_tile_size);
 
     } else {
         TT_THROW("Input must be sharded!");
     }
 
-    CircularBufferConfig cb_weight_config =
-        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{cb_indices.weight_cb, weight_df}})
-            .set_page_size(cb_indices.weight_cb, weight_tile_size);
-    auto cb_weight = tt_metal::CreateCircularBuffer(program, core, cb_weight_config);
+    tt::tt_metal::create_cb(cb_indices.weight_cb, program, core, weight_tile_size, num_cb1_tiles, weight_df);
     log_debug(LogOp, "Weight CB: {}, npages: {}, pagesize: {}", cb_indices.weight_cb, num_cb1_tiles, weight_tile_size);
 
     // Used for placing tilized activations
-    CircularBufferConfig cb_src0_tilized_config =
-        CircularBufferConfig(
-            num_cb0_tilized_tiles * tilized_act_tile_size, {{cb_indices.tilize_mode_tilized_act_cb, tilized_act_df}})
-            .set_page_size(cb_indices.tilize_mode_tilized_act_cb, tilized_act_tile_size);
-    auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, core, cb_src0_tilized_config);
+    tt::tt_metal::create_cb(
+        cb_indices.tilize_mode_tilized_act_cb,
+        program,
+        core,
+        tilized_act_tile_size,
+        num_cb0_tilized_tiles,
+        tilized_act_df);
     log_debug(
         LogOp,
         "Act Tilized CB: {}, npages: {}, pagesize: {}",
@@ -366,34 +342,30 @@ std::tuple<tt::tt_metal::CBHandle, tt::tt_metal::CBHandle, tt::tt_metal::CBHandl
     CoreRangeSet cores(std::set<CoreRange>({core}));
 
     // breakdown above as separate CBs
-    cb_indices.matmul_partials_cb = cb_indices.get_next_cb_index();
-    CircularBufferConfig cb_matmul_partials_config =
-        CircularBufferConfig(1 * out_tile_size, {{cb_indices.matmul_partials_cb, out_df}})
-            .set_page_size(cb_indices.matmul_partials_cb, out_tile_size);
-    auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+    CBHandle cb_matmul_partials = 0;
+
+    std::tie(cb_indices.matmul_partials_cb, cb_matmul_partials) =
+        tt::tt_metal::create_cb(cb_indices.get_next_cb_index(), program, core, out_tile_size, 1, out_df);
     log_debug(
         LogOp, "Matmul Partials CB: {}, npages: {}, pagesize: {}", cb_indices.matmul_partials_cb, 1, out_tile_size);
 
     cb_indices.temp_sum_cb = cb_indices.get_next_cb_index();
-    CircularBufferConfig cb_temp_sum_config =
-        CircularBufferConfig(1 * out_tile_size, {{cb_indices.temp_sum_cb, out_df}})
-            .set_page_size(cb_indices.temp_sum_cb, out_tile_size);
-    auto cb_temp_sum = tt_metal::CreateCircularBuffer(program, core, cb_temp_sum_config);
+    tt::tt_metal::create_cb(cb_indices.temp_sum_cb, program, core, out_tile_size, 1, out_df);
     log_debug(LogOp, "Temp Sum CB: {}, npages: {}, pagesize: {}", cb_indices.temp_sum_cb, 1, out_tile_size);
 
-    cb_indices.out0_cb = cb_indices.get_next_cb_index();
-    std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {{cb_indices.out0_cb, out_df}};
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
-            .set_page_size(cb_indices.out0_cb, out_tile_size);
+    std::tie(cb_indices.out0_cb, cb_output) = tt::tt_metal::create_cb(
+        cb_indices.get_next_cb_index(),
+        program,
+        cores,
+        out_tile_size,
+        num_output_tiles,
+        out_df,
+        output.is_sharded() ? output.buffer() : nullptr);
 
-    if (output.is_sharded()) {
-        cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
-    } else {
+    if (!output.is_sharded()) {
         log_debug(
             LogOp, "Output CB: {}, npages: {}, pagesize: {}", cb_indices.out0_cb, num_output_tiles, out_tile_size);
     }
-    cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
 
     return {cb_sharded_act, cb_output, cb_matmul_partials};
 }
@@ -1327,21 +1299,20 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         }
         // Local L1 to store array for reader indices
         // All convs use packed uint16 indices, so each entry can be 2B (not 4)
-        cb_indices.cb_for_reader_indices = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_for_reader_indices_config =
-            CircularBufferConfig(
-                out_block_h_datums * 2, {{cb_indices.cb_for_reader_indices, tt::DataFormat::Float16_b}})
-                .set_page_size(cb_indices.cb_for_reader_indices, out_block_h_datums * 2);
-        cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices_buffer);
-        auto cb_for_reader_indices_id =
-            tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
+        CBHandle cb_for_reader_indices_id = 0;
+        std::tie(cb_indices.cb_for_reader_indices, cb_for_reader_indices_id) = tt::tt_metal::create_cb(
+            cb_indices.get_next_cb_index(),
+            program,
+            all_cores,
+            out_block_h_datums * 2,
+            1,
+            tt::DataFormat::Float16_b,
+            &*conv_reader_indices_buffer);
 
         // Local L1 to store temp vars
         cb_indices.cb_for_l1_array = cb_indices.get_next_cb_index();
-        CircularBufferConfig cb_for_l1_array_config =
-            CircularBufferConfig(l1_scratchpad_CB_size, {{cb_indices.cb_for_l1_array, tt::DataFormat::Float16_b}})
-                .set_page_size(cb_indices.cb_for_l1_array, l1_scratchpad_CB_size);
-        auto cb_for_l1_array_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+        tt::tt_metal::create_cb(
+            cb_indices.cb_for_l1_array, program, all_cores, l1_scratchpad_CB_size, 1, tt::DataFormat::Float16_b);
     } else {
         TT_THROW("Sharded input not supported for this conv yet!");
     }


### PR DESCRIPTION
### Problem description
Creating Circular Buffers throughout code are repetitive code blocks which can be easily replaced by a single function.

### What's changed
Replacing circular buffer creation code blocks by util function create_cb

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13835909661)
- [x] [(Single-card) Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/13839208305)
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/13839220571/job/38766865589)