### PR TITLE
#0: Fix sub-device reconfiguration with multi-CQ and add unit test

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -21,6 +21,7 @@
 #include "tt_backend_api_types.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "command_queue_fixture.hpp"
+#include "multi_command_queue_fixture.hpp"
 #include "sub_device_test_utils.hpp"
 #include "dispatch_test_utils.hpp"
 
@@ -29,8 +30,7 @@ namespace tt::tt_metal {
 constexpr uint32_t k_local_l1_size = 3200;
 const std::string k_coordinates_kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp";
 
-TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
-    auto* device = devices_[0];
+void test_sub_device_synchronization(IDevice* device) {
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
     CoreRangeSet sharded_cores_1 = CoreRange({0, 0}, {2, 2});
@@ -98,6 +98,15 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
     // Full synchronization
     device->reset_sub_device_stall_group();
     Synchronize(device);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
+    auto* device = devices_[0];
+    test_sub_device_synchronization(device);
+}
+
+TEST_F(MultiCommandQueueSingleDeviceFixture, TensixTestMultiCQSubDeviceSynchronization) {
+    test_sub_device_synchronization(device_);
 }
 
 TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicPrograms) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1923,9 +1923,11 @@ void reset_worker_dispatch_state_on_device(
     // go_signal. Clear the dispatch <--> worker semaphore, since trace starts at 0.
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
         SubDeviceId sub_device_id(static_cast<uint8_t>(i));
-        uint32_t expected_num_workers = expected_num_workers_completed[i] +
-                                        device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) +
-                                        device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
+        uint32_t expected_num_workers = expected_num_workers_completed[i];
+        if (reset_launch_msg_state) {
+            expected_num_workers += device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) +
+                                    device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
+        }
         if (DispatchQueryManager::instance().distributed_dispatcher()) {
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Hang when reconfiguring sub-devices with multi-cq.
Issue is because we incorrectly incremented the expected wait count for CQ 1 when we don't send launch message reset using it.

### What's changed
Don't increment the expected wait count when resetting without launch message reset and add unit test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13866440093/job/38809720447
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes