### PR TITLE
#19351: Revert "Skip test_noc_event_profiler test" and revert "Remove unused imports"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,9 +8,11 @@ import random
 import os
 import numpy as np
 from functools import partial
+from itertools import chain
 from operator import contains, eq, getitem
 from pathlib import Path
 import json
+import copy
 import multiprocess
 import signal
 import time
@@ -117,6 +119,7 @@ def device(request, device_params):
 
     ttnn.DumpDeviceProfiler(device)
 
+    ttnn.synchronize_device(device)
     ttnn.close_device(device)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import re
+import sys
+import sysconfig
+import platform
 import subprocess
 from dataclasses import dataclass
 from functools import partial
@@ -35,6 +39,8 @@ def get_arch_name():
 
 
 def get_metal_local_version_scheme(metal_build_config, version):
+    from setuptools_scm.version import ScmVersion, guess_next_version
+
     arch_name = metal_build_config.arch_name
 
     if version.dirty:
@@ -44,6 +50,8 @@ def get_metal_local_version_scheme(metal_build_config, version):
 
 
 def get_metal_main_version_scheme(metal_build_config, version):
+    from setuptools_scm.version import ScmVersion, guess_next_version
+
     is_release_version = version.distance is None or version.distance == 0
     is_dirty = version.dirty
     is_clean_prod_build = (not is_dirty) and is_release_version

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -351,7 +351,6 @@ def test_timestamped_events():
         assert eventCount in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong event count"
 
 
-@pytest.mark.skip(reason="This test is currently broken")
 def test_noc_event_profiler():
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in ["grayskull", "wormhole_b0", "blackhole"]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19351

### Problem description
Provide context for the problem.

### What's changed
Reverts disable test https://github.com/tenstorrent/tt-metal/commit/b5d06fcdd55146fc50dff97deb551a477a9061bf
Reverts breaking change https://github.com/tenstorrent/tt-metal/commit/38e5f054350d271a7dbb4ba39cc2ae6bf3a2a706

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes