### PR TITLE
#12490: Split microbenchmark tests, do not use cursed run_tests.sh scripts no more, dockerize + upgrade to 22.04

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -112,13 +112,4 @@ jobs:
         with:
           name: microbenchmark-report-csv-${{ join(matrix.test-group.name) }}
           path: generated/profiler/.logs
-      - name: Cleanup
-        if: always()
-        run: |
-          # We are forced to checkout the repo into a subdir of the host's workdir; this pollutes the host
-          # with root-owned files.  Be sure to clean up after ourselves in case we're on a non-ephemeral runner.
-          echo "pre rm"
-          ls -al /__w/tt-metal/tt-metal
-          rm -rf /__w/tt-metal/tt-metal/docker-job
-          echo "post rm"
-          ls -al /__w/tt-metal/tt-metal
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -20,30 +20,54 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        runner-info: [
-          # Do not run N150 on microbenchmarks for now as we do not have the machines for it
-          # {arch: wormhole_b0, runs-on: ["pipeline-perf", "N150", "bare-metal", "in-service"]},
-          # N300
-          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"]},
-          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], ccl: true},
-          # T3000
+        test-group: [
           {
-              name: "T3000 uBenchmark tests",
-              arch: wormhole_b0,
-              runs-on: ["arch-wormhole_b0", "config-t3000", "pipeline-perf", "in-service"],
-              is-t3k: true
+            arch: wormhole_b0,
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            name: "N300 Moreh ubench",
+            cmd: "./tests/scripts/run_moreh_microbenchmark.sh",
+          },
+          {
+            arch: wormhole_b0,
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            name: "N300 metal ubench",
+            cmd: "pytest -svv tests/tt_metal/microbenchmarks",
+          },
+          {
+            arch: wormhole_b0,
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            name: "tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh -t n300",
+            cmd: "N300 ccl all gather",
+          },
+          {
+            arch: wormhole_b0,
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            name: "N300 ccl reduce scatter",
+            cmd: "tests/ttnn/unit_tests/operations/ccl/perf/run_reduce_scatter_profile.sh -t n300",
+          },
+          {
+            arch: wormhole_b0,
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            name: "N300 tunneler",
+            cmd: "TT_METAL_SLOW_DISPATCH_MODE=1 ./tests/scripts/run_tunneler_tests.sh --machine-type N300",
+          },
+          {
+            arch: wormhole_b0,
+            runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
+            name: "T3K ubench",
+            cmd: "pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py",
           },
         ]
     container:
       image: ${{ inputs.docker-image }}
       env:
-        # TODO: Remove TT_METAL_HOME, but it's currently being used in the script
-        TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.runner-info.arch }}
+        ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
         GITHUB_ACTIONS: true
+        # We make extensive use of device profiler
+        TT_METAL_DEVICE_PROFILER: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -52,7 +76,8 @@ jobs:
       run:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
