### PR TITLE
Fix profiler sync displayed coords

### DIFF
--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -109,6 +109,9 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     auto device_id = device->id();
     auto core = device->worker_core_from_logical_core(logical_core);
 
+    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+    auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
+
     deviceHostTimePair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
     smallestHostime.emplace(device_id, 0);
 
@@ -257,8 +260,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         log_file << fmt::format(
                         "{:5},{:5},{:5},{:20},{:20},{:20.2f},{:20},{:20},{:20.2f},{:20.15f},{:20.15f},{:20},1.0,0",
                         device_id,
-                        core.x,
-                        core.y,
+                        phys_core.x,
+                        phys_core.y,
                         deviceHostTimePair[device_id][i].first,
                         deviceHostTimePair[device_id][i].second,
                         (double)deviceHostTimePair[device_id][i].second * tracyToSecRatio,
@@ -279,7 +282,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         frequencyFit);
 
     tt_metal_device_profiler_map.at(device_id).device_core_sync_info.emplace(
-        core, std::make_tuple(smallestHostime[device_id], delay, frequencyFit));
+        phys_core, std::make_tuple(smallestHostime[device_id], delay, frequencyFit));
 }
 void setShift(int device_id, int64_t shift, double scale) {
     if (std::isnan(scale)) {


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/19213)

### What's changed
Translate virtual coords to physical for profiler sync to be displayed in it csv and used in its map

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13906862869)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/13906871383)