### PR TITLE
Slice handles non-aligned tiled inputs.

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -49,6 +49,7 @@ import torch
 import ttnn
 
 ttnn_dtype_to_torch_dtype = {
+    ttnn.uint16: torch.int16,
     ttnn.uint32: torch.int32,
     ttnn.bfloat16: torch.float32,
     ttnn.bfloat8_b: torch.bfloat16,
@@ -161,8 +162,8 @@ def test_fill_pad_bfloat8_b(
         (1, 2, 3, 2, 1, 2, 97, 97),
     ],
 )
-@pytest.mark.parametrize("fill_value", [1])
-@pytest.mark.parametrize("dtype", [ttnn.uint32])
+@pytest.mark.parametrize("fill_value", [1, 0])
+@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.uint16])
 @pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("output_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 def test_fill_pad_int(

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -329,8 +329,8 @@ def test_stride_slice_four_dim(dims, begins, ends, strides, layout, device):
 
 
 @pytest.mark.parametrize("dims", [[1, 56, 56, 96]])
-@pytest.mark.parametrize("begins", [[0, 0, 0, 0]])
-@pytest.mark.parametrize("ends", [[1, -1, 56, 96]])
+@pytest.mark.parametrize("begins", [[0, 0, 0, 0], [0, 0, 0, 90]])
+@pytest.mark.parametrize("ends", [[1, -1, 56, 96], [1, 56, 56, 95], [-1, 1, -1, -1]])
 @pytest.mark.parametrize("strides", [[1, 2, 1, 1]])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 def test_stride_slice_four_dim_tiled(dims, begins, ends, strides, layout, device):
@@ -749,39 +749,16 @@ def test_slice_adversarial_fixed(input_shape, dim, start, end, step, layout, dev
     assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
 
 
-@pytest.mark.xfail(reason="pytorch2 sweep test failures as of 2025-03")
-@pytest.mark.parametrize(
-    "input_shape, dim, start, end, step, layout",
-    (([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),),  # unaligned 1D
-)
-def test_pytorch2_failures(input_shape, dim, start, end, step, layout, device):
-    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
-
-    slice_obj = slice(start, end, step)
-
-    # Prepare indices for slicing in the specified dimension
-    indices = [slice(None)] * len(input_shape)  # By default, select all elements along every dimension
-    indices[dim] = slice_obj  # Apply slicing to the target dimension
-    indices = tuple(indices)
-
-    # Apply slicing to the input_tensor
-    torch_output_tensor = torch_input[indices]
-
-    ttnn_tensor = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=ttnn.bfloat16)
-    ttnn_output = ttnn_tensor[indices]
-
-    ttnn_output_tensor = ttnn.to_torch(ttnn_output)
-
-    assert_with_pcc(torch_output_tensor, ttnn_output_tensor, 0.999)
-
-
 # Op parameters from pytorch2 sweep tests that failed prior to 2025-03
 @pytest.mark.parametrize(
     "input_shape, dim, start, end, step, layout",
     (
+        ((1, 145, 768), 1, 1, -1, 1, ttnn.TILE_LAYOUT),  # tile-unaligned slice start were previously not supported
+        ((1, 1445, 192), 1, -100, -1, 1, ttnn.TILE_LAYOUT),  # tile-unaligned slice start were previously not supported
         ([1, 7], 0, 0, -1, 1, ttnn.ROW_MAJOR_LAYOUT),  # page size must equal buffer size
         ([1, 8, 2, 2], 2, -1, -1, 1, ttnn.TILE_LAYOUT),  # Buffer size and page size should be larger than 0 bytes
         ([8732, 4], 1, 0, -1, 4, ttnn.TILE_LAYOUT),  # Need tensor for this or a padding aware tiled kernel
+        ([3], 0, 0, -1, 1, ttnn.TILE_LAYOUT),  # unaligned 1D
         (
             [1, 7, 71, 64],
             3,
@@ -857,3 +834,66 @@ def test_slice_index(device, input_shape, layout, input_memory_config, indices):
     ttnn_output = ttnn.to_torch(ttnn_output)
 
     assert_with_pcc(torch_output, ttnn_output, 0.99)
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_start, input_ends, input_steps",
+    (
+        ((1, 1504, 1280), (0, 0, 0), (1, 1500, 1280), (1, 1, 1)),  # fill pad case
+        ((448, 1280), (0, 0), (1, 1280), (1, 1)),  # fill pad case
+    ),
+)
+@pytest.mark.parametrize(
+    "layout",
+    (ttnn.TILE_LAYOUT,),
+)
+@pytest.mark.parametrize(
+    "memory_config",
+    (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+)
+def test_ttnn_slice_whisper(
+    input_shape, input_start, input_ends, input_steps, memory_config, layout, device, use_program_cache
+):
+    # A couple of slices in whisper that only work for "logical" slicing.
+
+    for _ in range(3):
+        torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+        if len(input_shape) == 4:
+            torch_output = torch_input[
+                input_start[0] : input_ends[0] : input_steps[0],
+                input_start[1] : input_ends[1] : input_steps[1],
+                input_start[2] : input_ends[2] : input_steps[2],
+                input_start[3] : input_ends[3] : input_steps[3],
+            ]
+            ttnn_output = ttnn_input[
+                input_start[0] : input_ends[0] : input_steps[0],
+                input_start[1] : input_ends[1] : input_steps[1],
+                input_start[2] : input_ends[2] : input_steps[2],
+                input_start[3] : input_ends[3] : input_steps[3],
+            ]
+
+        if len(input_shape) == 3:
+            torch_output = torch_input[
+                input_start[0] : input_ends[0] : input_steps[0],
+                input_start[1] : input_ends[1] : input_steps[1],
+                input_start[2] : input_ends[2] : input_steps[2],
+            ]
+            ttnn_output = ttnn_input[
+                input_start[0] : input_ends[0] : input_steps[0],
+                input_start[1] : input_ends[1] : input_steps[1],
+                input_start[2] : input_ends[2] : input_steps[2],
+            ]
+
+        if len(input_shape) == 2:
+            torch_output = torch_input[
+                input_start[0] : input_ends[0] : input_steps[0],
+                input_start[1] : input_ends[1] : input_steps[1],
+            ]
+            ttnn_output = ttnn_input[
+                input_start[0] : input_ends[0] : input_steps[0],
+                input_start[1] : input_ends[1] : input_steps[1],
+            ]
+
+        ttnn_output = ttnn.to_torch(ttnn_output)
+        assert_with_pcc(torch_output, ttnn_output, 0.999999)

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -896,4 +896,4 @@ def test_ttnn_slice_whisper(
             ]
 
         ttnn_output = ttnn.to_torch(ttnn_output)
-        assert_with_pcc(torch_output, ttnn_output, 0.999999)
+        assert_with_pcc(torch_output, ttnn_output, 0.999)

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_op.cpp
@@ -15,6 +15,7 @@ using namespace tt::tt_metal;
 void FillPad::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.get_layout() == TILE_LAYOUT, "FillPad should only be used for tile layout");
+    TT_FATAL(detail::data_type_to_size.count(input_tensor_a.get_dtype()), "Unsupported datatype");
 }
 
 std::vector<TensorSpec> FillPad::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -4,6 +4,14 @@
 
 namespace ttnn::operations::data_movement::detail {
 
+const std::map<ttnn::DataType, uint32_t> data_type_to_size = {
+    {ttnn::DataType::BFLOAT16, 2},
+    {ttnn::DataType::FLOAT32, 4},
+    {ttnn::DataType::UINT16, 2},
+    {ttnn::DataType::UINT32, 4},
+    {ttnn::DataType::UINT8, 1},
+};
+
 tt::tt_metal::operation::ProgramWithCallbacks fill_pad_multi_core(const Tensor& input_tensor, float fill_value);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -113,7 +113,7 @@ void SliceDeviceOperation::validate_with_output_tensors(
         TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
         TT_FATAL(
             (output_tensor_shape[-2] % TILE_HEIGHT == 0) && (this->slice_start[-2] % TILE_HEIGHT == 0),
-            "Can only slice tilized tensor with with height begin index aligned to tiles");
+            "Can only slice tilized tensor with height begin index aligned to tiles");
         TT_FATAL(
             (output_tensor_shape[-1] % TILE_WIDTH == 0) && (this->slice_start[-1] % TILE_WIDTH == 0),
             "Can only slice tilized tensor with width begin index aligned to tiles");

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -113,10 +113,10 @@ void SliceDeviceOperation::validate_with_output_tensors(
         TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
         TT_FATAL(
             (output_tensor_shape[-2] % TILE_HEIGHT == 0) && (this->slice_start[-2] % TILE_HEIGHT == 0),
-            "Can only unpad tilized tensor with full tiles");
+            "Can only slice tilized tensor with with height begin index aligned to tiles");
         TT_FATAL(
             (output_tensor_shape[-1] % TILE_WIDTH == 0) && (this->slice_start[-1] % TILE_WIDTH == 0),
-            "Can only unpad tilized tensor with full tiles");
+            "Can only slice tilized tensor with width begin index aligned to tiles");
     } else if (input_tensor_a.get_layout() == Layout::ROW_MAJOR) {
         if (has_step) {
             for (uint32_t i = 0; i < input_tensor_a.get_padded_shape().rank(); i++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -2,14 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/common/constants.hpp"
 #include "slice.hpp"
 #include "device/slice_op.hpp"
-#include "ttnn/common/queue_id.hpp"
 #include "ttnn/run_operation.hpp"
+// #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
+#include "ttnn/common/queue_id.hpp"
 #include "cpp/ttnn/operations/creation.hpp"
-#include "cpp/ttnn/operations/data_movement/copy/copy.hpp"
-#include "cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
+#include "ttnn/common/constants.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 
 namespace ttnn::operations::data_movement {
@@ -22,11 +25,27 @@ ttnn::Tensor SliceOperation::invoke(
     tt::stl::Span<const T> ends,
     tt::stl::Span<const T> step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value) {
     // Ensure start and end vectors have matching sizes and correct tensor rank
 
     const auto& input_shape = input_tensor.get_logical_shape();
     uint32_t input_rank = input_shape.rank();
+    auto input_layout = input_tensor.get_layout();
+
+    const auto& input_dtype = input_tensor.get_dtype();
+
+    if (input_rank == 0) {
+        return input_tensor;
+    }
+    TT_FATAL(
+        input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
+    TT_FATAL(begins.size() == ends.size(), "Start {} and end {} must have the same size", begins.size(), ends.size());
+    TT_FATAL(
+        step.size() == begins.size(),
+        "Step {} must have the same size as start {} and end",
+        step.size(),
+        begins.size());
 
     bool no_step = std::ranges::all_of(step, [](uint32_t s) { return s == 1; });
     bool starts_zero = std::ranges::all_of(begins, [](uint32_t s) { return s == 0; });
@@ -38,59 +57,40 @@ ttnn::Tensor SliceOperation::invoke(
         }
     }
 
-    if (no_step && starts_zero && ends_max) {
+    const auto& tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
+
+    auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
+                                                            : memory_config_arg.value_or(input_tensor.memory_config());
+
+    auto ret_adjustment([&](const ttnn::Tensor& input_tensor) {
         if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value()
-                                     ? optional_output_tensor.value().memory_config()
-                                     : memory_config_arg.value_or(input_tensor.memory_config());
-            return ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            auto tensor = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            tensor = ttnn::to_layout(tensor, input_layout, std::nullopt, std::nullopt, (IDevice*)nullptr);
+            return tensor;
         }
         return input_tensor;
+    });
+
+    // No-op check
+    if (no_step && starts_zero && ends_max) {
+        return ret_adjustment(input_tensor);
     }
-
-    TT_FATAL(
-        input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
-    TT_FATAL(begins.size() == ends.size(), "Start {} and end {} must have the same size", begins.size(), ends.size());
-    TT_FATAL(
-        step.size() == begins.size(),
-        "Step {} must have the same size as start {} and end",
-        step.size(),
-        begins.size());
-
-    bool rm_only = !no_step && input_tensor.get_layout() == Layout::TILE;
-    Tensor input = input_tensor;
-    if (rm_only) {
-        TT_FATAL(input.get_dtype() == DataType::BFLOAT16, "Strided slice is not supported for BFLOAT8 tensors");
-        input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-    }
-
-    // Unsqueeze tensor to 4D if necessary
-    if (input_rank < 4) {
-        input = ttnn::unsqueeze_to_4D(input);
-    }
-
-    auto padded_shape = input.get_padded_shape();
-    size_t adjusted_rank = padded_shape.rank();  // Now adjusted to 4 after unsqueeze
 
     // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
-    ttnn::SmallVector<uint32_t> modified_begins(adjusted_rank, 0);
-    ttnn::SmallVector<uint32_t> modified_ends(padded_shape.cbegin(), padded_shape.cend());
-    ttnn::SmallVector<uint32_t> modified_step(adjusted_rank, 1);
-
-    size_t rank_diff = adjusted_rank - input_rank;
+    ttnn::SmallVector<uint32_t> modified_begins(input_rank, 0);
+    ttnn::SmallVector<uint32_t> modified_ends(input_rank, 0);
+    ttnn::SmallVector<uint32_t> modified_step(input_rank, 1);
 
     // Wrap indices and adjust begins, ends, and step
     for (size_t i = 0; i < begins.size(); ++i) {
-        size_t idx = i + rank_diff;
-
         if constexpr (std::is_signed_v<T>) {
-            modified_begins[idx] = wrap_index(begins[i], input_shape[i]);
-            modified_ends[idx] = wrap_index(ends[i], input_shape[i]);
-            modified_step[idx] = static_cast<uint32_t>(step[i]);
+            modified_begins[i] = wrap_index(begins[i], input_shape[i]);
+            modified_ends[i] = wrap_index(ends[i], input_shape[i]);
+            modified_step[i] = static_cast<uint32_t>(step[i]);
         } else {
-            modified_begins[idx] = begins[i];
-            modified_ends[idx] = ends[i];
-            modified_step[idx] = step[i];
+            modified_begins[i] = begins[i];
+            modified_ends[i] = ends[i];
+            modified_step[i] = step[i];
         }
     }
 
@@ -98,12 +98,37 @@ ttnn::Tensor SliceOperation::invoke(
         return (modified_ends[i] - modified_begins[i] + modified_step[i] - 1) / modified_step[i];
     };
 
+    auto check_handled_tile_alignment = [&modified_begins, &input_rank, &tile_shape]() -> bool {
+        return (
+            modified_begins[input_rank - 1] % tile_shape[1] == 0 &&
+            modified_begins[input_rank - 2] % tile_shape[0] == 0);
+    };
+
+    bool rm_only = false;
+    bool one_dimensional = input_rank == 1;
+    bool handled_tile_alignment = one_dimensional ? true : check_handled_tile_alignment();
+
+    Tensor input = input_tensor;
+    rm_only =
+        (input_tensor.get_layout() == Layout::TILE &&
+         (!no_step || one_dimensional || input_tensor.is_sharded() || !handled_tile_alignment));
+    if (rm_only) {
+        if (!no_step) {
+            TT_FATAL(input.get_dtype() != DataType::BFLOAT8_B, "Strided slice is not supported for BFLOAT8 tensors");
+        }
+        TT_FATAL(
+            input.get_dtype() != DataType::UINT16,
+            "This slice requires an implicit Tile->RM conversion and that is not currently supported for uint16");
+        input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config, (IDevice*)nullptr);
+        if (one_dimensional) {
+            std::cout << "ONE D" << std::endl;
+        }
+    }
+
     ttnn::SmallVector<uint32_t> padded_ends = modified_ends;
     if (input.layout() == Layout::TILE) {
-        padded_ends[adjusted_rank - 2] = std::max(
-            tt::round_up(padded_ends[adjusted_rank - 2], tt::constants::TILE_HEIGHT), tt::constants::TILE_HEIGHT);
-        padded_ends[adjusted_rank - 1] = std::max(
-            tt::round_up(padded_ends[adjusted_rank - 1], tt::constants::TILE_WIDTH), tt::constants::TILE_WIDTH);
+        padded_ends[input_rank - 2] = std::max(tt::round_up(padded_ends[input_rank - 2], tile_shape[0]), tile_shape[0]);
+        padded_ends[input_rank - 1] = std::max(tt::round_up(padded_ends[input_rank - 1], tile_shape[1]), tile_shape[1]);
     }
 
     ttnn::SmallVector<uint32_t> actual_shape_vec, final_padded_shape_vec;
@@ -113,26 +138,24 @@ ttnn::Tensor SliceOperation::invoke(
 
     // Compute actual and padded shapes for the original input rank
     for (size_t i = 0; i < input_rank; ++i) {
-        size_t idx = i + rank_diff;
         TT_FATAL(
-            modified_ends[idx] >= modified_begins[idx],
+            modified_ends[i] >= modified_begins[i],
             "End {} must be greater than or equal to start {}",
-            modified_ends[idx],
-            modified_begins[idx]);
-        auto val = output_dim_i(idx, modified_ends);
+            modified_ends[i],
+            modified_begins[i]);
+        auto val = output_dim_i(i, modified_ends);
         if (val == 0) {
             empty = true;
         }
         actual_shape_vec.push_back(val);
-        final_padded_shape_vec.push_back(std::max(output_dim_i(idx, padded_ends), static_cast<uint32_t>(1)));
+        final_padded_shape_vec.push_back(std::max(output_dim_i(i, padded_ends), static_cast<uint32_t>(1)));
     }
     ttnn::Shape actual_shape(actual_shape_vec);
     ttnn::Shape final_padded_shape(final_padded_shape_vec);
 
     if (empty) {
         TT_FATAL(
-            input_tensor.storage_type() == StorageType::DEVICE,
-            "Host tensor slice cannot return a scalar or empty tensor");
+            input.storage_type() == StorageType::DEVICE, "Host tensor slice cannot return a scalar or empty tensor");
         return ttnn::empty(
             actual_shape,
             input_tensor.dtype(),
@@ -141,64 +164,26 @@ ttnn::Tensor SliceOperation::invoke(
             memory_config_arg.value_or(input_tensor.memory_config()));
     }
 
-    // Early exit if slice is a no-op
-    if (final_padded_shape == input.get_padded_shape() && no_step) {
-        if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value()
-                                     ? optional_output_tensor.value().memory_config()
-                                     : memory_config_arg.value_or(input_tensor.memory_config());
-            auto res = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
-            return ttnn::reshape(res, actual_shape, final_padded_shape);
-        }
-        return ttnn::reshape(input_tensor, actual_shape, final_padded_shape);
+    auto res =
+        tt::tt_metal::operation::run(
+            SliceDeviceOperation{
+                ttnn::Shape(modified_begins), ttnn::Shape(padded_ends), ttnn::Shape(modified_step), memory_config},
+            {input},
+            {},
+            {optional_output_tensor},
+            queue_id)
+            .at(0);
+    res = ttnn::experimental::view(res, actual_shape, final_padded_shape);
+
+    auto dim_needs_fill = [&input_shape, &actual_shape, &final_padded_shape](int i) {
+        return ((actual_shape[i] != final_padded_shape[i]) && (input_shape[i] != actual_shape[i]));
+    };
+
+    if (pad_value.has_value() && (dim_needs_fill(-1) || dim_needs_fill(-2))) {
+        res = ttnn::fill_implicit_tile_padding(res, pad_value.value());
     }
 
-    if (input_tensor.storage_type() != StorageType::DEVICE) {
-        TT_FATAL(no_step, "Host tensor slice does not support strides");
-        if (input_tensor.get_padded_shape() == actual_shape) {
-            return input_tensor;
-        } else {
-            input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-            input = input.unpad(ttnn::Shape(modified_begins), ttnn::Shape(modified_ends));
-            input = ttnn::to_layout(input, input_tensor.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr);
-            return ttnn::reshape(input, actual_shape, final_padded_shape);
-        }
-    } else {
-        const auto& input_tensor_shape = input.get_padded_shape();
-        auto memory_config = optional_output_tensor.has_value()
-                                 ? optional_output_tensor.value().memory_config()
-                                 : memory_config_arg.value_or(input_tensor.memory_config());
-
-        if (input.is_sharded() && input.memory_config() == memory_config && input_tensor_shape.rank() > 1) {
-            TT_FATAL(no_step, "Sharded tensor slice implementation does not support striding");
-            uint32_t i;
-            bool in_place_unpad = true;
-            for (i = 0; i < input_tensor_shape.rank() - 2; ++i) {
-                in_place_unpad &= modified_begins[i] == 0 && modified_ends[i] == 1 && input_tensor_shape[i] == 1;
-            }
-            in_place_unpad &=
-                modified_begins[i] == 0 && tt::div_up(modified_ends[i], input.shard_spec().value().shape[0]) ==
-                                               tt::div_up(input_tensor_shape[i], input.shard_spec().value().shape[0]);
-            i++;
-            in_place_unpad &= modified_begins[i] == 0 && modified_ends[i] == input_tensor_shape[i];
-            if (in_place_unpad) {
-                return ttnn::reshape(input_tensor, actual_shape, final_padded_shape);
-            }
-        }
-
-        auto res =
-            tt::tt_metal::operation::run(
-                SliceDeviceOperation{
-                    ttnn::Shape(modified_begins), ttnn::Shape(padded_ends), ttnn::Shape(modified_step), memory_config},
-                {input},
-                {},
-                {optional_output_tensor},
-                queue_id)
-                .at(0);
-        res = ttnn::reshape(res, actual_shape, final_padded_shape);
-        return rm_only ? ttnn::to_layout(res, input_tensor.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr)
-                       : res;
-    }
+    return ret_adjustment(res);
 }
 
 template <typename T>
@@ -208,127 +193,10 @@ ttnn::Tensor SliceOperation::invoke(
     tt::stl::Span<const T> ends,
     tt::stl::Span<const T> step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor) {
-    return SliceOperation::invoke<T>(ttnn::DefaultQueueId, input_tensor, begins, ends, step, memory_config_arg);
-}
-
-// Specialization for uint32_t and N=4
-template <>
-ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
-    QueueId queue_id,
-    const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 4>& begins,
-    const std::array<uint32_t, 4>& ends,
-    const std::array<uint32_t, 4>& step,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor) {
-    const auto& padded_input_shape = input_tensor.get_padded_shape();
-    TT_FATAL(padded_input_shape.rank() == 4, "Input tensor must have rank 4");
-
-    bool no_step = step[0] == 1 && step[1] == 1 && step[2] == 1 && step[3] == 1;
-    bool starts_zero = begins[0] == 0 && begins[1] == 0 && begins[2] == 0 && begins[3] == 0;
-    bool ends_max = ends[0] == padded_input_shape[0] && ends[1] == padded_input_shape[1] &&
-                    ends[2] == padded_input_shape[2] && ends[3] == padded_input_shape[3];
-
-    if (no_step && starts_zero && ends_max) {
-        if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value()
-                                     ? optional_output_tensor.value().memory_config()
-                                     : memory_config_arg.value_or(input_tensor.memory_config());
-            return ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
-        }
-        return input_tensor;
-    }
-    bool rm_only = !no_step && input_tensor.get_layout() == Layout::TILE;
-    ttnn::Tensor input = input_tensor;
-    if (rm_only) {
-        input = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-    }
-
-    const bool tiled = input.get_layout() == Layout::TILE;
-    bool on_device = input.storage_type() == StorageType::DEVICE;
-
-    std::array<uint32_t, 4> actual_shape_vec;
-    std::array<uint32_t, 4> padded_shape_vec;
-    const std::array<uint32_t, 4> padded_ends =
-        tiled ? std::array<uint32_t, 4>(
-                    {ends[0],
-                     ends[1],
-                     std::max(tt::round_up(ends[2], tt::constants::TILE_HEIGHT), tt::constants::TILE_HEIGHT),
-                     std::max(tt::round_up(ends[3], tt::constants::TILE_WIDTH), tt::constants::TILE_WIDTH)})
-              : ends;
-    bool empty = false;
-    for (int i = 0; i < 4; ++i) {
-        TT_FATAL(ends[i] >= begins[i], "End {} must be greater than or equal to start {}", ends[i], begins[i]);
-        uint32_t offset = step[i] - begins[i] - 1;
-        uint32_t dim_size = (ends[i] + offset) / step[i];
-        empty |= dim_size == 0;
-        actual_shape_vec[i] = dim_size;
-        padded_shape_vec[i] = std::max((padded_ends[i] + offset) / step[i], 1u);
-    }
-    ttnn::Shape actual_shape(actual_shape_vec);
-    ttnn::Shape padded_shape(padded_shape_vec);
-
-    if (empty) {
-        TT_FATAL(on_device, "Host tensor slice cannot return a scalar or empty tensor");
-        auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
-                                                                : memory_config_arg.value_or(input.memory_config());
-        return ttnn::empty(actual_shape, input.dtype(), input_tensor.layout(), input.device(), memory_config);
-    }
-
-    // Early exit if slice is a no-op
-    if (padded_shape == padded_input_shape && no_step) {
-        if (input.storage_type() == StorageType::DEVICE) {
-            auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
-                                                                    : memory_config_arg.value_or(input.memory_config());
-            auto res = ttnn::to_memory_config(input, memory_config, std::nullopt);
-            return ttnn::reshape(res, actual_shape, padded_shape);
-        }
-        return ttnn::reshape(input, actual_shape, padded_shape);  // change to view
-    }
-
-    if (on_device) {
-        auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
-                                                                : memory_config_arg.value_or(input.memory_config());
-
-        // Check for in-place unpad optimization
-        if (input.is_sharded() && input.memory_config() == memory_config && padded_input_shape.rank() > 1) {
-            TT_FATAL(no_step, "Sharded tensor slice implementation does not support striding");
-            bool in_place_unpad = true;
-            for (int i = 0; i < 2; ++i) {
-                in_place_unpad &= begins[i] == 0 && ends[i] == 1 && padded_input_shape[i] == 1;
-            }
-            in_place_unpad &=
-                begins[2] == 0 && tt::div_up(ends[2], input.shard_spec().value().shape[0]) ==
-                                      tt::div_up(padded_input_shape[2], input.shard_spec().value().shape[0]);
-            in_place_unpad &= begins[3] == 0 && ends[3] == padded_input_shape[3];
-            if (in_place_unpad) {
-                return ttnn::reshape(input, actual_shape, padded_shape);
-            }
-        }
-
-        input = tt::tt_metal::operation::run(
-            SliceDeviceOperation{ttnn::Shape(begins), ttnn::Shape(padded_ends), ttnn::Shape(step), memory_config},
-            {input},
-            {},
-            {optional_output_tensor},
-            queue_id)[0];
-        input = ttnn::reshape(input, actual_shape, padded_shape);
-        return rm_only ? ttnn::to_layout(input, input.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr)
-                       : input;
-    }
-
-    TT_FATAL(no_step, "Host tensor slice does not support strides");
-
-    if (input.get_padded_shape() == actual_shape) {
-        return input;
-    } else {
-        auto input_4d_rm = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr);
-        auto output_4d = input_4d_rm.unpad(ttnn::Shape(begins), ttnn::Shape(ends));
-        auto output_4d_rm =
-            ttnn::to_layout(output_4d, input.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr);
-        return ttnn::reshape(output_4d_rm, actual_shape, padded_shape);
-    }
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value) {
+    return SliceOperation::invoke<T>(
+        ttnn::DefaultQueueId, input_tensor, begins, ends, step, memory_config_arg, optional_output_tensor, pad_value);
 }
 
 template <typename T, std::size_t N>
@@ -339,11 +207,13 @@ ttnn::Tensor SliceOperation::invoke(
     const std::array<T, N>& output_tensor_end,
     const std::array<T, N>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value) {
     tt::stl::Span<const T> start(output_tensor_start.begin(), output_tensor_start.end());
     tt::stl::Span<const T> end(output_tensor_end.begin(), output_tensor_end.end());
     tt::stl::Span<const T> step_vec(step.begin(), step.end());
-    return SliceOperation::invoke<T>(queue_id, input_tensor, start, end, step_vec, memory_config_arg);
+    return SliceOperation::invoke<T>(
+        queue_id, input_tensor, start, end, step_vec, memory_config_arg, optional_output_tensor, pad_value);
 }
 
 template <typename T, std::size_t N>
@@ -353,9 +223,17 @@ ttnn::Tensor SliceOperation::invoke(
     const std::array<T, N>& output_tensor_end,
     const std::array<T, N>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value) {
     return SliceOperation::invoke<T, N>(
-        ttnn::DefaultQueueId, input_tensor, output_tensor_start, output_tensor_end, step, memory_config_arg);
+        ttnn::DefaultQueueId,
+        input_tensor,
+        output_tensor_start,
+        output_tensor_end,
+        step,
+        memory_config_arg,
+        optional_output_tensor,
+        pad_value);
 }
 
 template ttnn::Tensor SliceOperation::invoke<int>(
@@ -365,7 +243,8 @@ template ttnn::Tensor SliceOperation::invoke<int>(
     tt::stl::Span<const int> ends,
     tt::stl::Span<const int> step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<int>(
     const ttnn::Tensor& input_tensor,
@@ -373,7 +252,8 @@ template ttnn::Tensor SliceOperation::invoke<int>(
     tt::stl::Span<const int> ends,
     tt::stl::Span<const int> step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     QueueId queue_id,
@@ -382,7 +262,8 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     tt::stl::Span<const uint32_t> ends,
     tt::stl::Span<const uint32_t> step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     const ttnn::Tensor& input_tensor,
@@ -390,7 +271,18 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t>(
     tt::stl::Span<const uint32_t> ends,
     tt::stl::Span<const uint32_t> step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
+
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 4>& output_tensor_start,
+    const std::array<uint32_t, 4>& output_tensor_end,
+    const std::array<uint32_t, 4>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
     const ttnn::Tensor& input_tensor,
@@ -398,7 +290,27 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
     const std::array<uint32_t, 4>& output_tensor_end,
     const std::array<uint32_t, 4>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
+
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 3>& output_tensor_start,
+    const std::array<uint32_t, 3>& output_tensor_end,
+    const std::array<uint32_t, 3>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
+
+template ttnn::Tensor SliceOperation::invoke<uint32_t, 3>(
+    const ttnn::Tensor& input_tensor,
+    const std::array<uint32_t, 3>& output_tensor_start,
+    const std::array<uint32_t, 3>& output_tensor_end,
+    const std::array<uint32_t, 3>& step,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
     QueueId queue_id,
@@ -407,7 +319,8 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
     const std::array<uint32_t, 1>& output_tensor_end,
     const std::array<uint32_t, 1>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
     const ttnn::Tensor& input_tensor,
@@ -415,6 +328,7 @@ template ttnn::Tensor SliceOperation::invoke<uint32_t, 1>(
     const std::array<uint32_t, 1>& output_tensor_end,
     const std::array<uint32_t, 1>& step,
     const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<Tensor>& optional_output_tensor);
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<float>& pad_value);
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -2,18 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/constants.hpp"
-#include "slice.hpp"
 #include "device/slice_op.hpp"
 #include "ttnn/run_operation.hpp"
-// #include "ttnn/operations/copy.hpp"
+#include "ttnn/common/constants.hpp"
+#include "ttnn/common/queue_id.hpp"
+#include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/operations/experimental/reshape/view.hpp"
-#include "ttnn/common/queue_id.hpp"
-#include "cpp/ttnn/operations/creation.hpp"
-#include "ttnn/common/constants.hpp"
-#include "cpp/ttnn/operations/data_movement/common/common.hpp"
+#include "slice.hpp"
 
 namespace ttnn::operations::data_movement {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -19,7 +19,8 @@ struct SliceOperation {
         tt::stl::Span<const T> ends,
         tt::stl::Span<const T> step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<float>& pad_value = std::nullopt);
 
     template <typename T>
     static ttnn::Tensor invoke(
@@ -28,7 +29,8 @@ struct SliceOperation {
         tt::stl::Span<const T> output_tensor_end,
         tt::stl::Span<const T> step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<float>& pad_value = std::nullopt);
 
     template <typename T>
     static ttnn::Tensor invoke(
@@ -38,7 +40,8 @@ struct SliceOperation {
         const ttnn::SmallVector<T>& ends,
         const ttnn::SmallVector<T>& step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<float>& pad_value = std::nullopt) {
         return invoke(
             queue_id,
             input_tensor,
@@ -46,7 +49,8 @@ struct SliceOperation {
             tt::stl::Span<const T>(ends),
             tt::stl::Span<const T>(step),
             memory_config_arg,
-            optional_output_tensor);
+            optional_output_tensor,
+            pad_value);
     }
 
     template <typename T>
@@ -56,14 +60,16 @@ struct SliceOperation {
         const ttnn::SmallVector<T>& ends,
         const ttnn::SmallVector<T>& step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<float>& pad_value = std::nullopt) {
         return invoke(
             input_tensor,
             tt::stl::Span<const T>(begins),
             tt::stl::Span<const T>(ends),
             tt::stl::Span<const T>(step),
             memory_config_arg,
-            optional_output_tensor);
+            optional_output_tensor,
+            pad_value);
     }
 
     template <typename T, std::size_t N>
@@ -74,7 +80,8 @@ struct SliceOperation {
         const std::array<T, N>& output_tensor_end,
         const std::array<T, N>& step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<float>& pad_value = std::nullopt);
 
     template <typename T, std::size_t N>
     static ttnn::Tensor invoke(
@@ -83,7 +90,8 @@ struct SliceOperation {
         const std::array<T, N>& output_tensor_end,
         const std::array<T, N>& step,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        const std::optional<float>& pad_value = std::nullopt);
 };
 
 }  // namespace data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
@@ -28,6 +28,7 @@ void bind_slice(py::module& module) {
             Keyword Args:
                 memory_config Memory Config of the output tensor
                 queue_id (uint8, optional) command queue id
+                pad_value: Optional value to fill padding for tiled tensors. Padding values are unmodified (and undefined) by default
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -57,6 +58,7 @@ void bind_slice(py::module& module) {
                const std::optional<ttnn::SmallVector<int>>& step,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
+               const std::optional<float>& pad_value,
                QueueId queue_id) {
                 const auto step_value = step.value_or(ttnn::SmallVector<int>(slice_end.size(), 1));
                 return self(
@@ -69,6 +71,7 @@ void bind_slice(py::module& module) {
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
+            py::arg("pad_value") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId,
         },
 
@@ -80,8 +83,10 @@ void bind_slice(py::module& module) {
                const std::array<uint32_t, 4>& step,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<Tensor>& optional_output_tensor,
+               const std::optional<float>& pad_value,
                QueueId queue_id) {
-                return self(queue_id, input_tensor, begins, ends, step, memory_config, optional_output_tensor);
+                return self(
+                    queue_id, input_tensor, begins, ends, step, memory_config, optional_output_tensor, pad_value);
             },
             py::arg("input_tensor"),
             py::arg("starts"),
@@ -90,6 +95,7 @@ void bind_slice(py::module& module) {
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
+            py::arg("pad_value") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId,
         });
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -27,15 +27,10 @@ std::vector<Tensor> split_dim_n_chunks_rm(
     const auto& input_shape = input_tensor.get_logical_shape();
     auto input_rank = input_shape.size();
 
-    // const bool on_host = input_tensor.is_host_tensor();
     std::optional<IDevice*> device = std::make_optional(input_tensor.device());
 
     Tensor preprocessed = ttnn::unsqueeze_to_4D(input_tensor);  // ensure we're 4D before slicing
     dim += 4 - input_rank;                                      // convert to 4D index
-
-    // if (!on_host && input_tensor.get_dtype() == DataType::BFLOAT16) {
-    //     preprocessed = preprocessed.cpu();  // bf16 tensors must be handled on host due to limitations in slice
-    // }
 
     const auto& preproc_shape = preprocessed.get_logical_shape();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -27,15 +27,15 @@ std::vector<Tensor> split_dim_n_chunks_rm(
     const auto& input_shape = input_tensor.get_logical_shape();
     auto input_rank = input_shape.size();
 
-    const bool on_host = input_tensor.is_host_tensor();
-    std::optional<IDevice*> device = on_host ? std::nullopt : std::make_optional(input_tensor.device());
+    // const bool on_host = input_tensor.is_host_tensor();
+    std::optional<IDevice*> device = std::make_optional(input_tensor.device());
 
     Tensor preprocessed = ttnn::unsqueeze_to_4D(input_tensor);  // ensure we're 4D before slicing
     dim += 4 - input_rank;                                      // convert to 4D index
 
-    if (!on_host && input_tensor.get_dtype() == DataType::BFLOAT16) {
-        preprocessed = preprocessed.cpu();  // bf16 tensors must be handled on host due to limitations in slice
-    }
+    // if (!on_host && input_tensor.get_dtype() == DataType::BFLOAT16) {
+    //     preprocessed = preprocessed.cpu();  // bf16 tensors must be handled on host due to limitations in slice
+    // }
 
     const auto& preproc_shape = preprocessed.get_logical_shape();
 
@@ -64,6 +64,11 @@ std::vector<Tensor> split_dim_n_chunks_rm(
             preprocessed, start_shape, end_shape, ttnn::SmallVector<uint32_t>(end_shape.size(), 1), mem_config);
         if (input_rank < 4) {
             output_chunk = ttnn::squeeze_from_4D(output_chunk, input_rank);
+        }
+
+        const bool on_host = input_tensor.is_host_tensor();
+        if (!on_host && input_tensor.get_dtype() == DataType::BFLOAT16) {
+            output_chunk = output_chunk.cpu();  // bf16 tensors must be handled on host due to limitations in slice
         }
 
         tt::tt_metal::Layout layout = input_tensor.get_layout();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9102

### Problem description
• Slice was not fully general as defined by pytorch2 sweep tests.

### What's changed
• Clean up slice logic
• tile non-aligned slice starts handled with RM fallback
• tile non-aligned slice ends properly handled by filling padding. Note: this is disabled by default, unless an optional argument is provided, as a workaround to avoid issues with whisper
• Add uint16 support to fill_pad. Specifically to support slice calls in topk 

• Added and ugly fix to `split` to get tests to pass. But this is temporary, `split` improvements coming in followup PR.

Context on Whisper issue:
[Here](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/whisper/tt/ttnn_optimized_functional_whisper.py#L234). In the decoder test this is a slice from (1, 1504, 1280) to (1, 1500, 1280), (tile aligned to non-aligned). If you perform a "logical" slice ie change shape metadata but leave the additional 4 rows of data intact this works fine: this is the current default behavior of slice and, in order to work around this issue, this behavior won't be immediately changing.
But if you do a real slice by zeroing out the additional 4 rows or doing the slice in RM, whisper PCC drops. Presumably whisper or a downstream op is incorrectly using the invalidated data.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13982670361) CI passes. [Submitted](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [submitted](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes