### PR TITLE
#0: Diagnose dynamic constructors on loading

### DIFF
--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -35,11 +35,11 @@ SECTIONS
     /* .gnu.warning sections are handled specially by elf32.em.  */
     *(.gnu.warning)
   } > REGION_APP_CODE :text
-  .init.fini :
+  .empty.init.fini :
   {
-    /* We don't use .init/.fini (this isn't the '90s), make sure there aren't any.  */
+    /* Out elf loader checks that .empty* sections are empty, and
+       can give a helpful error, rather than an ASSERT here.  */
     KEEP (*(.init .fini))
-    ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections present");
   } > REGION_APP_CODE :text
 
   .data : ALIGN(4)
@@ -60,13 +60,12 @@ SECTIONS
     *(.got.plt) *(.igot.plt) *(.got) *(.igot)
     . = ALIGN(4);
   } > REGION_APP_DATA :data
-  .ctors.dtors :
+  .empty.ctors.dtors :
   {
     /* We don't use .ctors/.dtors either (this still isn't the '90s), make sure there aren't any.  */
     KEEP (*(.ctors .ctors.* .dtors .dtors.*))
-    ASSERT(SIZEOF(.ctors.dtors) == 0, ".ctors/.dtors sections have contents");
   } > REGION_APP_DATA :data
-  .init_array.fini_array :
+  .empty.init_array.fini_array :
   {
     /* We don't support global static constructors or destructors. make sure there aren't any.  */
     KEEP (*(.preinit_array))
@@ -74,7 +73,6 @@ SECTIONS
     KEEP (*(.init_array))
     KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
     KEEP (*(.fini_array))
-    ASSERT(SIZEOF(.init_array.fini_array) == 0, ".{preinit,init,fini}_array sections have contents");
   } > REGION_APP_DATA :data
   .bss : ALIGN(4)
   {

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -42,11 +42,11 @@ SECTIONS
     /* .gnu.warning sections are handled specially by elf32.em.  */
     *(.gnu.warning)
   } > REGION_APP_KERNEL_CODE :text
-  .init.fini :
+  .empty.init.fini :
   {
-    /* We don't use .init/.fini (this isn't the '90s), make sure there aren't any.  */
+    /* Out elf loader checks that .empty* sections are empty, and
+       can give a helpful error, rather than an ASSERT here.  */
     KEEP (*(.init .fini))
-    ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections present");
   } > REGION_APP_KERNEL_CODE :text
 
   .data : ALIGN(16) {
@@ -66,13 +66,12 @@ SECTIONS
     *(.got.plt) *(.igot.plt) *(.got) *(.igot)
     . = ALIGN(4);
   } > REGION_APP_KERNEL_DATA :data
-  .ctors.dtors :
+  .empty.ctors.dtors :
   {
     /* We don't use .ctors/.dtors either (this still isn't the '90s), make sure there aren't any.  */
     KEEP (*(.ctors .ctors.* .dtors .dtors.*))
-    ASSERT(SIZEOF(.ctors.dtors) == 0, ".ctors/.dtors sections have contents");
   } > REGION_APP_KERNEL_DATA :data
-  .init_array.fini_array :
+  .empty.init_array.fini_array :
   {
     /* We don't support global static constructors or destructors. make sure there aren't any.  */
     KEEP (*(.preinit_array))
@@ -80,7 +79,6 @@ SECTIONS
     KEEP (*(.init_array))
     KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
     KEEP (*(.fini_array))
-    ASSERT(SIZEOF(.init_array.fini_array) == 0, ".{preinit,init,fini}_array sections have contents");
   } > REGION_APP_KERNEL_DATA :data
   .bss : ALIGN(4) {
     __ldm_bss_start = .;

--- a/tt_metal/hw/toolchain/sections.ld
+++ b/tt_metal/hw/toolchain/sections.ld
@@ -82,11 +82,11 @@ SECTIONS
     *(.gnu.warning)
     . = ALIGN(4);
   } > REGION_CODE :text
-  .init.fini :
+  .empty.init.fini :
   {
-    /* We don't use .init/.fini (this isn't the '90s), make sure there aren't any.  */
+    /* Out elf loader checks that .empty* sections are empty, and
+       can give a helpful error, rather than an ASSERT here.  */
     KEEP (*(.init .fini))
-    ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections have contents");
   } > REGION_CODE :text
 
 #if defined(TYPE_KERNEL)
@@ -137,13 +137,12 @@ SECTIONS
     . = ALIGN(4);
     __ldm_data_end = .;
   } > REGION_DATA :data
-  .ctors.dtors :
+  .empty.ctors.dtors :
   {
     /* We don't use .ctors/.dtors either (this still isn't the '90s), make sure there aren't any.  */
     KEEP (*(.ctors .ctors.* .dtors .dtors.*))
-    ASSERT(SIZEOF(.ctors.dtors) == 0, ".ctors/.dtors sections have contents");
   } > REGION_DATA :data
-  .init_array.fini_array :
+  .empty.init_array.fini_array :
   {
     /* We don't support global static constructors or destructors. make sure there aren't any.  */
     KEEP (*(.preinit_array))
@@ -151,7 +150,6 @@ SECTIONS
     KEEP (*(.init_array))
     KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
     KEEP (*(.fini_array))
-    ASSERT(SIZEOF(.init_array.fini_array) == 0, ".{preinit,init,fini}_array sections have contents");
   } > REGION_DATA :data
   .bss : ALIGN(4)
   {

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -323,6 +323,16 @@ void ElfFile::Impl::LoadImage() {
                 section.sh_size,
                 section.sh_offset);
         }
+        // If the name begins with .empty. it should be empty.  We can
+        // generate a better error here than the linker can -- and one
+        // has the binary to examine.
+        if (section.sh_flags & SHF_ALLOC && section.sh_size != 0) {
+            auto* name = GetName(section);
+            constexpr auto* prefix = ".empty.";
+            if (std::strncmp(name, prefix, std::strlen(prefix)) == 0) {
+                TT_THROW("{}: {} section has contents (namespace-scope constructor present?)", path_, name);
+            }
+        }
     }
     if (haveStack) {
         // Remove the stack segment, now we used it for checking the sections.


### PR DESCRIPTION
### Ticket
NA

### Problem description
We don't support dynamic constructors and the linker script asserts that such sections are empty.  This is an awful failure mode because the error is obscure and one doesn't have an executable to examine after the fact.

### What's changed
* do not diagnose in linker
* diagnose upon loading the executable

It was quicker to implement this change, rerun the test that failed, and go look at the binary than figure out what was happening in the original case. (see https://github.com/tenstorrent/tt-metal/issues/18560#issuecomment-2731009969)

### Checklist
- [ YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes