### PR TITLE
[skip ci] Light up the TG Quick test

### DIFF
--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -1,0 +1,22 @@
+name: "TG Quick"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-wheel: true
+      version: 22.04
+
+  tg-quick-test:
+    needs: build-artifact
+    uses: ./.github/workflows/tg-quick.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -25,10 +25,12 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
+        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/MLPerf:/mnt/MLPerf
       options: --device /dev/tenstorrent
     defaults:
       run:
@@ -58,9 +60,7 @@ jobs:
       - name: Run quick tests
         timeout-minutes: 20
         run: |
-          # TODO: Run the chosen tests here
-          # pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k quick
-          # pytest models/demos/llama3_subdevices/demo/demo_decode.py -k quick
+          pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k quick
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
### Ticket
#18419 

### Problem description
Galaxy gets broken because nobody runs it before merging.
Nobody runs it because it's off the beaten path and takes too long and the resources are scarce.

### What's changed
A fast test that doesn't hog resources placed right on the road well traveled.

NOTE: We'll monitor for any delays in APC, but for now FAFO'ing it.  Easy to adjust if we need to.

### Checklist
- [x] TG Choose Your Own Pipeline [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13841186994)