### PR TITLE
#0: Resolve hang with RandomizedMeshWorkload on N150

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -364,10 +364,6 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
 }
 
 TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
-    // TODO: #19149 - Re-enable the test.
-    if (mesh_device_->num_devices() == 1) {
-        GTEST_SKIP() << "Skipping test for a unit-size mesh device";
-    }
     uint32_t num_programs = 60;
     uint32_t num_iterations = 1500;
     auto random_seed = 10;

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -98,6 +98,8 @@ private:
         uint32_t expected_num_workers_completed,
         bool mcast_go_signals,
         bool unicast_go_signals);
+    // Clear the num_workers_completed counter on the dispatcher cores corresponding to this CQ.
+    void clear_expected_num_workers_completed();
     // Access a reference system memory manager, which acts as a global host side state manager for
     // specific MeshCommandQueue attributes.
     // TODO: All Mesh level host state managed by this class should be moved out, since its not
@@ -156,6 +158,9 @@ private:
     std::thread completion_queue_reader_thread_;
     // Global Mutex (used by both CQs) to safely use the reader_thread_pool_
     inline static std::mutex reader_thread_pool_mutex_;
+    // Used to Maintain state: Mark/Check if this data structure is being used for dispatch.
+    // This is temporary - will not be needed when we MeshCommandQueue is the only dispatch interface.
+    bool in_use_ = false;
 
 public:
     MeshCommandQueue(

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -50,6 +50,16 @@ MeshCommandQueue::MeshCommandQueue(
 }
 
 MeshCommandQueue::~MeshCommandQueue() {
+    if (in_use_) {
+        // If the MeshCommandQueue is being used, have it clear worker state
+        // before going out of scope. This is a blocking operation - it waits
+        // for all queued up work to complete.
+        // This allows physical device close to proceed correctly, since we still
+        // rely on single device CQs during this step. Not needed for functionality
+        // once single device CQs are removed, however this is still good practice.
+        this->clear_expected_num_workers_completed();
+    }
+
     TT_FATAL(completion_queue_reads_.empty(), "The completion reader queue must be empty when closing devices.");
 
     for (auto& queue : read_descriptors_) {
@@ -107,7 +117,40 @@ CoreCoord MeshCommandQueue::virtual_program_dispatch_core() const { return this-
 
 CoreType MeshCommandQueue::dispatch_core_type() const { return this->dispatch_core_type_; }
 
+void MeshCommandQueue::clear_expected_num_workers_completed() {
+    auto sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, {});
+    auto& sysmem_manager = this->reference_sysmem_manager();
+    auto event =
+        MeshEvent(sysmem_manager.get_next_event(id_), mesh_device_, id_, MeshCoordinateRange(mesh_device_->shape()));
+
+    // Issue commands to clear expected_num_workers_completed counter(s) on the dispatcher
+    for (auto device : mesh_device_->get_devices()) {
+        event_dispatch::issue_record_event_commands(
+            mesh_device_,
+            event.id(),
+            id_,
+            mesh_device_->num_hw_cqs(),
+            device->sysmem_manager(),
+            sub_device_ids,
+            expected_num_workers_completed_,
+            true, /* notify_host */
+            true /* clear_count */);
+    }
+    // Clear counter(s) on host to reflect update device state
+    for (auto sub_device_id : sub_device_ids) {
+        expected_num_workers_completed_[*sub_device_id] = 0;
+    }
+
+    // Block after clearing counter(s) on dispatcher
+    completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
+        std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
+    this->increment_num_entries_in_completion_queue();
+    std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
+    reads_processed_cv_.wait(lock, [this] { return num_outstanding_reads_.load() == 0; });
+}
+
 void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
+    in_use_ = true;
     std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.determine_sub_device_ids(mesh_device_);
     TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
     SubDeviceId sub_device_id = *(sub_device_ids.begin());
@@ -239,6 +282,7 @@ void MeshCommandQueue::write_shard_to_device(
     const void* src,
     const BufferRegion& region,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
     auto device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
@@ -252,6 +296,7 @@ void MeshCommandQueue::read_shard_from_device(
     const BufferRegion& region,
     std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
     auto device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
@@ -541,6 +586,7 @@ MeshEvent MeshCommandQueue::enqueue_record_event_helper(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     bool notify_host,
     const std::optional<MeshCoordinateRange>& device_range) {
+    in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
     auto& sysmem_manager = this->reference_sysmem_manager();
     auto event = MeshEvent(
@@ -580,6 +626,7 @@ MeshEvent MeshCommandQueue::enqueue_record_event_to_host(
 }
 
 void MeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
+    in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
     for (const auto& coord : sync_event.device_range()) {
         event_dispatch::issue_wait_for_event_commands(
@@ -674,6 +721,7 @@ void MeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& read
 
 void MeshCommandQueue::reset_worker_state(
     bool reset_launch_msg_state, uint32_t num_sub_devices, const vector_memcpy_aligned<uint32_t>& go_signal_noc_data) {
+    in_use_ = true;
     for (auto device : mesh_device_->get_devices()) {
         program_dispatch::reset_worker_dispatch_state_on_device(
             mesh_device_,
@@ -791,6 +839,7 @@ void MeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
 }
 
 void MeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blocking) {
+    in_use_ = true;
     auto trace_inst = mesh_device_->get_mesh_trace(trace_id);
     auto descriptor = trace_inst->desc;
     auto buffer = trace_inst->mesh_buffer;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -381,6 +381,7 @@ void MeshDevice::reshape(const MeshShape& new_shape) {
 }
 
 bool MeshDevice::close() {
+    mesh_command_queues_.clear();
     sub_device_manager_tracker_.reset();
     scoped_devices_.reset();
     parent_mesh_.reset();

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -30,7 +30,8 @@ void issue_record_event_commands(
     SystemMemoryManager& manager,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
-    bool notify_host) {
+    bool notify_host,
+    bool clear_count) {
     std::vector<uint32_t> event_payload(DispatchSettings::EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
     event_payload[0] = event_id;
 
@@ -70,7 +71,7 @@ void issue_record_event_commands(
         /* write_barrier ensures that all writes initiated by the dispatcher are
                                         flushed before the event is recorded */
         command_sequence.add_dispatch_wait(
-            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM |
+            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | (clear_count ? CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM : 0) |
                 ((i == num_worker_counters - 1) ? CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER : 0),
             0,
             DispatchMemMap::get(dispatch_core_type).get_dispatch_stream_index(offset_index),

--- a/tt_metal/impl/event/dispatch.hpp
+++ b/tt_metal/impl/event/dispatch.hpp
@@ -31,7 +31,8 @@ void issue_record_event_commands(
     SystemMemoryManager& manager,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
-    bool notify_host = true);
+    bool notify_host = true,
+    bool clear_count = false);
 
 void issue_wait_for_event_commands(
     uint8_t cq_id, uint8_t event_cq_id, SystemMemoryManager& sysmem_manager, uint32_t event_id);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19149

### Problem description
- `DevicePool` calls `Synchronize` when closing devices. This currently calls `finish` through the single device CQ path, which is decoupled from the `MeshCQ`.
- When running workloads through TT-Mesh, the `expected_num_workers_completed` counters in the single device CQ are never updated, which leads to an incorrect count being propagated to `cq_dispatch::process_wait` when `enqueue_record_event` is called
- This can cause a hang for large workloads with many programs, if the `expected_num_workers_completed` counter wraps

### What's changed
Have the `MeshCQ` clear this counter when its destructed by the `MeshDevice`. This change will not be functionally needed when we remove the single device CQ. However this should be considered correct behaviour, as it leads to the MeshCQ clearing its state after its done using the dispatch firmware.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes