### PR TITLE
Fix bug in AllReduce which caused hang on Llama-TG

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -72,10 +72,10 @@ def test_ag_tg_llama_perf(
 @pytest.mark.parametrize(
     "ar_type, warmup_iters, perf_target_us",
     [
-        ("ff2", 15, 29),
-        ("qkv", 15, 26.3),
-        ("ff1", 15, 30),
-        ("lm_head", 15, 78),
+        ("ff2", 15, 21),
+        ("qkv", 15, 13),
+        ("ff1", 15, 22),
+        ("lm_head", 15, 70),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -17,6 +17,7 @@ from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
     NORM_CRS,
     LM_HEAD_CRS,
     QKV_CRS,
+    FF1_CRS,
 )
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_matmul_1d_gather_in0 import (
     PREFETCHER_NOC1_GRID,
@@ -198,8 +199,8 @@ def test_all_gather_tg_llama(
     "output_shape, cluster_axis, num_links, input_num_cores, input_core_range_set, output_num_cores, output_core_range_set",
     [
         ([1, 1, 32, 2048], 0, 4, 24, RING_CRS, 16, NORM_CRS),  # FF2/DO all reduce
-        ([1, 1, 32, 1280], 1, 3, 24, RING_CRS, 40, QKV_CRS),  # QKV all reduce
-        ([1, 1, 32, 3584], 1, 3, 24, RING_CRS, 24, RING_CRS),  # FF1 all reduce
+        ([1, 1, 32, 1280], 1, 3, 24, RING_CRS, 10, QKV_CRS),  # QKV all reduce
+        ([1, 1, 32, 3584], 1, 3, 24, RING_CRS, 28, FF1_CRS),  # FF1 all reduce
         ([1, 1, 32, 16 * 1024], 1, 3, 32, LM_HEAD_CRS, 32, LM_HEAD_CRS),  # LM head all reduce
     ],
     ids=[

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
@@ -32,7 +32,7 @@ SUB_DEVICE_CRS = ttnn.CoreRangeSet(
     ]
 )
 
-QKV_CRS = ttnn.num_cores_to_corerangeset_in_subcoregrids(ttnn.CoreCoord(1, 0), 40, SUB_DEVICE_CRS, row_wise=True)
+QKV_CRS = ttnn.num_cores_to_corerangeset_in_subcoregrids(ttnn.CoreCoord(1, 0), 10, SUB_DEVICE_CRS, row_wise=True)
 
 RING_CRS = ttnn.CoreRangeSet(
     [
@@ -43,6 +43,8 @@ RING_CRS = ttnn.CoreRangeSet(
         for x, y in PREFETCHER_NOC1_GRID
     ]
 )
+
+FF1_CRS = ttnn.num_cores_to_corerangeset_in_subcoregrids(ttnn.CoreCoord(1, 0), 28, SUB_DEVICE_CRS, row_wise=True)
 
 NORM_CRS = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(2, 7))])
 
@@ -329,12 +331,12 @@ def run_all_reduce_impl(
     "output_shape, cluster_axis, num_links, input_num_cores, input_core_range_set, output_num_cores, output_core_range_set",
     [
         ([1, 1, 32, 2048], 0, 4, 24, RING_CRS, 16, NORM_CRS),  # FF2/DO all reduce
-        ([1, 1, 32, 1280], 1, 3, 24, RING_CRS, 40, QKV_CRS),  # QKV all reduce
-        ([1, 1, 32, 3584], 1, 3, 24, RING_CRS, 24, RING_CRS),  # FF1 all reduce
+        ([1, 1, 32, 1280], 1, 3, 24, RING_CRS, 10, QKV_CRS),  # QKV all reduce
+        ([1, 1, 32, 3584], 1, 3, 24, RING_CRS, 28, FF1_CRS),  # FF1 all reduce
         ([1, 1, 32, 2048], 0, 3, 24, RING_CRS, 16, NORM_CRS),  # FF2/DO all reduce
         ([1, 1, 32, 16 * 1024], 1, 3, 32, LM_HEAD_CRS, 32, LM_HEAD_CRS),  # LM Head all reduce
-        ([1, 1, 32, 1280], 1, 1, 24, RING_CRS, 40, QKV_CRS),  # QKV all reduce
-        ([1, 1, 32, 3584], 1, 1, 24, RING_CRS, 24, RING_CRS),  # FF1 all reduce
+        ([1, 1, 32, 1280], 1, 1, 24, RING_CRS, 10, QKV_CRS),  # QKV all reduce
+        ([1, 1, 32, 3584], 1, 1, 24, RING_CRS, 28, FF1_CRS),  # FF1 all reduce
         ([1, 1, 32, 2048], 0, 1, 24, RING_CRS, 16, NORM_CRS),  # FF2/DO all reduce
         ([1, 1, 32, 16 * 1024], 1, 1, 32, LM_HEAD_CRS, 32, LM_HEAD_CRS),  # LM Head all reduce
     ],
@@ -420,8 +422,8 @@ def test_all_reduce(
 @pytest.mark.parametrize(
     "output_shape, cluster_axis, num_links, input_num_cores, input_core_range_set, output_num_cores, output_core_range_set",
     [
-        ([1, 1, 32, 1280], 1, 1, 24, RING_CRS, 40, QKV_CRS),  # QKV all reduce
-        ([1, 1, 32, 3584], 1, 1, 24, RING_CRS, 24, RING_CRS),  # FF1 all reduce
+        ([1, 1, 32, 1280], 1, 1, 24, RING_CRS, 10, QKV_CRS),  # QKV all reduce
+        ([1, 1, 32, 3584], 1, 1, 24, RING_CRS, 28, FF1_CRS),  # FF1 all reduce
         ([1, 1, 32, 2048], 0, 1, 24, RING_CRS, 16, NORM_CRS),  # FF2/DO all reduce
     ],
 )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -110,8 +110,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
     // output_cores_all is the bounding box of the output_tensor_cores but respecting boundaries of subdevice grids
     CoreRangeSet output_cores_all(output_cores);
 
-    std::optional<CoreRangeSet> reserved_cores = output_cores_all;
-    auto available_cores = reserved_cores.has_value() ? sub_device_cores.subtract(*reserved_cores) : sub_device_cores;
+    CoreRangeSet reserved_cores = output_cores_all;
+    auto available_cores = sub_device_cores.subtract(reserved_cores);
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
     const auto [sender_worker_core_range, sender_worker_cores] =


### PR DESCRIPTION
### Problem description
Brian's [PR](https://github.com/tenstorrent/tt-metal/commit/cdec5773855f832caafe7a99c53f1c03afa9642e) for AR dispatch optimizations had an edge case which is causing hang on demo when output cores are modified from 40->10  for QKV AllReduce

### What's changed
* Updated unit tests for QKV and FF1 AllReduce to run on modified num_output_cores
* Updated perf target

### Checklist
All relevant pipeline tests have been ran locally and passed
- [x] [All Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/13999907686)