### PR TITLE
Add extra noc local state init only for BH

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -495,7 +495,10 @@ int main() {
                 if (prev_noc_mode != noc_mode) {
                     noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
                 }
+#ifdef ARCH_BLACKHOLE
+                // Need to add this to allow adding barrier after setup_remote_cb_interfaces
                 noc_local_state_init(noc_index);
+#endif
                 cmd_buf = BRISC_AT_CMD_BUF;
             } else {
                 if (prev_noc_mode != noc_mode) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Pushed some changes to make atomics non posted and needed an extra noc_local_state_init in brisc but need to uplift this to only be called on BH path

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13947676539) CI passes