### PR TITLE
#0: Fix benchmark profiling to be able to dump edm cores

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2490,15 +2490,9 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     for (IDevice* d : devices) {
         tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
     }
-    for (size_t i = 0; i < programs.size(); i++) {
-        auto d = worker_devices[i];
-        auto& program = programs[i];
-        tt_metal::DumpDeviceProfileResults(d, program);
-    }
-    for (size_t i = 0; i < fabric_programs->size(); i++) {
-        auto d = devices[i];
-        auto& program = fabric_programs.value()[i];
-        tt_metal::DumpDeviceProfileResults(d, program);
+
+    for (IDevice* d : devices) {
+        detail::DumpDeviceProfileResults(d);
     }
     log_info(tt::LogTest, "Finished");
 }

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -749,7 +749,7 @@ def test_all_gather_sharded(
     ],
 )
 @pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [False])
+@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_sharded_ring(
     pcie_mesh_device,
     num_devices,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19421

### Problem description
Calling the profile dumps by program seems to not dump the erisc profiling.

### What's changed
Switch to the device level api to enable dumping erisc in the ubench.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/13973277179
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/13973272586
Microbench: https://github.com/tenstorrent/tt-metal/actions/runs/13973266652/job/39120917868