### PR TITLE
#0: [skip ci] Add missing secrets:inherit to tg-quick-trigger.yaml

### DIFF
--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -15,6 +15,7 @@ jobs:
 
   tg-quick-test:
     needs: build-artifact
+    secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Failing tg-quick test doesn't send slack report:
https://github.com/tenstorrent/tt-metal/actions/runs/13951695608/job/39053215674#step:10:20
```
Error: Error: Need to provide at least one botToken or webhookUrl
```

### What's changed
Added `secrets: inherit` to tg-quick-trigger so that `slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}` is available to the tg-quick slack notification action.

### Checklist
- [ ] New/Existing tests provide coverage for changes