### PR TITLE
[skip ci] Do not waste time on useless endeavours

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -37,6 +37,7 @@ jobs:
     with:
       version: "22.04"
       build-type: Debug
+      publish-artifact: false
 
   find-changed-files:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft


### PR DESCRIPTION
### Ticket
None

### Problem description
Debug builds waste nearly 5m uploading a tarball.  PR Gate couldn't care less abou it and would rather those 5m be spent doing useful things.

### What's changed
Do not tar anything up and do not upload said tarball.