### PR TITLE
Increase BH BRISC FW size

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -48,7 +48,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 1024)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 1024)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 1536
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION
### Problem description
BH FW is growing larger than allowed size in profiler builds. 
 
### What's changed
Increase BH FW size by 1MB

- [ ] [BH post commit ](https://github.com/tenstorrent/tt-metal/actions/runs/13993849375)