### PR TITLE
Bitwise ops fix in BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -451,7 +451,7 @@ def test_acos_fixed(device, h, w):
     run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
 
 
-def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function, pcc=0.9999):
+def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function, pcc=1):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.full(size=(h, w), fill_value=fill_value).to(torch.int32)
@@ -467,7 +467,6 @@ def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function, pcc=0.99
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("fill_value", [-2147483647, 2147483648, 7534, 225, 97, 3])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -451,7 +451,7 @@ def test_acos_fixed(device, h, w):
     run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
 
 
-def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function, pcc=1):
+def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.full(size=(h, w), fill_value=fill_value).to(torch.int32)
@@ -464,7 +464,7 @@ def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function, pcc=1):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -5,9 +5,8 @@
 import torch
 import pytest
 import ttnn
-import random
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
-from models.utility_functions import skip_for_blackhole, is_grayskull, skip_for_grayskull
+from models.utility_functions import skip_for_blackhole, skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -1002,4 +1001,4 @@ def test_unary_bitwise_not(input_shapes, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
-    assert pcc >= 0.99
+    assert pcc == 1

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -18,9 +18,9 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_bitwise_not() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        vInt input = dst_reg[0];
-
-        dst_reg[0] = ~input;
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_7, 0);
+        TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_7, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -19,19 +19,8 @@ inline void calculate_bitwise_not() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
-        vInt res;
 
-        v_if(input < 0) {
-            vInt unsigned_mag = input & 0x7FFFFFFF;
-            res = unsigned_mag - 1;
-        }
-        v_else {
-            res = setsgn(input, -1);
-            res = res + 1;
-        }
-        v_endif;
-
-        dst_reg[0] = res;
+        dst_reg[0] = ~input;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
@@ -20,11 +20,11 @@ inline void calculate_right_shift(const uint shift_amt) {
         vInt input = dst_reg[0];
         vUInt val = reinterpret<vUInt>(input);
 
-        v_if(input < 0) { val = setsgn(val - 1, 0); }
+        v_if(input < 0) { val = ~val; }
         v_endif;
         vInt res = reinterpret<vInt>(val >> shift_amt);
 
-        v_if(input < 0) { res = setsgn(res + 1, input); }
+        v_if(input < 0) { res = ~res; }
         v_endif;
 
         dst_reg[0] = res;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -18,9 +18,9 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_bitwise_not() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(0, 4, 3, 0);
-        TT_SFPNOT(0, 0, 0, 1);
-        TTI_SFPSTORE(0, 4, 3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_3, 0);
+        TTI_SFPNOT(0, p_sfpu::LREG0, p_sfpu::LREG0, 1);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_3, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -18,20 +18,9 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_bitwise_not() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        vInt input = dst_reg[0];
-        vInt res;
-
-        v_if(input < 0) {
-            vInt unsigned_mag = input & 0x7FFFFFFF;
-            res = unsigned_mag - 1;
-        }
-        v_else {
-            res = setsgn(input, -1);
-            res = res + 1;
-        }
-        v_endif;
-
-        dst_reg[0] = res;
+        TTI_SFPLOAD(0, 4, 3, 0);
+        TT_SFPNOT(0, 0, 0, 1);
+        TTI_SFPSTORE(0, 4, 3, 0);
         dst_reg++;
     }
 }


### PR DESCRIPTION
### Ticket
#12592 
#19396 

### Problem description
Bitwise ops failing in BH

### What's changed
`setsgn` op is the root cause for the failure, replaced with complement operator (~)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/14034375646
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes