### PR TITLE
Adding missing inputs to reusable

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -45,6 +45,10 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     secrets: inherit
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   t3000-model-perf:
     needs: build-artifact
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Workflow was not completely satisfied as a reusable introduced new required parameters:
```
The workflow is not valid. .github/workflows/package-and-release.yaml (Line: 46, Col: 11): Input build-artifact-name is required, but not provided while calling. .github/workflows/package-and-release.yaml (Line: 46, Col: 11): Input wheel-artifact-name is required, but not provided while calling.
```

### What's changed
Adding missing inputs to reusable

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes