### PR TITLE
Remove debug tools dependency on Device

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -39,7 +39,7 @@ public:
         // Only difference is that we need to wait for the print server to catch
         // up after running a test.
         DebugToolsFixture::RunProgram(device, program);
-        tt::DprintServerAwait();
+        DprintServerAwait();
     }
 
 protected:
@@ -95,8 +95,8 @@ protected:
         IDevice* device
     ) {
         DebugToolsFixture::RunTestOnDevice(run_function, device);
-        tt::DPrintServerClearLogFile();
-        tt::DPrintServerClearSignals();
+        DPrintServerClearLogFile();
+        DPrintServerClearSignals();
     }
 
     // Override this function in child classes for additional setup commands between DPRINT setup

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -79,7 +79,7 @@ static void RunTest(
         );
 
         // Clear the log file for the next core's test
-        tt::DPrintServerClearLogFile();
+        DPrintServerClearLogFile();
     }
 }
 }

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -70,10 +70,6 @@ public:
     virtual CoreCoord grid_size() const = 0;
     virtual CoreCoord logical_grid_size() const = 0;
     virtual CoreCoord dram_grid_size() const = 0;
-    virtual CoreType core_type_from_virtual_core(const CoreCoord& virtual_coord) const = 0;
-
-    // Given a Virtual coordinate in noc_index space, get the equivalent coordinate in Virtual NOC0 space
-    virtual CoreCoord virtual_noc_coordinate(uint8_t noc_index, CoreCoord coord) const = 0;
 
     // Given a coordinate in Virtual NOC0 Space, get the equivalent coordinate in Virtual noc_index space
     virtual CoreCoord virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -64,10 +64,7 @@ public:
     CoreCoord grid_size() const override;
     CoreCoord logical_grid_size() const override;
     CoreCoord dram_grid_size() const override;
-    CoreType core_type_from_virtual_core(const CoreCoord& virtual_coord) const override;
 
-    // Given a Virtual coordinate in noc_index space, get the equivalent coordinate in Virtual NOC0 space
-    CoreCoord virtual_noc_coordinate(uint8_t noc_index, CoreCoord coord) const override;
     // Given a coordinate in Virtual NOC0 Space, get the equivalent coordinate in Virtual noc_index space
     CoreCoord virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const override;
 
@@ -226,7 +223,6 @@ private:
 
     CoreCoord physical_worker_core_from_logical_core(const CoreCoord &logical_core) const;
     CoreCoord dram_core_from_dram_channel(uint32_t dram_channel) const;
-    CoreType core_type_from_physical_core(const CoreCoord &physical_core) const;
     CoreCoord virtual_core_from_physical_core(const CoreCoord& physical_coord) const;
 
     chip_id_t id_;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -117,8 +117,6 @@ public:
     CoreCoord grid_size() const override;
     CoreCoord logical_grid_size() const override;
     CoreCoord dram_grid_size() const override;
-    CoreType core_type_from_virtual_core(const CoreCoord& virtual_coord) const override;
-    CoreCoord virtual_noc_coordinate(uint8_t noc_index, CoreCoord coord) const override;
     CoreCoord virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const override;
 
     std::vector<CoreCoord> worker_cores_from_logical_cores(const std::vector<CoreCoord>&logical_cores) const override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -488,16 +488,6 @@ CoreCoord MeshDevice::logical_grid_size() const {
     return validate_and_get_reference_value(
         scoped_devices_->root_devices(), [](const auto& device) { return device->logical_grid_size(); });
 }
-CoreType MeshDevice::core_type_from_virtual_core(const CoreCoord& virtual_coord) const {
-    return validate_and_get_reference_value(scoped_devices_->root_devices(), [virtual_coord](const auto& device) {
-        return device->core_type_from_virtual_core(virtual_coord);
-    });
-}
-CoreCoord MeshDevice::virtual_noc_coordinate(uint8_t noc_index, CoreCoord coord) const {
-    return validate_and_get_reference_value(scoped_devices_->root_devices(), [noc_index, coord](const auto& device) {
-        return device->virtual_noc_coordinate(noc_index, coord);
-    });
-}
 CoreCoord MeshDevice::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
     return validate_and_get_reference_value(scoped_devices_->root_devices(), [noc_index, coord](const auto& device) {
         return device->virtual_noc0_coordinate(noc_index, coord);

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -36,7 +36,7 @@ static CoreDescriptorSet GetAllCores(chip_id_t device_id) {
             all_cores.insert({{x, y}, CoreType::WORKER});
         }
     }
-    for (const auto& logical_core : tt::Cluster::instance().get_active_ethernet_cores(device_id, false)) {
+    for (const auto& logical_core : tt::Cluster::instance().get_active_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
     for (const auto& logical_core : tt::Cluster::instance().get_inactive_ethernet_cores(device_id)) {
@@ -60,15 +60,15 @@ static CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
     return dispatch_cores;
 }
 
-// Helper function to convert virtual core -> HalProgrammableCoreType
-inline tt::tt_metal::HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core, chip_id_t device_id) {
+// Helper function to convert virtual core -> HalProgrammableCoreType. TODO: Remove when we fix core types.
+static tt::tt_metal::HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core, chip_id_t device_id) {
     if (!tt::Cluster::instance().is_ethernet_core(virtual_core, device_id)) {
         return tt::tt_metal::HalProgrammableCoreType::TENSIX;
     }
 
     // Eth pcores have a different address, but only active ones.
     CoreCoord logical_core = tt::Cluster::instance().get_logical_ethernet_core_from_virtual(device_id, virtual_core);
-    auto active_ethernet_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id, false);
+    auto active_ethernet_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id);
     if (active_ethernet_cores.find(logical_core) != active_ethernet_cores.end()) {
         return tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
     }

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -10,7 +10,7 @@
 #include <tt-metalium/core_descriptor.hpp>
 #include "hostdevcommon/dprint_common.h"
 #include "impl/dispatch/dispatch_core_manager.hpp"
-#include <device.hpp>
+#include "llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal {
 
@@ -27,19 +27,19 @@ struct CoreDescriptorComparator {
 using CoreDescriptorSet = std::set<CoreDescriptor, CoreDescriptorComparator>;
 
 // Helper function to get CoreDescriptors for all debug-relevant cores on device.
-static CoreDescriptorSet GetAllCores(tt::tt_metal::IDevice* device) {
+static CoreDescriptorSet GetAllCores(chip_id_t device_id) {
     CoreDescriptorSet all_cores;
     // The set of all printable cores is Tensix + Eth cores
-    CoreCoord logical_grid_size = device->logical_grid_size();
+    CoreCoord logical_grid_size = tt::Cluster::instance().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t x = 0; x < logical_grid_size.x; x++) {
         for (uint32_t y = 0; y < logical_grid_size.y; y++) {
             all_cores.insert({{x, y}, CoreType::WORKER});
         }
     }
-    for (const auto& logical_core : device->get_active_ethernet_cores()) {
+    for (const auto& logical_core : tt::Cluster::instance().get_active_ethernet_cores(device_id, false)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
-    for (const auto& logical_core : device->get_inactive_ethernet_cores()) {
+    for (const auto& logical_core : tt::Cluster::instance().get_inactive_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
 
@@ -48,21 +48,37 @@ static CoreDescriptorSet GetAllCores(tt::tt_metal::IDevice* device) {
 
 // Helper function to get CoreDescriptors for all cores that are used for dispatch. Should be a subset of
 // GetAllCores().
-static CoreDescriptorSet GetDispatchCores(tt::tt_metal::IDevice* device) {
+static CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
     CoreDescriptorSet dispatch_cores;
-    unsigned num_cqs = device->num_hw_cqs();
+    unsigned num_cqs = tt::tt_metal::dispatch_core_manager::instance().get_num_hw_cqs();
     const auto& dispatch_core_config = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
     tt::log_warning("Dispatch Core Type = {}", dispatch_core_type);
-    for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_config)) {
+    for (auto logical_core : tt::get_logical_dispatch_cores(device_id, num_cqs, dispatch_core_config)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});
     }
     return dispatch_cores;
 }
 
-inline uint64_t GetDprintBufAddr(tt::tt_metal::IDevice* device, const CoreCoord& virtual_core, int risc_id) {
-    dprint_buf_msg_t* buf =
-        device->get_dev_addr<dprint_buf_msg_t*>(virtual_core, tt::tt_metal::HalL1MemAddrType::DPRINT);
+// Helper function to convert virtual core -> HalProgrammableCoreType
+inline tt::tt_metal::HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core, chip_id_t device_id) {
+    if (!tt::Cluster::instance().is_ethernet_core(virtual_core, device_id)) {
+        return tt::tt_metal::HalProgrammableCoreType::TENSIX;
+    }
+
+    // Eth pcores have a different address, but only active ones.
+    CoreCoord logical_core = tt::Cluster::instance().get_logical_ethernet_core_from_virtual(device_id, virtual_core);
+    auto active_ethernet_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id, false);
+    if (active_ethernet_cores.find(logical_core) != active_ethernet_cores.end()) {
+        return tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
+    }
+
+    return tt::tt_metal::HalProgrammableCoreType::IDLE_ETH;
+}
+
+inline uint64_t GetDprintBufAddr(chip_id_t device_id, const CoreCoord& virtual_core, int risc_id) {
+    dprint_buf_msg_t* buf = tt::tt_metal::hal.get_dev_addr<dprint_buf_msg_t*>(
+        get_programmable_core_type(virtual_core, device_id), tt::tt_metal::HalL1MemAddrType::DPRINT);
     return reinterpret_cast<uint64_t>(&(buf->data[risc_id]));
 }
 
@@ -70,9 +86,9 @@ inline uint64_t GetDprintBufAddr(tt::tt_metal::IDevice* device, const CoreCoord&
 #define DPRINT_NRISCVS 5
 #define DPRINT_NRISCVS_ETH 1
 
-inline int GetNumRiscs(tt::tt_metal::IDevice* device, const CoreDescriptor& core) {
+inline int GetNumRiscs(const CoreDescriptor& core) {
     if (core.type == CoreType::ETH) {
-        return (device->arch() == tt::ARCH::BLACKHOLE)? DPRINT_NRISCVS_ETH + 1 : DPRINT_NRISCVS_ETH;
+        return (tt::Cluster::instance().arch() == tt::ARCH::BLACKHOLE) ? DPRINT_NRISCVS_ETH + 1 : DPRINT_NRISCVS_ETH;
     } else {
         return DPRINT_NRISCVS;
     }

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -25,10 +25,10 @@
 
 #include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/blockfloat_common.hpp>
-#include <tt-metalium/device.hpp>
 
 #include "hostdevcommon/dprint_common.h"
 #include "hostdevcommon/kernel_structs.h"
+#include "llrt/tt_cluster.hpp"
 
 using std::cout;
 using std::endl;
@@ -44,7 +44,6 @@ using std::to_string;
 using std::tuple;
 using std::uint32_t;
 
-using tt::tt_metal::IDevice;
 using namespace tt;
 
 #define CAST_U8P(p) reinterpret_cast<uint8_t*>(p)
@@ -154,11 +153,11 @@ struct DebugPrintServerContext {
 
     // Attaches a device to be monitored by the print server.
     // This device should not already be attached.
-    void AttachDevice(IDevice* device);
+    void AttachDevice(chip_id_t device_id);
 
     // Detaches a device from being monitored by the print server.
     // This device must have been attached previously.
-    void DetachDevice(IDevice* device);
+    void DetachDevice(chip_id_t device_id);
 
     // Clears the log file of a currently-running print server.
     void ClearLogFile();
@@ -166,7 +165,7 @@ struct DebugPrintServerContext {
     // Clears any raised signals (so they can be used again in a later run).
     void ClearSignals();
 
-    bool ReadsDispatchCores(IDevice* device) { return device_reads_dispatch_cores_[device]; }
+    bool ReadsDispatchCores(chip_id_t device_id) { return device_reads_dispatch_cores_[device_id]; }
 
     int GetNumAttachedDevices() { return device_to_core_range_.size(); }
 
@@ -211,14 +210,14 @@ private:
 
     // A map from Device -> Core Range, which is used to determine which cores on which devices
     // to scan for print data. Also a lock for editing it.
-    std::map<IDevice*, std::vector<CoreDescriptor>> device_to_core_range_;
-    std::map<IDevice*, bool> device_reads_dispatch_cores_;  // True if given device reads any dispatch cores. Used to
-                                                           // know whether dprint can be compiled out.
+    std::map<chip_id_t, std::vector<CoreDescriptor>> device_to_core_range_;
+    std::map<chip_id_t, bool> device_reads_dispatch_cores_;  // True if given device reads any dispatch cores. Used to
+                                                             // know whether dprint can be compiled out.
     std::mutex device_to_core_range_lock_;
 
     // Used to signal to the print server to flush all intermediate streams for a device so that any remaining prints
     // are printed out.
-    std::map<IDevice*, bool> device_intermediate_streams_force_flush_;
+    std::map<chip_id_t, bool> device_intermediate_streams_force_flush_;
     std::mutex device_intermediate_streams_force_flush_lock_;
 
     // Polls specified cores/riscs on all attached devices and prints any new print data. This
@@ -231,11 +230,11 @@ private:
     // buffer on the device is only flushed  up to the WAIT, even if more print data is available
     // after it.
     bool PeekOneHartNonBlocking(
-        IDevice* device, const CoreDescriptor& logical_core, int risc_index, bool new_data_this_iter);
+        chip_id_t device_id, const CoreDescriptor& logical_core, int risc_index, bool new_data_this_iter);
 
     // Transfers data from each intermediate stream associated with the given device to the output stream and flushes
     // the output stream so that the data is visible to the user.
-    void TransferIntermediateStreamsToOutputStreamAndFlush(IDevice* device);
+    void TransferIntermediateStreamsToOutputStreamAndFlush(chip_id_t device_id);
 
     // Transfers data from the given intermediate stream to the output stream and flushes the output stream so that the
     // data is visible to the user.
@@ -272,7 +271,7 @@ static void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
     uint8_t* data = ptr + offsetof(TileSliceHostDev<0>, data);
 
     // Read any error codes and handle accordingly
-    enum CBIndex cb = static_cast<enum CBIndex>(ts->cb_id);
+    enum tt::CBIndex cb = static_cast<enum tt::CBIndex>(ts->cb_id);
     switch (ts->return_code) {
         case DPrintOK: break;  // Continue to print the tile slice
         case DPrintErrorBadPointer: {
@@ -458,15 +457,15 @@ static void PrintTypedUint32Array(
 
 // Writes a magic value at wpos ptr address for dprint buffer for a specific risc/core/chip
 // Used for debug print server startup sequence.
-void WriteInitMagic(IDevice* device, const CoreCoord& virtual_core, int risc_id, bool enabled) {
+void WriteInitMagic(chip_id_t device_id, const CoreCoord& virtual_core, int risc_id, bool enabled) {
     // compute the buffer address for the requested risc
-    uint64_t base_addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
+    uint64_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
 
     // TODO(AP): this could use a cleanup - need a different mechanism to know if a kernel is running on device.
     // Force wait for first kernel launch by first writing a non-zero and waiting for a zero.
     std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
     initbuf[0] = uint32_t(enabled ? DEBUG_PRINT_SERVER_STARTING_MAGIC : DEBUG_PRINT_SERVER_DISABLED_MAGIC);
-    tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, initbuf, base_addr);
+    tt::llrt::write_hex_vec_to_core(device_id, virtual_core, initbuf, base_addr);
 
     // Prevent race conditions during runtime by waiting until the init value is actually written
     // DPrint is only used for debug purposes so this delay should not be a big issue.
@@ -476,7 +475,7 @@ void WriteInitMagic(IDevice* device, const CoreCoord& virtual_core, int risc_id,
     // 4. now we will access wpos at the starting magic which is incorrect
     uint32_t num_tries = 100000;
     while (num_tries-- > 0) {
-        auto result = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, base_addr, 4);
+        auto result = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, base_addr, 4);
         if (result[0] == DEBUG_PRINT_SERVER_STARTING_MAGIC && enabled) {
             return;
         } else if (result[0] == DEBUG_PRINT_SERVER_DISABLED_MAGIC && !enabled) {
@@ -490,11 +489,11 @@ void WriteInitMagic(IDevice* device, const CoreCoord& virtual_core, int risc_id,
 // The assumption is that if our magic number was cleared,
 // it means there is a write in the queue and wpos/rpos are now valid
 // Note that this is not a bulletproof way to bootstrap the print server (TODO(AP))
-bool CheckInitMagicCleared(IDevice* device, const CoreCoord& virtual_core, int risc_id) {
+bool CheckInitMagicCleared(chip_id_t device_id, const CoreCoord& virtual_core, int risc_id) {
     // compute the buffer address for the requested risc
-    uint32_t base_addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
+    uint32_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
 
-    auto result = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, base_addr, 4);
+    auto result = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, base_addr, 4);
     return (result[0] != DEBUG_PRINT_SERVER_STARTING_MAGIC && result[0] != DEBUG_PRINT_SERVER_DISABLED_MAGIC);
 }  // CheckInitMagicCleared
 
@@ -590,13 +589,11 @@ void DebugPrintServerContext::WaitForPrintsFinished() {
     } while (num_riscs_waiting > 0 || new_data_last_iter_ || wait_loop_iterations_ < 2);
 }  // WaitForPrintsFinished
 
-void DebugPrintServerContext::AttachDevice(IDevice* device) {
-    chip_id_t device_id = device->id();
-
+void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
     // A set of all valid printable cores, used for checking the user input. Note that the coords
     // here are virtual.
-    tt::tt_metal::CoreDescriptorSet all_cores = GetAllCores(device->id());
-    tt::tt_metal::CoreDescriptorSet dispatch_cores = GetDispatchCores(device->id());
+    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(device_id);
+    tt::tt_metal::CoreDescriptorSet dispatch_cores = tt::tt_metal::GetDispatchCores(device_id);
 
     // Initialize all print buffers on all cores on the device to have print disabled magic. We
     // will then write print enabled magic for only the cores the user has specified to monitor.
@@ -604,9 +601,10 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
     // skip prints entirely to prevent kernel code from hanging waiting for the print buffer to be
     // flushed from the host.
     for (auto& logical_core : all_cores) {
-        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-        for (int risc_index = 0; risc_index < GetNumRiscs(logical_core); risc_index++) {
-            WriteInitMagic(device, virtual_core, risc_index, false);
+        CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
+        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(logical_core); risc_index++) {
+            WriteInitMagic(device_id, virtual_core, risc_index, false);
         }
     }
 
@@ -615,7 +613,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
     std::vector<chip_id_t> chip_ids =
         tt::llrt::RunTimeOptions::get_instance().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
     if (!tt::llrt::RunTimeOptions::get_instance().get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
-        if (std::find(chip_ids.begin(), chip_ids.end(), device->id()) == chip_ids.end()) {
+        if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
             return;
         }
     }
@@ -634,7 +632,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
             log_info(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, all {} cores.",
-                device->id(),
+                device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else if (
             tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
@@ -647,7 +645,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
             log_info(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, {} dispatch cores.",
-                device->id(),
+                device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else if (
             tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
@@ -663,7 +661,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
             log_info(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, {} worker cores.",
-                device->id(),
+                device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else {
             // No "all cores" option provided, which means print from the cores specified by the user
@@ -677,7 +675,8 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                 CoreCoord virtual_core;
                 bool valid_logical_core = true;
                 try {
-                    virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
+                    virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+                        device_id, logical_core, core_type);
                 } catch (std::runtime_error& error) {
                     valid_logical_core = false;
                 }
@@ -686,7 +685,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                     log_info(
                         tt::LogMetal,
                         "DPRINT enabled on device {}, {} core {} (virtual {}).",
-                        device->id(),
+                        device_id,
                         tt::tt_metal::get_core_type_name(core_type),
                         logical_core.str(),
                         virtual_core.str());
@@ -698,7 +697,7 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
                         tt::tt_metal::get_core_type_name(core_type),
                         logical_core.str(),
                         valid_logical_core ? virtual_core.str() : "INVALID",
-                        device->id());
+                        device_id);
                 }
             }
         }
@@ -706,45 +705,47 @@ void DebugPrintServerContext::AttachDevice(IDevice* device) {
 
     // Write print enable magic for the cores the user specified.
     for (auto& logical_core : print_cores_sanitized) {
-        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-        for (int risc_index = 0; risc_index < GetNumRiscs(logical_core); risc_index++) {
+        CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
+        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(logical_core); risc_index++) {
             if (RiscEnabled(logical_core, risc_index)) {
-                WriteInitMagic(device, virtual_core, risc_index, true);
+                WriteInitMagic(device_id, virtual_core, risc_index, true);
             }
         }
         if (dispatch_cores.count(logical_core)) {
-            device_reads_dispatch_cores_[device] = true;
+            device_reads_dispatch_cores_[device_id] = true;
         }
     }
 
     device_intermediate_streams_force_flush_lock_.lock();
     TT_ASSERT(
-        device_intermediate_streams_force_flush_.count(device) == 0,
+        device_intermediate_streams_force_flush_.count(device_id) == 0,
         "Device {} added to DPRINT server more than once!",
         device_id);
-    device_intermediate_streams_force_flush_[device] = false;
+    device_intermediate_streams_force_flush_[device_id] = false;
     device_intermediate_streams_force_flush_lock_.unlock();
 
     // Save this device + core range to the print server
     device_to_core_range_lock_.lock();
-    TT_ASSERT(device_to_core_range_.count(device) == 0, "Device {} added to DPRINT server more than once!", device_id);
-    device_to_core_range_[device] = print_cores_sanitized;
+    TT_ASSERT(
+        device_to_core_range_.count(device_id) == 0, "Device {} added to DPRINT server more than once!", device_id);
+    device_to_core_range_[device_id] = print_cores_sanitized;
     device_to_core_range_lock_.unlock();
     log_info(tt::LogMetal, "DPRINT Server attached device {}", device_id);
 }  // AttachDevice
 
-void DebugPrintServerContext::DetachDevice(IDevice* device) {
+void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
     // Don't detach the device if it's disabled by env vars - in this case it wasn't attached.
     std::vector<chip_id_t> chip_ids =
         tt::llrt::RunTimeOptions::get_instance().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
     if (!tt::llrt::RunTimeOptions::get_instance().get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
-        if (std::find(chip_ids.begin(), chip_ids.end(), device->id()) == chip_ids.end()) {
+        if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
             return;
         }
     }
 
     // When we detach a device, we should poll to make sure there's no outstanding prints.
-    chip_id_t chip_id = device->id();
+    chip_id_t chip_id = device_id;
     bool outstanding_prints = true;
     while (outstanding_prints && !server_killed_due_to_hang_) {
         // Polling interval of 1ms
@@ -752,18 +753,19 @@ void DebugPrintServerContext::DetachDevice(IDevice* device) {
 
         // Check all dprint-enabled cores on this device for outstanding prints.
         outstanding_prints = false;
-        for (auto& logical_core : device_to_core_range_.at(device)) {
-            CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-            for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
+        for (auto& logical_core : device_to_core_range_.at(device_id)) {
+            CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+                device_id, logical_core.coord, logical_core.type);
+            for (int risc_id = 0; risc_id < tt::tt_metal::GetNumRiscs(logical_core); risc_id++) {
                 if (RiscEnabled(logical_core, risc_id)) {
                     // No need to check if risc is not dprint-enabled.
-                    if (!CheckInitMagicCleared(device, virtual_core, risc_id)) {
+                    if (!CheckInitMagicCleared(device_id, virtual_core, risc_id)) {
                         continue;
                     }
 
                     // Check if rpos < wpos, indicating unprocessed prints.
                     constexpr int eightbytes = 8;
-                    uint32_t base_addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
+                    uint32_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
                     auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, virtual_core, base_addr, eightbytes);
                     uint32_t wpos = from_dev[0], rpos = from_dev[1];
                     if (rpos < wpos) {
@@ -783,14 +785,14 @@ void DebugPrintServerContext::DetachDevice(IDevice* device) {
     // transferred to the output stream and flushed to ensure that they are printed out to the user.
     if (!server_killed_due_to_hang_) {
         device_intermediate_streams_force_flush_lock_.lock();
-        device_intermediate_streams_force_flush_[device] = true;
+        device_intermediate_streams_force_flush_[device_id] = true;
         device_intermediate_streams_force_flush_lock_.unlock();
         bool intermediate_streams_need_to_be_flushed = true;
         while (intermediate_streams_need_to_be_flushed) {
             // Polling interval of 1ms
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
             device_intermediate_streams_force_flush_lock_.lock();
-            intermediate_streams_need_to_be_flushed = device_intermediate_streams_force_flush_[device];
+            intermediate_streams_need_to_be_flushed = device_intermediate_streams_force_flush_[device_id];
             device_intermediate_streams_force_flush_lock_.unlock();
         }
     }
@@ -798,30 +800,27 @@ void DebugPrintServerContext::DetachDevice(IDevice* device) {
     // Remove the device from relevant data structures.
     device_intermediate_streams_force_flush_lock_.lock();
     TT_ASSERT(
-        device_to_core_range_.count(device) > 0,
+        device_to_core_range_.count(device_id) > 0,
         "Device {} not present in DPRINT server but tried removing it!",
-        device->id());
-    device_intermediate_streams_force_flush_.erase(device);
+        device_id);
+    device_intermediate_streams_force_flush_.erase(device_id);
     device_intermediate_streams_force_flush_lock_.unlock();
 
     device_to_core_range_lock_.lock();
     TT_ASSERT(
-        device_to_core_range_.count(device) > 0,
+        device_to_core_range_.count(device_id) > 0,
         "Device {} not present in DPRINT server but tried removing it!",
-        device->id());
-    device_to_core_range_.erase(device);
-    log_info(tt::LogMetal, "DPRINT Server dettached device {}", device->id());
+        device_id);
+    device_to_core_range_.erase(device_id);
+    log_info(tt::LogMetal, "DPRINT Server dettached device {}", device_id);
 
     // When detaching a device, disable prints on it.
-<<<<<<< HEAD
-    tt::tt_metal::CoreDescriptorSet all_cores = GetAllCores(device);
-=======
-    CoreDescriptorSet all_cores = GetAllCores(device->id());
->>>>>>> 5b54de6523... #0: Change debug_helpers.hpp to no longer use Device
+    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(device_id);
     for (auto& logical_core : all_cores) {
-        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-        for (int risc_index = 0; risc_index < GetNumRiscs(logical_core); risc_index++) {
-            WriteInitMagic(device, virtual_core, risc_index, false);
+        CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
+        for (int risc_index = 0; risc_index < tt::tt_metal::GetNumRiscs(logical_core); risc_index++) {
+            WriteInitMagic(device_id, virtual_core, risc_index, false);
         }
     }
     device_to_core_range_lock_.unlock();
@@ -847,16 +846,17 @@ void DebugPrintServerContext::ClearSignals() {
 }  // ClearSignals
 
 bool DebugPrintServerContext::PeekOneHartNonBlocking(
-    IDevice* device, const CoreDescriptor& logical_core, int risc_id, bool new_data_this_iter) {
+    chip_id_t device_id, const CoreDescriptor& logical_core, int risc_id, bool new_data_this_iter) {
     // If init magic isn't cleared for this risc, then dprint isn't enabled on it, don't read it.
-    CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-    if (!CheckInitMagicCleared(device, virtual_core, risc_id)) {
+    CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+        device_id, logical_core.coord, logical_core.type);
+    if (!CheckInitMagicCleared(device_id, virtual_core, risc_id)) {
         return false;
     }
 
     // compute the buffer address for the requested risc
-    uint32_t base_addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
-    chip_id_t chip_id = device->id();
+    uint32_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
+    chip_id_t chip_id = device_id;
     HartKey risc_key{chip_id, logical_core, risc_id};
 
     if (!risc_to_prev_type_[risc_key]) {
@@ -1165,27 +1165,27 @@ void DebugPrintServerContext::PollPrintData() {
         }
 
         // Make a copy of the device->core map, so that it can be modified while polling.
-        std::map<IDevice*, std::vector<CoreDescriptor>> device_to_core_range_copy;
+        std::map<chip_id_t, std::vector<CoreDescriptor>> device_to_core_range_copy;
         device_to_core_range_lock_.lock();
         device_to_core_range_copy = device_to_core_range_;
 
         // Flag for whether any new print data was found in this round of polling.
         bool new_data_this_iter = false;
         for (auto& device_and_cores : device_to_core_range_copy) {
-            IDevice* device = device_and_cores.first;
+            chip_id_t device_id = device_and_cores.first;
             device_intermediate_streams_force_flush_lock_.lock();
-            if (device_intermediate_streams_force_flush_[device]) {
-                TransferIntermediateStreamsToOutputStreamAndFlush(device);
-                device_intermediate_streams_force_flush_[device] = false;
+            if (device_intermediate_streams_force_flush_[device_id]) {
+                TransferIntermediateStreamsToOutputStreamAndFlush(device_id);
+                device_intermediate_streams_force_flush_[device_id] = false;
             }
             device_intermediate_streams_force_flush_lock_.unlock();
             for (auto& logical_core : device_and_cores.second) {
-                int risc_count = GetNumRiscs(logical_core);
+                int risc_count = tt::tt_metal::GetNumRiscs(logical_core);
                 for (int risc_index = 0; risc_index < risc_count; risc_index++) {
                     if (RiscEnabled(logical_core, risc_index)) {
                         try {
                             new_data_this_iter |=
-                                PeekOneHartNonBlocking(device, logical_core, risc_index, new_data_this_iter);
+                                PeekOneHartNonBlocking(device_id, logical_core, risc_index, new_data_this_iter);
                         } catch (std::runtime_error& e) {
                             // Depending on if test mode is enabled, catch and stop server, or
                             // re-throw the exception.
@@ -1220,8 +1220,7 @@ void DebugPrintServerContext::PollPrintData() {
     }
 }  // PollPrintData
 
-void DebugPrintServerContext::TransferIntermediateStreamsToOutputStreamAndFlush(IDevice* device) {
-    const chip_id_t device_id = device->id();
+void DebugPrintServerContext::TransferIntermediateStreamsToOutputStreamAndFlush(chip_id_t device_id) {
     for (auto& [risc_key, intermediate_stream] : risc_to_intermediate_stream_) {
         const chip_id_t risc_key_device_id = get<0>(risc_key);
         if (device_id == risc_key_device_id) {
@@ -1295,9 +1294,9 @@ bool DebugPrintServerContext::ProfilerIsRunning = false;
 }  // namespace
 
 // Implementation for functions available from dprint_server.hpp.
-namespace tt {
+namespace tt::tt_metal {
 
-void DprintServerAttach(IDevice* device) {
+void DprintServerAttach(chip_id_t device_id) {
     // Skip if DPRINT not enabled, and make sure profiler is not running.
     if (!tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         return;
@@ -1312,12 +1311,12 @@ void DprintServerAttach(IDevice* device) {
     }
 
     // Add this device to the server
-    DebugPrintServerContext::inst->AttachDevice(device);
+    DebugPrintServerContext::inst->AttachDevice(device_id);
 }
 
-void DprintServerDetach(IDevice* device) {
+void DprintServerDetach(chip_id_t device_id) {
     if (DprintServerIsRunning()) {
-        DebugPrintServerContext::inst->DetachDevice(device);
+        DebugPrintServerContext::inst->DetachDevice(device_id);
 
         // Check if there's no devices left attached to the server, and close it if so.
         if (DebugPrintServerContext::inst->GetNumAttachedDevices() == 0) {
@@ -1363,8 +1362,8 @@ void DPrintServerClearSignals() {
         DebugPrintServerContext::inst->ClearSignals();
     }
 }
-bool DPrintServerReadsDispatchCores(IDevice* device) {
-    return DprintServerIsRunning() && DebugPrintServerContext::inst->ReadsDispatchCores(device);
+bool DPrintServerReadsDispatchCores(chip_id_t device_id) {
+    return DprintServerIsRunning() && DebugPrintServerContext::inst->ReadsDispatchCores(device_id);
 }
 
-}  // namespace tt
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -8,11 +8,7 @@
 
 #pragma once
 
-namespace tt {
-
-namespace tt_metal {
-class IDevice;
-}  // namespace tt_metal
+namespace tt::tt_metal {
 
 /*
 @brief Attaches a device to be monitored by the print server. If no devices were present on the
@@ -23,7 +19,7 @@ class IDevice;
 
 This call is not thread safe, and there is only one instance of print server supported at a time.
 */
-void DprintServerAttach(tt::tt_metal::IDevice* device);
+void DprintServerAttach(chip_id_t device_id);
 
 /*
 @brief Detach a device so it is no longer monitored by the print server. If no devices are present
@@ -34,7 +30,7 @@ void DprintServerAttach(tt::tt_metal::IDevice* device);
 
 Note that this api call is not thread safe at the moment.
 */
-void DprintServerDetach(tt::tt_metal::IDevice* device);
+void DprintServerDetach(chip_id_t device_id);
 
 /**
 @brief Set device side profiler state.
@@ -90,6 +86,6 @@ void DPrintServerClearSignals();
 /**
 @brief Returns true if the DPRINT server reads any dispatch cores on a given device.
 */
-bool DPrintServerReadsDispatchCores(tt::tt_metal::IDevice* device);
+bool DPrintServerReadsDispatchCores(chip_id_t device_id);
 
-}  // namespace tt
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -14,7 +14,6 @@
 #include "hostdevcommon/dprint_common.h"
 #include "llrt.hpp"
 #include "rtoptions.hpp"
-#include <device.hpp>
 #include "llrt/tt_cluster.hpp"
 
 using namespace tt::tt_metal;
@@ -41,12 +40,13 @@ void PrintNocData(noc_data_t noc_data, const string& file_name) {
     outfile.close();
 }
 
-void DumpCoreNocData(IDevice* device, const CoreDescriptor& logical_core, noc_data_t& noc_data) {
-    CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+void DumpCoreNocData(chip_id_t device_id, const CoreDescriptor& logical_core, noc_data_t& noc_data) {
+    CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+        device_id, logical_core.coord, logical_core.type);
     for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
-        uint64_t addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
-        auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, addr, DPRINT_BUFFER_SIZE);
+        uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
+        auto from_dev = tt::llrt::read_hex_vec_from_core(device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
         DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
         uint32_t* data = reinterpret_cast<uint32_t*>(l->data);
 
@@ -57,38 +57,38 @@ void DumpCoreNocData(IDevice* device, const CoreDescriptor& logical_core, noc_da
     }
 }
 
-void DumpDeviceNocData(IDevice* device, noc_data_t& noc_data, noc_data_t& dispatch_noc_data) {
+void DumpDeviceNocData(chip_id_t device_id, noc_data_t& noc_data, noc_data_t& dispatch_noc_data) {
     // Need to treat dispatch cores and normal cores separately, so keep track of which cores are dispatch.
-    CoreDescriptorSet dispatch_cores = GetDispatchCores(device->id());
+    CoreDescriptorSet dispatch_cores = GetDispatchCores(device_id);
 
     // Now go through all cores on the device, and dump noc data for them.
-    CoreDescriptorSet all_cores = GetAllCores(device->id());
+    CoreDescriptorSet all_cores = GetAllCores(device_id);
     for (const CoreDescriptor& logical_core : all_cores) {
         if (dispatch_cores.count(logical_core)) {
-            DumpCoreNocData(device, logical_core, dispatch_noc_data);
+            DumpCoreNocData(device_id, logical_core, dispatch_noc_data);
         } else {
-            DumpCoreNocData(device, logical_core, noc_data);
+            DumpCoreNocData(device_id, logical_core, noc_data);
         }
     }
 }
 
-void DumpNocData(const std::vector<IDevice*>& devices) {
+void DumpNocData(const std::vector<chip_id_t>& devices) {
     // Skip if feature is not enabled
     if (!tt::llrt::RunTimeOptions::get_instance().get_record_noc_transfers()) {
         return;
     }
 
     noc_data_t noc_data = {}, dispatch_noc_data = {};
-    for (IDevice* device : devices) {
-        log_info("Dumping noc data for Device {}...", device->id());
-        DumpDeviceNocData(device, noc_data, dispatch_noc_data);
+    for (chip_id_t device_id : devices) {
+        log_info("Dumping noc data for Device {}...", device_id);
+        DumpDeviceNocData(device_id, noc_data, dispatch_noc_data);
     }
 
     PrintNocData(noc_data, "noc_data.txt");
     PrintNocData(dispatch_noc_data, "dispatch_noc_data.txt");
 }
 
-void ClearNocData(IDevice* device) {
+void ClearNocData(chip_id_t device_id) {
     // Skip if feature is not enabled
     if (!tt::llrt::RunTimeOptions::get_instance().get_record_noc_transfers()) {
         return;
@@ -99,13 +99,14 @@ void ClearNocData(IDevice* device) {
         tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) == false,
         "NOC transfer recording is incompatible with DPRINT");
 
-    CoreDescriptorSet all_cores = GetAllCores(device->id());
+    CoreDescriptorSet all_cores = GetAllCores(device_id);
     for (const CoreDescriptor& logical_core : all_cores) {
-        CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
+        CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
         for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
-            uint64_t addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
+            uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
-            tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, initbuf, addr);
+            tt::llrt::write_hex_vec_to_core(device_id, virtual_core, initbuf, addr);
         }
     }
 }

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -12,9 +12,10 @@
 
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"
-#include <device.hpp>
 #include "llrt.hpp"
 #include "rtoptions.hpp"
+#include <device.hpp>
+#include "llrt/tt_cluster.hpp"
 
 using namespace tt::tt_metal;
 
@@ -42,9 +43,9 @@ void PrintNocData(noc_data_t noc_data, const string& file_name) {
 
 void DumpCoreNocData(IDevice* device, const CoreDescriptor& logical_core, noc_data_t& noc_data) {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-    for (int risc_id = 0; risc_id < GetNumRiscs(device, logical_core); risc_id++) {
+    for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
-        uint64_t addr = GetDprintBufAddr(device, virtual_core, risc_id);
+        uint64_t addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
         auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), virtual_core, addr, DPRINT_BUFFER_SIZE);
         DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
         uint32_t* data = reinterpret_cast<uint32_t*>(l->data);
@@ -58,10 +59,10 @@ void DumpCoreNocData(IDevice* device, const CoreDescriptor& logical_core, noc_da
 
 void DumpDeviceNocData(IDevice* device, noc_data_t& noc_data, noc_data_t& dispatch_noc_data) {
     // Need to treat dispatch cores and normal cores separately, so keep track of which cores are dispatch.
-    CoreDescriptorSet dispatch_cores = GetDispatchCores(device);
+    CoreDescriptorSet dispatch_cores = GetDispatchCores(device->id());
 
     // Now go through all cores on the device, and dump noc data for them.
-    CoreDescriptorSet all_cores = GetAllCores(device);
+    CoreDescriptorSet all_cores = GetAllCores(device->id());
     for (const CoreDescriptor& logical_core : all_cores) {
         if (dispatch_cores.count(logical_core)) {
             DumpCoreNocData(device, logical_core, dispatch_noc_data);
@@ -98,11 +99,11 @@ void ClearNocData(IDevice* device) {
         tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) == false,
         "NOC transfer recording is incompatible with DPRINT");
 
-    CoreDescriptorSet all_cores = GetAllCores(device);
+    CoreDescriptorSet all_cores = GetAllCores(device->id());
     for (const CoreDescriptor& logical_core : all_cores) {
         CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core.coord, logical_core.type);
-        for (int risc_id = 0; risc_id < GetNumRiscs(device, logical_core); risc_id++) {
-            uint64_t addr = GetDprintBufAddr(device, virtual_core, risc_id);
+        for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
+            uint64_t addr = GetDprintBufAddr(device->id(), virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
             tt::llrt::write_hex_vec_to_core(device->id(), virtual_core, initbuf, addr);
         }

--- a/tt_metal/impl/debug/noc_logging.hpp
+++ b/tt_metal/impl/debug/noc_logging.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <device.hpp>
+#include <host_api.hpp>
 
 namespace tt {
-void ClearNocData(tt_metal::IDevice* device);
-void DumpNocData(const std::vector<tt_metal::IDevice*>& devices);
+void ClearNocData(chip_id_t device_id);
+void DumpNocData(const std::vector<chip_id_t>& device_ids);
 }  // namespace tt

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -14,7 +14,6 @@
 #include <utility>
 #include <vector>
 #include <core_coord.hpp>
-#include <device.hpp>
 #include "umd/device/tt_soc_descriptor.h"
 #include <hal.hpp>
 
@@ -22,9 +21,6 @@
 #include <dev_msgs.h>
 
 namespace tt::watcher {
-
-#define GET_WATCHER_DEV_ADDR_FOR_CORE(dev, core, sub_type) \
-    (dev->get_dev_addr(core, HalL1MemAddrType::WATCHER) + offsetof(watcher_msg_t, sub_type))
 
 constexpr uint64_t DEBUG_SANITIZE_NOC_SENTINEL_OK_64 = 0xbadabadabadabada;
 constexpr uint32_t DEBUG_SANITIZE_NOC_SENTINEL_OK_32 = 0xbadabada;
@@ -42,7 +38,7 @@ class WatcherDeviceReader {
 public:
     WatcherDeviceReader(
         FILE* f,
-        tt_metal::IDevice* device,
+        chip_id_t device_id,
         std::vector<std::string>& kernel_names,
         void (*set_watcher_exception_message)(const std::string&));
     ~WatcherDeviceReader();
@@ -69,7 +65,7 @@ private:
     std::string GetKernelName(CoreDescriptor& core, const launch_msg_t* launch_msg, uint32_t type);
 
     FILE* f;
-    tt_metal::IDevice* device;
+    chip_id_t device_id;
     std::vector<std::string>& kernel_names;
     void (*set_watcher_exception_message)(const std::string&);
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -35,7 +35,7 @@ static std::atomic<bool> enabled = false;
 static std::atomic<bool> server_running = false;
 static std::atomic<int> dump_count = 0;
 static std::mutex watch_mutex;
-static std::map<IDevice*, watcher::WatcherDeviceReader> devices;
+static std::map<chip_id_t, watcher::WatcherDeviceReader> devices;
 static string logfile_path = "generated/watcher/";
 static string logfile_name = "watcher.log";
 static FILE* logfile = nullptr;
@@ -203,7 +203,7 @@ static void watcher_loop(int sleep_usecs) {
 
 }  // namespace watcher
 
-void watcher_init(IDevice* device) {
+void watcher_init(chip_id_t device_id) {
     std::vector<uint32_t> watcher_init_val;
     watcher_init_val.resize(sizeof(watcher_msg_t) / sizeof(uint32_t), 0);
     watcher_msg_t* data = reinterpret_cast<watcher_msg_t*>(&(watcher_init_val[0]));
@@ -258,7 +258,7 @@ void watcher_init(IDevice* device) {
          delay_feature = (tt::llrt::RunTimeDebugFeatures)((int)delay_feature + 1)) {
         std::vector<chip_id_t> chip_ids = tt::llrt::RunTimeOptions::get_instance().get_feature_chip_ids(delay_feature);
         bool this_chip_enabled = tt::llrt::RunTimeOptions::get_instance().get_feature_all_chips(delay_feature) ||
-                                 std::find(chip_ids.begin(), chip_ids.end(), device->id()) != chip_ids.end();
+                                 std::find(chip_ids.begin(), chip_ids.end(), device_id) != chip_ids.end();
         if (this_chip_enabled) {
             static_assert(sizeof(debug_sanitize_noc_addr_msg_t) % sizeof(uint32_t) == 0);
             debug_insert_delays_msg_t delay_setup;
@@ -283,7 +283,8 @@ void watcher_init(IDevice* device) {
                     CoreCoord virtual_core;
                     bool valid_logical_core = true;
                     try {
-                        virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
+                        virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+                            device_id, logical_core, core_type);
                     } catch (std::runtime_error& error) {
                         valid_logical_core = false;
                     }
@@ -306,7 +307,7 @@ void watcher_init(IDevice* device) {
                             tt::tt_metal::get_core_type_name(core_type),
                             logical_core.str(),
                             valid_logical_core ? virtual_core.str() : "INVALID",
-                            device->id(),
+                            device_id,
                             tt::llrt::RunTimeDebugFeatureNames[delay_feature]);
                     }
                 }
@@ -320,7 +321,7 @@ void watcher_init(IDevice* device) {
             tt::LogMetal,
             "Configured Watcher debug delays for device {}, core {}: read_delay_cores_mask=0x{:x}, "
             "write_delay_cores_mask=0x{:x}, atomic_delay_cores_mask=0x{:x}. Delay cycles: {}",
-            device->id(),
+            device_id,
             delay.first.str().c_str(),
             delay.second.read_delay_riscv_mask,
             delay.second.write_delay_riscv_mask,
@@ -334,18 +335,19 @@ void watcher_init(IDevice* device) {
     // cores from that to consolidate the loops below
 
     // Initialize worker cores debug values
-    CoreCoord grid_size = device->logical_grid_size();
+    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord logical_core(x, y);
-            CoreCoord worker_core = device->worker_core_from_logical_core(logical_core);
+            CoreCoord worker_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+                device_id, logical_core, CoreType::WORKER);
             if (debug_delays_val.find(worker_core) != debug_delays_val.end()) {
                 data->debug_insert_delays = debug_delays_val[worker_core];
             } else {
                 data->debug_insert_delays = debug_delays_val_zero;
             }
             tt::llrt::write_hex_vec_to_core(
-                device->id(),
+                device_id,
                 worker_core,
                 tt::stl::Span<const uint32_t>(watcher_init_val.data(), watcher_init_val.size()),
                 GET_WATCHER_TENSIX_DEV_ADDR());
@@ -353,33 +355,31 @@ void watcher_init(IDevice* device) {
     }
 
     // Initialize ethernet cores debug values
-    for (const CoreCoord& eth_core : device->ethernet_cores()) {
-        // Mailbox address is different depending on active vs inactive eth cores.
-        bool is_active_eth_core;
-        if (device->is_active_ethernet_core(eth_core)) {
-            is_active_eth_core = true;
-        } else if (device->is_inactive_ethernet_core(eth_core)) {
-            is_active_eth_core = false;
-        } else {
-            continue;
-        }
-        CoreCoord virtual_core = device->ethernet_core_from_logical_core(eth_core);
+    auto init_eth_debug_values = [&](const CoreCoord& eth_core, bool is_active_eth_core) {
+        CoreCoord virtual_core =
+            tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(device_id, eth_core, CoreType::ETH);
         if (debug_delays_val.find(virtual_core) != debug_delays_val.end()) {
             data->debug_insert_delays = debug_delays_val[virtual_core];
         } else {
             data->debug_insert_delays = debug_delays_val_zero;
         }
         tt::llrt::write_hex_vec_to_core(
-            device->id(),
+            device_id,
             virtual_core,
             watcher_init_val,
             is_active_eth_core ? GET_WATCHER_ERISC_DEV_ADDR() : GET_WATCHER_IERISC_DEV_ADDR());
+    };
+    for (const CoreCoord& active_eth_core : tt::Cluster::instance().get_active_ethernet_cores(device_id)) {
+        init_eth_debug_values(active_eth_core, true);
+    }
+    for (const CoreCoord& inactive_eth_core : tt::Cluster::instance().get_inactive_ethernet_cores(device_id)) {
+        init_eth_debug_values(inactive_eth_core, false);
     }
 
-    log_debug(LogLLRuntime, "Watcher initialized device {}", device->id());
+    log_debug(LogLLRuntime, "Watcher initialized device {}", device_id);
 }
 
-void watcher_attach(IDevice* device) {
+void watcher_attach(chip_id_t device_id) {
     const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
 
     if (!watcher::enabled && tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
@@ -398,31 +398,31 @@ void watcher_attach(IDevice* device) {
     }
 
     if (watcher::logfile != nullptr) {
-        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), device->id());
+        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), device_id);
     }
 
     if (watcher::enabled) {
-        log_info(LogLLRuntime, "Watcher attached device {}", device->id());
+        log_info(LogLLRuntime, "Watcher attached device {}", device_id);
     }
 
     // Always register the device w/ watcher, even if disabled
     // This allows dump() to be called from debugger
     watcher::devices.emplace(
-        device,
+        device_id,
         watcher::WatcherDeviceReader(
-            watcher::logfile, device, watcher::kernel_names, &watcher::set_watcher_exception_message));
+            watcher::logfile, device_id, watcher::kernel_names, &watcher::set_watcher_exception_message));
 }
 
-void watcher_detach(IDevice* old) {
+void watcher_detach(chip_id_t device_id) {
     {
         const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
 
-        TT_ASSERT(watcher::devices.find(old) != watcher::devices.end());
+        TT_ASSERT(watcher::devices.find(device_id) != watcher::devices.end());
         if (watcher::enabled && watcher::logfile != nullptr) {
-            log_info(LogLLRuntime, "Watcher detached device {}", old->id());
-            fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), old->id());
+            log_info(LogLLRuntime, "Watcher detached device {}", device_id);
+            fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), device_id);
         }
-        watcher::devices.erase(old);
+        watcher::devices.erase(device_id);
         if (watcher::enabled && watcher::devices.empty()) {
             // If no devices remain, shut down the watcher server.
             watcher::enabled = false;

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -3,21 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-
-#include <device.hpp>
+#include <string>
+#include <core_coord.hpp>
+#include <system_memory_manager.hpp>  // For chip_id_t
 
 struct metal_SocDescriptor;
 
 namespace tt {
 
-void watcher_init(tt_metal::IDevice* device);
-void watcher_attach(tt_metal::IDevice* device);
-void watcher_detach(tt_metal::IDevice* dev);
+void watcher_init(chip_id_t device_id);
+void watcher_attach(chip_id_t device_id);
+void watcher_detach(chip_id_t device_id);
 
 void watcher_sanitize_host_noc_read(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 void watcher_sanitize_host_noc_write(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 
-int watcher_register_kernel(const string& name);
+int watcher_register_kernel(const std::string& name);
 
 // Helper functions for manually dumping watcher contents.
 void watcher_dump();
@@ -35,7 +36,7 @@ std::string get_watcher_exception_message();
 void watcher_clear_log();
 
 // Helper function to get the current watcher log file name/path
-string watcher_get_log_file_name();
+std::string watcher_get_log_file_name();
 
 // Helper function to get the current watcher dump count
 int watcher_get_dump_count();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1032,7 +1032,7 @@ bool Device::close() {
     llrt::internal_::wait_until_cores_done(mmio_device_id, RUN_MSG_GO, wait_for_cores);
 
     DprintServerDetach(this->id());
-    watcher_detach(this);
+    watcher_detach(this->id());
 
     // Assert worker cores
     CoreCoord grid_size = this->logical_grid_size();
@@ -1123,24 +1123,6 @@ CoreCoord Device::compute_with_storage_grid_size() const {
     return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_config);
 }
 
-CoreType Device::core_type_from_physical_core(const CoreCoord &physical_coord) const {
-    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    CoreType core_type = soc_desc.translate_coord_to(physical_coord, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type;
-    if (core_type == CoreType::TENSIX) {
-        core_type = CoreType::WORKER;
-    }
-    return core_type;
-}
-
-CoreType Device::core_type_from_virtual_core(const CoreCoord &virtual_coord) const {
-    if (tt::Cluster::instance().is_worker_core(virtual_coord, this->id_)) {
-        return CoreType::WORKER;
-    } else if (tt::Cluster::instance().is_ethernet_core(virtual_coord, this->id_)) {
-        return CoreType::ETH;
-    }
-    return this->core_type_from_physical_core(virtual_coord);
-}
-
 CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
     if (coord.x >= this->grid_size().x || coord.y >= this->grid_size().y) {
         // Coordinate already in virtual space: NOC0 and NOC1 are the same
@@ -1155,23 +1137,6 @@ CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) co
             hal.noc_coordinate(noc_index, grid_size.y, coord.y)
         };
         return virtual_coord;
-    }
-}
-
-CoreCoord Device::virtual_noc_coordinate(uint8_t noc_index, CoreCoord coord) const {
-     if (coord.x >= this->grid_size().x || coord.y >= this->grid_size().y) {
-        // Coordinate already in virtual space: NOC0 and NOC1 are the same
-        return coord;
-    } else {
-        const auto& grid_size = this->grid_size();
-        // Coordinate passed in can be NOC0 or NOC1. The noc_index corresponds to
-        // the system this coordinate belongs to.
-        // Use this to convert to NOC0 coordinates and then derive Virtual Coords from it.
-        CoreCoord physical_coord = {
-            hal.noc_coordinate(noc_index, grid_size.x, coord.x),
-            hal.noc_coordinate(noc_index, grid_size.y, coord.y)
-        };
-        return this->virtual_core_from_physical_core(physical_coord);
     }
 }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1031,7 +1031,7 @@ bool Device::close() {
 
     llrt::internal_::wait_until_cores_done(mmio_device_id, RUN_MSG_GO, wait_for_cores);
 
-    DprintServerDetach(this);
+    DprintServerDetach(this->id());
     watcher_detach(this);
 
     // Assert worker cores

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -274,7 +274,7 @@ void DevicePool::initialize_host(IDevice* dev) const {
 
     ClearNocData(dev->id());
     DprintServerAttach(dev->id());
-    watcher_init(dev);
+    watcher_init(dev->id());
 
     // TODO: as optimization, investigate removing all this call for already initialized devivces
     if (!llrt::RunTimeOptions::get_instance().get_skip_reset_cores_on_init()) {
@@ -282,7 +282,7 @@ void DevicePool::initialize_host(IDevice* dev) const {
     }
     dev->initialize_and_launch_firmware();
 
-    watcher_attach(dev);
+    watcher_attach(dev->id());
 }
 
 void DevicePool::initialize_active_devices() const {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -273,7 +273,7 @@ void DevicePool::initialize_host(IDevice* dev) const {
     }
 
     ClearNocData(dev->id());
-    DprintServerAttach(dev);
+    DprintServerAttach(dev->id());
     watcher_init(dev);
 
     // TODO: as optimization, investigate removing all this call for already initialized devivces

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -272,7 +272,7 @@ void DevicePool::initialize_host(IDevice* dev) const {
         TT_ASSERT(dev->num_hw_cqs() == 1, "num_hw_cqs must be 1 in slow dispatch");
     }
 
-    ClearNocData(dev);
+    ClearNocData(dev->id());
     DprintServerAttach(dev);
     watcher_init(dev);
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -171,6 +171,8 @@ public:
 
     DispatchCoreConfig get_dispatch_core_config();
 
+    uint8_t get_num_hw_cqs() { return this->num_hw_cqs; }
+
     // TODO: remove this API, we should read the core descriptor once, should not have backdoors like this to add cores
     void add_dispatch_core_to_device(chip_id_t device_id, const CoreCoord& core);
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -124,7 +124,7 @@ void FDKernel::configure_kernel_variant(
     if (tt::llrt::RunTimeOptions::get_instance().watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (!tt::DPrintServerReadsDispatchCores(device_)) {
+    if (!DPrintServerReadsDispatchCores(device_->id())) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }
     defines.insert(defines_in.begin(), defines_in.end());

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -17,6 +17,7 @@
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include <utils.hpp>
 #include <core_coord.hpp>
+#include <device.hpp>
 #include "tt_metal/jit_build/genfiles.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "hw/inc/wormhole/eth_l1_address_map.h"

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -61,7 +61,7 @@ void dump_data(
         }
         // Watcher attach wthout watcher init - to avoid clearing mailboxes.
         if (dump_watcher) {
-            watcher_attach(device);
+            watcher_attach(device->id());
         }
     }
 

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -19,7 +19,7 @@ string output_dir_name = "generated/watcher/";
 string logfile_name = "cq_dump.txt";
 
 void dump_data(
-    vector<unsigned>& device_ids,
+    vector<chip_id_t>& device_ids,
     bool dump_watcher,
     bool dump_cqs,
     bool dump_cqs_raw_data,
@@ -46,7 +46,7 @@ void dump_data(
 
     // Only look at user-specified devices
     vector<IDevice*> devices;
-    for (unsigned id : device_ids) {
+    for (chip_id_t id : device_ids) {
         string cq_fname = cq_dir.string() + fmt::format("device_{}_completion_q.txt", id);
         std::ofstream cq_file = std::ofstream(cq_fname);
         string iq_fname = cq_dir.string() + fmt::format("device_{}_issue_q.txt", id);
@@ -73,7 +73,7 @@ void dump_data(
 
     // Dump noc data if requested
     if (dump_noc_xfers) {
-        DumpNocData(devices);
+        DumpNocData(device_ids);
     }
 }
 
@@ -98,9 +98,9 @@ void print_usage(const char* exec_name) {
 int main(int argc, char* argv[]) {
     cout << "Running watcher dump tool..." << endl;
     // Default devices is all of them.
-    vector<unsigned> device_ids;
+    vector<chip_id_t> device_ids;
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
-    for (unsigned id = 0; id < num_devices; id++) {
+    for (chip_id_t id = 0; id < num_devices; id++) {
         device_ids.push_back(id);
     }
 


### PR DESCRIPTION
As part of removing init dependencies on Device object, do so for watcher/dprint/noc dump. Just use device_id and directly call Cluster functions for these.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/13916175482
https://github.com/tenstorrent/tt-metal/actions/runs/13933480320