### PR TITLE
#18345: use fp32 acc by default for layernorm and specify parameter in models

### DIFF
--- a/models/demos/bert/tt/ttnn_bert.py
+++ b/models/demos/bert/tt/ttnn_bert.py
@@ -63,6 +63,7 @@ def bert_attention(
         weight=parameters.output.LayerNorm.weight,
         bias=parameters.output.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return attention_output
@@ -94,6 +95,7 @@ def bert_output(
         weight=parameters.LayerNorm.weight,
         bias=parameters.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return output
@@ -176,6 +178,7 @@ def bert(
         weight=parameters.embeddings.LayerNorm.weight,
         bias=parameters.embeddings.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     hidden_states = bert_encoder(

--- a/models/demos/bert/tt/ttnn_optimized_bert.py
+++ b/models/demos/bert/tt/ttnn_optimized_bert.py
@@ -84,6 +84,7 @@ def bert_attention(
         bias=parameters.output.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(hidden_states)
     ttnn.deallocate(self_output)
@@ -143,6 +144,7 @@ def bert_output(
         bias=parameters.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(output)
     ttnn.deallocate(residual)
@@ -226,6 +228,7 @@ def bert(
         weight=parameters.embeddings.LayerNorm.weight,
         bias=parameters.embeddings.LayerNorm.bias,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(embeddings)
 

--- a/models/demos/bert/tt/ttnn_optimized_sharded_bert.py
+++ b/models/demos/bert/tt/ttnn_optimized_sharded_bert.py
@@ -175,6 +175,7 @@ def bert_attention(
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
         program_config=config.program_configs["layernorm_program_config"],
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(self_output)
 
@@ -223,6 +224,7 @@ def bert_output(
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
         program_config=config.program_configs["layernorm_program_config"],
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(residual)
 
@@ -306,6 +308,7 @@ def bert(
         weight=parameters.embeddings.LayerNorm.weight,
         bias=parameters.embeddings.LayerNorm.bias,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(word_plus_token_type_embeddings)
     ttnn.deallocate(position_embeddings)

--- a/models/demos/bert_tiny/tt/bert_tiny.py
+++ b/models/demos/bert_tiny/tt/bert_tiny.py
@@ -86,6 +86,7 @@ def bert_attention(
         bias=parameters.output.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return attention_output
@@ -132,6 +133,7 @@ def bert_output(
         bias=parameters.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return output
@@ -222,6 +224,7 @@ def bert(
         bias=parameters.embeddings.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     hidden_states = bert_encoder(

--- a/models/demos/distilbert/tt/ttnn_optimized_distilbert.py
+++ b/models/demos/distilbert/tt/ttnn_optimized_distilbert.py
@@ -192,6 +192,7 @@ def transformer_block(
         bias=parameters.sa_layer_norm.bias,
         epsilon=1e-12,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(x)
 
@@ -203,6 +204,7 @@ def transformer_block(
         bias=parameters.output_layer_norm.bias,
         epsilon=1e-12,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     ttnn.deallocate(sa_output)
@@ -322,6 +324,7 @@ def distilbert(
         weight=parameters.embeddings.LayerNorm.weight,
         bias=parameters.embeddings.LayerNorm.bias,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return transformer(

--- a/models/demos/falcon7b_common/tt/model_utils.py
+++ b/models/demos/falcon7b_common/tt/model_utils.py
@@ -105,6 +105,7 @@ def layernorm(ln_input, ln_eps, ln_gamma, ln_betta, model_config):
             ln_input,
             epsilon=ln_eps,
             memory_config=model_config["LN_F_OUTPUT_MEMCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         ln_output = ttnn.multiply(ln_output, ln_gamma, memory_config=model_config["LN_F_OUTPUT_MEMCFG"])
         ln_output = ttnn.add(

--- a/models/demos/metal_BERT_large_11/tt/bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_encoder.py
@@ -175,6 +175,7 @@ class TtBertEncoder:
             bias=self.mha_beta,
             program_config=self.mha_ln_program_config,
             memory_config=self.model_config["OP8_LAYERNORM_OUTPUT_MEMCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         return mha_out_add_and_norm
 
@@ -187,6 +188,7 @@ class TtBertEncoder:
             bias=self.ffn_beta,
             program_config=self.ffn_ln_program_config,
             memory_config=self.model_config["OP11_LAYERNORM_OUTPUT_MEMCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         return ffn_out_add_and_norm
 

--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -200,6 +200,7 @@ class TtEmbeddings:
                 weight=self.layerNorm_gamma,
                 bias=self.layerNorm_beta,
                 memory_config=self.model_config["OP1_FUSED_QKV_MM_INPUT_MEMCFG"],
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
         else:
             embeddings_tt_tensor_layerNorm = ttnn.layer_norm(
@@ -209,5 +210,6 @@ class TtEmbeddings:
                 weight=self.layerNorm_gamma,
                 bias=self.layerNorm_beta,
                 memory_config=self.model_config["OP1_FUSED_QKV_MM_INPUT_MEMCFG"],
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
         return embeddings_tt_tensor_layerNorm

--- a/models/demos/segformer/tt/ttnn_segformer_efficient_selfattention.py
+++ b/models/demos/segformer/tt/ttnn_segformer_efficient_selfattention.py
@@ -128,6 +128,7 @@ class TtSegformerEfficientSelfAttention:
                 weight=parameters.layer_norm.weight,
                 bias=parameters.layer_norm.bias,
                 memory_config=ttnn.L1_MEMORY_CONFIG,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)

--- a/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
+++ b/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
@@ -150,6 +150,7 @@ def squeezebert_conv_layernorm(
         weight=parameters.layernorm.weight,
         bias=parameters.layernorm.bias,
         epsilon=config.layer_norm_eps,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(self_output_layernorm)
     attention_output = permute_reshape(attention_output)
@@ -410,6 +411,7 @@ def squeezebert(
         weight=parameters.embeddings.LayerNorm.weight,
         bias=parameters.embeddings.LayerNorm.bias,
         memory_config=ttnn.DRAM_MEMORY_CONFIG if is_grayskull() else ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(embeddings)
 

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
@@ -125,6 +125,7 @@ class TtFalconLayernorm:
                     block_w=32,
                     inplace=False,
                 ),
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
         else:  # Interleaved does not work for falcon40b dims [32, 8192] since once one core per tile-height is used to process the whole row
             # Uses only one core; runs out of L1
@@ -135,6 +136,7 @@ class TtFalconLayernorm:
                 epsilon=self.layernorm_eps,
                 weight=self.gamma,
                 bias=self.beta,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
 
         return out

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
@@ -183,6 +183,7 @@ class TtFusedFalconLayernorm:
             bias=None,
             memory_config=self.sharded_memconfig,
             program_config=self.prg_config,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
 
         out1 = ttnn.bcast(

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -325,6 +325,7 @@ class TtFalconDecoderLayer:
             bias=self.ln_attn_beta,
             memory_config=self.model_config["LN_ATTN_OUTPUT_MEMCFG"],
             program_config=self.model_config["LN_ATTN_PROGCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         mlp_ln_output = ttnn.layer_norm(
             replicated_hidden_states,
@@ -333,6 +334,7 @@ class TtFalconDecoderLayer:
             bias=self.ln_mlp_beta,
             memory_config=self.model_config["LN_MLP_OUTPUT_MEMCFG"],
             program_config=self.model_config["LN_MLP_PROGCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
 
         output = hidden_states

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -388,6 +388,7 @@ class TtFalconModelShared:
             bias=self.layernorm_beta,
             memory_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
             program_config=self.model_config["LN_F_PROGCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
 
         return layer_output, presents

--- a/models/demos/t3000/falcon40b/tt/model_utils.py
+++ b/models/demos/t3000/falcon40b/tt/model_utils.py
@@ -379,6 +379,7 @@ def partial_layernorm(
                 bias=ln_beta,
                 memory_config=memconfig,
                 program_config=pgmconfig,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
             ttnn.sharded_to_interleaved_partial(
                 xs_slice,
@@ -397,6 +398,7 @@ def partial_layernorm(
             bias=ln_beta,
             memory_config=memconfig,
             program_config=pgmconfig,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         xs = convert_to_layout(xs, memconfig, get_dram_memcfg())
         xs_output_cat = ttnn.experimental.typecast(xs, dtype, memory_config=ttnn.DRAM_MEMORY_CONFIG)
@@ -497,6 +499,7 @@ def fused_partial_layernorm(
                 bias=None,
                 memory_config=memconfig,
                 program_config=pgmconfig,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
 
             # Apply first layernorm gamma+beta
@@ -560,6 +563,7 @@ def fused_partial_layernorm(
             bias=None,
             memory_config=memconfig,
             program_config=pgmconfig,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
 
         # Apply first layernorm gamma+beta

--- a/models/demos/ttnn_falcon7b/tt/falcon_decoder.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_decoder.py
@@ -61,6 +61,7 @@ class TtFalconDecoderLayer:
             hidden_states,
             epsilon=self.layernorm_eps,
             memory_config=self.model_config["INPUT_LAYERNORM_OUTPUT_MEMCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         layernorm_output = ttnn.mul(
             layernorm_output,

--- a/models/demos/ttnn_falcon7b/tt/falcon_model.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_model.py
@@ -133,6 +133,7 @@ class TtFalconModelShared:
             layer_output,
             epsilon=self.layernorm_eps,
             memory_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         layer_output = ttnn.mul(
             layer_output,

--- a/models/demos/whisper/tt/ttnn_optimized_functional_whisper.py
+++ b/models/demos/whisper/tt/ttnn_optimized_functional_whisper.py
@@ -244,6 +244,7 @@ def encoder_layer(config, hidden_states, *, parameters):
         weight=parameters.self_attn_layer_norm.weight,
         bias=parameters.self_attn_layer_norm.bias,
         memory_config=WHISPER_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     hidden_states = whisper_attention(
@@ -258,6 +259,7 @@ def encoder_layer(config, hidden_states, *, parameters):
         weight=parameters.final_layer_norm.weight,
         bias=parameters.final_layer_norm.bias,
         memory_config=WHISPER_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     hidden_states = hidden_states @ parameters.fc1.weight + parameters.fc1.bias
     hidden_states = gelu(hidden_states)
@@ -280,6 +282,7 @@ def encoder(config, inputs_embeds, *, parameters):
         hidden_states,
         weight=parameters.layer_norm.weight,
         bias=parameters.layer_norm.bias,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     return hidden_states
 
@@ -316,6 +319,7 @@ def decoder_layer(
         hidden_states,
         weight=parameters.self_attn_layer_norm.weight,
         bias=parameters.self_attn_layer_norm.bias,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     hidden_states = whisper_attention(
@@ -336,6 +340,7 @@ def decoder_layer(
         hidden_states,
         weight=parameters.encoder_attn_layer_norm.weight,
         bias=parameters.encoder_attn_layer_norm.bias,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     hidden_states = whisper_attention(
@@ -357,6 +362,7 @@ def decoder_layer(
         hidden_states,
         weight=parameters.final_layer_norm.weight,
         bias=parameters.final_layer_norm.bias,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     hidden_states = hidden_states @ parameters.fc1.weight + parameters.fc1.bias
     hidden_states = gelu(hidden_states)
@@ -416,6 +422,7 @@ def decoder(
         hidden_states,
         weight=parameters.layer_norm.weight,
         bias=parameters.layer_norm.bias,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return hidden_states

--- a/models/demos/wormhole/bert_tiny/tt/bert_tiny.py
+++ b/models/demos/wormhole/bert_tiny/tt/bert_tiny.py
@@ -99,6 +99,7 @@ def bert_attention(
         bias=parameters.output.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return attention_output
@@ -145,6 +146,7 @@ def bert_output(
         bias=parameters.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return output
@@ -235,6 +237,7 @@ def bert(
         bias=parameters.embeddings.LayerNorm.bias,
         epsilon=config.layer_norm_eps,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     hidden_states = bert_encoder(

--- a/models/demos/wormhole/distilbert/tt/ttnn_optimized_distilbert.py
+++ b/models/demos/wormhole/distilbert/tt/ttnn_optimized_distilbert.py
@@ -176,6 +176,7 @@ def transformer_block(
         bias=parameters.sa_layer_norm.bias,
         epsilon=1e-12,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
     ttnn.deallocate(x)
 
@@ -187,6 +188,7 @@ def transformer_block(
         bias=parameters.output_layer_norm.bias,
         epsilon=1e-12,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     ttnn.deallocate(sa_output)
@@ -301,6 +303,7 @@ def distilbert(
         weight=parameters.distilbert.embeddings.LayerNorm.weight,
         bias=parameters.distilbert.embeddings.LayerNorm.bias,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
     )
 
     return transformer(

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_basic_transformer_block.py
@@ -87,6 +87,7 @@ class basic_transformer_block:
             bias=self.parameters.norm1.bias,
             memory_config=sharded_mem_cfg,
             program_config=program_config,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
 
         # 1. Self-Attention
@@ -126,6 +127,7 @@ class basic_transformer_block:
                 bias=self.parameters.norm2.bias,
                 memory_config=sharded_mem_cfg,
                 program_config=program_config,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
 
             # 2. Cross-Attention
@@ -159,6 +161,7 @@ class basic_transformer_block:
             bias=self.parameters.norm3.bias,
             memory_config=sharded_mem_cfg,
             program_config=program_config,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
         )
         if use_ada_layer_norm_zero:
             assert False, "AdaLayerNormZero not supported and not used in stable diffusion"

--- a/models/tt_transformers/tt/multimodal/llama_layernorm.py
+++ b/models/tt_transformers/tt/multimodal/llama_layernorm.py
@@ -91,6 +91,7 @@ class TtLayerNorm(LightweightModule):
                 bias=self.bias,
                 program_config=self.sharded_program_config,
                 memory_config=self.sharded_output_config,
+                compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
             )
             if out_sharded:
                 return x

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
@@ -21,8 +21,10 @@ ttnn::Tensor ExecuteLayerNorm::invoke(
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    bool approx_mode = false;
+    bool fp32_acc = true;
     auto kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, approx_mode, fp32_acc);
     return tt::tt_metal::operation::run(
                LayerNorm{
                    .norm_type = LayerNormType::LAYERNORM,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/18345

### Problem description
- default layernorm accuracy is not sufficient for PyTorch

### What's changed
- disable approx mode and enable fp32_acc by default for layernorm
- update models to pass in compute kernel config aligned with pre-existing functionlity where it wasn't specified before

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13930985010
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A main not in a good state, branch run has unrelated random errors https://github.com/tenstorrent/tt-metal/actions/runs/13930995122/job/38988138935
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13931000545
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13930997968
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes

T3k model perf passes https://github.com/tenstorrent/tt-metal/actions/runs/13931010059