### PR TITLE
#15132: Improve ttnn.tanh accuracy 

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/tanh/tanh.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/tanh/tanh.py
@@ -27,6 +27,7 @@ parameters = {
         "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "accuracy": [True, False],
     },
 }
 
@@ -37,6 +38,8 @@ parameters = {
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
         return True, "ROW_MAJOR_LAYOUT is not supported"
+    elif test_vector["accuracy"] == True and test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "accuracy mode is not supported in bfloat8_b"
     return False, None
 
 
@@ -50,6 +53,7 @@ def run(
     input_layout,
     input_memory_config,
     output_memory_config,
+    accuracy,
     *,
     device,
 ) -> list:
@@ -71,7 +75,7 @@ def run(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.tanh(input_tensor, memory_config=output_memory_config)
+    result = ttnn.tanh(input_tensor, memory_config=output_memory_config, accuracy=accuracy)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def test_tanh_range(device):
+    torch_input_tensor_a = torch.tensor(
+        [
+            [
+                [
+                    [
+                        -1.8125,
+                        -2.828125,
+                        -3.125,
+                        -3.234375,
+                        -2.765625,
+                        -1.890625,
+                        -3.359375,
+                        -2.0625,
+                        -3.015625,
+                        -2.203125,
+                        -2.015625,
+                        -2.9375,
+                        -1.3046875,
+                        -1.359375,
+                        -1.3984375,
+                        -1.2265625,
+                        -2,
+                        -3,
+                        -1.5,
+                        -2.5,
+                        -3.5,
+                        -3.75,
+                        -3.359375,
+                        -1.8828125,
+                        -3.255,
+                        -0.9,
+                        -0.1,
+                        0.25,
+                        0.75,
+                        -0.8359375,
+                        -0.5,
+                        0.9,
+                    ]
+                ]
+            ]
+        ],
+        dtype=torch.bfloat16,
+    )
+    torch_output_tensor = torch.tanh(torch_input_tensor_a)
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.tanh(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG, accuracy=True)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc, pcc_msg = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    # print("pcc_msg", pcc_msg) # pcc_msg 0.9999663646890817, accuracy=False pcc 0.9978378297942829
+    assert pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([2, 4, 320, 1024])),
+        (torch.Size([1, 9, 8192])),
+    ),
+)
+@pytest.mark.parametrize(
+    "input_range",
+    [
+        {"high": 1, "low": -1},
+        {"high": 100, "low": -100},
+        {"high": 10000, "low": -10000},
+        {"high": 4, "low": -4},
+    ],
+)
+def test_tanh_accuracy(device, input_shapes, input_range):
+    high = input_range["high"]
+    low = input_range["low"]
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16) * (high - low) + low
+    golden_function = ttnn.get_golden_function(ttnn.tanh)
+    torch_output_tensor = golden_function(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output = ttnn.tanh(input_tensor, accuracy=True)
+    output_tensor = ttnn.to_torch(output)
+    pcc, pcc_msg = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    # print("pcc_msg", pcc_msg)  # pcc_msg 0.9999 or above
+    assert pcc

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -184,6 +184,15 @@ struct Mish {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Tanh {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        bool accuracy = false);
+};
+
 }  // namespace unary
 }  // namespace operations
 
@@ -246,7 +255,6 @@ REGISTER_UNARY_OPERATION(sin, SIN);
 REGISTER_UNARY_OPERATION(sqrt, SQRT);
 REGISTER_UNARY_OPERATION(square, SQUARE);
 REGISTER_UNARY_OPERATION(tan, TAN);
-REGISTER_UNARY_OPERATION(tanh, TANH);
 REGISTER_UNARY_OPERATION(tiled_prod, TILED_PROD);
 REGISTER_UNARY_OPERATION(bitwise_not, BITWISE_NOT);
 
@@ -289,6 +297,7 @@ constexpr auto ceil = ttnn::register_operation_with_auto_launch_op<"ttnn::ceil",
 constexpr auto mish = ttnn::register_operation_with_auto_launch_op<"ttnn::mish", ttnn::operations::unary::Mish>();
 constexpr auto softplus =
     ttnn::register_operation_with_auto_launch_op<"ttnn::softplus", ttnn::operations::unary::Softplus>();
+constexpr auto tanh = ttnn::register_operation_with_auto_launch_op<"ttnn::tanh", ttnn::operations::unary::Tanh>();
 constexpr auto prelu_sfpu =
     ttnn::register_operation_with_auto_launch_op<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -796,6 +796,68 @@ void bind_softplus(py::module& module, const unary_operation_t& operation) {
 }
 
 template <typename unary_operation_t>
+void bind_tanh(py::module& module, const unary_operation_t& operation) {
+    auto doc = fmt::format(
+        R"doc(
+        Applies {0} to :attr:`input_tensor` element-wise.
+
+        .. math::
+            \mathrm{{output\_tensor}}_i = {0}(\mathrm{{input\_tensor}}_i)
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            accuracy (Boolean, optional): provides better accuracy for input range -3 to 3, for dtype BFLOAT16. Defaults to `False`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - BFLOAT16, BFLOAT8_B
+                 - TILE
+                 - 2, 3, 4
+
+        Example:
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor, accuracy=False)
+        )doc",
+        ttnn::tanh.base_name(),
+        ttnn::tanh.python_fully_qualified_name());
+
+    bind_registered_operation(
+        module,
+        ttnn::tanh,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const Tensor& input,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<Tensor>& output_tensor,
+               bool accuracy,
+               const QueueId queue_id) {
+                return self(queue_id, input, memory_config, output_tensor, accuracy);
+            },
+            py::arg("input_tensor"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("accuracy") = false,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+template <typename unary_operation_t>
 void bind_sigmoid_accurate(py::module& module, const unary_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
@@ -1648,7 +1710,6 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::sqrt, R"doc(\mathrm{{output\_tensor}}_i = \verb|sqrt|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::square, R"doc(\mathrm{{output\_tensor}}_i = \verb|square|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::tan, R"doc(\mathrm{{output\_tensor}}_i = \verb|tan|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc" , "Supported input range is (-1.45, 1.45)");
-    detail::bind_unary_operation(module, ttnn::tanh, R"doc(\mathrm{{output\_tensor}}_i = \verb|tanh|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::log_sigmoid, R"doc(\mathrm{{output\_tensor}}_i = \verb|log_sigmoid|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::bitwise_not, R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_not|(\mathrm{{input\_tensor}}_i))doc", R"doc(INT32)doc",
     R"doc(Supported input range is [-2147483647, 2147483647]. Supported for Wormhole_B0 only.)doc",
@@ -1729,6 +1790,7 @@ void py_module(py::module& module) {
 
     // Other unaries (unary chain operations)
     detail::bind_softplus(module, ttnn::softplus);
+    detail::bind_tanh(module, ttnn::tanh);
     detail::bind_sigmoid_accurate(module, ttnn::sigmoid_accurate);
     detail::bind_unary_chain(module, ttnn::unary_chain);
     detail::bind_identity(module, ttnn::identity);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -254,7 +254,7 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardPow::invoke(
         return grad_tensor;
     }
 
-    Tensor power_input = ttnn::power(queue_id, input, fabs(exponent - 1.0f), output_mem_config);
+    Tensor power_input = ttnn::power(queue_id, input, std::fabs(exponent - 1.0f), output_mem_config);
     if (exponent < 1.0f) {
         power_input = ttnn::reciprocal(queue_id, power_input, output_mem_config);
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue #15132

### Problem description
ttnn.tanh has low PCC for input range  (-3.5, 3.5)

### What's changed
- An alternate implementation that is not dependant on the look-up table LLK implementation to provide better PCC necessary for models. 
- overall the accuracy for range  (-3, 3) has improved with the PCC greater than 0.9999 for BFLOAT16 dtype

As per @amalbasaTT 's comment the new improved PCC on using this implementation
albert_v2_base: 0.9666459989505328
albert_v2_large: 0.9673880460396883
albert_v2_xlarge: 0.9682215217344369
albert_v2_xxlarge: 0.9918737729342227

### Follow-up: 
- Convert this composite implementation into a device operation https://github.com/tenstorrent/tt-metal/issues/19461

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13971672604
https://github.com/tenstorrent/tt-metal/actions/runs/14139810091
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] Sweeps - https://github.com/tenstorrent/tt-metal/actions/runs/13991964779
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes