### PR TITLE
fix missing semi-colon for WATCHER statement in kernel profiler

### DIFF
--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -197,7 +197,7 @@ FORCE_INLINE
 void profiler_noc_async_flush_posted_write(uint8_t noc = noc_index) {
     WAYPOINT("NPPW");
     while (!ncrisc_noc_posted_writes_sent(noc));
-    WAYPOINT("NPPD")
+    WAYPOINT("NPPD");
 }
 
 #endif


### PR DESCRIPTION
### Problem description
Missing semicolon to `WATCHER` statement in `kernel_profiler.hpp` . Not caught by CI because profiler and watcher are not enabled simultaneously in any tests due to code size issues.

### What's changed
Added missing semicolon to `WATCHER` statement in kernel_profiler.hpp

### Checklist
- [] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes