### PR TITLE
Guard shared data with a mutex

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -151,7 +151,7 @@ private:
     // Number of outstanding reads to be completed by the completion queue reader
     std::atomic<uint32_t> num_outstanding_reads_ = 0;
     // Exit signal for the completion queue reader
-    bool exit_condition_ = false;
+    std::atomic<bool> exit_condition_ = false;
     // Completion Queue Reader thread
     std::thread completion_queue_reader_thread_;
     // Global Mutex (used by both CQs) to safely use the reader_thread_pool_

--- a/tt_metal/api/tt-metalium/system_memory_manager.hpp
+++ b/tt_metal/api/tt-metalium/system_memory_manager.hpp
@@ -73,7 +73,7 @@ public:
     // TODO: RENAME issue_queue_stride ?
     void issue_queue_push_back(uint32_t push_size_B, uint8_t cq_id);
 
-    uint32_t completion_queue_wait_front(uint8_t cq_id, volatile bool& exit_condition) const;
+    uint32_t completion_queue_wait_front(uint8_t cq_id, std::atomic<bool>& exit_condition) const;
 
     void send_completion_queue_read_ptr(uint8_t cq_id) const;
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1031,7 +1031,7 @@ void copy_completion_queue_data_into_user_space(
     uint16_t channel,
     uint32_t cq_id,
     SystemMemoryManager& sysmem_manager,
-    volatile bool& exit_condition) {
+    std::atomic<bool>& exit_condition) {
     const auto& [buffer_layout, page_size, padded_page_size, buffer_page_mapping, dst, dst_offset, num_pages_read, cur_dev_page_id, starting_host_page_id] =
         read_buffer_descriptor;
     const uint32_t padded_num_bytes = (num_pages_read * padded_page_size) + sizeof(CQDispatchCmd);

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -142,7 +142,7 @@ void copy_completion_queue_data_into_user_space(
     uint16_t channel,
     uint32_t cq_id,
     SystemMemoryManager& sysmem_manager,
-    volatile bool& exit_condition);
+    std::atomic<bool>& exit_condition);
 
 std::vector<CoreCoord> get_cores_for_sharded_buffer(
     bool width_split, const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping, Buffer& buffer);

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -154,19 +154,15 @@ HWCommandQueue::~HWCommandQueue() {
 void HWCommandQueue::increment_num_entries_in_completion_q() {
     // Increment num_entries_in_completion_q and inform reader thread
     // that there is work in the completion queue to process
+    std::lock_guard lock(this->reader_thread_cv_mutex_);
     this->num_entries_in_completion_q_++;
-    {
-        std::lock_guard lock(this->reader_thread_cv_mutex_);
-        this->reader_thread_cv_.notify_one();
-    }
+    this->reader_thread_cv_.notify_one();
 }
 
 void HWCommandQueue::set_exit_condition() {
+    std::lock_guard lock(this->reader_thread_cv_mutex_);
     this->exit_condition_ = true;
-    {
-        std::lock_guard lock(this->reader_thread_cv_mutex_);
-        this->reader_thread_cv_.notify_one();
-    }
+    this->reader_thread_cv_.notify_one();
 }
 
 IDevice* HWCommandQueue::device() { return this->device_; }
@@ -454,16 +450,21 @@ void HWCommandQueue::read_completion_queue() {
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
     while (true) {
+        bool has_events_to_read = false;
+        uint32_t num_events_to_read = 0;
         {
             std::unique_lock<std::mutex> lock(this->reader_thread_cv_mutex_);
             this->reader_thread_cv_.wait(lock, [this] {
                 return this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_ or
                        this->exit_condition_;
             });
+            has_events_to_read = this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_;
+            if (has_events_to_read) {
+                num_events_to_read = this->num_entries_in_completion_q_ - this->num_completed_completion_q_reads_;
+            }
         }
-        if (this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_) {
+        if (has_events_to_read) {
             ZoneScopedN("CompletionQueueReader");
-            uint32_t num_events_to_read = this->num_entries_in_completion_q_ - this->num_completed_completion_q_reads_;
             for (uint32_t i = 0; i < num_events_to_read; i++) {
                 ZoneScopedN("CompletionQueuePopulated");
                 auto read_descriptor = *(this->issued_completion_q_reads_.pop());
@@ -496,9 +497,9 @@ void HWCommandQueue::read_completion_queue() {
                     },
                     read_descriptor);
             }
-            this->num_completed_completion_q_reads_ += num_events_to_read;
             {
                 std::unique_lock<std::mutex> lock(this->reads_processed_cv_mutex_);
+                this->num_completed_completion_q_reads_ += num_events_to_read;
                 this->reads_processed_cv_.notify_one();
             }
         } else if (this->exit_condition_) {

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -450,7 +450,6 @@ void HWCommandQueue::read_completion_queue() {
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
     while (true) {
-        bool has_events_to_read = false;
         uint32_t num_events_to_read = 0;
         {
             std::unique_lock<std::mutex> lock(this->reader_thread_cv_mutex_);
@@ -458,12 +457,11 @@ void HWCommandQueue::read_completion_queue() {
                 return this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_ or
                        this->exit_condition_;
             });
-            has_events_to_read = this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_;
-            if (has_events_to_read) {
+            if (this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_) {
                 num_events_to_read = this->num_entries_in_completion_q_ - this->num_completed_completion_q_reads_;
             }
         }
-        if (has_events_to_read) {
+        if (num_events_to_read > 0) {
             ZoneScopedN("CompletionQueueReader");
             for (uint32_t i = 0; i < num_events_to_read; i++) {
                 ZoneScopedN("CompletionQueuePopulated");

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -97,11 +97,11 @@ private:
     //  call
     DispatchArray<uint32_t> expected_num_workers_completed_;
 
-    volatile bool exit_condition_;
-    volatile uint32_t num_entries_in_completion_q_;  // issue queue writer thread increments this when an issued command
-                                                     // is expected back in the completion queue
-    volatile uint32_t num_completed_completion_q_reads_;  // completion queue reader thread increments this after
-                                                          // reading an entry out of the completion queue
+    std::atomic<bool> exit_condition_;
+    std::atomic<uint32_t> num_entries_in_completion_q_;  // issue queue writer thread increments this when an issued
+                                                         // command is expected back in the completion queue
+    std::atomic<uint32_t> num_completed_completion_q_reads_;  // completion queue reader thread increments this after
+                                                              // reading an entry out of the completion queue
 
     MultiProducerSingleConsumerQueue<CompletionReaderVariant> issued_completion_q_reads_;
     // These values are used to reset the host side launch message wptr after a trace is captured

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -342,7 +342,8 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
     }
 }
 
-uint32_t SystemMemoryManager::completion_queue_wait_front(const uint8_t cq_id, volatile bool& exit_condition) const {
+uint32_t SystemMemoryManager::completion_queue_wait_front(
+    const uint8_t cq_id, std::atomic<bool>& exit_condition) const {
     uint32_t write_ptr_and_toggle;
     uint32_t write_ptr;
     uint32_t write_toggle;


### PR DESCRIPTION
### Ticket
#19210

### Problem description
We have a data race.  Some data is being read without the protection of a mutex.

### What's changed
Expand the scope of existing mutexes to protect shared data within the critical section.

### Checklist
- [x] C++ Unit Tests pre-change [shows the data race](https://github.com/tenstorrent/tt-metal/actions/runs/13907645825/job/38915441030#step:5:1854), then with this change does [not show this data race](https://github.com/tenstorrent/tt-metal/actions/runs/13909664310/job/38921282513#step:4:1545) (it does report other data races which are separate issues).
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13910402940)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes