### PR TITLE
[skip ci] Cron triggers don't allow us to have defaults.

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -56,9 +56,9 @@ jobs:
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
-      distro: ${{ inputs.distro }}
-      version: ${{ inputs.version }}
-      architecture: ${{ inputs.architecture }}
+      distro: ${{ inputs.distro || 'ubuntu' }}
+      version: ${{ inputs.version || '22.04' }}
+      architecture: ${{ inputs.architecture || 'amd64' }}
 
   clang-tidy:
     name: 🤖 Clang Tidy


### PR DESCRIPTION
### Ticket
None

### Problem description
Cron triggers don't allow us to have defaults.  The run is failing.

### What's changed
Repeat the defaults again.  WET.