### PR TITLE
#19203: Deprecated CQ_DISPATCH_CMD_GO (#19203)

### DIFF
--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -186,7 +186,6 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
                 break;
             // These commands don't have any additional data to dump.
             case CQ_DISPATCH_CMD_ILLEGAL: break;
-            case CQ_DISPATCH_CMD_GO: break;
             case CQ_DISPATCH_CMD_SINK: break;
             case CQ_DISPATCH_CMD_EXEC_BUF_END: break;
             case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: break;

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -40,17 +40,16 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_WRITE_PACKED = 5,         // write to multiple noc addresses with packed data
     CQ_DISPATCH_CMD_WRITE_PACKED_LARGE = 6,   // write to multiple noc/dst addresses and varying lengnths w/ packed data
     CQ_DISPATCH_CMD_WAIT = 7,                 // wait until workers are done
-    CQ_DISPATCH_CMD_GO = 8,                   // send go message
-    CQ_DISPATCH_CMD_SINK = 9,                 // act as a data sink (for testing)
-    CQ_DISPATCH_CMD_DEBUG = 10,               // log waypoint data to watcher, checksum
-    CQ_DISPATCH_CMD_DELAY = 11,               // insert delay (for testing)
-    CQ_DISPATCH_CMD_EXEC_BUF_END = 12,        // dispatch_d notify prefetch_h that exec_buf has completed
-    CQ_DISPATCH_CMD_SET_WRITE_OFFSET = 13,  // set the offset to add to all non-host destination addresses (relocation)
-    CQ_DISPATCH_CMD_TERMINATE = 14,         // quit
-    CQ_DISPATCH_CMD_SEND_GO_SIGNAL = 15,
-    CQ_DISPATCH_NOTIFY_SLAVE_GO_SIGNAL = 16,
-    CQ_DISPATCH_SET_NUM_WORKER_SEMS = 17,
-    CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA = 18,
+    CQ_DISPATCH_CMD_SINK = 8,                 // act as a data sink (for testing)
+    CQ_DISPATCH_CMD_DEBUG = 9,                // log waypoint data to watcher, checksum
+    CQ_DISPATCH_CMD_DELAY = 10,               // insert delay (for testing)
+    CQ_DISPATCH_CMD_EXEC_BUF_END = 11,        // dispatch_d notify prefetch_h that exec_buf has completed
+    CQ_DISPATCH_CMD_SET_WRITE_OFFSET = 12,  // set the offset to add to all non-host destination addresses (relocation)
+    CQ_DISPATCH_CMD_TERMINATE = 13,         // quit
+    CQ_DISPATCH_CMD_SEND_GO_SIGNAL = 14,
+    CQ_DISPATCH_NOTIFY_SLAVE_GO_SIGNAL = 15,
+    CQ_DISPATCH_SET_NUM_WORKER_SEMS = 16,
+    CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA = 17,
     CQ_DISPATCH_CMD_MAX_COUNT,  // for checking legal IDs
 };
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1101,8 +1101,6 @@ re_run_command:
             process_wait();
             break;
 
-        case CQ_DISPATCH_CMD_GO: DPRINT << "cmd_go" << ENDL(); break;
-
         case CQ_DISPATCH_CMD_SINK: DPRINT << "cmd_sink" << ENDL(); break;
 
         case CQ_DISPATCH_CMD_DEBUG:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19203

### Problem description
Cleanup: removed dead dispatcher command

### What's changed
Deleted all code references to symbol CQ_DISPATCH_CMD_GO

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes