### PR TITLE
#0: move log printing on kernel build failure to TT_THROW

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -51,8 +51,7 @@ static void build_failure(const string& target_name, const string& op, const str
     std::ifstream file{log_file};
     if (file.is_open()) {
         std::string log_contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-        log_error(tt::LogBuildKernels, "{}", log_contents);
-        TT_THROW("{} build failed", target_name);
+        TT_THROW("{} build failed. Log: {}", target_name, log_contents);
     } else {
         TT_THROW("Failed to open {} failure log file {}", op, log_file);
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
- the log contents were not printing for me, delaying root causing issues

### What's changed
- move the log contents printing to the TT_THROW

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/13974153723
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A