### PR TITLE
tt_transformers: Enable support for non-uniform decoder configurations

### DIFF
--- a/models/tt_transformers/demo/config_16_decoders.json
+++ b/models/tt_transformers/demo/config_16_decoders.json
@@ -1,0 +1,68 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8" },
+            "fidelity_cfg": { }
+        },
+        "1": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP4", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2" }
+        },
+        "2": {
+            "precision_cfg": { "FF1_FF3": "BF16", "WQKV": "BF16", "WO": "BFP8", "KV_CACHE": "BFP8"},
+            "fidelity_cfg": { "SDPA_DECODE": "HIFI2_NA", "LI_QKV_DECODE": "HIFI4" }
+        },
+        "3": {
+            "precision_cfg": { },
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI", "SDPA_PREFILL": "HIFI4" }
+        },
+        "4": {
+            "precision_cfg": { "WO": "BFP4", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "LI_FF2": "HIFI2", "LI_O_PREFILL": "HIFI2_FP16" }
+        },
+        "5": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP8", "KV_CACHE": "BFP8" },
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2" }
+        },
+        "6": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BF16", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "HIFI2_FP16" }
+        },
+        "7": {
+            "precision_cfg": { "FF1_FF3": "BF16", "FF2": "BFP8", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI", "LI_FF2": "HIFI2" }
+        },
+        "8": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "WO": "BFP8"},
+            "fidelity_cfg": { "LI_O_DECODE": "HIFI2_FP16" }
+        },
+        "9": {
+            "precision_cfg": { "FF1_FF3": "BFP8"},
+            "fidelity_cfg": { "SDPA_DECODE": "HIFI2_NA" }
+        },
+        "10": {
+            "precision_cfg": { "FF1_FF3": "BF16", "WO": "BFP8", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "LI_QKV_PREFILL": "HIFI2" }
+        },
+        "11": {
+            "precision_cfg": { "FF1_FF3": "BFP4"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI", "SDPA_PREFILL": "HIFI4" }
+        },
+        "12": {
+            "precision_cfg": { "WO": "BFP4"},
+            "fidelity_cfg": { "LI_FF2": "HIFI2", "LI_O_PREFILL": "HIFI2_FP16" }
+        },
+        "13": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP8", "WQKV": "BF16", "WO": "BFP8", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI", "LI_FF2": "HIFI2", "LI_QKV_DECODE": "HIFI4", "SDPA_DECODE": "HIFI2_NA" }
+        },
+        "14": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP4", "KV_CACHE": "BFP8" },
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2" }
+        },
+        "15": {
+            "precision_cfg": { "FF1_FF3": "BF16", "WO": "BFP8", "KV_CACHE": "BF16" },
+            "fidelity_cfg": { "SDPA_DECODE": "HIFI2_NA", "LI_QKV_DECODE": "HIFI4" }
+        }
+    }
+}

--- a/models/tt_transformers/demo/conftest.py
+++ b/models/tt_transformers/demo/conftest.py
@@ -30,3 +30,10 @@ def pytest_addoption(parser):
         type=parse_optimizations,
         help="Precision and fidelity configuration diffs over default (i.e., accuracy)",
     )
+    parser.addoption(
+        "--decoder_config_file",
+        action="store",
+        default=None,
+        type=str,
+        help="Provide a JSON file defining per-decoder precision and fidelity settings",
+    )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -15,7 +15,7 @@ import ttnn
 
 
 from models.tt_transformers.tt.generator import Generator
-from models.tt_transformers.tt.model_config import ModelOptimizations
+from models.tt_transformers.tt.model_config import ModelOptimizations, DecodersPrecision, parse_decoder_json
 from models.tt_transformers.tt.common import (
     preprocess_inputs_prefill,
     PagedAttentionConfig,
@@ -409,9 +409,10 @@ def prepare_generator_args(
 @pytest.mark.parametrize(
     "optimizations",
     [
-        ModelOptimizations.performance,
-        ModelOptimizations.accuracy,
+        lambda model_args: DecodersPrecision(model_args.n_layers, ModelOptimizations.performance()),
+        lambda model_args: DecodersPrecision(model_args.n_layers, ModelOptimizations.accuracy()),
     ],
+    ids=["performance", "accuracy"],
 )
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
@@ -472,7 +473,13 @@ def test_demo_text(
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
     sampling_params = request.config.getoption("--sampling_params") or sampling_params
-    optimizations = request.config.getoption("--optimizations") or optimizations
+    json_config_file = request.config.getoption("--decoder_config_file")
+
+    if json_config_file:
+        optimizations = parse_decoder_json(json_config_file)
+    else:
+        optimizations = request.config.getoption("--optimizations") or optimizations
+
     if request.config.getoption("--stop_at_eos") in [
         0,
         1,

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -15,7 +15,7 @@ import ttnn
 
 
 from models.tt_transformers.tt.generator import Generator
-from models.tt_transformers.tt.model_config import ModelOptimizations, DecodersPrecision, parse_decoder_json
+from models.tt_transformers.tt.model_config import DecodersPrecision, parse_decoder_json
 from models.tt_transformers.tt.common import (
     preprocess_inputs_prefill,
     PagedAttentionConfig,
@@ -409,8 +409,8 @@ def prepare_generator_args(
 @pytest.mark.parametrize(
     "optimizations",
     [
-        lambda model_args: DecodersPrecision(model_args.n_layers, ModelOptimizations.performance()),
-        lambda model_args: DecodersPrecision(model_args.n_layers, ModelOptimizations.accuracy()),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
     ],
     ids=["performance", "accuracy"],
 )
@@ -447,8 +447,8 @@ def test_demo_text(
     """
     Simple demo with limited dependence on reference code.
     """
-
-    if is_ci_env and (optimizations == ModelOptimizations.accuracy or not ci_only):
+    test_id = request.node.callspec.id
+    if is_ci_env and (test_id == "accuracy" or not ci_only):
         pytest.skip("CI only runs the CI-only tests")
 
     # TODO: Remove this once all batch sizes are supported on TG

--- a/models/tt_transformers/lt
+++ b/models/tt_transformers/lt
@@ -16,6 +16,7 @@ import psutil
 import json
 import matplotlib.pyplot as plt
 import numpy as np
+from pathlib import Path
 
 from models.tt_transformers.tt.model_config import parse_optimizations
 
@@ -47,6 +48,18 @@ pareto_commands = {
         for i, setting in enumerate(dtype_mf_settings)
     ]
     for k, v in cmd.items()
+}
+
+DECODER_CONFIG_FOLDER = Path("models/tt_transformers/tests/configurations/")
+decoder_config_files = [file for file in DECODER_CONFIG_FOLDER.glob("*.json")]
+
+pareto_commands_from_json = {
+    k: v
+    for i, file in enumerate(decoder_config_files)
+    for k, v in {
+        f"accuracy-dmf-json-{i}": f"pytest models/tt_transformers/tests/test_accuracy.py -k 'attention-accuracy and file' --decoder_config_file {file}",
+        f"demo-dmf-json-{i}": f"pytest models/tt_transformers/demo/simple_text_demo.py -k 'params0 and batch-1' --decoder_config_file {file}",
+    }.items()
 }
 
 
@@ -518,6 +531,9 @@ def main(stdscr):
                         if command_input == "pareto":
                             command_input = ",".join(pareto_commands.keys())
 
+                        if command_input == "pareto_from_json":
+                            command_input = ",".join(pareto_commands_from_json.keys())
+
                         # Parse models, devices, and commands
                         models = parse_list(model_input)
                         devices = parse_list(device_input)
@@ -917,6 +933,7 @@ def run_entry_command(entry, screen_lock, output_entries, screen_needs_update):
         "model-prefill": "pytest models/tt_transformers/tests/test_model_prefill.py -k performance-4096",
         # Precision and Math Fidelity tests for Pareto analysis
         **pareto_commands,
+        **pareto_commands_from_json,
         # Vision tests (require 11B weights)
         "vision-mlp": "pytest models/tt_transformers/tests/multimodal/test_image_mlp.py",
         "vision-attn": "pytest models/tt_transformers/tests/multimodal/test_image_attention.py",
@@ -1341,7 +1358,10 @@ def export_results_to_markdown(output_entries, stdscr):
                 speed = entry.speed
                 ttft = entry.ttft
 
-                setting_idx = int(entry.command_name[len("demo-dmf-") :])
+                match = re.search(r"demo-dmf(?:-json)?-(\d+)", entry.command_name)
+                if not match:
+                    continue
+                setting_idx = int(match.group(1))
                 if setting_idx not in dmf_entries:
                     dmf_entries[setting_idx] = {key: ["N/A", "N/A", speed or "N/A", ttft]}
                 else:
@@ -1356,7 +1376,10 @@ def export_results_to_markdown(output_entries, stdscr):
                     if match:
                         top1, top5 = match.group(1), match.group(2)
 
-                setting_idx = int(entry.command_name[len("accuracy-dmf-") :])
+                match = re.search(r"accuracy-dmf(?:-json)?-(\d+)", entry.command_name)
+                if not match:
+                    continue
+                setting_idx = int(match.group(1))
                 if setting_idx not in dmf_entries:
                     dmf_entries[setting_idx] = {key: [top1, top5, "N/A", "N/A"]}
                 else:
@@ -1417,7 +1440,9 @@ def export_results_to_markdown(output_entries, stdscr):
     if dmf_entries:
         data_to_plot = {}
         for setting_idx, entries in dmf_entries.items():
-            desc = gen_description(setting_idx)
+            # Check if any entry used this setting_idx and came from JSON
+            used_json_for_setting = any(f"json-{setting_idx}" in e.command_name for e in output_entries)
+            desc = "" if used_json_for_setting else gen_description(setting_idx)
             markdown_lines.extend(
                 [
                     "",
@@ -1445,26 +1470,33 @@ def export_results_to_markdown(output_entries, stdscr):
             speed, top1, desc = data
             plot_data_with_desc(speed, top1, "Speed (t/s/u)", "Top-1 (%)", desc, model_device_name)
 
-    # Write to PERF.md
-    with open("PERF.md", "w") as f:
-        f.write("\n".join(markdown_lines) + "\n")
+    # Check if any entry came from a JSON config
+    used_json = any("json" in entry.command_name for entry in output_entries)
 
-    # Clear screen and show message
-    stdscr.clear()
+    # Only update PERF.md and display it if not using JSON
+    if not used_json:
+        with open("PERF.md", "w") as f:
+            f.write("\n".join(markdown_lines) + "\n")
 
-    # display 'PERF.md' using less
-    # Save current terminal state
-    curses.def_prog_mode()
-    # Exit curses temporarily
-    curses.endwin()
-    # Run less command
-    os.system(f"less -R PERF.md")
-    # Resume curses
-    curses.reset_prog_mode()
-    stdscr.refresh()
+        # Clear screen and show message
+        stdscr.clear()
 
-    # display helpful message at the bottom of the screen
-    stdscr.addstr(0, 0, f"Table written to {os.path.abspath('PERF.md')}")
+        # display 'PERF.md' using less
+        # Save current terminal state
+        curses.def_prog_mode()
+        # Exit curses temporaril
+        curses.endwin()
+        # Run less command
+        os.system(f"less -R PERF.md")
+        # Resume curses
+        curses.reset_prog_mode()
+        stdscr.refresh()
+
+        # display helpful message at the bottom of the screen
+        stdscr.addstr(0, 0, f"Table written to {os.path.abspath('PERF.md')}")
+    else:
+        stdscr.clear()
+
     stdscr.addstr(1, 0, f"Plots written to .svg files in {os.path.abspath('data_plots/')}")
     stdscr.addstr(2, 0, "Press any key to return...")
     stdscr.refresh()
@@ -1578,35 +1610,36 @@ def plot_data_with_desc(objective1, objective2, objective1_label, objective2_lab
     x = 0.1
     y = height_incr / 4
 
-    # add footnote to the plot
+    # add footnote to the plot only when json is not used
     for i in pareto_indices:
         desc_splits = point_desc[i].split("}")
-        fidelity_desc = desc_splits[1][2:] + "}"  # 2: slice to remove the leading ", "
-        # find substring "li_qkv_prefill" in fidelity_desc and insert a new line before it so the text fits in the plot
-        idx = fidelity_desc.find("li_qkv_prefill")
-        assert idx != -1, f"li_qkv_prefill not found in {fidelity_desc}"
-        fidelity_desc_part2 = " " * len("fidelity_cfg = {") + fidelity_desc[idx:]
-        plt.figtext(
-            x, y, f"{fidelity_desc_part2}", ha="left", transform=fig.dpi_scale_trans, family="monospace", fontsize=6
-        )
-        y += height_incr / 8
-        fidelity_desc_part1 = fidelity_desc[:idx]
-        plt.figtext(
-            x, y, f"{fidelity_desc_part1}", ha="left", transform=fig.dpi_scale_trans, family="monospace", fontsize=6
-        )
-        y += height_incr / 8
-        dtype_desc = desc_splits[0] + "}"
-        plt.figtext(x, y, f"{dtype_desc}", ha="left", transform=fig.dpi_scale_trans, family="monospace", fontsize=6)
-        y += height_incr / 8
-        plt.figtext(
-            x,
-            y,
-            f"{i}: {objective1_label}={objective1[i]}, {objective2_label}={objective2[i]}",
-            ha="left",
-            transform=fig.dpi_scale_trans,
-            fontsize=10,
-        )
-        y += height_incr / 3
+        if len(desc_splits) >= 2:
+            fidelity_desc = desc_splits[1][2:] + "}"  # 2: slice to remove the leading ", "
+            # find substring "li_qkv_prefill" in fidelity_desc and insert a new line before it so the text fits in the plot
+            idx = fidelity_desc.find("li_qkv_prefill")
+            assert idx != -1, f"li_qkv_prefill not found in {fidelity_desc}"
+            fidelity_desc_part2 = " " * len("fidelity_cfg = {") + fidelity_desc[idx:]
+            plt.figtext(
+                x, y, f"{fidelity_desc_part2}", ha="left", transform=fig.dpi_scale_trans, family="monospace", fontsize=6
+            )
+            y += height_incr / 8
+            fidelity_desc_part1 = fidelity_desc[:idx]
+            plt.figtext(
+                x, y, f"{fidelity_desc_part1}", ha="left", transform=fig.dpi_scale_trans, family="monospace", fontsize=6
+            )
+            y += height_incr / 8
+            dtype_desc = desc_splits[0] + "}"
+            plt.figtext(x, y, f"{dtype_desc}", ha="left", transform=fig.dpi_scale_trans, family="monospace", fontsize=6)
+            y += height_incr / 8
+            plt.figtext(
+                x,
+                y,
+                f"{i}: {objective1_label}={objective1[i]}, {objective2_label}={objective2[i]}",
+                ha="left",
+                transform=fig.dpi_scale_trans,
+                fontsize=10,
+            )
+            y += height_incr / 3
 
     x = fig_width / 2
     plt.figtext(

--- a/models/tt_transformers/tests/configurations/conf0.json
+++ b/models/tt_transformers/tests/configurations/conf0.json
@@ -1,0 +1,68 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "1": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "2": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "3": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "4": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "5": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "6": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "7": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "8": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "9": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "10": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "11": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "12": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "13": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "14": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "15": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        }
+    }
+}

--- a/models/tt_transformers/tests/configurations/conf1.json
+++ b/models/tt_transformers/tests/configurations/conf1.json
@@ -1,0 +1,68 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "1": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "2": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "3": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "4": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "5": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "6": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "7": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "8": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "9": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "10": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "11": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "12": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "13": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "14": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "15": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        }
+    }
+}

--- a/models/tt_transformers/tests/configurations/conf2.json
+++ b/models/tt_transformers/tests/configurations/conf2.json
@@ -1,0 +1,68 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "1": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "2": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "3": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "4": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "5": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "6": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "7": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "8": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "9": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "10": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "11": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "12": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "13": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "14": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "15": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        }
+    }
+}

--- a/models/tt_transformers/tests/configurations/conf3.json
+++ b/models/tt_transformers/tests/configurations/conf3.json
@@ -1,0 +1,68 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "1": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "2": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "3": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "4": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "5": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "6": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "7": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "8": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "9": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "10": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "11": {
+            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2",  "LI_FF2": "HIFI2", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "12": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "13": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "14": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        },
+        "15": {
+            "precision_cfg": { "FF1_FF3": "BFP4", "FF2": "BFP4", "WQKV": "BFP8", "WO": "BFP4", "KV_CACHE": "BFP8", "ACTIVATION": "BFP8"},
+            "fidelity_cfg": { "LI_FF1_FF3": "LOFI",  "LI_FF2": "LOFI", "SDPA_DECODE": "HIFI2_NA", "LI_O_DECODE": "LOFI", "LI_QKV_PREFILL": "HIFI2", "SDPA_PREFILL": "HIFI4", "LI_O_PREFILL": "LOFI" }
+        }
+    }
+}

--- a/models/tt_transformers/tests/conftest.py
+++ b/models/tt_transformers/tests/conftest.py
@@ -20,3 +20,11 @@ def pytest_addoption(parser):
         type=parse_optimizations,
         help="Precision and fidelity configuration diffs over default (i.e., accuracy)",
     )
+
+    parser.addoption(
+        "--decoder_config_file",
+        action="store",
+        default=None,
+        type=str,
+        help="Provide a JSON file defining per-decoder precision and fidelity settings",
+    )

--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -13,11 +13,11 @@ from models.tt_transformers.tt.common import (
     preprocess_inputs_prefill,
 )
 from models.tt_transformers.tt.model import Transformer
-from models.tt_transformers.tt.model_config import ModelArgs, ModelOptimizations
+from models.tt_transformers.tt.model_config import ModelArgs, ModelOptimizations, parse_decoder_json
 from pathlib import Path
 
 
-def get_accuracy_thresholds(base_model_name: str, device_name: str, optimizations: ModelOptimizations):
+def get_accuracy_thresholds(model_args, optimizations):
     """Parse accuracy thresholds from PERF.md for the given model, optimization mode, and device."""
     # Read PERF.md
     perf_file = Path(__file__).parent.parent / "PERF.md"
@@ -26,10 +26,15 @@ def get_accuracy_thresholds(base_model_name: str, device_name: str, optimization
 
     # Split into sections based on optimization mode
     sections = content.split("## ")
-    target_section = next(s for s in sections if s.lower().startswith(f"{optimizations.__name__}\n"))
+    if callable(optimizations):
+        optimizations = optimizations(model_args)
+    first_decoder_conf = optimizations.decoder_optimizations[0]
+    target_section = next(s for s in sections if s.lower().startswith(f"{first_decoder_conf.__name__}\n"))
 
     # Parse the table and find the row for our model and device
     # Potential lines have the form "| Llama3.1-8b    | T3K    | 91        | 99        | 49.8          |"
+    base_model_name = model_args.base_model_name
+    device_name = model_args.device_name
     correct_line = (
         lambda line: "|" in line
         and base_model_name.lower() in line.split("|")[1].strip().lower()
@@ -129,7 +134,11 @@ def test_tt_model_acc(
 
     mesh_device.enable_async(True)
 
-    optimizations = request.config.getoption("--optimizations") or optimizations
+    json_config_file = request.config.getoption("--decoder_config_file")
+    if json_config_file:
+        optimizations = parse_decoder_json(json_config_file)
+    else:
+        optimizations = request.config.getoption("--optimizations") or optimizations
 
     # Load model args and tokenizer
     model_args = ModelArgs(mesh_device, optimizations=optimizations, max_batch_size=batch_size, max_seq_len=max_seq_len)
@@ -442,17 +451,17 @@ def test_tt_model_acc(
                 logger.info(f"{error['position']}: {context}[{incorrect}] != [{expected}], true: [{true_word}]")
 
     if use_reference_file:
-        # Get accuracy thresholds from PERF.md
-        min_top1_acc, min_top5_acc = get_accuracy_thresholds(
-            model_args.base_model_name,
-            model_args.device_name,
-            optimizations,
-        )
+        if not json_config_file:
+            # Get accuracy thresholds from PERF.md, unless the configuration is from a json
+            min_top1_acc, min_top5_acc = get_accuracy_thresholds(
+                model_args,
+                optimizations,
+            )
+            assert (
+                total_top1_acc >= min_top1_acc
+            ), f"Top-1 accuracy {total_top1_acc:.1f}% is too low (expected >={min_top1_acc}%)"
+            assert (
+                total_top5_acc >= min_top5_acc
+            ), f"Top-5 accuracy {total_top5_acc:.1f}% is too low (expected >={min_top5_acc}%)"
 
         logger.info(f"Top-1: {total_top1_acc:.0f}% | Top-5: {total_top5_acc:.0f}%")
-        assert (
-            total_top1_acc >= min_top1_acc
-        ), f"Top-1 accuracy {total_top1_acc:.1f}% is too low (expected >={min_top1_acc}%)"
-        assert (
-            total_top5_acc >= min_top5_acc
-        ), f"Top-5 accuracy {total_top5_acc:.1f}% is too low (expected >={min_top5_acc}%)"

--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -13,7 +13,7 @@ from models.tt_transformers.tt.common import (
     preprocess_inputs_prefill,
 )
 from models.tt_transformers.tt.model import Transformer
-from models.tt_transformers.tt.model_config import ModelArgs, ModelOptimizations, parse_decoder_json
+from models.tt_transformers.tt.model_config import ModelArgs, DecodersPrecision, parse_decoder_json
 from pathlib import Path
 
 
@@ -81,9 +81,10 @@ def get_accuracy_thresholds(model_args, optimizations):
 @pytest.mark.parametrize(
     "optimizations",
     [
-        ModelOptimizations.accuracy,
-        ModelOptimizations.performance,
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
     ],
+    ids=["performance", "accuracy"],
 )
 @pytest.mark.parametrize(
     "paged_attention",

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -12,7 +12,7 @@ from models.tt_transformers.tt.common import (
     num_blocks_in_seq,
 )
 from models.tt_transformers.tt.model import Transformer
-from models.tt_transformers.tt.model_config import ModelArgs, ModelOptimizations
+from models.tt_transformers.tt.model_config import ModelArgs
 from models.tt_transformers.tt.generator import Generator
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Transformer as ReferenceTransformer
 from models.utility_functions import (
@@ -50,7 +50,7 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "optimizations",
     [
-        pytest.param(ModelOptimizations.accuracy, id="accuracy"),
+        pytest.param(lambda model_args: DecodersPrecision.accuracy(model_args.n_layers), id="accuracy"),
     ],
 )
 def test_chunked_prefill_single_user(
@@ -64,6 +64,7 @@ def test_chunked_prefill_single_user(
     reset_seeds,
     ensure_gc,
     is_ci_env,
+    request,
 ):
     mesh_device.enable_async(True)
 
@@ -71,10 +72,11 @@ def test_chunked_prefill_single_user(
     batch_size = 1  # For prefill we only support batch_size = 1
 
     # This sets the minimum PCC for each iteration based on optimization mode
-    if optimizations == ModelOptimizations.accuracy:
+    test_id = request.node.callspec.id
+    if test_id == "accuracy":
         pcc = 0.91  # TODO Look on improving PCC
     else:  # performance mode
-        assert optimizations == ModelOptimizations.performance
+        assert test_id == "performance"
         pcc = 0.869  # TODO Look on improving PCC
 
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, optimizations=optimizations, max_seq_len=seq_len)

--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -10,7 +10,7 @@ from models.tt_transformers.tt.common import (
     sample_host,
     PagedAttentionConfig,
 )
-from models.tt_transformers.tt.model_config import ModelArgs, ModelOptimizations
+from models.tt_transformers.tt.model_config import ModelArgs, DecodersPrecision
 from models.tt_transformers.tt.model import Transformer
 from models.utility_functions import (
     comp_pcc,
@@ -57,9 +57,10 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "optimizations",
     [
-        pytest.param(ModelOptimizations.accuracy, id="accuracy"),
-        pytest.param(ModelOptimizations.performance, id="performance"),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
     ],
+    ids=["performance", "accuracy"],
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -82,12 +83,14 @@ def test_model_inference(
     use_program_cache,
     reset_seeds,
     ensure_gc,
+    request,
 ):
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
     dtype = ttnn.bfloat8_b
     mesh_device.enable_async(True)
-    mode_accuracy = optimizations == ModelOptimizations.accuracy
+    test_id = request.node.callspec.id
+    mode_accuracy = test_id == "accuracy"
     instruct = False  # True if weights == "instruct" else False
     dummy_weights = True if weights == "random" else False
     model_args = ModelArgs(

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -12,7 +12,7 @@ from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
 )
 from models.tt_transformers.tt.model import Transformer
-from models.tt_transformers.tt.model_config import ModelArgs, ModelOptimizations
+from models.tt_transformers.tt.model_config import ModelArgs
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
@@ -56,9 +56,10 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "optimizations",
     [
-        pytest.param(ModelOptimizations.accuracy, id="accuracy"),
-        pytest.param(ModelOptimizations.performance, id="performance"),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
     ],
+    ids=["performance", "accuracy"],
 )
 def test_model_inference(
     seq_len,
@@ -70,8 +71,10 @@ def test_model_inference(
     reset_seeds,
     ensure_gc,
     is_ci_env,
+    request,
 ):
-    if is_ci_env and optimizations == ModelOptimizations.accuracy:
+    test_id = request.node.callspec.id
+    if is_ci_env and test_id == "accuracy":
         pytest.skip("CI test only runs performance mode to reduce CI pipeline load")
 
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
@@ -81,10 +84,10 @@ def test_model_inference(
     batch_size = 1  # For prefill we only support batch_size = 1
 
     # This sets the minimum PCC for each iteration based on optimization mode
-    if optimizations == ModelOptimizations.accuracy:
+    if test_id == "accuracy":
         pcc = 0.91  # TODO Look on improving PCC
     else:  # performance mode
-        assert optimizations == ModelOptimizations.performance
+        assert test_id == "performance"
         pcc = 0.869  # TODO Look on improving PCC
 
     mesh_device.enable_async(True)

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -7,6 +7,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.tt_transformers.tt.common import pad_to_size
 from models.tt_transformers.tt.ccl import tt_all_reduce
+from models.tt_transformers.tt.model_config import TensorGroup, OpGroup
 
 
 class MLP(LightweightModule):
@@ -20,6 +21,7 @@ class MLP(LightweightModule):
         self.args = args
         self.dim = args.dim
         self.model_config = model_config
+        self.layer_num = layer_num
         state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
         torch_weight = lambda name: torch.transpose(self.state_dict[f"{state_dict_prefix}.{name}.weight"], -2, -1)
         pad_hidden_dim = lambda tensor, dim: pad_to_size(tensor, dim=dim, size=args.hidden_dim)
@@ -53,11 +55,18 @@ class MLP(LightweightModule):
         w1_dims = (-1, -2) if args.is_galaxy else (-2, -1)
         w2_dims = (-2, -1) if args.is_galaxy else (-1, -2)
 
+        ff1_3_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.FF1_FF3
+        )
+        ff2_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.FF2
+        )
+
         self.w1 = as_sharded_tensor(
-            "w1_sharded", self.model_config["FF1_3_DTYPE"], dims=w1_dims
+            "w1_sharded", ff1_3_dtype, dims=w1_dims
         )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
-        self.w2 = as_sharded_tensor("w2_sharded", self.model_config["FF2_DTYPE"], dims=w2_dims)
-        self.w3 = as_sharded_tensor("w3_sharded", self.model_config["FF1_3_DTYPE"], dims=w1_dims)
+        self.w2 = as_sharded_tensor("w2_sharded", ff2_dtype, dims=w2_dims)
+        self.w3 = as_sharded_tensor("w3_sharded", ff1_3_dtype, dims=w1_dims)
 
     def forward(self, x: ttnn.Tensor, mode) -> ttnn.Tensor:
         """
@@ -68,6 +77,12 @@ class MLP(LightweightModule):
         """
         seq_len = x.shape[-2]
         TG = self.args.is_galaxy
+        activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
+            decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+        )
+        li_ff1_3_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=self.layer_num, op=OpGroup.LI_FF1_FF3, configuration=self.args
+        )
 
         if mode == "decode":  # Sharded config
             if TG:  # TODO: Fix this when TG supports DRAM sharded matmuls
@@ -91,9 +106,9 @@ class MLP(LightweightModule):
         w1_out = ttnn.linear(
             x,
             self.w1,
-            dtype=ttnn.bfloat8_b if TG else self.model_config["ACTIVATION_DTYPE"] or ttnn.bfloat16,
+            dtype=ttnn.bfloat8_b if TG else activation_dtype or ttnn.bfloat16,
             core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
-            compute_kernel_config=self.model_config["LI_FF1_3_COMPUTE_KERNEL_CFG"],
+            compute_kernel_config=li_ff1_3_compute_kernel_cfg,
             program_config=pc_1,
             memory_config=x.memory_config(),
         )
@@ -101,9 +116,9 @@ class MLP(LightweightModule):
         w3_out = ttnn.linear(
             x,
             self.w3,
-            dtype=ttnn.bfloat8_b if TG else self.model_config["ACTIVATION_DTYPE"] or ttnn.bfloat16,
+            dtype=ttnn.bfloat8_b if TG else activation_dtype or ttnn.bfloat16,
             core_grid=None,  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
-            compute_kernel_config=self.model_config["LI_FF1_3_COMPUTE_KERNEL_CFG"],
+            compute_kernel_config=li_ff1_3_compute_kernel_cfg,
             program_config=pc_3,
             memory_config=x.memory_config(),
         )
@@ -159,7 +174,7 @@ class MLP(LightweightModule):
             w1_out,
             w3_out,
             input_tensor_a_activation=ttnn.UnaryOpType.SILU,
-            dtype=self.model_config["ACTIVATION_DTYPE"] or ttnn.bfloat8_b,
+            dtype=activation_dtype or ttnn.bfloat8_b,
             memory_config=w1_out.memory_config(),
         )
 
@@ -183,11 +198,14 @@ class MLP(LightweightModule):
             if mode == "decode":
                 w2_in = ttnn.to_memory_config(w2_in, ttnn.L1_MEMORY_CONFIG)
 
+        li_ff2_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
+            decoder_id=self.layer_num, op=OpGroup.LI_FF2, configuration=self.args
+        )
         w2_out = ttnn.linear(
             w2_in,
             self.w2,
-            compute_kernel_config=self.model_config["LI_FF2_COMPUTE_KERNEL_CFG"],
-            dtype=self.args.ccl_dtype if TG else self.model_config["ACTIVATION_DTYPE"] or ttnn.bfloat16,
+            compute_kernel_config=li_ff2_compute_kernel_cfg,
+            dtype=self.args.ccl_dtype if TG else activation_dtype or ttnn.bfloat16,
             program_config=pc_2,
             memory_config=(
                 (ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG)

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -75,7 +75,7 @@ class MathFidelitySetting(Enum):
 
 class ModelOptimizations:
     @classmethod
-    def accuracy(cls, model_name):
+    def accuracy(cls, model_name=None):
         """Configuration optimized for accuracy
         Only 70B models uses bfp4 MLPs in this configuration
         """
@@ -87,7 +87,7 @@ class ModelOptimizations:
         return inst
 
     @classmethod
-    def performance(cls, model_name):
+    def performance(cls, model_name=None):
         """Configuration optimized for performance
         All models use bfp4 in FF1 and FF3 MLPs in this configuration
         """
@@ -235,7 +235,54 @@ def parse_optimizations(string):
         value = MathFidelitySetting(value.strip())
         settings["OpFidelity"][key] = value
 
-    return ModelOptimizations(settings)
+    model_opt = ModelOptimizations(settings)
+
+    def apply_settings(model_args):
+        return DecodersPrecision(model_args.n_layers, model_opt)
+
+    apply_settings.__name__ = model_opt.__name__
+    return apply_settings
+
+
+def parse_decoder_json(json_file_path):
+    """
+    Reads a JSON file and returns a DecodersPrecision instance.
+    """
+    if not json_file_path:
+        return None
+
+    json_file_path = Path(json_file_path)
+    if not json_file_path.exists():
+        raise FileNotFoundError(f"JSON configuration file not found: {json_file_path}")
+
+    try:
+        with open(json_file_path, "r") as f:
+            config_data = json.load(f)
+
+        if "decoders" not in config_data:
+            raise ValueError("Invalid JSON format: Missing 'decoders' key")
+
+        num_decoders = max(int(decoder_id) for decoder_id in config_data["decoders"].keys()) + 1
+        decoders_precision = DecodersPrecision(num_decoders)
+
+        for decoder_id, settings in config_data["decoders"].items():
+            decoder_id = int(decoder_id)
+
+            tensor_precision = {
+                TensorGroup[key]: PrecisionSetting[value] for key, value in settings.get("precision_cfg", {}).items()
+            }
+
+            op_fidelity = {
+                OpGroup[key]: MathFidelitySetting[value] for key, value in settings.get("fidelity_cfg", {}).items()
+            }
+
+            custom_opt = ModelOptimizations({"TensorPrecision": tensor_precision, "OpFidelity": op_fidelity})
+            decoders_precision.set_decoder_conf(decoder_id, custom_opt)
+
+        return decoders_precision
+
+    except Exception as e:
+        raise ValueError(f"Error loading JSON configuration: {e}")
 
 
 class CheckpointType(Enum):
@@ -284,7 +331,7 @@ class ModelArgs:
         dummy_weights=False,
         max_batch_size=1,
         max_seq_len=1024 * 128,
-        optimizations=ModelOptimizations.accuracy,
+        optimizations=None,
     ):
         self.num_devices = mesh_device.get_num_devices() if mesh_device else 0
         self.mesh_device = mesh_device
@@ -424,7 +471,7 @@ class ModelArgs:
         self.max_prefill_chunk_size = max_prefill_chunk_size_div1024 * 1024
 
         if callable(optimizations):
-            self.optimizations = optimizations(self.model_name)
+            self.optimizations = optimizations(self)
         else:
             self.optimizations = optimizations
 
@@ -511,26 +558,9 @@ class ModelArgs:
             )
 
             # Configure data precision and math fidelity for tensors and kernels
-            self.model_config["COMPUTE_KERNEL_CONFIG_HIFI2"] = self.compute_kernel_config_hifi2
-            precision_setting_lookup = {
-                PrecisionSetting.BFP4: ttnn.bfloat4_b,
-                PrecisionSetting.BFP8: ttnn.bfloat8_b,
-                PrecisionSetting.BF16: ttnn.bfloat16,
-                None: None,  # this signals that original dtype should be used
-            }
-            for tensor_group, precision in self.optimizations.tensor_dtype_settings.items():
-                dtype = precision_setting_lookup[precision]
-                self.model_config[f"{tensor_group.value.upper()}_DTYPE"] = dtype
-            math_fidelity_setting_lookup = {
-                MathFidelitySetting.LOFI: self.compute_kernel_config_lofi,
-                MathFidelitySetting.HIFI2: self.compute_kernel_config_hifi2,
-                MathFidelitySetting.HIFI2_NA: self.compute_kernel_config_hifi2_na,
-                MathFidelitySetting.HIFI2_FP16: self.compute_kernel_config_hifi2_fp16,
-                MathFidelitySetting.HIFI4: self.compute_kernel_config_hifi4,
-            }
-            for op_group, math_fidelity in self.optimizations.op_fidelity_settings.items():
-                math_cfg = math_fidelity_setting_lookup[math_fidelity]
-                self.model_config[f"{op_group.value.upper()}_COMPUTE_KERNEL_CFG"] = math_cfg
+            if self.optimizations is None:
+                self.optimizations = DecodersPrecision(num_decoders=self.n_layers)
+            self.model_config["DECODERS_OPTIMIZATIONS"] = self.optimizations
 
             # Create memory config for sharded tensors
             residual_grid = self.dram_shard_core_grid_for_k(self.dim // self.num_devices)
@@ -2050,6 +2080,40 @@ class HfModelWrapper:
 
     def eval(self):
         self.model.eval()
+
+
+class DecodersPrecision:
+    def __init__(self, num_decoders, decoder_conf: dict = ModelOptimizations.accuracy()):
+        self.decoder_optimizations = {decoder_id: decoder_conf for decoder_id in range(num_decoders)}
+        self._update_full_name()
+
+    def set_decoder_conf(self, decoder_id, conf: ModelOptimizations):
+        self.decoder_optimizations[decoder_id] = conf
+        self._update_full_name()
+
+    def get_tensor_dtype(self, decoder_id, tensor: TensorGroup):
+        precision_setting_lookup = {
+            PrecisionSetting.BFP4: ttnn.bfloat4_b,
+            PrecisionSetting.BFP8: ttnn.bfloat8_b,
+            PrecisionSetting.BF16: ttnn.bfloat16,
+            None: None,  # this signals that original dtype should be used
+        }
+        return precision_setting_lookup[self.decoder_optimizations[decoder_id].tensor_dtype_settings[tensor]]
+
+    def get_math_fidelity(self, decoder_id, op: OpGroup, configuration: ModelArgs):
+        math_fidelity_setting_lookup = {
+            MathFidelitySetting.LOFI: configuration.compute_kernel_config_lofi,
+            MathFidelitySetting.HIFI2: configuration.compute_kernel_config_hifi2,
+            MathFidelitySetting.HIFI2_NA: configuration.compute_kernel_config_hifi2_na,
+            MathFidelitySetting.HIFI2_FP16: configuration.compute_kernel_config_hifi2_fp16,
+            MathFidelitySetting.HIFI4: configuration.compute_kernel_config_hifi4,
+        }
+        return math_fidelity_setting_lookup[self.decoder_optimizations[decoder_id].op_fidelity_settings[op]]
+
+    def _update_full_name(self):
+        self._full_name = " | ".join(
+            f"Decoder {decoder_id}: {conf._full_name}" for decoder_id, conf in self.decoder_optimizations.items()
+        )
 
 
 def num_to_corerange(x):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2083,6 +2083,18 @@ class HfModelWrapper:
 
 
 class DecodersPrecision:
+    @classmethod
+    def accuracy(cls, num_decoders):
+        inst = cls(num_decoders, ModelOptimizations.accuracy())
+        inst.__name__ = "accuracy"
+        return inst
+
+    @classmethod
+    def performance(cls, num_decoders):
+        inst = cls(num_decoders, ModelOptimizations.performance())
+        inst.__name__ = "performance"
+        return inst
+
     def __init__(self, num_decoders, decoder_conf: dict = ModelOptimizations.accuracy()):
         self.decoder_optimizations = {decoder_id: decoder_conf for decoder_id in range(num_decoders)}
         self._update_full_name()


### PR DESCRIPTION
**Problem description**
Currently, all the decoders in a model have the same computation precision.
Ideally we would want to configure each layer individually to explore possible optimizations.

**What's changed**
This PR allows us to provide a json file (or a folder with several json files), e.g., 
```
"decoders": {
        "0": {
            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP8" },
            "fidelity_cfg": { }
        },
        "1": {
            "precision_cfg": { "FF1_FF3": "BFP8", "FF2": "BFP4", "KV_CACHE": "BF16" },
            "fidelity_cfg": { "LI_FF1_FF3": "HIFI2" }
        },
        "2": {
            "precision_cfg": { "FF1_FF3": "BF16", "WQKV": "BF16", "WO": "BFP8", "KV_CACHE": "BFP8"},
            "fidelity_cfg": { "SDPA_DECODE": "HIFI2_NA", "LI_QKV_DECODE": "HIFI4" }
        },
...
```
which sets the configuration of each decoder. When a component is not provided (i.e. FF2 is missing for decoder 2), the default configuration for that component is the one that is set.
We can also run the `lt` tool for the configurations in the folder, and create the Pareto graph for them:
<img width="673" alt="Screenshot 2025-04-03 at 6 18 37 PM" src="https://github.com/user-attachments/assets/41d728f8-d8c5-4459-9a1f-38c6599f975d" />
Note that the configuration description in the graph is removed when the configuration is read from a json file, since the entire description is too long. In addition, when the configuration is read from a json file, the result is not compared against PERF.md, and is also not written no PERF.md