### PR TITLE
[skip ci] Extract ClangTidy from APC and run it on a schedule instead of every 3hrs.

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -165,11 +165,6 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       os: ubuntu-22.04
-  code-analysis:
-    uses: ./.github/workflows/code-analysis.yaml
-    secrets: inherit
-    with:
-      version: 22.04
   tt-train-cpp-unit-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -1,6 +1,8 @@
 name: "Code analysis"
 
 on:
+  schedule:
+    - cron: "0 */3 * * *" # This cron schedule runs the workflow every 3 hours
   workflow_call:
     inputs:
       distro:


### PR DESCRIPTION
### Ticket
None

### Problem description
We have a pretty solid gate to guard against ClangTidy breakages reaching main.
Though the gate may have holes.

### What's changed
* Removed the ClangTidy scan in APC (triggered on every merge to main + whenever a dev wants to sanity check on their branch).
  * This saves unnecessary compute resources.
* Run ClangTidy every 3hrs.
  * This guards against any possible holes in the MergeQueue (or someone bypassing the MQ)