### PR TITLE
Fixes for slice, and torch style API

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -749,12 +749,12 @@ def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, dev
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
 
 
+@pytest.mark.xfail(reason="pytorch2 sweep test failures as of 2025-03")
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
-    (([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),),  # Difference in expected shape as it's a 1D tensor
+    (([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),),  # unaligned 1D
 )
 def test_pytorch2_failures(input_shape, dim, start, end, step, layout, device):
-    pytest.skip("These tests are known to fail")
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
 
     slice_obj = slice(start, end, step)
@@ -775,6 +775,7 @@ def test_pytorch2_failures(input_shape, dim, start, end, step, layout, device):
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
 
 
+# Op parameters from pytorch2 sweep tests that failed prior to 2025-03
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
     (

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -829,7 +829,6 @@ def test_slice_former_pytorch2_failures(input_shape, dim, start, end, step, layo
     (
         [0, 0, 0, slice(0, 33, 1), slice(0, 33, 1)],
         [1, -1, 2, slice(0, 33, 1), slice(0, 33, 1)],
-        # [slice(0, 8, 1), slice(0, 8, 1), slice(0, 8, 1), 2, 2],
     ),
 )
 def test_slice_index(device, input_shape, layout, input_memory_config, indices):

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -751,13 +751,9 @@ def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, dev
 
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
-    (
-        ([1, 7], 0, 0, -1, 1, ttnn.ROW_MAJOR_LAYOUT),  # page size must equal buffer size
-        ([1, 8, 2, 2], 2, -1, -1, 1, ttnn.TILE_LAYOUT),  # Buffer size and page size should be larger than 0 bytes
-        ([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),  # Difference in expected shape as it's a 1D tensor
-    ),
+    (([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),),  # Difference in expected shape as it's a 1D tensor
 )
-def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
+def test_pytorch2_failures(input_shape, dim, start, end, step, layout, device):
     pytest.skip("These tests are known to fail")
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
 
@@ -782,6 +778,8 @@ def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
     (
+        ([1, 7], 0, 0, -1, 1, ttnn.ROW_MAJOR_LAYOUT),  # page size must equal buffer size
+        ([1, 8, 2, 2], 2, -1, -1, 1, ttnn.TILE_LAYOUT),  # Buffer size and page size should be larger than 0 bytes
         ([8732, 4], 1, 0, -1, 4, ttnn.TILE_LAYOUT),  # Need tensor for this or a padding aware tiled kernel
         (
             [1, 7, 71, 64],
@@ -793,7 +791,7 @@ def test_slice_adversarial(input_shape, dim, start, end, step, layout, device):
         ),  # An unpadding slice operations for a RowMajor layout on the output tensor requires the last dimension to be on a 32 bit boundary
     ),
 )
-def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, device):
+def test_slice_former_pytorch2_failures(input_shape, dim, start, end, step, layout, device):
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
 
     slice_obj = slice(start, end, step)
@@ -812,3 +810,50 @@ def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, dev
     ttnn_output_tensor = ttnn.to_torch(ttnn_output)
 
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    ([8, 8, 8, 33, 33],),
+)
+@pytest.mark.parametrize(
+    "layout",
+    (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+)
+@pytest.mark.parametrize(
+    "input_memory_config",
+    (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+)
+@pytest.mark.parametrize(
+    "indices",
+    (
+        [0, 0, 0, slice(0, 33, 1), slice(0, 33, 1)],
+        [1, -1, 2, slice(0, 33, 1), slice(0, 33, 1)],
+        # [slice(0, 8, 1), slice(0, 8, 1), slice(0, 8, 1), 2, 2],
+    ),
+)
+def test_slice_index(device, input_shape, layout, input_memory_config, indices):
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(
+        torch_input, device=device, dtype=ttnn.bfloat16, memory_config=input_memory_config, layout=layout
+    )
+
+    torch_output = torch_input[
+        indices[0],
+        indices[1],
+        indices[2],
+        indices[3],
+        indices[4],
+    ]
+
+    ttnn_output = ttnn_input[
+        indices[0],
+        indices[1],
+        indices[2],
+        indices[3],
+        indices[4],
+    ]
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.99)

--- a/tests/ttnn/unit_tests/test_getitem.py
+++ b/tests/ttnn/unit_tests/test_getitem.py
@@ -76,16 +76,6 @@ def test_getitem_2d(device, height, width, input_layout, on_device):
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
-def test_getitem_scalar_output():
-    torch_input_tensor = torch.rand((16, 32), dtype=torch.bfloat16)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor)
-
-    with pytest.raises(RuntimeError) as e:
-        input_tensor[0, 0]
-    assert "Host tensor slice cannot return a scalar or empty tensor" in str(e.value)
-
-
 @pytest.mark.parametrize("batch_sizes", [(), (1, 1)])
 @pytest.mark.parametrize("height", [32, 64])
 @pytest.mark.parametrize("width", [32, 96])

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1197,8 +1197,8 @@ void pytensor_module(py::module& m_tensor) {
         .def(
             "unpad",
             [](const Tensor& self,
-               const std::array<uint32_t, 4>& output_tensor_start,
-               const std::array<uint32_t, 4>& output_tensor_end) {
+               const ttnn::SmallVector<uint32_t>& output_tensor_start,
+               const ttnn::SmallVector<uint32_t>& output_tensor_end) {
                 return self.unpad(ttnn::Shape(output_tensor_start), ttnn::Shape(output_tensor_end));
             },
             R"doc(
@@ -1211,11 +1211,11 @@ void pytensor_module(py::module& m_tensor) {
             +---------------------+----------------------------------------------+--------------+-----------------------------------------------------+----------+
             | Argument            | Description                                  | Data type    | Valid range                                         | Required |
             +=====================+==============================================+==============+=====================================================+==========+
-            | arg0                | Start indices of input tensor                | List[int[4]] | Values along each dim must be                       | Yes      |
+            | arg0                | Start indices of input tensor                | List[int] | Values along each dim must be                       | Yes      |
             |                     |                                              |              |                                                     |          |
             |                     |                                              |              | < input_tensor_shape[i] and <= output_tensor_end[i] |          |
             +---------------------+----------------------------------------------+--------------+-----------------------------------------------------+----------+
-            | arg1                | End indices of input tensor in output tensor | List[int[4]] | Values along each dim must be                       | Yes      |
+            | arg1                | End indices of input tensor in output tensor | List[int] | Values along each dim must be                       | Yes      |
             |                     |                                              |              |                                                     |          |
             |                     |                                              |              | < input_tensor_shape[i]                             |          |
             +---------------------+----------------------------------------------+--------------+-----------------------------------------------------+----------+

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1211,11 +1211,11 @@ void pytensor_module(py::module& m_tensor) {
             +---------------------+----------------------------------------------+--------------+-----------------------------------------------------+----------+
             | Argument            | Description                                  | Data type    | Valid range                                         | Required |
             +=====================+==============================================+==============+=====================================================+==========+
-            | arg0                | Start indices of input tensor                | List[int] | Values along each dim must be                       | Yes      |
+            | arg0                | Start indices of input tensor                | List[int]    | Values along each dim must be                       | Yes      |
             |                     |                                              |              |                                                     |          |
             |                     |                                              |              | < input_tensor_shape[i] and <= output_tensor_end[i] |          |
             +---------------------+----------------------------------------------+--------------+-----------------------------------------------------+----------+
-            | arg1                | End indices of input tensor in output tensor | List[int] | Values along each dim must be                       | Yes      |
+            | arg1                | End indices of input tensor in output tensor | List[int]    | Values along each dim must be                       | Yes      |
             |                     |                                              |              |                                                     |          |
             |                     |                                              |              | < input_tensor_shape[i]                             |          |
             +---------------------+----------------------------------------------+--------------+-----------------------------------------------------+----------+

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -21,6 +22,8 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* id_per_dim = num_padded_sticks + num_dims;
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t misalignment = get_compile_time_arg_val(1);
+    uint32_t read_size = unpadded_stick_size + misalignment;
 
     const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = padded_stick_size};
 
@@ -35,7 +38,12 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
             uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
-            noc_async_read(src_noc_addr, src_buffer_l1_addr, unpadded_stick_size);
+            noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+            if constexpr (misalignment != 0) {
+                noc_async_read_barrier();
+                tt::data_movement::common::tt_memmove<false, false, false, 0>(
+                    src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
+            }
             src_buffer_l1_addr += stick_size_offset;
             src_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/strided_slice_reader_rm_interleaved_nd.cpp
@@ -38,7 +38,8 @@ void kernel_main() {
     uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
     volatile tt_l1_ptr uint16_t* in_stick = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_buffer_l1_addr);
 
-    uint32_t index[dims - 1];  // To hold current index in each of the first dims-1 dimensions
+    uint32_t index[dims];  // To hold current index in each of the first dims-1 dimensions
+    index[dims - 1] = 0;   // Initialize the last index to 0
     for (uint32_t i = 0; i < dims - 1; i++) {
         index[i] = starts[i];  // Initialize the index with the start values
     }
@@ -68,16 +69,19 @@ void kernel_main() {
             out_stick_id++;
         }
         cb_push_back(cb_id_out0, 1);
-
-        // Increment the indices for the first dims-1 dimensions
-        for (int32_t i = dims - 2; i >= 0; i--) {  // Start from the last of the first dims-1
-            index[i] += strides[i];
-            if (index[i] < ends[i]) {
-                break;  // Successfully incremented this dimension, no carry over
-            } else {
-                index[i] = starts[i];  // Reset this dimension and carry over to the next
-                if (i == 0) {
-                    done = true;  // If the first dimension is reset, we've completed all iterations
+        if constexpr (dims == 1) {
+            break;  // If there's only one dimension, we're done
+        } else {
+            // Increment the indices for the first dims-1 dimensions
+            for (int32_t i = dims - 2; i >= 0; i--) {  // Start from the last of the first dims-1
+                index[i] += strides[i];
+                if (index[i] < ends[i]) {
+                    break;  // Successfully incremented this dimension, no carry over
+                } else {
+                    index[i] = starts[i];  // Reset this dimension and carry over to the next
+                    if (i == 0) {
+                        done = true;  // If the first dimension is reset, we've completed all iterations
+                    }
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
+#include <tt-metalium/hal_exp.hpp>
 #include <tt-metalium/host_api.hpp>
 
 #include "slice_op.hpp"
@@ -59,12 +60,22 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
 
-    uint32_t unpadded_row_size_bytes_offset = output_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                                  ? tt::round_up(unpadded_row_size_bytes, TILE_WIDTH)
-                                                  : tt::round_up(unpadded_row_size_bytes, TILE_WIDTH / 2);
+    using namespace tt::tt_metal::experimental;
+    auto SRC_BUFFER_ALIGNMENT = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    auto DST_BUFFER_ALIGNMENT = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    auto ALIGNMENT = std::max(SRC_BUFFER_ALIGNMENT, DST_BUFFER_ALIGNMENT);
+    uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
+    uint32_t misalignment = begins_bytes % SRC_BUFFER_ALIGNMENT;
+
+    uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, ALIGNMENT);
+    uint32_t start_addr = input_tensor.buffer()->address();
 
     std::vector<uint32_t> common_reader_kernel_args = {
-        input_tensor.buffer()->address() + output_tensor_start[-1] * output_tensor.element_size(),
+        start_addr + begins_bytes - misalignment,  // read from nearest aligned address,
         padded_row_size_bytes,
         unpadded_row_size_bytes,
         unpadded_row_size_bytes_offset,
@@ -167,7 +178,6 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram};
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
 
     uint32_t src_stick_size = padded_row_size_bytes;
@@ -175,8 +185,24 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     uint32_t src0_cb_index = 0;
     uint32_t max_read_size = 4096;
-    uint32_t cb_page_size = dst_is_dram ? tt::round_up(unpadded_row_size_bytes, TILE_WIDTH)
-                                        : tt::round_up(unpadded_row_size_bytes, TILE_WIDTH / 2);
+
+    using namespace tt::tt_metal::experimental;
+    auto SRC_BUFFER_ALIGNMENT = a.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? hal::get_dram_alignment()
+                                                                                            : hal::get_l1_alignment();
+    auto DST_BUFFER_ALIGNMENT = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? hal::get_dram_alignment()
+                                    : hal::get_l1_alignment();
+    auto ALIGNMENT = std::max(SRC_BUFFER_ALIGNMENT, DST_BUFFER_ALIGNMENT);
+
+    // if begins is not aligned then we need to pad the cb size, so that we can read from the nearest aligned address
+    uint32_t begins_bytes = output_tensor_start[-1] * a.element_size();
+    uint32_t misalignment = begins_bytes % SRC_BUFFER_ALIGNMENT;
+
+    if (misalignment != 0) {
+        ALIGNMENT *= 2;
+    }
+    uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, ALIGNMENT);
+
     uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                          : num_sticks_per_core_group_2;
     uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
@@ -193,6 +219,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
 
+    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram, misalignment};
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -20,54 +20,145 @@ def _golden_function(input_tensor: ttnn.Tensor, slices):
     return output_tensor
 
 
+def _host_slice_with_unpad(input_tensor: ttnn.Tensor, begins, ends) -> ttnn.Tensor:
+    """Hacky fallback to old `unpad` methods for host based accessing"""
+
+    working_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT).unpad(begins, ends)
+    working_tensor = ttnn.view(working_tensor, [e - b for e, b in zip(ends, begins)])
+    return ttnn.to_layout(working_tensor, input_tensor.get_layout())
+
+
 @ttnn.register_python_operation(
     name="ttnn.Tensor.__getitem__",
     is_method=True,
     golden_function=_golden_function,
 )
 def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
+    """
+    Mimics PyTorch-style indexing for ttnn.Tensor using ttnn.slice and ttnn.squeeze.
+    """
+
+    # Gather some basic info
     input_rank = len(input_tensor.shape)
+    shape = input_tensor.shape  # Or input_tensor.logical_shape, depending on your library's conventions
 
-    if isinstance(slices, int):
-        slices = (slice(None, slices, None),)
-    elif isinstance(slices, slice):
+    # 1) Normalize slices into a tuple.
+    #    e.g. if user wrote a[3], slices is just int(3), so wrap it into (3,).
+    #    or if user wrote a[2:5], slices is slice(2,5).
+    if isinstance(slices, (int, slice, type(...))):
         slices = (slices,)
-    elif isinstance(slices, type(...)):
-        return ttnn.clone(input_tensor)
+    else:
+        # ensure it's a tuple in case user wrote something like a[1, 2:5, ...]
+        slices = tuple(slices)
 
+    # 2) Expand any bare Ellipsis into enough slice(None) to fill out to input_rank.
+    #    But we have to do this carefully in the presence of other slices.
+    #    We'll do it in two passes:
+    #      - first copy slices to a “normalized_slices”, remembering where Ellipsis is
+    #      - then replace the Ellipsis with however many slice(None) are needed
     normalized_slices = []
-
     ellipsis_found = False
+
     for s in slices:
-        if isinstance(s, int):
-            normalized_slices.append(slice(None, s, None))
-        elif isinstance(s, slice):
-            normalized_slices.append(s)
-        elif s is Ellipsis:
+        if s is Ellipsis:
             if ellipsis_found:
                 raise ValueError("Only one ellipsis ('...') is allowed in a slice.")
+            # We'll deal with actually expanding it after this loop.
             ellipsis_found = True
-            # Fill in the remaining dimensions with slice(None) based on how many slices are missing
-            num_missing_slices = input_rank - len(slices) + 1
-            normalized_slices.extend([slice(None)] * num_missing_slices)
+            normalized_slices.append(Ellipsis)
         else:
-            raise TypeError(f"Invalid slice object: {s}")
+            normalized_slices.append(s)
 
-    # If fewer slices than the rank, pad with slice(None)
+    # If there's exactly one Ellipsis, expand it
+    if ellipsis_found:
+        ellipsis_index = normalized_slices.index(Ellipsis)
+        # Number of slices ignoring the Ellipsis
+        num_slices_no_ellipsis = len(normalized_slices) - 1
+        # How many dimensions are “missing”
+        num_missing = input_rank - num_slices_no_ellipsis
+        if num_missing < 0:
+            raise IndexError(f"Too many indices for tensor of dimension {input_rank}")
+
+        # Remove the Ellipsis placeholder
+        del normalized_slices[ellipsis_index]
+        # Insert slice(None) for however many dims are missing
+        for _ in range(num_missing):
+            normalized_slices.insert(ellipsis_index, slice(None, None, None))
+
+    # If there was no Ellipsis and we still have fewer slices than rank, pad with slice(None)
     while len(normalized_slices) < input_rank:
-        normalized_slices.append(slice(None))
+        normalized_slices.append(slice(None, None, None))
 
-    slices = tuple(normalized_slices)
+    # Now if we have more slices than the rank, that’s an error
+    if len(normalized_slices) > input_rank:
+        raise IndexError(f"Too many indices for tensor of dimension {input_rank}")
 
-    if isinstance(slices, tuple):
-        if len(slices) > input_rank:
-            raise RuntimeError(f"Too many slices for tensor of rank {input_rank}")
+    # 3) Convert everything into slice objects (including integer indices),
+    #    and record which dimensions we’ll need to squeeze out (integer-indexed dims).
+    final_slices = []
+    singled_out_dims = []  # dims where user gave an integer index
 
-    slice_start = [_slice.start if _slice.start is not None else 0 for _slice in slices]
-    slice_end = [_slice.stop if _slice.stop is not None else input_tensor.shape[i] for i, _slice in enumerate(slices)]
-    slice_step = [_slice.step if _slice.step is not None else 1 for _slice in slices]
+    for dim_idx, s in enumerate(normalized_slices):
+        if isinstance(s, int):
+            # Negative index => convert as in python: s + size if s < 0
+            idx = s if s >= 0 else (s + shape[dim_idx])
+            if not 0 <= idx < shape[dim_idx]:
+                raise IndexError(
+                    f"Index {s} (converted to {idx}) is out of bounds "
+                    f"for dimension {dim_idx} of size {shape[dim_idx]}"
+                )
+            final_slices.append(slice(idx, idx + 1, 1))
+            singled_out_dims.append(dim_idx)
+        elif isinstance(s, slice):
+            # We mimic Python negative slicing for start/stop
+            start, stop, step = s.start, s.stop, s.step
 
-    output = ttnn.slice(input_tensor, slice_start, slice_end, slice_step)
+            # default values
+            if start is None:
+                start = 0
+            if stop is None:
+                stop = shape[dim_idx]
+            if step is None:
+                step = 1
+
+            final_slices.append(slice(start, stop, step))
+        else:
+            raise TypeError(f"Invalid slice type: {s}")
+
+    # 4) Prepare the lists for ttnn.slice
+    slice_start = []
+    slice_end = []
+    slice_step = []
+
+    for dim_idx, sl in enumerate(final_slices):
+        # No further negative indexing needed: we already converted above
+        st = sl.start
+        end = sl.stop
+        stp = sl.step
+        slice_start.append(st)
+        slice_end.append(end)
+        slice_step.append(stp)
+
+    # 5) Perform the slicing
+    if ttnn.is_tensor_storage_on_device(input_tensor):
+        output = ttnn.slice(input_tensor, slice_start, slice_end, slice_step)
+    else:
+        if not all([s == 1 for s in slice_step]):
+            raise RuntimeError("Host tensors cannot be accessed with non-unit stride")
+        output = _host_slice_with_unpad(input_tensor, slice_start, slice_end)
+
+    # 6) Squeeze out all dimensions that were indexed by an integer.
+    #    We do this from left to right, adjusting each subsequent dimension index
+    #    or do it from right to left so we don't need to adjust. Either approach works
+    #    if we’re careful. The simplest is ascending order with a small counter.
+    shift = 0
+    singled_out_dims_sorted = sorted(singled_out_dims)
+    for original_dim in singled_out_dims_sorted:
+        # after removing 'shift' dims, the current dim is (original_dim - shift)
+        squeeze_dim = original_dim - shift
+        # Squeeze only if that dim is actually size 1 after slicing
+        output = ttnn.squeeze(output, squeeze_dim)
+        shift += 1
 
     return output
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -132,12 +132,9 @@ def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
 
     for dim_idx, sl in enumerate(final_slices):
         # No further negative indexing needed: we already converted above
-        st = sl.start
-        end = sl.stop
-        stp = sl.step
-        slice_start.append(st)
-        slice_end.append(end)
-        slice_step.append(stp)
+        slice_start.append(sl.start)
+        slice_end.append(sl.stop)
+        slice_step.append(sl.step)
 
     # 5) Perform the slicing
     if ttnn.is_tensor_storage_on_device(input_tensor):
@@ -152,8 +149,7 @@ def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
     #    or do it from right to left so we don't need to adjust. Either approach works
     #    if we’re careful. The simplest is ascending order with a small counter.
     shift = 0
-    singled_out_dims_sorted = sorted(singled_out_dims)
-    for original_dim in singled_out_dims_sorted:
+    for original_dim in sorted(singled_out_dims):
         # after removing 'shift' dims, the current dim is (original_dim - shift)
         squeeze_dim = original_dim - shift
         # Squeeze only if that dim is actually size 1 after slicing


### PR DESCRIPTION
### Ticket
#17351 
#16966 

### Problem description
A few bugs/missing features/bad practices in slice:

- Python style list splicing slices do not work when we want to slice off a single dimension eg) tensor[0, :::]
- When begins is unaligned for row major slice, we get PCC errors
- 1D row major strided slice gets a hang
- Host side fall back to unpad when the tensor is on host
- No support for non-tile aligned begins/ends for tiled slice

### What's changed

- Add Python style list splicing for single dimensions
- Fix row major slice on unaligned begins
- Add support for 1D strided RM slice

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes. [Submitted](https://github.com/tenstorrent/tt-metal/actions/runs/13933324664)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [Submitted](https://github.com/tenstorrent/tt-metal/actions/runs/13930158916)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes