### PR TITLE
#18922: Add int support for zero comparison ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -530,7 +530,7 @@ def test_unary_ceil(input_shapes, device):
     ],
 )
 @pytest.mark.parametrize(
-    "ttn_function",
+    "ttnn_function",
     [
         ttnn.eqz,
         ttnn.nez,
@@ -540,19 +540,16 @@ def test_unary_ceil(input_shapes, device):
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_ttnn(input_shapes, low, high, ttn_function, device):
+def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
     in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
     cq_id = 0
-    output_tensor = ttn_function(input_tensor, queue_id=cq_id)
-    golden_function = ttnn.get_golden_function(ttn_function)
+    output_tensor = ttnn_function(input_tensor, queue_id=cq_id)
+    golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    print(in_data)
-    print(golden_tensor)
-    print(output_tensor)
     pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert pcc == 1
 
@@ -567,7 +564,7 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttn_function, device):
     ),
 )
 @pytest.mark.parametrize(
-    "ttn_function",
+    "ttnn_function",
     [
         ttnn.eqz,
         ttnn.nez,
@@ -577,7 +574,7 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttn_function, device):
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_edge_case(input_shapes, ttn_function, device):
+def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -591,8 +588,8 @@ def test_unary_zero_comp_edge_case(input_shapes, ttn_function, device):
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttn_function(input_tensor)
-    golden_function = ttnn.get_golden_function(ttn_function)
+    output_tensor = ttnn_function(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn_function)
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -529,17 +529,30 @@ def test_unary_ceil(input_shapes, device):
         (-5, 5),  # Small range
     ],
 )
-def test_unary_eqz_ttnn(input_shapes, low, high, device):
+@pytest.mark.parametrize(
+    "ttn_function",
+    [
+        ttnn.eqz,
+        ttnn.nez,
+        ttnn.ltz,
+        ttnn.lez,
+        ttnn.gtz,
+        ttnn.gez,
+    ],
+)
+def test_unary_zero_comp_ttnn(input_shapes, low, high, ttn_function, device):
     in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
     cq_id = 0
-    output_tensor = ttnn.eqz(input_tensor, queue_id=cq_id)
-    golden_function = ttnn.get_golden_function(ttnn.eqz)
+    output_tensor = ttn_function(input_tensor, queue_id=cq_id)
+    golden_function = ttnn.get_golden_function(ttn_function)
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)
-
+    print(in_data)
+    print(golden_tensor)
+    print(output_tensor)
     pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
     assert pcc == 1
 
