### PR TITLE
#19198: Return the TensorSpec for the output tensor from query_op_constraints to enable the compiler optimizer

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -667,8 +667,9 @@ TEST_P(Conv2dOpIfTest, Conv2d) {
             std::nullopt,
             output_spec.tensor_layout().get_memory_config());
 
+        // Todo(arminaleTT): There is a known problem with calculating conv output size. Once fixed, this test will be
+        // expanded
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Error);
-        std::cout << "Armin: " << query.error_message.value();
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -607,19 +607,19 @@ INSTANTIATE_TEST_SUITE_P(
 class Conv2dOpIfTest : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(Conv2dOpIfTest, Conv2d) {
     const auto input_spec = ttnn::TensorSpec(
-        ttnn::Shape({1, 1, 50176, 3}),
+        ttnn::Shape{1, 1, 50176, 3},
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::DRAM_MEMORY_CONFIG));
     const auto weight_spec = ttnn::TensorSpec(
-        ttnn::Shape({1, 1, 1568, 64}),
+        ttnn::Shape{1, 1, 1568, 64},
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::DRAM_MEMORY_CONFIG));
     const auto output_spec = ttnn::TensorSpec(
-        ttnn::Shape({1, 1, 12544, 64}),
+        ttnn::Shape{1, 1, 12544, 64},
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -607,19 +607,19 @@ INSTANTIATE_TEST_SUITE_P(
 class Conv2dOpIfTest : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(Conv2dOpIfTest, Conv2d) {
     const auto input_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array4D{1, 1, 50176, 3}),
+        ttnn::Shape({1, 1, 50176, 3}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::DRAM_MEMORY_CONFIG));
     const auto weight_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1568, 64}),
+        ttnn::Shape({1, 1, 1568, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::DRAM_MEMORY_CONFIG));
     const auto output_spec = ttnn::TensorSpec(
-        ttnn::Shape(tt::tt_metal::Array4D{1, 1, 12544, 64}),
+        ttnn::Shape({1, 1, 12544, 64}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -26,6 +26,7 @@
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
@@ -602,6 +603,114 @@ INSTANTIATE_TEST_SUITE_P(
                      .cb_peak_size_per_core = 28736,
                      .l1_buffers_peak_per_core = 26624,
                      .l1_output_buffer_per_core = 26624}}})));
+
+class Conv2dOpIfTest : public TTNNFixtureWithDevice,
+                       public testing::WithParamInterface<std::tuple<
+                           ttnn::TensorSpec,         // input
+                           ttnn::TensorSpec,         // weight
+                           ttnn::TensorSpec,         // output
+                           uint32_t,                 // in_channels
+                           uint32_t,                 // out_channels
+                           uint32_t,                 // batch_size
+                           uint32_t,                 // input_height
+                           uint32_t,                 // input_width
+                           std::array<uint32_t, 2>,  // kernel_size
+                           std::array<uint32_t, 2>,  // stride
+                           std::array<uint32_t, 2>,  // padding
+                           std::array<uint32_t, 2>,  // dilation
+                           uint32_t,                 // groups
+                           ResourceUsageMap>> {};
+
+TEST_P(Conv2dOpIfTest, Conv2d) {
+    const auto& input_spec = std::get<0>(GetParam());
+    const auto& weight_spec = std::get<1>(GetParam());
+    const auto& output_spec = std::get<2>(GetParam());
+    const uint32_t in_channels = std::get<3>(GetParam());
+    const uint32_t out_channels = std::get<4>(GetParam());
+    const uint32_t batch_size = std::get<5>(GetParam());
+    const uint32_t input_height = std::get<6>(GetParam());
+    const uint32_t input_width = std::get<7>(GetParam());
+    const std::array<uint32_t, 2> kernel_size = std::get<8>(GetParam());
+    const std::array<uint32_t, 2> stride = std::get<9>(GetParam());
+    const std::array<uint32_t, 2> padding = std::get<10>(GetParam());
+    const std::array<uint32_t, 2> dilation = std::get<11>(GetParam());
+    const uint32_t groups = std::get<12>(GetParam());
+    const auto& expected_resource_usage_map = std::get<ResourceUsageMap>(GetParam());
+    const BoardType board_type = tt::Cluster::instance().get_board_type(0);
+    if (expected_resource_usage_map.count(board_type) == 0) {
+        GTEST_SKIP();
+    }
+    const auto& expected_resource_usage = expected_resource_usage_map.at(board_type);
+
+    // Run the test
+    {
+        tt::tt_metal::IDevice* device = device_;
+        const auto& output_spec = input_spec;
+        auto query = ttnn::graph::query_op_constraints(
+            ttnn::conv2d,
+            device,
+            input_spec,
+            weight_spec,
+            device,
+            in_channels,
+            out_channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            output_spec.tensor_layout().get_memory_config());
+
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Error);
+        std::cout << "Armin: " << query.error_message.value();
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QueryOpConstraints,  // Prefix for the instantiated test suite
+    Conv2dOpIfTest,      // Test suite name
+    ::testing::Values(std::make_tuple(
+        ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 50176, 3}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::DRAM_MEMORY_CONFIG)),
+        ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1568, 64}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::DRAM_MEMORY_CONFIG)),
+        ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 12544, 64}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::DRAM_MEMORY_CONFIG)),
+        3,
+        64,
+        1,
+        224,
+        224,
+        std::array<uint32_t, 2>{7, 7},
+        std::array<uint32_t, 2>{2, 2},
+        std::array<uint32_t, 2>{3, 3},
+        std::array<uint32_t, 2>{1, 1},
+        1,
+        ResourceUsageMap{
+            {BoardType::N300,
+             ttnn::graph::ResourceUsage{
+                 .cb_peak_size_per_core = 0, .l1_buffers_peak_per_core = 0, .l1_output_buffer_per_core = 0}},
+            {BoardType::E150,
+             ttnn::graph::ResourceUsage{
+                 .cb_peak_size_per_core = 0, .l1_buffers_peak_per_core = 0, .l1_output_buffer_per_core = 0}}})));
 
 }  // namespace test
 }  // namespace binary

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -207,6 +207,7 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
         EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
         EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
     }
 }
 
@@ -285,6 +286,7 @@ TEST_P(SoftmaxOpIfTest, Softmax) {
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
         EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
         EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
     }
 }
 
@@ -525,6 +527,7 @@ TEST_P(MatmulOpIfTest, Matmul) {
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
         EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
         EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }
 }
 

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -20,7 +20,7 @@ namespace detail {
 // supported and a new overload should be added
 
 // most ops just return a tensor
-Tensor extract_output_tensor(const Tensor& result) { return result; }
+inline Tensor extract_output_tensor(const Tensor& result) { return result; }
 
 // conv2d output
 template <typename... Args>

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -103,7 +103,8 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
 
     } catch (const std::exception& e) {
         tt::log_debug(tt::LogOp, "op_constraints - error: {}", e.what());
-        return ConstraintQueryResponse{ExecutionStatus::Error, {0, 0, 0}, std::nullopt, e.what()};
+        return ConstraintQueryResponse{
+            ExecutionStatus::Error, {0, 0, 0}, /* output_tensor_spec= */ std::nullopt, e.what()};
     }
 }
 

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -15,6 +15,10 @@ namespace ttnn::graph {
 
 namespace detail {
 
+// These overloaded extract_output_tensor functions abstract the return type of an arbitrary op from the rest of the
+// constraints query function. An overload resolution failure means the return type for the op in that query is not yet
+// supported and a new overload should be added
+
 // most ops just return a tensor
 Tensor extract_output_tensor(const Tensor& result) { return result; }
 
@@ -23,25 +27,6 @@ template <typename... Args>
 Tensor extract_output_tensor(const std::tuple<Tensor, Args...>& result) {
     return std::get<0>(result);
 }
-
-// template <typename Result>
-// Tensor extract_output_tensor(Result&& result) {
-//     constexpr bool is_tensor =
-//         std::is_same_v<std::decay_t<Result>, Tensor>;
-
-//     constexpr bool is_tuple_with_tensor =
-//         (std::tuple_size_v<std::decay_t<Result>> > 0 &&
-//          std::is_same_v<std::tuple_element_t<0, std::decay_t<Result>>, Tensor>);
-
-//     static_assert(is_tensor || is_tuple_with_tensor,
-//                   "Unsupported return type: Must be Tensor or a tuple with Tensor as the first element.");
-
-//     if constexpr (is_tensor) {
-//         return std::forward<Result>(result);
-//     } else if constexpr (is_tuple_with_tensor) {
-//         return std::get<0>(std::forward<Result>(result));
-//     }
-// }
 
 }  // namespace detail
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19198

### Problem description
We need to reduce the search space for the forge optimizer. One way to do that is by taking advantage of the fact that for many ops, there is a 1-1 mapping between input layout and output layout. By inspecting the output tensor for a given input layout, we can avoid searching for legal output layouts. For more details, see: https://github.com/tenstorrent/tt-mlir/issues/2450

### What's changed
- `query_op_constraints` now includes the `TensorSpec` of the output tensor in its result struct 
  - In tt-mlir, we will have conversion functions to create an MLIR type from this
- Most ops return just a `Tensor`, but some (like conv2d) return more complex objects. Created overloaded wrappers around the op execution to get the output tensor based on the return types of currently supported ops in tt-mlir. 
  - Attempting to get the constraints for an op with an unsupported return type will cause an overload-resolution compile error
- Added a unit test to exercise the `conv2d` wrapper
- Modified existing unit tests to verify the `TensorSpec`
- Closes #19198 
- **This is the fixed version of #19352. That PR had to be reverted due to build issues**
  - In C++20, when using if-constexpr in a templated function, the discarded branch cannot not be ill-formed for all template specializations. i.e. the following structure used in the old PR is **ill-formed** 
```
template<typename T>
void f()
{
    if constexpr (std::is_arithmetic_v<T>)
        // ...
    else {
        static_assert(false, "Must be arithmetic"); // ill-formed before CWG2518 (C++23)
    }
}
```

For more information, see https://en.cppreference.com/w/cpp/language/if#Constexpr_If

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [X] New/Existing tests provide coverage for changes