### PR TITLE
Full Product Reduction - Update Output Tensor Shape

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
@@ -53,15 +53,13 @@ def test_prod(shapes, device):
     torch_output = torch.prod(torch_input)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = (
-        ttnn.prod(tt_input, all_dimensions=True).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
-    )
-    N, C, H, W = tt_output_cpu.shape
+    tt_output_cpu = ttnn.prod(tt_input, all_dimensions=True).cpu().to(cpu_layout).to_torch()
+    N = tt_output_cpu.shape
     torch.set_printoptions(threshold=10000, precision=5, sci_mode=False)
     logger.info("Input shape")
     logger.info(torch_input.shape)
     logger.info("TT Output")
-    logger.info(tt_output_cpu[0, 0, 0, 0])
+    logger.info(tt_output_cpu)
     logger.info("Torch Output")
     logger.info(torch_output)
 
@@ -69,9 +67,7 @@ def test_prod(shapes, device):
     # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
     rtol = atol = 0.12
     # passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    passing, output_pcc = comp_allclose_and_pcc(
-        torch_output, tt_output_cpu[0, 0, 0, 0], pcc=0.999, rtol=rtol, atol=atol
-    )
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu[0], pcc=0.999, rtol=rtol, atol=atol)
 
     logger.info(f"Out passing={passing}")
     logger.info(f"Output pcc={output_pcc}")

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -26,11 +26,10 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
     // This should allocate a DRAM buffer on the device
     tt_metal::IDevice* device = a.device();
 
-    uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
     tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tt::CBIndex::c_0, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_0, single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     tt_metal::CircularBufferConfig cb_inter_config =
@@ -84,7 +83,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
 
     SetRuntimeArgs(program, unary_reader_kernel_id, core, {src_buffer->address(), num_tiles, 0});
 
-    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles, 0});
+    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), /*num_tiles=*/1, 0});
 
     auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id](
                                               const void* operation,
@@ -108,7 +107,6 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
             runtime_args[0] = dst_buffer->address();
         }
     };
-
     return {std::move(program), override_runtime_args_callback};
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <optional>
-
 #include "prod_op_all.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include <tt-metalium/constants.hpp>
@@ -24,14 +23,14 @@ void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL((input_tensor_a.get_layout() == tt::tt_metal::Layout::TILE), "Input Layout must be tilized");
     TT_FATAL(input_tensor_a.memory_config().memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Error");
+    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Error - prod requires BFLOAT16");
 }
 
 std::vector<tt::tt_metal::TensorSpec> Prod_op::compute_output_specs(
     const std::vector<tt::tt_metal::Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     return {tt::tt_metal::TensorSpec(
-        input_tensor.get_logical_shape(),
+        ttnn::Shape({1, 1, 1, TILE_HW}),
         tt::tt_metal::TensorLayout(
             input_tensor.get_dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), output_mem_config))};
 }
@@ -47,13 +46,7 @@ tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_me
     tt::tt_metal::Tensor result = ttnn::tiled_prod(
         tt::tt_metal::operation::run(Prod_op{.output_mem_config = output_mem_config}, {input}).at(0),
         output_mem_config);
-    auto arch_env = tt_ClusterDescriptor::detect_arch((chip_id_t)0);
-    if (arch_env == tt::ARCH::WORMHOLE_B0) {
-        return ttnn::prod_result_computation_WH_B0<bfloat16>(
-            result, result.get_dtype(), result.get_layout(), result.device(), output_mem_config);
-    }
-    // else --> GS Arch
-    return ttnn::prod_result_computation_GS<bfloat16>(
+    return ttnn::prod_result_computation_WH_B0<bfloat16>(
         result, result.get_dtype(), result.get_layout(), result.device(), output_mem_config);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -22,8 +22,7 @@ inline Tensor prod_all(const Tensor& input_a, const MemoryConfig& output_mem_con
     auto formatted_input_tensor = input_a;
     if (formatted_input_tensor.get_layout() == Layout::ROW_MAJOR) {
         auto a_pad_shape = AutoFormat::pad_to_tile_shape(input_a.get_padded_shape());
-        auto out_shape = input_a.get_padded_shape();
-        out_shape = ttnn::Shape({out_shape[0], out_shape[1], out_shape[2], out_shape[3]});
+
         if (!AutoFormat::check_input_tensor_format(input_a, a_pad_shape)) {
             formatted_input_tensor =
                 AutoFormat::format_input_tensor(input_a, input_a.device(), a_pad_shape, 1.0, Layout::TILE);
@@ -84,6 +83,7 @@ Tensor ProdOperation::invoke(
         size - 1);
 
     if (all_dimensions) {
+        TT_FATAL(size == 4, "All dimension prod is only supported with input tensor of rank 4");
         return prod_all(input_a, output_mem_config);
     }
 


### PR DESCRIPTION
### Ticket
#16915

### Problem description
Running a full product previously returned a tensor with the same shape as the input tensor, with the first element of the output containing the product and the remaining elements containing 0. This did not match other TTNN reduction operations that would return an output of dimension [1,1,1,1].

### What's changed
Output tensor will now have a shape of [1,1,1,1], rather than padding with 0 to retain the input tensor's shape.
Also provides a clearer error message when trying to run a full product on a non-4D tensor.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13954579076)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13932950751)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes