### PR TITLE
Pjosipovic/fix 19167

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -2748,6 +2748,40 @@ def test_small_in_large_out_channels_auto_shard(device, torch_tensor_map):
     )
 
 
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_silu_auto_shard_mm_conv(device, torch_tensor_map):
+    batch_size = 1
+    in_channels = 64
+    out_channels = 64
+    kernel_size = (1, 1)
+    stride = (1, 1)
+    padding = (0, 0)
+    height = 160
+    width = 160
+
+    run_conv(
+        device,
+        torch_tensor_map,
+        ttnn.MathFidelity.LoFi,
+        ttnn.bfloat16,
+        ttnn.bfloat16,
+        batch_size,
+        out_channels,
+        in_channels,
+        height,
+        width,
+        kernel_size[0],
+        kernel_size[1],
+        stride[0],
+        stride[1],
+        padding[0],
+        padding[1],
+        None,
+        auto_shard=True,
+        activation="silu",
+    )
+
+
 # fmt: off
 @pytest.mark.parametrize(
     "batch, input_channels, output_channels, input_height, input_width, kernel, stride, padding",

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -244,9 +244,7 @@ Result conv2d(
         std::optional<ttnn::operations::matmul::MatmulProgramConfig> program_config = std::nullopt;
         std::optional<MemoryConfig> mm_output_memory_config = std::nullopt;
         std::optional<std::string> activation = std::nullopt;
-        if (!conv_config.activation.empty()) {
-            activation = conv_config.activation;
-        }
+
         if (input_tensor_post_tm.is_sharded()) {
             uint32_t num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
             program_config = determine_matmul_op_config_from_conv_op_config(
@@ -257,6 +255,10 @@ Result conv2d(
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
                 num_cores_c);
             mm_output_memory_config = conv_out_memory_config;
+        } else {
+            if (!conv_config.activation.empty()) {
+                activation = conv_config.activation;
+            }
         }
         Tensor matmul_output = ttnn::linear(
             input_tensor_post_tm,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <optional>
+#include <string>
 #include <utility>
 
 #include <tt-metalium/buffer_constants.hpp>
@@ -242,6 +243,10 @@ Result conv2d(
         // run conv as matmul
         std::optional<ttnn::operations::matmul::MatmulProgramConfig> program_config = std::nullopt;
         std::optional<MemoryConfig> mm_output_memory_config = std::nullopt;
+        std::optional<std::string> activation = std::nullopt;
+        if (!conv_config.activation.empty()) {
+            activation = conv_config.activation;
+        }
         if (input_tensor_post_tm.is_sharded()) {
             uint32_t num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
             program_config = determine_matmul_op_config_from_conv_op_config(
@@ -261,7 +266,8 @@ Result conv2d(
             false,
             mm_output_memory_config,
             std::nullopt,
-            program_config);
+            program_config,
+            activation);
 
         if (memory_config.has_value() && memory_config.value() != matmul_output.memory_config()) {
             matmul_output = ttnn::to_memory_config(matmul_output, memory_config.value(), std::nullopt);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19167)

### Problem description
Fix conv2d with activation function which maps to matmul device op in auto-shard codeepath

### What's changed
In case we have conv2d which maps to matmul op and auto sharding is used activacation function wasn't properly pass
through to the matmul op.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13966725037) CI passes