### PR TITLE
Move get_core_type_name into impl

### DIFF
--- a/tt_metal/api/tt-metalium/rtoptions.hpp
+++ b/tt_metal/api/tt-metalium/rtoptions.hpp
@@ -16,25 +16,11 @@
 #include <vector>
 
 #include "core_coord.hpp"
-#include "dispatch_core_common.hpp"        // For DispatchCoreConfig
-#include "umd/device/tt_soc_descriptor.h"  // For CoreType
+#include "dispatch_core_common.hpp"  // For DispatchCoreConfig
 
 namespace tt {
 
 namespace llrt {
-
-static inline const char* get_core_type_name(CoreType ct) {
-    switch (ct) {
-        case CoreType::ARC: return "ARC";
-        case CoreType::DRAM: return "DRAM";
-        case CoreType::ETH: return "ethernet";
-        case CoreType::PCIE: return "PCIE";
-        case CoreType::WORKER: return "worker";
-        case CoreType::HARVESTED: return "harvested";
-        case CoreType::ROUTER_ONLY: return "router_only";
-        default: return "UNKNOWN";
-    }
-}
 
 // TODO: This should come from the HAL
 enum DebugHartFlags : unsigned int {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -12,6 +12,8 @@
 #include "impl/dispatch/dispatch_core_manager.hpp"
 #include <device.hpp>
 
+namespace tt::tt_metal {
+
 // Helper function for comparing CoreDescriptors for using in sets.
 struct CoreDescriptorComparator {
     bool operator()(const CoreDescriptor& x, const CoreDescriptor& y) const {
@@ -22,7 +24,7 @@ struct CoreDescriptorComparator {
         }
     }
 };
-#define CoreDescriptorSet std::set<CoreDescriptor, CoreDescriptorComparator>
+using CoreDescriptorSet = std::set<CoreDescriptor, CoreDescriptorComparator>;
 
 // Helper function to get CoreDescriptors for all debug-relevant cores on device.
 static CoreDescriptorSet GetAllCores(tt::tt_metal::IDevice* device) {
@@ -75,3 +77,20 @@ inline int GetNumRiscs(tt::tt_metal::IDevice* device, const CoreDescriptor& core
         return DPRINT_NRISCVS;
     }
 }
+
+inline const std::string_view get_core_type_name(CoreType ct) {
+    switch (ct) {
+        case CoreType::ARC: return "ARC";
+        case CoreType::DRAM: return "DRAM";
+        case CoreType::ETH: return "ethernet";
+        case CoreType::PCIE: return "PCIE";
+        case CoreType::WORKER: return "worker";
+        case CoreType::HARVESTED: return "harvested";
+        case CoreType::ROUTER_ONLY: return "router_only";
+        case CoreType::ACTIVE_ETH: return "active_eth";
+        case CoreType::IDLE_ETH: return "idle_eth";
+        case CoreType::TENSIX: return "tensix";
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -124,7 +124,7 @@ struct HartKeyComparator {
             return x_device_id < y_device_id;
         }
 
-        CoreDescriptorComparator core_desc_cmp;
+        tt::tt_metal::CoreDescriptorComparator core_desc_cmp;
         if (core_desc_cmp(x_core_desc, y_core_desc)) {
             return true;
         }
@@ -595,8 +595,8 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
 
     // A set of all valid printable cores, used for checking the user input. Note that the coords
     // here are virtual.
-    CoreDescriptorSet all_cores = GetAllCores(device);
-    CoreDescriptorSet dispatch_cores = GetDispatchCores(device);
+    tt::tt_metal::CoreDescriptorSet all_cores = GetAllCores(device);
+    tt::tt_metal::CoreDescriptorSet dispatch_cores = GetDispatchCores(device);
 
     // Initialize all print buffers on all cores on the device to have print disabled magic. We
     // will then write print enabled magic for only the cores the user has specified to monitor.
@@ -635,7 +635,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                 tt::LogMetal,
                 "DPRINT enabled on device {}, all {} cores.",
                 device->id(),
-                tt::llrt::get_core_type_name(core_type));
+                tt::tt_metal::get_core_type_name(core_type));
         } else if (
             tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
                 tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassDispatch) {
@@ -648,7 +648,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                 tt::LogMetal,
                 "DPRINT enabled on device {}, {} dispatch cores.",
                 device->id(),
-                tt::llrt::get_core_type_name(core_type));
+                tt::tt_metal::get_core_type_name(core_type));
         } else if (
             tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
                 tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassWorker) {
@@ -664,7 +664,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                 tt::LogMetal,
                 "DPRINT enabled on device {}, {} worker cores.",
                 device->id(),
-                tt::llrt::get_core_type_name(core_type));
+                tt::tt_metal::get_core_type_name(core_type));
         } else {
             // No "all cores" option provided, which means print from the cores specified by the user
             std::vector<CoreCoord>& print_cores = tt::llrt::RunTimeOptions::get_instance().get_feature_cores(
@@ -687,7 +687,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                         tt::LogMetal,
                         "DPRINT enabled on device {}, {} core {} (virtual {}).",
                         device->id(),
-                        tt::llrt::get_core_type_name(core_type),
+                        tt::tt_metal::get_core_type_name(core_type),
                         logical_core.str(),
                         virtual_core.str());
                 } else {
@@ -695,7 +695,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                         tt::LogMetal,
                         "TT_METAL_DPRINT_CORES included {} core with logical coordinates {} (virtual coordinates {}), "
                         "which is not a valid core on device {}. This coordinate will be ignored by the dprint server.",
-                        tt::llrt::get_core_type_name(core_type),
+                        tt::tt_metal::get_core_type_name(core_type),
                         logical_core.str(),
                         valid_logical_core ? virtual_core.str() : "INVALID",
                         device->id());
@@ -813,7 +813,7 @@ void DebugPrintServerContext::DetachDevice(IDevice* device) {
     log_info(tt::LogMetal, "DPRINT Server dettached device {}", device->id());
 
     // When detaching a device, disable prints on it.
-    CoreDescriptorSet all_cores = GetAllCores(device);
+    tt::tt_metal::CoreDescriptorSet all_cores = GetAllCores(device);
     for (auto& logical_core : all_cores) {
         CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
         for (int risc_index = 0; risc_index < GetNumRiscs(device, logical_core); risc_index++) {
@@ -885,7 +885,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                 string core_str = fmt::format(
                     "Device {}, {} core {}, riscv {}",
                     chip_id,
-                    tt::llrt::get_core_type_name(logical_core.type),
+                    tt::tt_metal::get_core_type_name(logical_core.type),
                     logical_core.coord,
                     risc_id);
                 string error_str = fmt::format(
@@ -1269,7 +1269,7 @@ ostream* DebugPrintServerContext::GetOutputStream(const HartKey& risc_key) {
             filename += fmt::format(
                 "device-{}_{}-core-{}-{}_{}.txt",
                 chip_id,
-                tt::llrt::get_core_type_name(logical_core.type),
+                tt::tt_metal::get_core_type_name(logical_core.type),
                 logical_core.coord.x,
                 logical_core.coord.y,
                 GetRiscName(logical_core.type, risc_id));

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -9,10 +9,8 @@
 #include <chrono>
 #include <ctime>
 #include <filesystem>
-#include <memory>
 #include <mutex>
 #include <thread>
-#include <unordered_map>
 
 #include <hal.hpp>
 #include <dev_msgs.h>
@@ -20,6 +18,7 @@
 #include <rtoptions.hpp>
 #include "debug/ring_buffer.h"
 #include "watcher_device_reader.hpp"
+#include "debug_helpers.hpp"
 
 using namespace tt::tt_metal;
 
@@ -304,7 +303,7 @@ void watcher_init(IDevice* device) {
                             "TT_METAL_{}_CORES included {} core with logical coordinates {} (virtual coordinates {}), "
                             "which is not a valid core on device {}. This coordinate will be ignored by {} feature.",
                             tt::llrt::RunTimeDebugFeatureNames[delay_feature],
-                            tt::llrt::get_core_type_name(core_type),
+                            tt::tt_metal::get_core_type_name(core_type),
                             logical_core.str(),
                             valid_logical_core ? virtual_core.str() : "INVALID",
                             device->id(),

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "build.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::tt_metal {
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
get_core_type_name and the umd include can be moved into impl

### What's changed
Move to impl

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes