### PR TITLE
#0: [skip ci] Reduce BH post commit timeouts

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -64,6 +64,7 @@ jobs:
     secrets: inherit
     with:
       arch: "blackhole"
+      timeout: 20
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
@@ -81,13 +82,14 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 30
+      timeout: 15
       os: "ubuntu-22.04"
   fd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     secrets: inherit
     with:
+      timeout: 20
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       os: "ubuntu-22.04"
@@ -99,7 +101,7 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 60
+      timeout: 20
       os: "ubuntu-22.04"
 
 #   profiler-regression:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Currently only 4 P100 blackhole runners in CI pool. When jobs running on the runners hang intermittent/ND they waste a lot of time clogging the queue, which extends to >8hrs right now.

### What's changed
Set 20 minute timeouts for non-sd blackhole test jobs.
Reduce sd-unit-test timeout from 30m to 15m (these tests are stable).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes