### PR TITLE
[skip ci] [TG] 22.04 FTW

### DIFF
--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
+      version: 22.04
       build-wheel: true
   tg-demo-tests:
     needs: build-artifact

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
+      version: 22.04
       build-wheel: true
   tg-frequent-tests:
     needs: build-artifact

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -10,7 +10,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
-      version: 22.04
       build-wheel: true
   tg-frequent-tests:
     needs: build-artifact

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
+      version: 22.04
       build-wheel: true
   tg-nightly-tests:
     needs: build-artifact


### PR DESCRIPTION
### Ticket
#12490

### Problem description
20.04 is dead.  Long live 22.04 (for '2 years' value of 'long')

### What's changed
Flip TG-Demo and TG-Nightly to 22.04

### Checklist
- [x] TG Demo [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13913654124)
- [x] TG Nightly [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13913659650)