### PR TITLE
Update argument pass for falcon7b in N300 functionality tests in Single-card Demo Tests

### DIFF
--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -6,7 +6,7 @@ run_common_func_tests() {
   fail=0
 
   # Falcon7B
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-default_mode_1024_stochastic]; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k "default_mode_1024_stochastic"; fail+=$?
 
   # Mistral7B
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/demo/demo.py; fail+=$?


### PR DESCRIPTION
### Problem description
N300 functionality was failing in Single-card Demo Tests due to falcon7b tests getting completely skipped

### What's changed
The arguments for falcon7b were not being passed correctly after this commit: https://github.com/tenstorrent/tt-metal/commit/f39460be0de6497075510e85f2dc8fbc1dd5f3ef

### Checklist
- [Y] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/13949281439) CI passes 
- [Y] New/Existing tests provide coverage for changes