### PR TITLE
include completion sync in 1D fabric bw test when computing bw

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -24,17 +24,16 @@ def get_device_freq():
     return freq
 
 
-def profile_results(is_unicast, num_mcasts, num_unicasts, line_size, packet_size):
+def profile_results(zone_name, packets_per_src_chip, line_size, packet_size):
     freq = get_device_freq() / 1000.0
     setup = device_post_proc_config.default_setup()
     setup.deviceInputLog = profiler_log_path
-    main_test_body_string = "MAIN-WRITE-UNICAST-ZONE" if is_unicast else "MAIN-WRITE-MCAST-ZONE"
     setup.timerAnalysis = {
-        main_test_body_string: {
+        zone_name: {
             "across": "device",
             "type": "session_first_last",
-            "start": {"core": "ANY", "risc": "ANY", "zone_name": main_test_body_string},
-            "end": {"core": "ANY", "risc": "ANY", "zone_name": main_test_body_string},
+            "start": {"core": "ANY", "risc": "ANY", "zone_name": zone_name},
+            "end": {"core": "ANY", "risc": "ANY", "zone_name": zone_name},
         },
     }
     devices_data = import_log_run_stats(setup)
@@ -43,12 +42,9 @@ def profile_results(is_unicast, num_mcasts, num_unicasts, line_size, packet_size
     # MAIN-TEST-BODY
     main_loop_cycles = []
     for device in devices:
-        main_loop_cycle = devices_data["devices"][device]["cores"]["DEVICE"]["analysis"][main_test_body_string][
-            "stats"
-        ]["Average"]
+        main_loop_cycle = devices_data["devices"][device]["cores"]["DEVICE"]["analysis"][zone_name]["stats"]["Average"]
         main_loop_cycles.append(main_loop_cycle)
 
-    packets_per_src_chip = num_unicasts if is_unicast else num_mcasts
     traffic_streams_through_boundary = line_size / 2
     total_byte_sent = packets_per_src_chip * traffic_streams_through_boundary * packet_size
     bandwidth = total_byte_sent / max(main_loop_cycles)
@@ -89,7 +85,14 @@ def run_fabric_edm(
         logger.info("Error in running the test")
         assert False
 
-    bandwidth = profile_results(is_unicast, num_mcasts, num_unicasts, line_size, packet_size)
+    zone_name_inner = "MAIN-WRITE-UNICAST-ZONE" if is_unicast else "MAIN-WRITE-MCAST-ZONE"
+    zone_name_main = "MAIN-TEST-BODY"
+    packets_per_src_chip = num_mcasts, num_unicasts
+
+    num_messages = num_mcasts + num_unicasts
+    bandwidth_inner_loop = profile_results(zone_name_inner, num_messages, line_size, packet_size)
+    bandwidth = profile_results(zone_name_main, num_messages, line_size, packet_size)
+    logger.info("bandwidth_inner_loop: {} B/c", bandwidth_inner_loop)
     logger.info("bandwidth: {} B/c", bandwidth)
     assert expected_bw - 0.07 <= bandwidth <= expected_bw + 0.07
 

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -89,6 +89,7 @@ void kernel_main() {
 
     const size_t start_sync_val = total_workers_per_sync;
     const size_t finish_sync_val = 3 * total_workers_per_sync;
+    const size_t second_finish_sync_val = 4 * total_workers_per_sync;
 
     fabric_connection.open();
 
@@ -130,70 +131,86 @@ void kernel_main() {
     unicast_packet_header->to_chip_unicast(static_cast<uint8_t>(unicast_hops));
 
     {
-        DeviceZoneScopedN("MAIN-WRITE-MCAST-ZONE");
-        for (size_t i = 0; i < num_mcasts; i++) {
-            auto noc0_dest_addr = safe_get_noc_addr(
-                static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr, 0);
-            auto dest_addr =
-                safe_get_noc_addr(static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr);
-            noc_async_write(source_l1_buffer_address, dest_addr, packet_payload_size_bytes);
-            if (fabric_connection.has_forward_connection()) {
-                mcast_fwd_packet_header->to_noc_unicast_write(
-                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
-                fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-                print_pkt_header(mcast_fwd_packet_header);
-                fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
-                    source_l1_buffer_address, packet_payload_size_bytes);
-                fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
-                    (uint32_t)mcast_fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
-            }
+        DeviceZoneScopedN("MAIN-TEST-BODY");
+        {
+            DeviceZoneScopedN("MAIN-WRITE-MCAST-ZONE");
+            for (size_t i = 0; i < num_mcasts; i++) {
+                auto noc0_dest_addr = safe_get_noc_addr(
+                    static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr, 0);
+                auto dest_addr = safe_get_noc_addr(
+                    static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr);
+                noc_async_write(source_l1_buffer_address, dest_addr, packet_payload_size_bytes);
+                if (fabric_connection.has_forward_connection()) {
+                    mcast_fwd_packet_header->to_noc_unicast_write(
+                        NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
+                    fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+                    print_pkt_header(mcast_fwd_packet_header);
+                    fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
+                        source_l1_buffer_address, packet_payload_size_bytes);
+                    fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
+                        (uint32_t)mcast_fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
+                }
 
-            if (fabric_connection.has_backward_connection()) {
-                mcast_bwd_packet_header->to_noc_unicast_write(
-                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
-                fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-                print_pkt_header(mcast_bwd_packet_header);
-                fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
-                    source_l1_buffer_address, packet_payload_size_bytes);
-                fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
-                    (uint32_t)mcast_bwd_packet_header, sizeof(PACKET_HEADER_TYPE));
-            }
-            {
-                noc_async_writes_flushed();
+                if (fabric_connection.has_backward_connection()) {
+                    mcast_bwd_packet_header->to_noc_unicast_write(
+                        NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
+                    fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+                    print_pkt_header(mcast_bwd_packet_header);
+                    fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
+                        source_l1_buffer_address, packet_payload_size_bytes);
+                    fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
+                        (uint32_t)mcast_bwd_packet_header, sizeof(PACKET_HEADER_TYPE));
+                }
+                {
+                    noc_async_writes_flushed();
+                }
             }
         }
-    }
 
-    {
-        DeviceZoneScopedN("MAIN-WRITE-UNICAST-ZONE");
-        for (size_t i = 0; i < num_unicasts; i++) {
-            auto noc0_dest_addr =
-                safe_get_noc_addr(static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr, 0);
-            auto& fabric_conn =
-                unicast_is_fwd ? fabric_connection.get_forward_connection() : fabric_connection.get_backward_connection();
-            unicast_packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
-            fabric_conn.wait_for_empty_write_slot();
-            fabric_conn.send_payload_without_header_non_blocking_from_address(
-                source_l1_buffer_address, packet_payload_size_bytes);
-            fabric_conn.send_payload_blocking_from_address((uint32_t)unicast_packet_header, sizeof(PACKET_HEADER_TYPE));
+        {
+            DeviceZoneScopedN("MAIN-WRITE-UNICAST-ZONE");
+            for (size_t i = 0; i < num_unicasts; i++) {
+                auto noc0_dest_addr = safe_get_noc_addr(
+                    static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr, 0);
+                auto& fabric_conn = unicast_is_fwd ? fabric_connection.get_forward_connection()
+                                                   : fabric_connection.get_backward_connection();
+                unicast_packet_header->to_noc_unicast_write(
+                    NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
+                fabric_conn.wait_for_empty_write_slot();
+                fabric_conn.send_payload_without_header_non_blocking_from_address(
+                    source_l1_buffer_address, packet_payload_size_bytes);
+                fabric_conn.send_payload_blocking_from_address(
+                    (uint32_t)unicast_packet_header, sizeof(PACKET_HEADER_TYPE));
+            }
         }
-    }
 
-    if (enable_finish_synchronization) {
-        line_sync(
-            fabric_connection,
-            mcast_fwd_packet_header,
-            mcast_bwd_packet_header,
-            sync_bank_addr,
-            sync_noc_x,
-            sync_noc_y,
-            finish_sync_val);
+        if (enable_finish_synchronization) {
+            // Send a completion message
+            line_sync(
+                fabric_connection,
+                mcast_fwd_packet_header,
+                mcast_bwd_packet_header,
+                sync_bank_addr,
+                sync_noc_x,
+                sync_noc_y,
+                finish_sync_val);
+            // Ack the complation and wait for everyone to do the same. This guarantees
+            // all other workers have received all messages.
+            line_sync(
+                fabric_connection,
+                mcast_fwd_packet_header,
+                mcast_bwd_packet_header,
+                sync_bank_addr,
+                sync_noc_x,
+                sync_noc_y,
+                second_finish_sync_val);
 
-        if (sync_noc_x == my_x[0] && sync_noc_y == my_y[0]) {
-            // reset the global semaphore in case it is used in a op/kernel
-            // invocation
-            *reinterpret_cast<volatile uint32_t*>(sync_bank_addr) = 0;
-            ;
+            if (sync_noc_x == my_x[0] && sync_noc_y == my_y[0]) {
+                // reset the global semaphore in case it is used in a op/kernel
+                // invocation
+                *reinterpret_cast<volatile uint32_t*>(sync_bank_addr) = 0;
+                ;
+            }
         }
     }
 


### PR DESCRIPTION
### Problem description

There was a small possibility of an assumption being invalid for  earlier measurement in the 1D fabric BW profiling. It was/is possible that this  small assumption leaves open a hole for performance regression.

Basic setup is we create a line fabric with 4 devices and on each device we create a worker multi-caster (sends left and right) that does a fabric mcast to every chip in both directions. It sends a large amount of packets (200k) each direction. Before test starts there is an all-to-all sync to make sure all devices start at roughly the same time. Then everyone sends their messages to fabric and we measure the time that takes.

This is not a 100% accurate time (there is a very small amount of error) because we technically ignore the time for the last few packets to arrive from fabric. However, the total memory capacity of fabric relative to the total # packets is << 1% so we deemed the margin of error "acceptable". However, there is no mechanism that prevents the margin of error from growing.

This PR closes that gap.

### What's changed
For BW tests, stop timer only after receiving acks from everyone that they have received all messages. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13906721116
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13906729823
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable): N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [z] New/Existing tests provide coverage for changes