-    runs-on: ${{ matrix.runner-info.runs-on }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
@@ -76,22 +101,13 @@ jobs:
           WHEEL_FILENAME=$(ls -1 *.whl)
           pip3 install $WHEEL_FILENAME
       - name: Run microbenchmark tests
-        timeout-minutes: 90
-        run: |
-          PIPELINE_TYPE="microbenchmarks"
-          if [ "${{ matrix.runner-info.ccl }}" == "true" ]; then
-            PIPELINE_TYPE="ccl_microbenchmarks"
-          elif [ "${{ matrix.runner-info.is-t3k }}" == "true" ]; then
-            PIPELINE_TYPE="T3K_microbenchmark"
-          else
-            TT_METAL_SLOW_DISPATCH_MODE=1 ./tests/scripts/run_tunneler_tests.sh --machine-type ${{ matrix.runner-info.runs-on[0] }}
-          fi
-          ./tests/scripts/run_tests.sh --tt-arch ${{ matrix.runner-info.arch }} --pipeline-type "$PIPELINE_TYPE"
+        timeout-minutes: 45
+        run: ${{ matrix.test-group.cmd }}
       - name: Upload microbenchmark report csvs
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:
-          name: microbenchmark-report-csv-${{ matrix.runner-info.arch }}
+          name: microbenchmark-report-csv-${{ join(matrix.test-group.name) }}
           path: generated/profiler/.logs
       - name: Cleanup
         if: always()

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -36,8 +36,8 @@ jobs:
           {
             arch: wormhole_b0,
             runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
-            name: "tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh -t n300",
-            cmd: "N300 ccl all gather",
+            name: "N300 ccl all gather",
+            cmd: "tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh -t n300",
           },
           {
             arch: wormhole_b0,

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -1,0 +1,104 @@
+name: "[internal] metal - Run microbenchmarks impl"
+
+on:
+  workflow_call:
+    inputs:
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+
+jobs:
+  run-microbenchmarks:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        runner-info: [
+          # Do not run N150 on microbenchmarks for now as we do not have the machines for it
+          # {arch: wormhole_b0, runs-on: ["pipeline-perf", "N150", "bare-metal", "in-service"]},
+          # N300
+          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"]},
+          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], ccl: true},
+          # T3000
+          {
+              name: "T3000 uBenchmark tests",
+              arch: wormhole_b0,
+              runs-on: ["arch-wormhole_b0", "config-t3000", "pipeline-perf", "in-service"],
+              is-t3k: true
+          },
+        ]
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ matrix.runner-info.arch }}
+        LOGURU_LEVEL: INFO
+        GITHUB_ACTIONS: true
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    runs-on: ${{ matrix.runner-info.runs-on }}
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.build-artifact-name }}
+          path: docker-job
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
+          path: docker-job
+      - name: Install Wheel
+        run: |
+          WHEEL_FILENAME=$(ls -1 *.whl)
+          pip3 install $WHEEL_FILENAME
+      - name: Run microbenchmark tests
+        timeout-minutes: 90
+        run: |
+          PIPELINE_TYPE="microbenchmarks"
+          if [ "${{ matrix.runner-info.ccl }}" == "true" ]; then
+            PIPELINE_TYPE="ccl_microbenchmarks"
+          elif [ "${{ matrix.runner-info.is-t3k }}" == "true" ]; then
+            PIPELINE_TYPE="T3K_microbenchmark"
+          else
+            TT_METAL_SLOW_DISPATCH_MODE=1 ./tests/scripts/run_tunneler_tests.sh --machine-type ${{ matrix.runner-info.runs-on[0] }}
+          fi
+          ./tests/scripts/run_tests.sh --tt-arch ${{ matrix.runner-info.arch }} --pipeline-type "$PIPELINE_TYPE"
+      - name: Upload microbenchmark report csvs
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: microbenchmark-report-csv-${{ matrix.runner-info.arch }}
+          path: generated/profiler/.logs
+      - name: Cleanup
+        if: always()
+        run: |
+          # We are forced to checkout the repo into a subdir of the host's workdir; this pollutes the host
+          # with root-owned files.  Be sure to clean up after ourselves in case we're on a non-ephemeral runner.
+          echo "pre rm"
+          ls -al /__w/tt-metal/tt-metal
+          rm -rf /__w/tt-metal/tt-metal/docker-job
+          echo "post rm"
+          ls -al /__w/tt-metal/tt-metal

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -61,6 +61,8 @@ jobs:
     container:
       image: ${{ inputs.docker-image }}
       env:
+        # All of these tests need this environment variable...
+        TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ matrix.test-group.arch }}

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -88,6 +88,7 @@ jobs:
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
       - name: ⬇️ Download Build
         uses: actions/download-artifact@v4
+        timeout-minutes: 10
         with:
           name: ${{ inputs.build-artifact-name }}
           path: docker-job
@@ -95,6 +96,7 @@ jobs:
         run: tar -xvf ttm_any.tar
       - name: ⬇️ Download Wheel
         uses: actions/download-artifact@v4
+        timeout-minutes: 10
         with:
           name: ${{ inputs.wheel-artifact-name }}
           path: docker-job

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -37,6 +37,7 @@ jobs:
     container:
       image: ${{ inputs.docker-image }}
       env:
+        # TODO: Remove TT_METAL_HOME, but it's currently being used in the script
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -67,7 +67,6 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
-        GITHUB_ACTIONS: true
         # We make extensive use of device profiler
         TT_METAL_DEVICE_PROFILER: 1
       volumes:

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -14,7 +14,7 @@ jobs:
     secrets: inherit
   run-microbenchmarks:
     needs: build-artifact
-    uses: ./.github/workflows/metal-run-microbenchmarks.yaml
+    uses: ./.github/workflows/metal-run-microbenchmarks-impl.yaml
     secrets: inherit
     with:
       docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -11,6 +11,7 @@ jobs:
     with:
       build-wheel: true
       version: "22.04"
+      tracy: true
     secrets: inherit
   run-microbenchmarks:
     needs: build-artifact

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -4,58 +4,19 @@ on:
   schedule:
     - cron: "0 1,15 * * *"
   workflow_dispatch:
-  workflow_call:
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      build-wheel: true
+      version: "22.04"
+    secrets: inherit
   run-microbenchmarks:
-    strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
-      fail-fast: false
-      matrix:
-        runner-info: [
-          # Do not run N150 on microbenchmarks for now as we do not have the machines for it
-          # {arch: wormhole_b0, runs-on: ["pipeline-perf", "N150", "bare-metal", "in-service"]},
-          # N300
-          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"]},
-          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], ccl: true},
-          # T3000
-          {
-              name: "T3000 uBenchmark tests",
-              arch: wormhole_b0,
-              runs-on: ["arch-wormhole_b0", "config-t3000", "pipeline-perf", "in-service"],
-              is-t3k: true
-          },
-        ]
-    env:
-      # Use BM for microbenchmarks
-      ARCH_NAME: ${{ matrix.runner-info.arch }}
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ matrix.runner-info.runs-on }}
-    steps:
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          ./build_metal.sh --enable-profiler --build-programming-examples --build-tests
-          ./create_venv.sh
-      - name: Run microbenchmark tests
-        timeout-minutes: 90
-        run: |
-          PIPELINE_TYPE="microbenchmarks"
-          if [ "${{ matrix.runner-info.ccl }}" == "true" ]; then
-            PIPELINE_TYPE="ccl_microbenchmarks"
-          elif [ "${{ matrix.runner-info.is-t3k }}" == "true" ]; then
-            PIPELINE_TYPE="T3K_microbenchmark"
-          else
-            TT_METAL_SLOW_DISPATCH_MODE=1 ./tests/scripts/run_tunneler_tests.sh --machine-type ${{ matrix.runner-info.runs-on[0] }}
-          fi
-          ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type "$PIPELINE_TYPE"
-      - name: Upload microbenchmark report csvs
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 10
-        with:
-          name: microbenchmark-report-csv-${{ matrix.runner-info.arch }}
-          path: generated/profiler/.logs
+    needs: build-artifact
+    uses: ./.github/workflows/metal-run-microbenchmarks.yaml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/tests/scripts/run_moreh_microbenchmark.sh
+++ b/tests/scripts/run_moreh_microbenchmark.sh
@@ -20,8 +20,6 @@ run_profiling_test() {
 
   echo "Make sure this test runs in a build with cmake option ENABLE_TRACY=ON"
 
-  source python_env/bin/activate
-  export PYTHONPATH=$TT_METAL_HOME
   export TT_METAL_CLEAR_L1=1
 
   pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_pcie_h2d_dram --timeout=720

--- a/tests/scripts/run_moreh_microbenchmark.sh
+++ b/tests/scripts/run_moreh_microbenchmark.sh
@@ -8,11 +8,6 @@ run_profiling_test() {
     exit 1
   fi
 
-  if [[ -z "$TT_METAL_HOME" ]]; then
-    echo "Must provide TT_METAL_HOME in environment" 1>&2
-    exit 1
-  fi
-
   if [[ "$TT_METAL_DEVICE_PROFILER" != 1 ]]; then
     echo "Must set TT_METAL_DEVICE_PROFILER to 1 to run microbenchmarks" 1>&2
     exit 1

--- a/tests/scripts/run_moreh_microbenchmark.sh
+++ b/tests/scripts/run_moreh_microbenchmark.sh
@@ -30,15 +30,9 @@ run_profiling_test() {
   pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_matmul_dram -k $ARCH_NAME # how to set r and c for this
   pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_matmul_l1 -k $ARCH_NAME # how to set r and c for this
 
-  if [[ "$ARCH_NAME" != "grayskull" ]]; then
-    pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_matmul_single_core_sharded -k $ARCH_NAME
-    pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_dram_read_all_core -k $ARCH_NAME
-    pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_dram_read_remote_cb_sync -k $ARCH_NAME
-  fi
-  # bypass wh_b0 for now until we can move FD cores to last col
-  if [[ "$ARCH_NAME" != "wormhole_b0" ]]; then
-    pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_dram_read_l1_write_core -k $ARCH_NAME
-  fi
+  pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_matmul_single_core_sharded -k $ARCH_NAME
+  pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_dram_read_all_core -k $ARCH_NAME
+  pytest --capture=tee-sys $TT_METAL_HOME/tests/scripts/test_moreh_microbenchmark.py::test_dram_read_remote_cb_sync -k $ARCH_NAME
 }
 
 run_profiling_test

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -152,65 +152,6 @@ run_post_commit_multi_device_unstable_pipeline_tests() {
     ./tests/scripts/multi_chip/run_unstable_multi_device.sh
 }
 
-run_microbenchmarks_pipeline_tests() {
-    local tt_arch=$1
-    local pipeline_type=$2
-    local dispatch_mode=$3
-
-    export TT_METAL_DEVICE_PROFILER=1
-
-    ./tests/scripts/run_moreh_microbenchmark.sh
-    pytest -svv tests/tt_metal/microbenchmarks
-}
-
-run_ccl_microbenchmarks_pipeline_tests() {
-    export TT_METAL_DEVICE_PROFILER=1
-
-    # Record the start time
-    fail=0
-    start_time=$(date +%s)
-
-    echo "LOG_METAL: Running run_n300_ccl_all_gather_perf_tests"
-
-    tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh -t n300
-    fail+=$?
-
-    # Record the end time
-    end_time=$(date +%s)
-    duration=$((end_time - start_time))
-    echo "LOG_METAL: run_n300_ccl_all_gather_perf_tests $duration seconds to complete"
-    if [[ $fail -ne 0 ]]; then
-      exit 1
-    fi
-
-    # Record the start time
-    fail=0
-    start_time=$(date +%s)
-
-    echo "LOG_METAL: Running run_n300_ccl_reduce_scatter_perf_tests"
-
-    tests/ttnn/unit_tests/operations/ccl/perf/run_reduce_scatter_profile.sh -t n300
-    fail+=$?
-
-    # Record the end time
-    end_time=$(date +%s)
-    duration=$((end_time - start_time))
-    echo "LOG_METAL: run_n300_ccl_reduce_scatter_perf_tests $duration seconds to complete"
-    if [[ $fail -ne 0 ]]; then
-      exit 1
-    fi
-}
-
-run_T3K_microbenchmarks_pipeline_tests() {
-    local tt_arch=$1
-    local pipeline_type=$2
-    local dispatch_mode=$3
-
-    export TT_METAL_DEVICE_PROFILER=1
-
-    pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
-}
-
 run_ttnn_sweeps_pipeline_tests() {
     local tt_arch=$1
     local pipeline_type=$2
@@ -355,12 +296,6 @@ run_pipeline_tests() {
         run_models_performance_virtual_machine_pipeline_tests "$tt_arch" "$pipeline_type"
     elif [[ $pipeline_type == "stress_post_commit" ]]; then
         run_stress_post_commit_pipeline_tests "$tt_arch" "$pipeline_type" "$dispatch_mode"
-    elif [[ $pipeline_type == "microbenchmarks" ]]; then
-        run_microbenchmarks_pipeline_tests "$tt_arch" "$pipeline_type" "$dispatch_mode"
-    elif [[ $pipeline_type == "ccl_microbenchmarks" ]]; then
-        run_ccl_microbenchmarks_pipeline_tests "$tt_arch" "$pipeline_type" "$dispatch_mode"
-    elif [[ $pipeline_type == "T3K_microbenchmark" ]]; then
-        run_T3K_microbenchmarks_pipeline_tests "$tt_arch" "$pipeline_type" "$dispatch_mode"
     elif [[ $pipeline_type == "ttnn_sweeps" ]]; then
         run_ttnn_sweeps_pipeline_tests "$tt_arch" "$pipeline_type" "$dispatch_mode"
     # T3000 pipelines

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -159,7 +159,6 @@ run_microbenchmarks_pipeline_tests() {
 
     export TT_METAL_DEVICE_PROFILER=1
 
-    source python_env/bin/activate
     ./tests/scripts/run_moreh_microbenchmark.sh
     pytest -svv tests/tt_metal/microbenchmarks
 }
@@ -167,7 +166,6 @@ run_microbenchmarks_pipeline_tests() {
 run_ccl_microbenchmarks_pipeline_tests() {
     export TT_METAL_DEVICE_PROFILER=1
 
-    source python_env/bin/activate
     # Record the start time
     fail=0
     start_time=$(date +%s)
@@ -210,7 +208,6 @@ run_T3K_microbenchmarks_pipeline_tests() {
 
     export TT_METAL_DEVICE_PROFILER=1
 
-    source python_env/bin/activate
     pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
 }
 

--- a/tests/scripts/run_tunneler_tests.sh
+++ b/tests/scripts/run_tunneler_tests.sh
@@ -2,11 +2,6 @@
 
 set -eo pipefail
 
-if [[ -z "$TT_METAL_HOME" ]]; then
-    echo "Must provide TT_METAL_HOME in environment" 1>&2
-    exit 1
-fi
-
 if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]]; then
     echo "Must provide TT_METAL_SLOW_DISPATCH_MODE in environment" 1>&2
     exit 1

--- a/tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh
+++ b/tests/ttnn/unit_tests/operations/ccl/perf/run_all_gather_profile.sh
@@ -5,6 +5,8 @@ MODULE_DIR="tests/ttnn/unit_tests/operations/ccl/perf"
 DEBUG=false
 TARGET="n300"
 
+set -e
+
 # Function to display help
 show_help() {
     echo "Usage: ./tests/ttnn/unit_tests/operations/ccl/perf/run_profile.sh [OPTIONS]"

--- a/tests/ttnn/unit_tests/operations/ccl/perf/run_reduce_scatter_profile.sh
+++ b/tests/ttnn/unit_tests/operations/ccl/perf/run_reduce_scatter_profile.sh
@@ -5,6 +5,8 @@ MODULE_DIR="tests/ttnn/unit_tests/operations/ccl/perf"
 DEBUG=false
 TARGET="n300"
 
+set -e
+
 # Function to display help
 show_help() {
     echo "Usage: ./tests/ttnn/unit_tests/operations/ccl/perf/run_profile.sh [OPTIONS]"


### PR DESCRIPTION
### Ticket

#12490 

### Problem description

We need to upgrade to 22.04!

### What's changed

Dockerize using `container: ` and upgrade to 22.04

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [ ] ubench: https://github.com/tenstorrent/tt-metal/actions/runs/13901593558/job/38895022298