### PR TITLE
#19251: Use indestructible for dispatch mem map

### DIFF
--- a/tt_metal/api/tt-metalium/dispatch_mem_map.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_mem_map.hpp
@@ -7,6 +7,8 @@
 #include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/command_queue_common.hpp>
 
+#include <tt_stl/indestructible.hpp>
+
 namespace tt::tt_metal {
 
 //
@@ -78,6 +80,8 @@ public:
     uint8_t get_dispatch_message_update_offset(uint32_t index) const;
 
 private:
+    friend class tt::stl::Indestructible<DispatchMemMap>;
+
     DispatchMemMap() = default;
 
     static DispatchMemMap& get_instance();

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/dispatch_mem_map.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/fabric_host_interface.h>
+#include "indestructible.hpp"
 #include "rtoptions.hpp"
 
 namespace tt::tt_metal {
@@ -104,8 +105,8 @@ uint8_t DispatchMemMap::get_dispatch_message_update_offset(uint32_t index) const
 }
 
 DispatchMemMap& DispatchMemMap::get_instance() {
-    static DispatchMemMap instance;
-    return instance;
+    static tt::stl::Indestructible<DispatchMemMap> instance;
+    return instance.get();
 }
 
 // Reset the instance using the settings for the core_type and num_hw_cqs.


### PR DESCRIPTION
### Ticket
#19251

### Problem description
Dispatch mem map is destroyed before device pool, which triggers the assertion described in #19251.

### What's changed
Use `tt::stl::Indestructible` to disable dtor of the static instance of dispatch mem map.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13932194914) - expected failures as on main.
- [X] Reproed the issue described in #19251 and confirmed the fix resolves it.