### PR TITLE
[2D Fabric] Fix for deadlock in sending pull requests

### DIFF
--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -103,7 +103,11 @@ inline void fabric_send_pull_request(
     } else {
         router_addr = get_noc_addr_helper(routing, FABRIC_ROUTER_REQ_QUEUE_START);
     }
-    tt_fabric_send_pull_request(router_addr, (volatile local_pull_request_t*)&client_interface->local_pull_request);
+
+    volatile local_pull_request_t* pull_request = (volatile local_pull_request_t*)&client_interface->local_pull_request;
+    tt_fabric_reserve_pull_request_slot(router_addr, pull_request);
+    tt_fabric_check_pull_request_slot<true>(router_addr, pull_request);
+    tt_fabric_send_pull_request(router_addr, pull_request);
 }
 
 FORCE_INLINE void fabric_wait_for_pull_request_words_flushed(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19294

### Problem description
Calling `tt_fabric_send_pull_request` in a blocking mode can lead to deadlocks.

### What's changed
Fragmented the existing `tt_fabric_send_pull_request` into APIs that allow context management and retries. If the destination req queue is full, the sender router processes outbound data and retries. Also added an optional template parameter which can be used by the workers to send the pull request in a blocking fashion.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/13949444993)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes