### PR TITLE
#0: Add K and KD waypoints around kernel_main

### DIFF
--- a/tt_metal/hw/firmware/src/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/active_erisck.cc
@@ -32,7 +32,9 @@ void kernel_launch(uint32_t kernel_base_addr) {
 
     {
         DeviceZoneScopedMainChildN("ACTIVE-ERISC-KERNEL");
+        WAYPOINT("K");
         kernel_main();
+        WAYPOINT("KD");
         if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
             WAYPOINT("NKFW");
             // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -45,7 +45,9 @@ void kernel_launch(uint32_t kernel_base_addr) {
     {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
         EARLY_RETURN_FOR_DEBUG
+        WAYPOINT("K");
         kernel_main();
+        WAYPOINT("KD");
     }
 #endif
 }

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -35,5 +35,7 @@ extern "C" [[gnu::section(".start")]] void _start(uint32_t) {
 
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
+    WAYPOINT("K");
     kernel_main();
+    WAYPOINT("KD");
 }

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -31,7 +31,9 @@ void kernel_launch(uint32_t kernel_base_addr) {
 
     {
         DeviceZoneScopedMainChildN("IDLE-ERISC-KERNEL");
+        WAYPOINT("K");
         kernel_main();
+        WAYPOINT("KD");
         if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
             WAYPOINT("NKFW");
             // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -53,7 +53,9 @@ void kernel_launch(uint32_t kernel_base_addr) {
     wait_for_go_message();
     DeviceZoneScopedMainChildN("NCRISC-KERNEL");
     EARLY_RETURN_FOR_DEBUG
+    WAYPOINT("K");
     kernel_main();
+    WAYPOINT("KD");
     if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
         WAYPOINT("NKFW");
         // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -60,6 +60,8 @@ void kernel_launch(uint32_t kernel_base_addr) {
     wait_for_go_message();
     DeviceZoneScopedMainChildN("TRISC-KERNEL");
     EARLY_RETURN_FOR_DEBUG
+    WAYPOINT("K");
     run_kernel();
+    WAYPOINT("KD");
 #endif
 }


### PR DESCRIPTION
### Problem description
Sometimes it can be hard to tell if a hang is happening before the kernel starts, or at the beginning of the kernel before more waypoints have been set.

### What's changed
Adding K and KD waypoints around kernel_main lets us determine if the user kernel code is executing, or if it's in the dispatcher.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes