### PR TITLE
[tt-train] Add option to set tokenizer in config

### DIFF
--- a/tt-train/sources/ttml/datasets/utils.cpp
+++ b/tt-train/sources/ttml/datasets/utils.cpp
@@ -9,14 +9,12 @@
 #include "tokenizers/char_tokenizer_trainer.hpp"
 #include "tokenizers/tokenizer_base.hpp"
 
-namespace {
-constexpr auto gpt2_tokenizer_file_name = "/gpt2-tokenizer.json";
-}
 namespace ttml::datasets {
 
 template <>
 std::tuple<InMemoryTokenDataset, std::unique_ptr<tokenizers::TokenizerBase>>
-create_in_memory_token_dataset<tokenizers::CharTokenizer>(const std::string &text, uint32_t seq_length) {
+create_in_memory_token_dataset<tokenizers::CharTokenizer>(
+    const std::string &text, uint32_t seq_length, [[maybe_unused]] const std::string &json_file_path) {
     std::unique_ptr<tokenizers::TokenizerBase> tokenizer = tokenizers::CharTokenizerTrainer::train(text);
 
     std::vector<uint32_t> tokenized_text = tokenizer->encode(text);
@@ -26,13 +24,46 @@ create_in_memory_token_dataset<tokenizers::CharTokenizer>(const std::string &tex
 
 template <>
 std::tuple<InMemoryTokenDataset, std::unique_ptr<tokenizers::TokenizerBase>>
-create_in_memory_token_dataset<tokenizers::BPETokenizer>(const std::string &text, uint32_t seq_length) {
-    auto json_file_path = std::string(TOKENIZERS_DATA_PATH) + gpt2_tokenizer_file_name;
+create_in_memory_token_dataset<tokenizers::BPETokenizer>(
+    const std::string &text, uint32_t seq_length, const std::string &json_file_path) {
     std::unique_ptr<tokenizers::TokenizerBase> tokenizer = std::make_unique<tokenizers::BPETokenizer>(json_file_path);
 
     const std::vector<uint32_t> tokenized_text = tokenizer->encode(text);
 
     return {InMemoryTokenDataset(tokenized_text, seq_length), std::move(tokenizer)};
+}
+
+template <>
+std::tuple<InMemoryTokenDataset, std::unique_ptr<tokenizers::TokenizerBase>>
+create_in_memory_token_dataset<tokenizers::BPETokenizer>(
+    const std::vector<uint32_t> &tokens, uint32_t seq_length, const std::string &json_file_path) {
+    std::unique_ptr<tokenizers::TokenizerBase> tokenizer = std::make_unique<tokenizers::BPETokenizer>(json_file_path);
+
+    return {InMemoryTokenDataset(tokens, seq_length), std::move(tokenizer)};
+}
+
+std::vector<uint32_t> load_tokens_from_space_separated_file(const std::string &file_path) {
+    std::ifstream file(file_path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open file: " + file_path);
+    }
+
+    std::vector<uint32_t> tokens;
+    uint32_t token;
+    size_t line_number = 1;
+
+    while (file >> token) {
+        tokens.push_back(token);
+    }
+
+    if (file.bad()) {
+        throw std::runtime_error("I/O error while reading file: " + file_path);
+    } else if (!file.eof()) {
+        throw std::runtime_error("Non-integer data encountered in file: " + file_path);
+    }
+
+    file.close();
+    return tokens;
 }
 
 }  // namespace ttml::datasets

--- a/tt-train/sources/ttml/datasets/utils.hpp
+++ b/tt-train/sources/ttml/datasets/utils.hpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include <numeric>
 #include <random>
 #include <span>
+#include <string>
 
 #include "autograd/auto_context.hpp"
 #include "dataset_subset.hpp"
@@ -16,7 +18,11 @@ namespace ttml::datasets {
 
 template <typename Tokenizer>
 std::tuple<InMemoryTokenDataset, std::unique_ptr<tokenizers::TokenizerBase>> create_in_memory_token_dataset(
-    const std::string& text, uint32_t seq_length);
+    const std::string& text, uint32_t seq_length, const std::string& json_file_path = "");
+
+template <typename Tokenizer>
+std::tuple<InMemoryTokenDataset, std::unique_ptr<tokenizers::TokenizerBase>> create_in_memory_token_dataset(
+    const std::vector<uint32_t>& tokens, uint32_t seq_length, const std::string& json_file_path = "");
 
 template <typename DatasetType>
 std::vector<DatasetSubset<DatasetType>> random_split(
@@ -46,5 +52,7 @@ std::vector<DatasetSubset<DatasetType>> random_split(
 
     return subsets;
 }
+
+std::vector<uint32_t> load_tokens_from_space_separated_file(const std::string& file_path);
 
 }  // namespace ttml::datasets

--- a/tt-train/tools/dataset_to_tokens.py
+++ b/tt-train/tools/dataset_to_tokens.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tokenizes a text dataset using a pre-trained tokenizer
+and saves the tokenized data as a flat list in MessagePack or CSV format using space delimiter.
+This helps to avoid a pretty long starting times for the nano_gpt example.
+Tokenizing is done in 128 splits to avoid memory issues.
+"""
+
+import os
+import argparse
+import numpy as np
+import msgpack
+import msgpack_numpy as m
+import csv
+
+# Enable numpy serialization for msgpack
+m.patch()
+
+
+def load_text_data(text_file):
+    """
+    Reads a text file line by line and returns the content as a single string.
+    """
+    with open(text_file, "r", encoding="utf-8") as file:
+        return " ".join([line.strip() for line in file.readlines()])
+
+
+def tokenize_text_data(tokenizer_file, text_data):
+    """
+    Tokenizes the text data using a pre-trained tokenizer and returns a flat list of tokens (integers).
+    """
+    from tokenizers import Tokenizer
+
+    tokenizer = Tokenizer.from_file(tokenizer_file)
+    tokenized_data = tokenizer.encode(text_data).ids
+    return tokenized_data
+
+
+def save_to_msgpack(data, output_file):
+    """
+    Saves the tokenized data as a flat NumPy array in MessagePack format.
+    """
+    np_data = np.array(data, dtype=np.int32)
+    with open(output_file, "wb") as file:
+        msgpack.pack(np_data, file, default=m.encode)
+    print(f"Saved tokenized data as MessagePack to {output_file}")
+
+
+def save_to_csv(data, output_file):
+    """
+    Saves the tokenized data as a single space-separated line in a CSV file.
+    """
+    with open(output_file, "w", newline="", encoding="utf-8") as file:
+        writer = csv.writer(file, delimiter=" ", quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(data)
+    print(f"Saved tokenized data as CSV to {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Preprocess a text dataset using a tokenizer and save all tokens as a single flat list in MessagePack or CSV format."
+    )
+    parser.add_argument(
+        "--text_file", type=str, required=True, help="Path to the input text dataset (e.g., merged.txt)."
+    )
+    parser.add_argument(
+        "--tokenizer_file", type=str, required=True, help="Path to the pre-trained tokenizer.json file."
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        default="tokenized_data",
+        help="Base path to save the tokenized data (extension will be added based on format).",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["msgpack", "csv"],
+        default="csv",
+        help="Output format for tokenized data (default: msgpack).",
+    )
+    args = parser.parse_args()
+
+    # Load text data
+    print(f"Loading text data from {args.text_file}...")
+    text_data = load_text_data(args.text_file)
+
+    # Tokenize the text data
+    print(f"Tokenizing data using tokenizer {args.tokenizer_file}...")
+    splits_num = 128
+    tokenized_data = []
+    for i in range(splits_num):
+        text_data_split = text_data[i * len(text_data) // splits_num : (i + 1) * len(text_data) // splits_num]
+        tokenized_data_split = tokenize_text_data(args.tokenizer_file, text_data_split)
+        tokenized_data.extend(tokenized_data_split)
+
+    # Save tokenized data in the specified format
+    if args.format == "msgpack":
+        output_file = f"{args.output_file}.msgpack"
+        save_to_msgpack(tokenized_data, output_file)
+    elif args.format == "csv":
+        output_file = f"{args.output_file}"
+        save_to_csv(tokenized_data, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/tools/tokenize_folder.py
+++ b/tt-train/tools/tokenize_folder.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Creates one large file with all the data from valid_exts and trains a BPE tokenizer on it.
+The tokenizer is saved as a JSON file.
+Dataset is saved to the txt file.
+"""
+
+import os
+import argparse
+from tokenizers import Tokenizer
+from tokenizers.models import BPE
+from tokenizers.trainers import BpeTrainer
+from tokenizers.pre_tokenizers import Whitespace, ByteLevel
+from tokenizers.normalizers import Sequence, NFD, Lowercase
+from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+
+
+def gather_source_files(folder):
+    """
+    Recursively walk `folder`, yielding paths to files with
+    extensions in ('.hpp', '.cpp', '.h', '.c').
+    """
+    valid_exts = {".hpp", ".cpp", ".h", ".c", ".cxx", ".hxx", ".py", ".md"}
+    for root, _, files in os.walk(folder):
+        for fname in files:
+            _, ext = os.path.splitext(fname)
+            if ext.lower() in valid_exts:
+                print(f"Found file: {fname}")
+                yield os.path.join(root, fname)
+
+
+def merge_into_one_file(file_paths, merged_file_path="merged.txt"):
+    """
+    Merges the content of all files in `file_paths` into
+    a single text file `merged_file_path`, removing trailing
+    whitespace from each line.
+    """
+    with open(merged_file_path, "w", encoding="utf-8") as writer:
+        for path in file_paths:
+            try:
+                with open(path, "r", encoding="utf-8") as reader:
+                    for line in reader:
+                        # Remove trailing whitespace from each line
+                        line = " ".join(line.split())
+                        writer.write(line + "\n")
+            except Exception as e:
+                print(f"Warning: Could not read file {path}: {e}")
+    return merged_file_path
+
+
+def train_bpe_tokenizer(text_file, output_tokenizer="tokenizer.json", vocab_size=32000):
+    """
+    Trains a BPE tokenizer on the text file, saves it to `output_tokenizer`.
+    """
+    tokenizer = Tokenizer(BPE(unk_token=None))
+    # 2. No normalizer; GPT-2 works byte-level, so we skip lowercasing or accent-stripping
+    # tokenizer.normalizer = None
+
+    # 3. Byte-level pre-tokenizer + Byte-level decoder
+    tokenizer.pre_tokenizer = ByteLevel()
+    tokenizer.decoder = ByteLevelDecoder()
+    tokenizer.pre_tokenizer.add_prefix_space = False
+    tokenizer.decoder.add_prefix_space = False
+    # tokenizer.pre_tokenizer = Whitespace()
+
+    # 3. Setup BPE trainer with desired vocab size + special tokens
+    trainer = BpeTrainer(vocab_size=vocab_size, special_tokens=["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]", "\n"])
+
+    # 4. Train on the merged text file
+    tokenizer.train([text_file], trainer)
+
+    # 5. Save the tokenizer as a single JSON
+    tokenizer.save(output_tokenizer)
+    print(f"Saved tokenizer to {output_tokenizer}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recursively gather .hpp/.cpp/.h/.c files, merge them, then train a BPE tokenizer."
+    )
+    parser.add_argument("--folder", type=str, required=True, help="Root folder to recursively find source files.")
+    parser.add_argument(
+        "--merged_txt",
+        type=str,
+        default="merged.txt",
+        help="Path to the merged output text file (default: merged.txt).",
+    )
+    parser.add_argument(
+        "--tokenizer_output",
+        type=str,
+        default="tokenizer.json",
+        help="Path to save the trained tokenizer JSON (default: tokenizer.json).",
+    )
+    parser.add_argument("--vocab_size", type=int, default=32000, help="Desired vocabulary size (default: 32000).")
+    args = parser.parse_args()
+
+    # 1. Gather source files
+    file_paths = list(gather_source_files(args.folder))
+    if not file_paths:
+        print("No .hpp, .cpp, .h, or .c files found. Exiting.")
+        return
+
+    # 2. Merge into one file
+    merged_path = merge_into_one_file(file_paths, args.merged_txt)
+
+    # 3. Train tokenizer
+    train_bpe_tokenizer(merged_path, args.tokenizer_output, args.vocab_size)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Problem description
Tokenizer was hardcoded previously in our code base.
Also we missed some useful functions.
For example currently every time we start we tokenize dataset. When it is very small it is not an issue but if it > 100m it takes forever.
### What's changed
* Add tokenizer_path to the yaml.
* Add folder to dataset python file which creates one large txt file from multiple in the folder.
* Add txt to tokenized csv. Which speedups runs

If you downloaded model and tokenizer using hugging face then path to the tokenizer will be something like this:
`~/.cache/huggingface/hub/models--gpt2/snapshots/607a30d783dfa663caf39e06633721c8d4cfcd7e
`
Overall all changes just to enable training right now and anyone should be able to reproduce my results.
Plan is to rewrite all datasets architecture for really large datasets.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes