### PR TITLE
Fix arguments for distilbert test in Single-card Device perf

### DIFF
--- a/models/demos/wormhole/distilbert/tests/test_perf_distilbert.py
+++ b/models/demos/wormhole/distilbert/tests/test_perf_distilbert.py
@@ -179,7 +179,7 @@ def test_distilbert_perf_device(batch_size, test, reset_seeds):
     if ttnn.GetNumAvailableDevices() == 2:
         batch_size = batch_size * 2
 
-    command = f"pytest tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert_wh.py::test_distilbert_for_question_answering[silicon_arch_name=wormhole_b0-silicon_arch_wormhole_b0=True-sequence_size=768-batch_size=8-model_name=distilbert-base-uncased-distilled-squad]"
+    command = f"pytest tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert_wh.py::test_distilbert_for_question_answering"
 
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"


### PR DESCRIPTION
### Problem description
Single-card Device perf pipeline was failing due to distilbert and a file not found error: https://github.com/tenstorrent/tt-metal/actions/runs/13905388970/job/38907600215#step:9:4812

### What's changed
This was occurring due to fixture error, explained here: https://drive.google.com/file/d/1zx-haD_piQrtr6kfOTi43hijMW-yMm8U/view?ts=67d8a164
where the arguments passed don't match

The changes in this commit: f39460b on March 14, 2025 (https://github.com/tenstorrent/tt-metal/commit/f39460be0de6497075510e85f2dc8fbc1dd5f3ef)
requires the arguments passed in to be updated for the distilbert test

### Checklist
CI passes here: https://github.com/tenstorrent/tt-metal/actions/runs/13910748213