### PR TITLE
#0: [skip ci] Add arch-wormhole_b0 label to tg-quick.yaml

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on:
       - in-service
       - config-tg
+      - arch-wormhole_b0
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:


### PR DESCRIPTION
Fixes crash on produce data workflow: 
https://github.com/tenstorrent/tt-metal/actions/runs/13865626339/job/38803999673

### Ticket
Link to Github Issue

### Problem description
Produce data workflow expects runs-on to have arch specified

### What's changed
Add arch-wormhole_b0 to tg-quick workflow

### Checklist
- [ ] New/Existing tests provide coverage for changes