### PR TITLE
#17725: Set all SD matmuls when slow_mm enabled

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_feedforward.py
@@ -1,14 +1,15 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import math
+import os
+import torch
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_geglu import geglu
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (
     determine_largest_subblock_size,
 )
-import torch
-import math
 
 
 def compare(tensor, name, reshape=False):
@@ -51,6 +52,8 @@ class feedforward:
         self.grid_sizes = {8192: (5, 8), 2048: (5, 8), 512: (8, 8), 128: (8, 4)}
         self.out_subblock_hs = {8192: 8, 2048: 8, 512: 2, 128: 1}
 
+        self.slow_mm = os.environ.get("SLOW_MATMULS", "0") == "1"
+
     def __call__(self, config, hidden_states):
         hidden_states = self.geglu(config, hidden_states)
 
@@ -64,7 +67,7 @@ class feedforward:
         out_block_w = math.ceil(N / grid_size[0] / 32)
         out_subblock_h, out_subblock_w = determine_largest_subblock_size(out_block_h, out_block_w)
         # TODO: https://github.com/tenstorrent/tt-metal/issues/7560
-        if size == 512:
+        if size == 512 or self.slow_mm:
             out_subblock_h = 1
             out_subblock_w = 1
         program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(


### PR DESCRIPTION
### Ticket
#17225

### What's changed
Not all matmuls in SD were set to have out_subblock_h/w 1,1 when SLOW_MATMULS env var was on.

### Checklist
Nightly ttnn and models: https://github.com/tenstorrent/tt-metal/actions/runs/13898051746
Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/13898049998
Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/13898045843
Demo: https://github.com/tenstorrent/tt-metal/actions/runs/13898043670