### PR TITLE
erisc wrapper kernel enable IRAM

### DIFF
--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -62,13 +62,14 @@ void iram_setup() {
     // Copy code from L1 to IRAM.
     volatile uint32_t* iram_load_reg = (volatile uint32_t*)(ETH_CTRL_REGS_START + ETH_CORE_IRAM_LOAD);
 
-    toggle_macpcs_ptr = (void (*)(uint32_t))RtosTable[1];
-    toggle_macpcs_ptr(0);  // To disable MAC
+    *(volatile uint32_t*)0xFFBA0000 = 0x30000000;
+    *(volatile uint32_t*)0xFFBA0004 = 0x6;
 
     l1_to_erisc_iram_copy(iram_load_reg);
     l1_to_erisc_iram_copy_wait(iram_load_reg);
 
-    toggle_macpcs_ptr(1);  // To re-enable MAC
+    *(volatile uint32_t*)0xFFBA0000 = 0x30000001;
+    *(volatile uint32_t*)0xFFBA0004 = 0x7;
 }
 
 #endif


### PR DESCRIPTION
NOTE: Usage is opt-in with `TT_METAL_ENABLE_ERISC_IRAM=1`


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/13960698639
  - same as main
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/13960508035
  - same as main