### PR TITLE
Track the number of msgs outstanding so we are not concerned with rollover bugs

### DIFF
--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -97,12 +97,6 @@ private:
     //  call
     DispatchArray<uint32_t> expected_num_workers_completed_;
 
-    std::atomic<bool> exit_condition_;
-    std::atomic<uint32_t> num_entries_in_completion_q_;  // issue queue writer thread increments this when an issued
-                                                         // command is expected back in the completion queue
-    std::atomic<uint32_t> num_completed_completion_q_reads_;  // completion queue reader thread increments this after
-                                                              // reading an entry out of the completion queue
-
     MultiProducerSingleConsumerQueue<CompletionReaderVariant> issued_completion_q_reads_;
     // These values are used to reset the host side launch message wptr after a trace is captured
     // Trace capture is a fully host side operation, but it modifies the state of the wptrs above
@@ -113,11 +107,14 @@ private:
     DispatchArray<tt::tt_metal::WorkerConfigBufferMgr> config_buffer_mgr_reset_;
     IDevice* device_;
 
-    std::condition_variable reader_thread_cv_;
-    std::mutex reader_thread_cv_mutex_;
+    std::mutex completion_q_count_mutex_;
+    std::atomic<bool> exit_condition_;
+    std::atomic<uint32_t> num_outstanding_in_completion_q_;  // issue queue writer thread increments this when an issued
+                                                             // command is expected back in the completion queue
+                                                             // and completion queue reader thread decrements this after
+                                                             // reading an entry out of the completion queue
+    std::condition_variable completion_q_count_cv_;
 
-    std::condition_variable reads_processed_cv_;
-    std::mutex reads_processed_cv_mutex_;
     CoreType get_dispatch_core_type();
 
     CoreCoord virtual_enqueue_program_dispatch_core_;

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -113,7 +113,8 @@ private:
                                                              // command is expected back in the completion queue
                                                              // and completion queue reader thread decrements this after
                                                              // reading an entry out of the completion queue
-    std::condition_variable completion_q_count_cv_;
+    std::condition_variable completion_q_empty_cv_;
+    std::condition_variable completion_q_nonempty_cv_;
 
     CoreType get_dispatch_core_type();
 


### PR DESCRIPTION
### Ticket
Second part of #19210

### Problem description
Two variables were being used to track a delta and each would increment ad infinitum.  This opens the door to a rollover bug where one becomes smaller than the other but comparison logic may assume it's always equal or larger.  Also two mutexes were being used and it was unclear which mutex was support to guard which variable.

### What's changed
* Use a single variable to track the delta.  This will grow and shrink.
* Use a single mutex and CV.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/13934182860)
- [ ] C++ API tests [do not show any threading issues](https://github.com/tenstorrent/tt-metal/actions/runs/13934193992/job/38998700345) related to this change.