### PR TITLE
Remove redundant `ttnn.synchronize_device`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -116,8 +116,6 @@ def device(request, device_params):
     yield device
 
     ttnn.DumpDeviceProfiler(device)
-
-    ttnn.synchronize_device(device)
     ttnn.close_device(device)
 
 

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -230,8 +230,8 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [17, 12, 3899],
-        "Ethernet CQ Prefetch": [18, 1951],
+        "Ethernet CQ Dispatch": [17, 12, 3896],
+        "Ethernet CQ Prefetch": [18, 1948],
     }
     os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
     devicesData = run_device_profiler_test(

--- a/tests/ttnn/unit_tests/light_metal/conftest.py
+++ b/tests/ttnn/unit_tests/light_metal/conftest.py
@@ -18,7 +18,6 @@ def reset_device(request, device_params):
     def _reset_device(device):
         """Closes and reopens the device to ensure a fresh state."""
         ttnn.DumpDeviceProfiler(device)
-        ttnn.synchronize_device(device)
         ttnn.close_device(device)
 
         # Reopen a new device instance


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`ttnn.synchronize_device` is being called inside `ttnn.close_device` already.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] [T3K profiler tests](https://github.com/tenstorrent/tt-metal/actions/runs/14000312286)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes