### PR TITLE
[skip ci] Fix permissions for APC Nightly

### DIFF
--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -14,6 +14,7 @@ permissions:
   pages: write
   id-token: write
   packages: write
+  checks: write
 
 jobs:
   nightly-debug:


### PR DESCRIPTION
### Ticket
None

### Problem description
This is failing: https://github.com/tenstorrent/tt-metal/actions/runs/13912527576

### What's changed
Granted the missing permission.