### PR TITLE
#19077: Add resnet50 batch=16 to blackhole post-commit

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -72,5 +72,5 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 
 run_python_model_tests_blackhole() {
     SLOW_MATMULS=1 pytest models/demos/blackhole/stable_diffusion/tests
-    pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_blackhole_ci.py::test_resnet_batch_16
+    pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
 }

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -72,4 +72,5 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 
 run_python_model_tests_blackhole() {
     SLOW_MATMULS=1 pytest models/demos/blackhole/stable_diffusion/tests
+    pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_blackhole_ci.py::test_resnet_batch_16
 }

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -9,24 +9,7 @@ from models.demos.ttnn_resnet.tests.resnet50_test_infra import create_test_infra
 from models.utility_functions import is_blackhole
 
 
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "batch_size, act_dtype, weight_dtype, math_fidelity",
-    (
-        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
-        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
-        (32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
-    ),
-)
-@pytest.mark.parametrize(
-    "use_pretrained_weight",
-    [True, False],
-    ids=[
-        "pretrained_weight_true",
-        "pretrained_weight_false",
-    ],
-)
-def test_resnet_50(
+def run_resnet_50(
     device,
     use_program_cache,
     batch_size,
@@ -65,18 +48,40 @@ def test_resnet_50(
     assert passed, message
 
 
-def resnet_batch_16_lofi_pretrained_false(
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype, math_fidelity",
+    (
+        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
+        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
+        (32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
+    ),
+)
+@pytest.mark.parametrize(
+    "use_pretrained_weight",
+    [True, False],
+    ids=[
+        "pretrained_weight_true",
+        "pretrained_weight_false",
+    ],
+)
+def test_resnet_50(
     device,
     use_program_cache,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    math_fidelity,
+    use_pretrained_weight,
     model_location_generator,
 ):
-    test_resnet_50(
+    run_resnet_50(
         device,
         use_program_cache,
-        16,
-        ttnn.bfloat8_b,
-        ttnn.bfloat8_b,
-        ttnn.MathFidelity.LoFi,
-        False,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        use_pretrained_weight,
         model_location_generator,
     )

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -63,3 +63,20 @@ def test_resnet_50(
     test_infra.run()
     passed, message = test_infra.validate()
     assert passed, message
+
+
+def resnet_batch_16_lofi_pretrained_false(
+    device,
+    use_program_cache,
+    model_location_generator,
+):
+    test_resnet_50(
+        device,
+        use_program_cache,
+        16,
+        ttnn.bfloat8_b,
+        ttnn.bfloat8_b,
+        ttnn.MathFidelity.LoFi,
+        False,
+        model_location_generator,
+    )

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
 import ttnn
-from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import test_resnet_50
+from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import resnet_batch_16_lofi_pretrained_false
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
@@ -13,13 +13,8 @@ def test_resnet_batch_16(
     use_program_cache,
     model_location_generator,
 ):
-    test_resnet_50(
+    resnet_batch_16_lofi_pretrained_false(
         device,
         use_program_cache,
-        16,
-        ttnn.bfloat8_b,
-        ttnn.bfloat8_b,
-        ttnn.MathFidelity.LoFi,
-        False,
         model_location_generator,
     )

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
@@ -4,7 +4,7 @@
 
 import pytest
 import ttnn
-from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import resnet_batch_16_lofi_pretrained_false
+from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import run_resnet_50
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
@@ -13,8 +13,13 @@ def test_resnet_batch_16(
     use_program_cache,
     model_location_generator,
 ):
-    resnet_batch_16_lofi_pretrained_false(
+    run_resnet_50(
         device,
         use_program_cache,
+        16,
+        ttnn.bfloat8_b,
+        ttnn.bfloat8_b,
+        ttnn.MathFidelity.LoFi,
+        False,
         model_location_generator,
     )

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_blackhole_ci.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_blackhole_ci.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import test_resnet_50
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+def test_resnet_batch_16(
+    device,
+    use_program_cache,
+    model_location_generator,
+):
+    test_resnet_50(
+        device,
+        use_program_cache,
+        16,
+        ttnn.bfloat8_b,
+        ttnn.bfloat8_b,
+        ttnn.MathFidelity.LoFi,
+        False,
+        model_location_generator,
+    )


### PR DESCRIPTION
### Ticket
#19077

Added Resnet50 with a batch size of 16 to the blackhole post-commit to track its regression.

Added new file (`tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py`) for running test to be aligned with #7586 

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13920852155) - the added test is passing, but there are some failures in pipeline that seem to be caused by the bad state of the blackhole post-commit