### PR TITLE
#19111: Add unit tests for data and hybrid data parallel examples

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -86,6 +86,8 @@ run_t3000_ttnn_tests() {
   pytest -n auto tests/ttnn/unit_tests/test_multi_device.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/test_multi_device_async.py ; fail+=$?
   pytest tests/ttnn/distributed/test_tensor_parallel_example_T3000.py ; fail+=$?
+  pytest tests/ttnn/distributed/test_data_parallel_example.py ; fail+=$?
+  pytest tests/ttnn/distributed/test_hybrid_data_tensor_parallel_example_T3000.py ; fail+=$?
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Incremental porting of changes of integration branch back to main.

### What's changed
- Fix API call in `ttnn.distribute`
- Added new test cases for data parallel and hybrid data parallel examples in the T3000 unit tests.
- Updated the test script to include these new tests for comprehensive coverage.

### Checklist
- [x] New tests provide coverage for changes
- [x] T3000 Unit Tests