### PR TITLE
#0: Add check for missing docker images in workflows

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -46,7 +46,7 @@ runs:
       if: ${{ ! inputs.docker_image }}
       uses: ./.github/actions/generate-docker-tag
       with:
-        image: ${{ inputs.docker_os_arch }}
+        image: ${{ inputs.docker_os_arch || 'docker-image-unresolved!'}}
     - name: Set
       shell: bash
       run: |
@@ -68,7 +68,7 @@ runs:
         username: ${{ inputs.docker_username }}
         password: ${{ inputs.docker_password }}
         registry: ghcr.io
-        image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
+        image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG || 'docker-image-unresolved!'}}
         # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
         # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
         # for newly created files.

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -130,7 +130,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag }}
+      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -68,7 +68,7 @@ jobs:
       - build
       - in-service
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag }}
+      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/cpp-ttnn-project.yaml
+++ b/.github/workflows/cpp-ttnn-project.yaml
@@ -29,7 +29,7 @@ jobs:
         id: generate-docker-tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: tt-metalium/ubuntu-22.04-amd64
+          image: ${{ 'tt-metalium/ubuntu-22.04-amd64' || 'docker-image-unresolved!' }}
       - name: Docker login
         uses: docker/login-action@v3
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: Build Metalium
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
+          image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG || 'docker-image-unresolved!'}}
           options: |
             --rm
             --tmpfs /tmp
@@ -70,7 +70,7 @@ jobs:
       - name: Build TTNN Project
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
+          image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG || 'docker-image-unresolved!'}}
           options: |
             --rm
             --tmpfs /tmp

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -30,7 +30,7 @@ jobs:
     name: "${{ matrix.test-info.name }} device perf"
     runs-on: ${{ matrix.test-info.runs-on }}
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -25,6 +25,8 @@ jobs:
         os: [ubuntu-20.04]
     runs-on:
       - ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.generate-tag-name.outputs.TAG_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +50,7 @@ jobs:
           echo "REPO_IMAGE_NAME=$REPO_IMAGE_NAME" >> $GITHUB_ENV
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -79,7 +82,7 @@ jobs:
           ]
     runs-on: ${{ matrix.test_group.runs-on }}
     container:
-      image: ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release:${{ inputs.version }}
+      image: ${{ needs.create-docker-release-image.outputs.tag_name || 'docker-image-unresolved!' }}
       env:
         LOGURU_LEVEL: INFO
         ARCH_NAME: ${{ matrix.test_group.arch }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -70,7 +70,7 @@ jobs:
       - cloud-virtual-machine
       - in-service
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
       - ${{ matrix.test-group.label}}
       - ${{ inputs.extra-tag }}
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work

--- a/.github/workflows/tg-frequent-tests-impl.yaml
+++ b/.github/workflows/tg-frequent-tests-impl.yaml
@@ -30,7 +30,7 @@ jobs:
       - bare-metal
       - pipeline-functional
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -24,7 +24,7 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "pipeline-functional"]
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -33,7 +33,7 @@ jobs:
       - cloud-virtual-machine
       - in-service
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         LD_LIBRARY_PATH: /work/build/lib


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
When using Github Actions `jobs.<job_id>.container.image`, there is no graceful failure if the image does not exist. 

### What's changed
Add invalid image 'docker-image-unresolved!' to be the fallback for any missing images. This makes the string 'docker-image-unresolved!' show up in error logs.

### Checklist
Example of failure: https://github.com/tenstorrent/tt-metal/actions/runs/13904684653/job/38905589360#step:3:26
Confirm smoke-test-docker-image job successful https://github.com/tenstorrent/tt-metal/actions/runs/13933841408