### PR TITLE
[tt_transformers/test] Fix generate_reference_outputs.py

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -454,7 +454,7 @@ class ModelArgs:
         self.tokenizer = None if dummy_weights else self.create_tokenizer()
 
         device = mesh_device.get_devices()[0] if mesh_device is not None else None
-        self.cluster_shape = list(mesh_device.shape)
+        self.cluster_shape = list(mesh_device.shape) if mesh_device is not None else None
         self.is_galaxy = self.num_devices == 32
         if device is not None:  # Avoid issue with test_torch.py not having a device
             self.n_local_heads = self.n_heads // self.cluster_shape[1]


### PR DESCRIPTION
Fix generate_reference_outputs.py for checkpoint_type other than CheckpointType.Meta

### Ticket
19376

### Problem description
Fix generate_reference_outputs.py for HuggingFace models

### What's changed
Add import, None type  handling, create model_args for checkpoint_type is none Meta (e.g. HuggingFace)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes