### PR TITLE
#0: Resolve APC Profiler Failures and enable device to device syncing…

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -215,7 +215,6 @@ def test_dispatch_cores():
         if stat in stats.keys():
             verifiedStat.append(stat)
             assert stats[stat]["stats"]["Count"] == REF_COUNT_DICT[ENV_VAR_ARCH_NAME][stat], "Wrong Dispatch zone count"
-
     statTypes = ["Dispatch", "Prefetch"]
     statTypesSet = set(statTypes)
     for statType in statTypes:
@@ -230,8 +229,8 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [17, 12, 3899],
-        "Ethernet CQ Prefetch": [18, 1951],
+        "Ethernet CQ Dispatch": [17, 12, 3902],
+        "Ethernet CQ Prefetch": [18, 1954],
     }
     os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
     devicesData = run_device_profiler_test(

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -6,7 +6,7 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE };
+enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE, FORCE_UMD_READ };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/program_impl.hpp
+++ b/tt_metal/api/tt-metalium/program_impl.hpp
@@ -158,7 +158,7 @@ class Program {
     // XXXXX TODO: this should return a const reference
     std::vector<std::vector<CoreCoord>> logical_cores() const;
 
-    void compile(IDevice* device, bool fd_bootloader_mode = false);
+    void compile(IDevice* device, bool force_slow_dispatch = false);
 
     void generate_dispatch_commands(IDevice* device);
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -122,9 +122,14 @@ void ReadShard(Buffer& buffer, std::vector<DType>& host_buffer, const uint32_t& 
 
 // Launches all kernels on cores specified with kernels in the program.
 // All kernels on a given Tensix core must be launched.
-void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done = true);
-void LaunchProgram(IDevice* device, const std::shared_ptr<Program>& program, bool wait_until_cores_done = true);
-void WaitProgramDone(IDevice* device, Program& program);
+void LaunchProgram(
+    IDevice* device, Program& program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
+void LaunchProgram(
+    IDevice* device,
+    const std::shared_ptr<Program>& program,
+    bool wait_until_cores_done = true,
+    bool force_slow_dispatch = false);
+void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile_results = true);
 
 /**
  *  Compiles all kernels within the program, and generates binaries that are written to
@@ -147,10 +152,11 @@ void WaitProgramDone(IDevice* device, Program& program);
  * |---------------------------|------------------------------------------------------------------|-----------|----------------------------------------------------|----------|
  * | device                    | Which device the program is compiled for                         | IDevice*  | Must be
  * initialized via tt_metal::InitializeDevice | Yes      | | program                   | The program to compile |
- * Program & |                                                    | Yes      | | fd_bootloader_mode        | Set when
- * compiling program to initialize fast dispatch           | bool      | | No       |
+ * Program & |                                                    | Yes      | | force_slow_dispatch        | Set when
+ * a user wants to compile a program with Slow Dispatch Force Enabled (advanced feature, currently used internally to
+ * launch Fast Dispatch Firmware and in the Device Performance Profiler)           | bool      | | No |
  */
-void CompileProgram(IDevice* device, Program& program, bool fd_bootloader_mode = false);
+void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
 /**
  * Writes runtime args that are saved in the program to device
@@ -164,13 +170,13 @@ void CompileProgram(IDevice* device, Program& program, bool fd_bootloader_mode =
  * | program             | The program holding the runtime args                                   | const Program & | |
  * Yes      |
  */
-void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloader_mode = false);
+void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
 // Configures a given device with a given program.
 // - Loads all kernel binaries into L1s of assigned Tensix cores
 // - Configures circular buffers (inits regs with buffer data)
 // - Takes the device out of reset
-bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootloader_mode = false);
+bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
 /**
  * Clear profiler control buffer

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -207,7 +207,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     for (size_t i = 0; i < device_ids.size(); i++) {
         submeshes[i]->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
         for (auto device : submeshes[i]->get_devices()) {
-            dynamic_cast<Device*>(device)->mesh_device = mesh_device;
+            dynamic_cast<Device*>(device)->mesh_device = submeshes[i];
         }
         result[device_ids[i]] = submeshes[i];
     }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -809,7 +809,7 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
     }
 
     // Compile the program and return it so Device can register it
-    detail::CompileProgram(device, *cq_program, /*fd_bootloader_mode=*/true);
+    detail::CompileProgram(device, *cq_program, /*force_slow_dispatch=*/true);
     // Erase from map. Note: program in map is no longer valid
     // It is returned from this function and the caller will take ownership of it
     command_queue_pgms.erase(device->id());
@@ -932,7 +932,7 @@ std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, F
         tt_metal::SetRuntimeArgs(*fabric_program_ptr, kernel, router_logical_core, router_runtime_args);
     }
 
-    detail::CompileProgram(device, *fabric_program_ptr, /*fd_bootloader_mode=*/device->using_fast_dispatch());
+    detail::CompileProgram(device, *fabric_program_ptr, /*force_slow_dispatch=*/device->using_fast_dispatch());
     return fabric_program_ptr;
 }
 
@@ -1070,7 +1070,7 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
         tt::tt_metal::SetRuntimeArgs(*fabric_program_ptr, eth_sender_kernel, eth_logical_core, edm_kernel_rt_args);
     }
 
-    detail::CompileProgram(device, *fabric_program_ptr, /*fd_bootloader_mode=*/device->using_fast_dispatch());
+    detail::CompileProgram(device, *fabric_program_ptr, /*force_slow_dispatch=*/device->using_fast_dispatch());
     return fabric_program_ptr;
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -668,21 +668,28 @@ void ReadShard(Buffer& buffer, uint8_t* host_buffer, const uint32_t& core_id) {
     }
 }
 
-void LaunchProgram(IDevice* device, const std::shared_ptr<Program>& program, bool wait_until_cores_done) {
-    LaunchProgram(device, *program, wait_until_cores_done);
+void LaunchProgram(
+    IDevice* device, const std::shared_ptr<Program>& program, bool wait_until_cores_done, bool force_slow_dispatch) {
+    LaunchProgram(device, *program, wait_until_cores_done, force_slow_dispatch);
 }
 
-void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done) {
+void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done, bool force_slow_dispatch) {
     {  // Profiler scope start
         ZoneScoped;
-        detail::DispatchStateCheck(false);
+        /// This function is shared between FD and SD.
+        // We call this function when initializing HW Command Queues or when reading Profiler Device to Device
+        // sync information from the accelerators.
+        // Must be set by the user only when its safe to mix slow dispatch with fast dispatch (advanced feature).
+        if (!force_slow_dispatch) {
+            detail::DispatchStateCheck(false);
+        }
         detail::CompileProgram(device, program);
         if (!program.is_finalized()) {
             program_dispatch::finalize_program_offsets(program, device);
         }
 
-        detail::WriteRuntimeArgsToDevice(device, program);
-        detail::ConfigureDeviceWithProgram(device, program);
+        detail::WriteRuntimeArgsToDevice(device, program, force_slow_dispatch);
+        detail::ConfigureDeviceWithProgram(device, program, force_slow_dispatch);
 
         auto device_id = device->id();
 
@@ -723,7 +730,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
     }
 }
 
-void WaitProgramDone(IDevice* device, Program& program) {
+void WaitProgramDone(IDevice* device, Program& program, bool dump_device_profile_results) {
     auto device_id = device->id();
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
     std::unordered_set<CoreCoord> not_done_cores;
@@ -737,17 +744,21 @@ void WaitProgramDone(IDevice* device, Program& program) {
     }
     // Wait for all cores to be done
     llrt::internal_::wait_until_cores_done(device_id, RUN_MSG_GO, not_done_cores);
-    DumpDeviceProfileResults(device, program);
+    if (dump_device_profile_results) {
+        DumpDeviceProfileResults(device, program);
+    }
 }
 
-bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootloader_mode) {
+bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch) {
     ZoneScoped;
     bool pass = true;
-    // This is function is shared between FD and SD.
-    // We call this function when initializing HW Command Queues (tracked as fd_bootloader_mode) for Fast Dispatch.
-    // Used to Launch programs for Slow dispatch.
-    bool using_fast_dispatch = fd_bootloader_mode;
-    detail::DispatchStateCheck(using_fast_dispatch);
+    // This function is shared between FD and SD.
+    // We call this function when initializing HW Command Queues or when reading Profiler Device to Device
+    // sync information from the accelerators.
+    // Must be set by the user only when its safe to mix slow dispatch with fast dispatch (advanced feature).
+    if (!force_slow_dispatch) {
+        detail::DispatchStateCheck(false);
+    }
 
     auto device_id = device->id();
 
@@ -804,10 +815,16 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootl
     return pass;
 }
 
-void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloader_mode) {
+void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow_dispatch) {
     ZoneScoped;
     auto device_id = device->id();
-    detail::DispatchStateCheck(fd_bootloader_mode);
+    // This function is shared between FD and SD.
+    // We call this function when initializing HW Command Queues or when reading Profiler Device to Device
+    // sync information from the accelerators.
+    // Must be set by the user only when its safe to mix slow dispatch with fast dispatch (advanced feature).
+    if (!force_slow_dispatch) {
+        detail::DispatchStateCheck(false);
+    }
 
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
@@ -869,9 +886,9 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloa
     }
 }
 
-void CompileProgram(IDevice* device, Program& program, bool fd_bootloader_mode) {
+void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch) {
     ZoneScoped;
-    program.compile(device, fd_bootloader_mode);
+    program.compile(device, force_slow_dispatch);
 }
 
 void SynchronizeWorkerThreads(const std::vector<IDevice*>& workers) {


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
Few outstanding issues with Device Profiler being integrated with TT-Mesh and TT-Fabric remain:
- Device to Device syncs are currently done by Fast Dispatching Programs to Ethernet Cores and issuing readbacks through FD
  - Launching programs to ethernet cores is not supported in TT-Mesh and the FD of programs + readback to ethernet cores will be completely incorrect with Fabric Routers being enabled
- `create_unit_meshes` generates SubMeshes and assigns all devices across all SubMeshes to an uninitialized parent `MeshDevice`. This is incorrect, since the parent is empty, leading to a segfault in the profiler.
- Reference values for dispatch zones are outdated in `tests/tt_metal/tools/profiler/test_device_profiler.py` since they don't account for TT-Mesh's use of dispatch firmware

### What's changed
- Use slow dispatch to write sync programs and issue readbacks in `syncDeviceDevice`. This requires a `force_slow_dispatch` arg to be added to TT-Metal Slow Dispatch functions, to ensure that we don't assert when mixing FD and SD states
- Resolve issues with mesh assignment in `create_unit_meshes`
- Update profiler tests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes