### PR TITLE
#0: Increase MEM_BRISC_FIRMWARE_SIZE to fix bh profiler bug

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -48,7 +48,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 1024)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 1024)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 1536
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION
### Problem description
When trying to run any test with enabled profiler on blackhole, this is error:
```
 BuildKernels | ERROR    | brisc link failure -- cmd: cd /localdev/skrstic/tt-metal/built/bd58d5629d/1052672/firmware/brisc/ && /localdev/skrstic/tt-metal/runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++ -Os -mcpu=tt-bh -fno-rvtt-sfpu-replay -std=c++17 -flto -ffast-math -fno-exceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles -T/localdev/skrstic/tt-metal/runtime/hw/toolchain/blackhole/firmware_brisc.ld brisc.o /localdev/skrstic/tt-metal/runtime/hw/lib/blackhole/tmu-crt0.o /localdev/skrstic/tt-metal/runtime/hw/lib/blackhole/noc.o /localdev/skrstic/tt-metal/runtime/hw/lib/blackhole/substitutes.o -o /localdev/skrstic/tt-metal/built/bd58d5629d/1052672/firmware/brisc/brisc.elf
           BuildKernels | ERROR    | In file included from /localdev/skrstic/tt-metal/tt_metal/hw/inc/dataflow_api.h:31,
                 from /localdev/skrstic/tt-metal/tt_metal/hw/inc/firmware_common.h:20,
                 from /localdev/skrstic/tt-metal/tt_metal/hw/firmware/src/brisc.cc:20:
/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp: In function 'void kernel_profiler::quick_push()':
/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp:22:22: note: '#pragma message: PROFILER-NOC-QUICK-SEND,/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp,275,KERNEL_PROFILER'
   22 | #define DO_PRAGMA(x) _Pragma(#x)
      |                      ^~~~~~~
/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp:32:5: note: in expansion of macro 'DO_PRAGMA'
   32 |     DO_PRAGMA(message(PROFILER_MSG_NAME(name))); \
      |     ^~~~~~~~~
/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp:275:5: note: in expansion of macro 'SrcLocNameToHash'
  275 |     SrcLocNameToHash("PROFILER-NOC-QUICK-SEND");
      |     ^~~~~~~~~~~~~~~~
/localdev/skrstic/tt-metal/tt_metal/hw/firmware/src/brisc.cc: In function 'int main()':
/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp:22:22: note: '#pragma message: BRISC-FW,/localdev/skrstic/tt-metal/tt_metal/hw/firmware/src/brisc.cc,460,KERNEL_PROFILER'
   22 | #define DO_PRAGMA(x) _Pragma(#x)
      |                      ^~~~~~~
/localdev/skrstic/tt-metal/tt_metal/tools/profiler/kernel_profiler.hpp:458:5: note: in expansion of macro 'DO_PRAGMA'
  458 |     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
      |     ^~~~~~~~~
/localdev/skrstic/tt-metal/tt_metal/hw/firmware/src/brisc.cc:460:13: note: in expansion of macro 'DeviceZoneScopedMainN'
  460 |             DeviceZoneScopedMainN("BRISC-FW");
      |             ^~~~~~~~~~~~~~~~~~~~~
/localdev/skrstic/tt-metal/runtime/sfpi/compiler/bin/../lib/gcc/riscv32-unknown-elf/12.4.0/../../../../riscv32-unknown-elf/bin/ld: address 0x4c18 of /localdev/skrstic/tt-metal/built/bd58d5629d/1052672/firmware/brisc/brisc.elf section `.firmware_text' is not within region `BRISC_FIRMWARE_CODE'
/localdev/skrstic/tt-metal/runtime/sfpi/compiler/bin/../lib/gcc/riscv32-unknown-elf/12.4.0/../../../../riscv32-unknown-elf/bin/ld: address 0x4c18 of /localdev/skrstic/tt-metal/built/bd58d5629d/1052672/firmware/brisc/brisc.elf section `.firmware_text' is not within region `BRISC_FIRMWARE_CODE'
collect2: error: ld returned 1 exit status

libc++abi: terminating due to uncaught exception of type std::runtime_error: TT_THROW @ /localdev/skrstic/tt-metal/tt_metal/jit_build/build.cpp:55: tt::exception
info:
brisc build failed
```

### What's changed
`MEM_BRISC_FIRMWARE_SIZE` is increased.

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13986957322) - profiler regression is OK after this commit, but generally bh post-commit looks flaky rn so it is not 100% green