### PR TITLE
Use prng in dropout_init for Blackhole

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -241,9 +241,6 @@ void test_dropout(tt_metal::IDevice* device, const DropoutConfig& test_config) {
 }  // namespace unit_tests::compute::sfpu::dropout
 
 TEST_F(DeviceFixture, TensixComputeDropout) {
-    if (this->arch_ != tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP();
-    }
     srand(0);
     int num_tests = 5;
     float fill_constant = 9.0;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
+#include "sfpu/ckernel_sfpu_dropout.h"
 
 using namespace sfpi;
 
@@ -13,48 +12,13 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_dropout(uint prob, uint scale) {
-    // SFPU microcode
-
-    vUInt rand = l_reg[LRegs::LReg3];
-
-#pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        ////////////////////////
-        // Scale samples
-        ///////////////////////
-        dst_reg[0] = dst_reg[0] * s2vFloat16b(scale);
-
-        ////////////////////////
-        // Drop samples
-        ///////////////////////
-        v_if(rand < prob) { dst_reg[0] = vConst0; }
-        v_endif;
-
-        ////////////////////////
-        // 16-bit PRNG update
-        ///////////////////////
-        vUInt lfsr = vConstIntPrgm1;
-        vUInt tmp = lfsr & rand;
-        rand = rand >> 1;
-        v_if(tmp != 0) {
-            vUInt mask = vConstIntPrgm0;
-            rand ^= mask;
-        }
-        v_endif;
-
-        dst_reg++;
-    }
-
-    l_reg[LRegs::LReg3] = rand;
+inline void calculate_dropout(uint probability, uint scale) {
+    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, probability, scale);
 }
 
 template <bool APPROXIMATION_MODE>
 inline void dropout_init(const uint seed) {
-    vConstIntPrgm0 = 0xb400;
-    vConstIntPrgm1 = 0x1;  // binary 0b1 - used to extract LSB
-
-    _init_dropout_seed_(seed);
+    _init_dropout_(seed);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_dropout.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,9 +19,9 @@ inline void llk_math_eltwise_unary_sfpu_dropout_init(uint seed = 0) {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_dropout(
-    uint dst_index, int vector_mode = (int)VectorMode::RC, int integer_dropout, int scale_factor) {
+    uint dst_index, uint integer_probability, uint scale_factor, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_dropout<APPROXIMATE>, dst_index, vector_mode, integer_dropout, scale_factor);
+        ckernel::sfpu::calculate_dropout<APPROXIMATE>, dst_index, vector_mode, integer_probability, scale_factor);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_dropout.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/7736
Required PR: https://github.com/tenstorrent/tt-llk/pull/43

### Problem description
Blackhole currently has GS template for dropout which should be updated to mirror Wormhole's.

### What's changed
- Mirrored Wormhole's dropout related files to blackhole (Implemented dropout using hardware PRNG)
- Removed arch skip in dropout test since it now also works in BH

### Checklist
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13988168885) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes