### PR TITLE
Logical and Relative coordinates in compute kernel

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1540,6 +1540,13 @@ TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesDataMovement)
     }
 }
 
+// Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
+TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesCompute) {
+    for (IDevice* device : devices_) {
+        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
+    }
+}
+
 // Ensure the eth core can access their own logical coordinate. Same binary enqueued to multiple cores.
 TEST_F(CommandQueueSingleCardProgramFixture, TestLogicalCoordinatesEth) {
     for (IDevice* device : devices_) {
@@ -1558,6 +1565,14 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesDataMo
         local_test_functions::test_my_coordinates(device, tt::RISCV::BRISC, 1);
         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC);
         local_test_functions::test_my_coordinates(device, tt::RISCV::NCRISC, 1);
+    }
+}
+
+// Ensure the compute core can access their own logical coordinate. Same binary enqueued to multiple cores.
+TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TestLogicalCoordinatesCompute) {
+    for (IDevice* device : devices_) {
+        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE);
+        local_test_functions::test_my_coordinates(device, tt::RISCV::COMPUTE, 1);
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/read_my_coordinates.cpp
@@ -11,14 +11,30 @@
 // Applicable for Data Movement cores only
 //
 
-#include "hw/inc/dataflow_api.h"
+// TODO FIXME: this build system is ridiculously stupid
+#ifdef COMPILE_FOR_TRISC
+#include "compute_kernel_api/common.h"
+#else
+#include "dataflow_api.h"
+#endif
 
+#ifdef COMPILE_FOR_TRISC
+namespace NAMESPACE {
+void MAIN {
+#else
 void kernel_main() {
+#endif
     volatile tt_l1_ptr uint32_t* results = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_compile_time_arg_val(0));
+#ifndef COMPILE_FOR_TRISC
     results[0] = my_x[noc_index];
     results[1] = my_y[noc_index];
+#endif
     results[2] = get_absolute_logical_x();
     results[3] = get_absolute_logical_y();
     results[4] = get_relative_logical_x();
     results[5] = get_relative_logical_y();
+
+#ifdef COMPILE_FOR_TRISC
+}
+#endif
 }

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -34,6 +34,11 @@ namespace kernel_profiler {
 uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 
+uint8_t my_logical_x_ __attribute__((used));
+uint8_t my_logical_y_ __attribute__((used));
+uint8_t my_relative_x_ __attribute__((used));
+uint8_t my_relative_y_ __attribute__((used));
+
 namespace ckernel {
 
 enum class ttRiscCores : std::uint32_t { Unpack = 0, Math = 1, Pack = 2, Brisc = 3, Nrisc = 4 };
@@ -100,6 +105,9 @@ int main(int argc, char *argv[]) {
 
     reset_cfg_state_id();
 
+    my_logical_x_ = mailboxes->core_info.absolute_logical_x;
+    my_logical_y_ = mailboxes->core_info.absolute_logical_y;
+
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
         WAYPOINT("W");
@@ -136,6 +144,8 @@ int main(int argc, char *argv[]) {
         crta_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base +
                                   launch_msg->kernel_config.rta_offset[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
+        my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
+        my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 
         WAYPOINT("R");
         int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::MATH0) + thread_id;

--- a/tt_metal/include/compute_kernel_api/common.h
+++ b/tt_metal/include/compute_kernel_api/common.h
@@ -80,3 +80,55 @@ FORCE_INLINE T get_common_arg_val(int arg_idx) {
     static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
     return *((tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }
+
+// clang-format off
+/**
+ * Returns the absolute logical X coordinate value that this kernel is running on. The absolute coordinate
+ * is the one relative to the origin of the physical grid.
+ *
+ * Return value: X coordinate value.
+ */
+// clang-format on
+inline uint8_t get_absolute_logical_x() {
+    extern uint8_t my_logical_x_;  // Set in FW
+    return my_logical_x_;
+}
+
+// clang-format off
+/**
+ * Returns the absolute logical Y coordinate value that this kernel is running on. The absolute coordinate
+ * is the one relative to the origin of the physical grid.
+ *
+ * Return value: Y coordinate value.
+ */
+// clang-format on
+inline uint8_t get_absolute_logical_y() {
+    extern uint8_t my_logical_y_;  // Set in FW
+    return my_logical_y_;
+}
+
+// clang-format off
+/**
+ * Returns the relative logical X coordinate value that this kernel is running on. The relative coordinate
+ * is with respect to the origin of the sub device for this core type.
+ *
+ * Return value: X coordinate value.
+ */
+// clang-format on
+inline uint8_t get_relative_logical_x() {
+    extern uint8_t my_relative_x_;  // Set in FW
+    return my_relative_x_;
+}
+
+// clang-format off
+/**
+ * Returns the relative logical Y coordinate value that this kernel is running on. The relative coordinate
+ * is with respect to the origin of the sub device for this core type.
+ *
+ * Return value: Y coordinate value.
+ */
+// clang-format on
+inline uint8_t get_relative_logical_y() {
+    extern uint8_t my_relative_y_;  // Set in FW
+    return my_relative_y_;
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Logical and Relative coordinates can be accessed in data movement kernels but not compute kernels. It's a useful feature for some op developers to remove sending the coordinate through CRTA.

### What's changed
Add functions to get the logical and relative coordinates in the compute kernel API

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/13952000212
BH
https://github.com/tenstorrent/tt-metal/actions/runs/13935663508
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/13935667916