### PR TITLE
Re-enable RandomizedMeshWorkload test

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -363,8 +363,11 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-// TODO: #19149 - Re-enable the test.
-TEST_F(MeshWorkloadTestSuite, DISABLED_RandomizedMeshWorkload) {
+TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
+    // TODO: #19149 - Re-enable the test.
+    if (mesh_device_->num_devices() == 1) {
+        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
     uint32_t num_programs = 60;
     uint32_t num_iterations = 1500;
     auto random_seed = 10;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The test only fails on 1x1 mesh, should be enabled for other mesh devices.

### What's changed
Skip a test for 1x1 instead of using DISABLED_ prefix that disables it for all types of devices.

### Checklist
- [X] New/Existing tests provide coverage for changes
- [X] Ran the test locally