### PR TITLE
#19316: [skip ci] Read timestamps using fromisoformat() in produce_data workflow

### DIFF
--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -191,8 +191,8 @@ def get_pydantic_test_from_testcase_(testcase, default_timestamp=datetime.now(),
             properties = junit_xml_utils.get_pytest_testcase_properties(testcase)
             # Check if properties is none to see if pytest recorded the timestamps
             if properties is not None:
-                test_start_ts = datetime.strptime(properties["start_timestamp"], "%Y-%m-%dT%H:%M:%S")
-                test_end_ts = datetime.strptime(properties["end_timestamp"], "%Y-%m-%dT%H:%M:%S")
+                test_start_ts = datetime.fromisoformat(properties["start_timestamp"])
+                test_end_ts = datetime.fromisoformat(properties["end_timestamp"])
             else:
                 test_start_ts = default_timestamp
                 test_end_ts = default_timestamp
@@ -283,8 +283,7 @@ def get_tests_from_test_report_path(test_report_path):
     if report_root.tag == "testsuite":
         logger.info("Root tag is testsuite, found ctest xml")
         tests = []
-        # ctest timestamp format is not the same as pytest/gtest
-        default_timestamp = datetime.strptime(report_root.attrib["timestamp"], "%Y-%m-%dT%H:%M:%S")
+        default_timestamp = datetime.fromisoformat(report_root.attrib["timestamp"])
         for testcase in report_root.findall("testcase"):
             if is_valid_testcase_(testcase):
                 # Process ctest testcase
@@ -303,7 +302,7 @@ def get_tests_from_test_report_path(test_report_path):
         for i in range(len(report_root)):
             testsuite = report_root[i]
             testsuite_name = testsuite.attrib.get("name") if is_gtest else None
-            default_timestamp = datetime.strptime(testsuite.attrib["timestamp"], "%Y-%m-%dT%H:%M:%S.%f")
+            default_timestamp = datetime.fromisoformat(testsuite.attrib["timestamp"])
             get_pydantic_test = partial(
                 get_pydantic_test_from_testcase_,
                 default_timestamp=default_timestamp,


### PR DESCRIPTION
### Ticket
#19316

### Problem description
Fixes produce_data crash when the timestamp is missing fractional seconds for some odd reason:
https://github.com/tenstorrent/tt-metal/actions/runs/13921485499/job/38975579816
```
2025-03-18 15:46:58.874 | INFO     | infra.data_collection.cicd:create_cicd_json_for_data_analysis:80 - Job id:38952637641 Analyzing test report /home/runner/work/tt-metal/tt-metal/generated/cicd/13918518051/artifacts/test_reports_03fea9c0-f115-4153-98c0-2416d5d741e1/most_recent_tests.xml
2025-03-18 15:46:58.906 | DEBUG    | infra.data_collection.junit_xml_utils:sanity_check_test_xml_:27 - Asserted pytest junit xml
2025-03-18 15:46:58.906 | INFO     | infra.data_collection.github.workflows:get_tests_from_test_report_path:301 - Found 1 testsuites
Traceback (most recent call last):
  File ".github/scripts/data_analysis/create_pipeline_json.py", line 15, in <module>
    pipeline = create_cicd_json_for_data_analysis(
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/cicd.py", line 81, in create_cicd_json_for_data_analysis
    tests += get_tests_from_test_report_path(test_report_path)
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/github/workflows.py", line 306, in get_tests_from_test_report_path
    default_timestamp = datetime.strptime(testsuite.attrib["timestamp"], "%Y-%m-%dT%H:%M:%S.%f")
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2025-03-18T08:36:31' does not match format '%Y-%m-%dT%H:%M:%S.%f'
```

### What's changed
Use `.fromisoformat()` to parse the timestamps instead of `.strptime()` and providing our own time format specifier.

### Checklist
- [x] New/Existing tests provide coverage for changes
Pipeline rerun with branch:  https://github.com/tenstorrent/tt-metal/actions/runs/13933532743/job/38996270720