### PR TITLE
#19127: Allow merging CRTA writes with CB/SEM writes.

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -437,21 +437,24 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     // TODO: this test would be better if it varied args across core ranges and kernel type
 
     CoreRangeSet cr_set = program_config.cr_set;
+    constexpr uint32_t kCommonRTASeparation = 1024 * sizeof(uint32_t);
 
     uint32_t rta_base_dm0 = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    ;
-    uint32_t rta_base_dm1 = rta_base_dm0 + 1024 * sizeof(uint32_t);
-    uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
+    uint32_t rta_base_dm1 = rta_base_dm0 + 2048 * sizeof(uint32_t);
+    uint32_t rta_base_compute = rta_base_dm1 + 4096 * sizeof(uint32_t);
     // Copy max # runtime args in the kernel for simplicity
     std::map<string, string> dm_defines0 = {
+        {"COMMON_RUNTIME_ARGS", "1"},
         {"DATA_MOVEMENT", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(256)},
         {"RESULTS_ADDR", std::to_string(rta_base_dm0)}};
     std::map<string, string> dm_defines1 = {
+        {"COMMON_RUNTIME_ARGS", "1"},
         {"DATA_MOVEMENT", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(256)},
         {"RESULTS_ADDR", std::to_string(rta_base_dm1)}};
     std::map<string, string> compute_defines = {
+        {"COMMON_RUNTIME_ARGS", "1"},
         {"COMPUTE", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(256)},
         {"RESULTS_ADDR", std::to_string(rta_base_compute)}};
@@ -489,6 +492,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     uint32_t idx = 0;
     constexpr uint32_t num_common_runtime_args = 13;
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
+        SCOPED_TRACE(iter);
         dummy_cr0_args.clear();
         dummy_cr1_args.clear();
         dummy_common_args.clear();
@@ -531,11 +535,23 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
             SetRuntimeArgs(program, dummy_compute_kernel, core_coord, dummy_cr1_args);
         }
 
-        // These aren't validated yet...
         if (iter == 0) {
             SetCommonRuntimeArgs(program, dummy_kernel0, dummy_common_args);
             SetCommonRuntimeArgs(program, dummy_kernel1, dummy_common_args);
             SetCommonRuntimeArgs(program, dummy_compute_kernel, dummy_common_args);
+        } else {
+            memcpy(
+                GetCommonRuntimeArgs(program, dummy_kernel0).rt_args_data,
+                dummy_common_args.data(),
+                dummy_common_args.size() * sizeof(uint32_t));
+            memcpy(
+                GetCommonRuntimeArgs(program, dummy_kernel1).rt_args_data,
+                dummy_common_args.data(),
+                dummy_common_args.size() * sizeof(uint32_t));
+            memcpy(
+                GetCommonRuntimeArgs(program, dummy_compute_kernel).rt_args_data,
+                dummy_common_args.data(),
+                dummy_common_args.size() * sizeof(uint32_t));
         }
 
         EnqueueProgram(cq, program, false);
@@ -548,33 +564,65 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
                 first = false;
                 continue;
             }
+            {
+                vector<uint32_t> dummy_kernel0_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm0,
+                    dummy_cr0_args.size() * sizeof(uint32_t),
+                    dummy_kernel0_args_readback);
+                pass &= (dummy_cr0_args == dummy_kernel0_args_readback);
 
-            vector<uint32_t> dummy_kernel0_args_readback;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                rta_base_dm0,
-                dummy_cr0_args.size() * sizeof(uint32_t),
-                dummy_kernel0_args_readback);
-            pass &= (dummy_cr0_args == dummy_kernel0_args_readback);
+                vector<uint32_t> dummy_kernel1_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm1,
+                    dummy_cr0_args.size() * sizeof(uint32_t),
+                    dummy_kernel1_args_readback);
+                pass &= (dummy_cr0_args == dummy_kernel1_args_readback);
 
-            vector<uint32_t> dummy_kernel1_args_readback;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                rta_base_dm1,
-                dummy_cr0_args.size() * sizeof(uint32_t),
-                dummy_kernel1_args_readback);
-            pass &= (dummy_cr0_args == dummy_kernel1_args_readback);
+                vector<uint32_t> dummy_compute_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_compute,
+                    dummy_cr0_args.size() * sizeof(uint32_t),
+                    dummy_compute_args_readback);
+                pass &= (dummy_cr0_args == dummy_compute_args_readback);
+            }
+            {
+                vector<uint32_t> dummy_kernel0_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm0 + kCommonRTASeparation,
+                    dummy_common_args.size() * sizeof(uint32_t),
+                    dummy_kernel0_args_readback);
+                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
+                pass &= (dummy_common_args == dummy_kernel0_args_readback);
 
-            vector<uint32_t> dummy_compute_args_readback;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                rta_base_compute,
-                dummy_cr0_args.size() * sizeof(uint32_t),
-                dummy_compute_args_readback);
-            pass &= (dummy_cr0_args == dummy_compute_args_readback);
+                vector<uint32_t> dummy_kernel1_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm1 + kCommonRTASeparation,
+                    dummy_common_args.size() * sizeof(uint32_t),
+                    dummy_kernel1_args_readback);
+                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
+                pass &= (dummy_common_args == dummy_kernel1_args_readback);
+
+                vector<uint32_t> dummy_compute_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_compute + kCommonRTASeparation,
+                    dummy_common_args.size() * sizeof(uint32_t),
+                    dummy_compute_args_readback);
+                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
+                pass &= (dummy_common_args == dummy_compute_args_readback);
+            }
         }
 
         first = true;
@@ -584,33 +632,65 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
                 first = false;
                 continue;
             }
+            {
+                vector<uint32_t> dummy_kernel0_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm0,
+                    dummy_cr1_args.size() * sizeof(uint32_t),
+                    dummy_kernel0_args_readback);
+                pass &= (dummy_cr1_args == dummy_kernel0_args_readback);
 
-            vector<uint32_t> dummy_kernel0_args_readback;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                rta_base_dm0,
-                dummy_cr1_args.size() * sizeof(uint32_t),
-                dummy_kernel0_args_readback);
-            pass &= (dummy_cr1_args == dummy_kernel0_args_readback);
+                vector<uint32_t> dummy_kernel1_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm1,
+                    dummy_cr1_args.size() * sizeof(uint32_t),
+                    dummy_kernel1_args_readback);
+                pass &= (dummy_cr1_args == dummy_kernel1_args_readback);
 
-            vector<uint32_t> dummy_kernel1_args_readback;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                rta_base_dm1,
-                dummy_cr1_args.size() * sizeof(uint32_t),
-                dummy_kernel1_args_readback);
-            pass &= (dummy_cr1_args == dummy_kernel1_args_readback);
+                vector<uint32_t> dummy_compute_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_compute,
+                    dummy_cr1_args.size() * sizeof(uint32_t),
+                    dummy_compute_args_readback);
+                pass &= (dummy_cr1_args == dummy_compute_args_readback);
+            }
+            {
+                vector<uint32_t> dummy_kernel0_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm0 + kCommonRTASeparation,
+                    dummy_common_args.size() * sizeof(uint32_t),
+                    dummy_kernel0_args_readback);
+                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
+                pass &= (dummy_common_args == dummy_kernel0_args_readback);
 
-            vector<uint32_t> dummy_compute_args_readback;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core_coord,
-                rta_base_compute,
-                dummy_cr1_args.size() * sizeof(uint32_t),
-                dummy_compute_args_readback);
-            pass &= (dummy_cr1_args == dummy_compute_args_readback);
+                vector<uint32_t> dummy_kernel1_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_dm1 + kCommonRTASeparation,
+                    dummy_common_args.size() * sizeof(uint32_t),
+                    dummy_kernel1_args_readback);
+                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
+                pass &= (dummy_common_args == dummy_kernel1_args_readback);
+
+                vector<uint32_t> dummy_compute_args_readback;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    core_coord,
+                    rta_base_compute + kCommonRTASeparation,
+                    dummy_common_args.size() * sizeof(uint32_t),
+                    dummy_compute_args_readback);
+                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
+                pass &= (dummy_common_args == dummy_compute_args_readback);
+            }
         }
     }
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -24,10 +24,10 @@ void kernel_main() {
         int i;
         for (i = 0; i < NUM_RUNTIME_ARGS; i++) {
 #ifdef COMMON_RUNTIME_ARGS
-            results[i] = get_common_arg_val<uint32_t>(i);
-#else
-            results[i] = get_arg_val<uint32_t>(i);
+            constexpr uint32_t kCommonRTASeparation = 1024;
+            results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
 #endif
+            results[i] = get_arg_val<uint32_t>(i);
         }
 
 #ifdef COORDS_ADDR

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -74,9 +74,6 @@ void insert_empty_program_dispatch_preamble_cmd(ProgramCommandSequence& program_
 
 void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDeviceId sub_device_id, IDevice* device);
 
-void assemble_runtime_args_commands(
-    ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device);
-
 void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr);
 
 void reserve_space_in_kernel_config_buffer(

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1328,7 +1328,6 @@ void Program::generate_dispatch_commands(IDevice* device) {
         ProgramCommandSequence program_command_sequence;
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id, device);
-        program_dispatch::assemble_runtime_args_commands(program_command_sequence, *this, device);
         program_dispatch::assemble_device_commands(program_command_sequence, *this, device, sub_device_id);
         cached_program_command_sequences.insert({command_hash, std::move(program_command_sequence)});
         pimpl_->set_cached();

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -18,7 +18,13 @@ class CircularBuffer;
 
 constexpr uint32_t UncachedStallSequenceIdx = 0;
 constexpr uint32_t CachedStallSequenceIdx = 1;
+
 struct ProgramCommandSequence {
+    struct RtaUpdate {
+        const void* src;
+        void* dst;
+        uint32_t size;
+    };
     HostMemDeviceCommand preamble_command_sequence;
     uint32_t current_stall_seq_idx = 0;
     HostMemDeviceCommand stall_command_sequences[2];
@@ -27,6 +33,9 @@ struct ProgramCommandSequence {
     HostMemDeviceCommand device_command_sequence;
     std::vector<uint32_t*> cb_configs_payloads;
     std::vector<std::vector<std::shared_ptr<CircularBuffer>>> circular_buffers_on_core_ranges;
+    // Note: some RTAs may be have their RuntimeArgsData modified so the source-of-truth of their data is the command
+    // sequence. They won't be listed in rta_updates.
+    std::vector<RtaUpdate> rta_updates;
     std::vector<launch_msg_t*> go_signals;
     uint32_t program_config_buffer_data_size_bytes;
     std::vector<CQDispatchWritePackedCmd*> launch_msg_write_packed_cmd_ptrs;


### PR DESCRIPTION
### Ticket
#19127

### Problem description
If we have multiple kernels using CRTAs on the same core, the current code requires a multicast per kernel, which is inefficient.

### What's changed
Instead, in those cases we can try to merge those writes to a single core together, as well as with CBs and semaphores. This works better in most cases, but does require duplicating the CRTA data per kernel-group, which also means we sometimes need to copy the CRTA data into the command sequence every time we issue the commands.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes