### PR TITLE
Active and Idle Ethernet Loopback Tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -1,27 +1,45 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include "dispatch_fixture.hpp"
 #include "gtest/gtest.h"
+#include "kernel_types.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/command_queue.hpp>
-#include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/logger.hpp>
+#include <variant>
 
 using namespace tt;
 
 namespace unit_tests_common::dram::test_dram {
 struct DRAMConfig {
+    using CfgVariant = std::variant<tt_metal::DataMovementConfig, tt_metal::EthernetConfig>;
+
+    static constexpr size_t k_KernelCfgDM = 0;
+    static constexpr size_t k_KernelCfgETH = 1;
+
     // CoreRange, Kernel, dram_buffer_size
     CoreRange core_range;
     std::string kernel_file;
     std::uint32_t dram_buffer_size;
     std::uint32_t l1_buffer_addr;
-    tt_metal::DataMovementConfig data_movement_cfg;
+    CfgVariant kernel_cfg;
 };
+
+tt::tt_metal::KernelHandle CreateKernelFromVariant(tt::tt_metal::Program& program, DRAMConfig cfg) {
+    tt::tt_metal::KernelHandle kernel;
+    std::visit([&](auto&& cfg_variant) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(cfg_variant)>, tt::tt_metal::EthernetConfig>) {
+            kernel = tt_metal::CreateKernel(program, cfg.kernel_file, cfg.core_range, cfg_variant);
+        } else if constexpr (std::is_same_v<std::decay_t<decltype(cfg_variant)>, tt::tt_metal::DataMovementConfig>) {
+            kernel = tt_metal::CreateKernel(program, cfg.kernel_file, cfg.core_range, cfg_variant);
+        }
+    }, cfg.kernel_cfg);
+    return kernel;
+}
 
 bool dram_single_core_db(tt::tt_metal::DispatchFixture* fixture, tt_metal::IDevice* device) {
     tt_metal::Program program = tt_metal::CreateProgram();
@@ -87,8 +105,10 @@ bool dram_single_core_db(tt::tt_metal::DispatchFixture* fixture, tt_metal::IDevi
 bool dram_single_core(
     tt::tt_metal::DispatchFixture* fixture,
     tt_metal::IDevice* device,
-    const DRAMConfig& cfg,
-    std::vector<uint32_t> src_vec) {
+    const DRAMConfig& cfg) {
+    std::vector<uint32_t> src_vec =
+        create_random_vector_of_bfloat16(cfg.dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+
     // Create a program
     tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -105,19 +125,20 @@ bool dram_single_core(
 
     log_debug(tt::LogVerif, "Creating kernel");
     // Create the kernel
-    auto dram_kernel = tt_metal::CreateKernel(program, cfg.kernel_file, cfg.core_range, cfg.data_movement_cfg);
+    tt::tt_metal::KernelHandle kernel = CreateKernelFromVariant(program, cfg);
+
     fixture->WriteBuffer(device, input_dram_buffer, src_vec);
 
     tt_metal::SetRuntimeArgs(
-            program,
-            dram_kernel,
-            cfg.core_range,
-            {cfg.l1_buffer_addr,
-            input_dram_buffer_addr,
-            (std::uint32_t)0,
-            output_dram_buffer_addr,
-            (std::uint32_t)0,
-            cfg.dram_buffer_size});
+        program,
+        kernel,
+        cfg.core_range,
+        {cfg.l1_buffer_addr,
+        input_dram_buffer_addr,
+        (std::uint32_t)0,
+        output_dram_buffer_addr,
+        (std::uint32_t)0,
+        cfg.dram_buffer_size});
 
     fixture->RunProgram(device, program);
 
@@ -129,8 +150,9 @@ bool dram_single_core(
 bool dram_single_core_pre_allocated(
     tt::tt_metal::DispatchFixture* fixture,
     tt_metal::IDevice* device,
-    const DRAMConfig& cfg,
-    std::vector<uint32_t> src_vec) {
+    const DRAMConfig& cfg) {
+    std::vector<uint32_t> src_vec =
+        create_random_vector_of_bfloat16(cfg.dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     // Create a program
     tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -155,7 +177,7 @@ bool dram_single_core_pre_allocated(
     EXPECT_EQ(output_dram_buffer_addr, output_dram_pre_allocated_buffer_addr);
 
     // Create the kernel
-    auto dram_kernel = tt_metal::CreateKernel(program, cfg.kernel_file, cfg.core_range, cfg.data_movement_cfg);
+    tt::tt_metal::KernelHandle dram_kernel = CreateKernelFromVariant(program, cfg);
     fixture->WriteBuffer(device, input_dram_pre_allocated_buffer, src_vec);
 
     tt_metal::SetRuntimeArgs(
@@ -181,38 +203,34 @@ bool dram_single_core_pre_allocated(
 namespace tt::tt_metal {
 
 TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCore) {
-    uint32_t buffer_size = 2 * 1024 * 25;
-    std::vector<uint32_t> src_vec =
-        create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    constexpr uint32_t buffer_size = 2 * 1024 * 25;
     unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
         .core_range = {{0, 0}, {0, 0}},
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = 400 * 1024,
-        .data_movement_cfg =
-            {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
+        .kernel_cfg =
+            tt::tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
     };
     for (unsigned int id = 0; id < devices_.size(); id++) {
         ASSERT_TRUE(
-            unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config, src_vec));
+            unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config));
     }
 }
 
 TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCorePreAllocated) {
-    uint32_t buffer_size = 2 * 1024 * 25;
-    std::vector<uint32_t> src_vec =
-        create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    constexpr uint32_t buffer_size = 2 * 1024 * 25;
     unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
         .core_range = {{0, 0}, {0, 0}},
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = 400 * 1024,
-        .data_movement_cfg =
-            {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
+        .kernel_cfg =
+            tt::tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
     };
     for (unsigned int id = 0; id < devices_.size(); id++) {
         ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core_pre_allocated(
-            this, devices_.at(id), dram_test_config, src_vec));
+            this, devices_.at(id), dram_test_config));
     }
 }
 
@@ -223,6 +241,25 @@ TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCoreDB) {
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {
         ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core_db(this, devices_.at(id)));
+    }
+}
+
+TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
+    constexpr uint32_t buffer_size = 2 * 1024 * 25;
+
+    unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
+        .core_range = {{0, 0}, {0, 0}}, // Set below
+        .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+        .dram_buffer_size = buffer_size,
+        .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::L1)),
+        .kernel_cfg = tt_metal::EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = tt_metal::NOC::NOC_0},
+    };
+
+    for (unsigned int id = 0; id < devices_.size(); id++) {
+        for (auto active_eth_core : devices_.at(id)->get_active_ethernet_cores(true)) {
+            dram_test_config.core_range = {active_eth_core, active_eth_core};
+            ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config));
+        }
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -248,7 +248,7 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
 
     unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
-        .core_range = {{0, 0}, {0, 0}}, // Set below
+        .core_range = {{0, 0}, {0, 0}},
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::L1)),
@@ -259,6 +259,28 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
         for (auto active_eth_core : devices_.at(id)->get_active_ethernet_cores(true)) {
             dram_test_config.core_range = {active_eth_core, active_eth_core};
             ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config));
+            break;
+        }
+        break;
+    }
+}
+
+TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
+    constexpr uint32_t buffer_size = 2 * 1024 * 25;
+
+    unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
+        .core_range = {{0, 0}, {0, 0}}, // Set below
+        .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+        .dram_buffer_size = buffer_size,
+        .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::L1)),
+        .kernel_cfg = tt_metal::EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0},
+    };
+
+    for (unsigned int id = 0; id < devices_.size(); id++) {
+        for (auto idle_eth_core : devices_.at(id)->get_inactive_ethernet_cores()) {
+            tt::log_info("Single Idle Eth Loopback. Logical core {}", idle_eth_core.str());
+            dram_test_config.core_range = {idle_eth_core, idle_eth_core};
+            unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -250,6 +250,11 @@ TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCoreDB) {
 TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
 
+    if (!this->IsSlowDispatch()) {
+        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        GTEST_SKIP();
+    }
+
     unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
         .core_range = {{0, 0}, {0, 0}},
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
@@ -270,6 +275,11 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
 
 TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
+
+    if (!this->IsSlowDispatch()) {
+        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        GTEST_SKIP();
+    }
 
     unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
         .core_range = {{0, 0}, {0, 0}}, // Set below

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "allocator.hpp"
 #include "dispatch_fixture.hpp"
 #include "device_fixture.hpp"
 #include "gtest/gtest.h"
@@ -296,22 +295,6 @@ TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
             tt::log_info("Single Idle Eth Loopback. Logical core {}", idle_eth_core.str());
             dram_test_config.core_range = {idle_eth_core, idle_eth_core};
             unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config);
-        }
-    }
-}
-
-// This wll be removed
-TEST_F(BlackholeSingleCardFixture, NopFixture) {
-    for (unsigned int id = 0; id < devices_.size(); id++) {
-        IDevice* device = this->devices_.at(id);
-        const auto& allocator = device->allocator();
-        auto address = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-        auto num_banks = allocator->get_num_banks(BufferType::DRAM);
-        auto bank_size = allocator->get_bank_size(BufferType::DRAM);  // Or can hardcode to subset like 16MB.
-        auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0);
-
-        for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-            tt::tt_metal::detail::WriteToDeviceDRAMChannel(device, bank_id, address, fill);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -269,9 +269,7 @@ TEST_F(BlackholeSingleCardFixture, ActiveEthDRAMLoopbackSingleCore) {
             tt::log_info("Active Eth Loopback. Logical core {}", active_eth_core.str());
             dram_test_config.core_range = {active_eth_core, active_eth_core};
             ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config));
-            break;
         }
-        break;
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -248,7 +248,7 @@ TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCoreDB) {
     }
 }
 
-TEST_F(BlackholeSingleCardFixture, ActiveEthDRAMLoopbackSingleCore) {
+TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
 
     if (!this->IsSlowDispatch()) {

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dispatch_fixture.hpp"
+#include "device_fixture.hpp"
 #include "gtest/gtest.h"
 #include "kernel_types.hpp"
 #include <tt-metalium/host_api.hpp>
@@ -247,7 +248,7 @@ TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCoreDB) {
     }
 }
 
-TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
+TEST_F(BlackholeSingleCardFixture, ActiveEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
 
     if (!this->IsSlowDispatch()) {

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -123,7 +123,10 @@ bool dram_single_core(
     auto output_dram_buffer = tt_metal::CreateBuffer(dram_config);
     uint32_t output_dram_buffer_addr = output_dram_buffer->address();
 
-    log_debug(tt::LogVerif, "Creating kernel");
+    tt::log_info("Creating kernel at {}", cfg.core_range.str());
+    tt::log_info("Input DRAM Address  = {:#x}", input_dram_buffer_addr);
+    tt::log_info("Output DRAM Address = {:#x}", output_dram_buffer_addr);
+    tt::log_info("L1 Buffer Address   = {:#x}", cfg.l1_buffer_addr);
     // Create the kernel
     tt::tt_metal::KernelHandle kernel = CreateKernelFromVariant(program, cfg);
 
@@ -251,7 +254,7 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
         .core_range = {{0, 0}, {0, 0}},
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
-        .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::L1)),
+        .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::DRAM)),
         .kernel_cfg = tt_metal::EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = tt_metal::NOC::NOC_0},
     };
 
@@ -272,7 +275,7 @@ TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
         .core_range = {{0, 0}, {0, 0}}, // Set below
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
-        .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::L1)),
+        .l1_buffer_addr = tt::align(hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED), hal.get_alignment(HalMemType::DRAM)),
         .kernel_cfg = tt_metal::EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0},
     };
 

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "allocator.hpp"
 #include "dispatch_fixture.hpp"
 #include "device_fixture.hpp"
 #include "gtest/gtest.h"
@@ -295,6 +296,22 @@ TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
             tt::log_info("Single Idle Eth Loopback. Logical core {}", idle_eth_core.str());
             dram_test_config.core_range = {idle_eth_core, idle_eth_core};
             unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config);
+        }
+    }
+}
+
+// This wll be removed
+TEST_F(BlackholeSingleCardFixture, NopFixture) {
+    for (unsigned int id = 0; id < devices_.size(); id++) {
+        IDevice* device = this->devices_.at(id);
+        const auto& allocator = device->allocator();
+        auto address = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+        auto num_banks = allocator->get_num_banks(BufferType::DRAM);
+        auto bank_size = allocator->get_bank_size(BufferType::DRAM);  // Or can hardcode to subset like 16MB.
+        auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0);
+
+        for (int bank_id = 0; bank_id < num_banks; bank_id++) {
+            tt::tt_metal::detail::WriteToDeviceDRAMChannel(device, bank_id, address, fill);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -266,6 +266,7 @@ TEST_F(BlackholeSingleCardFixture, ActiveEthDRAMLoopbackSingleCore) {
 
     for (unsigned int id = 0; id < devices_.size(); id++) {
         for (auto active_eth_core : devices_.at(id)->get_active_ethernet_cores(true)) {
+            tt::log_info("Active Eth Loopback. Logical core {}", active_eth_core.str());
             dram_test_config.core_range = {active_eth_core, active_eth_core};
             ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config));
             break;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "dataflow_api.h"
 
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -2,10 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
 #include <cstdint>
-#include "blackhole/noc/noc_parameters.h"
-#include "debug/pause.h"
 
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or
@@ -57,6 +54,5 @@ void kernel_main() {
     // DRAM NOC dst address
     std::uint64_t dram_buffer_dst_noc_addr = get_noc_addr_from_bank_id<true>(dram_dst_bank_id, dram_buffer_dst_addr);
     noc_async_write(l1_buffer_addr, dram_buffer_dst_noc_addr, dram_buffer_size);
-    noc_async_read_barrier();
-    // noc_async_write_barrier();
+    noc_async_write_barrier();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <cstdint>
+#include "blackhole/noc/noc_parameters.h"
+#include "debug/pause.h"
 
 /**
  * NOC APIs are prefixed w/ "ncrisc" (legacy name) but there's nothing NCRISC specific, they can be used on BRISC or
@@ -54,5 +57,6 @@ void kernel_main() {
     // DRAM NOC dst address
     std::uint64_t dram_buffer_dst_noc_addr = get_noc_addr_from_bank_id<true>(dram_dst_bank_id, dram_buffer_dst_addr);
     noc_async_write(l1_buffer_addr, dram_buffer_dst_noc_addr, dram_buffer_size);
-    noc_async_write_barrier();
+    noc_async_read_barrier();
+    // noc_async_write_barrier();
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -743,7 +743,7 @@ void noc_async_write_one_packet(
 
     WAYPOINT("NWPW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
-    while (!noc_cmd_buf_ready(noc, read_cmd_buf));
+    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
     WAYPOINT("NWPD");
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
@@ -751,20 +751,20 @@ void noc_async_write_one_packet(
                              0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                              NOC_CMD_RESP_MARKED;
 
-    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_cmd_field);
-    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
 #ifdef ARCH_BLACKHOLE
     // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
 #endif
     NOC_CMD_BUF_WRITE_REG(
         noc,
-        read_cmd_buf,
+        write_cmd_buf,
         NOC_RET_ADDR_COORDINATE,
         (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_AT_LEN_BE, size);
-    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
         inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
@@ -933,17 +933,17 @@ FORCE_INLINE void noc_async_read_tile(
 template <uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1>
 inline void noc_async_write(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
-    // if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-    //     noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size, noc);
-    // } else {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, NOC_UNICAST_WRITE_VC);
+    if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+        noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size, noc);
+    } else {
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, NOC_UNICAST_WRITE_VC);
 
-    WAYPOINT("NAWW");
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
-    ncrisc_noc_fast_write_any_len<noc_mode>(
-        noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
-    WAYPOINT("NAWD");
-    // }
+        WAYPOINT("NAWW");
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+        ncrisc_noc_fast_write_any_len<noc_mode>(
+            noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
+        WAYPOINT("NAWD");
+    }
 }
 
 template <bool DRAM, uint32_t tile_hw>


### PR DESCRIPTION
### Ticket
#18384

### Problem description
Bringing up Active + Idle ethernet cores on BH

### What's changed
- Minor refactoring to use EthernetConfig

- Create a single Active and Idle Ethernet core test.
1. Read from DRAM to L1
2. Write from L1 into DRAM
3. Check DRAM

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14048663030/job/39339744265
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14048663686