### PR TITLE
Increase trisc0/1 stack size on BH

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -108,8 +108,8 @@
 // Increasing the stack size comes at the expense of less local memory for globals
 #define MEM_BRISC_STACK_SIZE 768
 #define MEM_NCRISC_STACK_SIZE 1040
-#define MEM_TRISC0_STACK_SIZE 320
-#define MEM_TRISC1_STACK_SIZE 256
+#define MEM_TRISC0_STACK_SIZE 640
+#define MEM_TRISC1_STACK_SIZE 512
 #define MEM_TRISC2_STACK_SIZE 768
 
 #define MEM_BRISC_STACK_BASE (MEM_LOCAL_BASE + MEM_BRISC_LOCAL_SIZE - MEM_BRISC_STACK_SIZE)


### PR DESCRIPTION
### Problem description
Models and ops are hitting close to stack overflow/overflowing stack on BH but BH has larger local mem so we can increase stack sizes

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13955042459) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13955050939)