### PR TITLE
#0: Dump text start addresses in watcher

### DIFF
--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -461,6 +461,19 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
             mbox_data->launch[launch_msg_read_ptr].kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0],
             mbox_data->launch[launch_msg_read_ptr].kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1],
             mbox_data->launch[launch_msg_read_ptr].kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]);
+
+        if (tt::llrt::RunTimeOptions::get_instance().get_watcher_text_start()) {
+            uint32_t kernel_config_base = mbox_data->launch[launch_msg_read_ptr].kernel_config.kernel_config_base[0];
+            fprintf(f, " text_start:");
+            for (size_t i = 0; i < NUM_PROCESSORS_PER_CORE_TYPE; i++) {
+                const char* separator = (i > 0) ? "|" : "";
+                fprintf(
+                    f,
+                    "%s0x%x",
+                    separator,
+                    kernel_config_base + mbox_data->launch[launch_msg_read_ptr].kernel_config.kernel_text_offset[i]);
+            }
+        }
     }
 
     // Ring buffer at the end because it can print a bunch of data, same for stack usage

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -210,6 +210,9 @@ void RunTimeOptions::ParseWatcherEnv() {
     const char* watcher_phys_str = getenv("TT_METAL_WATCHER_PHYS_COORDS");
     watcher_phys_coords = (watcher_phys_str != nullptr);
 
+    const char* watcher_text_start_str = getenv("TT_METAL_WATCHER_TEXT_START");
+    watcher_text_start = (watcher_text_start_str != nullptr);
+
     // Auto unpause is for testing only, no env var.
     watcher_auto_unpause = false;
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -90,6 +90,7 @@ class RunTimeOptions {
     bool watcher_auto_unpause = false;
     bool watcher_noinline = false;
     bool watcher_phys_coords = false;
+    bool watcher_text_start = false;
     bool record_noc_transfer_data = false;
 
     TargetSelection feature_targets[RunTimeDebugFeatureCount];
@@ -174,6 +175,8 @@ public:
     inline void set_watcher_noinline(bool noinline) { watcher_noinline = noinline; }
     inline int get_watcher_phys_coords() { return watcher_phys_coords; }
     inline void set_watcher_phys_coords(bool phys_coords) { watcher_phys_coords = phys_coords; }
+    inline int get_watcher_text_start() { return watcher_text_start; }
+    inline void set_watcher_text_start(bool text_start) { watcher_text_start = text_start; }
     inline std::set<std::string>& get_watcher_disabled_features() { return watcher_disabled_features; }
     inline bool watcher_status_disabled() { return watcher_feature_disabled(watcher_waypoint_str); }
     inline bool watcher_noc_sanitize_disabled() { return watcher_feature_disabled(watcher_noc_sanitize_str); }


### PR DESCRIPTION

### Problem description
When debugging kernels we need to know the text start address so we can load symbols. 

### What's changed
Add a flag to enable dumping the text start address for each kernel from watcher.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes