### PR TITLE
Add policy about notification, and possible grace period, if convenient

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,6 +473,12 @@ To set up pre-commit on your local machine, follow these steps:
 ### CI/CD Principles
 
 - Revert commits on main which fail post-commit tests immediately.
+  - The names listed in the commit, and technical leads if their names are
+    convenient and clear to find, will be pinged in #tt-metal-pipelines.
+  - We will usually give a grace period during working hours depending on the
+    load of the teams to see if the author(s) can merge a fix quickly.
+    Otherwise, the revert will be immediate to prevent the issue from spreading
+    to other peoples' pipelines.
 - There shall be a periodic discussion among the technical leads of this
   project concerning:
   - Certain codeowners and project-specific members review current tests in


### PR DESCRIPTION
### Ticket

Policy fix.

### Problem description

We reverted this: https://github.com/tenstorrent/tt-metal/commit/117aa5c5c891b20ee4d0237fcbe4e64a2a1e8d2d

but @TT-BrianLiu had been telling teammates to use it on main for llama optimizations. We didn't notify properly. We should have.

### What's changed

Create formal policy of notifying authors after reverts.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes