### PR TITLE
Fix gelu_backward_pybind.cpp docstring

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.cpp
@@ -35,7 +35,7 @@ void bind_experimental_gelu_backward_operation(py::module& module) {
 
             .. list-table::
                 :header-rows: 1
-    
+
                 * - Dtypes
                     - Layouts
                     - Ranks

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.cpp
@@ -34,14 +34,14 @@ void bind_experimental_gelu_backward_operation(py::module& module) {
             Supported dtypes, layouts, and ranks:
 
             .. list-table::
-            :header-rows: 1
-
-            * - Dtypes
-                - Layouts
-                - Ranks
-            * - BFLOAT16
-                - TILE
-                - 2, 3, 4
+                :header-rows: 1
+    
+                * - Dtypes
+                    - Layouts
+                    - Ranks
+                * - BFLOAT16
+                    - TILE
+                    - 2, 3, 4
 
 
         Example:


### PR DESCRIPTION
### Ticket
None

### Problem description
Creates post-commit eror
https://github.com/tenstorrent/tt-metal/actions/runs/13934776978/job/39000834512#step:8:1129

```
/usr/local/lib/python3.10/dist-packages/ttnn/decorators.py:docstring of ttnn.experimental.gelu_bw:23:The "list-table" directive is empty; content required.
```

### What's changed
Fix docustring
### Checklist
- [x] [Docs build](https://github.com/tenstorrent/tt-metal/actions/runs/13936508993)