### PR TITLE
Revert "Revert "Fixed bug with buffers that have page sizes > 128K bytes""

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: ./.github/actions/prepare-metal-run
       - uses: ./.github/actions/install-python-deps
       - name: Run demo regression tests
-        timeout-minutes: 70
+        timeout-minutes: 90
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -72,7 +72,7 @@ run_common_perf_tests(){
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/demo/demo_with_prefill.py; fail+=$?
 
   # Mamba
-  # WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py --timeout 420; fail+=$?
 
   return $fail
 }

--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -128,11 +128,8 @@ public:
     // When page size of buffer to write/read exceeds the max prefetch command size, the PCIe-aligned page size is
     // broken down into equal sized partial pages. The base partial page size is incremented until it
     // is PCIE-aligned. If the resulting partial page size doesn't evenly divide the full page size, the last partial
-    // page size is padded appropriately. The base partial page size is different for tensix dispatch and eth dispatch
-    // because the max prefetch command size is different depending on the dispatch core type.
-    static constexpr uint32_t BASE_PARTIAL_PAGE_SIZE_TENSIX_DISPATCH = 4096;
-    static constexpr uint32_t BASE_PARTIAL_PAGE_SIZE_ETH_DISPATCH = BASE_PARTIAL_PAGE_SIZE_TENSIX_DISPATCH / 4;
-    static_assert(BASE_PARTIAL_PAGE_SIZE_TENSIX_DISPATCH % 4 == 0);
+    // page size is padded appropriately.
+    static constexpr uint32_t BASE_PARTIAL_PAGE_SIZE_DISPATCH = 4096;
 
     static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30;                                        // 1GB
     static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                     // 256 MB;

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -312,16 +312,9 @@ ShardedBufferWriteDispatchParams initialize_sharded_buf_dispatch_params(
 }
 
 uint32_t calculate_partial_page_size(const Buffer& buffer) {
-    uint32_t partial_page_size = 0;
-    const CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
-    if (dispatch_core_type == CoreType::WORKER) {
-        partial_page_size = DispatchSettings::BASE_PARTIAL_PAGE_SIZE_TENSIX_DISPATCH;
-    } else {
-        TT_ASSERT(dispatch_core_type == CoreType::ETH);
-        partial_page_size = DispatchSettings::BASE_PARTIAL_PAGE_SIZE_ETH_DISPATCH;
-    }
     const HalMemType buffer_mem_type = buffer.memory_type();
-    partial_page_size = tt::align(partial_page_size, hal.get_common_alignment_with_pcie(buffer_mem_type));
+    const uint32_t partial_page_size = tt::align(
+        DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH, hal.get_common_alignment_with_pcie(buffer_mem_type));
     return partial_page_size;
 }
 


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#19390

I may have reverted the wrong commit.

Putting this back in, and waiting feedback for the earlier revert.

https://github.com/tenstorrent/tt-metal/commit/fac07e6f684c2103e0aa9c5f55979d5aff28bf0b