### PR TITLE
[skip ci] Fix input names in pipeline select workflow

### DIFF
--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -56,12 +56,12 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/perf-models-impl.yaml
-    if: ${{ inputs.perf-models }}
+    if: ${{ inputs.single-card-perf-models }}
   single-card-perf-device-models-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/perf-device-models-impl.yaml
-    if: ${{ inputs.perf-device-models }}
+    if: ${{ inputs.single-card-perf-device-models }}
     with:
       docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}


### PR DESCRIPTION
### Ticket

### Problem description
Single card choose your own pipeline did not have the right input names for single card model perf and single card perf device model

### What's changed
Fixed the input names

### Checklist