### PR TITLE
#12490: Move fast dispatch frequent single-card tests to 22.04 (not new containerization method yet)

### DIFF
--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -40,12 +40,14 @@ jobs:
           submodules: recursive
       - name: ⬇️ Download Build
         uses: actions/download-artifact@v4
+        timeout-minutes: 10
         with:
           name: ${{ inputs.build-artifact-name }}
       - name: Extract files
         run: tar -xvf ttm_any.tar
       - name: ⬇️ Download Wheel
         uses: actions/download-artifact@v4
+        timeout-minutes: 10
         with:
           name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }} tests

--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -3,10 +3,15 @@ name: "[internal] Fast dispatch frequent tests impl"
 on:
   workflow_call:
     inputs:
-      os:
-        required: false
+      build-artifact-name:
+        required: true
         type: string
-        default: "ubuntu-20.04"
+      wheel-artifact-name:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
 
 jobs:
   fd-frequent:
@@ -29,14 +34,28 @@ jobs:
       LOGURU_LEVEL: INFO
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - uses: ./.github/actions/prepare-metal-run
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.build-artifact-name }}
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_os_arch: tt-metalium/${{ inputs.os }}-amd64
+          docker_image: ${{ inputs.docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
+          # we want to eventually get rid of TT_METAL_HOME, but
+          # for these pgm dispatch things maybe not that big of a deal
           docker_opts: |
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}

--- a/.github/workflows/fast-dispatch-frequent-tests.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests.yaml
@@ -5,15 +5,19 @@ on:
   workflow_call:
   schedule:
     - cron: "0 */4 * * *"
-  push:
-    branches:
-      - "rkim/0-new-fd-frequent"
 
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
+    with:
+      version: "22.04"
+      build-wheel: true
   fd-nightly:
     needs: build-artifact
     uses: ./.github/workflows/fast-dispatch-frequent-tests-impl.yaml
     secrets: inherit
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket

#12490

### Problem description

Need to move to 22.04

### What's changed

- Run in 22.04

Did not move to new `container:` method yet

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [ ] Fast frequent: https://github.com/tenstorrent/tt-metal/actions/runs/13885904696/job/38850663281
  - looks like we're pretty close to the diffs to other runs on main: https://github.com/tenstorrent/tt-metal/actions/runs/13885098445/job/38848811939