### PR TITLE
#19261: Fix N150 hang on unit test round_new

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 from functools import partial
-from models.utility_functions import skip_for_grayskull, torch_random
+from models.utility_functions import torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 
@@ -27,7 +27,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-@skip_for_grayskull("Requires wormhole_b0 to run")
 def test_round_new(shape, dtypes, decimal, device):
     torch.manual_seed(0)
     torch_dtype, tt_dtype = dtypes
@@ -49,4 +48,4 @@ def test_round_new(shape, dtypes, decimal, device):
     output_tensor = ttnn.round(input_tensor, decimal)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.997
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999

--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -14,17 +14,12 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 @pytest.mark.parametrize(
     "shape",
     (
-        torch.Size([1, 1, 10, 10]),
-        torch.Size([4, 3, 32, 32]),
-        torch.Size([2, 2, 32, 32]),
-        torch.Size([6, 4, 32, 32]),
         torch.Size([1, 1, 320, 320]),
-        torch.Size([1, 3, 320, 64]),
         torch.Size([1, 1, 320, 384]),
         torch.Size([1, 3, 320, 384]),
     ),
 )
-@pytest.mark.parametrize("decimal", range(-6, 7))
+@pytest.mark.parametrize("decimal", [-3, 6, -1])
 @pytest.mark.parametrize(
     "dtypes",
     [

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -28,9 +28,9 @@ inline vFloat round_even(vFloat v) {
     v_if(sfpi::abs(v) < 0x1p30f) {
         result = int32_to_float(float_to_int31(v), 0);
         v_if(sfpi::abs(v - result) == 0.5F) {
-            vInt res = float_to_int16(result);
+            vInt res = float_to_int16(result, 0);
             res = res & 0x7FFE;
-            result = int32_to_float(res);
+            result = int32_to_float(res, 0);
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_round.h
@@ -28,9 +28,9 @@ inline vFloat round_even(vFloat v) {
     v_if(sfpi::abs(v) < 0x1p30f) {
         result = int32_to_float(float_to_int31(v), 0);
         v_if(sfpi::abs(v - result) == 0.5F) {
-            vInt res = float_to_int16(result);
+            vInt res = float_to_int16(result, 0);
             res = res & 0x7FFE;
-            result = int32_to_float(res);
+            result = int32_to_float(res, 0);
         }
         v_endif;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1820,7 +1820,7 @@ void py_module(py::module& module) {
     detail::bind_unary_operation_with_int_parameter(
         module,
         ttnn::round,
-        "decimals", "no. of decimal places to round off to",
+        "decimals", "no. of decimal places to round off to [supported range -6 to 7]",
         R"doc(Round the input tensor to `decimals` decimal places.)doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc",
         R"doc(Not supported on Grayskull.)doc");


### PR DESCRIPTION
### Ticket
#19261 

### Problem description
`timeout 18000 pytest tests/ttnn/unit_tests/operations/eltwise/test_round.py::test_round_new --count 1000` took 1.5h to repro. Test case needs to be narrowed down.
PCC drop in the first test run after device reset and fresh build.

### What's changed

- Reduced no. of test cases and retested with the above command (all test cases pass with no hang).
- Updated doc to include the supported decimal range from previous test cases.
- Set rounding mode for int-float conversions to 0 to avoid PCC drop - tests pass with atol = 0.0

### Results

**Test command:** 
`timeout 18000 pytest tests/ttnn/unit_tests/operations/eltwise/test_round.py::test_round_new --count 1000`
<img width="1618" alt="Screenshot 2025-03-21 at 16 58 37" src="https://github.com/user-attachments/assets/29a1adc0-3b88-415c-8076-1edb37501503" />

After device reset and fresh build:
<img width="1238" alt="Screenshot 2025-03-24 at 21 44 14" src="https://github.com/user-attachments/assets/a4739144-57df-4438-a4d4-3f601a1142a9" />

### Checklist
- [x] [Custom test dispatch - Round N150 1000x stress test](https://github.com/tenstorrent/tt-metal/actions/runs/14031656627) - PASSED
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14040528223) - PASSED
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14038582574)
- [x] New/Existing tests provide coverage for changes