### PR TITLE
[skip ci] Add ASan and TSan as build types

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -17,6 +17,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
       with-retries:
         default: false
         type: boolean

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -23,6 +23,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
   schedule:
     - cron: "0 */2 * * *"
   # Pause this since not enough runners to support every commit to main

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -11,6 +11,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
   schedule:
     - cron: "0 2,11 * * *"
 

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -10,6 +10,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
         default: "Release"
       build-with-tracy:
         required: false

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -10,6 +10,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
         default: "Release"
       extra-tag:
         required: true

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -10,6 +10,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
         default: "Release"
       build-with-tracy:
         required: false

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -21,6 +21,8 @@ on:
           - Release
           - Debug
           - RelWithDebInfo
+          - ASan
+          - TSan
       tracy:
         required: false
         type: boolean

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ endif()
 # Project setup
 ############################################
 
+# For single-config generators, default to RelWithDebInfo if unspecified
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT isMultiConfig)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type")
+endif()
+
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(version)
 ParseGitDescribe()
@@ -23,6 +29,11 @@ project(
 )
 message(STATUS "Metalium version: ${PROJECT_VERSION}")
 message(STATUS "Building Unified Library for all architectures, thanks to blozano-tt")
+
+# Defining build types is the pervue of the top-level project
+if(PROJECT_IS_TOP_LEVEL)
+    include(sanitizers)
+endif()
 
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
     message(
@@ -56,17 +67,7 @@ include(CTest)
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
 # Global settings if we're the top-level project
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    set(CMAKE_CONFIGURATION_TYPES
-        Release
-        RelWithDebInfo
-        Debug
-    )
-    if(NOT CMAKE_BUILD_TYPE AND NOT isMultiConfig)
-        message(STATUS "Setting build type to 'Release' as none was specified.")
-        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release build is the default" FORCE)
-    endif()
-
+if(PROJECT_IS_TOP_LEVEL)
     set_property(
         GLOBAL
         PROPERTY
@@ -75,16 +76,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     )
 
     if(ENABLE_CCACHE)
-        include(cmake/ccache.cmake)
+        include(ccache)
     endif()
 endif()
 
 include(compilers)
 CHECK_COMPILERS()
-
-if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE IN_LIST CMAKE_CONFIGURATION_TYPES)
-    message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}. Valid options are: ${CMAKE_CONFIGURATION_TYPES}")
-endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -8,7 +8,7 @@ show_help() {
     echo "  -h, --help                       Show this help message."
     echo "  -e, --export-compile-commands    Enable CMAKE_EXPORT_COMPILE_COMMANDS."
     echo "  -c, --enable-ccache              Enable ccache for the build."
-    echo "  -b, --build-type build_type      Set the build type. Default is Release. Other options are Debug, RelWithDebInfo, and CI."
+    echo "  -b, --build-type build_type      Set the build type. Default is Release. Other options are Debug, RelWithDebInfo, ASan and TSan."
     echo "  -t, --enable-time-trace          Enable build time trace (clang only)."
     echo "  -a, --enable-asan                Enable AddressSanitizer."
     echo "  -m, --enable-msan                Enable MemorySanitizer."
@@ -44,7 +44,7 @@ show_help() {
 
 clean() {
     echo "INFO: Removing build artifacts!"
-    rm -rf build_Release* build_Debug* build_RelWithDebInfo* build built
+    rm -rf build_Release* build_Debug* build_RelWithDebInfo* build_ASan* build_TSan* build built
     rm -rf ~/.cache/tt-metal-cache /tmp/tt-metal-cache
     if [[ ! -z $TT_METAL_CACHE ]]; then
         echo "User has TT_METAL_CACHE set, please make sure you delete it in order to delete all artifacts!"
@@ -222,9 +222,9 @@ if [[ $# -gt 0 ]]; then
 fi
 
 # Validate the build_type
-VALID_BUILD_TYPES=("Release" "Debug" "RelWithDebInfo")
+VALID_BUILD_TYPES=("Release" "Debug" "RelWithDebInfo" "ASan" "TSan")
 if [[ ! " ${VALID_BUILD_TYPES[@]} " =~ " ${build_type} " ]]; then
-    echo "ERROR: Invalid build type '$build_type'. Allowed values are Release, Debug, RelWithDebInfo."
+    echo "ERROR: Invalid build type '$build_type'. Allowed values are Release, Debug, RelWithDebInfo, ASan, TSan."
     show_help
     exit 1
 fi

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,42 @@
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(isMultiConfig)
+    if(NOT "ASan" IN_LIST CMAKE_CONFIGURATION_TYPES)
+        list(APPEND CMAKE_CONFIGURATION_TYPES ASan)
+    endif()
+    if(NOT "TSan" IN_LIST CMAKE_CONFIGURATION_TYPES)
+        list(APPEND CMAKE_CONFIGURATION_TYPES TSan)
+    endif()
+endif()
+
+set_property(
+    GLOBAL
+    APPEND
+    PROPERTY
+        DEBUG_CONFIGURATIONS
+            ASan
+            TSan
+)
+
+# ASan, LSan and UBSan do not conflict with each other and are each fast enough that we can combine them.
+# Saves us from an explosion of pipelines to test our code.
+set(asan_flags "-fsanitize=address -fsanitize=leak -fsanitize=undefined")
+set(asan_compile_flags "${asan_flags} -fno-omit-frame-pointer")
+set(CMAKE_C_FLAGS_ASAN "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${asan_compile_flags}")
+set(CMAKE_CXX_FLAGS_ASAN "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${asan_compile_flags}")
+set(CMAKE_EXE_LINKER_FLAGS_ASAN "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} ${asan_flags}")
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} ${asan_flags}")
+# set(CMAKE_STATIC_LINKER_FLAGS_ASAN "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} ${asan_flags}")
+set(CMAKE_MODULE_LINKER_FLAGS_ASAN "${CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO} ${asan_flags}")
+
+set(CMAKE_C_FLAGS_TSAN "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=thread -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_TSAN "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fsanitize=thread -fno-omit-frame-pointer")
+set(CMAKE_EXE_LINKER_FLAGS_TSAN "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=thread -fno-omit-frame-pointer")
+set(CMAKE_SHARED_LINKER_FLAGS_TSAN
+    "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=thread -fno-omit-frame-pointer"
+)
+# set(CMAKE_STATIC_LINKER_FLAGS_TSAN
+# "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=thread -fno-omit-frame-pointer"
+# )
+set(CMAKE_MODULE_LINKER_FLAGS_TSAN
+    "${CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=thread -fno-omit-frame-pointer"
+)


### PR DESCRIPTION
### Ticket
#10956

### Problem description
Current implementation of activating sanitizers is bespoke flags.  This doesn't integrate well with tooling or scale well for GH workflows.  They're just a different set of compiler/linker flags; set them the way we control other compiler/linker flags.  Build types.

### What's changed
* Defined an ASan build type (and lumped in LSan and UBSan since they're cheap)
* Defined a TSan build type (this cannot be combined with ASan and is too expensive for us to want to, anyway)
Two builds to rule them all.