### PR TITLE
Const correctness on RunTimeOptions

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/allocator.hpp>
+#include "rtoptions.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -667,8 +667,9 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                 tt::tt_metal::get_core_type_name(core_type));
         } else {
             // No "all cores" option provided, which means print from the cores specified by the user
-            std::vector<CoreCoord>& print_cores = tt::llrt::RunTimeOptions::get_instance().get_feature_cores(
-                tt::llrt::RunTimeDebugFeatureDprint)[core_type];
+            const std::vector<CoreCoord>& print_cores = tt::llrt::RunTimeOptions::get_instance()
+                                                            .get_feature_cores(tt::llrt::RunTimeDebugFeatureDprint)
+                                                            .at(core_type);
 
             // We should also validate that the cores the user specified are valid worker cores.
             for (auto& logical_core : print_cores) {

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -138,7 +138,7 @@ static void watcher_loop(int sleep_usecs) {
 
     // Print to the user which features are disabled via env vars.
     string disabled_features = "";
-    auto& disabled_features_set = tt::llrt::RunTimeOptions::get_instance().get_watcher_disabled_features();
+    const auto& disabled_features_set = tt::llrt::RunTimeOptions::get_instance().get_watcher_disabled_features();
     if (!disabled_features_set.empty()) {
         for (auto& feature : disabled_features_set) {
             disabled_features += feature + ",";
@@ -277,8 +277,8 @@ void watcher_init(IDevice* device) {
             }
 
             for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
-                std::vector<CoreCoord> delayed_cores =
-                    tt::llrt::RunTimeOptions::get_instance().get_feature_cores(delay_feature)[core_type];
+                const std::vector<CoreCoord>& delayed_cores =
+                    tt::llrt::RunTimeOptions::get_instance().get_feature_cores(delay_feature).at(core_type);
                 for (tt_xy_pair logical_core : delayed_cores) {
                     CoreCoord virtual_core;
                     bool valid_logical_core = true;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -147,65 +147,62 @@ public:
     RunTimeOptions(const RunTimeOptions&) = delete;
     RunTimeOptions& operator=(const RunTimeOptions&) = delete;
 
-    inline bool is_root_dir_specified() const { return this->is_root_dir_env_var_set; }
+    bool is_root_dir_specified() const { return this->is_root_dir_env_var_set; }
     const std::string& get_root_dir();
 
-    inline bool is_cache_dir_specified() const { return this->is_cache_dir_env_var_set; }
+    bool is_cache_dir_specified() const { return this->is_cache_dir_env_var_set; }
     const std::string& get_cache_dir();
 
-    inline bool is_kernel_dir_specified() const { return this->is_kernel_dir_env_var_set; }
+    bool is_kernel_dir_specified() const { return this->is_kernel_dir_env_var_set; }
     const std::string& get_kernel_dir() const;
 
-    inline bool get_build_map_enabled() { return build_map_enabled; }
+    bool get_build_map_enabled() const { return build_map_enabled; }
 
     // Info from watcher environment variables, setters included so that user
     // can override with a SW call.
-    inline bool get_watcher_enabled() { return watcher_enabled; }
-    inline void set_watcher_enabled(bool enabled) { watcher_enabled = enabled; }
-    inline int get_watcher_interval() { return watcher_interval_ms; }
-    inline void set_watcher_interval(int interval_ms) { watcher_interval_ms = interval_ms; }
-    inline int get_watcher_dump_all() { return watcher_dump_all; }
-    inline void set_watcher_dump_all(bool dump_all) { watcher_dump_all = dump_all; }
-    inline int get_watcher_append() { return watcher_append; }
-    inline void set_watcher_append(bool append) { watcher_append = append; }
-    inline int get_watcher_auto_unpause() { return watcher_auto_unpause; }
-    inline void set_watcher_auto_unpause(bool auto_unpause) { watcher_auto_unpause = auto_unpause; }
-    inline int get_watcher_noinline() { return watcher_noinline; }
-    inline void set_watcher_noinline(bool noinline) { watcher_noinline = noinline; }
-    inline int get_watcher_phys_coords() { return watcher_phys_coords; }
-    inline void set_watcher_phys_coords(bool phys_coords) { watcher_phys_coords = phys_coords; }
-    inline std::set<std::string>& get_watcher_disabled_features() { return watcher_disabled_features; }
-    inline bool watcher_status_disabled() { return watcher_feature_disabled(watcher_waypoint_str); }
-    inline bool watcher_noc_sanitize_disabled() { return watcher_feature_disabled(watcher_noc_sanitize_str); }
-    inline bool watcher_assert_disabled() { return watcher_feature_disabled(watcher_assert_str); }
-    inline bool watcher_pause_disabled() { return watcher_feature_disabled(watcher_pause_str); }
-    inline bool watcher_ring_buffer_disabled() { return watcher_feature_disabled(watcher_ring_buffer_str); }
-    inline bool watcher_stack_usage_disabled() { return watcher_feature_disabled(watcher_stack_usage_str); }
-    inline bool watcher_dispatch_disabled() { return watcher_feature_disabled(watcher_dispatch_str); }
+    bool get_watcher_enabled() const { return watcher_enabled; }
+    void set_watcher_enabled(bool enabled) { watcher_enabled = enabled; }
+    int get_watcher_interval() const { return watcher_interval_ms; }
+    void set_watcher_interval(int interval_ms) { watcher_interval_ms = interval_ms; }
+    int get_watcher_dump_all() const { return watcher_dump_all; }
+    void set_watcher_dump_all(bool dump_all) { watcher_dump_all = dump_all; }
+    int get_watcher_append() const { return watcher_append; }
+    void set_watcher_append(bool append) { watcher_append = append; }
+    int get_watcher_auto_unpause() const { return watcher_auto_unpause; }
+    void set_watcher_auto_unpause(bool auto_unpause) { watcher_auto_unpause = auto_unpause; }
+    int get_watcher_noinline() const { return watcher_noinline; }
+    void set_watcher_noinline(bool noinline) { this->watcher_noinline = noinline; }
+    int get_watcher_phys_coords() const { return watcher_phys_coords; }
+    void set_watcher_phys_coords(bool phys_coords) { watcher_phys_coords = phys_coords; }
+    const std::set<std::string>& get_watcher_disabled_features() const { return watcher_disabled_features; }
+    bool watcher_status_disabled() const { return watcher_feature_disabled(watcher_waypoint_str); }
+    bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
+    bool watcher_assert_disabled() const { return watcher_feature_disabled(watcher_assert_str); }
+    bool watcher_pause_disabled() const { return watcher_feature_disabled(watcher_pause_str); }
+    bool watcher_ring_buffer_disabled() const { return watcher_feature_disabled(watcher_ring_buffer_str); }
+    bool watcher_stack_usage_disabled() const { return watcher_feature_disabled(watcher_stack_usage_str); }
+    bool watcher_dispatch_disabled() const { return watcher_feature_disabled(watcher_dispatch_str); }
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
-    inline bool get_feature_enabled(RunTimeDebugFeatures feature) { return feature_targets[feature].enabled; }
-    inline void set_feature_enabled(RunTimeDebugFeatures feature, bool enabled) {
-        feature_targets[feature].enabled = enabled;
-    }
+    bool get_feature_enabled(RunTimeDebugFeatures feature) const { return feature_targets[feature].enabled; }
+    void set_feature_enabled(RunTimeDebugFeatures feature, bool enabled) { feature_targets[feature].enabled = enabled; }
     // Note: dprint cores are logical
-    inline std::map<CoreType, std::vector<CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) {
+    const std::map<CoreType, std::vector<CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].cores;
     }
-    inline void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<CoreCoord>> cores) {
+    void set_feature_cores(RunTimeDebugFeatures feature, const std::map<CoreType, std::vector<CoreCoord>>& cores) {
         feature_targets[feature].cores = cores;
     }
     // An alternative to setting cores by range, a flag to enable all.
-    inline void set_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type, int all_cores) {
+    void set_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type, int all_cores) {
         feature_targets[feature].all_cores[core_type] = all_cores;
     }
-    inline int get_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type) {
-        return feature_targets[feature].all_cores[core_type];
+    int get_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type) const {
+        return feature_targets[feature].all_cores.at(core_type);
     }
     // Note: core range is inclusive
-    inline void set_feature_core_range(
-        RunTimeDebugFeatures feature, CoreCoord start, CoreCoord end, CoreType core_type) {
+    void set_feature_core_range(RunTimeDebugFeatures feature, CoreCoord start, CoreCoord end, CoreType core_type) {
         feature_targets[feature].cores[core_type] = std::vector<CoreCoord>();
         for (uint32_t x = start.x; x <= end.x; x++) {
             for (uint32_t y = start.y; y <= end.y; y++) {
@@ -213,52 +210,50 @@ public:
             }
         }
     }
-    inline std::vector<int>& get_feature_chip_ids(RunTimeDebugFeatures feature) {
+    const std::vector<int>& get_feature_chip_ids(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].chip_ids;
     }
-    inline void set_feature_chip_ids(RunTimeDebugFeatures feature, std::vector<int> chip_ids) {
+    void set_feature_chip_ids(RunTimeDebugFeatures feature, const std::vector<int>& chip_ids) {
         feature_targets[feature].chip_ids = chip_ids;
     }
     // An alternative to setting cores by range, a flag to enable all.
-    inline void set_feature_all_chips(RunTimeDebugFeatures feature, bool all_chips) {
+    void set_feature_all_chips(RunTimeDebugFeatures feature, bool all_chips) {
         feature_targets[feature].all_chips = all_chips;
     }
-    inline bool get_feature_all_chips(RunTimeDebugFeatures feature) { return feature_targets[feature].all_chips; }
-    inline uint32_t get_feature_riscv_mask(RunTimeDebugFeatures feature) { return feature_targets[feature].riscv_mask; }
-    inline void set_feature_riscv_mask(RunTimeDebugFeatures feature, uint32_t riscv_mask) {
+    bool get_feature_all_chips(RunTimeDebugFeatures feature) const { return feature_targets[feature].all_chips; }
+    uint32_t get_feature_riscv_mask(RunTimeDebugFeatures feature) const { return feature_targets[feature].riscv_mask; }
+    void set_feature_riscv_mask(RunTimeDebugFeatures feature, uint32_t riscv_mask) {
         feature_targets[feature].riscv_mask = riscv_mask;
     }
-    inline std::string get_feature_file_name(RunTimeDebugFeatures feature) {
-        return feature_targets[feature].file_name;
-    }
-    inline void set_feature_file_name(RunTimeDebugFeatures feature, std::string file_name) {
+    std::string get_feature_file_name(RunTimeDebugFeatures feature) const { return feature_targets[feature].file_name; }
+    void set_feature_file_name(RunTimeDebugFeatures feature, const std::string& file_name) {
         feature_targets[feature].file_name = file_name;
     }
-    inline bool get_feature_one_file_per_risc(RunTimeDebugFeatures feature) {
+    bool get_feature_one_file_per_risc(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].one_file_per_risc;
     }
-    inline void set_feature_one_file_per_risc(RunTimeDebugFeatures feature, bool one_file_per_risc) {
+    void set_feature_one_file_per_risc(RunTimeDebugFeatures feature, bool one_file_per_risc) {
         feature_targets[feature].one_file_per_risc = one_file_per_risc;
     }
-    inline bool get_feature_prepend_device_core_risc(RunTimeDebugFeatures feature) {
+    bool get_feature_prepend_device_core_risc(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].prepend_device_core_risc;
     }
-    inline void set_feature_prepend_device_core_risc(RunTimeDebugFeatures feature, bool prepend_device_core_risc) {
+    void set_feature_prepend_device_core_risc(RunTimeDebugFeatures feature, bool prepend_device_core_risc) {
         feature_targets[feature].prepend_device_core_risc = prepend_device_core_risc;
     }
-    inline TargetSelection get_feature_targets(RunTimeDebugFeatures feature) { return feature_targets[feature]; }
-    inline void set_feature_targets(RunTimeDebugFeatures feature, TargetSelection targets) {
+    TargetSelection get_feature_targets(RunTimeDebugFeatures feature) const { return feature_targets[feature]; }
+    void set_feature_targets(RunTimeDebugFeatures feature, const TargetSelection& targets) {
         feature_targets[feature] = targets;
     }
 
-    inline bool get_record_noc_transfers() { return record_noc_transfer_data; }
-    inline void set_record_noc_transfers(bool val) { record_noc_transfer_data = val; }
+    bool get_record_noc_transfers() const { return record_noc_transfer_data; }
+    void set_record_noc_transfers(bool val) { record_noc_transfer_data = val; }
 
-    inline bool get_validate_kernel_binaries() { return validate_kernel_binaries; }
-    inline void set_validate_kernel_binaries(bool val) { validate_kernel_binaries = val; }
+    bool get_validate_kernel_binaries() const { return validate_kernel_binaries; }
+    void set_validate_kernel_binaries(bool val) { validate_kernel_binaries = val; }
 
     // Returns the string representation for hash computation.
-    inline std::string get_feature_hash_string(RunTimeDebugFeatures feature) {
+    std::string get_feature_hash_string(RunTimeDebugFeatures feature) const {
         switch (feature) {
             case RunTimeDebugFeatureDprint: return std::to_string(get_feature_enabled(feature));
             case RunTimeDebugFeatureReadDebugDelay:
@@ -279,53 +274,53 @@ public:
     // (test mode = false). We need to catch for gtesting, since an unhandled exception will kill
     // the gtest (and can't catch an exception from the server thread in main thread), but by
     // default we should throw so that the user can see the exception as soon as it happens.
-    bool get_test_mode_enabled() { return test_mode_enabled; }
-    inline void set_test_mode_enabled(bool enable) { test_mode_enabled = enable; }
+    bool get_test_mode_enabled() const { return test_mode_enabled; }
+    void set_test_mode_enabled(bool enable) { test_mode_enabled = enable; }
 
-    inline bool get_profiler_enabled() { return profiler_enabled; }
-    inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
-    inline bool get_profiler_sync_enabled() { return profiler_sync_enabled; }
-    inline bool get_profiler_buffer_usage_enabled() { return profiler_buffer_usage_enabled; }
-    inline bool get_profiler_noc_events_enabled() { return profiler_noc_events_enabled; }
-    inline std::string get_profiler_noc_events_report_path() { return profiler_noc_events_report_path; }
+    bool get_profiler_enabled() const { return profiler_enabled; }
+    bool get_profiler_do_dispatch_cores() const { return profile_dispatch_cores; }
+    bool get_profiler_sync_enabled() const { return profiler_sync_enabled; }
+    bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
+    bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
+    std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
 
-    inline void set_kernels_nullified(bool v) { null_kernels = v; }
-    inline bool get_kernels_nullified() { return null_kernels; }
+    void set_kernels_nullified(bool v) { null_kernels = v; }
+    bool get_kernels_nullified() const { return null_kernels; }
 
-    inline void set_kernels_early_return(bool v) { kernels_early_return = v; }
-    inline bool get_kernels_early_return() { return kernels_early_return; }
+    void set_kernels_early_return(bool v) { kernels_early_return = v; }
+    bool get_kernels_early_return() { return kernels_early_return; }
 
-    inline bool get_clear_l1() { return clear_l1; }
-    inline void set_clear_l1(bool clear) { clear_l1 = clear; }
+    bool get_clear_l1() const { return clear_l1; }
+    void set_clear_l1(bool clear) { clear_l1 = clear; }
 
-    inline bool get_skip_loading_fw() { return skip_loading_fw; }
-    inline bool get_skip_reset_cores_on_init() { return skip_reset_cores_on_init; }
+    bool get_skip_loading_fw() const { return skip_loading_fw; }
+    bool get_skip_reset_cores_on_init() const { return skip_reset_cores_on_init; }
 
     // Whether to compile with -g to include DWARF debug info in the binary.
-    inline bool get_riscv_debug_info_enabled() { return riscv_debug_info_enabled; }
-    inline void set_riscv_debug_info_enabled(bool enable) { riscv_debug_info_enabled = enable; }
+    bool get_riscv_debug_info_enabled() const { return riscv_debug_info_enabled; }
+    void set_riscv_debug_info_enabled(bool enable) { riscv_debug_info_enabled = enable; }
 
-    inline unsigned get_num_hw_cqs() { return num_hw_cqs; }
-    inline void set_num_hw_cqs(unsigned num) { num_hw_cqs = num; }
+    unsigned get_num_hw_cqs() const { return num_hw_cqs; }
+    void set_num_hw_cqs(unsigned num) { num_hw_cqs = num; }
 
-    inline bool get_fd_fabric() const { return fb_fabric_en; }
+    bool get_fd_fabric() const { return fb_fabric_en; }
 
-    inline uint32_t get_watcher_debug_delay() { return watcher_debug_delay; }
-    inline void set_watcher_debug_delay(uint32_t delay) { watcher_debug_delay = delay; }
+    uint32_t get_watcher_debug_delay() const { return watcher_debug_delay; }
+    void set_watcher_debug_delay(uint32_t delay) { watcher_debug_delay = delay; }
 
-    inline bool get_dispatch_data_collection_enabled() { return enable_dispatch_data_collection; }
-    inline void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
+    bool get_dispatch_data_collection_enabled() const { return enable_dispatch_data_collection; }
+    void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
 
-    inline bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
+    bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
 
     tt_metal::DispatchCoreConfig get_dispatch_core_config() const;
 
-    inline bool get_skip_deleting_built_cache() { return skip_deleting_built_cache; }
+    bool get_skip_deleting_built_cache() const { return skip_deleting_built_cache; }
 
-    inline bool get_simulator_enabled() { return simulator_enabled; }
-    inline const std::filesystem::path& get_simulator_path() { return simulator_path; }
+    bool get_simulator_enabled() const { return simulator_enabled; }
+    const std::filesystem::path& get_simulator_path() const { return simulator_path; }
 
-    inline bool get_erisc_iram_enabled() { return erisc_iram_enabled; }
+    bool get_erisc_iram_enabled() const { return erisc_iram_enabled; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.
@@ -350,7 +345,7 @@ private:
     const std::string watcher_stack_usage_str = "STACK_USAGE";
     const std::string watcher_dispatch_str = "DISPATCH";
     std::set<std::string> watcher_disabled_features;
-    bool watcher_feature_disabled(const std::string& name) {
+    bool watcher_feature_disabled(const std::string& name) const {
         return watcher_disabled_features.find(name) != watcher_disabled_features.end();
     }
 };


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Getters should be const to prevent accidental mutation
- Let people with a const reference to access these getters

### What's changed
Make them const

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes