### PR TITLE
#0: Set subblock to (1,1) in conv2d for resnet50 ci

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -81,5 +81,5 @@ run_python_model_tests_blackhole() {
         echo "LOG_METAL: Llama3 tests for $llama_dir completed"
     done
 
-    pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
+    TT_METAL_CONV2D_1_1_SUBBLOCK=1 pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_batch_16.py
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -283,6 +283,13 @@ static std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
         {1, 5}, {5, 1}, {2, 2}, {1, 4}, {4, 1}, {1, 3}, {3, 1}, {1, 2}, {2, 1}, {1, 1},
     }};
 
+    // # Issue 18812. Temporarily solution for BH CI while hang is not resolved.
+    static bool conv2d_subblock_env_set = (std::getenv("TT_METAL_CONV2D_1_1_SUBBLOCK") != nullptr);
+
+    if (conv2d_subblock_env_set) {
+        return {1, 1};
+    }
+
     uint32_t subblock_h = 0;
     uint32_t subblock_w = 0;
     for (auto [subblock_height, subblock_width] : subblocks) {


### PR DESCRIPTION
### Ticket
#19462 

### Problem description
Resnet50 test is currently hanging on blackhole post-commit.

### What's changed
Set subblock to (1,1) in conv2d for resnet50 ci, to avoid hang.

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13990868018) - models unit test passed, some failing tests seem to be flaky these days