### PR TITLE
#19118: Build L2 in 22.04 container because we now default old docker-run to use 22.04, and change to use newer docker in another PR

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -41,6 +41,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
+      version: 22.04
   test:
     needs: build
     strategy:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
         test-group:
           - name: ttnn nightly conv tests
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"


### PR DESCRIPTION
…
### Ticket

#19118

### Problem description

When we changed docker-run to use 22.04 by default, we forgot that one workflow (I think one left), L2, still built wheels for 20.04
Change now!!

### What's changed

Build in 22.04

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] L2 https://github.com/tenstorrent/tt-metal/actions/runs/13858870497
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes