### PR TITLE
Update Whisper test targets and Blackhole nightly/demo CI schedule

### DIFF
--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -2,10 +2,9 @@ name: "(Blackhole) Demo tests"
 
 on:
   workflow_dispatch:
-  # workflow_call:
-  # schedule:
-  #   - cron: "0 */6 * * 1,2,3,4,5"
-  #   - cron: "0 */4 * * 0,6"
+  workflow_call:
+  schedule:
+    - cron: "0 4 * * *"  # Every day at 4:00 UTC
 
 jobs:
   build-artifact:

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -2,9 +2,9 @@ name: "(Blackhole) Blackhole nightly tests"
 
 on:
   workflow_dispatch:
-  # workflow_call:
-  # schedule:
-  #   - cron: "0 */6 * * *"
+  workflow_call:
+  schedule:
+    - cron: "0 */12 * * *"  # Every day at 0:00 and 12:00 UTC
 
 jobs:
   build-artifact:

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -29,6 +29,7 @@ from models.demos.whisper.tt.ttnn_optimized_functional_whisper import (
 )
 from models.generation_utils import get_logits_processor
 from models.demos.utils.llm_demo_utils import verify_perf
+from models.utility_functions import is_blackhole
 
 
 def load_input_paths(folder_path):
@@ -467,18 +468,23 @@ def test_demo_for_audio_classification_dataset(ttnn_model, device, use_program_c
     (ttnn_optimized_functional_whisper,),
 )
 @pytest.mark.parametrize(
-    "num_inputs, expected_perf_metrics",
-    ((2, {"prefill_t/s": 3.81, "decode_t/s": 41.2, "decode_t/s/u": 41.2}),),
+    "num_inputs",
+    (2,),
 )
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_demo_for_conditional_generation(
-    input_path, ttnn_model, device, num_inputs, expected_perf_metrics, use_program_cache, enable_async_mode, is_ci_env
+    input_path, ttnn_model, device, num_inputs, use_program_cache, enable_async_mode, is_ci_env
 ):
     ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
         input_path, ttnn_model, device, num_inputs
     )
     if is_ci_env:
+        if is_blackhole():
+            expected_perf_metrics = {"prefill_t/s": 7.74, "decode_t/s/u": 86.3}
+        else:  # wormhole_b0
+            expected_perf_metrics = {"prefill_t/s": 3.84, "decode_t/s/u": 41.7}
+        expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1
         measurements = {"prefill_t/s": 1 / ttft, "decode_t/s": decode_throughput, "decode_t/s/u": decode_throughput}
         verify_perf(measurements, expected_perf_metrics)
 

--- a/models/demos/whisper/tests/test_whisper_modules.py
+++ b/models/demos/whisper/tests/test_whisper_modules.py
@@ -15,7 +15,7 @@ from datasets import load_dataset
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc, comp_pcc
-from models.utility_functions import torch_random
+from models.utility_functions import torch_random, is_blackhole
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 # MODEL_NAME = "openai/whisper-base"
@@ -453,5 +453,9 @@ def test_ttnn_whisper(
     )
     last_hidden_state = ttnn.to_torch(last_hidden_state)
 
-    _, pcc_message = assert_with_pcc(expected_last_hidden_state, last_hidden_state, 0.991)
+    if is_blackhole():
+        expec_out_pcc = 0.990
+    else:  # wormhole_b0
+        expec_out_pcc = 0.991
+    _, pcc_message = assert_with_pcc(expected_last_hidden_state, last_hidden_state, expec_out_pcc)
     logger.info(f"Output PCC: {pcc_message}")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Blackhole Whisper pcc target was incorrect (first time set, no regression)
- Blackhole model pipelines were not running on a schedule
- There were no blackhole specific perf targets in the Whisper demo

### What's changed
- Updated Whisper blackhole pcc/perf targets
- Set schedule for Blackhole nightly to every 12 hr and Blackhole demo to every 24 hr

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes