### PR TITLE
#17725: Clean up SD model initialization

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attn_upblock_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attn_upblock_new_conv.py
@@ -18,13 +18,6 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
 from loguru import logger
 
 
-def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
-    input = ttnn.from_torch(input, ttnn.bfloat16)
-    input = ttnn.to_layout(input, layout)
-    input = ttnn.to_device(input, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    return input
-
-
 class cross_attention_upblock2d:
     def __init__(
         self, device, parameters, reader_patterns_cache, batch_size, input_height, input_width, compute_kernel_config

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_geglu.py
@@ -11,19 +11,13 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
 )
 
 
-def ttnn_to_torch(input):
-    input = ttnn.from_device(input)
-    input = ttnn.to_torch(input)
-    return input
-
-
 def split_linear_params(params):
     dim = -1
     device = params.proj.weight.device()
     memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-    weight = ttnn_to_torch(params.proj.weight)
-    bias = ttnn_to_torch(params.proj.bias)
+    weight = ttnn.to_torch(params.proj.weight)
+    bias = ttnn.to_torch(params.proj.bias)
 
     proj_weight, gate_weight = torch.split(weight, weight.shape[dim] // 2, dim=dim)
     proj_bias, gate_bias = torch.split(bias, bias.shape[dim] // 2, dim=dim)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -21,19 +21,6 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
 from loguru import logger
 
 
-def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
-    input = ttnn.from_torch(input, ttnn.bfloat16)
-    input = ttnn.to_layout(input, layout)
-    input = ttnn.to_device(input, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    return input
-
-
-def ttnn_to_torch(input):
-    input = ttnn.from_device(input)
-    input = ttnn.to_torch(input)
-    return input
-
-
 config_override = {
     (320, 320, 64, 64): {"act_block_h": 64},
     (640, 640, 32, 32): {"act_block_h": 64},

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -22,12 +22,6 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions
 from loguru import logger
 
 
-def ttnn_to_torch(input):
-    input = ttnn.from_device(input)
-    input = ttnn.to_torch(input)
-    return input
-
-
 class transformer_2d_model:
     def __init__(self, device, parameters, batch_size, input_height, input_width, compute_kernel_config):
         self.device = device

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -68,19 +68,6 @@ def permute_conv_weights(weight, bias):
     return weight, bias
 
 
-def torch_to_ttnn(input, device, layout=ttnn.TILE_LAYOUT):
-    input = ttnn.from_torch(input, ttnn.bfloat16)
-    input = ttnn.to_layout(input, layout)
-    input = ttnn.to_device(input, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    return input
-
-
-def ttnn_to_torch(input):
-    input = ttnn.from_device(input)
-    input = ttnn.to_torch(input)
-    return input
-
-
 class UNet2DConditionModel:
     def __init__(
         self,


### PR DESCRIPTION
### Ticket
#17725

### Problem description
Model initialization hangs locally on Blackhole machine deterministically inside `ttnn_to_torch` or `weight_to_bfp8` methods; both of them were doing unnecessary steps needed back when ttnn API was more unstable. It hangs only in cross attention down block component unit test (which is not on the BH CI).

### What's changed
- Replace these funstions with `ttnn.typecast` and `ttnn.to_torch` APIs.
- Remove unused functions.

### Checklist
- [WH] Nightly model and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/13966508435
- [WH] Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/13966535437
- [BH] BH post commit already has a long queue so I didn't trigger it; instead I ran the CI tests locally; Let me know if you feel we should wait for it