### PR TITLE
Add sideband header support to tt-fabric.

### DIFF
--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -72,22 +72,32 @@ run_tg_tests() {
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*TG*
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DFixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DFixture.*"
-    # Unicast tests
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1
-    # Unicast tests for push router
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --push_router
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --push_router
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --push_router
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --push_router --metal_fabric_init_level 1
-    # Line Mcast tests
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 7
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 7
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 3
-    TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3 --metal_fabric_init_level 1
+    TESTS=(
+        # Unicast tests
+        "1 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
+        "2 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
+        "3 --fabric_command 65 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
+        "4 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1"
+        # Unicast tests for push router
+        "5 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --push_router"
+        "6 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --push_router"
+        "7 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --push_router"
+        "8 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --push_router --metal_fabric_init_level 1"
+        # Line Mcast tests
+        "9 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 7"
+        "10 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 7"
+        "11 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3"
+        "12 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 3"
+        "13 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3 --metal_fabric_init_level 1"
+    )
+    for TEST in "${TESTS[@]}"; do
+        # Extract test name and arguments
+        read -r TEST_NUMBER TEST_ARGS <<< "$TEST"
+        echo "LOG_FABRIC: Test $TEST_NUMBER: $TEST_ARGS"
+        # Execute the test command with extracted arguments
+        TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 $TEST_ARGS
+    done
+
   elif [[ "$1" == "llama3-70b" ]]; then
     run_tg_llama3.1-70b_tests
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_atomic_inc_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_atomic_inc_sender.cpp
@@ -11,6 +11,7 @@ using namespace tt::tt_fabric;
 
 void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t data_mode = get_compile_time_arg_val(1);
     uint32_t rt_args_idx = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t dst_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -31,7 +32,11 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
     fabric_endpoint_init(client_interface, 0 /* unused */);
 
-    fabric_async_write_atomic_inc(
+    fabric_async_write_atomic_inc<
+        decltype(client_interface),
+        (ClientDataMode)data_mode,
+        AsyncWriteMode::ALL,
+        RoutingType::ROUTER_XY>(
         client_interface,
         router_noc_xy,
         src_addr,  // source address in sender’s memory

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_multicast_multidirectional_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_multicast_multidirectional_sender.cpp
@@ -11,6 +11,8 @@ using namespace tt::tt_fabric;
 
 void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t data_mode = get_compile_time_arg_val(1);
+
     uint32_t rt_args_idx = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t dst_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -36,7 +38,11 @@ void kernel_main() {
         fabric_endpoint_init(client_interface + i, 0 /* unused */);
     }
 
-    fabric_async_write_multicast(
+    fabric_async_write_multicast<
+        decltype(client_interface),
+        (ClientDataMode)data_mode,
+        AsyncWriteMode::ALL,
+        RoutingType::ROUTER_XY>(
         client_interface,
         e_router_noc_xy,
         src_addr,  // source address in sender’s memory
@@ -49,31 +55,53 @@ void kernel_main() {
         0,
         0);
 
-    // Wait for packet header to be flushed since we will reuse it for the next mcast direction
-    fabric_wait_for_pull_request_bytes_flushed(client_interface, PACKET_HEADER_SIZE_BYTES);
-    packet_header_t* packet_header = (packet_header_t*)(src_addr);
-
     // West Mcast
-    client_interface++;
+    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+        // Wait for packet header to be flushed since we will reuse it for the next mcast direction
+        fabric_wait_for_pull_request_bytes_flushed(client_interface, PACKET_HEADER_SIZE_BYTES);
+        client_interface++;
+        packet_header_t* packet_header = (packet_header_t*)(src_addr);
+        packet_header->routing.dst_mesh_id = w_dst_mesh_id;
+        packet_header->routing.dst_dev_id = w_dst_device_id;
+        packet_header->packet_parameters.mcast_parameters.east = 0;
+        packet_header->packet_parameters.mcast_parameters.west = w_depth;
 
-    packet_header->routing.dst_mesh_id = w_dst_mesh_id;
-    packet_header->routing.dst_dev_id = w_dst_device_id;
-    packet_header->packet_parameters.mcast_parameters.east = 0;
-    packet_header->packet_parameters.mcast_parameters.west = w_depth;
-
-    fabric_async_write_multicast<AsyncWriteMode::ADD_AND_SEND_PR>(
-        client_interface,
-        w_router_noc_xy,
-        src_addr,  // source address in sender’s memory
-        w_dst_mesh_id,
-        w_dst_device_id,
-        dst_noc_addr,       // destination write address
-        packet_size_bytes,  // number of bytes to write to remote destination
-        0,
-        w_depth,
-        0,
-        0);
-
+        fabric_async_write_multicast<
+            decltype(client_interface),
+            (ClientDataMode)data_mode,
+            AsyncWriteMode::ADD_AND_SEND_PR,
+            RoutingType::ROUTER_XY>(
+            client_interface,
+            w_router_noc_xy,
+            src_addr,  // source address in sender’s memory
+            w_dst_mesh_id,
+            w_dst_device_id,
+            dst_noc_addr,       // destination write address
+            packet_size_bytes,  // number of bytes to write to remote destination
+            0,
+            w_depth,
+            0,
+            0);
+    } else {
+        // For sideband header, we will use header slot in second client interface.
+        // Use AsyncWriteMode::ALL, since the header slot needs to be initialized.
+        fabric_async_write_multicast<
+            decltype(client_interface),
+            (ClientDataMode)data_mode,
+            AsyncWriteMode::ALL,
+            RoutingType::ROUTER_XY>(
+            client_interface,
+            w_router_noc_xy,
+            src_addr,  // source address in sender’s memory
+            w_dst_mesh_id,
+            w_dst_device_id,
+            dst_noc_addr,       // destination write address
+            packet_size_bytes,  // number of bytes to write to remote destination
+            0,
+            w_depth,
+            0,
+            0);
+    }
     // Flush all pull requests
     client_interface = reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
     for (uint32_t i = 0; i < num_dirs; i++) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_multicast_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_multicast_sender.cpp
@@ -11,6 +11,7 @@ using namespace tt::tt_fabric;
 
 void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t data_mode = get_compile_time_arg_val(1);
     uint32_t rt_args_idx = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t dst_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -29,7 +30,11 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
     fabric_endpoint_init(client_interface, 0 /* unused */);
 
-    fabric_async_write_multicast(
+    fabric_async_write_multicast<
+        decltype(client_interface),
+        (ClientDataMode)data_mode,
+        AsyncWriteMode::ALL,
+        RoutingType::ROUTER_XY>(
         client_interface,
         e_router_noc_xy,
         src_addr,  // source address in sender’s memory

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_sender.cpp
@@ -11,6 +11,8 @@ using namespace tt::tt_fabric;
 
 void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t data_mode = get_compile_time_arg_val(1);
+
     uint32_t rt_args_idx = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t dst_noc_offset = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -28,7 +30,7 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
     fabric_endpoint_init(client_interface, 0 /* unused */);
 
-    fabric_async_write(
+    fabric_async_write<(ClientDataMode)data_mode, AsyncWriteMode::ALL, RoutingType::ROUTER_XY>(
         client_interface,
         router_noc_xy,
         src_addr,  // source address in sender’s memory

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -46,6 +46,7 @@ TEST_F(Fabric2DFixture, TestAsyncWrite) {
         GTEST_SKIP() << "No path found between sender and receivers";
     }
 
+    tt::log_info(tt::LogTest, "Async Write from {} to {}", start_mesh_chip_id.second, end_mesh_chip_id.second);
     // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
     auto routers = control_plane->get_routers_to_chip(
         start_mesh_chip_id.first, start_mesh_chip_id.second, end_mesh_chip_id.first, end_mesh_chip_id.second);
@@ -115,7 +116,7 @@ TEST_F(Fabric2DFixture, TestAsyncWrite) {
     auto client_interface_cb =
         tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
 
-    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index};
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 0};
     std::map<string, string> defines = {};
     defines["FVC_MODE_PULL"] = "";
     auto sender_kernel = tt_metal::CreateKernel(
@@ -169,6 +170,158 @@ TEST_F(Fabric2DFixture, TestAsyncWrite) {
     std::vector<uint32_t> received_buffer_data;
     tt::tt_metal::detail::ReadFromBuffer(receiver_buffer, received_buffer_data);
     EXPECT_EQ(receiver_buffer_data, received_buffer_data);
+}
+
+TEST_F(Fabric2DFixture, TestAsyncRawWrite) {
+    using tt::tt_metal::ShardedBufferConfig;
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::ShardSpecBuffer;
+
+    CoreCoord sender_logical_core = {0, 0};
+    CoreRangeSet sender_logical_crs = {sender_logical_core};
+    CoreCoord receiver_logical_core = {1, 0};
+    CoreRangeSet receiver_logical_crs = {receiver_logical_core};
+    std::pair<mesh_id_t, chip_id_t> start_mesh_chip_id;
+    chip_id_t physical_start_device_id;
+    std::pair<mesh_id_t, chip_id_t> end_mesh_chip_id;
+    chip_id_t physical_end_device_id;
+
+    auto control_plane = tt::Cluster::instance().get_control_plane();
+
+    // Find a device with a neighbour in the East direction
+    bool connection_found = false;
+    for (auto* device : devices_) {
+        start_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+        // Get neighbours within a mesh in the East direction
+        auto neighbors = control_plane->get_intra_chip_neighbors(
+            start_mesh_chip_id.first, start_mesh_chip_id.second, RoutingDirection::E);
+        if (neighbors.size() > 0) {
+            physical_start_device_id = device->id();
+            end_mesh_chip_id = {start_mesh_chip_id.first, neighbors[0]};
+            physical_end_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(end_mesh_chip_id);
+            connection_found = true;
+            break;
+        }
+    }
+    if (!connection_found) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+
+    tt::log_info(tt::LogTest, "Raw Async Write from {} to {}", start_mesh_chip_id.second, end_mesh_chip_id.second);
+    // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
+    auto routers = control_plane->get_routers_to_chip(
+        start_mesh_chip_id.first, start_mesh_chip_id.second, end_mesh_chip_id.first, end_mesh_chip_id.second);
+
+    auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
+    auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+
+    uint32_t data_size = tt::constants::TILE_HW * sizeof(uint32_t);
+
+    auto receiver_shard_parameters =
+        ShardSpecBuffer(receiver_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig receiver_shard_config = {
+        .device = receiver_device,
+        .size = data_size,
+        .page_size = data_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(receiver_shard_parameters),
+    };
+    auto receiver_buffer = CreateBuffer(receiver_shard_config);
+    // Reset buffer space for test validation
+    std::vector<uint32_t> receiver_buffer_data(data_size / sizeof(uint32_t), 0);
+    tt::tt_metal::detail::WriteToBuffer(receiver_buffer, receiver_buffer_data);
+
+    auto sender_shard_parameters =
+        ShardSpecBuffer(sender_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig sender_shard_config = {
+        .device = sender_device,
+        .size = data_size,
+        .page_size = data_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(sender_shard_parameters),
+    };
+    auto sender_buffer = CreateBuffer(sender_shard_config);
+    // Write the data to send to the buffer
+    std::vector<uint32_t> sender_buffer_data(data_size / sizeof(uint32_t), 0);
+    std::iota(sender_buffer_data.begin(), sender_buffer_data.end(), 0);
+    tt::tt_metal::detail::WriteToBuffer(sender_buffer, sender_buffer_data);
+
+    // Wait for buffer data to be written to device
+    tt::Cluster::instance().l1_barrier(physical_end_device_id);
+    tt::Cluster::instance().l1_barrier(physical_start_device_id);
+
+    auto receiver_noc_encoding = tt::tt_metal::hal.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+
+    // Allocate space for the client interface
+    uint32_t client_interface_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig client_interface_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            tt::tt_fabric::CLIENT_INTERFACE_SIZE, {{client_interface_cb_index, DataFormat::UInt32}})
+            .set_page_size(client_interface_cb_index, tt::tt_fabric::CLIENT_INTERFACE_SIZE);
+    auto client_interface_cb =
+        tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
+
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 1};
+    std::map<string, string> defines = {};
+    defines["FVC_MODE_PULL"] = "";
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_sender.cpp",
+        sender_logical_crs,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = sender_compile_time_args,
+            .defines = defines});
+
+    auto& sender_virtual_router_coord = routers[0].second;
+    auto sender_router_noc_xy =
+        tt_metal::hal.noc_xy_encoding(sender_virtual_router_coord.x, sender_virtual_router_coord.y);
+
+    std::vector<uint32_t> sender_runtime_args = {
+        sender_buffer->address(),
+        receiver_noc_encoding,
+        receiver_buffer->address(),
+        data_size,
+        end_mesh_chip_id.first,
+        end_mesh_chip_id.second,
+        sender_router_noc_xy};
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    // Create the receiver program for validation
+    auto receiver_program = tt_metal::CreateProgram();
+    auto receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_receiver.cpp",
+        {receiver_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .defines = defines});
+
+    std::vector<uint32_t> receiver_runtime_args = {
+        receiver_buffer->address(),
+        data_size,
+    };
+    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+    // Launch sender and receiver programs and wait for them to finish
+    this->RunProgramNonblocking(receiver_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(receiver_device, receiver_program);
+
+    // Validate the data received by the receiver
+    std::vector<uint32_t> received_buffer_data;
+    tt::tt_metal::detail::ReadFromBuffer(receiver_buffer, received_buffer_data);
+    EXPECT_EQ(sender_buffer_data, received_buffer_data);
 }
 
 TEST_F(Fabric2DFixture, TestAtomicInc) {
@@ -450,7 +603,7 @@ TEST_F(Fabric2DFixture, TestAsyncWriteAtomicInc) {
 
     std::map<string, string> defines = {};
     defines["FVC_MODE_PULL"] = "";
-    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index};
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 0};
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_atomic_inc_sender.cpp",
@@ -504,6 +657,176 @@ TEST_F(Fabric2DFixture, TestAsyncWriteAtomicInc) {
     std::vector<uint32_t> received_buffer_data;
     tt::tt_metal::detail::ReadFromBuffer(receiver_buffer, received_buffer_data);
     EXPECT_EQ(receiver_buffer_data, received_buffer_data);
+    received_buffer_data.clear();
+    tt::tt_metal::detail::ReadFromBuffer(receiver_atomic_buffer, received_buffer_data);
+    EXPECT_EQ(atomic_inc, received_buffer_data[0]);
+}
+
+TEST_F(Fabric2DFixture, TestAsyncRawWriteAtomicInc) {
+    using tt::tt_metal::ShardedBufferConfig;
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::ShardSpecBuffer;
+
+    CoreCoord sender_logical_core = {0, 0};
+    CoreRangeSet sender_logical_crs = {sender_logical_core};
+    CoreCoord receiver_logical_core = {1, 0};
+    CoreRangeSet receiver_logical_crs = {receiver_logical_core};
+    std::pair<mesh_id_t, chip_id_t> start_mesh_chip_id;
+    chip_id_t physical_start_device_id;
+    std::pair<mesh_id_t, chip_id_t> end_mesh_chip_id;
+    chip_id_t physical_end_device_id;
+
+    auto control_plane = tt::Cluster::instance().get_control_plane();
+
+    // Find a device with a neighbour in the East direction
+    bool connection_found = false;
+    for (auto* device : devices_) {
+        start_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+        // Get neighbours within a mesh in the East direction
+        auto neighbors = control_plane->get_intra_chip_neighbors(
+            start_mesh_chip_id.first, start_mesh_chip_id.second, RoutingDirection::E);
+        if (neighbors.size() > 0) {
+            physical_start_device_id = device->id();
+            end_mesh_chip_id = {start_mesh_chip_id.first, neighbors[0]};
+            physical_end_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(end_mesh_chip_id);
+            connection_found = true;
+            break;
+        }
+    }
+    if (!connection_found) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+
+    // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
+    auto routers = control_plane->get_routers_to_chip(
+        start_mesh_chip_id.first, start_mesh_chip_id.second, end_mesh_chip_id.first, end_mesh_chip_id.second);
+
+    auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
+    auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+
+    uint32_t data_size = tt::constants::TILE_HW * sizeof(uint32_t);
+    uint32_t atomic_inc_size = sizeof(uint32_t);
+
+    auto receiver_shard_parameters =
+        ShardSpecBuffer(receiver_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig receiver_shard_config = {
+        .device = receiver_device,
+        .size = data_size,
+        .page_size = data_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = receiver_shard_parameters,
+    };
+    auto receiver_buffer = CreateBuffer(receiver_shard_config);
+    ShardedBufferConfig receiver_atomic_shard_config = {
+        .device = receiver_device,
+        .size = atomic_inc_size,
+        .page_size = atomic_inc_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = receiver_shard_parameters,
+    };
+    auto receiver_atomic_buffer = CreateBuffer(receiver_atomic_shard_config);
+    // Reset buffer space for test validation
+    std::vector<uint32_t> receiver_buffer_data(atomic_inc_size / sizeof(uint32_t), 0);
+    tt::tt_metal::detail::WriteToBuffer(receiver_atomic_buffer, receiver_buffer_data);
+    receiver_buffer_data.resize(data_size / sizeof(uint32_t), 0);
+    tt::tt_metal::detail::WriteToBuffer(receiver_buffer, receiver_buffer_data);
+
+    auto sender_shard_parameters =
+        ShardSpecBuffer(sender_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig sender_shard_config = {
+        .device = sender_device,
+        .size = data_size,
+        .page_size = data_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(sender_shard_parameters),
+    };
+    auto sender_buffer = CreateBuffer(sender_shard_config);
+    // Write the data to send to the buffer
+    std::vector<uint32_t> sender_buffer_data(data_size / sizeof(uint32_t), 0);
+    std::iota(sender_buffer_data.begin(), sender_buffer_data.end(), 0);
+    tt::tt_metal::detail::WriteToBuffer(sender_buffer, sender_buffer_data);
+
+    uint32_t atomic_inc = 5;
+
+    // Wait for buffer data to be written to device
+    tt::Cluster::instance().l1_barrier(physical_end_device_id);
+    tt::Cluster::instance().l1_barrier(physical_start_device_id);
+
+    auto receiver_noc_encoding = tt::tt_metal::hal.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+
+    // Allocate space for the client interface
+    uint32_t client_interface_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig client_interface_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            tt::tt_fabric::CLIENT_INTERFACE_SIZE, {{client_interface_cb_index, DataFormat::UInt32}})
+            .set_page_size(client_interface_cb_index, tt::tt_fabric::CLIENT_INTERFACE_SIZE);
+    auto client_interface_cb =
+        tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
+
+    std::map<string, string> defines = {};
+    defines["FVC_MODE_PULL"] = "";
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 1};
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_atomic_inc_sender.cpp",
+        sender_logical_crs,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = sender_compile_time_args,
+            .defines = defines});
+
+    auto& sender_virtual_router_coord = routers[0].second;
+    auto sender_router_noc_xy =
+        tt_metal::hal.noc_xy_encoding(sender_virtual_router_coord.x, sender_virtual_router_coord.y);
+
+    std::vector<uint32_t> sender_runtime_args = {
+        sender_buffer->address(),
+        receiver_noc_encoding,
+        receiver_buffer->address(),
+        receiver_atomic_buffer->address(),
+        data_size,
+        atomic_inc,
+        end_mesh_chip_id.first,
+        end_mesh_chip_id.second,
+        sender_router_noc_xy};
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    // Create the receiver program for validation
+    auto receiver_program = tt_metal::CreateProgram();
+    auto receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_receiver.cpp",
+        {receiver_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .defines = defines});
+
+    std::vector<uint32_t> receiver_runtime_args = {
+        receiver_buffer->address(),
+        data_size,
+    };
+    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+    // Launch sender and receiver programs and wait for them to finish
+    this->RunProgramNonblocking(receiver_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(receiver_device, receiver_program);
+
+    // Validate the data received by the receiver
+    std::vector<uint32_t> received_buffer_data;
+    tt::tt_metal::detail::ReadFromBuffer(receiver_buffer, received_buffer_data);
+    EXPECT_EQ(sender_buffer_data, received_buffer_data);
     received_buffer_data.clear();
     tt::tt_metal::detail::ReadFromBuffer(receiver_atomic_buffer, received_buffer_data);
     EXPECT_EQ(atomic_inc, received_buffer_data[0]);
@@ -675,7 +998,7 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticast) {
     auto client_interface_cb =
         tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
 
-    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index};
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 0};
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_multicast_sender.cpp",
@@ -726,6 +1049,221 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticast) {
             std::vector<uint32_t> received_buffer_data;
             tt::tt_metal::detail::ReadFromBuffer(receiver_buffers[i], received_buffer_data);
             EXPECT_EQ(receiver_buffer_data, received_buffer_data);
+        }
+    }
+}
+
+TEST_F(Fabric2DFixture, TestAsyncRawWriteMulticast) {
+    using tt::tt_metal::ShardedBufferConfig;
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::ShardSpecBuffer;
+
+    CoreCoord sender_logical_core = {0, 0};
+    CoreRangeSet sender_logical_crs = {sender_logical_core};
+    CoreCoord receiver_logical_core = {1, 0};
+    CoreRangeSet receiver_logical_crs = {receiver_logical_core};
+    std::pair<mesh_id_t, chip_id_t> start_mesh_chip_id;
+    chip_id_t physical_start_device_id;
+    std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>> end_mesh_chip_ids_by_dir;
+    std::unordered_map<RoutingDirection, std::vector<chip_id_t>> physical_end_device_ids_by_dir;
+    std::unordered_map<RoutingDirection, uint32_t> mcast_hops;
+    auto routing_direction = RoutingDirection::E;
+    mcast_hops[routing_direction] = 1;
+
+    auto control_plane = tt::Cluster::instance().get_control_plane();
+
+    // Find a device with enough neighbours in the specified direction
+    bool connection_found = false;
+    for (auto* device : devices_) {
+        start_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+        std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>>
+            temp_end_mesh_chip_ids_by_dir;
+        std::unordered_map<RoutingDirection, std::vector<chip_id_t>> temp_physical_end_device_ids_by_dir;
+        connection_found = true;
+        for (auto [routing_direction, num_hops] : mcast_hops) {
+            bool direction_found = true;
+            auto& temp_end_mesh_chip_ids = temp_end_mesh_chip_ids_by_dir[routing_direction];
+            auto& temp_physical_end_device_ids = temp_physical_end_device_ids_by_dir[routing_direction];
+            uint32_t curr_mesh_id = start_mesh_chip_id.first;
+            uint32_t curr_chip_id = start_mesh_chip_id.second;
+            for (uint32_t i = 0; i < num_hops; i++) {
+                auto neighbors = control_plane->get_intra_chip_neighbors(curr_mesh_id, curr_chip_id, routing_direction);
+                if (neighbors.size() > 0) {
+                    temp_end_mesh_chip_ids.emplace_back(curr_mesh_id, neighbors[0]);
+                    temp_physical_end_device_ids.push_back(
+                        control_plane->get_physical_chip_id_from_mesh_chip_id(temp_end_mesh_chip_ids.back()));
+                    curr_mesh_id = temp_end_mesh_chip_ids.back().first;
+                    curr_chip_id = temp_end_mesh_chip_ids.back().second;
+                } else {
+                    direction_found = false;
+                    break;
+                }
+            }
+            if (!direction_found) {
+                connection_found = false;
+                break;
+            }
+        }
+        if (connection_found) {
+            physical_start_device_id = device->id();
+            end_mesh_chip_ids_by_dir = std::move(temp_end_mesh_chip_ids_by_dir);
+            physical_end_device_ids_by_dir = std::move(temp_physical_end_device_ids_by_dir);
+            break;
+        }
+    }
+
+    if (!connection_found) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+
+    tt::log_info(
+        tt::LogTest, "Async Raw Write Mcast from {} to {}", start_mesh_chip_id.second, end_mesh_chip_ids_by_dir);
+
+    auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    // Virtual coordinate space. All devices have the same logical to virtual mapping
+    CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
+
+    uint32_t data_size = tt::constants::TILE_HW * sizeof(uint32_t);
+
+    auto receiver_shard_parameters =
+        ShardSpecBuffer(receiver_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+
+    // Reset buffer space for test validation
+    std::vector<uint32_t> receiver_buffer_data(data_size / sizeof(uint32_t), 0);
+
+    std::map<string, string> defines = {};
+    defines["FVC_MODE_PULL"] = "";
+    std::vector<tt_metal::Program> receiver_programs;
+    std::vector<std::shared_ptr<tt_metal::Buffer>> receiver_buffers;
+    for (auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (auto physical_end_device_id : physical_end_device_ids) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
+            ShardedBufferConfig receiver_shard_config = {
+                .device = receiver_device,
+                .size = data_size,
+                .page_size = data_size,
+                .buffer_type = tt_metal::BufferType::L1,
+                .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+                .shard_parameters = receiver_shard_parameters,
+            };
+            auto receiver_buffer = CreateBuffer(receiver_shard_config);
+            tt::tt_metal::detail::WriteToBuffer(receiver_buffer, receiver_buffer_data);
+            tt::Cluster::instance().l1_barrier(physical_end_device_id);
+            // Create the receiver program for validation
+            auto receiver_program = tt_metal::CreateProgram();
+            auto receiver_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_receiver.cpp",
+                {receiver_logical_core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .defines = defines});
+
+            std::vector<uint32_t> receiver_runtime_args = {
+                receiver_buffer->address(),
+                data_size,
+            };
+            tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+            this->RunProgramNonblocking(receiver_device, receiver_program);
+            receiver_programs.push_back(std::move(receiver_program));
+            receiver_buffers.push_back(std::move(receiver_buffer));
+        }
+    }
+    // Assume all receiver buffers are at the same address
+    uint32_t receiver_buffer_addr = receiver_buffers[0]->address();
+    for (const auto& receiver_buffer : receiver_buffers) {
+        if (receiver_buffer_addr != receiver_buffer->address()) {
+            GTEST_SKIP() << "Receiver buffers are not at the same address";
+        }
+    }
+
+    auto sender_shard_parameters =
+        ShardSpecBuffer(sender_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig sender_shard_config = {
+        .device = sender_device,
+        .size = data_size,
+        .page_size = data_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(sender_shard_parameters),
+    };
+    auto sender_buffer = CreateBuffer(sender_shard_config);
+    // Write the data to send to the buffer
+    std::vector<uint32_t> sender_buffer_data(data_size / sizeof(uint32_t), 0);
+    std::iota(sender_buffer_data.begin(), sender_buffer_data.end(), 0);
+    tt::tt_metal::detail::WriteToBuffer(sender_buffer, sender_buffer_data);
+
+    // Wait for buffer data to be written to device
+    tt::Cluster::instance().l1_barrier(physical_start_device_id);
+
+    auto receiver_noc_encoding = tt::tt_metal::hal.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+
+    // Allocate space for the client interface
+    uint32_t client_interface_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig client_interface_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            mcast_hops.size() * tt::tt_fabric::CLIENT_INTERFACE_SIZE, {{client_interface_cb_index, DataFormat::UInt32}})
+            .set_page_size(client_interface_cb_index, tt::tt_fabric::CLIENT_INTERFACE_SIZE);
+    auto client_interface_cb =
+        tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
+
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 1};
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_pull_async_write_multicast_sender.cpp",
+        sender_logical_crs,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = sender_compile_time_args,
+            .defines = defines});
+
+    std::unordered_map<RoutingDirection, uint32_t> sender_router_noc_xys;
+    for (auto& [routing_direction, end_mesh_chip_ids] : end_mesh_chip_ids_by_dir) {
+        auto routers = control_plane->get_routers_to_chip(
+            start_mesh_chip_id.first,
+            start_mesh_chip_id.second,
+            end_mesh_chip_ids[0].first,
+            end_mesh_chip_ids[0].second);
+        auto& sender_virtual_router_coord = routers[0].second;
+        sender_router_noc_xys.try_emplace(
+            routing_direction,
+            tt_metal::hal.noc_xy_encoding(sender_virtual_router_coord.x, sender_virtual_router_coord.y));
+    }
+
+    std::vector<uint32_t> sender_runtime_args = {
+        sender_buffer->address(),
+        receiver_noc_encoding,
+        receiver_buffer_addr,
+        data_size,
+        end_mesh_chip_ids_by_dir[routing_direction][0].first,
+        end_mesh_chip_ids_by_dir[routing_direction][0].second,
+        mcast_hops[routing_direction],
+        sender_router_noc_xys[routing_direction]};
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    // Launch sender and receiver programs and wait for them to finish
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_ids[i]);
+            this->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+        }
+    }
+
+    // Validate the data received by the receiver
+    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
+            std::vector<uint32_t> received_buffer_data;
+            tt::tt_metal::detail::ReadFromBuffer(receiver_buffers[i], received_buffer_data);
+            EXPECT_EQ(sender_buffer_data, received_buffer_data);
         }
     }
 }
