### PR TITLE
[DO NOT MERGE][WIP][tt-train][BugFix] Fix scatter for LoudBox (device ids can be not consecutive)

### DIFF
--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -100,7 +100,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
 
     auto distributed_tensor = ttnn::distributed::create_multi_device_tensor(
         scattered_tensors, ttnn::StorageType::MULTI_DEVICE, storage.strategy);
-    
+
     return distributed_tensor;
 }
 


### PR DESCRIPTION
### Problem description
Scatter breaks with LoudBox because of non-consecutive device ids. 

### What's changed
* change iteration over devices logic 

### Why WIP and DO NOT MERGE? 
* we see issue that this PR tries to solve being resolved in integration branch of distributed team
* we need to investigate issue further, whether it can happen further 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/13975178764
- [x] New/Existing tests provide coverage for changes