### PR TITLE
#0: Dockerize umd tests and move to 22.04

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -70,11 +70,13 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:
+    needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml
     with:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
   sd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/build-and-unit-tests.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -50,25 +50,25 @@ jobs:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
       version: "22.04"
-  # build-artifact-profiler:
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   secrets: inherit
-  #   with:
-  #     build-type: ${{ inputs.build-type || 'Release' }}
-  #     build-wheel: true
-  #     tracy: true
-  #     version: "22.04"
-  # run-profiler-regression:
-  #   needs: build-artifact-profiler
-  #   uses: ./.github/workflows/run-profiler-regression.yaml
-  #   secrets: inherit
-  #   with:
-  #     arch: "blackhole"
-  #     timeout: 20
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
+      tracy: true
+      version: "22.04"
+  run-profiler-regression:
+    needs: build-artifact-profiler
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit
+    with:
+      arch: "blackhole"
+      timeout: 20
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -77,42 +77,42 @@ jobs:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  # sd-unit-tests:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     timeout: 15
-  #     os: "ubuntu-22.04"
-  # fd-unit-tests:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   with:
-  #     timeout: 20
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     os: "ubuntu-22.04"
-  # # FD C++ Unit Tests
-  # cpp-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/cpp-post-commit.yaml
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     timeout: 20
-  #     os: "ubuntu-22.04"
-  # models-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/models-post-commit.yaml
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     timeout: 20
+  sd-unit-tests:
+    needs: build-artifact
+    uses: ./.github/workflows/build-and-unit-tests.yaml
+    secrets: inherit
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 15
+      os: "ubuntu-22.04"
+  fd-unit-tests:
+    needs: build-artifact
+    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+    secrets: inherit
+    with:
+      timeout: 20
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      os: "ubuntu-22.04"
+  # FD C++ Unit Tests
+  cpp-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 20
+      os: "ubuntu-22.04"
+  models-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/models-post-commit.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 20
 
 #   profiler-regression:
 #     needs: build-artifact-profiler

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -50,25 +50,25 @@ jobs:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
       version: "22.04"
-  build-artifact-profiler:
-    uses: ./.github/workflows/build-artifact.yaml
-    secrets: inherit
-    with:
-      build-type: ${{ inputs.build-type || 'Release' }}
-      build-wheel: true
-      tracy: true
-      version: "22.04"
-  run-profiler-regression:
-    needs: build-artifact-profiler
-    uses: ./.github/workflows/run-profiler-regression.yaml
-    secrets: inherit
-    with:
-      arch: "blackhole"
-      timeout: 20
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+  # build-artifact-profiler:
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   secrets: inherit
+  #   with:
+  #     build-type: ${{ inputs.build-type || 'Release' }}
+  #     build-wheel: true
+  #     tracy: true
+  #     version: "22.04"
+  # run-profiler-regression:
+  #   needs: build-artifact-profiler
+  #   uses: ./.github/workflows/run-profiler-regression.yaml
+  #   secrets: inherit
+  #   with:
+  #     arch: "blackhole"
+  #     timeout: 20
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -77,42 +77,42 @@ jobs:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  sd-unit-tests:
-    needs: build-artifact
-    uses: ./.github/workflows/build-and-unit-tests.yaml
-    secrets: inherit
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 15
-      os: "ubuntu-22.04"
-  fd-unit-tests:
-    needs: build-artifact
-    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-    secrets: inherit
-    with:
-      timeout: 20
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      os: "ubuntu-22.04"
-  # FD C++ Unit Tests
-  cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/cpp-post-commit.yaml
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 20
-      os: "ubuntu-22.04"
-  models-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/models-post-commit.yaml
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 20
+  # sd-unit-tests:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/build-and-unit-tests.yaml
+  #   secrets: inherit
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     timeout: 15
+  #     os: "ubuntu-22.04"
+  # fd-unit-tests:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+  #   secrets: inherit
+  #   with:
+  #     timeout: 20
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     os: "ubuntu-22.04"
+  # # FD C++ Unit Tests
+  # cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/cpp-post-commit.yaml
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     timeout: 20
+  #     os: "ubuntu-22.04"
+  # models-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/models-post-commit.yaml
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     timeout: 20
 
 #   profiler-regression:
 #     needs: build-artifact-profiler

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -76,7 +76,7 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   sd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/build-and-unit-tests.yaml

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -24,4 +24,4 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      version: 22.04
+
   umd-unit-tests:
     secrets: inherit
     strategy:
@@ -15,5 +21,6 @@ jobs:
         ]
     uses: ./.github/workflows/umd-unit-tests.yaml
     with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
+        arch: ${{ matrix.test-group.arch }}
+        runner-label: ${{ matrix.test-group.runner-label }}
+        docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -11,6 +11,7 @@ jobs:
       version: 22.04
 
   umd-unit-tests:
+    needs: build-artifact
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -22,6 +22,6 @@ jobs:
         ]
     uses: ./.github/workflows/umd-unit-tests.yaml
     with:
-        arch: ${{ matrix.test-group.arch }}
-        runner-label: ${{ matrix.test-group.runner-label }}
-        docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -9,7 +9,6 @@ jobs:
     secrets: inherit
     with:
       version: 22.04
-
   umd-unit-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -47,7 +47,7 @@ jobs:
       image: ${{ inputs.docker-image }}
       env:
         ARCH_NAME: ${{ inputs.arch }}
-        GITHUB_ACTIONS: true
+        LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
       volumes:
@@ -64,10 +64,14 @@ jobs:
         with:
           submodules: recursive
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - uses: ./.github/actions/prepare-metal-run
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: TTMetal_build_any
+          path: docker-job
+      - name: Extract files
+        run: tar -xvf ttm_any.tar
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/test/umd/${{ inputs.arch }}/unit_tests

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -64,14 +64,10 @@ jobs:
         with:
           submodules: recursive
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@v4
-        timeout-minutes: 10
-        with:
-          name: TTMetal_build_any
-          path: docker-job
-      - name: Extract files
-        run: tar -xvf ttm_any.tar
+      - name: Build UMD device and tests
+        run: |
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake
+          cmake --build build --target umd_tests
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/test/umd/${{ inputs.arch }}/unit_tests

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -13,6 +13,9 @@ on:
         required: false
         type: number
         default: 15
+      docker-image:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       arch:
@@ -35,16 +38,32 @@ on:
 
 jobs:
   umd-unit-tests:
-    name: ${{ inputs.arch }} ${{ inputs.runner-label }}
+    name: UMD tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine
       - in-service
-    env:
-      ARCH_NAME: ${{ inputs.arch }}
-      LOGURU_LEVEL: INFO
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        ARCH_NAME: ${{ inputs.arch }}
+        GITHUB_ACTIONS: true
+        LOGURU_LEVEL: INFO
+        PYTHONPATH: /work
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -67,10 +67,7 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build UMD device and tests
-        run: |
-          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake
-          cmake --build build --target umd_tests
+      - uses: ./.github/actions/prepare-metal-run
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/test/umd/${{ inputs.arch }}/unit_tests


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19366)

### Problem description
Need to dockerize UMD tests to shift to 22.04

### What's changed
Updated UMD workflow to use in 22.04

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes UMD not tested in post-commit
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/13953643564

Workflow running only UMD wrapper
https://github.com/tenstorrent/tt-metal/actions/runs/13937155590