### PR TITLE
Integrate tt-npe and noc tracing into op perf table generation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,6 +137,8 @@ ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/ @
 ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/ @tenstorrent/metallium-maintainers-llama-models
 ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/ @tenstorrent/metallium-maintainers-llama-models
 ttnn/ttnn/operations/eltwise @patrickroberts @sjameelTT @ntarafdar @dchenTT
+ttnn/tracy/ @mo-tenstorrent
+ttnn/tools/profiler/ @mo-tenstorrent
 tests/ttnn/ @ayerofieiev-tt @dmakoviichuk-tt @rfurko-tt @cfjchu @TT-BrianLiu @razorback3 @dongjin-na @bbradelTT @omilyutin-tt
 tests/ttnn/unit_tests/gtests/ccl/ @SeanNijjar @jvegaTT @cfjchu @tt-aho
 tests/ttnn/unit_tests/operations/ccl/ @SeanNijjar @jvegaTT @tt-aho

--- a/tt_metal/tools/profiler/common.py
+++ b/tt_metal/tools/profiler/common.py
@@ -36,11 +36,11 @@ TRACY_CSVEXPROT_TOOL = "csvexport-release"
 
 
 def generate_logs_folder(outFolder):
-    return outFolder / ".logs"
+    return Path(outFolder) / ".logs"
 
 
 def generate_reports_folder(outFolder):
-    return outFolder / "reports"
+    return Path(outFolder) / "reports"
 
 
 PROFILER_LOGS_DIR = generate_logs_folder(PROFILER_ARTIFACTS_DIR)

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -87,7 +87,6 @@ OPS_CSV_HEADER = [
     "PM FPU UTIL (%)",
     "NOC UTIL (%)",
     "DRAM BW UTIL (%)",
-    "SHARE OF KERNEL DURATION (%)",
 ]
 
 
@@ -746,22 +745,6 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                             rowDict["PM FPU UTIL (%)"] = 0.0
 
             rowDicts.append(rowDict)
-
-        # calculate % share of device duration for each op
-        total_device_fw_duration = 0
-        for rowDict in rowDicts:
-            try:
-                total_device_fw_duration += float(rowDict.get("DEVICE KERNEL DURATION [ns]", 0))
-            except ValueError:
-                pass
-
-        for rowDict in rowDicts:
-            try:
-                rowDict["SHARE OF KERNEL DURATION (%)"] = round(
-                    100.0 * float(rowDict.get("DEVICE KERNEL DURATION [ns]", 0)) / total_device_fw_duration, 1
-                )
-            except:
-                rowDict["SHARE OF KERNEL DURATION (%)"] = 0.0
 
         ioHeaderIndex = OPS_CSV_HEADER.index("INPUTS")
         allHeaders = (

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -87,7 +87,7 @@ OPS_CSV_HEADER = [
     "PM FPU UTIL (%)",
     "NOC UTIL (%)",
     "DRAM BW UTIL (%)",
-    "SHARE OF DEVICE DURATION (%)",
+    "SHARE OF KERNEL DURATION (%)",
 ]
 
 
@@ -734,10 +734,12 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                     rowDict["PM REQ I BW"] = opData["performance_model"]["input_bws"]
                     rowDict["PM REQ O BW"] = opData["performance_model"]["output_bws"]
 
-                    if "DEVICE FW DURATION [ns]" in rowDict:
+                    if "DEVICE KERNEL DURATION [ns]" in rowDict:
                         try:
                             fpu_util = (
-                                100.0 * float(rowDict["PM COMPUTE [ns]"]) / float(rowDict["DEVICE FW DURATION [ns]"])
+                                100.0
+                                * float(rowDict["PM COMPUTE [ns]"])
+                                / float(rowDict["DEVICE KERNEL DURATION [ns]"])
                             )
                             rowDict["PM FPU UTIL (%)"] = round(fpu_util, 1)
                         except ZeroDivisionError:
@@ -749,17 +751,17 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
         total_device_fw_duration = 0
         for rowDict in rowDicts:
             try:
-                total_device_fw_duration += float(rowDict.get("DEVICE FW DURATION [ns]", 0))
+                total_device_fw_duration += float(rowDict.get("DEVICE KERNEL DURATION [ns]", 0))
             except ValueError:
                 pass
 
         for rowDict in rowDicts:
             try:
-                rowDict["SHARE OF DEVICE DURATION (%)"] = round(
-                    100.0 * float(rowDict.get("DEVICE FW DURATION [ns]", 0)) / total_device_fw_duration, 1
+                rowDict["SHARE OF KERNEL DURATION (%)"] = round(
+                    100.0 * float(rowDict.get("DEVICE KERNEL DURATION [ns]", 0)) / total_device_fw_duration, 1
                 )
             except:
-                rowDict["SHARE OF DEVICE DURATION (%)"] = 0.0
+                rowDict["SHARE OF KERNEL DURATION (%)"] = 0.0
 
         ioHeaderIndex = OPS_CSV_HEADER.index("INPUTS")
         allHeaders = (

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -389,8 +389,6 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
                     ops_found += 1
                     ops[op_id]["NOC UTIL (%)"] = round(op_npe_stats.result.overall_avg_link_util, 1)
                     ops[op_id]["DRAM BW UTIL (%)"] = round(op_npe_stats.result.dram_bw_util, 1)
-                else:
-                    logger.warning(f"No npe stats found for op ID {op_id}", op_id)
             logger.info(f"Analyzed {ops_found} operations with tt-npe trace data.")
 
     return devicesOps, traceOps

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -389,7 +389,9 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
                     ops_found += 1
                     ops[op_id]["NOC UTIL (%)"] = round(op_npe_stats.result.overall_avg_link_util, 1)
                     ops[op_id]["DRAM BW UTIL (%)"] = round(op_npe_stats.result.dram_bw_util, 1)
-            logger.info(f"Found {ops_found} operations with noc trace data")
+                else:
+                    logger.warning(f"No npe stats found for op ID {op_id}", op_id)
+            logger.info(f"Analyzed {ops_found} operations with tt-npe trace data.")
 
     return devicesOps, traceOps
 
@@ -780,14 +782,14 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
 
 def analyzeNoCTraces(logFolder):
     """Attempts to import tt-npe from $PYTHONPATH and process noc traces to
-    obtain per-operation dram and noc utilization statistics"""
+    obtain per-operation DRAM BW and NoC utilization statistics"""
     try:
         from npe_analyze_noc_trace_dir import analyze_noc_traces_in_dir
 
-        logger.info(f"tt-npe imported successfully; analyzing noc traces ... ")
+        logger.info(f"tt-npe module imported successfully; analyzing noc traces ... ")
         return analyze_noc_traces_in_dir(logFolder, False, True)
     except ImportError:
-        logger.warning("tt-npe is not available in this python environment. Try sourcing 'tt-npe/ENV_SETUP'")
+        logger.warning("Could not import tt-npe module. Ensure tt-npe is built, then source 'tt-npe/ENV_SETUP'")
         return None
     except Exception as e:
         logger.error("Unexpected error occured when analyzing noc traces, aborting ... ")
@@ -816,7 +818,7 @@ def process_ops(output_folder, name_append, date, device_only=False, analyze_noc
 @click.option("--date", default=False, is_flag=True, help="Append date to output files")
 @click.option("--device-only", default=False, is_flag=True, help="Only generate a device data report")
 @click.option(
-    "--analyze-noc-traces", is_flag=True, help="Attempt to use tt-npe to analyze profiler noc event trace files"
+    "--analyze-noc-traces", is_flag=True, help="Use tt-npe to analyze profiler noc event trace files (if available)"
 )
 def main(output_folder, name_append, date, device_only, analyze_noc_traces):
     if output_folder:

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -659,8 +659,8 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                 )
                 rowDict["HOST DURATION [ns]"] = int(opData["host_time"]["exec_time_ns"])
 
-                rowDict["NOC UTIL (%)"] = opData.get("NOC UTIL (%)", 0.0)
-                rowDict["DRAM BW UTIL (%)"] = opData.get("DRAM BW UTIL (%)", 0.0)
+                rowDict["NOC UTIL (%)"] = opData.get("NOC UTIL (%)", "")
+                rowDict["DRAM BW UTIL (%)"] = opData.get("DRAM BW UTIL (%)", "")
 
                 if "kernel_info" in opData.keys():
                     rowDict["COMPUTE KERNEL SOURCE"] = []

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -87,6 +87,7 @@ OPS_CSV_HEADER = [
     "PM FPU UTIL (%)",
     "NOC UTIL (%)",
     "DRAM BW UTIL (%)",
+    "SHARE OF DEVICE DURATION (%)",
 ]
 
 
@@ -743,6 +744,22 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                             rowDict["PM FPU UTIL (%)"] = 0.0
 
             rowDicts.append(rowDict)
+
+        # calculate % share of device duration for each op
+        total_device_fw_duration = 0
+        for rowDict in rowDicts:
+            try:
+                total_device_fw_duration += float(rowDict.get("DEVICE FW DURATION [ns]", 0))
+            except ValueError:
+                pass
+
+        for rowDict in rowDicts:
+            try:
+                rowDict["SHARE OF DEVICE DURATION (%)"] = round(
+                    100.0 * float(rowDict.get("DEVICE FW DURATION [ns]", 0)) / total_device_fw_duration, 1
+                )
+            except:
+                rowDict["SHARE OF DEVICE DURATION (%)"] = 0.0
 
         ioHeaderIndex = OPS_CSV_HEADER.index("INPUTS")
         allHeaders = (

--- a/tt_metal/tools/profiler/profile_this.py
+++ b/tt_metal/tools/profiler/profile_this.py
@@ -18,9 +18,15 @@ from tt_metal.tools.profiler.common import (
 )
 
 
-def profile_command(test_command, output_folder, name_append):
+def profile_command(test_command, output_folder, name_append, collect_noc_traces):
     currentEnvs = dict(os.environ)
     currentEnvs["TT_METAL_DEVICE_PROFILER"] = "1"
+    if collect_noc_traces:
+        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"
+        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = os.path.join(
+            os.path.abspath(output_folder), ".logs"
+        )
+
     options = ""
     if output_folder:
         options += f"-o {output_folder}"
@@ -34,13 +40,14 @@ def profile_command(test_command, output_folder, name_append):
 @click.option("-o", "--output-folder", type=click.Path(), help="Output folder for artifacts")
 @click.option("-c", "--command", type=str, required=True, help="Test command to profile")
 @click.option("-n", "--name-append", type=str, help="Name to be appended to artifact names and folders")
-def main(command, output_folder, name_append):
+@click.option("--collect-noc-traces", is_flag=True, default=False)
+def main(command, output_folder, name_append, collect_noc_traces):
     logger.warning(
         "profile_this.py is getting deprecated soon. Please use the tracy.py module with -r option to obtain op reports."
     )
     if command:
         logger.info(f"profile_this.py is running {command}")
-        profile_command(command, output_folder, name_append)
+        profile_command(command, output_folder, name_append, collect_noc_traces)
 
 
 if __name__ == "__main__":

--- a/tt_metal/tools/profiler/profile_this.py
+++ b/tt_metal/tools/profiler/profile_this.py
@@ -15,6 +15,7 @@ from tt_metal.tools.profiler.common import (
     PROFILER_SCRIPTS_ROOT,
     TT_METAL_HOME,
     PROFILER_OUTPUT_DIR,
+    generate_logs_folder,
 )
 
 
@@ -30,9 +31,10 @@ def profile_command(test_command, output_folder, name_append, collect_noc_traces
     if collect_noc_traces:
         options += f" --collect-noc-traces "
         currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"
-        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = os.path.join(
-            os.path.abspath(output_folder), ".logs"
+        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = generate_logs_folder(
+            os.path.abspath(output_folder)
         )
+
     opProfilerTestCommand = f"python3 -m tracy -v -r -p {options} -m {test_command}"
     subprocess.run([opProfilerTestCommand], shell=True, check=False, env=currentEnvs)
 

--- a/tt_metal/tools/profiler/profile_this.py
+++ b/tt_metal/tools/profiler/profile_this.py
@@ -30,10 +30,6 @@ def profile_command(test_command, output_folder, name_append, collect_noc_traces
         options += f" -n {name_append}"
     if collect_noc_traces:
         options += f" --collect-noc-traces "
-        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"
-        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = generate_logs_folder(
-            os.path.abspath(output_folder)
-        )
 
     opProfilerTestCommand = f"python3 -m tracy -v -r -p {options} -m {test_command}"
     subprocess.run([opProfilerTestCommand], shell=True, check=False, env=currentEnvs)

--- a/tt_metal/tools/profiler/profile_this.py
+++ b/tt_metal/tools/profiler/profile_this.py
@@ -21,17 +21,18 @@ from tt_metal.tools.profiler.common import (
 def profile_command(test_command, output_folder, name_append, collect_noc_traces):
     currentEnvs = dict(os.environ)
     currentEnvs["TT_METAL_DEVICE_PROFILER"] = "1"
-    if collect_noc_traces:
-        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"
-        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = os.path.join(
-            os.path.abspath(output_folder), ".logs"
-        )
 
     options = ""
     if output_folder:
         options += f"-o {output_folder}"
     if name_append:
         options += f" -n {name_append}"
+    if collect_noc_traces:
+        options += f" --collect-noc-traces "
+        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"
+        currentEnvs["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = os.path.join(
+            os.path.abspath(output_folder), ".logs"
+        )
     opProfilerTestCommand = f"python3 -m tracy -v -r -p {options} -m {test_command}"
     subprocess.run([opProfilerTestCommand], shell=True, check=False, env=currentEnvs)
 

--- a/ttnn/tracy/__init__.py
+++ b/ttnn/tracy/__init__.py
@@ -120,7 +120,7 @@ def run_report_setup(verbose, outputFolder, port):
     return toolsReady, captureProcess
 
 
-def generate_report(outputFolder, nameAppend, childCalls):
+def generate_report(outputFolder, nameAppend, childCalls, collect_noc_traces=False):
     logsFolder = generate_logs_folder(outputFolder)
     tracyOutFile = logsFolder / TRACY_FILE_NAME
     timeOut = 15
@@ -164,7 +164,7 @@ def generate_report(outputFolder, nameAppend, childCalls):
 
     logger.info(f"Host side ops data report generated at {logsFolder / TRACY_OPS_DATA_FILE_NAME}")
 
-    process_ops(outputFolder, nameAppend, True)
+    process_ops(outputFolder, nameAppend, True, device_only=False, analyze_noc_traces=collect_noc_traces)
 
 
 def get_available_port():

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -56,6 +56,13 @@ def main():
         help="Only process the logs avaialble in the default logs folder",
         default=False,
     )
+    parser.add_option(
+        "--collect-noc-traces",
+        dest="collect_noc_traces",
+        action="store_true",
+        help="Collect noc event traces when profiling",
+        default=False,
+    )
 
     if not sys.argv[1:]:
         parser.print_usage()
@@ -75,7 +82,7 @@ def main():
         outputFolder = Path(options.output_folder)
 
     if options.processLogsOnly:
-        generate_report(generate_logs_folder(outputFolder), "", None)
+        generate_report(generate_logs_folder(outputFolder), "", None, options.collect_noc_traces)
         sys.exit(0)
 
     if options.port:
@@ -176,7 +183,7 @@ def main():
 
             try:
                 captureProcess.communicate(timeout=15)
-                generate_report(outputFolder, options.name_append, options.child_functions)
+                generate_report(outputFolder, options.name_append, options.child_functions, options.collect_noc_traces)
             except subprocess.TimeoutExpired as e:
                 captureProcess.terminate()
                 captureProcess.communicate()

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -97,6 +97,12 @@ def main():
     else:
         os.environ[opInfoCacheStr] = "1"
 
+    if options.collect_noc_traces:
+        os.environ["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"
+        os.environ["TT_METAL_DEVICE_PROFILER_NOC_EVENTS_RPT_PATH"] = str(
+            generate_logs_folder(os.path.abspath(outputFolder))
+        )
+
     if len(args) > 0:
         doReport = False
         if options.report:


### PR DESCRIPTION
### Ticket

### Problem description
Call profile_this.py with --collect-noc-traces flag, and noc traces are automatically collected at model runtime, analyzed by tt-npe, and metrics populated into the op perf CSV table.

### What's changed
- `process_ops_logs.py` can automatically import tt-npe and call into it for analysis
  - new flag is `--analyze-noc-traces`
  - tt-npe is a _strictly optional_ module; absence of tt-npe or a crash will not bring down the flow overall
  - Two metrics added are "**DRAM BW UTIL (%)**" and "**NOC UTIL (%)**"
- `profile_this.py` has new `--collect-noc-traces` boolean flag that setups ENV variables for noc event tracing
  - Automatically enables --analyze-noc-traces flag during `process_ops`
- ttnn/tracy module has minor changes to support the above integration
- Additional derived columns unrelated to tt-npe have been added to the perf CSV
  - **SHARE OF DEVICE DURATION (%**) : proportion of overall device cycles an op took to run
  - **PM FPU UTIL (%)** : ratio of performance model's minimum device cycles based on compute divided by actual device cycles

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes