### PR TITLE
Modify llm_demo_utils.py::verify_perf to assert for higher than expected perf and update model perf targets

### DIFF
--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 8720, "decode_t/s": 3200, "decode_t/s/u": 12.5}, False, None),
-        (True, 1024, {"prefill_t/s": 10190, "decode_t/s": 2820, "decode_t/s/u": 11.0}, False, None),
-        (True, 2048, {"prefill_t/s": 8750, "decode_t/s": 2680, "decode_t/s/u": 10.5}, False, None),
+        (True, 128, {"prefill_t/s": 10650, "decode_t/s": 3640, "decode_t/s/u": 14.2}, False, None),
+        (True, 1024, {"prefill_t/s": 12730, "decode_t/s": 3390, "decode_t/s/u": 13.3}, False, None),
+        (True, 2048, {"prefill_t/s": 10790, "decode_t/s": 3080, "decode_t/s/u": 12.0}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 10650, "decode_t/s": 3640, "decode_t/s/u": 14.2}, False, None),
-        (True, 1024, {"prefill_t/s": 12730, "decode_t/s": 3390, "decode_t/s/u": 13.3}, False, None),
-        (True, 2048, {"prefill_t/s": 10790, "decode_t/s": 3080, "decode_t/s/u": 12.0}, False, None),
+        (True, 128, {"prefill_t/s": 10963, "decode_t/s": 3662, "decode_t/s/u": 14.3}, False, None),
+        (True, 1024, {"prefill_t/s": 12938, "decode_t/s": 3390, "decode_t/s/u": 13.3}, False, None),
+        (True, 2048, {"prefill_t/s": 10813, "decode_t/s": 3234, "decode_t/s/u": 12.6}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 12760, "decode_t/s": 3510, "decode_t/s/u": 3.4}, False, None),
-        (True, 1024, {"prefill_t/s": 17200, "decode_t/s": 3560, "decode_t/s/u": 3.5}, False, None),
-        (True, 2048, {"prefill_t/s": 12380, "decode_t/s": 3600, "decode_t/s/u": 3.5}, False, None),
+        (True, 128, {"prefill_t/s": 17460, "decode_t/s": 4550, "decode_t/s/u": 4.44}, False, None),
+        (True, 1024, {"prefill_t/s": 21350, "decode_t/s": 4397, "decode_t/s/u": 4.29}, False, None),
+        (True, 2048, {"prefill_t/s": 15150, "decode_t/s": 4344, "decode_t/s/u": 4.24}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -12,7 +12,7 @@ from models.utility_functions import is_wormhole_b0
     (
         (True, 128, {"prefill_t/s": 17460, "decode_t/s": 4550, "decode_t/s/u": 4.44}, False, None),
         (True, 1024, {"prefill_t/s": 21350, "decode_t/s": 4397, "decode_t/s/u": 4.29}, False, None),
-        (True, 2048, {"prefill_t/s": 15150, "decode_t/s": 4344, "decode_t/s/u": 4.24}, False, None),
+        (True, 2048, {"prefill_t/s": 15150, "decode_t/s": 4562, "decode_t/s/u": 4.45}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 17460, "decode_t/s": 4550, "decode_t/s/u": 4.44}, False, None),
+        (True, 128, {"prefill_t/s": 18123, "decode_t/s": 4909, "decode_t/s/u": 4.79}, False, None),
         (True, 1024, {"prefill_t/s": 21350, "decode_t/s": 4397, "decode_t/s/u": 4.29}, False, None),
-        (True, 2048, {"prefill_t/s": 15150, "decode_t/s": 4562, "decode_t/s/u": 4.45}, False, None),
+        (True, 2048, {"prefill_t/s": 16299, "decode_t/s": 4368, "decode_t/s/u": 4.27}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 18123, "decode_t/s": 4909, "decode_t/s/u": 4.79}, False, None),
-        (True, 1024, {"prefill_t/s": 21350, "decode_t/s": 4397, "decode_t/s/u": 4.29}, False, None),
-        (True, 2048, {"prefill_t/s": 16299, "decode_t/s": 4368, "decode_t/s/u": 4.27}, False, None),
+        (True, 128, {"prefill_t/s": 17921, "decode_t/s": 4873, "decode_t/s/u": 4.76}, False, None),
+        (True, 1024, {"prefill_t/s": 20143, "decode_t/s": 4504, "decode_t/s/u": 4.40}, False, None),
+        (True, 2048, {"prefill_t/s": 14136, "decode_t/s": 4290, "decode_t/s/u": 4.19}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 1370, "decode_t/s": 430, "decode_t/s/u": 13.4}, False, None),
-        (True, 1024, {"prefill_t/s": 1770, "decode_t/s": 370, "decode_t/s/u": 11.6}, False, None),
-        (True, 2048, {"prefill_t/s": 1600, "decode_t/s": 360, "decode_t/s/u": 11.2}, False, None),
+        (True, 128, {"prefill_t/s": 1750, "decode_t/s": 559, "decode_t/s/u": 17.5}, False, None),
+        (True, 1024, {"prefill_t/s": 2250, "decode_t/s": 499, "decode_t/s/u": 15.6}, False, None),
+        (True, 2048, {"prefill_t/s": 1990, "decode_t/s": 462, "decode_t/s/u": 14.4}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/wormhole/mamba/demo/demo.py
+++ b/models/demos/wormhole/mamba/demo/demo.py
@@ -372,11 +372,11 @@ def run_mamba_demo(
     )
     logger.info(f"Time to first token: {(1e3 * time_to_first_token):.2f} ms")
 
-    chunk_size_to_prefill_targets_tok_per_s = {32: 135.0, 128: 270.0}  # perf is different for different chunk sizes
+    chunk_size_to_prefill_targets_tok_per_s = {32: 135.0, 128: 430.0}  # perf is different for different chunk sizes
     targets = {
         "prefill_t/s": chunk_size_to_prefill_targets_tok_per_s[prefill_chunk_size],
-        "decode_t/s": 235.0,
-        "decode_t/s/u": 7.3,
+        "decode_t/s": 341.6,
+        "decode_t/s/u": 10.6,
     }
     warmup_iterations = {"inference_prefill": 0, "inference_decode": 0}
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -71,9 +71,6 @@ run_common_perf_tests(){
   # Mistral7B
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/demo/demo_with_prefill.py; fail+=$?
 
-  # Mamba
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420; fail+=$?
-
   return $fail
 }
 
@@ -128,6 +125,9 @@ run_n300_perf_tests(){
 
   # Falcon7b (perf verification for 128/1024/2048 seq lens and output token verification)
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py; fail+=$?
+
+  # Mamba
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420; fail+=$?
 
   # Whisper conditional generation
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation"; fail+=$?


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- For demos that were using the `verify_perf` helper function for asserting against perf, only lower than expected perf was being checked and not higher than expected perf, resulting in demo targets to become out of date over time

### What's changed
- Modified llm_demo_utils.py::verify_perf to assert for higher than expected perf
- Updated demo perf test targets for Falcon7b (wh/t3k/tg) & Mamba
- Moved Mamba demo test out of perf common demos (n150 / n300) and into perf n300 only so it only checks perf on BMs

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes