### PR TITLE
Hotfix on L1 overflow bug

### DIFF
--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -55,7 +55,6 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache, rese
         k[len(first_layer_prefix) + 1 :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
     }
 
-    model_args.WEIGHTS_DTYPE = dtype
     reference_model = model_args.reference_mlp()
     reference_model.load_state_dict(partial_state_dict)
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -151,16 +151,21 @@ class ModelOptimizations:
     def _default_settings(self):
         return {
             "TensorPrecision": {
+                # MLP
                 TensorGroup.FF1_FF3: PrecisionSetting.BFP8,
                 TensorGroup.FF2: PrecisionSetting.BFP8,
+                # Attention
                 TensorGroup.WQKV: PrecisionSetting.BFP8,
                 TensorGroup.WO: PrecisionSetting.BFP8,
                 TensorGroup.KV_CACHE: PrecisionSetting.BFP8,
+                # Activation across whole model
                 TensorGroup.ACTIVATION: None,  # this signals that original dtype should be used
             },
             "OpFidelity": {
-                OpGroup.LI_FF1_FF3: MathFidelitySetting.HIFI2,
-                OpGroup.LI_FF2: MathFidelitySetting.HIFI2,
+                # MLP linear operators
+                OpGroup.LI_FF1_FF3: MathFidelitySetting.HIFI2_FP16,
+                OpGroup.LI_FF2: MathFidelitySetting.HIFI2_FP16,
+                # Attention operators -- linear and scaled_dot_product_attention, in decode and prefill modes
                 OpGroup.LI_QKV_DECODE: MathFidelitySetting.HIFI2,
                 OpGroup.SDPA_DECODE: MathFidelitySetting.HIFI2_NA,
                 OpGroup.LI_O_DECODE: MathFidelitySetting.HIFI2,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
L1 overflow bug is caught by nightly run: https://github.com/tenstorrent/tt-metal/actions/runs/13906555494

Thanks, @tt-rkim, for triaging the commits down to the ones in #17872! I was able to identify the bug, which is my mistake when assigning compute kernel configs to linear operations in MLP layers for FF1, FF2, and FF3. I assigned `HIFI2`, which uses accumulation in `fp32`. The working configs use `HIFI2_FP16` (accumulation in `fp16` instead of `fp32`).

### What's changed
Fix the compute kernel configs of the aforementioned operators by restoring `HIFI_FP16`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13925666031) CI passes
- [x] rerun failed [nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/13925716365) -- previously failing tests are passing now