### PR TITLE
Fix errors in ttnn.nlp_create_qkv_heads_decode when input shard is bigger than one tile

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_attention.py
+++ b/models/demos/llama3_subdevices/tt/llama_attention.py
@@ -295,7 +295,7 @@ class TtLlamaAttention(LightweightModule):
             xqkv_reduced,
             num_heads=self.n_local_heads,
             num_kv_heads=self.n_local_kv_heads,
-            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+            memory_config=self.model_config["CREATE_HEAD_OUTPUT_MEMCFG"],
             overlap_qk_coregrid=False,
             batch_offset=self.batch_offset_tt_tensor,
             slice_size=self.slice_size,

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -1795,7 +1795,7 @@ def set_tg_attention_config(model_config, dim):
     )
     start_core = ttnn.CoreCoord(1, 0)
     shard_spec_n_cores_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(
-        start_core, 40, sub_core_grids, row_wise=True
+        start_core, 10, sub_core_grids, row_wise=True
     )
 
     model_config["CREATE_HEAD_INPUT_MEMCFG"] = (
@@ -1808,11 +1808,23 @@ def set_tg_attention_config(model_config, dim):
                 shard_spec_n_cores_grid,
                 [
                     32,
-                    32,
+                    128,
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),
         )
+    )
+    model_config["CREATE_HEAD_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            sub_core_grids,
+            [
+                32,
+                128,
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
     )
 
     num_cores = 40 if dim == 8192 else (24 if dim == 4096 else (20 if dim == 3072 else 12))

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -226,23 +226,17 @@ def run_test_create_min_width_shard(
     seq_len = 1
     total_heads = n_local_heads + n_local_kv_heads * 2
     total_cores = total_heads * head_dim // 32
-    core_x = min(total_cores, 8)
-    core_y = max(1, total_cores // core_x)
-    # Prepare input
-    proj_output = torch.rand(1, seq_len, batch, head_dim * total_heads)
 
-    # TT configs
-    if sub_core_grids is None:
-        shard_spec_n_cores_grid = ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(core_x - 1, core_y - 1),
-                ),
-            }
-        )
-    else:
-        device_core_grid_size = device.compute_with_storage_grid_size()
+    device_core_grid_size = device.compute_with_storage_grid_size()
+    device_core_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(device_core_grid_size.x - 1, device_core_grid_size.y - 1),
+            ),
+        }
+    )
+    if sub_core_grids is not None:
         sub_core_grids_bounds = sub_core_grids.bounding_box()
         if (
             sub_core_grids_bounds.start.x < 0
@@ -251,14 +245,15 @@ def run_test_create_min_width_shard(
             or sub_core_grids_bounds.end.y >= device_core_grid_size.y
         ):
             pytest.skip("Sub core grid is out of bounds")
+        device_core_grid = sub_core_grids
 
-        grid_start_coord = sub_core_grids_bounds.start
-        shard_spec_n_cores_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(
-            grid_start_coord, total_cores, sub_core_grids, True
-        )
+    device_core_grid_start = device_core_grid.bounding_box().start
+    input_shard_core_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(
+        device_core_grid_start, total_cores, device_core_grid, True
+    )
 
-    CREATE_HEAD_SHARD_SPEC = ttnn.ShardSpec(
-        shard_spec_n_cores_grid,
+    CREATE_HEAD_INPUT_SHARD_SPEC = ttnn.ShardSpec(
+        input_shard_core_grid,
         [
             32,
             32,
@@ -266,11 +261,24 @@ def run_test_create_min_width_shard(
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     CREATE_HEAD_INPUT_MEMCFG = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, CREATE_HEAD_SHARD_SPEC
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, CREATE_HEAD_INPUT_SHARD_SPEC
     )
-    HEIGHT_SHARDED_MEMCFG = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+
+    CREATE_HEAD_OUTPUT_MEMCFG = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            sub_core_grids,
+            [
+                32,
+                head_dim,
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
 
     # Prepare tt input
+    proj_output = torch.rand(1, seq_len, batch, head_dim * total_heads)
     proj_output_tt = ttnn.from_torch(
         proj_output, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=CREATE_HEAD_INPUT_MEMCFG
     )
@@ -287,7 +295,7 @@ def run_test_create_min_width_shard(
         overlap_qk_coregrid=overlap_coregrid,
         batch_offset=batch_offset,
         slice_size=slice_size,
-        memory_config=HEIGHT_SHARDED_MEMCFG,
+        memory_config=CREATE_HEAD_OUTPUT_MEMCFG,
     )
     logger.info(f"q_heads_tt: {q_heads_tt.shape}, {q_heads_tt.memory_config()}")
     logger.info(f"k_heads_tt: {k_heads_tt.shape}, {k_heads_tt.memory_config()}")

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -268,7 +268,7 @@ def run_test_create_min_width_shard(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.BufferType.L1,
         ttnn.ShardSpec(
-            sub_core_grids,
+            device_core_grid,
             [
                 32,
                 head_dim,
@@ -372,12 +372,6 @@ def test_create_min_width_shard(
     assert device.num_program_cache_entries() == expected_entries
 
 
-@pytest.fixture()
-def set_dispatch_col(device_params):
-    device_params["dispatch_core_axis"] = ttnn.DispatchCoreAxis.COL
-    return device_params
-
-
 @skip_for_blackhole("Requires eth connected devices to run, see #12349")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("batch", (32,))
@@ -421,14 +415,8 @@ def test_create_heads_with_slice(
     assert device.num_program_cache_entries() == expected_entries
 
 
-@pytest.fixture()
-def set_dispatch_col(device_params):
-    device_params["dispatch_core_axis"] = ttnn.DispatchCoreAxis.COL
-    return device_params
-
-
 @skip_for_blackhole("Requires eth connected devices to run, see #12349")
-@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 @pytest.mark.parametrize("batch", (1, 8, 16))
 @pytest.mark.parametrize(
     "n_local_heads, n_local_kv_heads, head_dim",
@@ -447,7 +435,6 @@ def set_dispatch_col(device_params):
     ),
 )
 def test_create_min_width_shard_subcoregrid(
-    set_dispatch_col,
     device,
     batch,
     n_local_heads,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -62,8 +62,8 @@ void kernel_main() {
     uint32_t qkv_y = 0;
     uint32_t total_input_cores = num_x * num_y;
     uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / total_input_cores;
-    uint32_t num_q_cores = num_tiles_per_core * num_q_heads * head_size_num_tiles;
-    uint32_t num_kv_cores = num_tiles_per_core * num_kv_heads * head_size_num_tiles;
+    uint32_t num_q_cores = (num_q_heads * head_size_num_tiles) / num_tiles_per_core;
+    uint32_t num_kv_cores = (num_kv_heads * head_size_num_tiles) / num_tiles_per_core;
 
     uint64_t qkv_read_addr =
         get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
@@ -59,8 +59,8 @@ void kernel_main() {
     // Q
     uint32_t cur_core_idx = 0;
     uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / in_num_cores;
-    uint32_t num_q_cores = num_tiles_per_core * num_q_heads * head_size_num_tiles;
-    uint32_t num_kv_cores = num_tiles_per_core * num_kv_heads * head_size_num_tiles;
+    uint32_t num_q_cores = (num_q_heads * head_size_num_tiles) / num_tiles_per_core;
+    uint32_t num_kv_cores = (num_kv_heads * head_size_num_tiles) / num_tiles_per_core;
 
     uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
                              in_tile_offset_by_batch;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -81,15 +81,8 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(
         this->num_q_heads,
         this->num_kv_heads);
 
-    uint32_t num_cores;
-    if (this->input_on_subcoregrids) {
-        auto input_core_grid = input_tensor.shard_spec().value().grid;
-        num_cores = input_core_grid.num_cores();
+    uint32_t num_cores = this->output_mem_config.shard_spec.value().grid.num_cores();
 
-    } else {
-        auto core_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-        num_cores = core_grid_size.x * core_grid_size.y;
-    }
     // 1 User Per Core Max and 32 users for now
     if (this->overlap_qk_coregrid) {
         TT_FATAL(num_cores >= num_users, "Grid Size is {}. Need at least 32 cores for decode", num_cores);
@@ -126,35 +119,26 @@ std::vector<ttnn::TensorSpec> NLPCreateHeadsDecodeDeviceOperation::compute_outpu
     MemoryConfig q_mem_config = this->output_mem_config;
     MemoryConfig k_mem_config = this->output_mem_config;
     MemoryConfig v_mem_config = this->output_mem_config;
+    CoreRangeSet output_core_grid = this->output_mem_config.shard_spec.value().grid;
     CoreRangeSet q_shard_grid, k_shard_grid, v_shard_grid;
-    if (!this->input_on_subcoregrids) {
-        auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
-        q_shard_grid = tt::tt_metal::num_cores_to_corerangeset(batch, core_grid, true);
-        if (this->overlap_qk_coregrid) {
-            k_shard_grid = q_shard_grid;
-        } else {
-            k_shard_grid = tt::tt_metal::num_cores_to_corerangeset(
-                CoreCoord{batch % core_grid.x, batch / core_grid.x}, batch, core_grid, true);
-        }
-        v_shard_grid = q_shard_grid;
+    auto start_core_coord = output_core_grid.ranges().front().start_coord;
+
+    q_shard_grid =
+        tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core_coord, batch, output_core_grid, true);
+    if (this->overlap_qk_coregrid) {
+        k_shard_grid = q_shard_grid;
     } else {
-        auto input_core_grid = input_tensor.shard_spec().value().grid;
-        auto start_core_coord = input_core_grid.bounding_box().start_coord;
-        q_shard_grid =
-            tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core_coord, batch, input_core_grid, true);
-        if (this->overlap_qk_coregrid) {
-            k_shard_grid = q_shard_grid;
-        } else {
-            CoreRangeSet q_plus_one_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
-                start_core_coord, batch + 1, input_core_grid, true);
-            if (!q_plus_one_grid.ranges().empty()) {
-                start_core_coord = q_plus_one_grid.ranges().back().end_coord;
-            }
-            k_shard_grid =
-                tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(start_core_coord, batch, input_core_grid, true);
+        CoreRangeSet q_plus_one_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+            start_core_coord, batch + 1, output_core_grid, true);
+        CoreCoord k_start_core_coord;
+        if (!q_plus_one_grid.ranges().empty()) {
+            k_start_core_coord = q_plus_one_grid.ranges().back().end_coord;
         }
-        v_shard_grid = q_shard_grid;
+        k_shard_grid =
+            tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(k_start_core_coord, batch, output_core_grid, true);
     }
+    v_shard_grid = q_shard_grid;
+
     tt::tt_metal::ShardSpec q_shard_spec{q_shard_grid, {num_q_heads_padded, this->head_dim}};
     q_mem_config.shard_spec = q_shard_spec;
     tt::tt_metal::ShardSpec k_shard_spec{k_shard_grid, {num_kv_heads_padded, this->head_dim}};

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
@@ -33,6 +33,20 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperati
         input_tensor.is_sharded() &&
         (input_tensor.shard_spec().value().grid.ranges().size() > 1 ||
          input_tensor.shard_spec().value().grid.bounding_box().start_coord != CoreCoord{0, 0});
+
+    CoreRangeSet output_core_grid;
+    if (memory_config.has_value() and memory_config.value().shard_spec.has_value()) {
+        output_core_grid = memory_config.value().shard_spec.value().grid;
+    } else {
+        const auto device_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+        output_core_grid =
+            CoreRangeSet{CoreRange{CoreCoord{0, 0}, CoreCoord{device_grid_size.x - 1, device_grid_size.y - 1}}};
+    }
+
+    MemoryConfig output_mem_config;
+    output_mem_config.buffer_type = BufferType::L1;
+    output_mem_config.memory_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    output_mem_config.shard_spec = tt::tt_metal::ShardSpec{output_core_grid, {}};
     // Infer head_dim
     TT_FATAL(
         input_tensor.get_padded_shape()[3] % (num_heads + 2 * num_kv_heads_val) == 0,
@@ -54,7 +68,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperati
             overlap_qk_coregrid_val,
             input_on_subcoregrids,
             slice_size,
-            memory_config.value_or(input_tensor.memory_config())},
+            output_mem_config},
         {input_tensor},
         {batch_offset},
         optional_outputs,


### PR DESCRIPTION
### Problem description
Presently, CreateQKV Decode Op is only tested with hardcoded input shard shape (32, 32).
When relaxing this constraint and moving to bigger shard (32, 128). This results into two issues
1. PCC issues when input is on contiguous core_grid 
2. FATAL error in creating output_specs when input is on subcoregrids.

### What's changed
1. Fixed bug in reader/writer kernel when calculating `num_q_cores` and `num_kv_cores`.
2. Simplified create_output_specs, now fetching available output core_grid from output memory config.
3. Automatic calculation of output core_grid, shard_shape, BufferType when no output_memory_config is specified.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13981327911) CI passes