### PR TITLE
Repeat Interleave Batched for Many Concats

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_repeat_interleave.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat_interleave.py
@@ -16,7 +16,7 @@ from models.utility_functions import (
 )
 
 
-@pytest.mark.parametrize("repeats", [1, 2, 3])
+@pytest.mark.parametrize("repeats", [1, 2, 3, 58])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint16])
 def test_repeat_interleave(device, repeats, dim, dtype):

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
@@ -49,11 +49,13 @@ ttnn::Tensor ExecuteRepeatInterleave::invoke(
 
     auto unsqueezed_tensor = ttnn::unsqueeze(rm_input, normalized_dim + 1);
     std::vector<Tensor> combined_tensors_batch;
+    constexpr uint32_t repeats_batched = 32;
+    combined_tensors_batch.reserve(std::min(repeat, repeats_batched));
     for (uint32_t i = 0; i < repeat; i++) {
         combined_tensors_batch.push_back(unsqueezed_tensor);
 
         // Concatenate every 32 tensors or at the end of the loop
-        if (combined_tensors_batch.size() == 32 || i == repeat - 1) {
+        if (combined_tensors_batch.size() == repeats_batched || i == repeat - 1) {
             auto batch_concat = ttnn::concat(combined_tensors_batch, normalized_dim + 1);
             combined_tensors.push_back(batch_concat);
             combined_tensors_batch.clear();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18951

### Problem description
When large amount of repeats runs out of runtime args, since number of runtime args scales up with number of tensors being concerted 

### What's changed
Batching repeats in groups of 32 to avoid large amount of runtime args. Solution proposed by @mstojkovicTT .
Eventually should pack into a metadata config vector instead of runtime args 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13933752764) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes