### PR TITLE
Update latest tags on push to main if image exists

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -11,10 +11,6 @@ on:
         required: false
         type: string
         default: "20.04"
-      target:
-        required: false
-        type: string
-        default: "dev"
       architecture:
         required: false
         type: string
@@ -42,15 +38,6 @@ on:
             - "20.04"
             - "22.04"
             - "24.04"
-      target:
-        required: false
-        type: choice
-        default: "dev"
-        options:
-            - "base"
-            - "ci-build"
-            - "ci-test"
-            - "dev"
       architecture:
         required: false
         type: choice
@@ -124,7 +111,7 @@ jobs:
         with:
           context: ${{ github.workspace }}
           file: dockerfile/Dockerfile
-          target: ${{ inputs.target }}
+          target: dev
           push: true
           tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
           build-args: UBUNTU_VERSION=${{ inputs.version }}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -59,7 +59,7 @@ on:
             - "amd64"
 
 env:
-  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.target }}-${{ inputs.architecture }}
+  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-dev-${{ inputs.architecture }}
 
 jobs:
   check-docker-images:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: "20.04"
+      target:
+        required: false
+        type: string
+        default: "dev"
       architecture:
         required: false
         type: string
@@ -38,6 +42,15 @@ on:
             - "20.04"
             - "22.04"
             - "24.04"
+      target:
+        required: false
+        type: choice
+        default: "dev"
+        options:
+            - "base"
+            - "ci-build"
+            - "ci-test"
+            - "dev"
       architecture:
         required: false
         type: choice
@@ -46,7 +59,7 @@ on:
             - "amd64"
 
 env:
-  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.architecture }}
+  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-${{ inputs.target }}-${{ inputs.architecture }}
 
 jobs:
   check-docker-images:
@@ -111,9 +124,32 @@ jobs:
         with:
           context: ${{ github.workspace }}
           file: dockerfile/Dockerfile
-          target: dev
+          target: ${{ inputs.target }}
           push: true
           tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
           build-args: UBUNTU_VERSION=${{ inputs.version }}
           cache-to: type=inline
           pull: true
+
+  tag-latest:
+    name: "🔄 Update latest tag"
+    needs: check-docker-images
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.check-docker-images.outputs.ci-build-exists == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push latest
+        run: |
+          IMAGE_REPO="ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}"
+          LATEST_TAG="${IMAGE_REPO}:latest"
+          BUILD_TAG="${{ needs.check-docker-images.outputs.ci-build-tag }}"
+          echo "Tagging ${BUILD_TAG} as ${LATEST_TAG}"
+          docker pull ${BUILD_TAG}
+          docker tag ${BUILD_TAG} ${LATEST_TAG}
+          docker push ${LATEST_TAG}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -118,6 +118,10 @@ jobs:
           cache-to: type=inline
           pull: true
 
+  # Cannot use needs.build-docker-image to ensure this job runs sequentially after the build job because it would break when the build job is skipped
+  # Instead, this setup causes the tag-latest job to lag one run behind the actual build.
+  # However, this isn't a huge issue because the image should already have been built on a branch before merging, and if it wasn't (like in a push scenario),
+  # the problem would self-correct on the next merge to main, which happens frequently.
   tag-latest:
     name: "🔄 Update latest tag"
     needs: check-docker-images


### PR DESCRIPTION
### Ticket
Closes #17960

### Problem description
Ubuntu 20.04 and 22.04 docker images that we manage, and are consumed by IRD folks have not had their latest tags updated in a while, and we have no automation to update them.

### What's changed
On push to main, docker image hash is computed, if the image exists, update the latest tag.

ALSO! The name of the image is updated to match what we agreed upon earlier:
https://github.com/tenstorrent/tt-metal/issues/12495#issuecomment-2730255067

`tt-metalium-ubuntu-22.04-dev-amd64:latest`

Notice `dev`


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/pull/19211#issue-2925968554) CI passes
- [ ] New/Existing tests provide coverage for changes