@@ -793,6 +1331,11 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticastMultidirectional) {
     if (!connection_found) {
         GTEST_SKIP() << "No path found between sender and receivers";
     }
+    tt::log_info(
+        tt::LogTest,
+        "Async Write Mcast Multidirection from {} to {}",
+        start_mesh_chip_id.second,
+        end_mesh_chip_ids_by_dir);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
     CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
@@ -897,7 +1440,7 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticastMultidirectional) {
     auto client_interface_cb =
         tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
 
-    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index};
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 0};
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/"
@@ -953,6 +1496,229 @@ TEST_F(Fabric2DFixture, TestAsyncWriteMulticastMultidirectional) {
             std::vector<uint32_t> received_buffer_data;
             tt::tt_metal::detail::ReadFromBuffer(receiver_buffers[i], received_buffer_data);
             EXPECT_EQ(receiver_buffer_data, received_buffer_data);
+        }
+    }
+}
+
+TEST_F(Fabric2DFixture, TestAsyncRawWriteMulticastMultidirectional) {
+    using tt::tt_metal::ShardedBufferConfig;
+    using tt::tt_metal::ShardOrientation;
+    using tt::tt_metal::ShardSpecBuffer;
+
+    CoreCoord sender_logical_core = {0, 0};
+    CoreRangeSet sender_logical_crs = {sender_logical_core};
+    CoreCoord receiver_logical_core = {1, 0};
+    CoreRangeSet receiver_logical_crs = {receiver_logical_core};
+    std::pair<mesh_id_t, chip_id_t> start_mesh_chip_id;
+    chip_id_t physical_start_device_id;
+    std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>> end_mesh_chip_ids_by_dir;
+    std::unordered_map<RoutingDirection, std::vector<chip_id_t>> physical_end_device_ids_by_dir;
+    RoutingDirection routing_direction = RoutingDirection::E;
+    std::unordered_map<RoutingDirection, uint32_t> mcast_hops;
+    mcast_hops[RoutingDirection::E] = 1;
+    mcast_hops[RoutingDirection::W] = 2;
+
+    auto control_plane = tt::Cluster::instance().get_control_plane();
+
+    // Find a device with enough neighbours in the specified direction
+    bool connection_found = false;
+    for (auto* device : devices_) {
+        start_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+        std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>>
+            temp_end_mesh_chip_ids_by_dir;
+        std::unordered_map<RoutingDirection, std::vector<chip_id_t>> temp_physical_end_device_ids_by_dir;
+        connection_found = true;
+        for (auto [routing_direction, num_hops] : mcast_hops) {
+            bool direction_found = true;
+            auto& temp_end_mesh_chip_ids = temp_end_mesh_chip_ids_by_dir[routing_direction];
+            auto& temp_physical_end_device_ids = temp_physical_end_device_ids_by_dir[routing_direction];
+            uint32_t curr_mesh_id = start_mesh_chip_id.first;
+            uint32_t curr_chip_id = start_mesh_chip_id.second;
+            for (uint32_t i = 0; i < num_hops; i++) {
+                auto neighbors = control_plane->get_intra_chip_neighbors(curr_mesh_id, curr_chip_id, routing_direction);
+                if (neighbors.size() > 0) {
+                    temp_end_mesh_chip_ids.emplace_back(curr_mesh_id, neighbors[0]);
+                    temp_physical_end_device_ids.push_back(
+                        control_plane->get_physical_chip_id_from_mesh_chip_id(temp_end_mesh_chip_ids.back()));
+                    curr_mesh_id = temp_end_mesh_chip_ids.back().first;
+                    curr_chip_id = temp_end_mesh_chip_ids.back().second;
+                } else {
+                    direction_found = false;
+                    break;
+                }
+            }
+            if (!direction_found) {
+                connection_found = false;
+                break;
+            }
+        }
+        if (connection_found) {
+            physical_start_device_id = device->id();
+            end_mesh_chip_ids_by_dir = std::move(temp_end_mesh_chip_ids_by_dir);
+            physical_end_device_ids_by_dir = std::move(temp_physical_end_device_ids_by_dir);
+            break;
+        }
+    }
+
+    if (!connection_found) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+    tt::log_info(
+        tt::LogTest,
+        "Async Raw Write Mcast Multidirection from {} to {}",
+        start_mesh_chip_id.second,
+        end_mesh_chip_ids_by_dir);
+
+    auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    // Virtual coordinate space. All devices have the same logical to virtual mapping
+    CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
+
+    uint32_t data_size = tt::constants::TILE_HW * sizeof(uint32_t);
+
+    auto receiver_shard_parameters =
+        ShardSpecBuffer(receiver_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+
+    // Reset buffer space for test validation
+    std::vector<uint32_t> receiver_buffer_data(data_size / sizeof(uint32_t), 0);
+
+    std::map<string, string> defines = {};
+    defines["FVC_MODE_PULL"] = "";
+    std::vector<tt_metal::Program> receiver_programs;
+    std::vector<std::shared_ptr<tt_metal::Buffer>> receiver_buffers;
+    for (auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (auto physical_end_device_id : physical_end_device_ids) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_id);
+            ShardedBufferConfig receiver_shard_config = {
+                .device = receiver_device,
+                .size = data_size,
+                .page_size = data_size,
+                .buffer_type = tt_metal::BufferType::L1,
+                .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+                .shard_parameters = receiver_shard_parameters,
+            };
+            auto receiver_buffer = CreateBuffer(receiver_shard_config);
+            tt::tt_metal::detail::WriteToBuffer(receiver_buffer, receiver_buffer_data);
+            tt::Cluster::instance().l1_barrier(physical_end_device_id);
+            // Create the receiver program for validation
+            auto receiver_program = tt_metal::CreateProgram();
+            auto receiver_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_receiver.cpp",
+                {receiver_logical_core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .defines = defines});
+
+            std::vector<uint32_t> receiver_runtime_args = {
+                receiver_buffer->address(),
+                data_size,
+            };
+            tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+            this->RunProgramNonblocking(receiver_device, receiver_program);
+            receiver_programs.push_back(std::move(receiver_program));
+            receiver_buffers.push_back(std::move(receiver_buffer));
+        }
+    }
+    // Assume all receiver buffers are at the same address
+    uint32_t receiver_buffer_addr = receiver_buffers[0]->address();
+    for (const auto& receiver_buffer : receiver_buffers) {
+        if (receiver_buffer_addr != receiver_buffer->address()) {
+            GTEST_SKIP() << "Receiver buffers are not at the same address";
+        }
+    }
+
+    auto sender_shard_parameters =
+        ShardSpecBuffer(sender_logical_crs, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+    ShardedBufferConfig sender_shard_config = {
+        .device = sender_device,
+        .size = data_size,
+        .page_size = data_size,
+        .buffer_type = tt_metal::BufferType::L1,
+        .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(sender_shard_parameters),
+    };
+    auto sender_buffer = CreateBuffer(sender_shard_config);
+    // Write the data to send to the buffer
+    std::vector<uint32_t> sender_buffer_data(data_size / sizeof(uint32_t), 0);
+    std::iota(sender_buffer_data.begin(), sender_buffer_data.end(), 0);
+    tt::tt_metal::detail::WriteToBuffer(sender_buffer, sender_buffer_data);
+
+    // Wait for buffer data to be written to device
+    tt::Cluster::instance().l1_barrier(physical_start_device_id);
+
+    auto receiver_noc_encoding = tt::tt_metal::hal.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+
+    // Allocate space for the client interface
+    uint32_t client_interface_cb_index = tt::CBIndex::c_0;
+    tt::tt_metal::CircularBufferConfig client_interface_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            mcast_hops.size() * tt::tt_fabric::CLIENT_INTERFACE_SIZE, {{client_interface_cb_index, DataFormat::UInt32}})
+            .set_page_size(client_interface_cb_index, tt::tt_fabric::CLIENT_INTERFACE_SIZE);
+    auto client_interface_cb =
+        tt::tt_metal::CreateCircularBuffer(sender_program, sender_logical_core, client_interface_cb_config);
+
+    std::vector<uint32_t> sender_compile_time_args = {client_interface_cb_index, 1};
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/"
+        "fabric_pull_async_write_multicast_multidirectional_sender.cpp",
+        sender_logical_crs,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = sender_compile_time_args,
+            .defines = defines});
+
+    std::unordered_map<RoutingDirection, uint32_t> sender_router_noc_xys;
+    for (auto& [routing_direction, end_mesh_chip_ids] : end_mesh_chip_ids_by_dir) {
+        auto routers = control_plane->get_routers_to_chip(
+            start_mesh_chip_id.first,
+            start_mesh_chip_id.second,
+            end_mesh_chip_ids[0].first,
+            end_mesh_chip_ids[0].second);
+        auto& sender_virtual_router_coord = routers[0].second;
+        sender_router_noc_xys.try_emplace(
+            routing_direction,
+            tt_metal::hal.noc_xy_encoding(sender_virtual_router_coord.x, sender_virtual_router_coord.y));
+    }
+
+    std::vector<uint32_t> sender_runtime_args = {
+        sender_buffer->address(),
+        receiver_noc_encoding,
+        receiver_buffer_addr,
+        data_size,
+        end_mesh_chip_ids_by_dir[RoutingDirection::E][0].first,
+        end_mesh_chip_ids_by_dir[RoutingDirection::E][0].second,
+        mcast_hops[RoutingDirection::E],
+        sender_router_noc_xys[RoutingDirection::E],
+        end_mesh_chip_ids_by_dir[RoutingDirection::W][0].first,
+        end_mesh_chip_ids_by_dir[RoutingDirection::W][0].second,
+        mcast_hops[RoutingDirection::W],
+        sender_router_noc_xys[RoutingDirection::W]};
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    // Launch sender and receiver programs and wait for them to finish
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
+            auto* receiver_device = DevicePool::instance().get_active_device(physical_end_device_ids[i]);
+            this->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+        }
+    }
+
+    // Validate the data received by the receiver
+    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
+            std::vector<uint32_t> received_buffer_data;
+            tt::tt_metal::detail::ReadFromBuffer(receiver_buffers[i], received_buffer_data);
+            EXPECT_EQ(sender_buffer_data, received_buffer_data);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
@@ -491,7 +491,8 @@ void kernel_main() {
                 (test_producer.current_packet_header.routing.packet_size_bytes + PACKET_WORD_SIZE_BYTES - 1) >> 4;
             uint32_t curr_data_words_sent = test_producer.pull_data_from_fvc_buffer<FVC_MODE_ENDPOINT>();
 #else
-            curr_packet_size = ((test_producer.packet_word_0[0] & 0x3FFFFFFF) + PACKET_WORD_SIZE_BYTES - 1) >> 4;
+            volatile uint32_t* header_word_0 = (volatile uint32_t*)test_producer.get_local_buffer_read_addr();
+            curr_packet_size = ((header_word_0[0] & 0x3FFFFFFF) + PACKET_WORD_SIZE_BYTES - 1) >> 4;
             uint32_t curr_data_words_sent = test_producer.push_data_to_eth_router<FVC_MODE_ENDPOINT>();
 #endif
             curr_packet_words_sent += curr_data_words_sent;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -16,7 +16,7 @@
 using namespace tt::tt_fabric;
 
 uint32_t src_endpoint_id;
-// constexpr uint32_t src_endpoint_id = get_compile_time_arg_val(0);
+constexpr uint32_t data_mode = get_compile_time_arg_val(0);
 constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(1);
 constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(2);
 
@@ -115,12 +115,16 @@ void kernel_main() {
     zero_l1_buf(
         reinterpret_cast<tt_l1_ptr uint32_t*>(data_buffer_start_addr), data_buffer_size_words * PACKET_WORD_SIZE_BYTES);
 
+    // initalize client
+    fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
+
     uint64_t data_words_sent = 0;
     uint32_t packet_count = 0;
 
     uint64_t dst_addr = ((uint64_t)noc_offset << 32 | target_address);
     if constexpr (mcast_data) {
         fabric_async_write_multicast_add_header(
+            client_interface,
             data_buffer_start_addr,  // source address in sender’s memory
             dest_device >> 16,
             dest_device & 0xFFFF,
@@ -131,7 +135,8 @@ void kernel_main() {
             n_depth,
             s_depth);
     } else {
-        fabric_async_write_add_header(
+        fabric_async_write_add_header<decltype(client_interface), (ClientDataMode)data_mode>(
+            client_interface,
             data_buffer_start_addr,  // source address in sender’s memory
             dest_device >> 16,
             dest_device & 0xFFFF,
@@ -139,9 +144,6 @@ void kernel_main() {
             max_packet_size_words * 16  // number of bytes to write to remote destination
         );
     }
-
-    // initalize client
-    fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
 
     // notify the controller kernel that this worker is ready to proceed
     notify_traffic_controller();
@@ -152,10 +154,17 @@ void kernel_main() {
     while (*(volatile tt_l1_ptr uint32_t*)signal_address == 0);
 
 #ifdef FVC_MODE_PULL
-    fabric_setup_pull_request(
-        client_interface,           // fabric client interface
-        data_buffer_start_addr,     // source address in sender’s memory
-        max_packet_size_words * 16  // number of bytes to write to remote destination
+    uint32_t pull_size_bytes = max_packet_size_words * 16;
+    if constexpr (data_mode == ClientDataMode::RAW_DATA) {
+        // In raw data mode, client data buffer dones not contain packet header.
+        // Packet header is referenced from client interface header buffer.
+        // The Data to pull in this case is packet size - packet header.
+        pull_size_bytes -= PACKET_HEADER_SIZE_BYTES;
+    }
+    fabric_setup_pull_request<(ClientDataMode)data_mode>(
+        client_interface,        // fabric client interface
+        data_buffer_start_addr,  // source address in sender’s memory
+        pull_size_bytes          // number of bytes to write to remote destination
     );
 
     uint64_t start_timestamp = get_timestamp();
@@ -163,7 +172,11 @@ void kernel_main() {
     while (true) {
         client_interface->local_pull_request.pull_request.words_read = 0;
         if constexpr (mcast_data) {
-            fabric_async_write_multicast<AsyncWriteMode::SEND_PR, RoutingType::ROUTING_TABLE>(
+            fabric_async_write_multicast<
+                decltype(client_interface),
+                (ClientDataMode)data_mode,
+                AsyncWriteMode::SEND_PR,
+                RoutingType::ROUTING_TABLE>(
                 client_interface,
                 0,                       // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
@@ -176,7 +189,7 @@ void kernel_main() {
                 n_depth,
                 s_depth);
         } else {
-            fabric_async_write<AsyncWriteMode::SEND_PR, RoutingType::ROUTING_TABLE>(
+            fabric_async_write<(ClientDataMode)data_mode, AsyncWriteMode::SEND_PR, RoutingType::ROUTING_TABLE>(
                 client_interface,
                 0,                       // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
@@ -205,8 +218,8 @@ void kernel_main() {
     uint64_t start_timestamp = get_timestamp();
 
     while (true) {
-        fabric_async_write<AsyncWriteMode::PUSH>(
-            client_interface,
+        fabric_async_write<(ClientDataMode)data_mode, AsyncWriteMode::PUSH>(
+            (fabric_push_client_interface_t*)client_interface,
             0,                       // the network plane to use for this transaction
             data_buffer_start_addr,  // source address in sender’s memory
             dest_device >> 16,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -1393,6 +1393,7 @@ int main(int argc, char **argv) {
         test_args::get_command_option_uint32(input_args, "--target_address", default_target_address);
     uint32_t atomic_increment =
         test_args::get_command_option_uint32(input_args, "--atomic_increment", default_atomic_increment);
+    uint32_t data_mode = test_args::has_command_option(input_args, "--raw_data");
 
     // Note here that currently mcast_depth considers the mcast origin as a hop, and not the distance from the origin
     // This has side effects that specifying a depth of 0 or 1 will result in the same behavior
@@ -1630,17 +1631,17 @@ int main(int argc, char **argv) {
             client_interface_addr + sizeof(fabric_pull_client_interface_t) + sizeof(fabric_router_l1_config_t) * 4;
 
         std::vector<uint32_t> tx_compile_args = {
-            0,                           //(device->id() << 8) + src_endpoint_start_id + i,  // 0: src_endpoint_id
-            num_dest_endpoints,          // 1: num_dest_endpoints
-            dest_endpoint_start_id,      // 2:
-            tx_queue_start_addr,         // 3: queue_start_addr_words
-            (tx_queue_size_bytes >> 4),  // 4: queue_size_words
-            routing_table_start_addr,    // 5: routeing table
-            test_results_addr,           // 6: test_results_addr
-            test_results_size,           // 7: test_results_size
-            prng_seed,                   // 8: prng_seed
-            data_kb_per_tx,              // 9: total_data_kb
-            max_packet_size_words,       // 10: max_packet_size_words
+            data_mode,                          // 0: Data mode. 0 - Packetized Data. 1 Raw Data.
+            num_dest_endpoints,                 // 1: num_dest_endpoints
+            dest_endpoint_start_id,             // 2:
+            tx_queue_start_addr,                // 3: queue_start_addr_words
+            (tx_queue_size_bytes >> 4),         // 4: queue_size_words
+            routing_table_start_addr,           // 5: routeing table
+            test_results_addr,                  // 6: test_results_addr
+            test_results_size,                  // 7: test_results_size
+            prng_seed,                          // 8: prng_seed
+            data_kb_per_tx,                     // 9: total_data_kb
+            max_packet_size_words,              // 10: max_packet_size_words
             timeout_mcycles * 1000 * 1000 * 4,  // 11: timeout_cycles
             tx_skip_pkt_content_gen,            // 12: skip_pkt_content_gen
             tx_pkt_dest_size_choice,            // 13: pkt_dest_size_choice

--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -28,8 +28,9 @@ static_assert(
     "LOG_BASE_2_NUM_CHANNELS_PER_UINT32 must be equal to log2(sizeof(std::uint32_t) / sizeof(chan_id_t))");
 
 static constexpr std::uint32_t CLIENT_INTERFACE_SIZE = 3280;
-static constexpr std::uint32_t PULL_CLIENT_INTERFACE_SIZE = 112;
-static constexpr std::uint32_t PUSH_CLIENT_INTERFACE_SIZE = 48;
+static constexpr std::uint32_t CLIENT_HEADER_BUFFER_ENTRIES = 4;
+static constexpr std::uint32_t PULL_CLIENT_INTERFACE_SIZE = 304;
+static constexpr std::uint32_t PUSH_CLIENT_INTERFACE_SIZE = 240;
 static constexpr std::uint32_t PACKET_WORD_SIZE_BYTES = 16;
 static constexpr std::uint32_t PACKET_HEADER_SIZE_BYTES = 48;
 static constexpr std::uint32_t PACKET_HEADER_SIZE_WORDS = PACKET_HEADER_SIZE_BYTES / PACKET_WORD_SIZE_BYTES;

--- a/tt_metal/fabric/hw/inc/tt_fabric.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric.h
@@ -34,9 +34,9 @@ extern volatile tt_l1_ptr fabric_router_l1_config_t* routing_table;
 extern chan_payload_ptr inbound_rdptr_ack;
 extern volatile chan_payload_ptr remote_rdptr;
 
-void tt_fabric_reserve_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request);
+void tt_fabric_reserve_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request, uint32_t num_slots = 1);
 template <bool blocking_mode>
-bool tt_fabric_check_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request);
+bool tt_fabric_check_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request, uint32_t wrptr);
 uint64_t tt_fabric_send_pull_request(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request);
 uint32_t num_words_available_to_pull(volatile pull_request_t* pull_request);
 uint32_t words_before_pull_buffer_wrap(uint32_t buffer_size, uint32_t rd_ptr);
@@ -244,9 +244,6 @@ typedef struct fvc_inbound_push_state {
     uint32_t router_push_addr;
     bool packet_corrupted;
     uint32_t packet_dest;
-    volatile uint32_t* packet_word_0;
-    volatile uint32_t* packet_word_1;
-    volatile uint32_t* packet_word_2;
     volatile uint32_t* words_received;
     uint32_t* words_received_local_update;
     uint32_t update_sender_buffer_space[4];
@@ -488,13 +485,8 @@ typedef struct fvc_inbound_push_state {
 
     template <uint8_t fvc_mode = FVC_MODE_ROUTER>
     FORCE_INLINE bool advance_next_packet() {
-        packet_word_0 = (volatile uint32_t*)get_local_buffer_read_addr();
-        packet_word_1 =
-            reinterpret_cast<tt_l1_ptr uint32_t*>(buffer_start + (out_rdptr_inc<fvc_mode>(1) * PACKET_WORD_SIZE_BYTES));
-        packet_word_2 =
-            reinterpret_cast<tt_l1_ptr uint32_t*>(buffer_start + (out_rdptr_inc<fvc_mode>(2) * PACKET_WORD_SIZE_BYTES));
-
-        uint32_t first_dword = packet_word_0[0];
+        volatile uint32_t* header_word_0 = (volatile uint32_t*)get_local_buffer_read_addr();
+        uint32_t first_dword = header_word_0[0];
         sender_buffer_index = first_dword >> 30;
         first_dword &= 0x3FFFFFFF;
         uint32_t packet_size = (first_dword + PACKET_WORD_SIZE_BYTES - 1) >> 4;
@@ -505,19 +497,20 @@ typedef struct fvc_inbound_push_state {
         if constexpr (fvc_mode == FVC_MODE_ROUTER) {
             free_sender_buffer_space(packet_size);
         }
-        for_local_chip = packet_word_0[1] == my_id;
+        for_local_chip = header_word_0[1] == my_id;
         packet_words_remaining = packet_size;
         return true;
     }
 
     uint32_t get_next_hop_router_noc_xy() {
-        uint32_t dst_mesh_id = packet_word_0[1] & 0xFFFF;
+        volatile uint32_t* header_word_0 = (volatile uint32_t*)get_local_buffer_read_addr();
+        uint32_t dst_mesh_id = header_word_0[1] & 0xFFFF;
         if (dst_mesh_id != routing_table->my_mesh_id) {
             uint32_t next_port = routing_table->inter_mesh_table.dest_entry[dst_mesh_id];
             remote_wrptr_direction = port_direction_table[next_port];
             return eth_chan_to_noc_xy[noc_index][next_port];
         } else {
-            uint32_t dst_device_id = packet_word_0[1] >> 16;
+            uint32_t dst_device_id = header_word_0[1] >> 16;
             uint32_t next_port = routing_table->intra_mesh_table.dest_entry[dst_device_id];
             remote_wrptr_direction = port_direction_table[next_port];
             return eth_chan_to_noc_xy[noc_index][next_port];
@@ -609,13 +602,11 @@ typedef struct fvc_inbound_push_state {
         return words_available;
     }
 
-    FORCE_INLINE void issue_async_write() {
+    FORCE_INLINE void issue_async_write(uint32_t addr_h, uint32_t addr_l) {
         advance_out_rdptr(PACKET_HEADER_SIZE_WORDS);
         uint32_t words_remaining = packet_words_remaining - PACKET_HEADER_SIZE_WORDS;
         uint32_t words_before_wrap = min(words_remaining, words_before_buffer_wrap(fvc_out_rdptr));
 
-        uint32_t addr_l = packet_word_1[1];
-        uint32_t addr_h = packet_word_1[2];
         noc_async_write_one_packet(
             get_local_buffer_read_addr(),
             get_noc_addr_helper(addr_h, addr_l),
@@ -638,28 +629,32 @@ typedef struct fvc_inbound_push_state {
     }
 
     template <uint8_t fvc_mode = FVC_MODE_ROUTER>
-    inline void process_inbound_packet() {
+    FORCE_INLINE void process_inbound_packet() {
         if (for_local_chip) {
+            volatile uint32_t* header_word_1 = reinterpret_cast<tt_l1_ptr uint32_t*>(
+                buffer_start + (out_rdptr_inc<fvc_mode>(1) * PACKET_WORD_SIZE_BYTES));
             if (words_cleared) {
                 flush_async_writes();
             }
-            uint32_t command = packet_word_1[0];
+            uint32_t command = header_word_1[0];
             if (command & ASYNC_WR) {
-                issue_async_write();
+                uint32_t header_word_2 = buffer_start + (out_rdptr_inc<fvc_mode>(2) * PACKET_WORD_SIZE_BYTES);
+                issue_async_write(header_word_1[2], header_word_1[1]);
                 // for fused command issue the atomic inc before invalidating the current packet
                 if (command & ATOMIC_INC) {
                     volatile async_wr_atomic_params* params =
-                        (volatile async_wr_atomic_params*)((uint32_t)packet_word_2 +
+                        (volatile async_wr_atomic_params*)((uint32_t)header_word_2 +
                                                            offsetof(packet_header_t, packet_parameters) - 32);
                     uint64_t noc_addr = get_noc_addr_helper(params->noc_xy, params->l1_offset);
                     noc_fast_atomic_increment(
                         noc_index, NCRISC_AT_CMD_BUF, noc_addr, NOC_UNICAST_WRITE_VC, params->increment, 31, false);
                 }
             } else if (command & ATOMIC_INC) {
+                uint32_t header_word_2 = buffer_start + (out_rdptr_inc<fvc_mode>(2) * PACKET_WORD_SIZE_BYTES);
                 volatile atomic_params* params =
-                    (volatile atomic_params*)((uint32_t)packet_word_2 + offsetof(packet_header_t, packet_parameters) -
+                    (volatile atomic_params*)((uint32_t)header_word_2 + offsetof(packet_header_t, packet_parameters) -
                                               32);
-                uint64_t noc_addr = get_noc_addr_helper(packet_word_1[2], packet_word_1[1]);
+                uint64_t noc_addr = get_noc_addr_helper(header_word_1[2], header_word_1[1]);
                 noc_fast_atomic_increment(
                     noc_index,
                     NCRISC_AT_CMD_BUF,
@@ -848,12 +843,22 @@ typedef struct fvc_outbound_pull_state {
 
         return num_words_to_pull;
     }
-
-    FORCE_INLINE uint32_t pull_data_to_fvc_buffer(volatile pull_request_t* pull_request) {
+    template <bool packetized = true>
+    FORCE_INLINE uint32_t
+    pull_data_to_fvc_buffer(volatile pull_request_t* pull_request, volatile pull_request_t* header) {
         if (packet_in_progress == 0) {
             uint32_t size = pull_request->size;
-            packet_words_remaining = (size + PACKET_WORD_SIZE_BYTES - 1) >> 4;
-            packet_in_progress = 1;
+            if constexpr (packetized == false) {
+                packet_words_remaining = PACKET_HEADER_SIZE_WORDS + ((size + PACKET_WORD_SIZE_BYTES - 1) >> 4);
+                if (move_data_to_fvc_buffer<false>(header)) {
+                    packet_in_progress = 1;
+                } else {
+                    return 0;
+                }
+            } else {
+                packet_words_remaining = (size + PACKET_WORD_SIZE_BYTES - 1) >> 4;
+                packet_in_progress = 1;
+            }
         }
 
         uint32_t num_words_to_pull = get_num_words_to_pull(pull_request);
@@ -874,10 +879,13 @@ typedef struct fvc_outbound_pull_state {
         return num_words_to_pull;
     }
 
-    inline uint32_t move_data_to_fvc_buffer(volatile pull_request_t* pull_request) {
-        if (packet_in_progress == 0) {
-            packet_words_remaining = PACKET_HEADER_SIZE_WORDS;
-            packet_in_progress = 1;
+    template <bool packet = true>
+    FORCE_INLINE uint32_t move_data_to_fvc_buffer(volatile pull_request_t* pull_request) {
+        if constexpr (packet == true) {
+            if (packet_in_progress == 0) {
+                packet_words_remaining = PACKET_HEADER_SIZE_WORDS;
+                packet_in_progress = 1;
+            }
         }
 
         // if fvc does not have enough space, try again later.
@@ -1272,7 +1280,7 @@ typedef struct fvc_inbound_pull_state {
 
         if (try_sending_pull_request) {
             bool can_send_pull_request =
-                tt_fabric_check_pull_request_slot<false>(this->pull_req_dest_address, local_pull_request);
+                tt_fabric_check_pull_request_slot<false>(this->pull_req_dest_address, local_pull_request, local_pull_request->wrptr.ptr);
             if (!can_send_pull_request) {
                 this->pull_request_pending = true;
                 return 0;
@@ -1462,7 +1470,7 @@ typedef struct fvc_inbound_pull_state {
 
             if (try_sending_pull_request) {
                 bool can_send_pull_request =
-                    tt_fabric_check_pull_request_slot<false>(this->pull_req_dest_address, local_pull_request);
+                    tt_fabric_check_pull_request_slot<false>(this->pull_req_dest_address, local_pull_request, local_pull_request->wrptr.ptr);
                 if (!can_send_pull_request) {
                     this->pull_request_pending = true;
                     return 0;
@@ -2157,8 +2165,15 @@ inline void req_buf_advance_wrptr(chan_req_buf* req_buf) { req_buf_ptr_advance(&
 
 inline void req_buf_advance_rdptr(chan_req_buf* req_buf) {
     // clear valid before incrementing read pointer.
+    // PACK and FORWARD requests take 2 entries in request buffer.
+    // First entry is pull reqeust itself, second entry is packet header.
     uint32_t rd_index = req_buf->rdptr.ptr & CHAN_REQ_BUF_SIZE_MASK;
-    req_buf->chan_req[rd_index].bytes[47] = 0;
+    if (req_buf->chan_req[rd_index].pull_request.flags == PACK_N_FORWARD) {
+        req_buf->chan_req[rd_index].pull_request.flags = 0;
+        req_buf_ptr_advance(&(req_buf->rdptr));
+        rd_index = (rd_index + 1) & CHAN_REQ_BUF_SIZE_MASK;
+    }
+    req_buf->chan_req[rd_index].pull_request.flags = 0;
     req_buf_ptr_advance(&(req_buf->rdptr));
 }
 
@@ -2253,14 +2268,14 @@ bool wait_all_src_dest_ready(volatile router_state_t* router_state, uint32_t tim
 }
 
 // reserve a slot in the req queue for sending the pull request
-inline void tt_fabric_reserve_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request) {
+inline void tt_fabric_reserve_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request, uint32_t num_slots) {
     uint64_t noc_addr = dest_addr + offsetof(chan_req_buf, wrptr);
     noc_fast_atomic_increment<DM_DEDICATED_NOC, true>(
         noc_index,
         NCRISC_AT_CMD_BUF,
         noc_addr,
         NOC_UNICAST_WRITE_VC,
-        1,
+        num_slots,
         CHAN_REQ_BUF_LOG_SIZE,
         false,
         false,
@@ -2271,9 +2286,8 @@ inline void tt_fabric_reserve_pull_request_slot(uint64_t dest_addr, volatile loc
 // check if the pull request can be sent
 // issuing this in a blocking mode on routers can result in deadlocks, use carefully
 template <bool blocking_mode = false>
-inline bool tt_fabric_check_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request) {
+inline bool tt_fabric_check_pull_request_slot(uint64_t dest_addr, volatile local_pull_request_t* local_pull_request, uint32_t wrptr) {
     uint64_t noc_addr = dest_addr + offsetof(chan_req_buf, rdptr);
-    uint32_t wrptr = local_pull_request->wrptr.ptr;
     do {
         noc_async_read_one_packet(noc_addr, (uint32_t)(&local_pull_request->rdptr.ptr), 4);
         noc_async_read_barrier();

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -23,6 +23,11 @@ enum AsyncWriteMode : uint8_t {
     ALL = ADD_HEADER | ADD_PR | SEND_PR,
 };
 
+enum ClientDataMode : uint8_t {
+    PACKETIZED_DATA = 0x0,
+    RAW_DATA = 0x1,
+};
+
 enum RoutingType : uint8_t {
     ROUTING_TABLE,
     ROUTER_XY,
@@ -71,6 +76,7 @@ inline uint32_t get_next_hop_router_direction(
 }
 #endif
 
+template <ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA>
 inline void fabric_setup_pull_request(
     volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface, uint32_t src_addr, uint32_t size) {
     uint32_t size_in_words = (size + PACKET_WORD_SIZE_BYTES - 1) >> 4;
@@ -86,27 +92,54 @@ inline void fabric_setup_pull_request(
     client_interface->local_pull_request.pull_request.words_read = 0;
     client_interface->local_pull_request.pull_request.ack_addr =
         xy_local_addr + (uint32_t)&client_interface->local_pull_request.pull_request.words_read;
-    client_interface->local_pull_request.pull_request.flags = FORWARD;
+    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+        client_interface->local_pull_request.pull_request.flags = FORWARD;
+    } else {
+        client_interface->local_pull_request.pull_request.flags = PACK_N_FORWARD;
+    }
 }
 
-template <RoutingType routing_type = RoutingType::ROUTER_XY>
+template <ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA, RoutingType routing_type = RoutingType::ROUTER_XY>
 inline void fabric_send_pull_request(
     volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface,
     uint32_t routing,  // routing refers to the router noc xy to use when using ROUTER_XY,
                        // and the routing plane to use when using ROUTING_TABLE
     uint16_t dst_mesh_id,
-    uint16_t dst_dev_id) {
+    uint16_t dst_dev_id,
+    uint32_t header_id = 0) {
     uint64_t router_addr;
     if constexpr (routing_type == RoutingType::ROUTING_TABLE) {
-        router_addr = ((uint64_t)get_next_hop_router_noc_xy(client_interface, routing, dst_mesh_id, dst_dev_id) << 32) |
-                      FABRIC_ROUTER_REQ_QUEUE_START;
+        router_addr = get_noc_addr_helper(get_next_hop_router_noc_xy(client_interface, routing, dst_mesh_id, dst_dev_id),
+                      FABRIC_ROUTER_REQ_QUEUE_START);
     } else {
         router_addr = get_noc_addr_helper(routing, FABRIC_ROUTER_REQ_QUEUE_START);
     }
 
     volatile local_pull_request_t* pull_request = (volatile local_pull_request_t*)&client_interface->local_pull_request;
-    tt_fabric_reserve_pull_request_slot(router_addr, pull_request);
-    tt_fabric_check_pull_request_slot<true>(router_addr, pull_request);
+
+    uint32_t increment;
+    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+        increment = 1;
+    } else {
+        // when sending raw data, we reserve two request slots in router.
+        // first slot is pull request, second slot holds packet header
+        // since the client data buffer does not contain the packet header.
+        increment = 2;
+    }
+
+    tt_fabric_reserve_pull_request_slot(router_addr, pull_request, increment);
+    uint32_t wrptr = pull_request->wrptr.ptr;
+    if constexpr (data_mode == ClientDataMode::RAW_DATA) {
+        uint32_t header_wrptr = (wrptr + 1) & CHAN_REQ_BUF_PTR_MASK;
+        tt_fabric_check_pull_request_slot<true>(router_addr, pull_request, header_wrptr);
+        uint32_t header_wr_index = header_wrptr & CHAN_REQ_BUF_SIZE_MASK;
+        uint64_t noc_addr = router_addr + offsetof(chan_req_buf, chan_req) + header_wr_index * sizeof(pull_request_t);
+        noc_async_write_one_packet(
+            (uint32_t)(&client_interface->header_buffer[header_id]), noc_addr, sizeof(pull_request_t), noc_index);
+    } else {
+        tt_fabric_check_pull_request_slot<true>(router_addr, pull_request, wrptr);
+    }
+
     tt_fabric_send_pull_request(router_addr, pull_request);
 }
 
@@ -131,14 +164,21 @@ inline void fabric_wait_for_pull_request_flushed(volatile tt_l1_ptr fabric_pull_
     fabric_wait_for_pull_request_words_flushed(client_interface, words_written);
 }
 
+template <typename T, ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA>
 inline void fabric_async_write_add_header(
+    T client_interface,
     uint32_t src_addr,  // source address in sender’s memory
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
     uint64_t dst_addr,
-    uint32_t size  // number of bytes to write to remote destination
-) {
-    packet_header_t* packet_header = (packet_header_t*)(src_addr);
+    uint32_t size,  // number of bytes to write to remote destination
+    uint32_t header_id = 0) {
+    packet_header_t* packet_header;
+    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+        packet_header = (packet_header_t*)(src_addr);
+    } else {
+        packet_header = (packet_header_t*)&client_interface->header_buffer[header_id];
+    }
     packet_header->routing.flags = FORWARD;
     packet_header->routing.packet_size_bytes = size;
     packet_header->routing.dst_mesh_id = dst_mesh_id;
@@ -152,7 +192,10 @@ inline void fabric_async_write_add_header(
 #ifdef FVC_MODE_PULL
 // Write packetized data over fabric to dst_mesh, dst_dev.
 // Packet is at src_addr in sender L1.
-template <AsyncWriteMode mode = AsyncWriteMode::ALL, RoutingType routing_type = RoutingType::ROUTER_XY>
+template <
+    ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA,
+    AsyncWriteMode mode = AsyncWriteMode::ALL,
+    RoutingType routing_type = RoutingType::ROUTER_XY>
 inline void fabric_async_write(
     volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface,
     uint32_t routing,   // routing refers to the router noc xy to use when using ROUTER_XY,
@@ -161,18 +204,24 @@ inline void fabric_async_write(
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
     uint64_t dst_addr,
-    uint32_t size  // number of bytes to write to remote destination
-) {
+    uint32_t size,  // number of bytes to write to remote destination
+    uint32_t header_id = 0) {
     if constexpr (mode & AsyncWriteMode::ADD_HEADER) {
-        fabric_async_write_add_header(src_addr, dst_mesh_id, dst_dev_id, dst_addr, size);
+        fabric_async_write_add_header<decltype(client_interface), data_mode>(
+            client_interface, src_addr, dst_mesh_id, dst_dev_id, dst_addr, size, header_id);
     }
 
     if constexpr (mode & AsyncWriteMode::ADD_PR) {
-        fabric_setup_pull_request(client_interface, src_addr, size);
+        if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+            fabric_setup_pull_request<data_mode>(client_interface, src_addr, size);
+        } else {
+            fabric_setup_pull_request<data_mode>(client_interface, src_addr, size - PACKET_HEADER_SIZE_BYTES);
+        }
     }
 
     if constexpr (mode & AsyncWriteMode::SEND_PR) {
-        fabric_send_pull_request<routing_type>(client_interface, routing, dst_mesh_id, dst_dev_id);
+        fabric_send_pull_request<data_mode, routing_type>(
+            client_interface, routing, dst_mesh_id, dst_dev_id, header_id);
     }
 }
 #else
@@ -206,54 +255,102 @@ inline void fabric_client_router_reserve(
         client_interface->buffer_size;
 }
 
+template <ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA>
 inline void fabric_async_write_push_data(
-    volatile tt_l1_ptr fabric_push_client_interface_t* client_interface, uint32_t src_addr, uint32_t size) {
+    fabric_push_client_interface_t* client_interface, uint32_t src_addr, uint32_t size, uint32_t header_id) {
     uint32_t total_words_to_send = (size + PACKET_WORD_SIZE_BYTES - 1) >> 4;
     uint64_t push_addr = get_noc_addr_helper(client_interface->router_addr_h, client_interface->router_push_addr);
+    uint32_t router_buf_space = *(volatile uint32_t*)client_interface->router_space;
+    // check and wait for sufficient router space for the entire packet.
+    if (router_buf_space < total_words_to_send) {
+        client_interface->reserved[0]++;
+        while (router_buf_space < total_words_to_send) {
+            router_buf_space = *(volatile uint32_t*)client_interface->router_space;
+        }
+    }
 
-    while (total_words_to_send > 0) {
-        uint32_t router_buf_space = *(volatile uint32_t*)client_interface->router_space;
+    uint64_t buffer_wr_addr = get_noc_addr_helper(
+        client_interface->router_addr_h,
+        (client_interface->buffer_start + (client_interface->wr_ptr * PACKET_WORD_SIZE_BYTES)));
+    uint32_t words_to_send = total_words_to_send;
+
+    if constexpr (data_mode == ClientDataMode::RAW_DATA) {
+        // In raw mode, pick up the header from header buffer in client interface.
         uint32_t words_before_wrap = client_interface->buffer_size - client_interface->wr_ptr;
-        uint32_t words_to_send = min(total_words_to_send, words_before_wrap);
-        words_to_send = min(router_buf_space, words_to_send);
-        if (words_to_send) {
-            uint64_t buffer_wr_addr = get_noc_addr_helper(
-                client_interface->router_addr_h,
-                (client_interface->buffer_start + (client_interface->wr_ptr * PACKET_WORD_SIZE_BYTES)));
-            noc_async_write_one_packet(src_addr, buffer_wr_addr, words_to_send * PACKET_WORD_SIZE_BYTES, noc_index);
-            noc_inline_dw_write(push_addr, words_to_send << REMOTE_DEST_BUF_WORDS_FREE_INC);
-            client_interface->wr_ptr += words_to_send;
-            *(volatile uint32_t*)client_interface->update_router_space = (-words_to_send)
-                                                                         << REMOTE_DEST_BUF_WORDS_FREE_INC;
+        if (words_before_wrap >= PACKET_HEADER_SIZE_WORDS) {
+            noc_async_write_one_packet(
+                (uint32_t)&client_interface->header_buffer[header_id],
+                buffer_wr_addr,
+                PACKET_HEADER_SIZE_BYTES,
+                noc_index);
+            client_interface->wr_ptr += PACKET_HEADER_SIZE_WORDS;
             if (client_interface->wr_ptr >= client_interface->buffer_size) {
                 client_interface->wr_ptr -= client_interface->buffer_size;
             }
-            total_words_to_send -= words_to_send;
-            src_addr += words_to_send * PACKET_WORD_SIZE_BYTES;
+        } else {
+            uint32_t header_addr = (uint32_t)&client_interface->header_buffer[header_id];
+            noc_async_write_one_packet(
+                header_addr, buffer_wr_addr, words_before_wrap * PACKET_WORD_SIZE_BYTES, noc_index);
+            uint32_t words_after_wrap = PACKET_HEADER_SIZE_WORDS - words_before_wrap;
+            buffer_wr_addr = get_noc_addr_helper(client_interface->router_addr_h, client_interface->buffer_start);
+            header_addr += words_before_wrap * PACKET_WORD_SIZE_BYTES;
+            noc_async_write_one_packet(
+                header_addr, buffer_wr_addr, words_after_wrap * PACKET_WORD_SIZE_BYTES, noc_index);
+            client_interface->wr_ptr = words_after_wrap;
         }
+        words_to_send -= PACKET_HEADER_SIZE_WORDS;
     }
+
+    uint32_t words_before_wrap = client_interface->buffer_size - client_interface->wr_ptr;
+    if (words_before_wrap >= words_to_send) {
+        buffer_wr_addr = get_noc_addr_helper(
+            client_interface->router_addr_h,
+            (client_interface->buffer_start + (client_interface->wr_ptr * PACKET_WORD_SIZE_BYTES)));
+        noc_async_write_one_packet(src_addr, buffer_wr_addr, words_to_send * PACKET_WORD_SIZE_BYTES, noc_index);
+        client_interface->wr_ptr += words_to_send;
+        if (client_interface->wr_ptr >= client_interface->buffer_size) {
+            client_interface->wr_ptr -= client_interface->buffer_size;
+        }
+    } else {
+        buffer_wr_addr = get_noc_addr_helper(
+            client_interface->router_addr_h,
+            (client_interface->buffer_start + (client_interface->wr_ptr * PACKET_WORD_SIZE_BYTES)));
+        noc_async_write_one_packet(src_addr, buffer_wr_addr, words_before_wrap * PACKET_WORD_SIZE_BYTES, noc_index);
+
+        src_addr += words_before_wrap * PACKET_WORD_SIZE_BYTES;
+        buffer_wr_addr = get_noc_addr_helper(client_interface->router_addr_h, client_interface->buffer_start);
+        noc_async_write_one_packet(
+            src_addr, buffer_wr_addr, (words_to_send - words_before_wrap) * PACKET_WORD_SIZE_BYTES, noc_index);
+        client_interface->wr_ptr = words_to_send - words_before_wrap;
+    }
+    noc_inline_dw_write(push_addr, total_words_to_send << REMOTE_DEST_BUF_WORDS_FREE_INC);
+    *(volatile uint32_t*)client_interface->update_router_space = (-total_words_to_send)
+                                                                 << REMOTE_DEST_BUF_WORDS_FREE_INC;
 }
 
-template <AsyncWriteMode mode = AsyncWriteMode::ALL>
+template <ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA, AsyncWriteMode mode = AsyncWriteMode::ALL>
 inline void fabric_async_write(
-    volatile tt_l1_ptr fabric_push_client_interface_t* client_interface,
+    fabric_push_client_interface_t* client_interface,
     uint32_t routing_plane,  // the network plane to use for this transaction
     uint32_t src_addr,       // source address in sender’s memory
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
     uint64_t dst_addr,
-    uint32_t size  // number of bytes to write to remote destination
-) {
+    uint32_t size,  // number of bytes to write to remote destination
+    uint32_t header_id = 0) {
     if constexpr (mode & AsyncWriteMode::ADD_HEADER) {
-        fabric_async_write_add_header(src_addr, dst_mesh_id, dst_dev_id, dst_addr, size);
+        fabric_async_write_add_header<decltype(client_interface), data_mode>(
+            client_interface, src_addr, dst_mesh_id, dst_dev_id, dst_addr, size, header_id);
     }
     if constexpr (mode & AsyncWriteMode::PUSH) {
-        fabric_async_write_push_data(client_interface, src_addr, size);
+        fabric_async_write_push_data<data_mode>(client_interface, src_addr, size, header_id);
     }
 }
 #endif
 
+template <typename T, ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA>
 inline void fabric_async_write_multicast_add_header(
+    T client_interface,
     uint32_t src_addr,  // source address in sender’s memory
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
@@ -262,8 +359,14 @@ inline void fabric_async_write_multicast_add_header(
     uint16_t e_depth,
     uint16_t w_depth,
     uint16_t n_depth,
-    uint16_t s_depth) {
-    packet_header_t* packet_header = (packet_header_t*)(src_addr);
+    uint16_t s_depth,
+    uint32_t header_id = 0) {
+    packet_header_t* packet_header;
+    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+        packet_header = (packet_header_t*)(src_addr);
+    } else {
+        packet_header = (packet_header_t*)&client_interface->header_buffer[header_id];
+    }
     packet_header->routing.flags = FORWARD | MCAST_DATA;
     packet_header->routing.packet_size_bytes = size;
     packet_header->routing.dst_mesh_id = dst_mesh_id;
@@ -279,9 +382,13 @@ inline void fabric_async_write_multicast_add_header(
 }
 // Write packetized data over fabric to dst_mesh, dst_dev.
 // Packet is at src_addr in sender L1.
-template <AsyncWriteMode mode = AsyncWriteMode::ALL, RoutingType routing_type = RoutingType::ROUTER_XY>
+template <
+    typename T,
+    ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA,
+    AsyncWriteMode mode = AsyncWriteMode::ALL,
+    RoutingType routing_type = RoutingType::ROUTER_XY>
 inline void fabric_async_write_multicast(
-    volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface,
+    T client_interface,
     uint32_t routing,   // routing refers to the router noc xy to use when using ROUTER_XY,
                         // and the routing plane to use when using ROUTING_TABLE
     uint32_t src_addr,  // source address in sender’s memory
@@ -292,18 +399,33 @@ inline void fabric_async_write_multicast(
     uint16_t e_depth,
     uint16_t w_depth,
     uint16_t n_depth,
-    uint16_t s_depth) {
+    uint16_t s_depth,
+    uint32_t header_id = 0) {
     if constexpr (mode & AsyncWriteMode::ADD_HEADER) {
-        fabric_async_write_multicast_add_header(
-            src_addr, dst_mesh_id, dst_dev_id, dst_addr, size, e_depth, w_depth, n_depth, s_depth);
+        fabric_async_write_multicast_add_header<decltype(client_interface), data_mode>(
+            client_interface,
+            src_addr,
+            dst_mesh_id,
+            dst_dev_id,
+            dst_addr,
+            size,
+            e_depth,
+            w_depth,
+            n_depth,
+            s_depth,
+            header_id);
     }
 
     if constexpr (mode & AsyncWriteMode::ADD_PR) {
-        fabric_setup_pull_request(client_interface, src_addr, size);
+        if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+            fabric_setup_pull_request<data_mode>(client_interface, src_addr, size);
+        } else {
+            fabric_setup_pull_request<data_mode>(client_interface, src_addr, size - PACKET_HEADER_SIZE_BYTES);
+        }
     }
 
     if constexpr (mode & AsyncWriteMode::SEND_PR) {
-        fabric_send_pull_request<routing_type>(client_interface, routing, dst_mesh_id, dst_dev_id);
+        fabric_send_pull_request<data_mode, routing_type>(client_interface, routing, dst_mesh_id, dst_dev_id);
     }
 }
 
@@ -329,7 +451,10 @@ inline void fabric_atomic_inc_add_header(
 
 // Write packetized data over fabric to dst_mesh, dst_dev.
 // Packet is at src_addr in sender L1.
-template <AsyncWriteMode mode = AsyncWriteMode::ALL, RoutingType routing_type = RoutingType::ROUTER_XY>
+template <
+    ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA,
+    AsyncWriteMode mode = AsyncWriteMode::ALL,
+    RoutingType routing_type = RoutingType::ROUTER_XY>
 inline void fabric_atomic_inc(
     volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface,
     uint32_t routing,   // routing refers to the router noc xy to use when using ROUTER_XY,
@@ -349,19 +474,27 @@ inline void fabric_atomic_inc(
     }
 
     if constexpr (mode & AsyncWriteMode::SEND_PR) {
-        fabric_send_pull_request<routing_type>(client_interface, routing, dst_mesh_id, dst_dev_id);
+        fabric_send_pull_request<data_mode, routing_type>(client_interface, routing, dst_mesh_id, dst_dev_id);
     }
 }
 
+template <typename T, ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA>
 inline void fabric_async_write_atomic_inc_add_header(
+    T client_interface,
     uint32_t src_addr,  // source address in sender’s memory
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
     uint64_t dst_write_addr,
     uint64_t dst_atomic_addr,
     uint32_t size,  // number of bytes to write to remote destination
-    uint32_t atomic_inc) {
-    packet_header_t* packet_header = (packet_header_t*)(src_addr);
+    uint32_t atomic_inc,
+    uint32_t header_id = 0) {
+    packet_header_t* packet_header;
+    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+        packet_header = (packet_header_t*)(src_addr);
+    } else {
+        packet_header = (packet_header_t*)&client_interface->header_buffer[header_id];
+    }
     packet_header->routing.flags = FORWARD;
     packet_header->routing.packet_size_bytes = size;
     packet_header->routing.dst_mesh_id = dst_mesh_id;
@@ -377,9 +510,13 @@ inline void fabric_async_write_atomic_inc_add_header(
 
 // Write packetized data over fabric to dst_mesh, dst_dev.
 // Packet is at src_addr in sender L1.
-template <AsyncWriteMode mode = AsyncWriteMode::ALL, RoutingType routing_type = RoutingType::ROUTER_XY>
+template <
+    typename T,
+    ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA,
+    AsyncWriteMode mode = AsyncWriteMode::ALL,
+    RoutingType routing_type = RoutingType::ROUTER_XY>
 inline void fabric_async_write_atomic_inc(
-    volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface,
+    T client_interface,
     uint32_t routing,   // routing refers to the router noc xy to use when using ROUTER_XY,
                         // and the routing plane to use when using ROUTING_TABLE
     uint32_t src_addr,  // source address in sender’s memory
@@ -388,18 +525,32 @@ inline void fabric_async_write_atomic_inc(
     uint64_t dst_write_addr,
     uint64_t dst_atomic_addr,
     uint32_t size,  // number of bytes to write to remote destination
-    uint32_t atomic_inc) {
+    uint32_t atomic_inc,
+    uint32_t header_id = 0) {
     if constexpr (mode & AsyncWriteMode::ADD_HEADER) {
-        fabric_async_write_atomic_inc_add_header(
-            src_addr, dst_mesh_id, dst_dev_id, dst_write_addr, dst_atomic_addr, size, atomic_inc);
+        fabric_async_write_atomic_inc_add_header<decltype(client_interface), data_mode>(
+            client_interface,
+            src_addr,
+            dst_mesh_id,
+            dst_dev_id,
+            dst_write_addr,
+            dst_atomic_addr,
+            size,
+            atomic_inc,
+            header_id);
     }
 
     if constexpr (mode & AsyncWriteMode::ADD_PR) {
-        fabric_setup_pull_request(client_interface, src_addr, size);
+        if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+            fabric_setup_pull_request<data_mode>(client_interface, src_addr, size);
+        } else {
+            fabric_setup_pull_request<data_mode>(client_interface, src_addr, size - PACKET_HEADER_SIZE_BYTES);
+        }
     }
 
     if constexpr (mode & AsyncWriteMode::SEND_PR) {
-        fabric_send_pull_request<routing_type>(client_interface, routing, dst_mesh_id, dst_dev_id);
+        fabric_send_pull_request<data_mode, routing_type>(
+            client_interface, routing, dst_mesh_id, dst_dev_id, header_id);
     }
 }
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_interface.h
@@ -352,8 +352,9 @@ typedef struct _fabric_pull_client_interface {
     uint64_t pull_req_buf_addr;
     uint32_t num_routing_planes;
     uint32_t routing_tables_l1_offset;
-    uint32_t return_status[3];
+    uint32_t return_status[4];
     local_pull_request_t local_pull_request;
+    packet_header_t header_buffer[CLIENT_HEADER_BUFFER_ENTRIES];
 } fabric_pull_client_interface_t;
 
 static_assert(sizeof(fabric_client_interface_t) % 16 == 0);
@@ -373,6 +374,7 @@ typedef struct _fabric_push_client_interface {
     uint32_t router_space;
     uint32_t update_router_space;
     uint32_t reserved[3];
+    packet_header_t header_buffer[CLIENT_HEADER_BUFFER_ENTRIES];
 } fabric_push_client_interface_t;
 
 static_assert(sizeof(fabric_push_client_interface_t) % 16 == 0);


### PR DESCRIPTION
This change is to add support to specify packet header at a different location than the payload in a sender core's L1 memory.
Client interface now holds 4 header slots. 
Users can setup the header fields and instruct the async write apis to use a specified header from the header slot.
Inline headers are still supported.