### PR TITLE
Simplify interaction with `MeshDeviceConfig` and `SystemMesh`

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -138,8 +138,7 @@ TEST(MeshBufferTest, DeallocationWithoutMeshDevice) {
     // Repeated device init takes very long on TG. Skip.
     skip_for_tg();
     for (int i = 0; i < 100; i++) {
-        auto config =
-            MeshDeviceConfig{.mesh_shape = MeshShape(1, 1), .offset = std::nullopt, .physical_device_ids = {}};
+        MeshDeviceConfig config(MeshShape(1, 1));
         auto mesh_device =
             MeshDevice::create(config, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreType::WORKER);
 
@@ -159,8 +158,7 @@ TEST(MeshBufferTest, DeallocationWithMeshDeviceClosed) {
     // Repeated device init takes very long on TG. Skip.
     skip_for_tg();
     for (int i = 0; i < 100; i++) {
-        auto config =
-            MeshDeviceConfig{.mesh_shape = MeshShape(1, 1), .offset = std::nullopt, .physical_device_ids = {}};
+        MeshDeviceConfig config(MeshShape(1, 1));
         auto mesh_device =
             MeshDevice::create(config, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, DispatchCoreType::WORKER);
 

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -21,7 +21,7 @@ using ::tt::tt_metal::distributed::MeshContainer;
 TEST(MeshDeviceInitTest, Init1x1Mesh) {
     auto& sys = SystemMesh::instance();
 
-    auto config = tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = MeshShape(1, 1)};
+    MeshDeviceConfig config(MeshShape(1, 1));
 
     EXPECT_NO_THROW({
         auto mesh = tt::tt_metal::distributed::MeshDevice::create(

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -58,7 +58,7 @@ class MeshConfigurationTest : public T3KReshapeTestFixture, public ::testing::Wi
 TEST_P(MeshConfigurationTest, MeshConfigurations) {
     const auto& shape = GetParam();
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(shape)},
+        MeshDeviceConfig(shape),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -71,9 +71,7 @@ TEST_P(MeshConfigurationTest, GetPhysicalDeviceIds) {
     const auto& shape = GetParam();
 
     auto& system_mesh = SystemMesh::instance();
-    EXPECT_THAT(
-        system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = MeshShape(shape)}),
-        SizeIs(shape.mesh_size()));
+    EXPECT_THAT(system_mesh.get_mapped_physical_device_ids(shape), SizeIs(shape.mesh_size()));
 }
 
 // Test all possible mesh configurations on T3000
@@ -93,7 +91,7 @@ TEST_P(MeshDeviceReshapeRoundtripTest, ReshapeBetweenConfigurations) {
     }
 
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(old_shape)},
+        MeshDeviceConfig(old_shape),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -127,27 +125,23 @@ TEST_F(MeshDeviceReshapeTest, InvalidRequestedShape) {
     auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
 
     // Shape too big.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = MeshShape(9)}));
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = MeshShape(2, 5)}));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(9)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 5)));
 
     // Invalid offset.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
-        MeshDeviceConfig{.mesh_shape = MeshShape(1, 8), .offset = MeshCoordinate(0, 1)}));
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
-        MeshDeviceConfig{.mesh_shape = MeshShape(2, 3), .offset = MeshCoordinate(1, 1)}));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(1, 8), /*offset=*/MeshCoordinate(0, 1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 3), /*offset=*/MeshCoordinate(1, 1)));
 
     // Offset dimensionality mismatch.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
-        MeshDeviceConfig{.mesh_shape = MeshShape(2, 3), .offset = MeshCoordinate(1)}));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(2, 3), /*offset=*/MeshCoordinate(1)));
 
     // Mismatch system mesh shape.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(
-        MeshDeviceConfig{.mesh_shape = MeshShape(8), .offset = MeshCoordinate(1)}));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_physical_device_ids(MeshShape(8), /*offset=*/MeshCoordinate(1)));
 }
 
 TEST_F(MeshDeviceReshapeTest, InvalidReshapeDimensions) {
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(1, 8)},
+        MeshDeviceConfig(MeshShape(1, 8)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -163,7 +157,7 @@ TEST_F(MeshDeviceReshapeTest, InvalidReshapeDimensions) {
 
 TEST_F(MeshDeviceReshapeTest, From1x8To2x4ThenBackTo1x8) {
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(1, 8)},
+        MeshDeviceConfig(MeshShape(1, 8)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -195,7 +189,7 @@ TEST_F(MeshDeviceReshapeTest, From1x8To2x4ThenBackTo1x8) {
 
 TEST_F(MeshDeviceReshapeTest, InvalidTotalDeviceCount) {
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(1, 8)},
+        MeshDeviceConfig(MeshShape(1, 8)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -211,7 +205,7 @@ TEST_F(MeshDeviceReshapeTest, InvalidTotalDeviceCount) {
 
 TEST_F(MeshDeviceReshapeTest, From1x4To2x2Invalid) {
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(1, 4)},
+        MeshDeviceConfig(MeshShape(1, 4)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -225,14 +219,12 @@ TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
     auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
 
     // Fetch the device ids for a physically connected 2x2 mesh.
-    auto physical_device_ids = system_mesh.get_mapped_physical_device_ids(MeshDeviceConfig{
-        .mesh_shape = MeshShape(2, 2),
-    });
+    auto physical_device_ids = system_mesh.get_mapped_physical_device_ids(MeshShape(2, 2));
 
     // Supply the physical device ids to the mesh constructor that we know we know is 2x2 physically connected.
     // We will create a 1x4 mesh and then reshape it to 2x2.
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(1, 4), .physical_device_ids = physical_device_ids},
+        MeshDeviceConfig(MeshShape(1, 4), /*offset=*/std::nullopt, /*physical_device_ids=*/physical_device_ids),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,
@@ -248,7 +240,7 @@ TEST_F(MeshDeviceReshapeTest, From1x4To2x2Valid) {
 
 TEST_F(MeshDeviceReshapeTest, From2x2To1x4) {
     auto mesh = tt::tt_metal::distributed::MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(2, 2)},
+        MeshDeviceConfig(MeshShape(2, 2)),
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         1,

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -144,7 +144,7 @@ protected:
         auto core_type = (config_.num_cqs >= 2 and *mesh_device_type != MeshDeviceType::TG) ? DispatchCoreType::ETH
                                                                                             : DispatchCoreType::WORKER;
         mesh_device_ = MeshDevice::create(
-            MeshDeviceConfig{.mesh_shape = get_mesh_shape(*mesh_device_type)},
+            MeshDeviceConfig(get_mesh_shape(*mesh_device_type)),
             0,
             config_.trace_region_size,
             config_.num_cqs,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -51,7 +51,7 @@ public:
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 8 and
             tt::tt_metal::GetNumPCIeDevices() == 4) {
-            mesh_device_ = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape{2, 4}});
+            mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape{2, 4}));
 
         } else {
             TT_THROW("This suite can only be run on T3000 Wormhole devices");

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -81,9 +81,9 @@ public:
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ >= 8 and tt::tt_metal::GetNumPCIeDevices() == 4) {
             if (num_devices_ == TG_num_devices || num_devices_ == galaxy_6u_num_devices) {
-                mesh_device_ = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape{8, 4}});
+                mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape{8, 4}));
             } else {
-                mesh_device_ = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape{2, 4}});
+                mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape{2, 4}));
             }
 
             std::vector<chip_id_t> ids(num_devices_, 0);

--- a/tt_metal/api/tt-metalium/mesh_config.hpp
+++ b/tt_metal/api/tt-metalium/mesh_config.hpp
@@ -4,35 +4,35 @@
 
 #pragma once
 
-#include <cstddef>
 #include <vector>
 
 #include "mesh_coord.hpp"
 
 namespace tt::tt_metal::distributed {
 
-using DeviceIds = std::vector<int>;
-using MeshDeviceID = int;
 using chip_id_t = int;
 
-/**
- * @brief Defines the organization of physical devices in a user-defined MeshDevice.
- *
- * The mesh type imposes properties on the physical connectivity of devices:
- *
- * - RowMajor: Devices are arranged in a 2D grid and accessed in row-major order.
- *             This is the default configuration for most multi-device setups.
- *
- * - Ring: Devices are arranged in a circular topology where each device is connected
- *         to its neighbors, forming a ring structure.
- *
- * - Line: Devices are arranged linearly in a single dimension.
- */
+// Specifies the configuration of a MeshDevice.
+class MeshDeviceConfig {
+public:
+    // Constructs a MeshDeviceConfig.
+    // `offset` is the optional parameter that specifies the offset of the mesh device within the connected system mesh.
+    // `physical_device_ids` is the optional parameter that allows to override physical device IDs used to create the
+    // mesh device.
+    MeshDeviceConfig(
+        const MeshShape& mesh_shape,
+        const std::optional<MeshCoordinate>& offset = std::nullopt,
+        const std::vector<chip_id_t>& physical_device_ids = {}) :
+        mesh_shape_(mesh_shape), offset_(offset), physical_device_ids_(physical_device_ids) {}
 
-struct MeshDeviceConfig {
-    MeshShape mesh_shape{0, 0};
-    std::optional<MeshCoordinate> offset;
-    std::vector<chip_id_t> physical_device_ids{};
+    const MeshShape& mesh_shape() const { return mesh_shape_; }
+    const std::optional<MeshCoordinate>& offset() const { return offset_; }
+    const std::vector<chip_id_t>& physical_device_ids() const { return physical_device_ids_; }
+
+private:
+    MeshShape mesh_shape_;
+    std::optional<MeshCoordinate> offset_;
+    std::vector<chip_id_t> physical_device_ids_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -33,6 +33,8 @@ class MeshDeviceView;
 class MeshSubDeviceManagerId;
 class MeshTraceBuffer;
 
+using DeviceIds = std::vector<int>;
+
 class MeshDevice : public IDevice, public std::enable_shared_from_this<MeshDevice> {
 private:
     // Resource management class / RAII wrapper for *physical devices* of the mesh
@@ -66,7 +68,7 @@ private:
     };
 
     std::shared_ptr<ScopedDevices> scoped_devices_;
-    MeshDeviceID mesh_id_;
+    int mesh_id_;
     std::unique_ptr<MeshDeviceView> view_;
     // Submesh keeps the parent mesh alive. Parent_mesh_ is null if the current mesh is the parent mesh.
     std::shared_ptr<MeshDevice> parent_mesh_;
@@ -105,7 +107,7 @@ public:
 
     // IDevice interface implementation
     tt::ARCH arch() const override;
-    MeshDeviceID id() const override;
+    int id() const override;
     chip_id_t build_id() const override;
     uint8_t num_hw_cqs() const override;
     bool is_initialized() const override;

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -7,14 +7,14 @@
 #include <memory>
 #include <vector>
 
-#include "mesh_config.hpp"
 #include "mesh_coord.hpp"
 #include <tt_stl/indestructible.hpp>
+
 namespace tt::tt_metal::distributed {
 
 // SystemMesh creates a virtualization over the physical devices in the system.
-// It creates a logical 2D-mesh of devices and manages the mapping between logical and physical device coordinates.
-// It serves as a query interface between the logical 2D coordinates to physical device IDs.
+// It creates a logical mesh of devices and manages the mapping between logical and physical device coordinates.
+// It serves as a query interface between the logical coordinates to physical device IDs.
 class SystemMesh {
 private:
     class Impl;  // Forward declaration only
@@ -33,12 +33,12 @@ public:
     // Returns the shape of the system mesh
     const MeshShape& get_shape() const;
 
-    // Returns the physical device ID for a given logical row and column index
-    chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
+    // Returns the physical device ID for a given logical coordinate
+    int get_physical_device_id(const MeshCoordinate& coord) const;
 
     // Returns the physical device IDs mapped to a MeshDevice
-    std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;
-    std::vector<chip_id_t> request_available_devices(const MeshDeviceConfig& config) const;
+    std::vector<int> get_mapped_physical_device_ids(
+        const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -30,10 +30,10 @@
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 
 namespace tt::tt_metal::distributed {
-
 namespace {
-MeshDeviceID generate_unique_mesh_id() {
-    static std::atomic<MeshDeviceID> next_id{0};
+
+int generate_unique_mesh_id() {
+    static std::atomic<int> next_id{0};
     return next_id++;
 }
 
@@ -75,7 +75,9 @@ MeshDevice::ScopedDevices::ScopedDevices(
     const DispatchCoreConfig& dispatch_core_config,
     const MeshDeviceConfig& config) :
     ScopedDevices(
-        SystemMesh::instance().request_available_devices(config),
+        config.physical_device_ids().empty()
+            ? SystemMesh::instance().get_mapped_physical_device_ids(config.mesh_shape(), config.offset())
+            : config.physical_device_ids(),
         l1_small_size,
         trace_region_size,
         num_command_queues,
@@ -145,7 +147,7 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     auto scoped_devices = std::make_shared<ScopedDevices>(
         l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, config);
-    MeshContainer<IDevice*> devices(config.mesh_shape, scoped_devices->root_devices());
+    MeshContainer<IDevice*> devices(config.mesh_shape(), scoped_devices->root_devices());
     auto mesh_device = std::make_shared<MeshDevice>(
         std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::shared_ptr<MeshDevice>());
 
@@ -349,8 +351,7 @@ std::vector<IDevice*> MeshDevice::get_row_major_devices(const MeshShape& new_sha
         return view_->get_line_devices();
     }
 
-    auto new_physical_device_ids =
-        SystemMesh::instance().request_available_devices(MeshDeviceConfig{.mesh_shape = new_shape});
+    auto new_physical_device_ids = SystemMesh::instance().get_mapped_physical_device_ids(new_shape);
 
     for (size_t i = 0; i < new_physical_device_ids.size(); i++) {
         if (physical_device_id_to_linearized_index.find(new_physical_device_ids[i]) ==
@@ -397,7 +398,7 @@ const MeshDeviceView& MeshDevice::get_view() const {
     return *view_;
 }
 
-MeshDeviceID MeshDevice::id() const { return mesh_id_; }
+int MeshDevice::id() const { return mesh_id_; }
 // For a mesh, build id is the same as the device id for the reference device
 chip_id_t MeshDevice::build_id() const { return reference_device()->id(); }
 

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -23,8 +23,8 @@ public:
     Impl();
 
     const MeshShape& get_shape() const;
-    std::vector<chip_id_t> get_mapped_physical_device_ids(const MeshDeviceConfig& config) const;
-    std::vector<chip_id_t> request_available_devices(const MeshDeviceConfig& config) const;
+    std::vector<chip_id_t> get_mapped_physical_device_ids(
+        const MeshShape& shape, const std::optional<MeshCoordinate>& offset = std::nullopt) const;
     chip_id_t get_physical_device_id(const MeshCoordinate& coord) const;
 };
 
@@ -61,32 +61,33 @@ chip_id_t SystemMesh::Impl::get_physical_device_id(const MeshCoordinate& coord) 
     return physical_coordinates_.at(coord).chip_id();
 }
 
-std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const MeshDeviceConfig& config) const {
+std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(
+    const MeshShape& shape, const std::optional<MeshCoordinate>& offset) const {
     std::vector<chip_id_t> physical_device_ids;
 
     const MeshShape& system_shape = this->get_shape();
     TT_FATAL(
-        config.mesh_shape.mesh_size() <= system_shape.mesh_size(),
+        shape.mesh_size() <= system_shape.mesh_size(),
         "Requested mesh is too big: {}, SystemMesh {}",
-        config.mesh_shape.mesh_size(),
+        shape.mesh_size(),
         system_shape.mesh_size());
 
     const size_t system_dimensions = system_shape.dims();
 
-    const MeshCoordinate system_offset = [&config, system_dimensions]() {
-        if (config.offset.has_value()) {
+    const MeshCoordinate system_offset = [&offset, system_dimensions]() {
+        if (offset.has_value()) {
             TT_FATAL(
-                config.offset->dims() == system_dimensions,
+                offset->dims() == system_dimensions,
                 "Provided offset dimensions mismatch: {} != {}",
-                config.offset,
+                offset,
                 system_dimensions);
-            return *config.offset;
+            return *offset;
         } else {
-            return MeshCoordinate(tt::stl::SmallVector<uint32_t>(system_dimensions, 0));
+            return MeshCoordinate::zero_coordinate(system_dimensions);
         }
     }();
 
-    if (is_line_topology(config.mesh_shape)) {
+    if (is_line_topology(shape)) {
         TT_FATAL(
             std::all_of(system_offset.coords().begin(), system_offset.coords().end(), [](int dim) { return dim == 0; }),
             "Offsets are unsupported for a line mesh");
@@ -95,7 +96,7 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
         TT_FATAL(system_shape.dims() == 2, "Line topology is only supported for 2D meshes");
         Shape2D shape_2d(system_shape[0], system_shape[1]);
 
-        auto line_length = config.mesh_shape.mesh_size();
+        auto line_length = shape.mesh_size();
         for (const auto& logical_coordinate : MeshDeviceView::get_line_coordinates(line_length, shape_2d)) {
             auto physical_device_id = get_physical_device_id(logical_coordinate);
             physical_device_ids.push_back(physical_device_id);
@@ -107,10 +108,7 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
     }
 
     TT_FATAL(
-        config.mesh_shape.dims() == system_dimensions,
-        "Requested mesh shape dimensions mismatch: {} != {}",
-        config.mesh_shape,
-        system_shape);
+        shape.dims() == system_dimensions, "Requested mesh shape dimensions mismatch: {} != {}", shape, system_shape);
 
     // Attempt to fit the requested mesh into the system mesh, potentially rotating it.
     auto requested_mesh_fits =
@@ -123,7 +121,7 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
             return true;
         };
 
-    tt::stl::SmallVector<uint32_t> rotated_shape(config.mesh_shape.cbegin(), config.mesh_shape.cend());
+    tt::stl::SmallVector<uint32_t> rotated_shape(shape.cbegin(), shape.cend());
     size_t rotations = 0;
     while (!requested_mesh_fits(rotated_shape) && rotations < system_dimensions) {
         std::rotate(rotated_shape.begin(), rotated_shape.begin() + 1, rotated_shape.end());
@@ -133,7 +131,7 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
     if (rotations == system_dimensions) {
         TT_THROW(
             "Requested mesh is too big and is not rotatable: {} and SystemMesh {}, offset {}",
-            config.mesh_shape,
+            shape,
             system_shape,
             system_offset);
     }
@@ -153,16 +151,6 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(const Me
     return physical_device_ids;
 }
 
-std::vector<chip_id_t> SystemMesh::Impl::request_available_devices(const MeshDeviceConfig& config) const {
-    log_debug(LogMetal, "Mapping MeshDevice ({})", config.mesh_shape);
-    if (config.offset.has_value()) {
-        log_debug(LogMetal, "Offset: {}", config.offset.value());
-    }
-
-    return config.physical_device_ids.empty() ? this->get_mapped_physical_device_ids(config)
-                                              : config.physical_device_ids;
-}
-
 SystemMesh::SystemMesh() : pimpl_(std::make_unique<Impl>()) {}
 
 SystemMesh& SystemMesh::instance() {
@@ -176,12 +164,9 @@ chip_id_t SystemMesh::get_physical_device_id(const MeshCoordinate& coord) const 
 
 const MeshShape& SystemMesh::get_shape() const { return pimpl_->get_shape(); }
 
-std::vector<chip_id_t> SystemMesh::request_available_devices(const MeshDeviceConfig& config) const {
-    return pimpl_->request_available_devices(config);
-}
-
-std::vector<chip_id_t> SystemMesh::get_mapped_physical_device_ids(const MeshDeviceConfig& config) const {
-    return pimpl_->get_mapped_physical_device_ids(config);
+std::vector<chip_id_t> SystemMesh::get_mapped_physical_device_ids(
+    const MeshShape& shape, const std::optional<MeshCoordinate>& offset) const {
+    return pimpl_->get_mapped_physical_device_ids(shape, offset);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
     using namespace tt::tt_metal;
     using namespace tt::tt_metal::distributed;
 
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
     auto& cq = mesh_device->mesh_command_queue();
 
     // In a typical single-device fashion, instantiate a program with

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
     using namespace tt::tt_metal::distributed;
     using tt::tt_metal::distributed::ShardedBufferConfig;
 
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
     auto& cq = mesh_device->mesh_command_queue();
 
     // Define the shape of the shard and the distributed buffer.

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -85,7 +85,7 @@ Program CreateEltwiseAddProgram(
 // The example showcases TT-Metalium's ability to abstract away the complexity
 // of distributed memory management and compute.
 int main(int argc, char** argv) {
-    auto mesh_device = MeshDevice::create(MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)});
+    auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
 
     // Define the global buffer shape and shard shape for distributed buffers
     auto shard_shape = Shape2D{32, 32};

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     constexpr uint32_t SUBTRACT_OP_ID = 2;
     // Create a 2x4 MeshDevice with 2 MeshCQs, 16MB allocated to the trace region and Ethernet Dispatch enabled
     auto mesh_device = MeshDevice::create(
-        MeshDeviceConfig{.mesh_shape = MeshShape(2, 4)}, // Shape of MeshDevice
+        MeshDeviceConfig(MeshShape(2, 4)),  // Shape of MeshDevice
         0,  // l1 small size
         16 << 20, // trace region size
         2, // num MeshCQs

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -29,9 +29,12 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     const DispatchCoreConfig& dispatch_core_config,
     const std::optional<MeshCoordinate>& offset,
     const std::vector<int>& physical_device_ids) {
-    auto config =
-        MeshDeviceConfig{.mesh_shape = mesh_shape, .offset = offset, .physical_device_ids = physical_device_ids};
-    return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
+    return MeshDevice::create(
+        MeshDeviceConfig(mesh_shape, offset, physical_device_ids),
+        l1_small_size,
+        trace_region_size,
+        num_command_queues,
+        dispatch_core_config);
 }
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_device->close(); }
@@ -148,7 +151,7 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     auto num_devices = instance.get_shape().mesh_size();
     TT_FATAL(num_devices == 8, "T3000 ring topology only works with 8 devices");
 
-    auto physical_device_ids = instance.get_mapped_physical_device_ids(MeshDeviceConfig{.mesh_shape = MeshShape(1, 8)});
+    auto physical_device_ids = instance.get_mapped_physical_device_ids(MeshShape(1, 8));
     return physical_device_ids;
 }
 

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -123,11 +123,7 @@ void py_module(py::module& module) {
                         const std::optional<MeshCoordinate>& offset,
                         const std::vector<chip_id_t>& physical_device_ids) {
                 return MeshDevice::create(
-                    MeshDeviceConfig{
-                        .mesh_shape = mesh_shape,
-                        .offset = offset,
-                        .physical_device_ids = physical_device_ids,
-                    },
+                    MeshDeviceConfig(mesh_shape, offset, physical_device_ids),
                     l1_small_size,
                     trace_region_size,
                     num_command_queues,

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -10,12 +10,12 @@
 
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
+
 namespace ttnn::distributed {
 
 using MeshShape = tt::tt_metal::distributed::MeshShape;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshCoordinateRange = tt::tt_metal::distributed::MeshCoordinateRange;
-using DeviceIds = tt::tt_metal::distributed::DeviceIds;
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using SystemMesh = tt::tt_metal::distributed::SystemMesh;
 using MeshDeviceView = tt::tt_metal::distributed::MeshDeviceView;
@@ -27,7 +27,6 @@ using MeshSubDeviceManagerId = tt::tt_metal::distributed::MeshSubDeviceManagerId
 namespace ttnn {
 
 // These types are exported to the ttnn namespace for convenience.
-using ttnn::distributed::DeviceIds;
 using ttnn::distributed::MeshCoordinate;
 using ttnn::distributed::MeshCoordinateRange;
 using ttnn::distributed::MeshDevice;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`SystemMesh` uses an awkward subset of `MeshDeviceConfig`, which leads to confusing interface.

### What's changed
* Get rid of useless aliases in `mesh_config.hpp`.
* Get rid of `SystemMesh::request_available_devices` and inline the functionality in one place it is used.
* Simplify `SystemMesh::get_mapped_physical_device_ids`.
* Make `MeshDeviceConfig` a class with immutable accessors. Add documentation.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13905799976/)
- [X] New/Existing tests provide coverage for changes