### PR TITLE
#19413: Only run test reports on forks because we need an extra workflow_run triggered workflow to do test reports for fork PRs. RIP

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -59,7 +59,9 @@ jobs:
           git init
       - name: Test Report
         uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
-        if: ${{ !cancelled() }}
+        # Because of https://github.com/tenstorrent/tt-metal/issues/19413, only run for our repo
+        # for now. No forks!
+        if: ${{ !cancelled() && github.repository_owner == 'tenstorrent' }}
         with:
           name: Metalium ${{ matrix.platform }} smoke tests
           path: /work/test-reports/*.xml


### PR DESCRIPTION
### Ticket

#19413

### Problem description

External PRs cannot get test reports because they don't have write access.

### What's changed

Only run test reports on our repo. Hope this works.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes