### PR TITLE
#18843: Reduce batch norm tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -17,9 +17,9 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([4, 5], [7, 8])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([4, 5], [7, 8])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([2, 3], [1, 2])),
+        torch.Size([5, 8, 32, 32]),
+        torch.Size([7, 3, 23, 23]),
+        torch.Size([3, 5, 64, 120]),
     ],
 )
 @pytest.mark.parametrize(
@@ -34,7 +34,7 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("training", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("eps", [1.0, 0.0, 1e-05])
+@pytest.mark.parametrize("eps", [1.0, 1e-05])
 @pytest.mark.parametrize("momentum", [0.0, 0.1])
 def test_batch_norm_tests_fp32(
     input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype="float32"
@@ -168,9 +168,9 @@ def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([3, 4], [3, 4])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([3, 4], [3, 4])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([2, 3], [3, 4])),
+        torch.Size([5, 8, 32, 32]),
+        torch.Size([7, 3, 23, 23]),
+        torch.Size([3, 5, 64, 120]),
     ],
 )
 @pytest.mark.parametrize(
@@ -184,7 +184,7 @@ def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
 )
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("eps", [1.0, 0.0, 1e-05])
+@pytest.mark.parametrize("eps", [0.0, 1e-05])
 def test_batch_norm_fp32(
     input_shapes, check_mean, check_var, weight, bias, eps, device, training=False, testing_dtype="float32"
 ):
@@ -243,9 +243,9 @@ def test_batch_norm_fp32(
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        *(torch.Size([n, c, 32, 32]) for n, c in product([4, 5], [7, 8])),
-        *(torch.Size([n, c, 23, 23]) for n, c in product([4, 5], [7, 8])),
-        *(torch.Size([n, c, 64, 120]) for n, c in product([2, 3], [1, 2])),
+        torch.Size([5, 8, 32, 32]),
+        torch.Size([7, 3, 23, 23]),
+        torch.Size([3, 5, 64, 120]),
     ],
 )
 @pytest.mark.parametrize(
@@ -263,7 +263,7 @@ def test_batch_norm_fp32(
 )
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34])
+@pytest.mark.parametrize("eps", [1.0, 2.34])
 @pytest.mark.parametrize("momentum", [0.0, 0.5])
 def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device):
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)


### PR DESCRIPTION
### Ticket
#18843

### Problem description
Reduce the number of test

### What's changed
Batch norm test runs for approximately 4 minutes. 
![Screenshot 2025-03-18 at 9 41 06 PM](https://github.com/user-attachments/assets/d6160578-6c5f-48f5-81f4-8dd72eebded0)

with the reduction in number of shapes tested, the time is nor 1 minute
<img width="337" alt="Screenshot 2025-03-19 at 3 34 21 PM" src="https://github.com/user-attachments/assets/42e46bd0-9be9-4ad2-8989-45e069b65e2b" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13960996074)