### PR TITLE
ScaledDotProductAttention Op Performance Model

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
@@ -32,6 +32,11 @@ struct ScaledDotProductAttention {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
 
+    tt::tt_metal::operation::OpPerformanceModel create_op_performance_model(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors) const;
+
     tt::tt_metal::operation::Hash compute_program_hash(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;


### PR DESCRIPTION
### Problem description
Adds a simple lower-bound on compute cycles needed to perform this operation, taking into account just the operations needed for the Q*K and attention_score * V matmuls.

This ignores the compute needed for sqrt normalization and softmax, so these numbers _are optimistic_ but a decent reference point for seeing how much perf is left on the table. 

### What's changed
Added `ScaledDotProductAttention::create_op_performance_model` to the `ScaledDotProductAttention` operation class.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes