### PR TITLE
#17362: Fix fmod low pcc

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -594,7 +594,7 @@ def test_binary_fmod_ttnn(input_shapes, device):
 
     output_tensor = ttnn.fmod(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.fmod)
-    golden_tensor = golden_function(in_data1, in_data2)
+    golden_tensor = golden_function(in_data1, in_data2, device=device)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass
@@ -617,7 +617,7 @@ def test_binary_fmod_decimal_ttnn(input_shapes, device):
     input_tensor2 = ttnn.Tensor(in_data2, ttnn.float32).to(ttnn.TILE_LAYOUT).to(device)
     output_tensor = ttnn.fmod(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.fmod)
-    golden_tensor = golden_function(in_data1, in_data2)
+    golden_tensor = golden_function(in_data1, in_data2, device=device)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor], 0.9999)
     assert comp_pass
@@ -641,7 +641,7 @@ def test_fmod_ttnn(input_shapes, scalar, device):
 
     output_tensor = ttnn.fmod(input_tensor1, scalar)
     golden_function = ttnn.get_golden_function(ttnn.fmod)
-    golden_tensor = golden_function(in_data1, scalar)
+    golden_tensor = golden_function(in_data1, scalar, device=device)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -6,10 +6,11 @@ import torch
 import ttnn
 
 import pytest
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import torch_random
+from functools import partial
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -31,7 +32,6 @@ def test_remainder_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -80,7 +80,6 @@ def test_div_no_nan_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -122,7 +121,6 @@ def generate_torch_tensor(shape, low, high, step=0.0025, dtype=torch.float32):
     return values.reshape(shape)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shapes",
     [[64, 640], [2, 32, 320], [2, 1, 1024, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 64]],
@@ -143,3 +141,48 @@ def test_binary_fmod_bf16(
 
     pcc = ttnn.pearson_correlation_coefficient(torch_output_tensor, output)
     assert pcc >= 0.99
+
+
+# This test was added for #17362
+# If input is a multiple of the scalar, the result should be 0, but both Torch and TT output either 0 or the scalar value itself depending on the operands.
+# This inconsistency is persistent due to some fp precision loss in both Torch and TT.
+# Eg: torch.remainder of (3, 1.5) = 0.0 and of (3, 0.003) = 0.003
+# Eg: ttnn.remainder of (4, 0.004) = 0.004 and of (3, 0.003) = 0.0
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([6, 5, 320, 320])),
+        (torch.Size([3, 123, 115])),
+        (torch.Size([69, 178])),
+        (torch.Size([1024])),
+        (torch.Size([])),
+    ),
+)
+@pytest.mark.parametrize("scalar", [-0.0029, -0.002, -0.0005, 0.0, 0.0007, 0.001, 0.0025])
+def test_unary_fmod(input_shapes, scalar, device):
+    torch.manual_seed(0)
+    if len(input_shapes) == 0:
+        torch_input_tensor = torch.tensor(5.0, dtype=torch.bfloat16)
+    else:
+        torch_input_tensor = gen_func_with_cast_tt(
+            partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), ttnn.bfloat16
+        )(input_shapes)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.fmod)
+    torch_output_tensor = golden_function(torch_input_tensor, scalar, device=device)
+
+    output_tensor = ttnn.fmod(input_tensor_a, scalar)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    if scalar == 0.0:
+        assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.999
+    else:
+        assert torch.allclose(output_tensor, torch_output_tensor, atol=0.001, rtol=0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -333,7 +333,7 @@ def run_unary_test_with_float(device, h, w, scalar, ttnn_function, pcc=0.9999):
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn_function)
-    torch_output_tensor = golden_function(torch_input_tensor, scalar)
+    torch_output_tensor = golden_function(torch_input_tensor, scalar, device=device)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn_function(input_tensor, scalar)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -39,6 +39,9 @@ inline void calculate_remainder(const uint value, const uint recip) {
         vFloat quotient;
         vInt exp = exexp(v * recip_val);
         v_if(exp < 0) { quotient = vConst0; }
+        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
+        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
+        // shifting it back using (0 - (exp - 23)).
         v_elseif(exp < 23) {
             quotient =
                 reinterpret<vFloat>(shft((shft(reinterpret<vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_fmod.h
@@ -13,8 +13,8 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_fmod_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::fmod, APPROXIMATE>();
+inline void llk_math_eltwise_unary_sfpu_fmod_init(uint param0, uint param1) {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::fmod, APPROXIMATE>(sfpu::init_fmod<APPROXIMATE>, param0, param1);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -39,6 +39,9 @@ inline void calculate_remainder(const uint value, const uint recip) {
         vFloat quotient;
         vInt exp = exexp(v * recip_val);
         v_if(exp < 0) { quotient = vConst0; }
+        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
+        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
+        // shifting it back using (0 - (exp - 23)).
         v_elseif(exp < 23) {
             quotient =
                 reinterpret<vFloat>(shft((shft(reinterpret<vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_fmod.h
@@ -13,8 +13,8 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_fmod_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::fmod, APPROXIMATE>();
+inline void llk_math_eltwise_unary_sfpu_fmod_init(uint param0, uint param1) {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::fmod, APPROXIMATE>(sfpu::init_fmod<APPROXIMATE>, param0, param1);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/fmod.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/fmod.h
@@ -26,7 +26,7 @@ namespace ckernel {
  *
  * | Argument       | Description                                                                 | Type     | Valid Range                                           | Required |
  * |----------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst           | The index of the tile in DST register buffer to perform fmod operation      | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst           | The index of the tile in DST register buffer to perform fmod operation      | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0         | Denominator value to perform fmod operation                                 | uint32_t |                                                       | True     |
  * | param1         | Reciprocal of param0, calculated on-host                                    | uint32_t |                                                       | False    |
  */
@@ -38,6 +38,8 @@ ALWI void fmod_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void fmod_tile_init() { MATH((llk_math_eltwise_unary_sfpu_fmod_init<APPROX>())); }
+ALWI void fmod_tile_init(uint32_t param0, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_fmod_init<APPROX>(param0, param1)));
+}
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -155,7 +155,10 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             break;
         case UnaryOpType::FMOD:
             op_init_and_name = {
-                "fmod_tile_init();",
+                fmt::format(
+                    "fmod_tile_init({:#x}u, {:#x}u);",
+                    std::bit_cast<uint32_t>(param0),
+                    std::bit_cast<uint32_t>(1.0f / param0)),
                 fmt::format(
                     "fmod_tile({}, {:#x}u, {:#x}u);",
                     idst,

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -368,10 +368,25 @@ def _golden_function_remainder(input_tensor_a, input_tensor_b, *args, device, **
 ttnn.attach_golden_function(ttnn.remainder, golden_function=_golden_function_remainder)
 
 
-def _golden_function_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
+def _golden_function_fmod(input_tensor_a, input_tensor_b, *args, device, **kwargs):
     import torch
 
-    return torch.fmod(input_tensor_a, input_tensor_b)
+    if not torch.is_tensor(input_tensor_b):
+        input_dtype = input_tensor_a.dtype
+        if input_dtype == torch.bfloat16:
+            input_tensor_a = input_tensor_a.float()
+        result = torch.nan_to_num(
+            torch.fmod(input_tensor_a, input_tensor_b),
+            nan=device.sfpu_nan(),
+            posinf=device.sfpu_inf(),
+            neginf=-device.sfpu_inf(),
+        )
+        if input_dtype == torch.bfloat16:
+            result = result.bfloat16()
+    else:
+        result = torch.fmod(input_tensor_a, input_tensor_b)
+
+    return result
 
 
 ttnn.attach_golden_function(ttnn.fmod, golden_function=_golden_function_fmod)


### PR DESCRIPTION
### Ticket
#17362 

### Problem description
ttnn.fmod unary low PCC when scalar is between -0.003 and 0.003

### What's changed
As per [comment](https://github.com/tenstorrent/tt-metal/issues/17361#issuecomment-2691371528) for ttnn.remainder, same changes are applied to fmod kernel to increase accuracy.

- floor operation has been reworked in the kernel
- value and recip are loaded as fp32
- Updated golden function for bf16 since torch.bfloat16 was giving inaccurate torch results for tensor-scalar case

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14110363911) - PASSED
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14110383951)
- [ ] [(Single-card) Tests for new models](https://github.com/tenstorrent/tt-metal/actions/runs/14039711409)
- [x] New/Existing tests provide coverage for changes