### PR TITLE
implement two phase barrier to sync all state

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -54,4 +54,16 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
         enable_persistent_fabric_mode);
 }
 
+ttnn::Tensor ExecuteAllGatherAsync::invoke(
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    MeshDevice& mesh_device,
+    const CoreRangeSet& cores,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology) {
+    return ttnn::operations::experimental::ccl::all_gather_async(
+        input_tensor, dim, mesh_device, cores, num_links, memory_config, topology);
+}
+
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -33,6 +33,15 @@ struct ExecuteAllGatherAsync {
         const std::optional<size_t> num_preferred_links = std::nullopt,
         std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
         bool enable_persistent_fabric_mode = false);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const int32_t dim,
+        MeshDevice& mesh_device,
+        const CoreRangeSet& cores,
+        const uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
@@ -89,7 +89,27 @@ void bind_all_gather_async(pybind11::module& module, const ccl_operation_t& oper
             py::arg("num_links") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("subdevice_id") = std::nullopt,
-            py::arg("enable_persistent_fabric_mode") = false});
+            py::arg("enable_persistent_fabric_mode") = false},
+
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const int32_t dim,
+               MeshDevice& mesh_device,
+               const CoreRangeSet& cores,
+               const uint32_t num_links,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const ttnn::ccl::Topology topology) -> ttnn::Tensor {
+                return self(input_tensor, dim, mesh_device, cores, num_links, memory_config, topology);
+            },
+            py::arg("input_tensor"),
+            py::arg("dim"),
+            py::arg("mesh_device"),
+            py::arg("cores"),
+            py::kw_only(),
+            py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -20,19 +20,19 @@ AllGatherAsync create_all_gather_async_struct(
     const std::optional<MemoryConfig>& memory_config,
     const std::vector<IDevice*>& devices,
     const ttnn::ccl::Topology topology,
-    const std::vector<GlobalSemaphore>& semaphores,
+    const std::pair<std::vector<GlobalSemaphore>, std::vector<GlobalSemaphore>>& semaphores,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
     bool enable_persistent_fabric_mode) {
     uint32_t num_devices = devices.size();
 
     std::optional<IDevice*> forward_device = std::nullopt;
     std::optional<IDevice*> backward_device = std::nullopt;
-    std::optional<GlobalSemaphore> semaphore = std::nullopt;
+    std::optional<std::pair<GlobalSemaphore, GlobalSemaphore>> semaphore = std::nullopt;
     uint32_t device_index = 0;  // Initialize device index
     for (uint32_t i = 0; i < num_devices; ++i) {
         if (devices.at(i) == input_tensor.device()) {
             device_index = i;
-            semaphore = semaphores.at(i);  // Get raw pointer
+            semaphore.emplace(semaphores.first.at(i), semaphores.second.at(i));
             if (i != 0) {
                 backward_device = devices.at(i - 1);
             } else if (topology == ttnn::ccl::Topology::Ring) {
@@ -140,7 +140,8 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
     log_trace(tt::LogOp, "[select_version] output_shard_num_cores: {}", output_shard_num_cores);
 
     // Check for minimal interleaved case
-    if (input_tensor_shape[0] == 1 && input_tensor_shape[1] == 1 && input_tensor_shape[2] == 32 &&
+    if (num_links == 1 &&  // 1 for T3K only
+        ((input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2]) % 32 == 0 && dim < 3) &&
         input_tensor_buffer_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
         input_tensor_page_layout == tt::tt_metal::Layout::TILE && this->enable_persistent_fabric_mode) {
         return AllGatherAsyncVersion::MINIMAL_INTERLEAVED_32;
@@ -258,7 +259,7 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program(
                 this->ring_size,
                 this->ring_index,
                 this->topology,
-                this->semaphore,
+                this->semaphore.first,
                 this->sub_device_id,
                 this->enable_persistent_fabric_mode);
     }
@@ -275,7 +276,8 @@ const tt::tt_metal::operation::Hash AllGatherAsync::compute_program_hash(
     auto input_memory_config = input_tensors[0].memory_config();
     if (version == AllGatherAsyncVersion::GENERIC) {
         // Generic version should hash semaphore address as well
-        uint32_t semaphore_address = this->semaphore.address();
+        uint32_t semaphore_address_first = this->semaphore.first.address();
+        uint32_t semaphore_address_second = this->semaphore.second.address();
         return tt::tt_metal::operation::hash_operation<AllGatherAsync>(
             this->dim,
             this->num_links,
@@ -287,7 +289,8 @@ const tt::tt_metal::operation::Hash AllGatherAsync::compute_program_hash(
             input_memory_layout,
             input_dtype,
             input_memory_config,
-            semaphore_address);
+            semaphore_address_first,
+            semaphore_address_second);
     }
     return tt::tt_metal::operation::hash_operation<AllGatherAsync>(
         this->dim,
@@ -336,7 +339,8 @@ Tensor all_gather_async(
     CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
 
-    std::vector<GlobalSemaphore> semaphores = multi_device_global_semaphore.global_semaphores;
+    std::pair<std::vector<GlobalSemaphore>, std::vector<GlobalSemaphore>> semaphores(
+        multi_device_global_semaphore.global_semaphores, multi_device_global_semaphore.global_semaphores);
 
     tt::tt_metal::operation::launch_op(
         [dim,
@@ -403,7 +407,8 @@ Tensor all_gather_async(
     std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
     CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-    std::vector<GlobalSemaphore> semaphores = multi_device_global_semaphore.global_semaphores;
+    std::pair<std::vector<GlobalSemaphore>, std::vector<GlobalSemaphore>> semaphores(
+        multi_device_global_semaphore.global_semaphores, multi_device_global_semaphore.global_semaphores);
 
     tt::tt_metal::operation::launch_op(
         [gather_dim,
@@ -441,6 +446,60 @@ Tensor all_gather_async(
                     semaphores,
                     sub_device_id,
                     enable_persistent_fabric_mode),
+                {input_tensor});
+        },
+        {input_tensor},
+        output_tensors);
+    return output_tensors.at(0);
+}
+
+Tensor all_gather_async(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    MeshDevice& mesh_device,
+    const CoreRangeSet& cores,
+    const uint32_t num_links,
+    const std::optional<MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology) {
+    TT_FATAL(
+        std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr,
+        "all_gather_async op is only supported for Fast Dispatch");
+    auto devices = input_tensor.get_workers();
+    uint32_t num_devices = devices.size();
+    TT_FATAL(num_devices > 1, "all_gather_async op will only work for num_devices > 1, but has {}", num_devices);
+    ttnn::ccl::Topology ccl_topology = topology;
+
+    if (num_devices == 2) {
+        ccl_topology = ttnn::ccl::Topology::Linear;
+    }
+    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
+
+    tt::log_debug(
+        tt::LogOp, "DEBUG: creating line_fabric with num devices: {}, num links: {}", devices.size(), num_links);
+    tt::log_debug(tt::LogOp, "DEBUG: line_fabric is created");
+
+    // create this semaphore for all cores since we don't know which core will be used for teardown draining
+    CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
+    auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+
+    std::pair<std::vector<GlobalSemaphore>, std::vector<GlobalSemaphore>> semaphores = make_pair(
+        ttnn::global_semaphore::create_global_semaphore_with_same_address(
+            &mesh_device, cores, 0, tt::tt_metal::BufferType::L1, 100)
+            .global_semaphores,
+        ttnn::global_semaphore::create_global_semaphore_with_same_address(
+            &mesh_device, cores, 0, tt::tt_metal::BufferType::L1, 100)
+            .global_semaphores);
+
+    tt::tt_metal::operation::launch_op(
+        [dim, num_links, num_devices, memory_config, devices, ccl_topology, semaphores](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor = input_tensors.at(0);
+
+            return tt::tt_metal::operation::run(
+                ttnn::ccl::all_gather_detail::create_all_gather_async_struct(
+                    input_tensor, dim, num_links, memory_config, devices, ccl_topology, semaphores, std::nullopt, true),
                 {input_tensor});
         },
         {input_tensor},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -63,7 +63,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const GlobalSemaphore& semaphore,
+    const std::pair<GlobalSemaphore, GlobalSemaphore>& semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     bool enable_persistent_fabric_mode) {
     tt::tt_metal::Program program{};
@@ -142,6 +142,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
 
     // Tensor Info
+    const auto input_tensor_shape = input_tensor.get_padded_shape();
     const auto input_tensor_layout = input_tensor.buffer()->buffer_layout();
     const auto input_tensor_buffer_type = input_tensor.buffer()->buffer_type();
     const auto input_tensor_page_layout = input_tensor.layout();
@@ -172,6 +173,10 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         reader_kernel_config);
 
     // Writer
+    bool two_phase_release = semaphore.first.address() != semaphore.second.address();
+    bool last_dim = dim == input_tensor_shape.rank() - 1;
+    uint32_t tile_rows = input_tensor_shape[dim - 1] / input_tensor.get_tensor_spec().tile().get_height();
+    uint32_t tile_cols_for_chip = input_tensor_shape[dim] / input_tensor.get_tensor_spec().tile().get_width();
     auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
     writer_kernel_config.compile_args = {
         ring_index,                                        // my_chip_id
@@ -183,6 +188,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         op_config.get_page_size(),                         // tensor0_page_size
         num_targets_forward,                               // num_targets_forward_direction
         num_targets_backward,                              // num_targets_backward_direction
+        two_phase_release,                                 // two_phase_release
     };
     log_trace(tt::LogOp, "Writer Compile Args:");
     for (const auto& arg : writer_kernel_config.compile_args) {
@@ -220,6 +226,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         uint32_t remainder = input_tensor_num_pages % num_links;
         uint32_t input_tile_id_start = link * base_pages_per_worker + std::min(link, remainder);
         uint32_t input_tile_id_end = (link + 1) * base_pages_per_worker + std::min(link + 1, remainder);
+        uint32_t num_tiles_per_chip = input_tensor_shape[2] * input_tensor_shape[3] / 1024;
         std::vector<uint32_t> reader_rt_args = {
             input_tensor.buffer()->address(),  // tensor_address0
             input_tile_id_start,               // tile_id_start
@@ -237,9 +244,14 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         uint32_t out_ready_sem_wait_value = ring_size * num_links;
         uint32_t output_tile_id_start = ring_index * input_tensor_num_pages + input_tile_id_start;
         uint32_t output_tile_id_end = ring_index * input_tensor_num_pages + input_tile_id_end;
+        if (last_dim) {
+            output_tile_id_start = tile_cols_for_chip * ring_index;  // multi width tile for each chip
+            output_tile_id_end = tile_rows * tile_cols_for_chip;
+        }
         std::vector<uint32_t> writer_rt_args = {
             output_tensor.buffer()->address(),  // tensor_address0
-            semaphore.address(),                // out_ready_sem_bank_addr (absolute address)
+            semaphore.first.address(),          // out_ready_sem_bank_addr (absolute address)
+            semaphore.second.address(),         // out_ready_sem_bank_addr (absolute address)
             output_tile_id_start,               // tile_id_start
             output_tile_id_end,                 // tile_id_end
             wait_output_semaphore,              // wait_output_semaphore
@@ -247,6 +259,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
             drain_sync_core.x,                  // out_ready_sem_noc0_x
             drain_sync_core.y,                  // out_ready_sem_noc0_y
             out_ready_sem_wait_value,           // out_ready_sem_wait_value
+            ring_size,                          // ring_size
         };
         log_trace(tt::LogOp, "Writer Runtime Args:");
         for (const auto& arg : writer_rt_args) {
@@ -269,7 +282,11 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
 
             auto semaphore = static_cast<const ttnn::AllGatherAsync*>(operation)->semaphore;
 
-            log_trace(tt::LogOp, "DEBUG: semaphore: {}", semaphore.address());
+            log_trace(
+                tt::LogOp,
+                "DEBUG: semaphore.first: {}, semaphore.second: {}",
+                semaphore.first.address(),
+                semaphore.second.address());
 
             // update senders
             auto& worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
@@ -281,7 +298,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
                 // writer
                 auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
                 worker_writer_sender_runtime_args[0] = output.buffer()->address();
-                worker_writer_sender_runtime_args[1] = semaphore.address();
+                worker_writer_sender_runtime_args[1] = semaphore.first.address();
+                worker_writer_sender_runtime_args[2] = semaphore.second.address();
             }
         };
 
@@ -298,7 +316,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const GlobalSemaphore& semaphore,
+    const std::pair<GlobalSemaphore, GlobalSemaphore>& semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     bool enable_persistent_fabric_mode) {
     tt::tt_metal::Program program{};
@@ -414,6 +432,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
         reader_kernel_config);
 
     // Writer
+    bool two_phase_release = semaphore.first.address() != semaphore.second.address();
     auto writer_kernel_config = tt::tt_metal::WriterDataMovementConfig{};
     writer_kernel_config.compile_args = {
         ring_index,                       // my_chip_id
@@ -424,6 +443,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
         op_config.get_page_size(),        // tensor0_page_size
         num_targets_forward,              // num_targets_forward_direction
         num_targets_backward,             // num_targets_backward_direction
+        two_phase_release,                // two_phase_release
     };
     log_trace(tt::LogOp, "Writer Compile Args:");
     for (const auto& arg : writer_kernel_config.compile_args) {
@@ -532,7 +552,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
         uint32_t out_ready_sem_wait_value = ring_size * num_links;
         std::vector<uint32_t> writer_rt_args = {
             output_tensor.buffer()->address(),    // tensor_address0
-            semaphore.address(),                  // out_ready_sem_bank_addr (absolute address)
+            semaphore.first.address(),            // out_ready_sem_bank_addr (absolute address)
+            semaphore.second.address(),           // out_ready_sem_bank_addr (absolute address)
             output_tensor_shard_num_pages,        // num_tiles_per_core
             worker_num_tiles_to_read,             // num_tiles_to_read
             output_first_core_tile_start_offset,  // first_core_tile_start_offset
@@ -566,7 +587,11 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
 
             auto semaphore = static_cast<const ttnn::AllGatherAsync*>(operation)->semaphore;
 
-            log_trace(tt::LogOp, "DEBUG: semaphore: {}", semaphore.address());
+            log_trace(
+                tt::LogOp,
+                "DEBUG: semaphore.first: {}, semaphore.second: {}",
+                semaphore.first.address(),
+                semaphore.second.address());
 
             // update senders
             auto& worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
@@ -578,7 +603,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
                 // writer
                 auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
                 worker_writer_sender_runtime_args[0] = output.buffer()->address();
-                worker_writer_sender_runtime_args[1] = semaphore.address();
+                worker_writer_sender_runtime_args[1] = semaphore.first.address();
+                worker_writer_sender_runtime_args[2] = semaphore.second.address();
             }
         };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -250,8 +250,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
         }
         std::vector<uint32_t> writer_rt_args = {
             output_tensor.buffer()->address(),  // tensor_address0
-            semaphore.first.address(),          // out_ready_sem_bank_addr (absolute address)
-            semaphore.second.address(),         // out_ready_sem_bank_addr (absolute address)
+            semaphore.first.address(),          // out_ready_sem_bank_addr_wait (absolute address)
+            semaphore.second.address(),         // out_ready_sem_bank_addr_release (absolute address)
             output_tile_id_start,               // tile_id_start
             output_tile_id_end,                 // tile_id_end
             wait_output_semaphore,              // wait_output_semaphore
@@ -552,8 +552,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
         uint32_t out_ready_sem_wait_value = ring_size * num_links;
         std::vector<uint32_t> writer_rt_args = {
             output_tensor.buffer()->address(),    // tensor_address0
-            semaphore.first.address(),            // out_ready_sem_bank_addr (absolute address)
-            semaphore.second.address(),           // out_ready_sem_bank_addr (absolute address)
+            semaphore.first.address(),            // out_ready_sem_bank_addr_wait (absolute address)
+            semaphore.second.address(),           // out_ready_sem_bank_addr_release (absolute address)
             output_tensor_shard_num_pages,        // num_tiles_per_core
             worker_num_tiles_to_read,             // num_tiles_to_read
             output_first_core_tile_start_offset,  // first_core_tile_start_offset

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -26,6 +26,7 @@ constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(5);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(7);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(8);
+constexpr bool two_phase_release = get_compile_time_arg_val(9);
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -39,7 +40,8 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
-    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr_wait = get_arg_val<uint32_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr_release = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
     uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
     bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
@@ -47,6 +49,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t ring_size = get_arg_val<uint32_t>(arg_idx++);
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
 
@@ -67,10 +70,12 @@ void kernel_main() {
     DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << "\n";
     DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << "\n";
     DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << "\n";
-    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << "\n";
+    DPRINT << "out_ready_sem_bank_addr_wait: " << (uint32_t)out_ready_sem_bank_addr_wait << "\n";
+    DPRINT << "out_ready_sem_bank_addr_release: " << (uint32_t)out_ready_sem_bank_addr_release << "\n";
     DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << "\n";
     DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << "\n";
     DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << "\n";
+    DPRINT << "ring_size: " << (uint32_t)ring_size << "\n";
 
     DPRINT << "arg_for_fab: " << (uint32_t)arg_for_fab << "\n";
     DPRINT << "fabric_connection arg 0" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
@@ -149,48 +154,18 @@ void kernel_main() {
         cb_pop_front(cb0_id, packet_size_in_pages);
     }
 
-    // 2. mcast output ready semaphore
-    uint64_t out_ready_sem_noc_addr_in_pkt =
-        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
-    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
-    pkt_hdr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-        out_ready_sem_noc_addr_in_pkt,
-        static_cast<uint16_t>(1),  // increment 1
-        32});
-    // Write the mcast packet (forward)
-    if (fabric_connection.has_forward_connection()) {
-        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
-        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
-    }
-    // Write the mcast packet (backward)
-    if (fabric_connection.has_backward_connection()) {
-        pkt_hdr->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
-        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
-    }
-    // increment locally
-    uint64_t out_ready_sem_noc_addr =
-        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
-    noc_semaphore_inc(out_ready_sem_noc_addr, 1);
-    DPRINT << "inc done\n";
-
-    // 3. wait for mcast output ready semaphore
-    if (wait_output_semaphore) {
-        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
-        DPRINT << "waitval done\n";
-    }
-
-    // 4. global semaphore reset
-    if (reset_global_semaphore) {
-        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
-        noc_inline_dw_write(dest_noc_addr, 0);
-        DPRINT << "reset done\n";
-    }
+    ccl_barrier<two_phase_release>(
+        fabric_connection,
+        out_ready_sem_bank_addr_wait,
+        out_ready_sem_bank_addr_release,
+        out_ready_sem_wait_value,
+        out_ready_sem_noc0_x,
+        out_ready_sem_noc0_y,
+        packet_header_buffer_seminc,
+        num_targets_forward_direction,
+        num_targets_backward_direction,
+        wait_output_semaphore,
+        reset_global_semaphore);
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/interleaved_dim3_1_1_32_any_writer.cpp
@@ -117,6 +117,19 @@ void kernel_main() {
         fabric_connection.open();
     }
 
+    ccl_barrier<two_phase_release>(
+        fabric_connection,
+        out_ready_sem_bank_addr_wait,
+        out_ready_sem_bank_addr_release,
+        out_ready_sem_wait_value,
+        out_ready_sem_noc0_x,
+        out_ready_sem_noc0_y,
+        packet_header_buffer_seminc,
+        num_targets_forward_direction,
+        num_targets_backward_direction,
+        wait_output_semaphore,
+        reset_global_semaphore);
+
     // 1. mcast via fabric to remote tensor addresses
     DPRINT << "num_targets_forward_direction: " << num_targets_forward_direction << "\n";
     DPRINT << "num_targets_backward_direction: " << num_targets_backward_direction << "\n";
@@ -153,19 +166,6 @@ void kernel_main() {
 
         cb_pop_front(cb0_id, packet_size_in_pages);
     }
-
-    ccl_barrier<two_phase_release>(
-        fabric_connection,
-        out_ready_sem_bank_addr_wait,
-        out_ready_sem_bank_addr_release,
-        out_ready_sem_wait_value,
-        out_ready_sem_noc0_x,
-        out_ready_sem_noc0_y,
-        packet_header_buffer_seminc,
-        num_targets_forward_direction,
-        num_targets_backward_direction,
-        wait_output_semaphore,
-        reset_global_semaphore);
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -119,6 +119,19 @@ void kernel_main() {
         fabric_connection.open();
     }
 
+    ccl_barrier<two_phase_release>(
+        fabric_connection,
+        out_ready_sem_bank_addr_wait,
+        out_ready_sem_bank_addr_release,
+        out_ready_sem_wait_value,
+        out_ready_sem_noc0_x,
+        out_ready_sem_noc0_y,
+        packet_header_buffer_seminc,
+        num_targets_forward_direction,
+        num_targets_backward_direction,
+        wait_output_semaphore,
+        reset_global_semaphore);
+
     // 1. mcast via fabric to remote tensor addresses
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
@@ -159,19 +172,6 @@ void kernel_main() {
             core_id++;
         }
     }
-
-    ccl_barrier<two_phase_release>(
-        fabric_connection,
-        out_ready_sem_bank_addr_wait,
-        out_ready_sem_bank_addr_release,
-        out_ready_sem_wait_value,
-        out_ready_sem_noc0_x,
-        out_ready_sem_noc0_y,
-        packet_header_buffer_seminc,
-        num_targets_forward_direction,
-        num_targets_backward_direction,
-        wait_output_semaphore,
-        reset_global_semaphore);
 
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp
@@ -46,3 +46,102 @@ FORCE_INLINE void write_and_advance_local_read_address_for_fabric_write(
 
     l1_read_addr += payload_size_bytes;
 }
+
+static inline void local_barrier(
+    FabricConnectionManager& fabric_connection,
+    const size_t semaphore,
+    uint32_t wait_num,
+    const uint8_t sem_noc0_x,
+    const uint8_t sem_noc0_y,
+    uint32_t pkt_hdr_buffer_seminc,
+    uint32_t num_targets_forward_direction,
+    uint32_t num_targets_backward_direction,
+    bool wait_semaphore,
+    bool reset_semaphore) {
+    // 2. mcast output ready semaphore
+    uint64_t out_ready_sem_noc_addr_in_pkt = safe_get_noc_addr(sem_noc0_x, sem_noc0_y, semaphore, 0);
+    auto pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(pkt_hdr_buffer_seminc);
+    pkt_hdr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_noc_addr_in_pkt,
+        static_cast<uint16_t>(1),  // increment 1
+        32});
+    // Write the mcast packet (forward)
+    if (fabric_connection.has_forward_connection()) {
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            pkt_hdr_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+    }
+    // Write the mcast packet (backward)
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+            pkt_hdr_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+    }
+    // increment locally
+    uint64_t out_ready_sem_noc_addr = safe_get_noc_addr(sem_noc0_x, sem_noc0_y, semaphore);
+    noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+    DPRINT << "inc done\n";
+
+    // 3. wait for mcast output ready semaphore
+    if (wait_semaphore) {
+        while (*reinterpret_cast<volatile uint32_t*>(semaphore) < wait_num);
+        DPRINT << "waitval done\n";
+    }
+
+    // 4. global semaphore reset
+    if (reset_semaphore) {
+        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], semaphore);
+        noc_inline_dw_write(dest_noc_addr, 0);
+        DPRINT << "reset done\n";
+    }
+}
+
+// Two phase barrier
+template <bool byTwoPhase>
+inline void ccl_barrier(
+    FabricConnectionManager& fabric_connection,
+    const size_t semaphore_wait,
+    const size_t semaphore_release,
+    uint32_t wait_num,
+    const uint8_t sem_noc0_x,
+    const uint8_t sem_noc0_y,
+    uint32_t pkt_hdr_buffer_seminc,
+    uint32_t num_targets_forward_direction,
+    uint32_t num_targets_backward_direction,
+    bool wait_semaphore,
+    bool reset_semaphore) {
+    // WAIT phase: ensure local chip got N signals from other N chips
+    DPRINT << "ccl_barrier: WAIT phase\n";
+    local_barrier(
+        fabric_connection,
+        semaphore_wait,
+        wait_num,
+        sem_noc0_x,
+        sem_noc0_y,
+        pkt_hdr_buffer_seminc,
+        num_targets_forward_direction,
+        num_targets_backward_direction,
+        wait_semaphore,
+        reset_semaphore);
+
+    // This "if" is for backward compatibility
+    if constexpr (byTwoPhase) {
+        // RELEASE phase: ensure all chip got N signals from other N chips
+        DPRINT << "ccl_barrier: RELEASE phase\n";
+        local_barrier(
+            fabric_connection,
+            semaphore_release,
+            wait_num,
+            sem_noc0_x,
+            sem_noc0_y,
+            pkt_hdr_buffer_seminc,
+            num_targets_forward_direction,
+            num_targets_backward_direction,
+            wait_semaphore,
+            reset_semaphore);
+    }
+}


### PR DESCRIPTION
### Ticket
?

### Problem description
There has been potential deadlock and data corruption by single semaphore wait with same address.

e.g. Chip A got N signals and goes to next operation (like allgather), but others are still waiting for signals. Chip A's next allgathers signal and send/recv could corrupt data if it uses same address of semaphore and tensors.


### What's changed
This uses two semaphore for WAIT and RELEASE phase.
- WAIT is to ensure local chip finish its processing and got N-1 signals from other N-1 chips
- RELEASE is to ensure all chip got N signals from other N chips

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes