### PR TITLE
#19302 Current kernel cache path is unsafe when using env var

### DIFF
--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -42,7 +42,7 @@ RunTimeOptions::RunTimeOptions() {
     const char* cache_dir_str = std::getenv(TT_METAL_CACHE_ENV_VAR);
     if (cache_dir_str != nullptr) {
         this->is_cache_dir_env_var_set = true;
-        this->cache_dir_ = std::string(cache_dir_str) + "/";
+        this->cache_dir_ = std::string(cache_dir_str) + "/tt-metal-cache/";
     }
 
     const char* kernel_dir_str = std::getenv(TT_METAL_KERNEL_PATH_ENV_VAR);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19302)

### Problem description
Current code allows user to set his cache folder anywhere, which can lead to unsafe behavior when we clean old caches.

### What's changed
Added a unique section to the path supplied by user to make sure we only check that part before removing any contents.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes