### PR TITLE
Add support for Height Sharded & Block Sharded outputs to slice.

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "optional"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/logger.hpp"
 #include "ttnn/operations/math.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
@@ -146,9 +148,139 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     return ret_val;
 }
 
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded_output(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    const std::vector<CoreCoord>& cores,
+    uint32_t max_read_size) {
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.get_logical_shape();
+    auto output_shape = output_tensor.get_logical_shape();
+    auto output_shard_spec = output_tensor.shard_spec().value();
+    auto output_shard_shape = output_shard_spec.shape;
+
+    uint32_t input_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+    uint32_t output_row_size_bytes = output_shard_shape[1] * input_tensor.element_size();
+
+    auto num_cores_total = cores.size();
+
+    bool rm_orientation = output_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    bool is_block_sharded = output_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+
+    tt::log_debug("input_row_size_bytes: {}, output_row_size_bytes: {}", input_row_size_bytes, output_row_size_bytes);
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    // This currently just matches tile version where we iterate over the row as well
+    num_output_sticks_per_dim[0] = 1;
+    num_input_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_output_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_input_dim = (num_total_dim - num_output_dim) * accumulated_total_per_dim[i - 1];
+        num_output_sticks_per_dim[i] = num_output_dim;
+        num_input_sticks_per_dim[i] = num_input_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    using namespace tt::tt_metal::experimental;
+    auto SRC_BUFFER_ALIGNMENT = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    auto DST_BUFFER_ALIGNMENT = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    auto ALIGNMENT = std::max(SRC_BUFFER_ALIGNMENT, DST_BUFFER_ALIGNMENT);
+    uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
+    uint32_t misalignment = begins_bytes % SRC_BUFFER_ALIGNMENT;
+
+    uint32_t output_row_size_bytes_offset = tt::round_up(output_row_size_bytes, ALIGNMENT);
+    uint32_t start_addr = input_tensor.buffer()->address();
+    std::vector<uint32_t> common_reader_kernel_args = {
+        start_addr + begins_bytes - misalignment,  // read from nearest aligned address
+        input_row_size_bytes,
+        output_row_size_bytes,
+        output_row_size_bytes_offset,
+        num_dims,
+        0,
+        0,
+        0,
+        0};
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_output_sticks_per_dim.begin(), num_output_sticks_per_dim.end());
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_input_sticks_per_dim.begin(), num_input_sticks_per_dim.end());
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
+
+    const auto num_sticks_per_core = output_shard_spec.shape[0];
+    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+    if (num_sticks_per_core != 0) {
+        num_sticks_per_core_read =
+            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core, output_row_size_bytes_offset, max_read_size);
+        num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
+    }
+    tt::log_debug(
+        "num_sticker_per_core: {}, num_sticker_per_core_read: {}, num_read_per_barrier: {}",
+        num_sticks_per_core,
+        num_sticks_per_core_read,
+        num_read_per_barrier);
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
+    uint32_t core_index = 0;
+    for (const auto& core : cores) {
+        uint32_t core_w_index = 0;
+        uint32_t core_h_index = core_index;
+        if (is_block_sharded) {
+            core_w_index = rm_orientation ? core.x : core.y;
+            core_h_index = rm_orientation ? core.y : core.x;
+        }
+
+        const uint32_t num_sticks_written = core_h_index * num_sticks_per_core;
+        const uint32_t width_offset = core_w_index * output_row_size_bytes_offset;
+        tt::log_debug(" Core : {}, num_sticks_written: {}, width_offset: {}", core, num_sticks_written, width_offset);
+
+        id_per_dim[0] = num_sticks_written % num_output_sticks_per_dim[0];
+        uint32_t output_written = num_sticks_written / num_output_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = output_written % num_output_sticks_per_dim[j];
+            output_written = output_written / num_output_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
+        reader_kernel_args[0] += width_offset;
+
+        uint32_t addr_offset = 5;
+        reader_kernel_args[addr_offset++] = start_id;
+        reader_kernel_args[addr_offset++] = num_sticks_per_core;
+        reader_kernel_args[addr_offset++] = num_sticks_per_core;
+        reader_kernel_args[addr_offset] = num_read_per_barrier;
+        reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+
+        std::vector<uint32_t> writer_kernel_args = {num_sticks_per_core};
+        ret_val[core_index] = {reader_kernel_args, writer_kernel_args};
+        core_index++;
+    }
+
+    return ret_val;
+}
+
 operation::ProgramWithCallbacks slice_rm_multi_core(
     const Tensor& a, Tensor& output, const ttnn::Shape& output_tensor_start, const ttnn::Shape& output_tensor_end) {
-    const ttnn::Shape output_shape = output.get_padded_shape();
+    const ttnn::Shape output_shape = output.get_logical_shape();
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -161,7 +293,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    CoreRangeSet total_cores(CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1}));
     uint32_t num_cores_total = num_cores_x * num_cores_y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
@@ -170,17 +302,29 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
-    uint32_t padded_row_size_bytes = a.get_padded_shape()[-1] * a.element_size();
-    uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+    uint32_t input_row_size_bytes = a.get_logical_shape()[-1] * a.element_size();
+    uint32_t output_row_size_bytes = output_shape[-1] * a.element_size();
+    auto output_shard_spec = output.shard_spec();
+    bool is_output_sharded = output.is_sharded();
+    bool rm_orientation = true;
+    std::vector<CoreCoord> iter_cores;
+    if (is_output_sharded) {
+        output_row_size_bytes = output_shard_spec.value().shape[1] * output.element_size();
+        total_cores = output.shard_spec().value().grid;
+        rm_orientation = output_shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        iter_cores = corerange_to_cores(total_cores, std::nullopt, rm_orientation);
+        num_cores_total = total_cores.num_cores();
+    }
 
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    // TT_FATAL(!output.is_sharded(),"Output tensor should not be sharded!");
 
     bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
 
-    uint32_t src_stick_size = padded_row_size_bytes;
-    uint32_t dst_stick_size = unpadded_row_size_bytes;
+    uint32_t src_stick_size = input_row_size_bytes;
+    uint32_t dst_stick_size = output_row_size_bytes;
 
     uint32_t src0_cb_index = 0;
     uint32_t max_read_size = 4096;
@@ -200,21 +344,33 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     if (misalignment != 0) {
         alignment *= 2;
     }
-    uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
+    uint32_t cb_page_size = tt::round_up(output_row_size_bytes, alignment);
 
     uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                          : num_sticks_per_core_group_2;
-    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
-    if (num_input_pages != 0) {
-        auto num_sticks_per_core_pad32 = num_input_pages + (32 - num_input_pages % 32) % 32;
-        num_sticks_per_core_read =
-            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, cb_page_size, max_read_size);
-        num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+    CBHandle cb_src0;
+    if (is_output_sharded) {
+        uint32_t num_output_sticks_per_core = output_shard_spec.value().shape[0];
+        tt::tt_metal::CircularBufferConfig cb_src0_config =
+            tt::tt_metal::CircularBufferConfig(
+                num_output_sticks_per_core * output_row_size_bytes, {{src0_cb_index, cb_data_format}})
+                .set_page_size(src0_cb_index, output_row_size_bytes)
+                .set_globally_allocated_address(*output.buffer());
+        cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
+    } else {
+        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+        if (num_input_pages != 0) {
+            auto num_sticks_per_core_pad32 = num_input_pages + (32 - num_input_pages % 32) % 32;
+            num_sticks_per_core_read =
+                tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, cb_page_size, max_read_size);
+            num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+        }
+        tt::tt_metal::CircularBufferConfig cb_src0_config =
+            tt::tt_metal::CircularBufferConfig(
+                num_read_per_barrier * 2 * cb_page_size, {{src0_cb_index, cb_data_format}})
+                .set_page_size(src0_cb_index, cb_page_size);
+        cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
     }
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(num_read_per_barrier * 2 * cb_page_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, cb_page_size);
-    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
     std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
 
@@ -226,42 +382,80 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
         total_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args_vec));
 
-    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_writer_unary_stick_layout_interleaved_start_id.cpp",
-        total_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
+    tt::tt_metal::KernelHandle unary_writer_kernel_id;
+    if (is_output_sharded) {
+        unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp",
+            total_cores,
+            tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
 
-    auto all_runtime_args = get_slice_runtime_args_rm(
-        a,
-        output,
-        output_tensor_start,
-        num_cores_total,
-        num_cores,
-        num_cores_y,
-        core_group_1,
-        core_group_2,
-        num_sticks_per_core_group_1,
-        num_sticks_per_core_group_2,
-        max_read_size);
-
-    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
-
-        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+    } else {
+        unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+            "slice_writer_unary_stick_layout_interleaved_start_id.cpp",
+            total_cores,
+            tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
     }
 
-    auto override_runtime_args_callback =
-        [unary_reader_kernel_id, unary_writer_kernel_id, compute_with_storage_grid_size, max_read_size](
-            const void* operation,
-            const Program& program,
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>&,
-            const std::vector<Tensor>& output_tensors) {
-            auto src_tensor = input_tensors.at(0);
-            auto dst_tensor = output_tensors.at(0);
+    auto all_runtime_args = is_output_sharded ? get_slice_runtime_args_rm_sharded_output(
+                                                    a, output, output_tensor_start, iter_cores, max_read_size)
+                                              : get_slice_runtime_args_rm(
+                                                    a,
+                                                    output,
+                                                    output_tensor_start,
+                                                    num_cores_total,
+                                                    num_cores,
+                                                    num_cores_y,
+                                                    core_group_1,
+                                                    core_group_2,
+                                                    num_sticks_per_core_group_1,
+                                                    num_sticks_per_core_group_2,
+                                                    max_read_size);
+
+    if (is_output_sharded) {
+        uint32_t i = 0;
+        for (const auto& core : iter_cores) {
+            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+            i++;
+        }
+    } else {
+        for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+            tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+        }
+    }
+
+    auto override_runtime_args_callback = [unary_reader_kernel_id,
+                                           unary_writer_kernel_id,
+                                           output_tensor_start,
+                                           compute_with_storage_grid_size,
+                                           max_read_size,
+                                           iter_cores,
+                                           cb_src0](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>&,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto src_tensor = input_tensors.at(0);
+        auto dst_tensor = output_tensors.at(0);
+        if (dst_tensor.is_sharded()) {
+            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_tensor.buffer());
+
+            auto all_runtime_args = get_slice_runtime_args_rm_sharded_output(
+                src_tensor, dst_tensor, output_tensor_start, iter_cores, max_read_size);
+
+            uint32_t i = 0;
+            for (const auto& core : iter_cores) {
+                tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+                tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
+                i++;
+            }
+        } else {
             uint32_t num_cores_x = compute_with_storage_grid_size.x;
             uint32_t num_cores_y = compute_with_storage_grid_size.y;
             uint32_t num_cores_total = num_cores_x * num_cores_y;
@@ -292,12 +486,11 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
             for (uint32_t i = 0, num_tiles_written = 0; i < num_cores_total; i++) {
                 CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-                { SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first); }
-
-                { SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second); }
+                SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+                SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
             }
-        };
+        }
+    };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }


### PR DESCRIPTION
### Ticket
#19062

### Problem description
The slice op doesn't support sharding in it's output memory config. 

### What's changed
Added support for Height & Block Sharded to the slice op's output memory. Implemented the appropriate program factories for this configs. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes