### PR TITLE
Use stateful API in fabric worker sync path

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -115,7 +115,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.1), (4, 2, 7.04)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.09), (4, 2, 7.03)])
 def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -206,7 +206,7 @@ def test_fabric_edm_mcast_full_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.94), (4, 2, 5.8)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.04), (4, 2, 5.91)])
 def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -236,7 +236,7 @@ def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.12), (4, 2, 7.11)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.49), (4, 2, 7.42)])
 def test_fabric_edm_mcast_bw(
     num_mcasts,
     num_unicasts,
@@ -267,7 +267,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.01), (2, 7.63)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 8.93), (2, 7.72)])
 def test_fabric_edm_unicast_bw(
     num_mcasts,
     num_unicasts,

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -115,7 +115,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.09), (4, 2, 7.03)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.35), (4, 2, 7.24)])
 def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -146,7 +146,7 @@ def test_fabric_edm_mcast_half_ring_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
 @pytest.mark.parametrize("line_size", [4])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 7.09), (2, 7.06)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 7.35), (2, 7.24)])
 def test_fabric_edm_mcast_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -176,7 +176,7 @@ def test_fabric_edm_mcast_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.27), (4, 2, 5.22), (8, 1, 3.93)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.38), (4, 2, 5.31), (8, 1, 4.03)])
 def test_fabric_edm_mcast_full_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -236,7 +236,7 @@ def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.49), (4, 2, 7.42)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.37), (4, 2, 7.31)])
 def test_fabric_edm_mcast_bw(
     num_mcasts,
     num_unicasts,
@@ -267,7 +267,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 8.93), (2, 7.72)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.22), (2, 7.61)])
 def test_fabric_edm_unicast_bw(
     num_mcasts,
     num_unicasts,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -160,8 +160,9 @@ void kernel_main() {
     // DRAM sharded write API
     for (uint32_t i = 0; i < iteration; i++) {
         uint32_t trid = i % 16 + 1;
-        noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, noc_index);
-        noc_async_write_one_packet_with_trid(l1_read_addr, addr_other_noc, page_size, trid, 1 - noc_index);
+        noc_async_write_one_packet_with_trid(l1_read_addr, addr_self_noc, page_size, trid, write_cmd_buf, noc_index);
+        noc_async_write_one_packet_with_trid(
+            l1_read_addr, addr_other_noc, page_size, trid, write_cmd_buf, 1 - noc_index);
     }
     for (uint32_t i = 1; i < 15; i++) {
         noc_async_write_barrier_with_trid(i, noc_index);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -206,7 +206,7 @@ FORCE_INLINE void write_worker(
     noc_async_write(buffer_slot_addr, worker_noc_addr, message_size);
     noc_async_writes_flushed();
 #else
-    noc_async_write_one_packet_with_trid_with_state(
+    noc_async_write_one_packet_with_trid_with_state<false, false>(
         buffer_slot_addr, worker_noc_addr, message_size, curr_trid_to_write);
 #endif
     // reset sync

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2245,15 +2245,31 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     // Get the inner 4 device ring on a WH T3K device so that we can use both links for all devices
     std::vector<IDevice*> devices_;
     if (use_tg) {
-        devices_ = {
-            view.get_device(MeshCoordinate(0, 0)),
-            view.get_device(MeshCoordinate(1, 0)),
-            view.get_device(MeshCoordinate(2, 0)),
-            view.get_device(MeshCoordinate(3, 0)),
-            view.get_device(MeshCoordinate(4, 0)),
-            view.get_device(MeshCoordinate(5, 0)),
-            view.get_device(MeshCoordinate(6, 0)),
-            view.get_device(MeshCoordinate(7, 0))};
+        if (line_size <= 4) {
+            if (topology == ttnn::ccl::Topology::Ring) {
+                devices_ = {
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(1, 0)),
+                    view.get_device(MeshCoordinate(1, 1)),
+                    view.get_device(MeshCoordinate(0, 1))};
+            } else {
+                devices_ = {
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(1, 0)),
+                    view.get_device(MeshCoordinate(2, 0)),
+                    view.get_device(MeshCoordinate(3, 0))};
+            }
+        } else {
+            devices_ = {
+                view.get_device(MeshCoordinate(0, 0)),
+                view.get_device(MeshCoordinate(1, 0)),
+                view.get_device(MeshCoordinate(2, 0)),
+                view.get_device(MeshCoordinate(3, 0)),
+                view.get_device(MeshCoordinate(4, 0)),
+                view.get_device(MeshCoordinate(5, 0)),
+                view.get_device(MeshCoordinate(6, 0)),
+                view.get_device(MeshCoordinate(7, 0))};
+        }
     } else {
         // Choosing pcie devices so that more links are supported. More links == more (likelihood of) congestion.
         if (line_size <= 4) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2260,15 +2260,27 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
                     view.get_device(MeshCoordinate(3, 0))};
             }
         } else {
-            devices_ = {
-                view.get_device(MeshCoordinate(0, 0)),
-                view.get_device(MeshCoordinate(1, 0)),
-                view.get_device(MeshCoordinate(2, 0)),
-                view.get_device(MeshCoordinate(3, 0)),
-                view.get_device(MeshCoordinate(4, 0)),
-                view.get_device(MeshCoordinate(5, 0)),
-                view.get_device(MeshCoordinate(6, 0)),
-                view.get_device(MeshCoordinate(7, 0))};
+            if (topology == ttnn::ccl::Topology::Ring) {
+                devices_ = {
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(1, 0)),
+                    view.get_device(MeshCoordinate(2, 0)),
+                    view.get_device(MeshCoordinate(3, 0)),
+                    view.get_device(MeshCoordinate(3, 1)),
+                    view.get_device(MeshCoordinate(2, 1)),
+                    view.get_device(MeshCoordinate(1, 1)),
+                    view.get_device(MeshCoordinate(0, 1))};
+            } else {
+                devices_ = {
+                    view.get_device(MeshCoordinate(0, 0)),
+                    view.get_device(MeshCoordinate(1, 0)),
+                    view.get_device(MeshCoordinate(2, 0)),
+                    view.get_device(MeshCoordinate(3, 0)),
+                    view.get_device(MeshCoordinate(4, 0)),
+                    view.get_device(MeshCoordinate(5, 0)),
+                    view.get_device(MeshCoordinate(6, 0)),
+                    view.get_device(MeshCoordinate(7, 0))};
+            }
         }
     } else {
         // Choosing pcie devices so that more links are supported. More links == more (likelihood of) congestion.

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
@@ -18,6 +18,7 @@ static constexpr uint8_t worker_sender2_sync_cmd_buf = write_cmd_buf;
 
 static constexpr uint8_t downstream_data_cmd_buf = write_reg_cmd_buf;
 static constexpr uint8_t downstream_sync_cmd_buf = read_cmd_buf;
+static constexpr uint8_t local_chip_data_cmd_buf = write_cmd_buf;
 
 enum EDM_IO_BLOCKING_MODE { FLUSH_BLOCKING, BLOCKING, NON_BLOCKING };
 
@@ -29,7 +30,7 @@ FORCE_INLINE void send_chunk_from_address_with_trid(
     uint32_t remote_l1_write_addr,
     uint8_t trid,
     uint8_t cmd_buf) {
-    noc_async_write_one_packet_with_trid_with_state(
+    noc_async_write_one_packet_with_trid_with_state<false, false>(
         local_l1_address, remote_l1_write_addr, page_size * num_pages, trid, cmd_buf, edm_to_local_chip_noc);
     // TODO: this barrier will no longer be functional since we are not incrementing noc counters, remove
     if constexpr (blocking_mode == EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING) {

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
@@ -12,6 +12,13 @@ namespace tt::tt_fabric {
 
 static constexpr uint8_t edm_to_local_chip_noc = 1;
 
+static constexpr uint8_t worker_sender0_sync_cmd_buf = write_reg_cmd_buf;
+static constexpr uint8_t worker_sender1_sync_cmd_buf = write_cmd_buf;
+static constexpr uint8_t worker_sender2_sync_cmd_buf = write_cmd_buf;
+
+static constexpr uint8_t downstream_data_cmd_buf = write_reg_cmd_buf;
+static constexpr uint8_t downstream_sync_cmd_buf = read_cmd_buf;
+
 enum EDM_IO_BLOCKING_MODE { FLUSH_BLOCKING, BLOCKING, NON_BLOCKING };
 
 template <EDM_IO_BLOCKING_MODE blocking_mode = EDM_IO_BLOCKING_MODE::BLOCKING>

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -325,10 +325,11 @@ private:
     FORCE_INLINE void update_edm_buffer_slot_wrptr(uint8_t noc = noc_index) {
         if constexpr (stateful_api) {
             if constexpr (enable_ring_support) {
-                noc_inline_dw_write_with_state<true>(
+                noc_inline_dw_write_with_state<true, false, false>(
                     *this->buffer_slot_wrptr_ptr, this->edm_buffer_slot_wrptr_addr, this->sync_noc_cmd_buf, noc);
             } else {
-                noc_inline_dw_write_with_state<false>(*this->buffer_slot_wrptr_ptr, 0, this->sync_noc_cmd_buf, noc);
+                noc_inline_dw_write_with_state<false, false, false>(
+                    *this->buffer_slot_wrptr_ptr, 0, this->sync_noc_cmd_buf, noc);
             }
         } else {
             const uint64_t noc_sem_addr =

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -85,7 +85,9 @@ struct WorkerToFabricEdmSenderImpl {
             edm_buffer_index_addr,
             writer_send_sem_addr,
             worker_teardown_sem_addr,
-            worker_buffer_index_semaphore_addr);
+            worker_buffer_index_semaphore_addr,
+            write_reg_cmd_buf,
+            write_at_cmd_buf);
     }
 
     WorkerToFabricEdmSenderImpl(
@@ -101,7 +103,9 @@ struct WorkerToFabricEdmSenderImpl {
         size_t edm_buffer_index_id,
         volatile uint32_t* const from_remote_buffer_slot_rdptr_ptr,
         volatile uint32_t* const worker_teardown_addr,
-        uint32_t local_buffer_index_addr) :
+        uint32_t local_buffer_index_addr,
+        uint8_t data_noc_cmd_buf,
+        uint8_t credit_noc_cmd_buf) :
         edm_buffer_addr(edm_buffer_base_addr),
         edm_buffer_slot_wrptr_addr(
             connected_to_persistent_fabric ? edm_l1_sem_id
@@ -123,8 +127,9 @@ struct WorkerToFabricEdmSenderImpl {
         last_buffer_index(num_buffers_per_channel - 1),
         edm_noc_x(edm_worker_x),
         edm_noc_y(edm_worker_y),
-        edm_noc_cmd_buf(write_reg_cmd_buf) {
-        setup_edm_noc_cmd_buf(write_reg_cmd_buf);
+        data_noc_cmd_buf(data_noc_cmd_buf),
+        credit_noc_cmd_buf(credit_noc_cmd_buf) {
+        setup_edm_noc_cmd_buf(data_noc_cmd_buf, credit_noc_cmd_buf);
         ASSERT(buffer_size_bytes > 0);
         if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
             ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
@@ -135,9 +140,12 @@ struct WorkerToFabricEdmSenderImpl {
         }
     }
 
-    FORCE_INLINE void setup_edm_noc_cmd_buf(uint8_t cmd_buf) const {
+    FORCE_INLINE void setup_edm_noc_cmd_buf(uint8_t data_cmd_buf, uint8_t credit_cmd_buf) const {
         uint64_t edm_noc_addr = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, edm_to_local_chip_noc);
-        noc_async_write_one_packet_with_trid_set_state(edm_noc_addr, cmd_buf, edm_to_local_chip_noc);
+        noc_async_write_one_packet_with_trid_set_state(edm_noc_addr, data_cmd_buf, edm_to_local_chip_noc);
+        const uint64_t noc_sem_addr =
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr, edm_to_local_chip_noc);
+        noc_inline_dw_write_set_state(noc_sem_addr, 0xF, credit_cmd_buf, edm_to_local_chip_noc);
     }
 
     FORCE_INLINE bool edm_has_space_for_packet() const {
@@ -307,13 +315,19 @@ struct WorkerToFabricEdmSenderImpl {
     uint8_t edm_noc_y;
 
     // the cmd buffer is used for edm-edm path
-    uint8_t edm_noc_cmd_buf;
+    uint8_t data_noc_cmd_buf;
+    uint8_t credit_noc_cmd_buf;
 
 private:
+    template <bool stateful_api = false>
     FORCE_INLINE void update_edm_buffer_slot_wrptr(uint8_t noc = noc_index) {
-        const uint64_t noc_sem_addr =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr, noc);
-        noc_inline_dw_write(noc_sem_addr, *this->buffer_slot_wrptr_ptr, 0xf, noc);
+        if constexpr (stateful_api) {
+            noc_inline_dw_write_with_state(*this->buffer_slot_wrptr_ptr, this->credit_noc_cmd_buf, noc);
+        } else {
+            const uint64_t noc_sem_addr =
+                get_noc_addr(this->edm_noc_x, this->edm_noc_y, this->edm_buffer_slot_wrptr_addr, noc);
+            noc_inline_dw_write(noc_sem_addr, *this->buffer_slot_wrptr_ptr, 0xf, noc);
+        }
     }
 
     FORCE_INLINE uint8_t get_buffer_slot_index() const {
@@ -346,9 +360,10 @@ private:
         }
     }
 
+    template <bool stateful_api = false>
     FORCE_INLINE void post_send_payload_increment_pointers(uint8_t noc = noc_index) {
         this->advance_buffer_slot_wrptr();
-        this->update_edm_buffer_slot_wrptr(noc);
+        this->update_edm_buffer_slot_wrptr<stateful_api>(noc);
     }
     template <EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_packet_header_and_notify_fabric(uint32_t source_address) {
@@ -389,12 +404,12 @@ private:
                 size_bytes,
                 this->edm_buffer_slot_addrs[this->get_buffer_slot_index()],
                 trid,
-                this->edm_noc_cmd_buf);
+                this->data_noc_cmd_buf);
         } else {
             send_chunk_from_address_with_trid<blocking_mode>(
-                source_address, 1, size_bytes, this->edm_buffer_addr, trid, this->edm_noc_cmd_buf);
+                source_address, 1, size_bytes, this->edm_buffer_addr, trid, this->data_noc_cmd_buf);
         }
-        post_send_payload_increment_pointers(edm_to_local_chip_noc);
+        post_send_payload_increment_pointers<true>(edm_to_local_chip_noc);
     }
 
     template <EDM_IO_BLOCKING_MODE blocking_mode>

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -96,11 +96,12 @@ FORCE_INLINE void execute_chip_unicast_to_local_chip(
     switch (noc_send_type) {
         case tt::tt_fabric::NocSendType::NOC_UNICAST_WRITE: {
             const auto dest_address = header.command_fields.unicast_write.noc_address;
-            noc_async_write_one_packet_with_trid(
+            noc_async_write_one_packet_with_trid<false, false>(
                 payload_start_address,
                 dest_address,
                 payload_size_bytes,
                 transaction_id,
+                tt::tt_fabric::local_chip_data_cmd_buf,
                 tt::tt_fabric::edm_to_local_chip_noc);
         } break;
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -164,7 +164,7 @@ FORCE_INLINE void update_packet_header_for_next_hop(
 // !!!WARNING!!! * do NOT call before determining if the packet should be consumed locally or forwarded
 // !!!WARNING!!! * ENSURE DOWNSTREAM EDM HAS SPACE FOR PACKET BEFORE CALLING
 // !!!WARNING!!!
-template <uint8_t NUM_SENDER_BUFFERS>
+template <uint8_t NUM_SENDER_BUFFERS, bool enable_ring_support>
 FORCE_INLINE void forward_payload_to_downstream_edm(
     volatile PACKET_HEADER_TYPE* packet_header,
     uint16_t payload_size_bytes,
@@ -177,6 +177,6 @@ FORCE_INLINE void forward_payload_to_downstream_edm(
     // This is a good place to print the packet header for debug if you are trying to inspect packets
     // because it is before we start manipulating the header for forwarding
     update_packet_header_for_next_hop(packet_header, cached_routing_fields);
-    downstream_edm_interface.send_payload_non_blocking_from_address_with_trid(
+    downstream_edm_interface.template send_payload_non_blocking_from_address_with_trid<enable_ring_support>(
         reinterpret_cast<size_t>(packet_header), payload_size_bytes + sizeof(PACKET_HEADER_TYPE), transaction_id);
 }

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -102,11 +102,7 @@ private:
     uint8_t channel_id;
 };
 
-template <
-    uint8_t NUM_BUFFERS,
-    bool USE_STATEFUL_NOC_API = false,
-    uint8_t PTR_UPDATE_NOC_CMD_BUF = write_at_cmd_buf,
-    uint8_t PTR_UPDATE_NOC_INDEX = noc_index>
+template <uint8_t NUM_BUFFERS>
 struct EdmChannelWorkerInterface {
     EdmChannelWorkerInterface() :
         worker_location_info_ptr(nullptr),

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -113,7 +113,7 @@ struct EdmChannelWorkerInterface {
         cached_worker_semaphore_address(0),
         remote_producer_wrptr(nullptr),
         connection_live_semaphore(nullptr),
-        sender_ack_noc_cmd_buf(write_at_cmd_buf),
+        sender_sync_noc_cmd_buf(write_at_cmd_buf),
         local_wrptr(),
         local_ackptr(),
         local_rdptr() {}
@@ -128,12 +128,12 @@ struct EdmChannelWorkerInterface {
         volatile EDMChannelWorkerLocationInfo* worker_location_info_ptr,
         volatile tt_l1_ptr uint32_t* const remote_producer_wrptr,
         volatile tt_l1_ptr uint32_t* const connection_live_semaphore,
-        uint8_t sender_ack_noc_cmd_buf) :
+        uint8_t sender_sync_noc_cmd_buf) :
         worker_location_info_ptr(worker_location_info_ptr),
         cached_worker_semaphore_address(0),
         remote_producer_wrptr(remote_producer_wrptr),
         connection_live_semaphore(connection_live_semaphore),
-        sender_ack_noc_cmd_buf(sender_ack_noc_cmd_buf),
+        sender_sync_noc_cmd_buf(sender_sync_noc_cmd_buf),
         local_wrptr(),
         local_ackptr(),
         local_rdptr() {
@@ -154,7 +154,7 @@ struct EdmChannelWorkerInterface {
     }
 
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
-        noc_inline_dw_write_with_state(new_ptr_val, this->sender_ack_noc_cmd_buf);
+        noc_inline_dw_write_with_state(new_ptr_val, this->sender_sync_noc_cmd_buf);
     }
 
     // Connection management methods
@@ -179,7 +179,7 @@ struct EdmChannelWorkerInterface {
         uint64_t worker_semaphore_address = get_noc_addr(
             (uint32_t)worker_info.worker_xy.x, (uint32_t)worker_info.worker_xy.y, worker_info.worker_semaphore_address);
         this->cached_worker_semaphore_address = worker_semaphore_address;
-        noc_inline_dw_write_set_state(worker_semaphore_address, 0xF, this->sender_ack_noc_cmd_buf);
+        noc_inline_dw_write_set_state(worker_semaphore_address, 0xF, this->sender_sync_noc_cmd_buf);
     }
 
     FORCE_INLINE bool all_eth_packets_acked() const { return this->local_ackptr.is_caught_up_to(this->local_wrptr); }
@@ -196,7 +196,7 @@ struct EdmChannelWorkerInterface {
     uint64_t cached_worker_semaphore_address = 0;
     volatile tt_l1_ptr uint32_t* const remote_producer_wrptr;
     volatile tt_l1_ptr uint32_t* const connection_live_semaphore;
-    uint8_t sender_ack_noc_cmd_buf;
+    uint8_t sender_sync_noc_cmd_buf;
 
     ChannelBufferPointer<NUM_BUFFERS> local_wrptr;
     ChannelBufferPointer<NUM_BUFFERS> local_ackptr;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -149,8 +149,14 @@ struct EdmChannelWorkerInterface {
         return cached_worker_semaphore_address & 0xFFFFFFFF;
     }
 
+    template <bool enable_ring_support>
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
-        noc_inline_dw_write_with_state(new_ptr_val, this->sender_sync_noc_cmd_buf);
+        if constexpr (enable_ring_support) {
+            noc_inline_dw_write_with_state<true>(
+                new_ptr_val, this->cached_worker_semaphore_address, this->sender_sync_noc_cmd_buf);
+        } else {
+            noc_inline_dw_write_with_state<false>(new_ptr_val, 0, this->sender_sync_noc_cmd_buf);
+        }
     }
 
     // Connection management methods

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -152,10 +152,10 @@ struct EdmChannelWorkerInterface {
     template <bool enable_ring_support>
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
         if constexpr (enable_ring_support) {
-            noc_inline_dw_write_with_state<true>(
+            noc_inline_dw_write_with_state<true, false, false>(
                 new_ptr_val, this->cached_worker_semaphore_address, this->sender_sync_noc_cmd_buf);
         } else {
-            noc_inline_dw_write_with_state<false>(new_ptr_val, 0, this->sender_sync_noc_cmd_buf);
+            noc_inline_dw_write_with_state<false, false, false>(new_ptr_val, 0, this->sender_sync_noc_cmd_buf);
         }
     }
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -102,13 +102,18 @@ private:
     uint8_t channel_id;
 };
 
-template <uint8_t NUM_BUFFERS>
+template <
+    uint8_t NUM_BUFFERS,
+    bool USE_STATEFUL_NOC_API = false,
+    uint8_t PTR_UPDATE_NOC_CMD_BUF = write_at_cmd_buf,
+    uint8_t PTR_UPDATE_NOC_INDEX = noc_index>
 struct EdmChannelWorkerInterface {
     EdmChannelWorkerInterface() :
         worker_location_info_ptr(nullptr),
         cached_worker_semaphore_address(0),
         remote_producer_wrptr(nullptr),
         connection_live_semaphore(nullptr),
+        sender_ack_noc_cmd_buf(write_at_cmd_buf),
         local_wrptr(),
         local_ackptr(),
         local_rdptr() {}
@@ -122,11 +127,13 @@ struct EdmChannelWorkerInterface {
         // semaphore directly (saving on regenerating it each time)
         volatile EDMChannelWorkerLocationInfo* worker_location_info_ptr,
         volatile tt_l1_ptr uint32_t* const remote_producer_wrptr,
-        volatile tt_l1_ptr uint32_t* const connection_live_semaphore) :
+        volatile tt_l1_ptr uint32_t* const connection_live_semaphore,
+        uint8_t sender_ack_noc_cmd_buf) :
         worker_location_info_ptr(worker_location_info_ptr),
         cached_worker_semaphore_address(0),
         remote_producer_wrptr(remote_producer_wrptr),
         connection_live_semaphore(connection_live_semaphore),
+        sender_ack_noc_cmd_buf(sender_ack_noc_cmd_buf),
         local_wrptr(),
         local_ackptr(),
         local_rdptr() {
@@ -147,7 +154,7 @@ struct EdmChannelWorkerInterface {
     }
 
     FORCE_INLINE void update_worker_copy_of_read_ptr(BufferPtr new_ptr_val) {
-        noc_inline_dw_write(this->cached_worker_semaphore_address, new_ptr_val);
+        noc_inline_dw_write_with_state(new_ptr_val, this->sender_ack_noc_cmd_buf);
     }
 
     // Connection management methods
@@ -172,6 +179,7 @@ struct EdmChannelWorkerInterface {
         uint64_t worker_semaphore_address = get_noc_addr(
             (uint32_t)worker_info.worker_xy.x, (uint32_t)worker_info.worker_xy.y, worker_info.worker_semaphore_address);
         this->cached_worker_semaphore_address = worker_semaphore_address;
+        noc_inline_dw_write_set_state(worker_semaphore_address, 0xF, this->sender_ack_noc_cmd_buf);
     }
 
     FORCE_INLINE bool all_eth_packets_acked() const { return this->local_ackptr.is_caught_up_to(this->local_wrptr); }
@@ -188,6 +196,7 @@ struct EdmChannelWorkerInterface {
     uint64_t cached_worker_semaphore_address = 0;
     volatile tt_l1_ptr uint32_t* const remote_producer_wrptr;
     volatile tt_l1_ptr uint32_t* const connection_live_semaphore;
+    uint8_t sender_ack_noc_cmd_buf;
 
     ChannelBufferPointer<NUM_BUFFERS> local_wrptr;
     ChannelBufferPointer<NUM_BUFFERS> local_ackptr;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1480,7 +1480,9 @@ void kernel_main() {
             local_sender_channel_1_connection_buffer_index_id,
             reinterpret_cast<volatile uint32_t* const>(edm_vc0_forwarding_semaphore_address),
             reinterpret_cast<volatile uint32_t* const>(edm_vc0_teardown_semaphore_address),
-            downstream_vc0_noc_interface_buffer_index_local_addr);
+            downstream_vc0_noc_interface_buffer_index_local_addr,
+            write_reg_cmd_buf,
+            read_cmd_buf);
     }
     if constexpr (enable_ring_support) {
         if (has_downstream_edm_vc1_buffer_connection) {
@@ -1499,7 +1501,9 @@ void kernel_main() {
                 local_sender_channel_2_connection_buffer_index_id,
                 reinterpret_cast<volatile uint32_t* const>(edm_vc1_forwarding_semaphore_address),
                 reinterpret_cast<volatile uint32_t* const>(edm_vc1_teardown_semaphore_address),
-                downstream_vc1_noc_interface_buffer_index_local_addr);
+                downstream_vc1_noc_interface_buffer_index_local_addr,
+                write_reg_cmd_buf,
+                read_cmd_buf);
         }
     }
     for (uint8_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1160,7 +1160,8 @@ void __attribute__((noinline)) init_local_sender_channel_worker_interfaces(
         new (&local_sender_channel_worker_interfaces[0]) tt::tt_fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>(
             connection_worker_info_ptr,
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_flow_control_semaphores[0]),
-            reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
+            write_reg_cmd_buf);
     }
     {
         auto connection_live_semaphore_ptr =
@@ -1171,7 +1172,8 @@ void __attribute__((noinline)) init_local_sender_channel_worker_interfaces(
         new (&local_sender_channel_worker_interfaces[1]) tt::tt_fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>(
             connection_worker_info_ptr,
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_flow_control_semaphores[1]),
-            reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
+            write_cmd_buf);
     }
     if constexpr (NUM_SENDER_CHANNELS > 2) {
         {
@@ -1184,7 +1186,8 @@ void __attribute__((noinline)) init_local_sender_channel_worker_interfaces(
                 tt::tt_fabric::EdmChannelWorkerInterface<SENDER_NUM_BUFFERS>(
                     connection_worker_info_ptr,
                     reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_flow_control_semaphores[2]),
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr));
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
+                    write_cmd_buf);
         }
     }
 }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1161,7 +1161,7 @@ void __attribute__((noinline)) init_local_sender_channel_worker_interfaces(
             connection_worker_info_ptr,
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_flow_control_semaphores[0]),
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
-            write_reg_cmd_buf);
+            worker_sender0_sync_cmd_buf);
     }
     {
         auto connection_live_semaphore_ptr =
@@ -1173,7 +1173,7 @@ void __attribute__((noinline)) init_local_sender_channel_worker_interfaces(
             connection_worker_info_ptr,
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_flow_control_semaphores[1]),
             reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
-            write_cmd_buf);
+            worker_sender1_sync_cmd_buf);
     }
     if constexpr (NUM_SENDER_CHANNELS > 2) {
         {
@@ -1187,7 +1187,7 @@ void __attribute__((noinline)) init_local_sender_channel_worker_interfaces(
                     connection_worker_info_ptr,
                     reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(local_sender_flow_control_semaphores[2]),
                     reinterpret_cast<volatile tt_l1_ptr uint32_t* const>(connection_live_semaphore_ptr),
-                    write_cmd_buf);
+                    worker_sender2_sync_cmd_buf);
         }
     }
 }
@@ -1481,8 +1481,8 @@ void kernel_main() {
             reinterpret_cast<volatile uint32_t* const>(edm_vc0_forwarding_semaphore_address),
             reinterpret_cast<volatile uint32_t* const>(edm_vc0_teardown_semaphore_address),
             downstream_vc0_noc_interface_buffer_index_local_addr,
-            write_reg_cmd_buf,
-            read_cmd_buf);
+            downstream_data_cmd_buf,
+            downstream_sync_cmd_buf);
     }
     if constexpr (enable_ring_support) {
         if (has_downstream_edm_vc1_buffer_connection) {
@@ -1502,8 +1502,8 @@ void kernel_main() {
                 reinterpret_cast<volatile uint32_t* const>(edm_vc1_forwarding_semaphore_address),
                 reinterpret_cast<volatile uint32_t* const>(edm_vc1_teardown_semaphore_address),
                 downstream_vc1_noc_interface_buffer_index_local_addr,
-                write_reg_cmd_buf,
-                read_cmd_buf);
+                downstream_data_cmd_buf,
+                downstream_sync_cmd_buf);
         }
     }
     for (uint8_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1549,6 +1549,9 @@ template <bool posted = false>
 FORCE_INLINE void noc_inline_dw_write_set_state(
     uint64_t addr, uint8_t be = 0xF, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
     WAYPOINT("NWIW");
+#ifdef ARCH_BLACKHOLE
+    static_assert(false, "stateful noc_inline_dw_write does not support BH");
+#else
     DEBUG_SANITIZE_NOC_ADDR(noc, addr, 4);
 
     uint32_t noc_cmd_field = NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | NOC_CMD_CPY | NOC_CMD_WR |
@@ -1564,6 +1567,7 @@ FORCE_INLINE void noc_inline_dw_write_set_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, addr & 0xFFFFFFFF);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
+#endif
     WAYPOINT("NWID");
 }
 
@@ -1572,7 +1576,9 @@ template <bool update_addr_lo = false, bool update_counter = true, bool posted =
 FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
     WAYPOINT("NWIW");
-
+#ifdef ARCH_BLACKHOLE
+    static_assert(false, "stateful noc_inline_dw_write does not support BH");
+#else
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     if constexpr (update_addr_lo) {
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, addr);
@@ -1596,6 +1602,7 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
             }
         }
     }
+#endif
     WAYPOINT("NWID");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1566,11 +1566,15 @@ void noc_inline_dw_write_set_state(
     WAYPOINT("NWID");
 }
 
-FORCE_INLINE
-void noc_inline_dw_write_with_state(uint32_t val, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
+template <bool update_addr_lo = false>
+FORCE_INLINE void noc_inline_dw_write_with_state(
+    uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
     WAYPOINT("NWIW");
 
     while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (update_addr_lo) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, addr);
+    }
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     WAYPOINT("NWID");

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1765,25 +1765,34 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     std::uint32_t size,
     std::uint32_t trid,
     uint8_t noc = noc_index) {
+#ifndef ARCH_GRAYSKULL
     WAYPOINT("NAWW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size, -1);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
-#ifndef ARCH_GRAYSKULL
-    ncrisc_noc_fast_write_any_len<noc_mode, true, true>(
+    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    WAYPOINT("NWPD");
+
+    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
+                             0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
+                             0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
+                             NOC_CMD_RESP_MARKED;
+
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
+#ifdef ARCH_BLACKHOLE
+    // Handles writing to PCIe
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
+#endif
+    NOC_CMD_BUF_WRITE_REG(
         noc,
         write_cmd_buf,
-        src_local_l1_addr,
-        dst_noc_addr,
-        size,
-        NOC_UNICAST_WRITE_VC,
-        false /*mcast*/,
-        false /*linked*/,
-        1 /*num_dests*/,
-        false /*multicast_path_reserve*/,
-        false /*posted*/,
-        trid /*trid*/);
+        NOC_RET_ADDR_COORDINATE,
+        (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 #endif
-    WAYPOINT("NAWD");
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1720,7 +1720,6 @@ void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
 
 FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
     std::uint64_t dst_noc_addr, uint8_t cmd_buf = write_cmd_buf, uint8_t noc = noc_index) {
-#ifndef ARCH_GRAYSKULL
     WAYPOINT("NAWW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, dst_noc_addr, 0, NOC_UNICAST_WRITE_VC);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
@@ -1737,7 +1736,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
 #endif
     NOC_CMD_BUF_WRITE_REG(
         noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-#endif
 }
 
 FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
@@ -1747,7 +1745,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     std::uint32_t trid,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index) {
-#ifndef ARCH_GRAYSKULL
     WAYPOINT("NWPW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_WITH_STATE, 0ull, size, -1);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
@@ -1760,7 +1757,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-#endif
 }
 
 FORCE_INLINE void noc_async_write_one_packet_with_trid(
@@ -1769,7 +1765,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     std::uint32_t size,
     std::uint32_t trid,
     uint8_t noc = noc_index) {
-#ifndef ARCH_GRAYSKULL
     WAYPOINT("NAWW");
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size, -1);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
@@ -1796,7 +1791,6 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
     NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
     NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-#endif
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1544,6 +1544,7 @@ FORCE_INLINE void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 
     WAYPOINT("NWID");
 }
 
+// on BH this api can only write to stream register, writing to L1 will cause hangs!
 template <bool posted = false>
 FORCE_INLINE void noc_inline_dw_write_set_state(
     uint64_t addr, uint8_t be = 0xF, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {
@@ -1566,6 +1567,7 @@ FORCE_INLINE void noc_inline_dw_write_set_state(
     WAYPOINT("NWID");
 }
 
+// on BH this api can only write to stream register, writing to L1 will cause hangs!
 template <bool update_addr_lo = false, bool update_counter = true, bool posted = false>
 FORCE_INLINE void noc_inline_dw_write_with_state(
     uint32_t val, uint32_t addr = 0, uint8_t cmd_buf = write_at_cmd_buf, uint8_t noc = noc_index) {


### PR DESCRIPTION
Use stateful API in fabric worker sync path to save some cycles, also remove sw counter update in noc txn.

some perf numbers 

no IRAM
![Screenshot 2025-03-20 at 5 34 47 PM](https://github.com/user-attachments/assets/7669cc66-e277-42c8-ab5e-7775b3d47cf1)


with IRAM
![image](https://github.com/user-attachments/assets/9326f580-b4a9-48ab-af5a-c0fe780f306b)

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/13996021267
- [x] ubench https://github.com/tenstorrent/tt-metal/actions/runs/13996057480
- [x] T3K nightly https://github.com/tenstorrent/tt-metal/actions/runs/13996488739
- [ ] T3K demo https://github.com/tenstorrent/tt-metal/actions/runs/13996494880
- [ ] TG demo https://github.com/tenstorrent/tt-metal/actions/runs/13996469280
- [ ] TG nightly https://github.com/tenstorrent/tt-metal/actions/runs/13996502256