### PR TITLE
#0: [skip ci] Set fail-fast to false when matrix building gcc/clang

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -212,6 +212,7 @@ jobs:
     needs: build-artifact
     secrets: inherit
     strategy:
+      fail-fast: false
       matrix:
         config:
           - version: "22.04"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

Fixes https://github.com/tenstorrent/tt-metal/actions/runs/13908721425/job/38918728770
```
FailFast: cancelling since parallel instance has failed
```

Currently without `fail-fast:false` when one build job fails, the other build jobs running in parallel get cancelled.
This causes the APC run itself to bubble up the run status to be cancelled, which is misleading if a dev didn't cancel the run, and also doesn't trigger the APC retry mechanism.

### What's changed
Set `fail-fast: false` in the build job matrix

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes