### PR TITLE
Making circular buffers contiguous by assigning them dynamically in pool program factories  

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
@@ -18,12 +18,16 @@
 
 template <uint32_t num_output_tiles, bool is_partial_tile, uint32_t split_reader, uint32_t unpA_face_r_dim>
 inline void reduce_h_fused(
-    const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t in_stick_index, const uint32_t out_cb_id) {
+    const uint32_t in_cb_id_0,
+    const uint32_t in_cb_id_1,
+    const uint32_t in_scalar_cb_id,
+    const uint32_t in_stick_index,
+    const uint32_t out_cb_id) {
     constexpr uint32_t num_faces_in_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
 
     cb_reserve_back(out_cb_id, num_output_tiles);
-    const uint32_t curr_in_cb_id = split_reader ? (in_cb_id + (in_stick_index & 0x1)) : in_cb_id;
+    const uint32_t curr_in_cb_id = (split_reader && (in_stick_index & 0x1)) ? in_cb_id_1 : in_cb_id_0;
     cb_wait_front(curr_in_cb_id, 1);
     tile_regs_acquire();
     unpack_tilizeA_B_block(
@@ -61,9 +65,10 @@ void MAIN {
     constexpr uint32_t in_c = get_compile_time_arg_val(14);
     constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(15);
 
-    constexpr uint32_t in_cb_id = tt::CBIndex::c_0;  // and CBIndex::c_1 for split reader
-    constexpr uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
-    constexpr uint32_t out_cb_id = tt::CBIndex::c_16;
+    const uint32_t in_cb_id_0 = get_compile_time_arg_val(17);
+    const uint32_t in_cb_id_1 = get_compile_time_arg_val(18);
+    const uint32_t in_scalar_cb_id = get_compile_time_arg_val(19);
+    const uint32_t out_cb_id = get_compile_time_arg_val(20);
 
     constexpr bool is_partial_tile = in_c < 32;
     static_assert((!is_partial_tile || (in_c == 16)), "Partial tile must have c_dim 16");
@@ -76,7 +81,8 @@ void MAIN {
         in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
-    tilizeA_B_reduce_init(in_cb_id, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
+    tilizeA_B_reduce_init(
+        in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
     pack_untilize_dst_init_short<in_ntiles_c>(out_cb_id, num_out_rows, num_faces_in_tile);
 
     cb_wait_front(in_scalar_cb_id, 1);
@@ -84,11 +90,11 @@ void MAIN {
         // perform the reduction over the first N - 1 whole chunks
         for (uint32_t b_i = 0; b_i < in_nblocks_c - 1; ++b_i) {
             reduce_h_fused<max_tiles_per_iter, is_partial_tile, split_reader, window_size_hw>(
-                in_cb_id, in_scalar_cb_id, i, out_cb_id);
+                in_cb_id_0, in_cb_id_1, in_scalar_cb_id, i, out_cb_id);
         }
         // perform the reduction over the either whole or partial chunk N
         reduce_h_fused<partial_iter_output_tiles, is_partial_tile, split_reader, window_size_hw>(
-            in_cb_id, in_scalar_cb_id, i, out_cb_id);
+            in_cb_id_0, in_cb_id_1, in_scalar_cb_id, i, out_cb_id);
     }
     cb_pop_front(in_scalar_cb_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
@@ -65,11 +65,11 @@ void kernel_main() {
     constexpr uint32_t MAX_ELE_PER_REDUCTION = 512;  // TILE_WIDTH * 8 * numbytes
     constexpr uint32_t ROW_HW = 64;
 
-    constexpr uint32_t in_cb_id = (reader_id == 1) ? tt::CBIndex::c_1 : tt::CBIndex::c_0;
-    constexpr uint32_t in_shard_cb_id = tt::CBIndex::c_2;  // local input shard
-    constexpr uint32_t in_reader_indices_cb_id = tt::CBIndex::c_3;
-    constexpr uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
-    constexpr uint32_t interm_reduction_cb_id = tt::CBIndex::c_25;
+    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
+    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t interm_reduction_cb_id = get_compile_time_arg_val(21);
 
     // minus infinity for bfp16
     uint16_t minus_inf = 63487;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_v2.cpp
@@ -57,10 +57,10 @@ void kernel_main() {
 
     constexpr uint32_t TILE_WIDTH = 32;
 
-    constexpr uint32_t in_cb_id = (reader_id == 1) ? tt::CBIndex::c_1 : tt::CBIndex::c_0;
-    constexpr uint32_t in_shard_cb_id = tt::CBIndex::c_2;  // local input shard
-    constexpr uint32_t in_reader_indices_cb_id = tt::CBIndex::c_3;
-    constexpr uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
+    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
+    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
 
     constexpr uint32_t ROW_HW = 64;
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_wide.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_wide.cpp
@@ -60,10 +60,10 @@ void kernel_main() {
     constexpr uint32_t TILE_WIDTH = 32;
     constexpr uint32_t MAX_ELE_PER_REDUCTION = 512;  // TILE_WIDTH * 8 * numbytes
 
-    constexpr uint32_t in_cb_id = (reader_id == 1) ? tt::CBIndex::c_1 : tt::CBIndex::c_0;
-    constexpr uint32_t in_shard_cb_id = tt::CBIndex::c_2;  // local input shard
-    constexpr uint32_t in_reader_indices_cb_id = tt::CBIndex::c_3;
-    constexpr uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
+    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
+    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
+    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
 
     constexpr uint32_t ROW_HW = 64;
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "pool_op.hpp"
 #include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/circular_buffer_types.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"  // for reduce_op_utils
 #include <tt-metalium/math.hpp>
 
@@ -116,45 +117,45 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     using tt::tt_metal::CBHandle;
     using tt::tt_metal::CircularBuffer;
     using tt::tt_metal::CircularBufferConfig;
-    uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
+
+    uint32_t next_cb_index = tt::CBIndex::c_0;
+    uint32_t in_scalar_cb_id = next_cb_index++;
     uint32_t in_scalar_cb_pagesize = tile_size(in_df);
     uint32_t in_scalar_cb_npages = 1;
-    CircularBufferConfig in_scalar_cb_config =
-        CircularBufferConfig(in_scalar_cb_npages * in_scalar_cb_pagesize, {{in_scalar_cb_id, in_df}})
-            .set_page_size(in_scalar_cb_id, in_scalar_cb_pagesize);
-    auto in_scalar_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_scalar_cb_config);
+
+    tt::tt_metal::create_cb(in_scalar_cb_id, program, all_cores, in_scalar_cb_pagesize, in_scalar_cb_npages, in_df);
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_scalar_cb_id, in_scalar_cb_pagesize, in_scalar_cb_npages);
 
     // incoming data is the input cb instead of raw l1/dram addr
     // this input shard has halo and padding inserted.
-    auto raw_in_cb_id = tt::CBIndex::c_2;
     uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
     uint32_t raw_in_cb_pagesize = in_nbytes_c;
-    CircularBufferConfig raw_in_cb_config =
-        CircularBufferConfig(raw_in_cb_npages * raw_in_cb_pagesize, {{raw_in_cb_id, in_df}})
-            .set_page_size(raw_in_cb_id, raw_in_cb_pagesize)
-            .set_globally_allocated_address(*input.buffer());
-    auto raw_in_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, raw_in_cb_config);
+    auto [raw_in_cb_id, raw_in_cb] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, raw_in_cb_pagesize, raw_in_cb_npages, in_df, input.buffer());
+
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages);
 
     // reader indices
-    auto in_reader_indices_cb_id = tt::CBIndex::c_3;
+    uint32_t in_reader_indices_cb_id = next_cb_index++;
     uint32_t in_reader_indices_cb_pagesize =
         tt::round_up(out_nhw_per_core * indices_nbytes, 4);  // pagesize needs to be multiple of 4
     uint32_t in_reader_indices_cb_npages = 1;
+
+    tt::tt_metal::create_cb(
+        in_reader_indices_cb_id,
+        program,
+        all_cores,
+        in_reader_indices_cb_pagesize,
+        in_reader_indices_cb_npages,
+        indices_df,
+        &*reader_indices_buffer);
+
     log_debug(
         tt::LogOp,
         "CB {} :: PS = {}, NP = {}",
         in_reader_indices_cb_id,
         in_reader_indices_cb_pagesize,
         in_reader_indices_cb_npages);
-    CircularBufferConfig in_reader_indices_cb_config =
-        CircularBufferConfig(
-            in_reader_indices_cb_npages * in_reader_indices_cb_pagesize, {{in_reader_indices_cb_id, indices_df}})
-            .set_page_size(in_reader_indices_cb_id, in_reader_indices_cb_pagesize)
-            .set_globally_allocated_address(*reader_indices_buffer);
-    auto in_reader_indices_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_reader_indices_cb_config);
-
     uint32_t in_cb_sz = 0;
     uint32_t in_nblocks_c = 1;
     if (is_wide_reduction) {
@@ -163,51 +164,51 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     } else {
         in_cb_sz = in_ntiles_c * tt::constants::TILE_HW;
     }
+
     // reader output == input to tilize
-    uint32_t in_cb_id_0 = tt::CBIndex::c_0;  // input rows for "multiple (out_nelems)" output pixels
-    uint32_t in_cb_id_1 = tt::CBIndex::c_1;  // input rows for "multiple (out_nelems)" output pixels
+    uint32_t in_cb_id_0 = next_cb_index++;  // input rows for "multiple (out_nelems)" output pixels
+    uint32_t in_cb_id_1 = 32;               // input rows for "multiple (out_nelems)" output pixels
     uint32_t in_cb_page_padded = tt::round_up(
         in_cb_sz,
         tt::constants::TILE_HW);  // NOTE: ceil to tile size since triscs work with tilesize instead of pagesize
     uint32_t in_cb_pagesize = in_nbytes * in_cb_page_padded;
     uint32_t in_cb_npages = multi_buffering_factor * nblocks;
 
-    CircularBufferConfig in_cb_config_0 = CircularBufferConfig(in_cb_npages * in_cb_pagesize, {{in_cb_id_0, in_df}})
-                                              .set_page_size(in_cb_id_0, in_cb_pagesize);
-    auto in_cb_0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_cb_config_0);
+    tt::tt_metal::create_cb(in_cb_id_0, program, all_cores, in_cb_pagesize, in_cb_npages, in_df);
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_0, in_cb_pagesize, in_cb_npages);
 
     if (split_reader) {
-        CircularBufferConfig in_cb_config_1 = CircularBufferConfig(in_cb_npages * in_cb_pagesize, {{in_cb_id_1, in_df}})
-                                                  .set_page_size(in_cb_id_1, in_cb_pagesize);
-        auto in_cb_1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, in_cb_config_1);
+        in_cb_id_1 = next_cb_index++;
+        tt::tt_metal::create_cb(in_cb_id_1, program, all_cores, in_cb_pagesize, in_cb_npages, in_df);
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_1, in_cb_pagesize, in_cb_npages);
     }
 
     // output of reduce == writer to write
-    uint32_t out_cb_id = tt::CBIndex::c_16;  // output rows in RM
+    // output rows in RM
     // after reduction
     uint32_t out_cb_pagesize = std::min(tt::constants::TILE_WIDTH, output.shard_spec().value().shape[1]) *
                                out_nbytes;  // there is just one row of channels after each reduction (or 1 block
                                             // of c if its greater than 8 tiles)
     uint32_t out_cb_npages = output.shard_spec().value().shape[0] * in_ntiles_c;
 
-    CircularBufferConfig cb_out_config = CircularBufferConfig(out_cb_npages * out_cb_pagesize, {{out_cb_id, out_df}})
-                                             .set_page_size(out_cb_id, out_cb_pagesize)
-                                             .set_globally_allocated_address(*output.buffer());
-    ;
-    auto cb_out = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+    auto [out_cb_id, cb_out] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, out_df, output.buffer());
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
 
+    // Invalid index for circular buffer, will report error if not assigned with valid value before creation
+    uint32_t max_pool_partials_cb_id = 32;
     if (is_large_kernel) {
-        uint32_t max_pool_partials_cb_id = tt::CBIndex::c_25;  // max_pool partials
+        max_pool_partials_cb_id = next_cb_index++;  // max_pool partials
         uint32_t max_pool_partials_cb_pagesize = out_cb_pagesize;
         uint32_t max_pool_partials_cb_npages = nblocks;
-        CircularBufferConfig max_pool_partials_cb_config =
-            CircularBufferConfig(
-                max_pool_partials_cb_npages * max_pool_partials_cb_pagesize, {{max_pool_partials_cb_id, out_df}})
-                .set_page_size(max_pool_partials_cb_id, max_pool_partials_cb_pagesize);
-        auto max_pool_partials_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, max_pool_partials_cb_config);
+
+        tt::tt_metal::create_cb(
+            max_pool_partials_cb_id,
+            program,
+            all_cores,
+            max_pool_partials_cb_pagesize,
+            max_pool_partials_cb_npages,
+            out_df);
         log_debug(
             tt::LogOp,
             "CB {} :: PS = {}, NP = {}",
@@ -285,7 +286,13 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_nblocks_c,
         in_cb_sz,
         max_rows_for_reduction,
-        ceil_pad_w};
+        ceil_pad_w,
+        in_cb_id_0,
+        in_cb_id_1,
+        raw_in_cb_id,
+        in_reader_indices_cb_id,
+        in_scalar_cb_id,
+        max_pool_partials_cb_id};
 
     std::vector<uint32_t> reader1_ct_args = {
         out_nhw_per_core,
@@ -303,7 +310,13 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_nblocks_c,
         in_cb_sz,
         max_rows_for_reduction,
-        ceil_pad_w};
+        ceil_pad_w,
+        in_cb_id_0,
+        in_cb_id_1,
+        raw_in_cb_id,
+        in_reader_indices_cb_id,
+        in_scalar_cb_id,
+        max_pool_partials_cb_id};
 
     std::string reader_kernel_fname;
     if (is_large_kernel) {
@@ -353,7 +366,12 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         out_nhw_per_core / nblocks,  // loop count with blocks
         input_shape[3] / num_shards_c,
         in_nblocks_c,
-        max_rows_for_reduction};
+        max_rows_for_reduction,
+        in_cb_id_0,
+        in_cb_id_1,
+        in_scalar_cb_id,
+        out_cb_id,
+        max_pool_partials_cb_id};
 
     auto reduce_op = tt::tt_metal::ReduceOpMath::MAX;
     auto reduce_dim = tt::tt_metal::ReduceOpDim::H;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -8,6 +8,7 @@
 #include "tt-metalium/circular_buffer_types.hpp"
 #include "upsample_op.hpp"
 #include "ttnn/operations/math.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
@@ -143,63 +144,54 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     using tt::tt_metal::CircularBuffer;
     using tt::tt_metal::CircularBufferConfig;
 
+    uint32_t next_cb_index = CBIndex::c_0;
     uint32_t buffering_factor = 2;
 
     // input data is in a sharded CB
-    uint32_t in_cb_id = CBIndex::c_0;
     uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
     uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
     uint32_t in_cb_npages = halo_shard_shape[0] * buffering_factor;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(in_cb_pagesize * in_cb_npages, {{in_cb_id, input_cb_data_format}})
-            .set_page_size(in_cb_id, in_cb_pagesize)
-            .set_globally_allocated_address(*halo_in.buffer());
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    auto [in_cb_id, cb_src0] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, halo_in.buffer());
 
     // intermediate tensor CB
-    uint32_t in_cb_id1 = CBIndex::c_1;
-    CircularBufferConfig cb_src1_config =
-        CircularBufferConfig(
-            4 * in_cb_pagesize * buffering_factor,  // since 4 pixels per page are needed for intermediate tensor.
-            {{in_cb_id1, input_cb_data_format}})
-            .set_page_size(in_cb_id1, in_cb_pagesize);
-    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    uint32_t in_cb_id1 = next_cb_index++;
+    tt::tt_metal::create_cb(
+        in_cb_id1,
+        program,
+        all_cores,
+        in_cb_pagesize,
+        4 * buffering_factor,
+        input_cb_data_format);  // since 4 pixels per page are needed for intermediate tensor.
 
     // intermediate tensor CB
-    uint32_t in_cb_id2 = CBIndex::c_2;
-    CircularBufferConfig cb_src2_config =
-        CircularBufferConfig(
-            4 * in_cb_pagesize * buffering_factor,  // since 4 pixels per page are needed for intermediate tensor.
-            {{in_cb_id2, input_cb_data_format}})
-            .set_page_size(in_cb_id2, in_cb_pagesize);
-    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
+    uint32_t in_cb_id2 = next_cb_index++;
+    tt::tt_metal::create_cb(
+        in_cb_id2,
+        program,
+        all_cores,
+        in_cb_pagesize,
+        4 * buffering_factor,
+        input_cb_data_format);  // since 4 pixels per page are needed for intermediate tensor.
 
     // scaler CB
     uint32_t in_scalar_cb_pagesize = tile_size(input_cb_data_format);
     uint32_t in_scalar_cb_npages = 1 * buffering_factor;
-    uint32_t in_scalar_cb_id1 = CBIndex::c_4;
-    CircularBufferConfig in_scalar_cb_config1 =
-        CircularBufferConfig(in_scalar_cb_npages * in_scalar_cb_pagesize, {{in_scalar_cb_id1, input_cb_data_format}})
-            .set_page_size(in_scalar_cb_id1, in_scalar_cb_pagesize);
 
-    auto in_scalar_cb1 = tt_metal::CreateCircularBuffer(program, all_cores, in_scalar_cb_config1);
+    uint32_t in_scalar_cb_id1 = next_cb_index++;
+    tt::tt_metal::create_cb(
+        in_scalar_cb_id1, program, all_cores, in_scalar_cb_pagesize, in_scalar_cb_npages, input_cb_data_format);
 
-    uint32_t in_scalar_cb_id2 = CBIndex::c_5;
-    CircularBufferConfig in_scalar_cb_config2 =
-        CircularBufferConfig(in_scalar_cb_npages * in_scalar_cb_pagesize, {{in_scalar_cb_id2, input_cb_data_format}})
-            .set_page_size(in_scalar_cb_id2, in_scalar_cb_pagesize);
+    uint32_t in_scalar_cb_id2 = next_cb_index++;
+    tt::tt_metal::create_cb(
+        in_scalar_cb_id2, program, all_cores, in_scalar_cb_pagesize, in_scalar_cb_npages, input_cb_data_format);
 
-    auto in_scalar_cb2 = tt_metal::CreateCircularBuffer(program, all_cores, in_scalar_cb_config2);
     // output sharded CB with upsampled data
-    uint32_t out_cb_id = CBIndex::c_16;
-    uint32_t aligned_output_stick_nbytes = round_up_to_mul32(output_stick_nbytes);
-    uint32_t out_cb_pagesize = aligned_output_stick_nbytes;
+    uint32_t out_cb_pagesize = round_up_to_mul32(output_stick_nbytes);  // aligned output stick n bytes
     uint32_t out_cb_npages = output_nsticks_per_core * buffering_factor;
-    CircularBufferConfig out_cb_config =
-        CircularBufferConfig(out_cb_pagesize * out_cb_npages, {{out_cb_id, output_cb_data_format}})
-            .set_page_size(out_cb_id, out_cb_pagesize)
-            .set_globally_allocated_address(*output.buffer());
-    auto out_cb = tt_metal::CreateCircularBuffer(program, all_cores, out_cb_config);
+    auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, output_cb_data_format, output.buffer());
 
     log_debug(LogOp, "input_cb: {}, npages: {}, pagesize: {}", in_cb_id, in_cb_npages, in_cb_pagesize);
     log_debug(LogOp, "output_cb: {}, npages: {}, pagesize: {}", out_cb_id, out_cb_npages, out_cb_pagesize);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -7,6 +7,7 @@
 #include <math.h>
 
 #include "upsample_op.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 
 #include <tt-metalium/host_api.hpp>
@@ -184,28 +185,21 @@ operation::ProgramWithCallbacks upsample_multi_core(
     // CBs
 
     uint32_t buffering_factor = 1;  // data is already fully buffered in the CBs since its sharded
-
+    uint32_t next_cb_index = CBIndex::c_0;
     // input data is in a sharded CB
-    uint32_t in_cb_id = CBIndex::c_0;
     uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
     uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
     uint32_t in_cb_npages = input_nsticks_per_core * buffering_factor;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(in_cb_pagesize * in_cb_npages, {{in_cb_id, input_cb_data_format}})
-            .set_page_size(in_cb_id, in_cb_pagesize)
-            .set_globally_allocated_address(*input.buffer());
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    auto [in_cb_id, cb_src0] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, input.buffer());
 
     // output sharded CB with upsampled data
-    uint32_t out_cb_id = CBIndex::c_16;
-    uint32_t aligned_output_stick_nbytes = round_up_to_mul32(output_stick_nbytes);
-    uint32_t out_cb_pagesize = aligned_output_stick_nbytes;
+    uint32_t out_cb_pagesize = round_up_to_mul32(output_stick_nbytes);  // aligned output stick n bytes
     uint32_t out_cb_npages = output_nsticks_per_core * buffering_factor;
-    CircularBufferConfig out_cb_config =
-        CircularBufferConfig(out_cb_pagesize * out_cb_npages, {{out_cb_id, output_cb_data_format}})
-            .set_page_size(out_cb_id, out_cb_pagesize)
-            .set_globally_allocated_address(*output.buffer());
-    auto out_cb = tt_metal::CreateCircularBuffer(program, all_cores, out_cb_config);
+
+    auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, output_cb_data_format, output.buffer());
 
     log_debug(LogOp, "input_cb: {}, npages: {}, pagesize: {}", in_cb_id, in_cb_npages, in_cb_pagesize);
     log_debug(LogOp, "output_cb: {}, npages: {}, pagesize: {}", out_cb_id, out_cb_npages, out_cb_pagesize);
@@ -246,11 +240,9 @@ operation::ProgramWithCallbacks upsample_multi_core(
     tt::DataFormat config_df = tt::DataFormat::RawUInt16;
     auto config_buffer = config_tensor_device.device_buffer();
     auto config_buffer_page_size = config_buffer->page_size();
-    uint32_t config_cb_id = CBIndex::c_6;
-    auto config_cb_config = CircularBufferConfig(config_buffer_page_size, {{config_cb_id, config_df}})
-                                .set_page_size(config_cb_id, config_buffer->page_size())
-                                .set_globally_allocated_address(*config_buffer);
-    CBHandle config_cb = CreateCircularBuffer(program, all_cores, config_cb_config);
+
+    auto [config_cb_id, config_cb] = tt::tt_metal::create_cb(
+        next_cb_index++, program, all_cores, config_buffer_page_size, 1, config_df, &*config_buffer);
 
     // Kernels
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
@@ -6,6 +6,7 @@
 
 #include "tt-metalium/hal.hpp"
 #include "upsample_op.hpp"
+#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 
 #include <tt-metalium/host_api.hpp>
@@ -38,14 +39,13 @@ operation::ProgramWithCallbacks upsample_single_core(
     tt_metal::IDevice* device = output.device();
 
     // circulat buffer for input
-    uint32_t src0_cb_index = CBIndex::c_0;
+    uint32_t next_cb_index = CBIndex::c_0;
+    uint32_t src0_cb_index = next_cb_index++;
     uint32_t num_input_units = 2;
     uint32_t aligned_input_unit_size = tt::round_up(input_unit_size, hal.get_alignment(HalMemType::DRAM));
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(
-            num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, aligned_input_unit_size);
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    tt::tt_metal::create_cb(
+        src0_cb_index, program, core, aligned_input_unit_size, num_input_units, input_cb_data_format);
 
     // circulat buffer same for input and output. No compute kernels.
     uint32_t output_cb_index = src0_cb_index;  // same as input cb


### PR DESCRIPTION
### Ticket
[18853](https://github.com/tenstorrent/tt-metal/issues/18853)

### Problem description
Circular buffer indices in pool op program factories are not sequential which is resulting in bunch of warnings that the fast dispatch is being hurt.

### What's changed
1. Making circular buffers contiguous by assigning them dynamically.
2. Passing CB indices as compile time arguments to the kernels.
3. Using create_cb util function for Circular Buffer creation.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13921256996)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/13921224336)
- [x] [(Single-card) Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/13895888945)