@@ -553,7 +566,18 @@ def test_unary_eqz_ttnn(input_shapes, low, high, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_edge_case(input_shapes, device):
+@pytest.mark.parametrize(
+    "ttn_function",
+    [
+        ttnn.eqz,
+        ttnn.nez,
+        ttnn.ltz,
+        ttnn.lez,
+        ttnn.gtz,
+        ttnn.gez,
+    ],
+)
+def test_unary_zero_comp_edge_case(input_shapes, ttn_function, device):
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -567,8 +591,8 @@ def test_unary_eqz_edge_case(input_shapes, device):
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.eqz(input_tensor)
-    golden_function = ttnn.get_golden_function(ttnn.eqz)
+    output_tensor = ttn_function(input_tensor)
+    golden_function = ttnn.get_golden_function(ttn_function)
     golden_tensor = golden_function(in_data)
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
@@ -9,7 +9,18 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
-@pytest.mark.parametrize("activations", [[], [ttnn.UnaryWithParam(ttnn.UnaryOpType.EQZ)]])
+@pytest.mark.parametrize(
+    "activations",
+    [
+        [],
+        [ttnn.UnaryWithParam(ttnn.UnaryOpType.EQZ)],
+        [ttnn.UnaryWithParam(ttnn.UnaryOpType.LTZ)],
+        [ttnn.UnaryWithParam(ttnn.UnaryOpType.LEZ)],
+        [ttnn.UnaryWithParam(ttnn.UnaryOpType.GTZ)],
+        [ttnn.UnaryWithParam(ttnn.UnaryOpType.GEZ)],
+        [ttnn.UnaryWithParam(ttnn.UnaryOpType.NEZ)],
+    ],
+)
 @pytest.mark.parametrize(
     "torch_dtype",
     [
@@ -23,8 +34,21 @@ def test_add_and_apply_activations(device, shape, activations, torch_dtype):
     torch_input_tensor_a = torch.Tensor(size=shape).uniform_(-100, 100).to(torch_dtype)
     torch_input_tensor_b = torch.Tensor(size=shape).uniform_(-150, 150).to(torch_dtype)
     torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
-    if activations != []:
-        torch_output_tensor = torch.eq(torch_output_tensor, 0)
+    if activations:
+        for activation in activations:
+            op_type = activation.op_type
+            if op_type == ttnn.UnaryOpType.EQZ:
+                torch_output_tensor = torch.eq(torch_output_tensor, 0)
+            elif op_type == ttnn.UnaryOpType.LTZ:
+                torch_output_tensor = torch.lt(torch_output_tensor, 0)
+            elif op_type == ttnn.UnaryOpType.LEZ:
+                torch_output_tensor = torch.le(torch_output_tensor, 0)
+            elif op_type == ttnn.UnaryOpType.GTZ:
+                torch_output_tensor = torch.gt(torch_output_tensor, 0)
+            elif op_type == ttnn.UnaryOpType.GEZ:
+                torch_output_tensor = torch.ge(torch_output_tensor, 0)
+            elif op_type == ttnn.UnaryOpType.NEZ:
+                torch_output_tensor = torch.ne(torch_output_tensor, 0)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -70,52 +70,47 @@ template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_int() {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
+        vInt zero = 0;
 
         // a[i] == 0
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            v_if(v == 0) { v = 1; }
-            v_else { v = 0; }
+            v_if(v == zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] != 0
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
-            v_if(v == 0) { v = 0; }
+            v_if(v == zero) { v = zero; }
             v_else { v = 1; }
             v_endif;
         }
 
         // a[i] < 0
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-            v_if(v < 0) { v = 1; }
-            v_else { v = 0; }
+            v_if(v < zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] > 0
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-            vInt temp = v;
-            v_if(v >= 0) { v = 1; }
-            v_else { v = 0; }
-            v_endif;
-            v_if(temp == 0) { v = 0; }
+            v_if(v > zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] <= 0
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
-            vInt temp = v;
-            v_if(v < 0) { v = 1; }
-            v_else { v = 0; }
-            v_endif;
-            v_if(temp == 0) { v = 1; }
+            v_if(v <= zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] >= 0
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-            v_if(v >= 0) { v = 1; }
-            v_else { v = 0; }
+            v_if(v >= zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -78,6 +78,47 @@ inline void calculate_comp_int() {
             v_endif;
         }
 
+        // a[i] != 0
+        if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
+            v_if(v == 0) { v = 0; }
+            v_else { v = 1; }
+            v_endif;
+        }
+
+        // a[i] < 0
+        if constexpr (COMP_MODE == SfpuType::less_than_zero) {
+            v_if(v < 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+        }
+
+        // a[i] > 0
+        if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
+            vInt temp = v;
+            v_if(v >= 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+            v_if(temp == 0) { v = 0; }
+            v_endif;
+        }
+
+        // a[i] <= 0
+        if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
+            vInt temp = v;
+            v_if(v < 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+            v_if(temp == 0) { v = 1; }
+            v_endif;
+        }
+
+        // a[i] >= 0
+        if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
+            v_if(v >= 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+        }
+
         dst_reg[0] = v;
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -38,6 +38,12 @@ inline void llk_math_eltwise_unary_sfpu_nez(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::not_equal_zero, APPROXIMATE>();
 }
@@ -47,6 +53,12 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_ltz(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::less_than_zero>, dst_index, vector_mode, 8);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_ltz_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::less_than_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -62,6 +74,12 @@ inline void llk_math_eltwise_unary_sfpu_gtz(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_gtz_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::greater_than_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_gtz_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::greater_than_zero, APPROXIMATE>();
 }
@@ -74,6 +92,12 @@ inline void llk_math_eltwise_unary_sfpu_lez(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_lez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::less_than_equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_lez_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::less_than_equal_zero, APPROXIMATE>();
 }
@@ -83,6 +107,12 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_gez(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::greater_than_equal_zero>, dst_index, vector_mode, 8);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_gez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::greater_than_equal_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -70,52 +70,47 @@ template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_int() {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
+        vInt zero = 0;
 
         // a[i] == 0
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            v_if(v == 0) { v = 1; }
-            v_else { v = 0; }
+            v_if(v == zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] != 0
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
-            v_if(v == 0) { v = 0; }
+            v_if(v == zero) { v = zero; }
             v_else { v = 1; }
             v_endif;
         }
 
         // a[i] < 0
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-            v_if(v < 0) { v = 1; }
-            v_else { v = 0; }
+            v_if(v < zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] > 0
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-            vInt temp = v;
-            v_if(v >= 0) { v = 1; }
-            v_else { v = 0; }
-            v_endif;
-            v_if(temp == 0) { v = 0; }
+            v_if(v > zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] <= 0
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
-            vInt temp = v;
-            v_if(v < 0) { v = 1; }
-            v_else { v = 0; }
-            v_endif;
-            v_if(temp == 0) { v = 1; }
+            v_if(v <= zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 
         // a[i] >= 0
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-            v_if(v >= 0) { v = 1; }
-            v_else { v = 0; }
+            v_if(v >= zero) { v = 1; }
+            v_else { v = zero; }
             v_endif;
         }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -6,7 +6,6 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 
 using namespace sfpi;
 
@@ -75,6 +74,47 @@ inline void calculate_comp_int() {
         // a[i] == 0
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
             v_if(v == 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+        }
+
+        // a[i] != 0
+        if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
+            v_if(v == 0) { v = 0; }
+            v_else { v = 1; }
+            v_endif;
+        }
+
+        // a[i] < 0
+        if constexpr (COMP_MODE == SfpuType::less_than_zero) {
+            v_if(v < 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+        }
+
+        // a[i] > 0
+        if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
+            vInt temp = v;
+            v_if(v >= 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+            v_if(temp == 0) { v = 0; }
+            v_endif;
+        }
+
+        // a[i] <= 0
+        if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
+            vInt temp = v;
+            v_if(v < 0) { v = 1; }
+            v_else { v = 0; }
+            v_endif;
+            v_if(temp == 0) { v = 1; }
+            v_endif;
+        }
+
+        // a[i] >= 0
+        if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
+            v_if(v >= 0) { v = 1; }
             v_else { v = 0; }
             v_endif;
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_comp.h
@@ -38,6 +38,12 @@ inline void llk_math_eltwise_unary_sfpu_nez(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_nez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::not_equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_nez_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::not_equal_zero, APPROXIMATE>();
 }
@@ -47,6 +53,12 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_ltz(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::less_than_zero>, dst_index, vector_mode, 8);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_ltz_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::less_than_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -62,6 +74,12 @@ inline void llk_math_eltwise_unary_sfpu_gtz(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_gtz_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::greater_than_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_gtz_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::greater_than_zero, APPROXIMATE>();
 }
@@ -74,6 +92,12 @@ inline void llk_math_eltwise_unary_sfpu_lez(uint dst_index, int vector_mode = (i
 }
 
 template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_lez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::less_than_equal_zero>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_lez_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::less_than_equal_zero, APPROXIMATE>();
 }
@@ -83,6 +107,12 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_gez(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::greater_than_equal_zero>, dst_index, vector_mode, 8);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_gez_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_comp_int<APPROXIMATE, SfpuType::greater_than_equal_zero>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -306,6 +306,22 @@ ALWI void square_tile_init() { MATH((llk_math_eltwise_unary_sfpu_square_init<APP
 // clang-format on
 ALWI void ltz_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_ltz<APPROX>(idst))); }
 
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element of a tile is less than zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void ltz_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_ltz_int32<APPROX>(idst))); }
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -364,6 +380,22 @@ ALWI void eqz_tile_init() { MATH((llk_math_eltwise_unary_sfpu_eqz_init<APPROX>()
 // clang-format on
 ALWI void lez_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_lez<APPROX>(idst))); }
 
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is less than or equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void lez_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_lez_int32<APPROX>(idst))); }
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -406,6 +438,22 @@ ALWI void tiled_prod_tile_init() { MATH((llk_math_eltwise_unary_sfpu_tiled_prod_
 // clang-format on
 ALWI void gtz_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_gtz<APPROX>(idst))); }
 
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is greater than zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void gtz_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_gtz_int32<APPROX>(idst))); }
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -427,6 +475,22 @@ ALWI void gtz_tile_init() { MATH((llk_math_eltwise_unary_sfpu_gtz_init<APPROX>()
  // clang-format on
 ALWI void nez_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_nez<APPROX>(idst))); }
 
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is not equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void nez_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_nez_int32<APPROX>(idst))); }
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -447,6 +511,22 @@ ALWI void nez_tile_init() { MATH((llk_math_eltwise_unary_sfpu_nez_init<APPROX>()
  */
  // clang-format on
 ALWI void gez_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_gez<APPROX>(idst))); }
+
+// clang-format off
+/**
+ * Will store in the output of the compute core True if each element is greater than or equal to zero.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void gez_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_gez_int32<APPROX>(idst))); }
 
 /**
  * Please refer to documentation for any_init.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -59,10 +59,18 @@ std::map<std::string, std::string> get_defines(
             op_name = "mul_tiles";
             op_binary_type = "EltwiseBinaryType::ELWMUL";
             break;
-        case BinaryOpType::GT: defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst)); break;
-        case BinaryOpType::LT: defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst)); break;
-        case BinaryOpType::GTE: defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst)); break;
-        case BinaryOpType::LTE: defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst)); break;
+        case BinaryOpType::GT:
+            defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::LT:
+            defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::GTE:
+            defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst, input_dtype));
+            break;
+        case BinaryOpType::LTE:
+            defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst, input_dtype));
+            break;
         case BinaryOpType::EQ:
             defines.merge(get_defines(UnaryOpType::EQZ, std::nullopt, "0", idst, input_dtype));
             break;
@@ -75,7 +83,7 @@ std::map<std::string, std::string> get_defines(
         case BinaryOpType::LOGICAL_AND:
             op_name = "mul_tiles";
             op_binary_type = "EltwiseBinaryType::ELWMUL";
-            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst, input_dtype));
             break;
         case BinaryOpType::BIAS_GELU:
             op_name = "add_tiles";
@@ -104,18 +112,18 @@ std::map<std::string, std::string> get_defines(
             op_binary_type = "EltwiseBinaryType::ELWMUL";
             break;
         case BinaryOpType::LOGICAL_OR:
-            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0"));
-            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0"));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_dtype));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_dtype));
             op_name = "add_tiles";
             op_binary_type = "EltwiseBinaryType::ELWADD";
-            defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst));
+            defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst, input_dtype));
             break;
         case BinaryOpType::LOGICAL_XOR:
-            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0"));
-            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0"));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_dtype));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_dtype));
             op_name = "sub_tiles";
             op_binary_type = "EltwiseBinaryType::ELWSUB";
-            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst));
+            defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst, input_dtype));
             break;
         case BinaryOpType::LDEXP:
             defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
@@ -268,7 +276,7 @@ std::map<std::string, std::string> get_defines_fp32(
             break;
         case BinaryOpType::LOGICAL_AND:
             op_name = "mul_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::BIAS_GELU:
             new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
@@ -276,34 +284,34 @@ std::map<std::string, std::string> get_defines_fp32(
             new_defines.merge(get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst1));
             break;
         case BinaryOpType::LOGICAL_OR:
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0"));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
             new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
             op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::LOGICAL_XOR:
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0"));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0", "0", input_a_dtype));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0", "0", input_b_dtype));
             op_name = "sub_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         // applied on A-B
         case BinaryOpType::GT:
             op_name = "sub_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::LT:
             op_name = "sub_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::GTE:
             op_name = "sub_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::LTE:
             op_name = "sub_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         case BinaryOpType::EQ:
             op_name = "sub_binary_tile";
@@ -311,7 +319,7 @@ std::map<std::string, std::string> get_defines_fp32(
             break;
         case BinaryOpType::NE:
             op_name = "sub_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1, input_a_dtype));
             break;
         default:
             tt::log_debug(tt::LogOp, "Undefined op type {}", op_type);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -356,11 +356,42 @@ std::pair<string, string> get_op_init_and_func_default(
                 op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile({});", idst)};
             }
             break;
-        case UnaryOpType::NEZ: op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)}; break;
-        case UnaryOpType::LTZ: op_init_and_name = {"ltz_tile_init();", fmt::format("ltz_tile({});", idst)}; break;
-        case UnaryOpType::GTZ: op_init_and_name = {"gtz_tile_init();", fmt::format("gtz_tile({});", idst)}; break;
-        case UnaryOpType::LEZ: op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile({});", idst)}; break;
-        case UnaryOpType::GEZ: op_init_and_name = {"gez_tile_init();", fmt::format("gez_tile({});", idst)}; break;
+        case UnaryOpType::NEZ:
+            if (input_dtype == DataType::INT32) {
+                std::cout << "hitting int file";
+                op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)};
+            }
+            break;
+        case UnaryOpType::LTZ:
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {"ltz_tile_init();", fmt::format("ltz_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"ltz_tile_init();", fmt::format("ltz_tile({});", idst)};
+            }
+            break;
+        case UnaryOpType::GTZ:
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {"gtz_tile_init();", fmt::format("gtz_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"gtz_tile_init();", fmt::format("gtz_tile({});", idst)};
+            }
+            break;
+        case UnaryOpType::GEZ:
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {"gez_tile_init();", fmt::format("gez_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"gez_tile_init();", fmt::format("gez_tile({});", idst)};
+            }
+            break;
+        case UnaryOpType::LEZ:
+            if (input_dtype == DataType::INT32) {
+                op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile_int32({});", idst)};
+            } else {
+                op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile({});", idst)};
+            }
+            break;
         case UnaryOpType::EXP2: op_init_and_name = {"exp2_tile_init();", fmt::format("exp2_tile({});", idst)}; break;
         case UnaryOpType::EXPM1: op_init_and_name = {"expm1_tile_init();", fmt::format("expm1_tile({});", idst)}; break;
         case UnaryOpType::ASIN: op_init_and_name = {"asin_tile_init();", fmt::format("asin_tile({});", idst)}; break;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -357,14 +357,17 @@ std::pair<string, string> get_op_init_and_func_default(
             }
             break;
         case UnaryOpType::NEZ:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
-                std::cout << "hitting int file";
                 op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile_int32({});", idst)};
             } else {
                 op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)};
             }
             break;
         case UnaryOpType::LTZ:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {"ltz_tile_init();", fmt::format("ltz_tile_int32({});", idst)};
             } else {
@@ -372,6 +375,8 @@ std::pair<string, string> get_op_init_and_func_default(
             }
             break;
         case UnaryOpType::GTZ:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {"gtz_tile_init();", fmt::format("gtz_tile_int32({});", idst)};
             } else {
@@ -379,6 +384,8 @@ std::pair<string, string> get_op_init_and_func_default(
             }
             break;
         case UnaryOpType::GEZ:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {"gez_tile_init();", fmt::format("gez_tile_int32({});", idst)};
             } else {
@@ -386,6 +393,8 @@ std::pair<string, string> get_op_init_and_func_default(
             }
             break;
         case UnaryOpType::LEZ:
+            TT_FATAL(
+                input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
             if (input_dtype == DataType::INT32) {
                 op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile_int32({});", idst)};
             } else {


### PR DESCRIPTION
### Ticket
Link to Github Issue #18922 

### Problem description
zero comparison ops do not support input of int type.

### What's changed
Added integer support for ltz, gtz, nez, lez, gez ops .

### Checklist
- [ ] All post commit CI