### PR TITLE
Changes to get ResNet50 Performance Parity on TG:

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -292,7 +292,9 @@ public:
     // and the MeshDevice has a single SubDeviceManager responsible for all Devices.
     void mesh_set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids);
     void mesh_reset_sub_device_stall_group();
-
+    // Currently expose users to the dispatch thread pool through the MeshDevice
+    void enqueue_to_thread_pool(std::function<void()>&& f);
+    void wait_for_thread_pool();
     static std::shared_ptr<MeshDevice> create(
         const MeshDeviceConfig& config,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -24,10 +24,10 @@ std::shared_ptr<ThreadPool> create_boost_thread_pool(int num_threads);
 std::shared_ptr<ThreadPool> create_distributed_boost_thread_pool(int num_threads);
 // API accespting the number of threads to spawn in the pool. Will bind each thread to a CPU core, but the
 // binding strategy will not be NUMA aware. Used for testing and benchmarking host-code.
-std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads, uint32_t logical_cpu_offset = 0);
+std::shared_ptr<ThreadPool> create_device_bound_thread_pool(int num_threads);
 // API accepting the physical devices the pool will be bound to. The threads will be bound to CPU cores in a
 // NUMA aware manner (will be "closest" to the device it serves). Used for production data-paths.
 std::shared_ptr<ThreadPool> create_device_bound_thread_pool(
-    const std::vector<tt::tt_metal::IDevice*>& physical_devices, uint32_t logical_cpu_offset = 0);
+    const std::vector<tt::tt_metal::IDevice*>& physical_devices);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -39,13 +39,12 @@ MeshDeviceID generate_unique_mesh_id() {
     return next_id++;
 }
 
-std::shared_ptr<ThreadPool> create_default_thread_pool(
-    const std::vector<IDevice*>& physical_devices, uint32_t logical_cpu_offset = 0) {
+std::shared_ptr<ThreadPool> create_default_thread_pool(const std::vector<IDevice*>& physical_devices) {
     // Bind the thread-pool to the physical devices being used.
     if (tt::parse_env("TT_MESH_BOOST_THREAD_POOL", false)) {
         return create_boost_thread_pool(physical_devices.size());
     } else {
-        return create_device_bound_thread_pool(physical_devices, logical_cpu_offset);
+        return create_device_bound_thread_pool(physical_devices);
     }
 }
 
@@ -154,7 +153,7 @@ MeshDevice::MeshDevice(
     parent_mesh_(std::move(parent_mesh)),
     program_cache_(std::make_unique<program_cache::detail::ProgramCache>()),
     dispatch_thread_pool_(create_default_thread_pool(scoped_devices_->root_devices())),
-    reader_thread_pool_(create_default_thread_pool(scoped_devices_->root_devices(), view_->shape().mesh_size())) {}
+    reader_thread_pool_(create_default_thread_pool(scoped_devices_->root_devices())) {}
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
     const MeshDeviceConfig& config,
@@ -172,6 +171,10 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
     return mesh_device;
 }
+
+void MeshDevice::enqueue_to_thread_pool(std::function<void()>&& f) { dispatch_thread_pool_->enqueue(std::move(f)); }
+
+void MeshDevice::wait_for_thread_pool() { dispatch_thread_pool_->wait(); }
 
 std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     const std::vector<int>& device_ids,

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -570,7 +570,6 @@ Tensor to_host<bfloat8_b>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_
     return to_host<uint32_t>(tensor, blocking, cq_id);
 }
 
-// TODO: need to add cq_id to this function
 template <typename T>
 Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
     // TT_FATAL(ttnn::distributed::is_mesh_buffer_tensor(tensor), "Tensor is not a mesh buffer tensor!");
@@ -582,23 +581,39 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
     distributed::MeshCommandQueue& mesh_cq = device->mesh_command_queue(*cq_id);
     const auto num_buffers = storage.specs.size();
 
+    // Initialize vector of host buffers that data will be read into
+    std::vector<OwnedBuffer> buffers(num_buffers);
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
     std::vector<TensorSpec> specs;
-    std::vector<OwnedBuffer> buffers;
-    buffers.reserve(num_buffers);
     specs.reserve(num_buffers);
     shard_data_transfers.reserve(num_buffers);
-    for (const auto& [coord, shard_tensor_spec] : storage.specs) {
-        std::vector<T> host_buffer;
-        const auto tensor_size_bytes = shard_tensor_spec.compute_packed_buffer_size_bytes();
-        host_buffer.resize(tensor_size_bytes / sizeof(T));
-        specs.push_back(shard_tensor_spec);
-        buffers.push_back(owned_buffer::create<T>(std::move(host_buffer)));
 
+    for (std::size_t shard_idx = 0; shard_idx < num_buffers; shard_idx++) {
+        const auto& [coord, shard_tensor_spec] = storage.specs[shard_idx];
+        const auto tensor_size_bytes = shard_tensor_spec.compute_packed_buffer_size_bytes();
+        // Multithreaded memory allocation on host. This is a bottleneck for models with large outputs
+        // and must thus be parallelized across devices.
+        tensor.mesh_device()->enqueue_to_thread_pool([shard_idx, &buffers, tensor_size_bytes]() {
+            ZoneScopedN("AllocateBuffer");
+            std::vector<T> host_buffer(tensor_size_bytes / sizeof(T));
+            {
+                // Track the buffer index, since the order of shards matters
+                buffers[shard_idx] = owned_buffer::create<T>(std::move(host_buffer));
+            }
+        });
+        // Populate tensor specs in storage and initialize the shard_data_transfers
+        // that will be used to issue the read.
+        specs.push_back(shard_tensor_spec);
         shard_data_transfers.push_back(distributed::MeshCommandQueue::ShardDataTransfer{
-            .shard_coord = coord,
-            .host_data = std::visit([](auto& b) { return reinterpret_cast<T*>(b.data()); }, buffers.back()),
-            .region = BufferRegion(0, tensor_size_bytes)});
+            .shard_coord = coord, .region = BufferRegion(0, tensor_size_bytes)});
+    }
+    // Wait for allocations to complete
+    tensor.mesh_device()->wait_for_thread_pool();
+    // Point shard_data_transfers to their associated host memory, which was allocated
+    // through the thread-pool.
+    for (std::size_t shard_idx = 0; shard_idx < num_buffers; shard_idx++) {
+        shard_data_transfers[shard_idx].host_data =
+            std::visit([](auto& b) { return reinterpret_cast<T*>(b.data()); }, buffers[shard_idx]);
     }
 
     mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, blocking);


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
TG ResNet50 performance on the TT-Mesh Integration branch needs to be brought up to parity with main.

### What's changed
 - Expose thread-pool to TTNN and use it to allocate host buffers for the read-back path.
 - Multi-Thread Dispatch of `RecordEvent` commands (500us on average on TG if we perform single threaded dispatch).
 - Spread worker threads across both NUMA Nodes on systems that have all physical devices bound to one NUMA Node). This allows minimizing CPU contention and leads to better host dispatch performance.
 - Modify Thread Pool worker wait mechanism: workers no longer wait on a semaphore. Instead, they busy wait (polling on the task queue) and use a linear fallback strategy to yield the CPU.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes