### PR TITLE
Remove unused imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,11 +8,9 @@ import random
 import os
 import numpy as np
 from functools import partial
-from itertools import chain
 from operator import contains, eq, getitem
 from pathlib import Path
 import json
-import copy
 import multiprocess
 import signal
 import time
@@ -119,7 +117,6 @@ def device(request, device_params):
 
     ttnn.DumpDeviceProfiler(device)
 
-    ttnn.synchronize_device(device)
     ttnn.close_device(device)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import re
-import sys
-import sysconfig
-import platform
 import subprocess
 from dataclasses import dataclass
 from functools import partial
@@ -39,8 +35,6 @@ def get_arch_name():
 
 
 def get_metal_local_version_scheme(metal_build_config, version):
-    from setuptools_scm.version import ScmVersion, guess_next_version
-
     arch_name = metal_build_config.arch_name
 
     if version.dirty:
@@ -50,8 +44,6 @@ def get_metal_local_version_scheme(metal_build_config, version):
 
 
 def get_metal_main_version_scheme(metal_build_config, version):
-    from setuptools_scm.version import ScmVersion, guess_next_version
-
     is_release_version = version.distance is None or version.distance == 0
     is_dirty = version.dirty
     is_clean_prod_build = (not is_dirty) and is_release_version


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Remove unused imports. Skip `ttnn.synchronize_device(device)` since it's already incorporated in `ttnn.close_device(device)`.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes