### PR TITLE
Revert "Change CTA to RTA in compute kernel of eltwise unary operations for interleaved layout"

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
@@ -10,8 +10,8 @@
 
 namespace NAMESPACE {
 void MAIN {
-    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
-    uint32_t per_core_block_dim = get_arg_val<uint32_t>(1);
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
     init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_2);
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -30,12 +30,11 @@ void validate_supported_arch_dtype(
                 static_cast<int>(op_type));
             break;
         case UnaryOpType::FILL:
-            if (arch == tt::ARCH::GRAYSKULL) {
+           if(arch == tt::ARCH::GRAYSKULL){
                 TT_FATAL(
                     (input_datatype == DataType::BFLOAT16 || input_datatype == DataType::BFLOAT8_B),
-                    "Unsupported dtype {}. On Grayskull only BFLOAT16/BFLOAT8_B are supported",
-                    input_datatype);
-            }
+                    "Unsupported dtype {}. On Grayskull only BFLOAT16/BFLOAT8_B are supported", input_datatype);
+                }
             break;
         case UnaryOpType::BITWISE_XOR:
         case UnaryOpType::BITWISE_NOT:
@@ -155,7 +154,7 @@ void UnaryDeviceOperation::validate_on_program_cache_miss(
             computed_output_shape,
             preallocated_output_shape);
 
-        if (!input_tensor.is_sharded()) {
+        if(!input_tensor.is_sharded()){
             TT_FATAL(
                 (preallocated_output_tensor.value().get_layout() == Layout::TILE),
                 "Unary operation requires output tensor to be in Tile layout when working with non-sharded tensor.");
@@ -196,7 +195,8 @@ tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
         args,
         program_factory.index(),
         input_tensor.dtype(),
-        std::get<DeviceStorage>(input_tensor.storage()).memory_config());
+        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        input_shape.volume());
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -17,9 +17,11 @@
 
 #include "unary_device_operation_types.hpp"
 
+
 namespace ttnn::operations::unary {
 
 struct UnaryDeviceOperation {
+
     using operation_attributes_t = unary::operation_attributes_t;
     using tensor_args_t = unary::tensor_args_t;
     using spec_return_value_t = unary::spec_return_value_t;
@@ -33,8 +35,7 @@ struct UnaryDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
@@ -55,4 +56,4 @@ struct UnaryDeviceOperation {
 
 namespace ttnn::prim {
 constexpr auto unary = ttnn::register_operation<"ttnn::prim::unary", ttnn::operations::unary::UnaryDeviceOperation>();
-}  // namespace ttnn::prim
+} // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -4,11 +4,12 @@
 
 #include <algorithm>
 
+#include "unary_program_factory.hpp"
+
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
-#include "ttnn/operations/eltwise/unary/device/unary_program_factory.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 
 namespace ttnn::operations::unary::program {
@@ -76,6 +77,11 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
         all_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
+        num_tiles_per_core_group_1,  // per_core_block_cnt
+        1                            // per_core_block_size
+    };
+
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (args.preserve_fp32_precision) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
@@ -84,18 +90,38 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     bool math_approx_mode = std::all_of(
         args.op_chain.begin(), args.op_chain.end(), [](const auto& u) { return utils::get_op_approx_mode(u.op_type); });
     std::map<string, string> unary_defines = utils::get_block_defines(args.op_chain);
-
-    auto unary_compute_kernel_id = tt::tt_metal::CreateKernel(
+    auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
-        all_cores,
+        core_group_1,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
             .fp32_dest_acc_en = args.fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .bfp8_pack_precise = args.bfp8_pack_precise,
             .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args_group_1,
             .defines = unary_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = {
+            num_tiles_per_core_group_2,  // per_core_block_cnt
+            1                            // per_core_block_size
+        };
+
+        auto eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .fp32_dest_acc_en = args.fp32_dest_acc_en,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
+                .bfp8_pack_precise = args.bfp8_pack_precise,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_kernel_args_group_2,
+                .defines = unary_defines});
+    }
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -111,16 +137,13 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
         tt::tt_metal::SetRuntimeArgs(
             program, unary_reader_kernel_id, core, {src_buffer->address(), num_tiles_per_core, num_tiles_written});
 
-        tt::tt_metal::SetRuntimeArgs(program, unary_compute_kernel_id, core, {num_tiles_per_core, 1});
-
         tt::tt_metal::SetRuntimeArgs(
             program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles_per_core, num_tiles_written});
         num_tiles_written += num_tiles_per_core;
     }
 
     return cached_program_t{
-        std::move(program),
-        {unary_reader_kernel_id, unary_compute_kernel_id, unary_writer_kernel_id, num_cores, num_cores_y}};
+        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, num_cores, num_cores_y}};
 }
 
 void UnaryProgramFactory::override_runtime_arguments(
@@ -129,7 +152,6 @@ void UnaryProgramFactory::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    auto& unary_compute_kernel_id = cached_program.shared_variables.unary_compute_kernel_id;
     auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
     const uint32_t num_cores = cached_program.shared_variables.num_cores;
     const uint32_t num_cores_y = cached_program.shared_variables.num_cores_y;
@@ -140,44 +162,18 @@ void UnaryProgramFactory::override_runtime_arguments(
     auto src_buffer = input.buffer();
     auto dst_buffer = output.buffer();
 
-    uint32_t num_tiles = input.volume() / tt::constants::TILE_HW;
-    tt::tt_metal::IDevice* device = input.device();
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    auto [_, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
-
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        uint32_t num_tiles_per_core = 0;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
-        }
 
         {
             auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            runtime_args[1] = num_tiles_per_core;
-            runtime_args[2] = num_tiles_written;
-        }
-
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_compute_kernel_id, core);
-            runtime_args[0] = num_tiles_per_core;
         }
 
         {
             auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            runtime_args[1] = num_tiles_per_core;
-            runtime_args[2] = num_tiles_written;
         }
-        num_tiles_written += num_tiles_per_core;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
@@ -12,7 +12,6 @@ namespace ttnn::operations::unary::program {
 struct UnaryProgramFactory {
     struct shared_variables_t {
         tt::tt_metal::KernelHandle unary_reader_kernel_id;
-        tt::tt_metal::KernelHandle unary_compute_kernel_id;
         tt::tt_metal::KernelHandle unary_writer_kernel_id;
         uint32_t num_cores;
         uint32_t num_cores_y;


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#19273

PR breaks RMSNorm tests (composite operation includes two unary ops)

What i tried:
* adding volume back to hash function -> makes this test pass

What I think is wrong with the PR: 
I think the problem that during initial call (when cache is generated), program uses less number of cores than during successful program cache hit. 

During program factory program creation we set two parameters for each used kernel
```
tt::tt_metal::SetRuntimeArgs(program, unary_compute_kernel_id, core, {num_tiles_per_core, 1});
```

During successful cache hit we set only one. Imagine that you used two kernels and than five. Second argument will be zero for last three cores.  
```
        {
            auto& runtime_args = GetRuntimeArgs(program, unary_compute_kernel_id, core);
            runtime_args[0] = num_tiles_per_core;
        }
```

I tried adding runtime_args[1] as well, but it didn't help. I think there are more problems in the PR. 

Test case that fails:

```
TEST_F(RMSNormOpTest, RMSNorm_Compare_Kernel_Composite) {
    std::vector<std::vector<uint32_t>> shapes = {
        {1U, 1U, 1U, 1024U},
        {32U, 1U, 1024U, 4096U},     
    };
    auto* device = &ttml::autograd::ctx().get_device();

    xt::xarray<float> x_data_0 = xt::random::rand(shapes[0], 0.F, 1.F);
    xt::xarray<float> x_data_1 = xt::random::rand(shapes[1], 0.F, 1.F);
    device->enable_program_cache();
    auto x_0 = ttml::autograd::create_tensor(ttml::core::from_xtensor(x_data_0, device));
    auto x_1 = ttml::autograd::create_tensor(ttml::core::from_xtensor(x_data_1, device));
    auto gamma_0 =
        ttml::autograd::create_tensor(ttml::core::ones(ttml::core::create_shape({1, 1, 1, shapes[0][3]}), device));
    auto gamma_1 =
        ttml::autograd::create_tensor(ttml::core::ones(ttml::core::create_shape({1, 1, 1, shapes[1][3]}), device));

    auto result_0 = ttml::ops::rmsnorm(x_0, gamma_0, 0.0078125F);
    auto result_1 = ttml::ops::rmsnorm(x_1, gamma_1, 0.0078125F);
    auto result_xtensor_0 = ttml::core::to_xtensor(result_0->get_value());
    auto result_xtensor_1 = ttml::core::to_xtensor(result_1->get_value());

    // device->disable_and_clear_program_cache();  <--------- uncomment this line for test to pass

    auto expected_result_0 = ttml::ops::rmsnorm_composite(x_0, gamma_0, 0.0078125F);
    auto expected_result_1 = ttml::ops::rmsnorm_composite(x_1, gamma_1, 0.0078125F);
    auto expected_result_xtensor_0 = ttml::core::to_xtensor(expected_result_0->get_value());
    auto expected_result_xtensor_1 = ttml::core::to_xtensor(expected_result_1->get_value());

    EXPECT_TRUE(xt::allclose(result_xtensor_0, expected_result_xtensor_0, 1.0e-3F, 3e-2F));
    EXPECT_TRUE(xt::allclose(result_xtensor_1, expected_result_xtensor_1, 1.0e-3F, 3e-2F));
}
```