### PR TITLE
[skip ci] Don't build tt-train by default

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -47,6 +47,7 @@ jobs:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
       version: 22.04
+      skip-tt-train: false
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     with:
@@ -218,6 +219,7 @@ jobs:
             toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Debug"
             publish-artifact: false
+            skip-tt-train: false
           - version: "22.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -46,7 +46,7 @@ on:
         #        Fow now enabling an opt-out. But this should get removed.
         required: false
         type: boolean
-        default: false
+        default: true
       profile:
         required: false
         type: boolean

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
+      skip-tt-train: false
       build-wheel: true
       version: 22.04
   tt-train-cpp-unit-tests:


### PR DESCRIPTION
### Problem description
tt-train is not used in most workflows in tt-metal.
However, we build it by default in build-artifact.
This wastes our builder machine time.

### What's changed
Don't build tt-train by default.
It is only built in all-post-commit for the non-profiler leg of tests.
And, in the tt-train wrapper workflow.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes