### PR TITLE
[1D fabric] Expose connection api for workers

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -60,6 +60,26 @@ protected:
         }
     }
 
+    bool find_device_with_neighbor_in_direction(
+        std::pair<mesh_id_t, chip_id_t>& src_mesh_chip_id,
+        std::pair<mesh_id_t, chip_id_t>& dst_mesh_chip_id,
+        RoutingDirection direction) {
+        auto* control_plane = tt::Cluster::instance().get_control_plane();
+        for (auto* device : devices_) {
+            src_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+
+            // Get neighbours within a mesh in the given direction
+            auto neighbors =
+                control_plane->get_intra_chip_neighbors(src_mesh_chip_id.first, src_mesh_chip_id.second, direction);
+            if (neighbors.size() > 0) {
+                dst_mesh_chip_id = {src_mesh_chip_id.first, neighbors[0]};
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void RunProgramNonblocking(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program) {
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::LaunchProgram(device, program, false);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -9,38 +9,29 @@
 
 #include "fabric_fixture.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 
 namespace tt::tt_fabric {
+namespace fabric_router_tests {
 
-TEST_F(Fabric1DFixture, TestUnicast) {
+TEST_F(Fabric1DFixture, TestUnicastRaw) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
+
+    auto* control_plane = tt::Cluster::instance().get_control_plane();
+
     std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
-    chip_id_t src_physical_device_id;
     std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
-    chip_id_t dst_physical_device_id;
-
-    auto control_plane = tt::Cluster::instance().get_control_plane();
-
     // Find a device with a neighbour in the East direction
-    bool connection_found = false;
-    for (auto* device : devices_) {
-        src_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
-        // Get neighbours within a mesh in the East direction
-        auto neighbors = control_plane->get_intra_chip_neighbors(
-            src_mesh_chip_id.first, src_mesh_chip_id.second, RoutingDirection::E);
-        if (neighbors.size() > 0) {
-            src_physical_device_id = device->id();
-            dst_mesh_chip_id = {src_mesh_chip_id.first, neighbors[0]};
-            dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
-            connection_found = true;
-            break;
-        }
-    }
+    bool connection_found =
+        find_device_with_neighbor_in_direction(src_mesh_chip_id, dst_mesh_chip_id, RoutingDirection::E);
     if (!connection_found) {
         GTEST_SKIP() << "No path found between sender and receivers";
     }
+
+    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
+    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
 
     // get a port to connect to
     std::vector<chan_id_t> eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
@@ -73,9 +64,7 @@ TEST_F(Fabric1DFixture, TestUnicast) {
 
     // common compile time args for sender and receiver
     std::vector<uint32_t> compile_time_args = {
-        test_results_address,
-        test_results_size_bytes,
-        target_address,
+        test_results_address, test_results_size_bytes, target_address, 0 /* mcast_mode */
     };
 
     // Create the sender program
@@ -94,10 +83,9 @@ TEST_F(Fabric1DFixture, TestUnicast) {
         source_l1_buffer_address,
         packet_payload_size_bytes,
         num_packets,
-        num_hops,
         receiver_noc_encoding,
         time_seed,
-    };
+        num_hops};
 
     // append the EDM connection rt args
     static constexpr std::size_t edm_buffer_size =
@@ -181,4 +169,271 @@ TEST_F(Fabric1DFixture, TestUnicast) {
     EXPECT_EQ(sender_bytes, receiver_bytes);
 }
 
+TEST_F(Fabric1DFixture, TestUnicastConnAPI) {
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+
+    auto* control_plane = tt::Cluster::instance().get_control_plane();
+
+    std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
+    std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
+    // Find a device with a neighbour in the East direction
+    bool connection_found =
+        find_device_with_neighbor_in_direction(src_mesh_chip_id, dst_mesh_chip_id, RoutingDirection::E);
+    if (!connection_found) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+
+    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
+    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
+
+    auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
+    auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+
+    auto receiver_noc_encoding = tt::tt_metal::hal.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // test parameters
+    uint32_t packet_header_address = 0x25000;
+    uint32_t source_l1_buffer_address = 0x30000;
+    uint32_t packet_payload_size_bytes = 4096;
+    uint32_t num_packets = 10;
+    uint32_t num_hops = 1;
+    uint32_t test_results_address = 0x100000;
+    uint32_t test_results_size_bytes = 128;
+    uint32_t target_address = 0x30000;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    // common compile time args for sender and receiver
+    std::vector<uint32_t> compile_time_args = {
+        test_results_address, test_results_size_bytes, target_address, 0 /* mcast_mode */
+    };
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        {sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    std::vector<uint32_t> sender_runtime_args = {
+        packet_header_address,
+        source_l1_buffer_address,
+        packet_payload_size_bytes,
+        num_packets,
+        receiver_noc_encoding,
+        time_seed,
+        num_hops};
+
+    // append the EDM connection rt args
+    append_fabric_connection_rt_args(
+        src_physical_device_id, dst_physical_device_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    std::vector<uint32_t> receiver_runtime_args = {packet_payload_size_bytes, num_packets, time_seed};
+
+    // Create the receiver program for validation
+    auto receiver_program = tt_metal::CreateProgram();
+    auto receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+        {receiver_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+    // Launch sender and receiver programs and wait for them to finish
+    this->RunProgramNonblocking(receiver_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(receiver_device, receiver_program);
+
+    // Validate the status and packets processed by sender and receiver
+    std::vector<uint32_t> sender_status;
+    std::vector<uint32_t> receiver_status;
+
+    tt_metal::detail::ReadFromDeviceL1(
+        sender_device,
+        sender_logical_core,
+        test_results_address,
+        test_results_size_bytes,
+        sender_status,
+        CoreType::WORKER);
+
+    tt_metal::detail::ReadFromDeviceL1(
+        receiver_device,
+        receiver_logical_core,
+        test_results_address,
+        test_results_size_bytes,
+        receiver_status,
+        CoreType::WORKER);
+
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    uint64_t sender_bytes =
+        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+    uint64_t receiver_bytes =
+        ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
+    EXPECT_EQ(sender_bytes, receiver_bytes);
+}
+
+TEST_F(Fabric1DFixture, TestMCastConnAPI) {
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+
+    auto control_plane = tt::Cluster::instance().get_control_plane();
+
+    // use control plane to find a mesh with 3 devices
+    auto user_meshes = control_plane->get_user_physical_mesh_ids();
+    std::optional<mesh_id_t> mesh_id;
+    for (const auto& mesh : user_meshes) {
+        auto mesh_shape = control_plane->get_physical_mesh_shape(mesh);
+        if (mesh_shape.mesh_size() >= 3) {
+            mesh_id = mesh;
+            break;
+        }
+    }
+    if (!mesh_id.has_value()) {
+        GTEST_SKIP() << "No mesh found for 3 chip mcast test";
+    }
+
+    // for this test, logical chip id 1 is the sender, 0 is the left receiver and 1 is the right receiver
+    auto src_phys_chip_id = control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 1));
+    auto left_recv_phys_chip_id =
+        control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 0));
+    auto right_recv_phys_chip_id =
+        control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 2));
+
+    auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
+    auto* left_recv_device = DevicePool::instance().get_active_device(left_recv_phys_chip_id);
+    auto* right_recv_device = DevicePool::instance().get_active_device(right_recv_phys_chip_id);
+
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
+
+    auto receiver_noc_encoding = tt::tt_metal::hal.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+
+    // test parameters
+    uint32_t packet_header_address = 0x25000;
+    uint32_t source_l1_buffer_address = 0x30000;
+    uint32_t packet_payload_size_bytes = 4096;
+    uint32_t num_packets = 100;
+    uint32_t test_results_address = 0x100000;
+    uint32_t test_results_size_bytes = 128;
+    uint32_t target_address = 0x30000;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    // common compile time args for sender and receiver
+    std::vector<uint32_t> compile_time_args = {
+        test_results_address, test_results_size_bytes, target_address, 1 /* mcast_mode */
+    };
+
+    // Create the sender program
+    auto sender_program = tt_metal::CreateProgram();
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        {sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    std::vector<uint32_t> sender_runtime_args = {
+        packet_header_address,
+        source_l1_buffer_address,
+        packet_payload_size_bytes,
+        num_packets,
+        receiver_noc_encoding,
+        time_seed,
+        1, /* mcast_fwd_hops */
+        1, /* mcast_bwd_hops */
+    };
+
+    // append the EDM connection rt args for fwd connection
+    append_fabric_connection_rt_args(
+        src_phys_chip_id, right_recv_phys_chip_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+    append_fabric_connection_rt_args(
+        src_phys_chip_id, left_recv_phys_chip_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    std::vector<uint32_t> receiver_runtime_args = {packet_payload_size_bytes, num_packets, time_seed};
+
+    // Create the receiver program for validation
+    auto receiver_program = tt_metal::CreateProgram();
+    auto receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+        {receiver_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+    // Launch sender and receiver programs and wait for them to finish
+    this->RunProgramNonblocking(left_recv_device, receiver_program);
+    this->RunProgramNonblocking(right_recv_device, receiver_program);
+    this->RunProgramNonblocking(sender_device, sender_program);
+    this->WaitForSingleProgramDone(sender_device, sender_program);
+    this->WaitForSingleProgramDone(right_recv_device, receiver_program);
+    this->WaitForSingleProgramDone(left_recv_device, receiver_program);
+
+    // Validate the status and packets processed by sender and receiver
+    std::vector<uint32_t> sender_status;
+    std::vector<uint32_t> left_recv_status;
+    std::vector<uint32_t> right_recv_status;
+
+    tt_metal::detail::ReadFromDeviceL1(
+        sender_device,
+        sender_logical_core,
+        test_results_address,
+        test_results_size_bytes,
+        sender_status,
+        CoreType::WORKER);
+
+    tt_metal::detail::ReadFromDeviceL1(
+        left_recv_device,
+        receiver_logical_core,
+        test_results_address,
+        test_results_size_bytes,
+        left_recv_status,
+        CoreType::WORKER);
+
+    tt_metal::detail::ReadFromDeviceL1(
+        right_recv_device,
+        receiver_logical_core,
+        test_results_address,
+        test_results_size_bytes,
+        right_recv_status,
+        CoreType::WORKER);
+
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    EXPECT_EQ(left_recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    EXPECT_EQ(right_recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    uint64_t sender_bytes =
+        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+    uint64_t left_recv_bytes =
+        ((uint64_t)left_recv_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | left_recv_status[TT_FABRIC_WORD_CNT_INDEX];
+    uint64_t right_recv_bytes =
+        ((uint64_t)right_recv_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | right_recv_status[TT_FABRIC_WORD_CNT_INDEX];
+
+    EXPECT_EQ(sender_bytes, left_recv_bytes);
+    EXPECT_EQ(left_recv_bytes, right_recv_bytes);
+}
+
+}  // namespace fabric_router_tests
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
         routing_table_generator.cpp
         mesh_graph.cpp
         erisc_datamover_builder.cpp
+        fabric_host_utils.cpp
 )
 
 target_sources(

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/erisc_datamover_builder.hpp>
+#include <tt-metalium/mesh_graph.hpp>
+
+#include "fabric_host_utils.hpp"
+
+namespace tt::tt_fabric {
+
+namespace {
+
+tt::tt_fabric::FabricEriscDatamoverConfig get_default_fabric_config() {
+    constexpr std::size_t edm_buffer_size =
+        tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
+        sizeof(tt::tt_fabric::PacketHeader);
+    return tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+}
+
+}  // namespace
+
+void append_fabric_connection_rt_args(
+    chip_id_t src_chip_id,
+    chip_id_t dst_chip_id,
+    routing_plane_id_t routing_plane,
+    tt::tt_metal::Program& worker_program,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args) {
+    TT_FATAL(
+        src_chip_id != dst_chip_id,
+        "Expected different src and dst chip ids but got same, src: {}, dst: {}",
+        src_chip_id,
+        dst_chip_id);
+
+    auto* control_plane = tt::Cluster::instance().get_control_plane();
+
+    // for now, both the src and dest chips should be on the same mesh
+    auto [src_mesh_id, src_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(src_chip_id);
+    auto [dst_mesh_id, dst_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dst_chip_id);
+    TT_FATAL(
+        src_mesh_id == dst_mesh_id,
+        "Currently only the chips on the same mesh are supported. Src mesh id: {}, Dst mesh id: {}",
+        src_mesh_id,
+        dst_mesh_id);
+
+    // currently the src and dest should be adjacent, until the control plane has enough logic to check on the same line
+    const auto& neighbor_chips_and_cores =
+        tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(src_chip_id);
+    const auto& dst_chip_and_cores = neighbor_chips_and_cores.find(dst_chip_id);
+    TT_FATAL(dst_chip_and_cores != neighbor_chips_and_cores.end(), "Src and Dst chips are not physically adjacent");
+
+    const auto& fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(src_chip_id);
+    const auto& candidate_ethernet_cores = dst_chip_and_cores->second;
+    const auto& logical_eth_core_to_chan_map =
+        tt::Cluster::instance().get_soc_desc(src_chip_id).logical_eth_core_to_chan_map;
+
+    std::optional<chan_id_t> fabric_router_channel;
+
+    for (const auto& eth_core : candidate_ethernet_cores) {
+        auto eth_chan = logical_eth_core_to_chan_map.at(eth_core);
+
+        // selected channel should match the requested routing plane and should be one of the active fabric channels
+        if (routing_plane != control_plane->get_routing_plane_id(eth_chan)) {
+            continue;
+        }
+        if (fabric_ethernet_channels.find(eth_chan) != fabric_ethernet_channels.end()) {
+            fabric_router_channel = eth_chan;
+            break;
+        }
+    }
+
+    TT_FATAL(
+        fabric_router_channel.has_value(),
+        "Could not find any fabric router for requested routing plane: {}",
+        routing_plane);
+
+    const auto& edm_config = get_default_fabric_config();
+    CoreCoord fabric_router_virtual_core =
+        tt::Cluster::instance().get_virtual_eth_core_from_channel(src_chip_id, fabric_router_channel.value());
+
+    tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
+        .edm_noc_x = fabric_router_virtual_core.x,
+        .edm_noc_y = fabric_router_virtual_core.y,
+        .edm_buffer_base_addr = edm_config.sender_channels_base_address[0],
+        .num_buffers_per_channel = edm_config.sender_channels_num_buffers[0],
+        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[0],
+        .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[0],
+        .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[0],
+        .buffer_size_bytes = edm_config.channel_buffer_size_bytes,
+        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[0],
+        .persistent_fabric = true};
+
+    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0);
+    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0);
+    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0);
+
+    append_worker_to_fabric_edm_sender_rt_args(
+        edm_connection,
+        worker_flow_control_semaphore_id,
+        worker_teardown_semaphore_id,
+        worker_buffer_index_semaphore_id,
+        worker_args);
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_impl.hpp>
+
+namespace tt::tt_fabric {
+
+// Used to get the run-time args for estabilishing connection with the fabric router.
+// The API appends the connection specific run-time args to the set of exisiting
+// run-time args for the worker programs, which allows the workers to conveniently
+// build connection management object(s) using the run-time args.
+// It is advised to call the API once all the other run-time args for the prgram are
+// determined/pushed to keep things clean and avoid any extra arg management.
+//
+// Inputs:
+// src_chip_id: physical chip id/device id of the sender chip
+// dst_chip_id: physical chip id/device id of the receiver chip
+// routing_plane: the link (0..n) to use b/w the src_chip_id and dst_chip_id. On WH for
+//                instance we can have upto 4 active links b/w two chips
+// worker_program: program handle
+// worker_core: worker core logical coordinates
+// worker_args: list of existing run-time args to which the connection args will be appended
+//
+// Constraints:
+// 1. Currently the sender and reciever chip should be physically adjacent
+// 2. Currently the sender and reciever chip should be on the same mesh (for 1D)
+// 3. When connecting with 1D fabric routers, users are responsible for setting up the
+// connection appropriately. The API will not perform any checks to ensure that the
+// connection is indeed a 1D connection b/w all the workers.
+void append_fabric_connection_rt_args(
+    chip_id_t src_chip_id,
+    chip_id_t dst_chip_id,
+    routing_plane_id_t routing_plane,
+    tt::tt_metal::Program& worker_program,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args);
+
+}  // namespace tt::tt_fabric


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Expose an API to let the workers connect to the fabric routers when the 1d fabric gets initialized during device init. This is needed since we wont have any helper classes/context such as `EdmLineFabricOpInterface` anymore.

### What's changed
Added a utility method to get the run-time args to establish connection with the fabric routers

```
void append_fabric_connection_rt_args(
     chip_id_t src_chip_id,
     chip_id_t dst_chip_id,
     routing_plane_id_t routing_plane,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args);
```

Description:

```
// The API appends the connection specific run-time args to the set of exisiting
// run-time args for the worker programs, which allows the workers to conveniently
// build connection management object(s) using the run-time args.
// It is advised to call the API once all the other run-time args for the prgram are
// determined/pushed to keep things clean and avoid any extra arg management.
//
// Inputs:
// src_chip_id: physical chip id/device id of the sender chip
// dst_chip_id: physical chip id/device id of the receiver chip
// routing_plane: the link (0..n) to use b/w the src_chip_id and dst_chip_id. On WH for
//                instance we can have upto 4 active links b/w two chips
// worker_program: program handle
// worker_core: worker core logical coordinates
// worker_args: list of existing run-time args to which the connection args will be appended
//
// Constraints:
// 1. Currently the sender and reciever chip should be physically adjacent
// 2. Currently the sender and reciever chip should be on the same mesh (for 1D)
// 3. When connecting with 1D fabric routers, users are responsible for setting up the
// connection appropriately. The API will not perform any checks to ensure that the
// connection is indeed a 1D connection b/w all the workers.
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13949016307)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes