### PR TITLE
Make tensix and eth dram endpoints the same for BH

### DIFF
--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -27,49 +27,49 @@ dram_views:
   [
     {
       channel: 0,
-      eth_endpoint: 1,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 1,
-      eth_endpoint: 0,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 2,
-      eth_endpoint: 1,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 3,
-      eth_endpoint: 0,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 4,
-      eth_endpoint: 1,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 5,
-      eth_endpoint: 0,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 6,
-      eth_endpoint: 1,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     },
     {
       channel: 7,
-      eth_endpoint: 0,
+      eth_endpoint: 2,
       worker_endpoint: 2,
       address_offset: 0
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[BH-76](https://tenstorrent.atlassian.net/browse/BH-76) describes bug where dram controller can deadlock if different VCs/NOC endpoints are used to access a particular dram.

Valid scenarios @vvukomanovicTT 
1.Both NOCs use only 1 endpoint - no limitation on read/write VCs used.
2.Each NOC exclusively uses only 1 assigned DRAM port - e.g NOC0 always uses DRAM port 0, NOC1 always uses DRAM port 1 - no limitations on read/write VCs used.
3.Both NOCs use any DRAM point they want but per endpoint VC must be the same for reads and writes.

### What's changed
Use same noc dram endpoint for tensix and eth. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13973128274) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13973131096) CI passes