### PR TITLE
Update default version to 22.04 in build artifact

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -24,7 +24,7 @@ on:
       version:
         required: false
         type: string
-        default: "20.04"
+        default: "22.04"
       architecture:
         required: false
         type: string
@@ -92,7 +92,7 @@ on:
       version:
         required: false
         type: string
-        default: "20.04"
+        default: "22.04"
       architecture:
         required: false
         type: string


### PR DESCRIPTION
### Ticket
Updating to ubuntu-22.04

### Problem description
Ubuntu-20.04 is not being supported anymore

### What's changed
Updated default version to 22.04 in build artifact

### Checklist
Build Artifact CI passes here: https://github.com/tenstorrent/tt-metal/actions/runs/13861037433
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes