### PR TITLE
Add new EDM perf tests

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -5,6 +5,7 @@
 import os
 import sys
 
+from enum import Enum
 from loguru import logger
 import pytest
 import csv
@@ -16,6 +17,14 @@ from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SI
 profiler_log_path = PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG
 
 
+# Python enum mirroring test_fabric_edm_common.hpp
+class FabricTestMode(Enum):
+    Linear = 0
+    HalfRing = 1
+    FullRing = 2
+    SaturateChipToChipRing = 3
+
+
 def get_device_freq():
     setup = device_post_proc_config.default_setup()
     setup.deviceInputLog = profiler_log_path
@@ -24,7 +33,7 @@ def get_device_freq():
     return freq
 
 
-def profile_results(zone_name, packets_per_src_chip, line_size, packet_size):
+def profile_results(zone_name, packets_per_src_chip, line_size, packet_size, fabric_mode):
     freq = get_device_freq() / 1000.0
     setup = device_post_proc_config.default_setup()
     setup.deviceInputLog = profiler_log_path
@@ -45,7 +54,12 @@ def profile_results(zone_name, packets_per_src_chip, line_size, packet_size):
         main_loop_cycle = devices_data["devices"][device]["cores"]["DEVICE"]["analysis"][zone_name]["stats"]["Average"]
         main_loop_cycles.append(main_loop_cycle)
 
-    traffic_streams_through_boundary = line_size / 2
+    if fabric_mode == FabricTestMode.FullRing:
+        traffic_streams_through_boundary = line_size - 1
+    elif fabric_mode == FabricTestMode.SaturateChipToChipRing:
+        traffic_streams_through_boundary = 3
+    else:
+        traffic_streams_through_boundary = line_size / 2
     total_byte_sent = packets_per_src_chip * traffic_streams_through_boundary * packet_size
     bandwidth = total_byte_sent / max(main_loop_cycles)
 
@@ -61,7 +75,7 @@ def run_fabric_edm(
     line_sync,
     line_size,
     packet_size,
-    ring_topology,
+    fabric_mode,
     expected_bw,
 ):
     logger.warning("removing file profile_log_device.csv")
@@ -76,7 +90,7 @@ def run_fabric_edm(
                 {int(line_sync)} \
                 {line_size} \
                 {packet_size} \
-                {int(ring_topology)}"
+                {fabric_mode.value}"
     rc = os.system(cmd)
     if rc != 0:
         if os.WEXITSTATUS(rc) == 1:
@@ -87,11 +101,10 @@ def run_fabric_edm(
 
     zone_name_inner = "MAIN-WRITE-UNICAST-ZONE" if is_unicast else "MAIN-WRITE-MCAST-ZONE"
     zone_name_main = "MAIN-TEST-BODY"
-    packets_per_src_chip = num_mcasts, num_unicasts
 
     num_messages = num_mcasts + num_unicasts
-    bandwidth_inner_loop = profile_results(zone_name_inner, num_messages, line_size, packet_size)
-    bandwidth = profile_results(zone_name_main, num_messages, line_size, packet_size)
+    bandwidth_inner_loop = profile_results(zone_name_inner, num_messages, line_size, packet_size, fabric_mode)
+    bandwidth = profile_results(zone_name_main, num_messages, line_size, packet_size, fabric_mode)
     logger.info("bandwidth_inner_loop: {} B/c", bandwidth_inner_loop)
     logger.info("bandwidth: {} B/c", bandwidth)
     assert expected_bw - 0.07 <= bandwidth <= expected_bw + 0.07
@@ -101,10 +114,9 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_unicasts", [0])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
-@pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.64), (2, 6.65)])
-def test_fabric_edm_mcast_ring_bw(
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.66), (4, 2, 6.62)])
+def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -123,7 +135,7 @@ def test_fabric_edm_mcast_ring_bw(
         line_sync,
         line_size,
         packet_size,
-        True,
+        FabricTestMode.HalfRing,
         expected_bw,
     )
 
@@ -132,9 +144,68 @@ def test_fabric_edm_mcast_ring_bw(
 @pytest.mark.parametrize("num_unicasts", [0])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
-@pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 6.82), (2, 6.82)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.17), (4, 2, 5.13), (8, 1, 3.93)])
+def test_fabric_edm_mcast_full_ring_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+):
+    run_fabric_edm(
+        False,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.FullRing,
+        expected_bw,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [200000])
+@pytest.mark.parametrize("num_unicasts", [0])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.83), (4, 2, 5.71)])
+def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+):
+    run_fabric_edm(
+        False,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.SaturateChipToChipRing,
+        expected_bw,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [200000])
+@pytest.mark.parametrize("num_unicasts", [0])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.84), (4, 2, 6.82)])
 def test_fabric_edm_mcast_bw(
     num_mcasts,
     num_unicasts,
@@ -154,7 +225,7 @@ def test_fabric_edm_mcast_bw(
         line_sync,
         line_size,
         packet_size,
-        False,
+        FabricTestMode.Linear,
         expected_bw,
     )
 
@@ -185,6 +256,6 @@ def test_fabric_edm_unicast_bw(
         line_sync,
         line_size,
         packet_size,
-        False,
+        FabricTestMode.Linear,
         expected_bw,
     )

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -17,6 +17,8 @@ static constexpr bool enable_any_synchronization = enable_start_synchronization 
 
 FORCE_INLINE void line_sync(
     FabricConnectionManager& fabric_connection,
+    bool sync_forward,
+    bool sync_backward,
     volatile PACKET_HEADER_TYPE* mcast_fwd_packet_header,
     volatile PACKET_HEADER_TYPE* mcast_bwd_packet_header,
     size_t sync_bank_addr,
@@ -27,7 +29,7 @@ FORCE_INLINE void line_sync(
 
     auto dest_noc_addr =
         safe_get_noc_addr(static_cast<uint8_t>(sync_noc_x), static_cast<uint8_t>(sync_noc_y), sync_bank_addr, 0);
-    if (fabric_connection.has_forward_connection()) {
+    if (sync_forward) {
         mcast_fwd_packet_header->to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader{dest_noc_addr, 1, 128});
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
         print_pkt_header(mcast_fwd_packet_header);
@@ -35,7 +37,7 @@ FORCE_INLINE void line_sync(
             (uint32_t)mcast_fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
     }
 
-    if (fabric_connection.has_backward_connection()) {
+    if (sync_backward) {
         mcast_bwd_packet_header->to_noc_unicast_atomic_inc(NocUnicastAtomicIncCommandHeader{dest_noc_addr, 1, 128});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         print_pkt_header(mcast_bwd_packet_header);
@@ -44,7 +46,7 @@ FORCE_INLINE void line_sync(
     }
     noc_semaphore_inc(get_noc_addr(sync_noc_x, sync_noc_y, sync_bank_addr), 1);
     if (sync_noc_x == my_x[0] && sync_noc_y == my_y[0]) {
-        noc_semaphore_wait_min(reinterpret_cast<volatile uint32_t*>(sync_bank_addr), sync_val);
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_bank_addr), sync_val);
     }
 }
 
@@ -76,16 +78,25 @@ void kernel_main() {
     if (!fabric_connection.is_logically_connected()) {
         return;
     }
+    bool mcast_fwd = mcast_fwd_hops > 0;
+    bool mcast_bwd = mcast_bwd_hops > 0;
+
     size_t sync_noc_x = 0;
     size_t sync_noc_y = 0;
     size_t sync_bank_addr = 0;
     size_t total_workers_per_sync = 0;
+    size_t sync_mcast_fwd_hops = 0;
+    size_t sync_mcast_bwd_hops = 0;
     if (enable_any_synchronization) {
         sync_noc_x = get_arg_val<uint32_t>(arg_idx++);
         sync_noc_y = get_arg_val<uint32_t>(arg_idx++);
         sync_bank_addr = get_arg_val<uint32_t>(arg_idx++);
         total_workers_per_sync = get_arg_val<uint32_t>(arg_idx++);
+        sync_mcast_fwd_hops = get_arg_val<uint32_t>(arg_idx++);
+        sync_mcast_bwd_hops = get_arg_val<uint32_t>(arg_idx++);
     }
+    bool sync_fwd = sync_mcast_fwd_hops > 0;
+    bool sync_bwd = sync_mcast_bwd_hops > 0;
 
     const size_t start_sync_val = total_workers_per_sync;
     const size_t finish_sync_val = 3 * total_workers_per_sync;
@@ -103,14 +114,23 @@ void kernel_main() {
         reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
     auto* unicast_packet_header =
         reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE) * 2);
-    mcast_fwd_packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_fwd_hops)});
-    mcast_bwd_packet_header->to_chip_multicast(MulticastRoutingCommandHeader{1, static_cast<uint8_t>(mcast_bwd_hops)});
-
+    auto* sync_mcast_fwd_packet_header =
+        reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE) * 3);
+    auto* sync_mcast_bwd_packet_header =
+        reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE) * 4);
+    if (enable_any_synchronization) {
+        sync_mcast_fwd_packet_header->to_chip_multicast(
+            MulticastRoutingCommandHeader{1, static_cast<uint8_t>(sync_mcast_fwd_hops)});
+        sync_mcast_bwd_packet_header->to_chip_multicast(
+            MulticastRoutingCommandHeader{1, static_cast<uint8_t>(sync_mcast_bwd_hops)});
+    }
     if (enable_start_synchronization) {
         line_sync(
             fabric_connection,
-            mcast_fwd_packet_header,
-            mcast_bwd_packet_header,
+            sync_fwd,
+            sync_bwd,
+            sync_mcast_fwd_packet_header,
+            sync_mcast_bwd_packet_header,
             sync_bank_addr,
             sync_noc_x,
             sync_noc_y,
@@ -118,8 +138,10 @@ void kernel_main() {
         noc_async_writes_flushed();
         line_sync(
             fabric_connection,
-            mcast_fwd_packet_header,
-            mcast_bwd_packet_header,
+            sync_fwd,
+            sync_bwd,
+            sync_mcast_fwd_packet_header,
+            sync_mcast_bwd_packet_header,
             sync_bank_addr,
             sync_noc_x,
             sync_noc_y,
@@ -140,22 +162,22 @@ void kernel_main() {
                 auto dest_addr = safe_get_noc_addr(
                     static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr);
                 noc_async_write(source_l1_buffer_address, dest_addr, packet_payload_size_bytes);
-                if (fabric_connection.has_forward_connection()) {
+                if (mcast_fwd) {
                     mcast_fwd_packet_header->to_noc_unicast_write(
                         NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
                     fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-                    print_pkt_header(mcast_fwd_packet_header);
+                    // print_pkt_header(mcast_fwd_packet_header);
                     fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
                         source_l1_buffer_address, packet_payload_size_bytes);
                     fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
                         (uint32_t)mcast_fwd_packet_header, sizeof(PACKET_HEADER_TYPE));
                 }
 
-                if (fabric_connection.has_backward_connection()) {
+                if (mcast_bwd) {
                     mcast_bwd_packet_header->to_noc_unicast_write(
                         NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
                     fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-                    print_pkt_header(mcast_bwd_packet_header);
+                    // print_pkt_header(mcast_bwd_packet_header);
                     fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
                         source_l1_buffer_address, packet_payload_size_bytes);
                     fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
@@ -188,8 +210,10 @@ void kernel_main() {
             // Send a completion message
             line_sync(
                 fabric_connection,
-                mcast_fwd_packet_header,
-                mcast_bwd_packet_header,
+                sync_fwd,
+                sync_bwd,
+                sync_mcast_fwd_packet_header,
+                sync_mcast_bwd_packet_header,
                 sync_bank_addr,
                 sync_noc_x,
                 sync_noc_y,
@@ -198,17 +222,21 @@ void kernel_main() {
             // all other workers have received all messages.
             line_sync(
                 fabric_connection,
-                mcast_fwd_packet_header,
-                mcast_bwd_packet_header,
+                sync_fwd,
+                sync_bwd,
+                sync_mcast_fwd_packet_header,
+                sync_mcast_bwd_packet_header,
                 sync_bank_addr,
                 sync_noc_x,
                 sync_noc_y,
                 second_finish_sync_val);
 
             if (sync_noc_x == my_x[0] && sync_noc_y == my_y[0]) {
+                // Sanity check to ensure we don't receive more acks than expected
+                ASSERT(*reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_bank_addr) == second_finish_sync_val);
                 // reset the global semaphore in case it is used in a op/kernel
                 // invocation
-                *reinterpret_cast<volatile uint32_t*>(sync_bank_addr) = 0;
+                *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_bank_addr) = 0;
                 ;
             }
         }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -13,7 +13,7 @@ int main(int argc, char** argv) {
     bool line_sync = std::stoi(argv[arg_idx++]);
     std::size_t line_size = std::stoi(argv[arg_idx++]);
     std::size_t packet_payload_size_bytes = std::stoi(argv[arg_idx++]);
-    bool ring_topology = std::stoi(argv[arg_idx++]);
+    uint32_t fabric_mode = std::stoi(argv[arg_idx++]);
 
     uint32_t min_test_num_devices = 8;
     if (tt::tt_metal::GetNumAvailableDevices() < min_test_num_devices) {
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
     WriteThroughputStabilityTestWithPersistentFabricParams params;
     params.line_sync = line_sync;
     params.line_size = line_size;
-    params.topology = ring_topology ? ttnn::ccl::Topology::Ring : ttnn::ccl::Topology::Linear;
+    params.fabric_mode = static_cast<FabricTestMode>(fabric_mode);
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params, packet_payload_size_bytes);
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add new EDM benchmarks for ring.
Our existing benchmark has us sending half the ring length, alternating whether the forward or backward path is the longer length if it is not even.
Need some additional benchmarks for perf characterization.

### What's changed
Add two new benchmarks:
Sending the full line length in both directions.
Using the minimal number of mcasts per chip in order to fully saturate the channels/links between a pair of devices. Example below. Blue are unused channels in the test. Red are unused/disabled channels in a typical ring topology setup. Note that in this benchmark we make use of some of these normally unused channels to be able to mcast through the target chips, which does mean some of our mcasts are loopbacks to src.
<img width="1950" alt="image" src="https://github.com/user-attachments/assets/722d5bcd-d0f7-479b-bd53-dd338ed3aa7e" />

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/13961339100
Microbenchmarks: https://github.com/tenstorrent/tt-metal/actions/runs/13961343029